### PR TITLE
Fixes #26898 - Add taxonomies inheritance on smart class params

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -147,7 +147,7 @@ class Hostgroup < ApplicationRecord
   end
 
   def inherited_lookup_value(key)
-    if key.path_elements.flatten.include?("hostgroup") && Setting["host_group_matchers_inheritance"]
+    if key.path_elements.flatten.include?("hostgroup") && Setting["matchers_inheritance"]
       ancestors.reverse_each do |hg|
         if (v = LookupValue.find_by(:lookup_key_id => key.id, :id => hg.lookup_values))
           return v.value, hg.to_label

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -10,6 +10,7 @@ class LookupKey < ApplicationRecord
   KEY_DELM = ","
   EQ_DELM  = "="
   VALUE_REGEX = /\A[^#{KEY_DELM}]+#{EQ_DELM}[^#{KEY_DELM}]+(#{KEY_DELM}[^#{KEY_DELM}]+#{EQ_DELM}[^#{KEY_DELM}]+)*\Z/
+  MATCHERS_INHERITANCE = ['hostgroup', 'organization', 'location'].freeze
 
   validates_lengths_from_database
 

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -13,7 +13,7 @@ class Setting::Puppet < Setting
       self.set('use_uuid_for_certificates', N_("Foreman will use random UUIDs for certificate signing instead of hostnames"), false, N_('Use UUID for certificates')),
       self.set('update_environment_from_facts', N_("Foreman will update a host's environment from its facts"), false, N_('Update environment from facts')),
       self.set('update_subnets_from_facts', N_("Foreman will update a host's subnet from its facts"), false, N_('Update subnets from facts')),
-      self.set('host_group_matchers_inheritance', N_("Foreman host group matchers will be inherited by children when evaluating smart class parameters"), true, N_('Host group matchers inheritance')),
+      self.set('matchers_inheritance', N_("Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"), true, N_('Matchers inheritance')),
       self.set('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true, N_('Create new host when facts are uploaded')),
       self.set('create_new_host_when_report_is_uploaded', N_("Foreman will create the host when a report is received"), true, N_('Create new host when report is uploaded')),
       self.set('location_fact', N_("Hosts created after a puppet run will be placed in the location this fact dictates. The content of this fact should be the full label of the location."), 'foreman_location', N_('Location fact')),

--- a/app/services/classification/values_hash_query.rb
+++ b/app/services/classification/values_hash_query.rb
@@ -72,7 +72,7 @@ module Classification
         lookup_value.match.split(LookupKey::KEY_DELM).each do |match_key|
           element = match_key.split(LookupKey::EQ_DELM).first
           matcher_key += element + ','
-          if element == 'hostgroup'
+          if LookupKey::MATCHERS_INHERITANCE.include?(element)
             matcher_value = match_key.split(LookupKey::EQ_DELM).last
           end
         end

--- a/db/migrate/20190621160800_rename_host_group_matchers.rb
+++ b/db/migrate/20190621160800_rename_host_group_matchers.rb
@@ -1,0 +1,21 @@
+class RenameHostGroupMatchers < ActiveRecord::Migration[5.2]
+  def up
+    host_group_matchers = Setting.find_by_name('host_group_matchers_inheritance')
+    matchers_inheritance = Setting.find_by_name('matchers_inheritance')
+    return unless host_group_matchers.present? && matchers_inheritance.present?
+    matchers_inheritance.update_attribute(
+      :value,
+      host_group_matchers.value
+    )
+    host_group_matchers.destroy
+  end
+
+  def down
+    host_group_matchers = Setting.find_by_name('host_group_matchers_inheritance')
+    matchers_inheritance = Setting.find_by_name('matchers_inheritance')
+    host_group_matchers&.destroy
+    matchers_inheritance.update(
+      :name => 'host_group_matchers_inheritance'
+    )
+  end
+end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Add organization and location smart class parameters inheritance as it is already the case for hostgroups. As Orgs and locs can be nested as hostgroups it seems legit to me to have the same behavior for smart class parameters.

It:
* add two new settings `organization_matchers_inheritance` and `location_matchers_inheritance` (I know adding new settings is a sensible point, but I wanted to mimic hostgroup implementation)
* rename `host_group_matchers_inheritance` to `hostgroup_matchers_inheritance` to be able to make some code factorization.

Defaults values for these new settings are the same as hostgroup one ('opt-out') and will change the default behavior for nested orgs/locs in two cases (but of course we can make it 'opt-in' by default if wanted):
  * when inheritance setting set to true and matcher is defined on a parent taxonomy and no matcher is defined on the host taxonomy: Before change it return no value, but it will return parent taxonomy matcher value
  * when inheritance setting set to true and `merge_override` set to true: before change it return current host taxonomy matches values (if defined) merged with other matchers values (but not merged with parent's taxonomy values if defined), but it will return also merged parent taxonomy  values if defined

Katello side note: As now Katello don't support nested orgs, maybe the `organization_matchers_inheritance` setting should be hidden in katello ?