### PR TITLE
Fixes #27794: Add ForemanModal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Modal } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import ForemanModalHeader from './subcomponents/ForemanModalHeader';
+import ForemanModalFooter from './subcomponents/ForemanModalFooter';
+import ModalContext from './ForemanModalContext';
+import { extractModalNodes } from './helpers';
+
+const ForemanModal = props => {
+  const { isOpen, onClose, title, ...propsToPassDown } = props; // don't pass down those two as it causes PF problems
+  // Extract header and footer from children, if provided
+  const { headerChild, footerChild, otherChildren } = extractModalNodes(
+    props.children
+  );
+  const context = {
+    isOpen,
+    onClose,
+    title,
+  };
+
+  return (
+    <ModalContext.Provider value={context}>
+      {/* Change the name of the props we are passing down to Modal to conform to Patternfly 3 api */}
+      <Modal
+        onHide={onClose}
+        show={isOpen}
+        className="foreman-modal"
+        {...propsToPassDown}
+      >
+        {headerChild}
+        <Modal.Body>{otherChildren}</Modal.Body>
+        {footerChild}
+      </Modal>
+    </ModalContext.Provider>
+  );
+};
+
+// Header and Footer use the provided children, or default markup if none provided
+
+ForemanModal.Header = ForemanModalHeader;
+ForemanModal.Footer = ForemanModalFooter;
+
+ForemanModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  children: PropTypes.node,
+  title: PropTypes.string.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+ForemanModal.defaultProps = {
+  children: null,
+};
+
+export default ForemanModal;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.stories.js
@@ -1,0 +1,159 @@
+import React, { useState } from 'react';
+import { Button } from 'patternfly-react';
+import { storiesOf } from '@storybook/react';
+import ForemanModal from '.';
+import Story from '../../../../../stories/components/Story';
+
+// This custom Hook is only for the Storybook
+const useModalState = initialModalState => {
+  const [modalOpen, setModalOpen] = useState(initialModalState);
+  const toggleModal = () => setModalOpen(!modalOpen);
+  return [modalOpen, toggleModal];
+};
+
+storiesOf('Components/ForemanModal', module).add(
+  'With default header & footer',
+  () =>
+    // using createElement here so that hooks work in stories
+    React.createElement(() => {
+      const [modalOpen, toggleModal] = useModalState(false);
+      return (
+        <Story>
+          <Button bsStyle="primary" onClick={toggleModal}>
+            Show Modal
+          </Button>
+          <ForemanModal
+            isOpen={modalOpen}
+            title="I'm a modal!"
+            onClose={toggleModal}
+          >
+            <ForemanModal.Header />
+            This is the modal body
+            <ForemanModal.Footer />
+          </ForemanModal>
+        </Story>
+      );
+    })
+);
+
+storiesOf('Components/ForemanModal', module).add(
+  'With custom header & footer',
+  () =>
+    React.createElement(() => {
+      const [modalOpen, toggleModal] = useModalState(false);
+      return (
+        <Story>
+          <Button bsStyle="primary" onClick={toggleModal}>
+            Show Modal
+          </Button>
+          <ForemanModal
+            isOpen={modalOpen}
+            title="I'm a custom modal!"
+            onClose={toggleModal}
+          >
+            <ForemanModal.Header>
+              <h3>This is a custom header! :)</h3>
+            </ForemanModal.Header>
+            If a {`<ForemanModal.Header>`} is provided AND has children, the
+            title prop will be ignored.
+            <ForemanModal.Footer>
+              Click the X in the upper right to close
+            </ForemanModal.Footer>
+          </ForemanModal>
+        </Story>
+      );
+    })
+);
+
+storiesOf('Components/ForemanModal', module).add('With no close button', () =>
+  React.createElement(() => {
+    const [modalOpen, toggleModal] = useModalState(false);
+    return (
+      <Story>
+        <Button bsStyle="primary" onClick={toggleModal}>
+          Show Modal
+        </Button>
+        <ForemanModal
+          isOpen={modalOpen}
+          title="I'm an X-less modal!"
+          onClose={toggleModal}
+        >
+          <ForemanModal.Header closeButton={false} />
+          <br />
+          Props passed to ForemanModal.Header will be passed down to
+          Modal.Header
+          <ForemanModal.Footer />
+        </ForemanModal>
+      </Story>
+    );
+  })
+);
+
+storiesOf('Components/ForemanModal', module).add('With no footer', () =>
+  React.createElement(() => {
+    const [modalOpen, toggleModal] = useModalState(false);
+    return (
+      <Story>
+        <Button bsStyle="primary" onClick={toggleModal}>
+          Show Modal
+        </Button>
+        <ForemanModal
+          isOpen={modalOpen}
+          title="I'm a modal!"
+          onClose={toggleModal}
+        >
+          <ForemanModal.Header />
+          This is the modal body. There is no footer.
+        </ForemanModal>
+      </Story>
+    );
+  })
+);
+
+storiesOf('Components/ForemanModal', module).add('With no header', () =>
+  React.createElement(() => {
+    const [modalOpen, toggleModal] = useModalState(false);
+    return (
+      <Story>
+        <Button bsStyle="primary" onClick={toggleModal}>
+          Show Modal
+        </Button>
+        <ForemanModal
+          isOpen={modalOpen}
+          title="I'm a modal!"
+          onClose={toggleModal}
+        >
+          This is the modal body. There is no header.
+          <ForemanModal.Footer />
+        </ForemanModal>
+      </Story>
+    );
+  })
+);
+
+storiesOf('Components/ForemanModal', module).add(
+  'With props passed down via spread syntax',
+  () =>
+    React.createElement(() => {
+      const [modalOpen, toggleModal] = useModalState(false);
+      return (
+        <Story>
+          <Button bsStyle="primary" onClick={toggleModal}>
+            Show Modal
+          </Button>
+          <ForemanModal
+            isOpen={modalOpen}
+            title="I'm a modal!"
+            onClose={toggleModal}
+            myProp="Hii"
+          >
+            <ForemanModal.Header />
+            The inner {`<Modal>`} component will have any props you pass to
+            {`<ForemanModal>`}. (Look in the React dev tools for
+            &lsquo;myProp&rsquo;)
+            <ForemanModal.Footer />
+          </ForemanModal>
+        </Story>
+      );
+    })
+);

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.test.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import ForemanModal from '.';
+import { testComponentSnapshotsWithFixtures } from '../../common/testHelpers';
+
+const headerChild = (
+  <ForemanModal.Header>this is the header</ForemanModal.Header>
+);
+const footerChild = (
+  <ForemanModal.Footer>this is the footer</ForemanModal.Footer>
+);
+const modalBody = <div>This is the body</div>;
+
+const fixtures = {
+  'should render': {
+    isOpen: true,
+    title: 'Test modal',
+    onClose: jest.fn(),
+  },
+  'should render closed': {
+    isOpen: false,
+    title: 'Test modal',
+    onClose: jest.fn(),
+  },
+  'renders when header and footer are supplied': {
+    isOpen: true,
+    title: 'Test modal',
+    onClose: jest.fn(),
+    children: [headerChild, modalBody, footerChild],
+  },
+  'renders header and footer in correct order regardless of ordering of children': {
+    isOpen: true,
+    title: 'Test modal',
+    onClose: jest.fn(),
+    children: [modalBody, footerChild, headerChild],
+  },
+};
+
+describe('ForemanModal', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(ForemanModal, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalContext.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalContext.js
@@ -1,0 +1,4 @@
+import { createContext } from 'react';
+
+// creating context in a separate file to avoid circular imports
+export default createContext(null);

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalHooks.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalHooks.js
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import ModalContext from './ForemanModalContext';
+
+// Because enzyme doesn't support useContext yet
+export const useModalContext = () => useContext(ModalContext);
+
+// to get enzyme hacky test to work
+export default ModalContext;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/__snapshots__/ForemanModal.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/__snapshots__/ForemanModal.test.js.snap
@@ -1,0 +1,209 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForemanModal rendering renders header and footer in correct order regardless of ordering of children 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "isOpen": true,
+      "onClose": [MockFunction],
+      "title": "Test modal",
+    }
+  }
+>
+  <Modal
+    animation={true}
+    autoFocus={true}
+    backdrop={true}
+    bsClass="modal"
+    className="foreman-modal"
+    dialogComponentClass={[Function]}
+    enforceFocus={true}
+    keyboard={true}
+    manager={
+      ModalManager {
+        "add": [Function],
+        "containers": Array [],
+        "data": Array [],
+        "handleContainerOverflow": true,
+        "hideSiblingNodes": true,
+        "isTopModal": [Function],
+        "modals": Array [],
+        "remove": [Function],
+      }
+    }
+    onHide={[MockFunction]}
+    renderBackdrop={[Function]}
+    restoreFocus={true}
+    show={true}
+  >
+    <ForemanModalHeader
+      key=".2"
+    >
+      this is the header
+    </ForemanModalHeader>
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
+    >
+      <div
+        key=".0"
+      >
+        This is the body
+      </div>
+    </ModalBody>
+    <ForemanModalFooter
+      key=".1"
+    >
+      this is the footer
+    </ForemanModalFooter>
+  </Modal>
+</ContextProvider>
+`;
+
+exports[`ForemanModal rendering renders when header and footer are supplied 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "isOpen": true,
+      "onClose": [MockFunction],
+      "title": "Test modal",
+    }
+  }
+>
+  <Modal
+    animation={true}
+    autoFocus={true}
+    backdrop={true}
+    bsClass="modal"
+    className="foreman-modal"
+    dialogComponentClass={[Function]}
+    enforceFocus={true}
+    keyboard={true}
+    manager={
+      ModalManager {
+        "add": [Function],
+        "containers": Array [],
+        "data": Array [],
+        "handleContainerOverflow": true,
+        "hideSiblingNodes": true,
+        "isTopModal": [Function],
+        "modals": Array [],
+        "remove": [Function],
+      }
+    }
+    onHide={[MockFunction]}
+    renderBackdrop={[Function]}
+    restoreFocus={true}
+    show={true}
+  >
+    <ForemanModalHeader
+      key=".0"
+    >
+      this is the header
+    </ForemanModalHeader>
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
+    >
+      <div
+        key=".1"
+      >
+        This is the body
+      </div>
+    </ModalBody>
+    <ForemanModalFooter
+      key=".2"
+    >
+      this is the footer
+    </ForemanModalFooter>
+  </Modal>
+</ContextProvider>
+`;
+
+exports[`ForemanModal rendering should render 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "isOpen": true,
+      "onClose": [MockFunction],
+      "title": "Test modal",
+    }
+  }
+>
+  <Modal
+    animation={true}
+    autoFocus={true}
+    backdrop={true}
+    bsClass="modal"
+    className="foreman-modal"
+    dialogComponentClass={[Function]}
+    enforceFocus={true}
+    keyboard={true}
+    manager={
+      ModalManager {
+        "add": [Function],
+        "containers": Array [],
+        "data": Array [],
+        "handleContainerOverflow": true,
+        "hideSiblingNodes": true,
+        "isTopModal": [Function],
+        "modals": Array [],
+        "remove": [Function],
+      }
+    }
+    onHide={[MockFunction]}
+    renderBackdrop={[Function]}
+    restoreFocus={true}
+    show={true}
+  >
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
+    />
+  </Modal>
+</ContextProvider>
+`;
+
+exports[`ForemanModal rendering should render closed 1`] = `
+<ContextProvider
+  value={
+    Object {
+      "isOpen": false,
+      "onClose": [MockFunction],
+      "title": "Test modal",
+    }
+  }
+>
+  <Modal
+    animation={true}
+    autoFocus={true}
+    backdrop={true}
+    bsClass="modal"
+    className="foreman-modal"
+    dialogComponentClass={[Function]}
+    enforceFocus={true}
+    keyboard={true}
+    manager={
+      ModalManager {
+        "add": [Function],
+        "containers": Array [],
+        "data": Array [],
+        "handleContainerOverflow": true,
+        "hideSiblingNodes": true,
+        "isTopModal": [Function],
+        "modals": Array [],
+        "remove": [Function],
+      }
+    }
+    onHide={[MockFunction]}
+    renderBackdrop={[Function]}
+    restoreFocus={true}
+    show={false}
+  >
+    <ModalBody
+      bsClass="modal-body"
+      componentClass="div"
+    />
+  </Modal>
+</ContextProvider>
+`;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/helpers.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import ForemanModalHeader from './subcomponents/ForemanModalHeader';
+import ForemanModalFooter from './subcomponents/ForemanModalFooter';
+
+/**
+ * Extract Header and Footer child nodes from ForemanModal.
+ * @param  {PropTypes.node} children ForemanModal props.children
+ * @return {object} Child nodes separated out into headerChild, footerChild, otherChildren
+ */
+export const extractModalNodes = children => {
+  children = React.Children.toArray(children);
+  const headerChild = children.find(child => child.type === ForemanModalHeader);
+  const footerChild = children.find(child => child.type === ForemanModalFooter);
+  const otherChildren = children.filter(
+    child => child !== headerChild && child !== footerChild
+  );
+  return { headerChild, footerChild, otherChildren };
+};

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/helpers.test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import ForemanModal from './';
+import { extractModalNodes } from './helpers';
+
+const headerNode = <ForemanModal.Header />;
+const footerNode = <ForemanModal.Footer />;
+const modalChildren = [headerNode, <p>hi</p>, footerNode];
+
+describe('ForemanModal helpers', () => {
+  describe('extractModalNodes', () => {
+    it('returns an object with these three keys', () => {
+      const result = extractModalNodes([]);
+      expect(new Set(Object.keys(result))).toEqual(
+        new Set(['headerChild', 'footerChild', 'otherChildren'])
+      );
+    });
+    it('does not include header in otherChildren', () => {
+      const result = extractModalNodes(modalChildren).otherChildren;
+      expect(result.find(el => el.type === ForemanModal.Header)).toEqual(
+        undefined
+      );
+    });
+    it('does not include footer in otherChildren', () => {
+      const result = extractModalNodes(modalChildren).otherChildren;
+      expect(result.find(el => el.type === ForemanModal.Footer)).toEqual(
+        undefined
+      );
+    });
+    it('includes all nodes somewhere in the returned object', () => {
+      const result = Object.values(extractModalNodes(modalChildren)); // array of arrays
+      const expectedLength = modalChildren.length;
+      let actualLength = 0;
+      for (let i = 0; i < result.length; i++) {
+        // result[i] can be an array of React elements or a single element
+        if (Array.isArray(result[i])) {
+          actualLength += result[i].length;
+        } else {
+          actualLength++;
+        }
+      }
+      expect(actualLength).toEqual(expectedLength);
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/index.js
@@ -1,0 +1,3 @@
+import ForemanModal from './ForemanModal';
+
+export default ForemanModal;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalFooter.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalFooter.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal, Button } from 'patternfly-react';
+import { useModalContext } from '../ForemanModalHooks';
+
+const ForemanModalFooter = props => {
+  const childCount = React.Children.count(props.children);
+  const { onClose } = useModalContext();
+  // Render the provided children, or default markup if none given
+  return (
+    <Modal.Footer {...props}>
+      {props.children}
+      {childCount === 0 && (
+        <Button bsStyle="default" onClick={onClose}>
+          Close
+        </Button>
+      )}
+    </Modal.Footer>
+  );
+};
+
+ForemanModalFooter.propTypes = {
+  children: PropTypes.node,
+};
+
+ForemanModalFooter.defaultProps = {
+  children: null,
+};
+
+export default ForemanModalFooter;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalFooter.test.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalFooter.test.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Button, Modal } from 'patternfly-react';
+import ForemanModalFooter from './ForemanModalFooter';
+import * as ModalContext from '../ForemanModalHooks'; // so enzyme test works
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+
+const fixtures = {
+  'should render with default markup': {
+    title: 'foo',
+  },
+  'should render with supplied children': {
+    title: 'ignored',
+    children: <h4>Modal Footer</h4>,
+  },
+};
+
+const contextValues = {
+  onClose: jest.fn(),
+};
+
+jest
+  .spyOn(ModalContext, 'useModalContext')
+  .mockImplementation(() => contextValues);
+
+describe('ForemanModal.Footer', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(ForemanModalFooter, fixtures);
+  });
+  describe('data flow', () => {
+    it('should make onClose available thru context', () => {
+      const wrapper = shallow(<ForemanModalFooter />);
+      expect(wrapper.find(Button).prop('onClick')).toEqual(
+        contextValues.onClose
+      );
+    });
+    it('passes props to PF component using spread', () => {
+      const wrapper = shallow(<ForemanModalFooter myCustomProp="hi" />);
+      expect(wrapper.find(Modal.Footer).prop('myCustomProp')).toEqual('hi');
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalHeader.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalHeader.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Modal } from 'patternfly-react';
+import { useModalContext } from '../ForemanModalHooks';
+
+const ForemanModalHeader = props => {
+  const childCount = React.Children.count(props.children);
+  const { title } = useModalContext();
+  // Render the provided children, or default markup if none given
+  return (
+    <Modal.Header closeButton {...props}>
+      {props.children}
+      {childCount === 0 && title && <Modal.Title>{title}</Modal.Title>}
+    </Modal.Header>
+  );
+};
+
+ForemanModalHeader.propTypes = {
+  children: PropTypes.node,
+};
+
+ForemanModalHeader.defaultProps = {
+  children: null,
+};
+
+export default ForemanModalHeader;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalHeader.test.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/ForemanModalHeader.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { Modal } from 'patternfly-react';
+import ForemanModalHeader from './ForemanModalHeader';
+import * as ModalContext from '../ForemanModalHooks'; // so enzyme test works
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+
+const fixtures = {
+  'should render with default markup': {
+    title: 'foo',
+  },
+  'should render with supplied children': {
+    title: 'should not be in markup',
+    children: <h1>Modal Title</h1>,
+  },
+};
+
+const contextValues = {
+  title: 'modal title passed thru mock context :)',
+};
+
+jest
+  .spyOn(ModalContext, 'useModalContext')
+  .mockImplementation(() => contextValues);
+
+describe('ForemanModal.Header', () => {
+  describe('rendering', () => {
+    testComponentSnapshotsWithFixtures(ForemanModalHeader, fixtures);
+  });
+  describe('data flow', () => {
+    it('renders a <Modal.Title> and title prop when no children are given', () => {
+      const wrapper = shallow(<ForemanModalHeader />);
+      expect(wrapper.find(Modal.Title)).toHaveLength(1);
+      expect(
+        wrapper
+          .find(Modal.Title)
+          .dive()
+          .text()
+      ).toMatch(contextValues.title);
+    });
+    it('ignores title prop if children are given', () => {
+      const wrapper = shallow(
+        <ForemanModalHeader>
+          <div>custom title</div>
+        </ForemanModalHeader>
+      );
+      expect(wrapper.find(Modal.Title)).toHaveLength(0);
+    });
+    it('passes props to PF component using spread', () => {
+      const wrapper = shallow(<ForemanModalHeader myCustomProp="hi" />);
+      expect(wrapper.find(Modal.Header).prop('myCustomProp')).toEqual('hi');
+    });
+    it('has a close button by default', () => {
+      const closeButtonHtml = `<button type="button" class="close">`;
+      const wrapper = shallow(<ForemanModalHeader />);
+      expect(wrapper.html()).toEqual(expect.stringContaining(closeButtonHtml));
+    });
+    it('has no close button if overridden via props', () => {
+      const closeButtonHtml = `<button type="button" class="close">`;
+      const wrapper = shallow(<ForemanModalHeader closeButton={false} />);
+      expect(wrapper.html()).not.toEqual(
+        expect.stringContaining(closeButtonHtml)
+      );
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/__snapshots__/ForemanModalFooter.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/__snapshots__/ForemanModalFooter.test.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForemanModal.Footer rendering should render with default markup 1`] = `
+<ModalFooter
+  bsClass="modal-footer"
+  componentClass="div"
+  title="foo"
+>
+  <Button
+    active={false}
+    block={false}
+    bsClass="btn"
+    bsStyle="default"
+    disabled={false}
+    onClick={[MockFunction]}
+  >
+    Close
+  </Button>
+</ModalFooter>
+`;
+
+exports[`ForemanModal.Footer rendering should render with supplied children 1`] = `
+<ModalFooter
+  bsClass="modal-footer"
+  componentClass="div"
+  title="ignored"
+>
+  <h4>
+    Modal Footer
+  </h4>
+</ModalFooter>
+`;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/__snapshots__/ForemanModalHeader.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/subcomponents/__snapshots__/ForemanModalHeader.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForemanModal.Header rendering should render with default markup 1`] = `
+<ModalHeader
+  bsClass="modal-header"
+  closeButton={true}
+  closeLabel="Close"
+  title="foo"
+>
+  <ModalTitle
+    bsClass="modal-title"
+    componentClass="h4"
+  >
+    modal title passed thru mock context :)
+  </ModalTitle>
+</ModalHeader>
+`;
+
+exports[`ForemanModal.Header rendering should render with supplied children 1`] = `
+<ModalHeader
+  bsClass="modal-header"
+  closeButton={true}
+  closeLabel="Close"
+  title="should not be in markup"
+>
+  <h1>
+    Modal Title
+  </h1>
+</ModalHeader>
+`;

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -50,14 +50,12 @@ const PageLayout = ({
           <Col className="title_filter" md={searchable ? 6 : 4}>
             {searchable && (
               <div id="search-bar">
-                {
-                  <SearchBar
-                    data={searchProps}
-                    initialQuery={searchQuery}
-                    onSearch={onSearch}
-                    onBookmarkClick={onBookmarkClick}
-                  />
-                }
+                <SearchBar
+                  data={searchProps}
+                  initialQuery={searchQuery}
+                  onSearch={onSearch}
+                  onBookmarkClick={onBookmarkClick}
+                />
               </div>
             )}
           </Col>


### PR DESCRIPTION
Create a React modal component.  It will be reusable across Foreman and plugins, and will support the upcoming UI team work around the Host creation wizard.
