### PR TITLE
Fixes #27745 - fix param before_save to run db:migrate

### DIFF
--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -78,7 +78,10 @@ class Parameter < ApplicationRecord
   private
 
   def set_searchable_value
-    self.searchable_value = Parameter.format_value_before_type_cast(value, key_type)
+    # has_attribute is for enabling old DB migrations to run
+    if has_attribute?(:searchable_value)
+      self.searchable_value = Parameter.format_value_before_type_cast(value, key_type)
+    end
   end
 
   def set_priority

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -78,10 +78,7 @@ class Parameter < ApplicationRecord
   private
 
   def set_searchable_value
-    # has_attribute is for enabling old DB migrations to run
-    if has_attribute?(:searchable_value)
-      self.searchable_value = Parameter.format_value_before_type_cast(value, key_type)
-    end
+    self.searchable_value = Parameter.format_value_before_type_cast(value, key_type)
   end
 
   def set_priority

--- a/db/migrate/20181105061336_cast_key_types_and_values_in_parameters.rb
+++ b/db/migrate/20181105061336_cast_key_types_and_values_in_parameters.rb
@@ -31,14 +31,9 @@ class CastKeyTypesAndValuesInParameters < ActiveRecord::Migration[5.2]
 
   def save_param(param, new_value, new_key_type)
     if Parameter::KEY_TYPES.include?(new_key_type)
-      param.class.without_auditing do
-        param.value = new_value
-        param.key_type = new_key_type
-        result = param.save(:validate => false)
-        return if result
-      end
+      result = param.update_columns(value: new_value, key_type: new_key_type)
+      return if result
       say "Failed to update param(#{param.id}): #{param.inspect}"
-      say "Error: #{param.errors.full_messages.inspect}"
     else
       say "Failed to cast value #{param.value} of param(#{param.id}): #{param.inspect}"
     end


### PR DESCRIPTION
Before this commit, db:migrate fails on old versions. Parameter related old migrations fails with undefined method for 'searchable_value'.

Related to [PR-6946](https://github.com/theforeman/foreman/pull/6946)

+ adding @tbrisker and @ezr-ondrej into loop.