### PR TITLE
Fixes #27724 - Add a unique-id setting to foreman.

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -26,6 +26,7 @@ class Setting::General < Setting
       self.set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
       self.set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
       self.set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 30, N_('Out of sync interval')),
+      self.set('instance_id', N_("Foreman instance ID, uniquely identifies this Foreman instance."), 'uuid', N_('Foreman UUID'), Foreman.uuid),
       self.set('default_locale', N_("Language to use for new users"), nil, N_('Default language'), nil, { :collection => Proc.new { locales } }),
       self.set('default_timezone', N_("Timezone to use for new users"), nil, N_('Default timezone'), nil, { :collection => Proc.new { timezones } }),
     ]

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -22,4 +22,12 @@ module Foreman
   def self.in_setup_db_rake?
     in_rake?('db:create', 'db:migrate', 'db:drop')
   end
+
+  def self.instance_id
+    Setting[:instance_id]
+  end
+
+  def self.instance_id=(value)
+    Setting[:instance_id] = value
+  end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -404,3 +404,8 @@ attribute86:
   category: Setting::Provisioning
   default: 100
   description: 'Maximum structured facts'
+attribute87:
+  name: instance_id
+  category: Setting::General
+  default: '2abbbe02-4ace-4269-9e20-2753f3206cc2'
+  description: 'Foreman UUID'


### PR DESCRIPTION
This introduces a persisted randomly generated identifier of the Foreman
instance. This is useful for correlating foreman-debug tarballs with 
logs and
other debugging data that users upload to developers when they need 
help. This
can be also useful to identify multiple instances in external systems, 
e.g.
when workflows across multiple Foremans are orchestrated.