### PR TITLE
Fixes #27360 - show selected network on host edit

### DIFF
--- a/app/models/concerns/fog_extensions/google/server.rb
+++ b/app/models/concerns/fog_extensions/google/server.rb
@@ -11,7 +11,6 @@ module FogExtensions
 
       attribute :network
       attribute :associate_external_ip
-      attribute :external_ip
 
       def to_s
         name || identity
@@ -75,6 +74,13 @@ module FogExtensions
 
       def associate_external_ip
         external_nat_present?
+      end
+
+      # Added a getter method here as this attribute removed from fog-google
+      def network
+        return nil if network_interfaces.blank?
+        network_path = network_interfaces[0][:network]
+        network_path ? network_path.split('/')[-1] : nil
       end
 
       private


### PR DESCRIPTION
Opening this pull-request as per @jyejare's [comment](https://github.com/theforeman/foreman/pull/6923#issuecomment-525279078) on closed [PR-6923]((https://github.com/theforeman/foreman/pull/6923).

This change is required for compute-profile selection as well as host edit page.

adding @jyejare and @ezr-ondrej into the loop.