### PR TITLE
Fixes #27897 - Parameter type is not required

### DIFF
--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -56,7 +56,7 @@ module Api
           param :group_parameters_attributes, Array, :required => false, :desc => N_("Array of parameters") do
             param :name, String, :desc => N_("Name of the parameter"), :required => true
             param :value, String, :desc => N_("Parameter value"), :required => true
-            param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value"), :required => true
+            param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value")
             param :hidden_value, :bool
           end
           Hostgroup.registered_smart_proxies.each do |name, options|

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -100,7 +100,7 @@ module Api
           param :host_parameters_attributes, Array, :desc => N_("Host's parameters (array or indexed hash)") do
             param :name, String, :desc => N_("Name of the parameter"), :required => true
             param :value, String, :desc => N_("Parameter value"), :required => true
-            param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value"), :required => true
+            param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value")
             param :hidden_value, :bool
           end
           param :build, :bool

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -39,7 +39,7 @@ class Parameter < ApplicationRecord
   default_scope -> { order("parameters.name") }
 
   before_create :set_priority
-  before_save :set_searchable_value
+  before_save :set_searchable_value, :set_default_key_type
 
   PRIORITY = { :common_parameter => 0,
                :organization_parameter => 10,
@@ -76,6 +76,10 @@ class Parameter < ApplicationRecord
   end
 
   private
+
+  def set_default_key_type
+    self.key_type ||= Parameter::KEY_TYPES.first
+  end
 
   def set_searchable_value
     self.searchable_value = Parameter.format_value_before_type_cast(value, key_type)

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -236,6 +236,21 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
       assert_equal 42, show_response['parameters'].first['value'].to_i
       assert_equal 'integer', show_response['parameters'].first['parameter_type']
     end
+
+    test "should create a group parameter with default parameter type" do
+      hostgroup_params = [{ :name => "foo", :value => 42 }]
+      post :create, params: { hostgroup: valid_attrs.merge(parameters: hostgroup_params) }
+      assert_response :success
+    end
+
+    test "should show a group parameter with default parameter type" do
+      hostgroup = FactoryBot.create(:hostgroup)
+      hostgroup.group_parameters.create!(:name => "foo", :value => 42)
+      get :show, params: { :id => hostgroup.id }
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 42, show_response['parameters'].first['value']
+      assert_equal 'string', show_response['parameters'].first['parameter_type']
+    end
   end
 
   context 'hidden parameters' do

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -994,6 +994,22 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       assert_equal 42, show_response['parameters'].first['value'].to_i
       assert_equal 'integer', show_response['parameters'].first['parameter_type']
     end
+
+    test "should create an host parameter with default parameter type" do
+      host = FactoryBot.build(:host)
+      host_params = [{ :name => "foo", :value => 42 }]
+      post :create, params: { host: host.attributes.merge(parameters: host_params) }
+      assert_response :success
+    end
+
+    test "should show an host parameter with default parameter type" do
+      host = FactoryBot.create(:host)
+      host.host_parameters.create!(:name => "foo", :value => 42)
+      get :show, params: { :id => host.id }
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal 42, show_response['parameters'].first['value'].to_i
+      assert_equal 'string', show_response['parameters'].first['parameter_type']
+    end
   end
 
   context 'hidden parameters' do


### PR DESCRIPTION
As I mentioned in the issue, it causes backward incompatibility (at least in the [hammer](https://projects.theforeman.org/issues/27868), but there could be a problem in the custom scripts that use API).