### PR TITLE
Fixes #27681 - Fix test for rest-client 2.1 support

### DIFF
--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -217,13 +217,7 @@ class ActiveSupport::TestCase
   def fake_rest_client_response(data)
     net_http_resp = Net::HTTPResponse.new(1.0, 200, 'OK')
     req = RestClient::Request.new(:method => 'get', :url => 'http://localhost:8443')
-    if RestClient::Response.method(:create).arity == 3 # 2.0.0+
-      RestClient::Response.create(data.to_json, net_http_resp, req)
-    elsif RestClient::Response.method(:create).arity == 4 # 1.8.x
-      RestClient::Response.create(data.to_json, net_http_resp, nil, req)
-    else
-      raise "unknown RestClient::Response.create version (#{RestClient.version}, arity #{RestClient::Response.method(:create).arity})"
-    end
+    RestClient::Response.create(data.to_json, net_http_resp, req)
   end
 
   # Minitest provides a "_" expects syntax which overrides the gettext "_" method


### PR DESCRIPTION
The arity of Response.create funciton changed in 2.1, causing an old
workaround to allow working with bot 1.8 and 2.x to fail. Since we
require >2.0 now there is no more need for the check for older versions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
