### PR TITLE
Fixes #27854 - Don't fail seed on invalid templates

### DIFF
--- a/db/seeds.d/050-taxonomies.rb
+++ b/db/seeds.d/050-taxonomies.rb
@@ -22,7 +22,11 @@ User.as_anonymous_admin do
       # Only default templates are assigned during taxonomy creation
       Template.where(default: false).each do |template|
         template.without_auditing do
-          template.send("#{taxonomy.to_s.parameterize.pluralize}=", [tax])
+          begin
+            template.send("#{taxonomy.to_s.parameterize.pluralize}=", [tax])
+          rescue
+            puts "Failed to assign template #{template.name} to #{tax_name}. Please verify the template is valid and assign manually."
+          end
         end
       end
 


### PR DESCRIPTION
In case any non-default template is invalid, assigning it to the default
taxonomy will fail and block the seeding from continuing. This commit
catches such failures and prints a message informing the user what
to do to fix the issue.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
