### PR TITLE
Fixes #27004 - fix broken link to vm list

### DIFF
--- a/app/views/compute_resources_vms/index.html.erb
+++ b/app/views/compute_resources_vms/index.html.erb
@@ -1,4 +1,21 @@
 <% title(_("Virtual Machines on %s") % @compute_resource) %>
+<%= breadcrumbs(
+    items:
+    [
+      {
+        caption: _("Compute Resouces"),
+        url: compute_resources_path
+      },
+      {
+        caption: @compute_resource.provider,
+        url: compute_resource_path(@compute_resource)
+      },
+      {
+        caption: _("VMs"),
+      },
+    ],
+    switchable: false
+) %>
 <%= vms_table do %>
   <%= render "compute_resources_vms/index/#{@compute_resource.provider.downcase}" %>
 <% end %>

--- a/app/views/compute_resources_vms/show.html.erb
+++ b/app/views/compute_resources_vms/show.html.erb
@@ -1,3 +1,26 @@
+<%= breadcrumbs(
+    items:
+    [
+      {
+        caption: _("Compute Resouces"),
+        url: compute_resources_path
+      },
+      {
+        caption: @compute_resource.provider,
+        url: compute_resource_path(@compute_resource)
+      },
+      {
+        caption: _("VMs"),
+        url: compute_resource_vms_path(@compute_resource)
+      },
+      {
+        caption: @vm.name
+      }
+    ],
+    switchable: false
+) %>
+
+
 <div class='row'>
   <%= render "compute_resources_vms/show/#{@compute_resource.provider.downcase}" %>
 </div>


### PR DESCRIPTION
When viewing a VM on a compute resource, the breadcrumb link to navigate back to the list of VM's in the top left corner "Compute Resources Vms" does not take you back to the list. No action is taken

the switcher has been removed due to lack of vm list via API