### PR TITLE
Fixes #27559 - match old login page button attr

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^1.4.0",
+    "@theforeman/vendor": "^1.7.0",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -33,7 +33,7 @@
     "@storybook/addon-knobs": "~3.4.12",
     "@storybook/react": "~3.4.12",
     "@storybook/storybook-deployer": "^2.0.0",
-    "@theforeman/vendor-dev": "^1.4.0",
+    "@theforeman/vendor-dev": "^1.7.0",
     "argv-parse": "^1.0.1",
     "axios-mock-adapter": "^1.10.0",
     "babel-cli": "^6.10.1",

--- a/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/__snapshots__/LoginPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/__snapshots__/LoginPage.test.js.snap
@@ -22,6 +22,10 @@ exports[`AutoComplete rendering renders LoginPage 1`] = `
           "placeholder": "Password",
           "type": "password",
         },
+        "submitButtonAttributes": Object {
+          "id": "login_submit_btn",
+          "name": "commit",
+        },
         "submitError": Array [
           "some-error",
         ],

--- a/webpack/assets/javascripts/react_app/components/LoginPage/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/helpers.js
@@ -49,4 +49,8 @@ export const defaultFormProps = {
     placeholder: __('Password'),
   },
   submitText: __('Log In'),
+  submitButtonAttributes: {
+    id: 'login_submit_btn',
+    name: 'commit',
+  },
 };


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Satellite 6.6 have login button like this:

```<input type="submit" name="commit" value="Log In" class="btn btn-primary" data-disable-with="Log In">```

New LoginPage form have:

```<button type="submit" disabled="" class="login-pf-submit-button btn btn-lg btn-primary btn-block">Log In</button>```

in this PR I have added the missing attributes,
blocked by patternfly PR: https://github.com/patternfly/patternfly-react/pull/2682