### PR TITLE
Fixes #27660 - adds a doc for legacy js in storybook

### DIFF
--- a/webpack/stories/docs/LegacyJs.md
+++ b/webpack/stories/docs/LegacyJs.md
@@ -1,0 +1,34 @@
+# Legacy JS
+
+Foreman's legacy javascript is based on ruby on rails assets pipeline and located in `assets/javascripts`
+
+
+### Access webpack javascript
+In order to access new js logic in old js files, we created a global object -`tfm`, which contains a set of functions and located in `/webpack/assets/javascripts/bundle.js`
+Please use this object instead of using the `window` object directly.
+
+### Observing the store
+
+With `observeStore` you can observe for changes of the store:
+
+```js
+ tfm.store.observeStore('notifications.items', tfm.doSomething);
+ ```
+`observeStore` accepts two parameters:
+1. the part of the store to be observed.
+2. a function to run when a change is detected.
+
+```js
+const doSomething = (items, unsubscribe) => {
+  if (items.length) {
+    doSomething();
+  }
+  else {
+    unsubscribe();
+  }
+}
+
+```
+This function have two paramteres as well:
+1. the observed store.
+2. an unsubscribe function to stop the observation (optional).

--- a/webpack/stories/index.js
+++ b/webpack/stories/index.js
@@ -11,6 +11,7 @@ import addingDependencies from './docs/addingDependencies.md';
 import internationalization from './docs/internationalization.md';
 import plugins from './docs/plugins.md';
 import SlotAndFill from './docs/SlotAndFill.md';
+import LegacyJs from './docs/LegacyJs.md';
 
 require('../assets/javascripts/bundle');
 require('../../app/assets/javascripts/application');
@@ -57,6 +58,11 @@ storiesOf('Introduction', module)
   .add('Slot&Fill', () => (
     <Story>
       <Markdown source={SlotAndFill} />
+    </Story>
+  ))
+  .add('Legacy Javascript', () => (
+    <Story>
+      <Markdown source={LegacyJs} />
     </Story>
   ));
 


### PR DESCRIPTION
This doc explains how to access new js code in old js files, and how to observe the store for changes.