### PR TITLE
Fixes #26312 - assign an Org/Loc for external users

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -308,6 +308,8 @@ class User < ApplicationRecord
       User.as_anonymous_admin do
         auth_source = AuthSourceExternal.create!(:name => auth_source_name) if auth_source.nil?
         user = User.create!(attrs.merge(:auth_source => auth_source))
+        user.locations = auth_source.locations
+        user.organizations = auth_source.organizations
         if external_groups.present?
           user.usergroups = auth_source.external_usergroups.where(:name => external_groups).map(&:usergroup).uniq
         end


### PR DESCRIPTION
While creating an external user, the user is assigned to a `none`  Org and a `none` Location. This patch makes sure there is an Org and Loc assigned to a user when it is newly created. @tbrisker can you please take a look at this pr?