### PR TITLE
Fixes #26655 - show content after creating a host

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ToastsList/ToastList.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/ToastList.js
@@ -26,8 +26,11 @@ const ToastsList = ({ messages, deleteToast }) => {
         </ToastComponent>
       );
     });
-
-  return <ToastNotificationList>{toastsList}</ToastNotificationList>;
+  return (
+    toastsList.length > 0 && (
+      <ToastNotificationList>{toastsList}</ToastNotificationList>
+    )
+  );
 };
 
 ToastsList.propTypes = {

--- a/webpack/assets/javascripts/react_app/components/ToastsList/__snapshots__/ToastsList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/__snapshots__/ToastsList.test.js.snap
@@ -49,22 +49,7 @@ exports[`ToastList should render with emptyState 1`] = `
         "unsubscribe": [Function],
       }
     }
-  >
-    <ToastNotificationList
-      className=""
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseOver={[Function]}
-    >
-      <div
-        className="toast-notifications-list-pf"
-        onFocus={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseOver={[Function]}
-      />
-    </ToastNotificationList>
-  </ToastsList>
+  />
 </Connect(ToastsList)>
 `;
 

--- a/webpack/assets/javascripts/react_app/redux/reducers/toasts/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/toasts/index.js
@@ -18,7 +18,7 @@ export default (state = initialState, action) => {
     }
 
     case TOASTS_CLEAR: {
-      return initialState;
+      return state.set('messages', {});
     }
 
     default: {


### PR DESCRIPTION
after creating a new host, the UI for the newly created host disappear. this happens because of the `storeObserver` for `layout`  stopped from listening for changes.

After triggering `onContentLoad`, the storeObserver continue to listen for changes in the layout.