### PR TITLE
Fixes #27662 - template inputs - adding field

### DIFF
--- a/app/views/template_inputs/_form.html.erb
+++ b/app/views/template_inputs/_form.html.erb
@@ -4,8 +4,8 @@
       <%= text_f f, :name, :disabled => @template.locked? %>
       <%= checkbox_f f, :required, :disabled => @template.locked? %>
       <%= selectable_f f, :input_type, template_input_types_options(@template.acceptable_template_input_types), {}, :class => 'input_type_selector without_select2', :disabled => @template.locked? %>
-      <%= selectable_f f, :value_type, [[_('Plain'), 'plain'], [_("Search"), 'search'], [_('Date'), 'date']], {}, {'data-item': f.object.id, class: 'select-value-type', onchange: "tfm.templateInputs.inputValueOnchange(this)"}  %> 
-      <%= selectable_f f, :resource_type, Permission.resources_with_translations, {}, {wrapper_class: "#{hide_resource_type_input(f.object)} form-group resource-type-#{f.object.id}"} %>
+      <%= selectable_f f, :value_type, [[_('Plain'), 'plain'], [_("Search"), 'search'], [_('Date'), 'date']], {}, {'data-item': f.index || f.object.id, class: 'select-value-type', onchange: "tfm.templateInputs.inputValueOnchange(this)"}  %>
+      <%= selectable_f f, :resource_type, Permission.resources_with_translations, {}, {wrapper_class: "#{hide_resource_type_input(f.object)} form-group resource-type-#{f.index || f.object.id}"} %>
       <div class="fact_input_type custom_input_type_fields" style="<%= f.object.fact_template_input? ? '' : 'display:none' %>">
         <%= text_f f, :fact_name, :class => 'fact_input_type', :required => true, :disabled => @template.locked? %>
       </div>
@@ -19,7 +19,7 @@
       <div class="user_input_type custom_input_type_fields" style="<%= (f.object.user_template_input? || f.object.new_record?) ? '' : 'display:none' %>">
         <%= checkbox_f f, :advanced, :disabled => @template.locked? %>
         <%= textarea_f f, :options, :rows => 3, :class => 'user_input_type', :help_inline => _("A list of options the user can select from. If not provided, the user will be given a free-form field"),
-                                    :disabled => @template.locked?, wrapper_class: "form-group input-options-#{f.object.id}"  %>
+                                    :disabled => @template.locked?, wrapper_class: "form-group input-options-#{f.index || f.object.id}#{' hide' if f.object.value_type != 'plain'}"  %>
       </div>
       <%= textarea_f f, :description, :rows => 3, :disabled => @template.locked? %>
     <% end %>

--- a/webpack/assets/javascripts/foreman_template_inputs.js
+++ b/webpack/assets/javascripts/foreman_template_inputs.js
@@ -42,10 +42,11 @@ export const pollReportData = url => {
 export const inputValueOnchange = input => {
   const searchValue = input.value === 'search';
   const plainValue = input.value === 'plain';
-  const inputId = input.dataset.item || '';
+  const inputId = input.dataset.item;
+  const $fields = $(input).closest('.fields');
 
-  $(`.resource-type-${inputId}`).toggle(searchValue);
-  $(`.input-options-${inputId}`).toggle(plainValue);
+  $fields.find(`.resource-type-${inputId}`).toggle(searchValue);
+  $fields.find(`.input-options-${inputId}`).toggle(plainValue);
 };
 export function snippetChanged(item) {
   const checked = $(item).is(':checked');


### PR DESCRIPTION
Proper fix for #6955, fixes the new template inputs identification in javascript.
`f.index` is set by Rails if the builder is `fields_for`