### PR TITLE
Fixes #27589 - add sequence reset task

### DIFF
--- a/lib/tasks/convert.rake
+++ b/lib/tasks/convert.rake
@@ -151,14 +151,14 @@ namespace :db do
                 end
           DevelopmentModelClass.connection.execute(sql) if sql.present?
 
+          # reset primary key sequence
+          DevelopmentModelClass.connection.reset_pk_sequence!(table_name) if DevelopmentModelClass.connection.respond_to?(:reset_pk_sequence!)
+
           print "#{count} records converted in #{Process.clock_gettime(Process::CLOCK_MONOTONIC) - time} seconds\n"
         rescue StandardError => e
           print "Unable to convert #{table_name}, skipping: #{e}"
         end
       end
     end
-
-    desc 'Migrate MySQL (prod) to PostgreSQL (dev). Deletes ALL DATA in the development database.'
-    task :mysql2pgsql => :prod2dev
   end
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,20 @@
+# TRANSLATORS: do not translate
+desc <<-END_DESC
+  Reset PostgreSQL sequences to their max values. Does nothing on other databases.
+
+  Examples:
+    rake db:sequence:reset - reset primary key sequence to max value (only for PostgreSQL)
+
+END_DESC
+
+namespace :db do
+  namespace :sequence do
+    task :reset => :environment do
+      if ActiveRecord::Base.connection.adapter_name.downcase.starts_with?('postgresql')
+        ActiveRecord::Base.connection.tables.each do |t|
+          ActiveRecord::Base.connection.reset_pk_sequence!(t)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
For MySQL migration we need a nice way to reset sequence generators. Looks like Rails does provide this.