### PR TITLE
fixes #27742 - preload usergroup ssh keys

### DIFF
--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -19,8 +19,9 @@ class Usergroup < ApplicationRecord
   has_many :usergroups, :through => :usergroup_members, :source => :member, :source_type => 'Usergroup', :dependent => :destroy
   has_many :external_usergroups, :dependent => :destroy, :inverse_of => :usergroup
 
-  has_many :cached_usergroups, :through => :cached_usergroup_members, :source => :usergroup
   has_many :cached_usergroup_members, :foreign_key => 'usergroup_id'
+  has_many :cached_users, :through => :cached_usergroup_members, :source => :user
+  has_many :cached_usergroups, :through => :cached_usergroup_members, :source => :usergroup
   has_many :usergroup_parents, -> { where("member_type = 'Usergroup'") }, :dependent => :destroy,
            :foreign_key => 'member_id', :class_name => 'UsergroupMember'
   has_many :parents,    :through => :usergroup_parents, :source => :usergroup, :dependent => :destroy
@@ -74,7 +75,7 @@ class Usergroup < ApplicationRecord
   end
 
   def to_export
-    all_users.map(&:to_export).reduce({}, :merge)
+    cached_users.includes(:ssh_keys).map(&:to_export).reduce({}, :merge)
   end
 
   def ssh_keys

--- a/test/factories/user_related.rb
+++ b/test/factories/user_related.rb
@@ -40,6 +40,10 @@ FactoryBot.define do
     trait :with_usergroup do
       usergroups { [FactoryBot.create(:usergroup)] }
     end
+
+    trait :with_ssh_key do
+      after(:create) { |user, _| FactoryBot.create(:ssh_key, user: user) }
+    end
   end
 
   factory :permission do


### PR DESCRIPTION
Fixes:
![image](https://user-images.githubusercontent.com/4107560/64016247-bce79480-cb26-11e9-84b5-c068e2936548.png)
