### PR TITLE
Fixes #27788 - IPv6 support for trusted hosts

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -105,10 +105,15 @@ module Foreman::Controller::SmartProxyAuth
   def detect_matching_host(allowed_hosts, request_hosts)
     allowed_hosts.product(request_hosts).each do |allowed, request|
       if request.starts_with?('*')
+        # certificate wildcard name
         rex = /\A#{Regexp.escape(request).sub('\\*', '.*')}\Z/
         return allowed if allowed =~ rex
+      elsif (allowed_ip = IPAddr.new(allowed) rescue nil) && (request_ip = IPAddr.new(request) rescue nil)
+        # IPv4, IPv6 address or subnet
+        return allowed if allowed_ip == request_ip || allowed_ip.include?(request_ip)
       else
-        return allowed if allowed == request
+        # plain hostname
+        return allowed if (allowed == request)
       end
     end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -48,7 +48,7 @@ class Setting < ApplicationRecord
   validates :value, :regexp => true, :if => Proc.new { |s| REGEXP_ATTRS.include? s.name }
   validates :value, :array_type => true, :if => Proc.new { |s| s.settings_type == "array" }
   validates_with ValueValidator, :if => Proc.new {|s| s.respond_to?("validate_#{s.name}") }
-  validates :value, :array_hostnames => true, :if => Proc.new { |s| ARRAY_HOSTNAMES.include? s.name }
+  validates :value, :array_hostnames_ips => true, :if => Proc.new { |s| ARRAY_HOSTNAMES.include? s.name }
   validates :value, :email => true, :if => Proc.new { |s| EMAIL_ATTRS.include? s.name }
   before_validation :set_setting_type_from_value
   before_save :clear_value_when_default

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -8,7 +8,7 @@ class Setting::Auth < Setting
       self.set('failed_login_attempts_limit', N_("Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"), 30, N_('Failed login attempts limit')),
       self.set('restrict_registered_smart_proxies', N_('Only known Smart Proxies may access features that use Smart Proxy authentication'), true, N_('Restrict registered smart proxies')),
       self.set('require_ssl_smart_proxies', N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'), true, N_('Require SSL for smart proxies')),
-      self.set('trusted_hosts', N_('Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted hosts')),
+      self.set('trusted_hosts', N_('List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'), [], N_('Trusted hosts')),
       self.set('ssl_certificate', N_("SSL Certificate path that Foreman would use to communicate with its proxies"), nil, N_('SSL certificate')),
       self.set('ssl_ca_file', N_("SSL CA file that Foreman will use to communicate with its proxies"), nil, N_('SSL CA file')),
       self.set('ssl_priv_key', N_("SSL Private Key file that Foreman will use to communicate with its proxies"), nil, N_('SSL private key')),

--- a/app/validators/array_hostnames_ips_validator.rb
+++ b/app/validators/array_hostnames_ips_validator.rb
@@ -1,0 +1,8 @@
+# validates hostnames, IPv4, IPv6 and subnets
+class ArrayHostnamesIpsValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    record.errors.add attribute, _("must contain valid hostnames") unless value.all? do |item|
+      item.to_s.match(URI::HOST) || (IPAddr.new(item.to_s) rescue nil)
+    end
+  end
+end

--- a/test/unit/validators/array_hostnames_ips_validator_test.rb
+++ b/test/unit/validators/array_hostnames_ips_validator_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class ArrayHostnamesIpsValidatorTest < ActiveSupport::TestCase
+  class Validatable
+    include ActiveModel::Validations
+    validates :hostnames, :array_hostnames_ips => true
+    attr_accessor :hostnames
+  end
+
+  setup do
+    @item = Validatable.new
+    @item.hostnames = ["localhost", "test-host.example.com"]
+  end
+
+  test "should pass when valid hostnames present" do
+    assert @item.valid?
+  end
+
+  test "should pass when valid IPv4 present" do
+    @item.hostnames = ["127.0.0.1"]
+    assert @item.valid?
+  end
+
+  test "should pass when valid IPv4 subnet present" do
+    @item.hostnames = ["129.168.1.1/32"]
+    assert @item.valid?
+  end
+
+  test "should pass when valid IPv6 present" do
+    @item.hostnames = ["2001:beef::1"]
+    assert @item.valid?
+  end
+
+  test "should pass when valid hostname-based IPv6 present" do
+    @item.hostnames = ["[2001:beef::1]"]
+    assert @item.valid?
+  end
+
+  test "should pass when valid IPv6 subnet present" do
+    @item.hostnames = ["2001:beef::/48"]
+    assert @item.valid?
+  end
+
+  test "should fail when invalid hostname present" do
+    @item.hostnames = ["invalid^.host", "valid.host"]
+    refute @item.valid?
+  end
+
+  test "should fail when hostnames have invalid characters" do
+    @item.hostnames = ["短期教室に.短に期"]
+    refute @item.valid?
+  end
+
+  test "should pass when no hostnames present" do
+    @item.hostnames = []
+    assert @item.valid?
+  end
+end


### PR DESCRIPTION
User can set IPv6 address in hostname format correctly, e.g.
`[::ffff:127.0.0.1]` however the matching code will not recognize this
syntax and will not match a proxy connecting through IPv6.

Added also a test cases for the cases.