### PR TITLE
Fixes #27877 - no conflicts on DHCP filename change

### DIFF
--- a/test/models/orchestration/dhcp_test.rb
+++ b/test/models/orchestration/dhcp_test.rb
@@ -323,6 +323,17 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     assert_equal :set_dhcp, h.queue.find_by_id("dhcp_create_aa:bb:cc:dd:ee:ff").action.last
   end
 
+  test "when an existing host changes its PXE loader, its dhcp records should be updated" do
+    h = as_admin do
+      FactoryBot.create(:host, :with_dhcp_orchestration, :mac => "aa:bb:cc:dd:ee:ff", :pxe_loader => "PXELinux BIOS")
+    end
+    h.pxe_loader = "PXELinux UEFI"
+    assert h.valid?
+    assert_equal ["dhcp_remove_aa:bb:cc:dd:ee:ff", "dhcp_create_aa:bb:cc:dd:ee:ff"], h.queue.task_ids
+    assert_equal :del_dhcp, h.queue.find_by_id("dhcp_remove_aa:bb:cc:dd:ee:ff").action.last
+    assert_equal :set_dhcp, h.queue.find_by_id("dhcp_create_aa:bb:cc:dd:ee:ff").action.last
+  end
+
   test "when an existing host change its bmc ip address, its dhcp records should be updated" do
     h = nil
     as_admin do

--- a/test/unit/net/dhcp_test.rb
+++ b/test/unit/net/dhcp_test.rb
@@ -48,21 +48,22 @@ class DhcpTest < ActiveSupport::TestCase
   test "record should be equal if one record has no hostname" do
     record1 = make_record
     record2 = make_record :hostname => "test"
-    assert_equal record1, record2
-    assert_equal record2, record1
+    assert record1.eql_for_conflicts?(record2)
+    assert record2.eql_for_conflicts?(record1)
   end
 
   test "record should be equal if one record has no filename" do
     record1 = make_record
     record2 = make_record :filename => "pxelinux.0"
-    assert_equal record1, record2
-    assert_equal record2, record1
+    assert record1.eql_for_conflicts?(record2)
+    assert record2.eql_for_conflicts?(record1)
   end
 
   test "record should not be equal if their attrs are not the same" do
     record1 = make_record :hostname => "test1"
     record2 = make_record :hostname => "test2"
-    refute_equal record1, record2
+    refute record1.eql_for_conflicts?(record2)
+    refute record2.eql_for_conflicts?(record1)
   end
 
   test "conflicts should be detected for mismatched records" do


### PR DESCRIPTION
Our orchestration code checks existing DHCP records against MAC, IP, hostname and filename. However filename must not be included when comparing DHCP records for conflicts - it is totally possible to create multiple records with the same filename option. It should have never been considered as a subject of conflict. This change is about removing the filename from the check so it won't issue unnecessary conflict errors on updates of PXE loader.