### PR TITLE
Refs #27806 - clean git before container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ARG HOME=/home/foreman
 USER 1001
 WORKDIR $HOME
 COPY --chown=1001:0 . ${HOME}/
+RUN git clean -dfx
 # Adding missing gems, for tzdata see https://bugzilla.redhat.com/show_bug.cgi?id=1611117
 RUN echo gem '"rdoc"' > bundler.d/container.rb && echo gem '"tzinfo-data"' >> bundler.d/container.rb
 RUN bundle install --without "${BUNDLER_SKIPPED_GROUPS}" \


### PR DESCRIPTION
During testing of https://github.com/theforeman/foreman/pull/7024 I
realized that the build process copies working directory including all
ignored files (e.g. `bundler.d/Gemfile.local.rb`) which then breaks the
build. This adds `git clean` step prior `bundle install` so it's fresh
checkout.

All local changes must be commited prior building an image however,
filed which are not under git control would be deleted from now on.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->