### PR TITLE
Fixes #27881 - fix jQuery disabled buttons listener

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -34,9 +34,9 @@ $(function() {
 $(document).on('click', 'a[disabled="disabled"]', function(evt) {
   // this check is required in case the link was "enabled" after the
   // function has registered.
-  this.disabled = this.disabled || $(this).attr('disabled') === 'disabled';
-  if (this.disabled) evt.preventDefault();
-  return !this.disabled;
+  var disabled = this.disabled || $(this).attr('disabled') === 'disabled';
+  if (disabled) evt.preventDefault();
+  return !disabled;
 });
 
 function onContentLoad() {


### PR DESCRIPTION
Disabled button is clickable after the first click,
it seem that changing the disable on the jQuery `this` pointer is causing it.
saving this to var instead, seems to resolve the issue. 