### PR TITLE
Fixes #27813 - disabled buttons all over the app are still clickable

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -75,8 +75,8 @@ function onContentLoad() {
     // return false for actual disabled links, this is
     // required in case the link was "enabled" after the
     // function has registered.
-
-    return !this.disabled;
+    var isDisabled = $(this).attr('disabled') === 'disabled';
+    return !isDisabled;
   });
 
   // allow opening new window for selected links


### PR DESCRIPTION
the problem: disabled buttons all over the app are still clickable while their actions should be ignored.

it appears that there is an event listener in `application.js` which its duty is to prevent disabled buttons from being clicked by returning `false`.

it may affected some other places in the code and the code was changed to return `!this.disabled`
because we should return false for actual disabled links, 
this is required in case the link was "enabled" after the function has registered.

by mistake it seem that it always returns `true` since `this` - the DOM node's
`disabled` is defined under `this.attributes.disabled` so currently calling `this.disabled` returns `undefined`

 returning `!$(this).attr('disabled') === 'disabled'` fixed that problem.
