### PR TITLE
Fixes #27900 - Associate features before validation

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -24,7 +24,8 @@ class SmartProxy < ApplicationRecord
     :uniqueness => { :message => N_('Only one declaration of a proxy is allowed') }
 
   # There should be no problem with associating features before the proxy is saved as the whole operation is in a transaction
-  before_save :sanitize_url, :associate_features
+  before_save :sanitize_url
+  before_validation :associate_features
 
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :url, :complete_value => :true


### PR DESCRIPTION
We want to run associate_features before validation.
One way to test this is to edit a smart proxy with some dummy URL.
**Before change:** Update goes through fine.
**After change:** If foreman is unable to communicate with the URL, you get an error when saving.
