### PR TITLE
Fixes #11367 - Default values for the template inputs

### DIFF
--- a/app/controllers/api/v2/template_inputs_controller.rb
+++ b/app/controllers/api/v2/template_inputs_controller.rb
@@ -34,6 +34,7 @@ module Api
           param :puppet_class_name, String, :required => false, :desc => N_('Puppet class name, used when input type is puppet_parameter')
           param :puppet_parameter_name, String, :required => false, :desc => N_('Puppet parameter name, used when input type is puppet_parameter')
           param :options, Array, :required => false, :desc => N_('Selectable values for user inputs')
+          param :default, String, :required => false, :desc => N_('Default value for user input')
           param :value_type, TemplateInput::VALUE_TYPE, :required => false, :desc => N_('Value type, defaults to plain')
           param :resource_type, Permission.resources, :required => false, :desc => N_('For values of type search, this is the resource the value searches in')
         end

--- a/app/controllers/concerns/foreman/controller/parameters/template_input.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template_input.rb
@@ -6,7 +6,7 @@ module Foreman::Controller::Parameters::TemplateInput
       Foreman::ParameterFilter.new(::TemplateInput).tap do |filter|
         filter.permit_by_context :id, :_destroy, :name, :required, :input_type, :fact_name, :resource_type, :value_type,
                                  :variable_name, :puppet_class_name, :puppet_parameter_name, :description, :template_id,
-                                 :options, :advanced, :nested => true
+                                 :options, :default, :advanced, :nested => true
       end
     end
   end

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -145,6 +145,7 @@ class ReportComposer
     # process values from params (including empty hash)
     template.template_inputs.each do |input|
       val = input_values[input.id.to_s].try(:[], 'value') unless input_values.nil?
+      val = input.default if val.blank?
       inputs[input.id.to_s] = InputValue.new(value: val, template_input: input)
     end
 

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -12,7 +12,7 @@ class TemplateInput < ApplicationRecord
 
   attr_exportable(:name, :required, :input_type, :fact_name, :variable_name, :puppet_class_name,
                   :puppet_parameter_name, :description, :options, :advanced, :value_type,
-                  :resource_type)
+                  :resource_type, :default)
 
   belongs_to :template
 
@@ -26,6 +26,7 @@ class TemplateInput < ApplicationRecord
   validates :variable_name, :presence => { :if => :variable_template_input? }
   validates :puppet_parameter_name, :puppet_class_name, :presence => { :if => :puppet_parameter_template_input? }
   validates :value_type, inclusion: { in: VALUE_TYPE }
+  validates :default, inclusion: { in: :options_array }, if: -> { options.present? }, allow_blank: true
 
   def user_template_input?
     input_type == 'user'

--- a/app/views/api/v2/template_inputs/main.json.rabl
+++ b/app/views/api/v2/template_inputs/main.json.rabl
@@ -3,7 +3,7 @@ object @template_input
 extends 'api/v2/template_inputs/base'
 
 attributes :template_id, :fact_name, :variable_name, :puppet_parameter_name, :puppet_class_name,
-           :description, :required
+           :description, :required, :default
 
 node :options do |input|
   input.options.split(/\r?\n/) if input.options.present?

--- a/app/views/template_inputs/_form.html.erb
+++ b/app/views/template_inputs/_form.html.erb
@@ -20,6 +20,7 @@
         <%= checkbox_f f, :advanced, :disabled => @template.locked? %>
         <%= textarea_f f, :options, :rows => 3, :class => 'user_input_type', :help_inline => _("A list of options the user can select from. If not provided, the user will be given a free-form field"),
                                     :disabled => @template.locked?, wrapper_class: "form-group input-options-#{f.index || f.object.id}#{' hide' if f.object.value_type != 'plain'}"  %>
+        <%= text_f f, :default, :disabled => @template.locked? %>
       </div>
       <%= textarea_f f, :description, :rows => 3, :disabled => @template.locked? %>
     <% end %>

--- a/db/migrate/20190918170516_add_default_to_template_inputs.rb
+++ b/db/migrate/20190918170516_add_default_to_template_inputs.rb
@@ -1,0 +1,5 @@
+class AddDefaultToTemplateInputs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :template_inputs, :default, :string
+  end
+end


### PR DESCRIPTION
Adds possibility to specify default values for the template inputs while creating one. After, the default value is selected automatically.

![ScreenShot-1568903125610](https://user-images.githubusercontent.com/32508194/65254973-60f8a600-dafd-11e9-84d5-1ac0f466a60f.png)
![ScreenShot-1568903143398](https://user-images.githubusercontent.com/32508194/65254975-60f8a600-dafd-11e9-95d7-3b5f208bfa60.png)

Chages are in UI and API (probably will require a PR to hammer to add needed changes there as well).