### PR TITLE
Fixes #27763 - remove redundant url_for

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -192,7 +192,7 @@ module AuditsHelper
       items: [
         {
           caption: _("Hosts"),
-          url: (url_for(hosts_path) if authorized_for(hash_for_hosts_path)),
+          url: (hosts_path if authorized_for(hash_for_hosts_path)),
         },
         {
           caption: @host.name,
@@ -200,7 +200,7 @@ module AuditsHelper
         },
         {
           caption: _('Audits'),
-          url: url_for(audits_path),
+          url: audits_path,
         },
       ]
     )

--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -57,7 +57,7 @@ module FactValuesHelper
       items: [
         {
           caption: _("Facts Values"),
-          url: (url_for(fact_values_path) if authorized_for(hash_for_fact_values_path)),
+          url: (fact_values_path if authorized_for(hash_for_fact_values_path)),
         },
         {
           caption: params[:host_id],

--- a/app/helpers/images_helper.rb
+++ b/app/helpers/images_helper.rb
@@ -16,15 +16,15 @@ module ImagesHelper
       items: [
         {
           caption: _('Compute Resources'),
-          url: (url_for(compute_resources_path) if authorized_for(hash_for_compute_resources_path)),
+          url: (compute_resources_path if authorized_for(hash_for_compute_resources_path)),
         },
         {
           caption: @compute_resource.to_s,
-          url: (url_for(compute_resource_path(@compute_resource)) if authorized_for(hash_for_compute_resource_path(@compute_resource))),
+          url: (compute_resource_path(@compute_resource) if authorized_for(hash_for_compute_resource_path(@compute_resource))),
         },
         {
           caption: _('Images'),
-          url: url_for(compute_resource_images_path(@compute_resource)),
+          url: compute_resource_images_path(@compute_resource),
         },
         {
           caption: ((action == 'new') ? _('Create image') : _("Edit %s") % @image),

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -102,9 +102,9 @@ module Orchestration::Compute
     if template.nil?
       failure((_("%{image} needs user data, but %{os_link} is not associated to any provisioning template of the kind user_data. Please associate it with a suitable template or uncheck 'User data' for %{compute_resource_image_link}.") %
       { :image => image.name,
-        :os_link => "<a target='_blank' rel='noopener noreferrer' href='#{url_for(edit_operatingsystem_path(operatingsystem))}'>#{operatingsystem.title}</a>",
+        :os_link => "<a target='_blank' rel='noopener noreferrer' href='#{edit_operatingsystem_path(operatingsystem)}'>#{operatingsystem.title}</a>",
         :compute_resource_image_link =>
-          "<a target='_blank' rel='noopener noreferrer' href='#{url_for(edit_compute_resource_image_path(:compute_resource_id => compute_resource.id, :id => image.id))}'>#{image.name}</a>"}).html_safe)
+          "<a target='_blank' rel='noopener noreferrer' href='#{edit_compute_resource_image_path(:compute_resource_id => compute_resource.id, :id => image.id)}'>#{image.name}</a>"}).html_safe)
       return false
     end
 

--- a/app/views/auth_source_ldaps/_form.html.erb
+++ b/app/views/auth_source_ldaps/_form.html.erb
@@ -15,7 +15,7 @@
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
       <%= text_f f, :name %>
-      <%= text_f f, :host, :help_inline => link_to_function(_("Test Connection"), "tfm.authSource.testConnection(this, '#{url_for test_connection_auth_source_ldaps_url}')",
+      <%= text_f f, :host, :help_inline => link_to_function(_("Test Connection"), "tfm.authSource.testConnection(this, '#{test_connection_auth_source_ldaps_url}')",
                       :title => _("Test LDAP connectivity"), :id => "test_connection_button", :class =>"btn btn-success") + hidden_spinner('', :id => 'test_connection_indicator').html_safe %>
       <%= checkbox_f(f, :tls, {:label => "LDAPS", :onchange => 'tfm.authSource.changeLdapPort(this)'}) %>
       <%= number_f f, :port, :min => 1, :max => 65535,

--- a/app/views/compute_attributes/edit.html.erb
+++ b/app/views/compute_attributes/edit.html.erb
@@ -2,7 +2,7 @@
     items: [
       {
         caption: _("Compute Resources"),
-        url: (url_for(compute_resources_path) if authorized_for(hash_for_compute_resources_path))
+        url: (compute_resources_path if authorized_for(hash_for_compute_resources_path))
       },
       {
         caption: @set.compute_resource.to_label,
@@ -10,7 +10,7 @@
       },
       {
         caption: _("Compute Profiles"),
-        url: (url_for(compute_profiles_path) if authorized_for(hash_for_compute_profiles_path))
+        url: (compute_profiles_path if authorized_for(hash_for_compute_profiles_path))
       },
       {
         caption: _('Edit %s' % @set.compute_profile.to_label)

--- a/app/views/compute_attributes/new.html.erb
+++ b/app/views/compute_attributes/new.html.erb
@@ -3,7 +3,7 @@
     [
       {
         caption: _("Compute Resources"),
-        url: (url_for(compute_resources_path) if authorized_for(hash_for_compute_resources_path))
+        url: (compute_resources_path if authorized_for(hash_for_compute_resources_path))
       },
       {
         caption: @set.compute_resource.to_label,
@@ -11,7 +11,7 @@
       },
       {
         caption: _("Compute Profiles"),
-        url: (url_for(compute_profiles_path) if authorized_for(hash_for_compute_profiles_path))
+        url: (compute_profiles_path if authorized_for(hash_for_compute_profiles_path))
       },
       {
         caption: _('New %s' % @set.compute_profile.to_label)

--- a/app/views/config_reports/index.html.erb
+++ b/app/views/config_reports/index.html.erb
@@ -2,7 +2,7 @@
     items: [
     {
       caption: _("Hosts"),
-      url: (url_for(hosts_path) if authorized_for(hash_for_hosts_path))
+      url: (hosts_path if authorized_for(hash_for_hosts_path))
     },
     {
       caption: @host.name,
@@ -10,7 +10,7 @@
     },
     {
       caption: _('Reports'),
-      url: url_for(config_reports_path(search: 'eventful=true'))
+      url: config_reports_path(search: 'eventful=true')
     },
   ]
 ) if @host %>

--- a/app/views/filters/edit.html.erb
+++ b/app/views/filters/edit.html.erb
@@ -6,7 +6,7 @@ breadcrumbs(
   items: [
     {
       caption: _("Roles"),
-      url: (url_for(roles_path) if authorized_for(hash_for_roles_path))
+      url: (roles_path if authorized_for(hash_for_roles_path))
     },
     {
       caption: _('%s Filters') % @filter.role.name,

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -3,7 +3,7 @@
     items: [
       {
         caption: _("Roles"),
-        url: (url_for(roles_path) if authorized_for(hash_for_roles_path))
+        url: (roles_path if authorized_for(hash_for_roles_path))
       },
       {
         caption: _("%s filters") % @role.to_s

--- a/app/views/filters/new.html.erb
+++ b/app/views/filters/new.html.erb
@@ -1,6 +1,6 @@
 <%= breadcrumbs(
   items: [
-    (@role.present? ? {caption: _('Roles'), url: (url_for(roles_path) if authorized_for(hash_for_roles_path))} : {caption: _("Filters"), url: filters_path}),
+    (@role.present? ? {caption: _('Roles'), url: (roles_path if authorized_for(hash_for_roles_path))} : {caption: _("Filters"), url: filters_path}),
     ({caption: _("%s filters") % @role.to_s, url: filters_path(role_id: @role.id)} if @role.present?),
     {caption: _('Create Filter')},
   ].compact

--- a/app/views/images/index.html.erb
+++ b/app/views/images/index.html.erb
@@ -2,11 +2,11 @@
       items: [
       {
         caption: _("Compute Resources"),
-        url: (url_for(compute_resources_path) if authorized_for(hash_for_compute_resources_path))
+        url: (compute_resources_path if authorized_for(hash_for_compute_resources_path))
       },
       {
         caption: _(@compute_resource.to_s),
-        url: (url_for(compute_resource_path(@compute_resource)) if authorized_for(hash_for_compute_resources_path))
+        url: (compute_resource_path(@compute_resource) if authorized_for(hash_for_compute_resources_path))
       },
       {
         caption: _("Images")

--- a/app/views/ssh_keys/new.html.erb
+++ b/app/views/ssh_keys/new.html.erb
@@ -4,7 +4,7 @@
     [
       {
          caption: _("Users"),
-         url: (url_for(users_path) if authorized_for(hash_for_users_path))
+         url: (users_path if authorized_for(hash_for_users_path))
       },
       {
         caption: @user.name,

--- a/app/views/variable_lookup_keys/edit.html.erb
+++ b/app/views/variable_lookup_keys/edit.html.erb
@@ -5,7 +5,7 @@
     [
       {
         caption: _("Smart variables"),
-        url: (url_for(variable_lookup_keys_path) if authorized_for(hash_for_variable_lookup_keys_path))
+        url: (variable_lookup_keys_path if authorized_for(hash_for_variable_lookup_keys_path))
       },
       {
         caption: _("Edit %s") % @variable_lookup_key.to_label


### PR DESCRIPTION
when `url_for` gets a string it returns the same string
```ruby
url_for(compute_resource_path(@compute_resource))
```
equals to:
```ruby
compute_resource_path(@compute_resource)
```
therefore there are few cases that url_for is redundant.