### PR TITLE
Fixes #27904 - allow set min for ui-spinner

### DIFF
--- a/webpack/assets/javascripts/jquery.ui.custom_spinners.js
+++ b/webpack/assets/javascripts/jquery.ui.custom_spinners.js
@@ -10,6 +10,7 @@ $(() => {
   $.widget('ui.limitedSpinner', $.ui.spinner, {
     options: {
       softMaximum: 0,
+      min: 1,
       errorTarget: null,
     },
     validate() {
@@ -114,11 +115,13 @@ export function initCounter() {
   $('input.counter_spinner').each(function() {
     const field = $(this);
     const errorMessage = field.closest('.form-group').find('.maximum-limit');
+    let min = field.data('min');
+    min = typeof min === 'number' ? min : 1;
 
     field.limitedSpinner({
       softMaximum: field.data('softMax'),
       errorTarget: errorMessage,
-      min: 1,
+      min,
     });
 
     field.change(() => {


### PR DESCRIPTION
allow specifying a minimum-value for `counter_f` ui-elements using `data-min` attribute.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
