### PR TITLE
Fixes #27382 - doublequote of fact value

### DIFF
--- a/app/controllers/facts_controller.rb
+++ b/app/controllers/facts_controller.rb
@@ -8,8 +8,8 @@ class FactsController < ApplicationController
   def show
     @fact = FactName.find(params[:id])
     begin
-      data = {:name => CGI.escapeHTML(@fact.name),
-              :values => FactValue.count_each(@fact.name).to_a.each {|v| v[:label] = CGI.escapeHTML(v[:label])}}
+      data = {:name => @fact.name,
+              :values => FactValue.count_each(@fact.name).to_a}
     rescue
       data = @fact
     end

--- a/test/controllers/facts_controller_test.rb
+++ b/test/controllers/facts_controller_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class FactsControllerTest < ActionController::TestCase
+  describe '#show' do
+    let(:fact_value) do
+      FactoryBot.create(:fact_value, value: '<script>avalue</script>')
+    end
+
+    it 'doesnt escape values' do
+      get :show, params: { id: fact_value.fact_name_id, format: :json }, session: set_session_user
+      json = JSON.parse(response.body)
+      assert_equal json['values'][0][0], fact_value.value
+    end
+  end
+end


### PR DESCRIPTION
Facts has been quoted, but it is not necessary as C3 library quotes it's labels properly internaly.
As we do not use it anywhere else, it should be safe not to quote the facts (let it on consumer of the action endpoint).