### PR TITLE
Fixes #27624 - connection error rescue for ec2

### DIFF
--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -45,7 +45,7 @@ module Foreman::Model
 
     def find_vm_by_uuid(uuid)
       super
-    rescue Fog::Compute::AWS::Error
+    rescue Fog::AWS::Compute::Error
       raise(ActiveRecord::RecordNotFound)
     end
 
@@ -87,7 +87,7 @@ module Foreman::Model
     def test_connection(options = {})
       super
       errors[:user].empty? && errors[:password].empty? && regions
-    rescue Fog::Compute::AWS::Error => e
+    rescue Fog::AWS::Compute::Error => e
       errors[:base] << e.message
     rescue Excon::Error::Socket => e
       errors[:base] << e.message
@@ -138,7 +138,7 @@ module Foreman::Model
       end.to_h
 
       normalized
-    rescue Fog::Compute::AWS::Error => e
+    rescue Fog::AWS::Compute::Error => e
       Foreman::Logging.exception("Unhandled EC2 error", e)
       {}
     end

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -9,9 +9,9 @@ Fog::Model.send(:include, FogExtensions::Model) if defined? Fog::Model
 if Foreman::Model::EC2.available?
   require 'fog/aws'
   require 'fog/aws/models/compute/flavor'
-  Fog::Compute::AWS::Flavor.send(:include, FogExtensions::AWS::Flavor)
+  Fog::AWS::Compute::Flavor.send(:include, FogExtensions::AWS::Flavor)
   require 'fog/aws/models/compute/server'
-  Fog::Compute::AWS::Server.send(:include, FogExtensions::AWS::Server)
+  Fog::AWS::Compute::Server.send(:include, FogExtensions::AWS::Server)
 end
 
 if Foreman::Model::GCE.available?

--- a/test/models/compute_resources/ec2_test.rb
+++ b/test/models/compute_resources/ec2_test.rb
@@ -25,7 +25,7 @@ module Foreman
         end
 
         it "raises RecordNotFound when the compute raises EC2 error" do
-          cr = mock_cr_servers(Foreman::Model::EC2.new, servers_raising_exception(Fog::Compute::AWS::Error))
+          cr = mock_cr_servers(Foreman::Model::EC2.new, servers_raising_exception(Fog::AWS::Compute::Error))
           assert_find_by_uuid_raises(ActiveRecord::RecordNotFound, cr)
         end
       end

--- a/test/models/concerns/fog_extensions/aws/server_test.rb
+++ b/test/models/concerns/fog_extensions/aws/server_test.rb
@@ -4,7 +4,7 @@ class AwsServerTest < ActiveSupport::TestCase
   setup { Fog.mock! }
   teardown { Fog.unmock! }
 
-  let(:server) { Fog::Compute::AWS::Server.new }
+  let(:server) { Fog::AWS::Compute::Server.new }
   let(:instance_id) { "i-#{Fog::Mock.random_hex(8)}" }
 
   test "#to_s and #name return name from tags" do


### PR DESCRIPTION
We did not change the namespace properly. To test create a EC2 CR and
fill in some random details, try Load regions and the error is not being
catched properly.