### PR TITLE
Fixes #27077 - Multiple http proxies with same name

### DIFF
--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -12,7 +12,7 @@ class HttpProxy < ApplicationRecord
 
   has_many :compute_resources
 
-  validates :name, :presence => true
+  validates :name, :presence => true, :uniqueness => true
 
   validates :url, :presence => true
   validates :url, :format => URI.regexp(["http", "https"])

--- a/db/migrate/20190829102315_http_proxy_unique_name.rb
+++ b/db/migrate/20190829102315_http_proxy_unique_name.rb
@@ -1,0 +1,17 @@
+class HttpProxyUniqueName < ActiveRecord::Migration[5.2]
+  def up
+    duplicates = HttpProxy.group(:name).count.select { |key, value| value > 1 }.keys
+    unless duplicates.empty?
+      HttpProxy.where(name: duplicates).find_each do |proxy|
+        say "Http Proxy with duplicate name #{proxy.name} detected. Renaming it as '#{proxy.name}-#{proxy.id}'"
+        proxy.update_column(:name, "#{proxy.name}-#{proxy.id}")
+      end
+    end
+
+    add_index :http_proxies, :name, :unique => true
+  end
+
+  def down
+    remove_index :http_proxies, :name
+  end
+end

--- a/test/factories/http_proxy.rb
+++ b/test/factories/http_proxy.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :http_proxy, :class => ::HttpProxy do
-    name { 'http_proxies' }
+    sequence(:name) { |n| "http_proxy_#{n}" }
     sequence(:url) { |n| "http://url_#{n}" }
   end
 end


### PR DESCRIPTION
This PR adds the `uniqueness` constraint on **name** field of http proxies as earlier it allowed user to define multiple http proxy records with same name.
