### PR TITLE
Fixes #24805 - Clean up remaining taxonomy enabled checks

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -233,7 +233,7 @@ module Api
 
     def assign_lone_taxonomies
       return unless resource_class_for(resource_name)
-      [Location, Organization].each do |taxonomy|
+      Taxonomy.types.each do |taxonomy|
         tax_name = taxonomy.to_s.downcase
         if resource_class.reflections.has_key? tax_name.pluralize
           tax_ids = "#{tax_name}_ids"
@@ -388,7 +388,7 @@ module Api
       return nil if parent_name.nil? || parent_class.nil?
       # for admin we don't want to add any context condition, that would fail for hosts since we'd add join to
       # taxonomy table without any condition, inner join would return no host in this case
-      return nil if User.current.admin? && [ Organization, Location ].include?(parent_class) && parent_id.blank?
+      return nil if User.current.admin? && Taxonomy.types.include?(parent_class) && parent_id.blank?
       # for taxonomies, nil is valid value which indicates, we need to search in Users all taxonomies
       return [parent_name, User.current.my_organizations] if parent_class == Organization && parent_id.blank?
       return [parent_name, User.current.my_locations] if parent_class == Location && parent_id.blank?

--- a/app/models/concerns/host_params.rb
+++ b/app/models/concerns/host_params.rb
@@ -59,14 +59,8 @@ module HostParams
 
     def host_inherited_params_objects
       params = CommonParameter.all
-      if SETTINGS[:organizations_enabled] && organization
-        params += extract_params_from_object_ancestors(organization)
-      end
-
-      if SETTINGS[:locations_enabled] && location
-        params += extract_params_from_object_ancestors(location)
-      end
-
+      params += extract_params_from_object_ancestors(organization) if organization
+      params += extract_params_from_object_ancestors(location) if location
       params += domain.domain_parameters.authorized(:view_params) if domain
       params += subnet.subnet_parameters.authorized(:view_params) if subnet
       params += subnet6.subnet_parameters.authorized(:view_params) if subnet6

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -70,14 +70,11 @@ module Hostext
 
       scoped_search :relation => :reported_data, :on => :boot_time, :rename => 'boot_time'
 
-      if SETTINGS[:locations_enabled]
-        scoped_search :relation => :location, :on => :title, :rename => :location, :complete_value => true, :only_explicit => true
-        scoped_search :on => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-      end
-      if SETTINGS[:organizations_enabled]
-        scoped_search :relation => :organization, :on => :title, :rename => :organization, :complete_value => true, :only_explicit => true
-        scoped_search :on => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-      end
+      scoped_search :relation => :location, :on => :title, :rename => :location, :complete_value => true, :only_explicit => true
+      scoped_search :on => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+      scoped_search :relation => :organization, :on => :title, :rename => :organization, :complete_value => true, :only_explicit => true
+      scoped_search :on => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+
       scoped_search :relation => :config_groups, :on => :name, :complete_value => true, :rename => :config_group, :only_explicit => true, :operators => ['= ', '~ '], :ext_method => :search_by_config_group
 
       if SETTINGS[:unattended]

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -195,11 +195,7 @@ module Taxonomix
   # for existing records it would block saving global objects if taxonomies were not changed
   # for new records this would allow to create global objects for non global users
   def ensure_taxonomies_not_escalated
-    taxonomies = []
-    taxonomies << Organization if SETTINGS[:organizations_enabled]
-    taxonomies << Location if SETTINGS[:locations_enabled]
-
-    taxonomies.each do |taxonomy|
+    Taxonomy.types.each do |taxonomy|
       assoc_base = taxonomy.to_s.downcase
       assoc = assoc_base.pluralize
       key = assoc_base + '_ids'

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -9,16 +9,12 @@ class FactValue < ApplicationRecord
 
   has_one :parent_fact_name, :through => :fact_name, :source => :parent, :class_name => 'FactName'
 
-  if SETTINGS[:locations_enabled]
-    has_one :location, :through => :host
-    scoped_search :relation => :location, :on => :name, :rename => :location, :complete_value => true, :only_explicit => true
-    scoped_search :relation => :location, :on => :id, :rename => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-  end
-  if SETTINGS[:organizations_enabled]
-    has_one :organization, :through => :host
-    scoped_search :relation => :organization, :on => :name, :rename => :organization, :complete_value => true, :only_explicit => true
-    scoped_search :relation => :organization, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-  end
+  has_one :location, :through => :host
+  scoped_search :relation => :location, :on => :name, :rename => :location, :complete_value => true, :only_explicit => true
+  scoped_search :relation => :location, :on => :id, :rename => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+  has_one :organization, :through => :host
+  scoped_search :relation => :organization, :on => :name, :rename => :organization, :complete_value => true, :only_explicit => true
+  scoped_search :relation => :organization, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
   scoped_search :on => :value, :in_key => :fact_name, :on_key => :name, :rename => :facts, :complete_value => true, :only_explicit => true, :ext_method => :search_cast_facts
   scoped_search :on => :value, :default_order => true, :ext_method => :search_value_cast_facts

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -46,8 +46,8 @@ module Host
     default_scope -> { where(taxonomy_conditions) }
 
     def self.taxonomy_conditions
-      org = Organization.expand(Organization.current) if SETTINGS[:organizations_enabled]
-      loc = Location.expand(Location.current) if SETTINGS[:locations_enabled]
+      org = Organization.expand(Organization.current)
+      loc = Location.expand(Location.current)
       conditions = {}
       conditions[:organization_id] = Array(org).map { |o| o.subtree_ids }.flatten.uniq unless org.nil?
       conditions[:location_id] = Array(loc).map { |l| l.subtree_ids }.flatten.uniq unless loc.nil?

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -205,8 +205,8 @@ class Host::Managed < Host::Base
   alias_attribute :arch, :architecture
 
   validates :environment_id, :presence => true, :unless => Proc.new { |host| host.puppet_proxy_id.blank? }
-  validates :organization_id, :presence => true, :if => Proc.new { |host| host.managed? && SETTINGS[:organizations_enabled] }
-  validates :location_id,     :presence => true, :if => Proc.new { |host| host.managed? && SETTINGS[:locations_enabled] }
+  validates :organization_id, :presence => true, :if => Proc.new { |host| host.managed? }
+  validates :location_id,     :presence => true, :if => Proc.new { |host| host.managed? }
   validate :compute_resource_in_taxonomy, :if => Proc.new { |host| host.managed? && host.compute_resource_id.present? }
 
   if SETTINGS[:unattended]

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -56,16 +56,6 @@ class Taxonomy < ApplicationRecord
     end
   }
 
-  def self.locations_enabled
-    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.locations_enabled is always true, settings to disable taxonomies has been removed in 1.21.')
-    true
-  end
-
-  def self.organizations_enabled
-    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.organizations_enabled is always true, settings to disable taxonomies has been removed in 1.21.')
-    true
-  end
-
   def self.no_taxonomy_scope
     as_taxonomy nil, nil do
       yield if block_given?
@@ -80,15 +70,8 @@ class Taxonomy < ApplicationRecord
     end
   end
 
-  def self.enabled?(taxonomy)
-    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.enabled? is always true, settings to disable taxonomies has been removed in 1.21.')
-    true
-  end
-
-  def self.enabled_taxonomies
-    Foreman::Deprecation.deprecation_warning('1.23', 'Taxonomy.enabled_taxonomies is always locations and organizations, settings to disable taxonomies has been removed in 1.21.')
-    true
-    %w(locations organizations)
+  def self.types
+    [Organization, Location]
   end
 
   def self.ignore?(taxable_type)

--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -4,7 +4,7 @@ skip_associations = [:associated_audits, :audits, :default_users, :hosts, :disco
                      :taxable_taxonomies, :reports ] + Template.descendants.map {|type| type.to_s.tableize.to_sym}
 
 User.as_anonymous_admin do
-  [Organization, Location].select(&:none?).each do |taxonomy|
+  Taxonomy.types.select(&:none?).each do |taxonomy|
     taxonomy.without_auditing do
       tax_name = ENV.fetch("SEED_#{taxonomy.to_s.upcase}", "Default #{taxonomy}")
       tax = taxonomy.create!(name: tax_name)


### PR DESCRIPTION
Also removes related methods that have been deprecated since 1.21.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
