### PR TITLE
Fixes #22269 - Added consistent order to os templates

### DIFF
--- a/app/views/operatingsystems/_template_defaults.html.erb
+++ b/app/views/operatingsystems/_template_defaults.html.erb
@@ -11,8 +11,7 @@
                 :text => (_("You probably need to configure your %s first.") %
                           link_to("templates", provisioning_templates_path)).html_safe) %>
     <% end %>
-
-    <%= f.fields_for :os_default_templates do |builder| %>
+    <%= f.fields_for :os_default_templates, @operatingsystem.os_default_templates.joins(:template_kind).order('LOWER(template_kinds.name)') do |builder| %>
       <%= render 'templates', :f => builder %>
     <% end %>
   <% end %>


### PR DESCRIPTION
the templates are ordered by the template_kind_id.