### PR TITLE
Fixes #27891 - Add description field to templates

### DIFF
--- a/app/controllers/api/v2/config_templates_controller.rb
+++ b/app/controllers/api/v2/config_templates_controller.rb
@@ -36,6 +36,7 @@ module Api
       def_param_group :config_template do
         param :config_template, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true, :desc => N_("template name")
+          param :description, String
           param :template, String, :required => true
           param :snippet, :bool, :allow_nil => true
           param :audit_comment, String, :allow_nil => true

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -35,6 +35,7 @@ module Api
       def_param_group :provisioning_template do
         param :provisioning_template, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true, :desc => N_("template name")
+          param :description, String
           param :template, String, :required => true
           param :snippet, :bool, :allow_nil => true
           param :audit_comment, String, :allow_nil => true

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -31,6 +31,7 @@ module Api
       def_param_group :ptable do
         param :ptable, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
+          param :description, String
           param :layout, String, :required => true
           param :snippet, :bool, :allow_nil => true
           param :audit_comment, String, :allow_nil => true

--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -30,6 +30,7 @@ module Api
       def_param_group :report_template do
         param :report_template, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
+          param :description, String
           param :template, String, :required => true
           param :snippet, :bool, :allow_nil => true
           param :audit_comment, String, :allow_nil => true

--- a/app/controllers/concerns/foreman/controller/parameters/template.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template.rb
@@ -8,6 +8,7 @@ module Foreman::Controller::Parameters::Template
         :default,
         :locked,
         :name,
+        :description,
         :snippet,
         :template,
         :template_kind, :template_kind_id, :template_kind_name,

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -93,6 +93,7 @@ class Template < ApplicationRecord
     Foreman::Logging.logger('app').debug "setting attributes for #{self.name} with id: #{self.id || 'N/A'}"
     self.snippet = !!@importing_metadata[:snippet]
     self.default = options[:default] unless options[:default].nil?
+    self.description = @importing_metadata[:description]
     handle_lock_on_import(options)
 
     import_taxonomies(options)

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -25,7 +25,7 @@ class Template < ApplicationRecord
 
   before_save :remove_trailing_chars
 
-  attr_exportable :name, :snippet, :template_inputs, :model => ->(template) { template.class.to_s }
+  attr_exportable :name, :description, :snippet, :template_inputs, :model => ->(template) { template.class.to_s }
 
   class Jail < Safemode::Jail
     allow :name

--- a/app/views/api/v2/provisioning_templates/main.json.rabl
+++ b/app/views/api/v2/provisioning_templates/main.json.rabl
@@ -2,4 +2,4 @@ object @provisioning_template
 
 extends "api/v2/provisioning_templates/base"
 
-attributes :snippet, :audit_comment, :created_at, :updated_at
+attributes :snippet, :description, :audit_comment, :created_at, :updated_at

--- a/app/views/api/v2/ptables/main.json.rabl
+++ b/app/views/api/v2/ptables/main.json.rabl
@@ -2,4 +2,4 @@ object @ptable
 
 extends "api/v2/ptables/base"
 
-attributes :os_family, :created_at, :updated_at
+attributes :description, :os_family, :created_at, :updated_at

--- a/app/views/api/v2/report_templates/main.json.rabl
+++ b/app/views/api/v2/report_templates/main.json.rabl
@@ -2,4 +2,4 @@ object @report_template
 
 extends "api/v2/report_templates/base"
 
-attributes :created_at, :updated_at
+attributes :description, :created_at, :updated_at

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -32,6 +32,8 @@
         <%= checkbox_f f, :default, :label=>_('Default'), :label_help => default_template_description %>
       <% end -%>
 
+      <%= textarea_f f, :description, :size => 'col-md-10', :rows => 3, :label => _('Description') %>
+
       <%= render "custom_tabs", :f => f if type == 'ptable' %>
 
       <% if pxe_with_building_hosts?(@template) -%>

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -32,8 +32,6 @@
         <%= checkbox_f f, :default, :label=>_('Default'), :label_help => default_template_description %>
       <% end -%>
 
-      <%= textarea_f f, :description, :size => 'col-md-10', :rows => 3, :label => _('Description') %>
-
       <%= render "custom_tabs", :f => f if type == 'ptable' %>
 
       <% if pxe_with_building_hosts?(@template) -%>
@@ -58,6 +56,8 @@
               }.to_json) %>
         </div>
       </div>
+
+      <%= textarea_f f, :description, :size => 'col-md-10', :rows => 3, :label => _('Description'), :disabled => @template.locked? %>
 
       <%= textarea_f f, :audit_comment, :size => "col-md-10", :rows => 3, :label => _("Audit Comment"),
                      :help_block => _("The Audit Comment field is saved with the template auditing to document the template changes") %>

--- a/db/migrate/20190919155550_add_description_to_templates.rb
+++ b/db/migrate/20190919155550_add_description_to_templates.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToTemplates < ActiveRecord::Migration[5.2]
+  def change
+    add_column :templates, :description, :text
+  end
+end


### PR DESCRIPTION
Adds description field to templates.
![ScreenShot-1568909963756](https://user-images.githubusercontent.com/32508194/65262244-33662980-db0a-11e9-8d04-739d9ed4cdc9.png)

Chages are in UI and API (probably will require a PR to hammer to add the field there as well).