### PR TITLE
Fixes #27903 - Do not init template-form-elements

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -135,6 +135,7 @@ function add_child_node(item) {
   $('a[rel="popover"]').popover();
   $('a[rel="twipsy"]').tooltip();
   activate_select2($(field).not('.matcher_key'));
+  tfm.numFields.initAll(field);
   return new_id;
 }
 

--- a/webpack/assets/javascripts/jquery.ui.custom_spinners.js
+++ b/webpack/assets/javascripts/jquery.ui.custom_spinners.js
@@ -106,55 +106,72 @@ $(() => {
   });
 });
 
-export function initAll() {
-  initByte();
-  initCounter();
+export function initAll(selection = null) {
+  // might be called with Event-argument, if used as EventHandler
+  if (
+    selection !== null &&
+    typeof selection === 'object' &&
+    (selection.hasOwnProperty('originalEvent') ||
+      selection.constructor === $.Event)
+  ) {
+    selection = null;
+  }
+  initByte(selection);
+  initCounter(selection);
 }
 
-export function initCounter() {
-  $('input.counter_spinner').each(function() {
-    const field = $(this);
-    const errorMessage = field.closest('.form-group').find('.maximum-limit');
-    let min = field.data('min');
-    min = typeof min === 'number' ? min : 1;
+export function initCounter(selection = null) {
+  // Do not initialize form_templates
+  $('input.counter_spinner', selection)
+    .not('.form_template input.counter_spinner')
+    .each(function() {
+      const field = $(this);
+      const errorMessage = field.closest('.form-group').find('.maximum-limit');
+      let min = field.data('min');
+      min = typeof min === 'number' ? min : 1;
 
-    field.limitedSpinner({
-      softMaximum: field.data('softMax'),
-      errorTarget: errorMessage,
-      min,
+      field.limitedSpinner({
+        softMaximum: field.data('softMax'),
+        errorTarget: errorMessage,
+        min,
+      });
+
+      field.change(() => {
+        field.limitedSpinner('validate');
+      });
+
+      field
+        .parents('div.form-group')
+        .find('label a')
+        .popover();
     });
-
-    field.change(() => {
-      field.limitedSpinner('validate');
-    });
-
-    field
-      .parents('div.form-group')
-      .find('label a')
-      .popover();
-  });
 }
 
-export function initByte() {
-  $('input.byte_spinner').each(function() {
-    const field = $(this);
-    const errorMessage = field.closest('.form-group').find('.maximum-limit');
-    const valueTarget = field.closest('.form-group').find('.real-hidden-value');
+export function initByte(selection = null) {
+  // Do not initialize form_templates
+  $('input.byte_spinner', selection)
+    .not('.form_template input.byte_spinner')
+    .each(function() {
+      const field = $(this);
+      const errorMessage = field.closest('.form-group').find('.maximum-limit');
+      const valueTarget = field
+        .closest('.form-group')
+        .find('.real-hidden-value');
 
-    field.byteSpinner({
-      valueTarget,
-      softMaximum: field.data('softMax'),
-      errorTarget: errorMessage,
+      field.byteSpinner({
+        valueTarget,
+        softMaximum: field.data('softMax'),
+        errorTarget: errorMessage,
+      });
+
+      field.change(() => {
+        field.byteSpinner('updateValueTarget');
+        field.byteSpinner('validate');
+      });
+
+      field
+        .parents('div.form-group')
+        .find('label a')
+        .popover();
     });
-
-    field.change(() => {
-      field.byteSpinner('updateValueTarget');
-      field.byteSpinner('validate');
-    });
-
-    field
-      .parents('div.form-group')
-      .find('label a')
-      .popover();
-  });
 }


### PR DESCRIPTION
fixes problem with not initialized counter and byte-size input elements
within dynamically added volumes of compute-resources in host-create

This fixed the error for me on https://github.com/theforeman/foreman_fog_proxmox, but I am open for better solutions :wink: 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
