### PR TITLE
Refs #27644: Add PermissionDenied component

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -328,7 +328,7 @@ module Api
         fail_message = _('Missing one of the required permissions: %s') % missing_permissions.map(&:name).join(', ')
         Foreman::Logging.logger('permissions').info fail_message
         if options.fetch(:locals, {}).fetch(:details, nil).blank?
-          options = options.deep_merge({:locals => {:details => fail_message }})
+          options = options.deep_merge({:locals => {:details => fail_message, :missing_permissions => missing_permissions.map(&:name)}})
         end
       end
       options

--- a/app/views/api/v2/errors/access_denied.json.rabl
+++ b/app/views/api/v2/errors/access_denied.json.rabl
@@ -2,3 +2,4 @@ object false => :error
 
 node(:message) {_('Access denied')}
 node(:details) {locals[:details]}
+node(:missing_permissions) {locals[:missing_permissions]}

--- a/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.js
+++ b/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import { Button, Icon } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import { translate as __ } from '../../common/I18n';
+
+const PermissionDenied = ({ missingPermissions, texts, backHref }) => {
+  const { notAuthorizedMsg, permissionDeniedMsg, pleaseRequestMsg } = texts;
+  return (
+    <div className="blank-slate-pf">
+      <div className="blank-slate-pf-icon">
+        <Icon name="lock" color="#9c9c9c" size="2x" title="lock" />
+      </div>
+      {notAuthorizedMsg}
+
+      <h1>{permissionDeniedMsg}</h1>
+      <p>
+        {notAuthorizedMsg}
+        <br />
+        {pleaseRequestMsg}
+        <br />
+      </p>
+      <ul className="list-unstyled">
+        {missingPermissions.map(permission => (
+          <li key={permission}>
+            <strong>{permission}</strong>
+          </li>
+        ))}
+      </ul>
+      <p>
+        <a href={backHref}>
+          <Button>{__('Back')}</Button>
+        </a>
+      </p>
+    </div>
+  );
+};
+
+PermissionDenied.propTypes = {
+  missingPermissions: PropTypes.node,
+  texts: PropTypes.shape({
+    notAuthorizedMsg: PropTypes.string,
+    permissionDeniedMsg: PropTypes.string,
+    pleaseRequestMsg: PropTypes.string,
+  }),
+  backHref: PropTypes.string,
+};
+
+PermissionDenied.defaultProps = {
+  missingPermissions: ['unknown'],
+  texts: {
+    notAuthorizedMsg: __('You are not authorized to perform this action.'),
+    permissionDeniedMsg: __('Permission denied'),
+    pleaseRequestMsg: __(
+      'Please request one of the required permissions listed below from a Foreman administrator:'
+    ),
+  },
+  backHref: '/',
+};
+
+export default PermissionDenied;

--- a/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.stories.js
+++ b/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import PermissionDenied from '.';
+import Story from '../../../../../stories/components/Story';
+
+storiesOf('Components/PermissionDenied', module)
+  .add('With default text', () => (
+    <Story>
+      <PermissionDenied
+        missingPermissions={['view_organizations', 'import_manifest']}
+      />
+    </Story>
+  ))
+  .add('With custom text', () => (
+    <Story>
+      <PermissionDenied
+        backHref="/home/dashboard"
+        texts={{
+          notAuthorizedMsg: "Hey! You can't do that.",
+          pleaseRequestMsg:
+            'Please ask an admin to get you the following permissions:',
+          permissionDeniedMsg: 'Access denied',
+        }}
+        missingPermissions={['view_organizations', 'import_manifest']}
+      />
+    </Story>
+  ));

--- a/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.test.js
+++ b/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.test.js
@@ -1,0 +1,20 @@
+import PermissionDenied from '.';
+import { testComponentSnapshotsWithFixtures } from '../../common/testHelpers';
+
+const fixtures = {
+  'should render with default props': {},
+  'should render with custom props': {
+    backHref: '/home/dashboard',
+    texts: {
+      notAuthorizedMsg: 'notAuthorizedMsg',
+      pleaseRequestMsg: 'pleaseRequestMsg',
+      permissionDeniedMsg: 'permissionDeniedMsg',
+    },
+  },
+};
+
+describe('PermissionDenied', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(PermissionDenied, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/PermissionDenied/__snapshots__/PermissionDenied.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/PermissionDenied/__snapshots__/PermissionDenied.test.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PermissionDenied rendering should render with custom props 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <div
+    className="blank-slate-pf-icon"
+  >
+    <Icon
+      color="#9c9c9c"
+      name="lock"
+      size="2x"
+      title="lock"
+      type="fa"
+    />
+  </div>
+  notAuthorizedMsg
+  <h1>
+    permissionDeniedMsg
+  </h1>
+  <p>
+    notAuthorizedMsg
+    <br />
+    pleaseRequestMsg
+    <br />
+  </p>
+  <ul
+    className="list-unstyled"
+  >
+    <li
+      key="unknown"
+    >
+      <strong>
+        unknown
+      </strong>
+    </li>
+  </ul>
+  <p>
+    <a
+      href="/home/dashboard"
+    >
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        disabled={false}
+      >
+        Back
+      </Button>
+    </a>
+  </p>
+</div>
+`;
+
+exports[`PermissionDenied rendering should render with default props 1`] = `
+<div
+  className="blank-slate-pf"
+>
+  <div
+    className="blank-slate-pf-icon"
+  >
+    <Icon
+      color="#9c9c9c"
+      name="lock"
+      size="2x"
+      title="lock"
+      type="fa"
+    />
+  </div>
+  You are not authorized to perform this action.
+  <h1>
+    Permission denied
+  </h1>
+  <p>
+    You are not authorized to perform this action.
+    <br />
+    Please request one of the required permissions listed below from a Foreman administrator:
+    <br />
+  </p>
+  <ul
+    className="list-unstyled"
+  >
+    <li
+      key="unknown"
+    >
+      <strong>
+        unknown
+      </strong>
+    </li>
+  </ul>
+  <p>
+    <a
+      href="/"
+    >
+      <Button
+        active={false}
+        block={false}
+        bsClass="btn"
+        bsStyle="default"
+        disabled={false}
+      >
+        Back
+      </Button>
+    </a>
+  </p>
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/PermissionDenied/index.js
+++ b/webpack/assets/javascripts/react_app/components/PermissionDenied/index.js
@@ -1,0 +1,3 @@
+import PermissionDenied from './PermissionDenied';
+
+export default PermissionDenied;


### PR DESCRIPTION
For use in concert with issue #27450 / PR #8262 (see the discussion on that PR)

* Add `<PermissionDenied />` React component
* Add `missing_permissions` to rabl view for access denied errors
