### PR TITLE
fixes #16818 - support slash in fact name

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,7 +140,7 @@ Foreman::Application.routes.draw do
         resources :facts, :only => :index, :controller => :fact_values
         resources :puppetclasses, :only => :index
 
-        get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts', :parent_fact => /[\w.:_-]+/
+        get 'parent_facts/*parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts', :parent_fact => /[\/\w.:_-]+/
       end
     end
 

--- a/test/integration/fact_value_test.rb
+++ b/test/integration/fact_value_test.rb
@@ -3,7 +3,7 @@ require 'integration_test_helper'
 class ChildFactValueIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     @host = FactoryBot.create(:host)
-    @parent_name = FactoryBot.create(:fact_name, :compose => true)
+    @parent_name = FactoryBot.create(:fact_name, name: 'test/test', :compose => true)
     @parent_value = FactoryBot.create(:fact_value, :value => nil, :host => @host, :fact_name => @parent_name)
 
     @child_suffix = 'child'


### PR DESCRIPTION
Alternative fix for #6950.

https://guides.rubyonrails.org/routing.html#route-globbing-and-wildcard-segments

cc: @tbrisker, @ares