### PR TITLE
Fixes #27914 - Drop puppet_server setting

### DIFF
--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -5,7 +5,6 @@ class Setting::Puppet < Setting
       self.set('puppet_out_of_sync_disabled', N_("Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval") % 'Puppet', false, N_('%s out of sync disabled') % 'Puppet'),
       self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Proc.new {Hash[Environment.all.map {|env| [env[:name], env[:name]]}]} }),
       self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),
-      self.set('puppet_server', N_("Default Puppet server hostname"), "puppet", N_('Puppet server')),
       self.set('Default_variables_Lookup_Path', N_("Foreman will evaluate host smart variables in this order by default"), ["fqdn", "hostgroup", "os", "domain"], N_('Default variables lookup path')),
       self.set('Enable_Smart_Variables_in_ENC', N_("Foreman smart variables will be exposed via the ENC yaml output"), true, N_('Enable smart variables in ENC')),
       self.set('Parametrized_Classes_in_ENC', N_("Foreman will use the new (2.6.5+) format for classes in the ENC yaml output"), true, N_('Parameterized classes in ENC')),

--- a/db/migrate/20190923180644_drop_puppet_server_setting.rb
+++ b/db/migrate/20190923180644_drop_puppet_server_setting.rb
@@ -1,0 +1,9 @@
+class DropPuppetServerSetting < ActiveRecord::Migration[5.2]
+  def up
+    Setting.where(:name => 'puppet_server').delete_all
+  end
+
+  def down
+    # settings would be created by Setting on code version that uses it
+  end
+end

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -84,7 +84,6 @@ module Foreman
         :outofsync_interval,
         :default_puppet_environment,
         :puppetrun,
-        :puppet_server,
         :update_ip_from_built_request,
       ]
 

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -46,11 +46,6 @@ attributes9:
   category: Setting::Puppet
   default: production
   description: "The Setting::Puppet environment foreman would default to in case it can't auto detect it"
-attributes12:
-  name: puppet_server
-  category: Setting::Puppet
-  default: puppet
-  description: Default Setting::Puppet Server hostname
 attributes13:
   name: failed_report_email_notification
   category: Setting::Puppet


### PR DESCRIPTION
ace6fbadcda81080648fbc06a8f3d2ec552bb0bf stopped using this setting and 7c08e30a47a16d387f26d1c617cdedc60d9d0582 removed it from the example file, but it was never removed from the database.