### PR TITLE
Fixes #27879 - token is properly generated for iPXE Embedded

### DIFF
--- a/app/models/concerns/hostext/token.rb
+++ b/app/models/concerns/hostext/token.rb
@@ -8,7 +8,7 @@ module Hostext
       scope :for_token, ->(token) { joins(:token).where(:tokens => { :value => token }).where("expires >= ?", Time.now.utc.to_s(:db)).select('hosts.*') }
       scope :for_token_when_built, ->(token) { joins(:token).where(:tokens => { :value => token }).select('hosts.*') }
 
-      after_validation :refresh_token_on_build
+      before_validation :refresh_token_on_build
     end
 
     # Sets and expire provisioning tokens

--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -171,8 +171,13 @@ module Orchestration::DHCP
   # do we need to update our dhcp reservations
   def dhcp_update_required?
     # IP Address / name changed, or 'rebuild' action is triggered and DHCP record on the smart proxy is not present/identical.
-    return true if ((old.ip != ip) || (old.hostname != hostname) || provision_mac_addresses_changed? || (old.subnet != subnet) || (operatingsystem.boot_filename(old.host) != operatingsystem.boot_filename(host)) ||
-                    (!old.build? && build? && !all_dhcp_records_valid?))
+    return true if ((old.ip != ip) ||
+      (old.hostname != hostname) ||
+      provision_mac_addresses_changed? ||
+      (old.subnet != subnet) ||
+      (old.operatingsystem.boot_filename(old.host) != operatingsystem.boot_filename(host)) ||
+      ((old.host.pxe_loader == "iPXE Embedded" || host.pxe_loader == "iPXE Embedded") && (old.host.build != host.build)) ||
+      (!old.build? && build? && !all_dhcp_records_valid?))
     # Handle jumpstart
     # TODO, abstract this way once interfaces are fully used
     if is_a?(Host::Base) && jumpstart?

--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -53,7 +53,7 @@ module Foreman
       url_for :only_path => false, :controller => "/unattended", :action => 'host_template',
         :protocol => options[:protocol], :host => options[:host],
         :port => options[:port], :script_name => options[:path],
-        :token => (host.token.value unless host.try(:token).nil?),
+        :token => (host.token.value if (host.try(:build) && host.try(:token))),
         :kind => options[:action], **params
     end
 

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -144,6 +144,10 @@ FactoryBot.define do
       set_environment_taxonomies(host)
     end
 
+    trait :with_build do
+      build { true }
+    end
+
     trait :with_model do
       model
     end

--- a/test/unit/foreman_url_renderer_test.rb
+++ b/test/unit/foreman_url_renderer_test.rb
@@ -13,7 +13,7 @@ class ForemanUrlRendererTest < ActiveSupport::TestCase
     attr_accessor :host, :template_url
   end
 
-  let(:host) { FactoryBot.build_stubbed(:host, :managed, :with_dhcp_orchestration) }
+  let(:host) { FactoryBot.build_stubbed(:host, :managed, :with_dhcp_orchestration, :with_build) }
   let(:renderer) { Renderer.new }
   let(:action) { 'provision' }
 


### PR DESCRIPTION
I've encountered two problems with iPXE Embedded:

* DHCP filename option does not include token at all when NEW host is created (EDIT or BUILD does work fine)
* when BUILD is canceled/exited a token which is no longer valid is inserted

For (1) the problem is that token is generated/saved after the host record is saved. Our orchestration triggers earlier than token is generated. So for this case I am proposing to change token generation to be before_validation instead of after_validation. I hope this will not cause any issues elsewhere or I have no other ideas how to fix this.

For (2) foreman_url helper is modified only to include token when build flag is on because during orchestration host record (build flag) is correctly updated but associated token is being removed after DHCP orchestration later on (expiration). And then the build flag is compared for iPXE Embedded loader hosts and DHCP update is properly scheduled.

When testing this, this patch needs to be applied first otherwise DHCP
conflict is always preventing from doing htis workflow:

https://github.com/theforeman/foreman/pull/7047