### PR TITLE
Fixes #27907 - Add update_subnets_from_facts setting

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -409,7 +409,10 @@ class Host::Managed < Host::Base
   end
 
   def attributes_to_import_from_facts
-    attrs = [:architecture, :hostgroup]
+    attrs = [:architecture]
+    if Setting[:update_hostgroup_from_facts]
+      attrs << :hostgroup
+    end
     if !Setting[:ignore_facts_for_operatingsystem] || (Setting[:ignore_facts_for_operatingsystem] && operatingsystem.blank?)
       attrs << :operatingsystem
     end

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -19,6 +19,7 @@ class Setting::Puppet < Setting
       self.set('use_uuid_for_certificates', N_("Foreman will use random UUIDs for certificate signing instead of hostnames"), false, N_('Use UUID for certificates')),
       self.set('update_environment_from_facts', N_("Foreman will update a host's environment from its facts"), false, N_('Update environment from facts')),
       self.set('update_subnets_from_facts', N_("Foreman will update a host's subnet from its facts"), 'none', N_('Update subnets from facts'), nil, { :collection => Proc.new { self.update_subnets_from_facts_types } }),
+      self.set('update_hostgroup_from_facts', N_("Foreman will update a host's hostgroup from its facts"), true, N_('Update hostgroup from facts')),
       self.set('matchers_inheritance', N_("Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"), true, N_('Matchers inheritance')),
       self.set('create_new_host_when_facts_are_uploaded', N_("Foreman will create the host when new facts are received"), true, N_('Create new host when facts are uploaded')),
       self.set('create_new_host_when_report_is_uploaded', N_("Foreman will create the host when a report is received"), true, N_('Create new host when report is uploaded')),

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -421,3 +421,8 @@ attribute92:
   category: Setting::Auth
   default: 'External'
   description: 'Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'
+attribute93:
+  name: update_hostgroup_from_facts
+  category: Setting::Puppet
+  default: true
+  description: "Foreman will update a host's hostgroup from its facts"

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -812,6 +812,31 @@ class HostTest < ActiveSupport::TestCase
       end
     end
 
+    test 'host hostgroup updated from facts' do
+      Setting[:update_hostgroup_from_facts] = true
+
+      raw = read_json_fixture('facts/facts.json')
+      raw['facts']['foreman_hostgroup'] = 'base'
+      hostgroup = FactoryBot.create(:hostgroup, :name => 'base')
+      host = FactoryBot.create(:host, :hostgroup => FactoryBot.create(:hostgroup, :name => 'test'))
+      assert host.import_facts(raw['facts'])
+      host.reload
+      assert_equal hostgroup, host.hostgroup
+    end
+
+    test 'host hostgroup not updated from facts' do
+      Setting[:update_hostgroup_from_facts] = false
+
+      raw = read_json_fixture('facts/facts.json')
+      raw['facts']['foreman_hostgroup'] = 'base'
+      FactoryBot.create(:hostgroup, :name => 'base')
+      hostgroup = FactoryBot.create(:hostgroup, :name => 'test')
+      host = FactoryBot.create(:host, :hostgroup => hostgroup)
+      assert host.import_facts(raw['facts'])
+      host.reload
+      assert_equal hostgroup, host.hostgroup
+    end
+
     describe 'a host with primary interface on a bond' do
       let(:raw_facts) { read_json_fixture('facts/facts_with_primary_interface_bond.json').merge(_type: 'puppet') }
       let(:hostname) { 'host01.example.com' }


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Allow hostgroup updates from facts to be disabled via the
update_subnets_from_facts setting