### PR TITLE
Refs #27666 - Clean up sass-rails pinning

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -5,5 +5,5 @@ group :assets do
   gem 'gettext_i18n_rails_js', '~> 1.0'
   gem 'execjs', '>= 1.4.0', '< 3.0'
   gem 'uglifier', '>= 1.0.3'
-  gem 'sass-rails', '~> 5.0', ((RUBY_VERSION < '2.4') ? '< 5.0.8' : '< 6')
+  gem 'sass-rails', '>= 5.0', ((RUBY_VERSION < '2.4') ? '< 5.0.8' : '< 6.0')
 end


### PR DESCRIPTION
This is semantically the same, but makes it a bit easier on the
packaging side where we have a script that converts it into the RPM
spec. Previously it generated:

    Requires: %{?scl_prefix_ror}rubygem(sass-rails) >= 5.0
    Requires: %{?scl_prefix_ror}rubygem(sass-rails) < 6.0
    Requires: %{?scl_prefix_ror}rubygem(sass-rails) < 6

After it generates:

    Requires: %{?scl_prefix_ror}rubygem(sass-rails) >= 5.0
    Requires: %{?scl_prefix_ror}rubygem(sass-rails) < 6.0