### PR TITLE
Fixes #27830 - fix audit's main_objects list to load audit page

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -135,7 +135,7 @@ module AuditExtensions
 
     def non_abstract_parents(classes_list)
       parents_list = classes_list.map(&:superclass).uniq
-      parents_list.select { |cl| !cl.abstract_class? && cl.table_exists? }.compact
+      parents_list.select { |cl| cl != ActiveRecord::Base && !cl.abstract_class? && cl.table_exists? }.compact
     end
   end
 


### PR DESCRIPTION
+ adding @ares into loop.

In case of `ActiveRecord::Base` superclass .table_exists? raises exception `undefined method 'abstract_class?' for Object:Class`.  

Currently it is occurred due to audit's main_object `ForemanVirtWhoConfigure::Config` as superclass of this class is `ActiveRecord::Base`. 
There might be possibility that some other main_object will have same `superclass` so excluding it from parent_list.