### PR TITLE
Fixes #26816 - fixed bug in major, minor filtering

### DIFF
--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -142,6 +142,63 @@ module Hostext
           assert_empty result
         end
       end
+
+      context "search by operatingsystem major and minor" do
+        let (:operatingsystem) { FactoryBot.create(:operatingsystem, :major => '7', :minor => '6.1810') }
+        let (:host) { FactoryBot.create(:host, :operatingsystem => operatingsystem) }
+
+        test "searching os_major returns correct host" do
+          result = Host.search_for("os_major > 5")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_major < 10")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_major = 7")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_major <= 7")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_major >= 7")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_major < 5")
+          assert_equal(0, result.count)
+          assert_empty result
+        end
+
+        test "searching os_minor returns correct host" do
+          result = Host.search_for("os_minor > 6.2")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_minor < 10")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_minor = 6.1810")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_minor <= 6.1810")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_minor >= 6.1810")
+          assert_equal(1, result.count)
+          assert_equal(host.id, result.first.id)
+
+          result = Host.search_for("os_minor < 6")
+          assert_equal(0, result.count)
+          assert_empty result
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Description of problem:

Filter by os_minor includes unexpected values.

Version-Release number of selected component (if applicable):

How reproducible:

To reproduce:

1. navigate to Hosts => All Hosts
2. enter the following filter: "os_major = 6 and os_minor < 4" and click Search

If version 6.10 is included in the search results, even though 10 is not < than 4.

Notice in the other attached that 6.2 and 6.3 servers are also mentioned, and no 6.4 through 6.9 servers are in the results. However, 6.10 should also not show

Expected: only 6.0, 6.1, 6.2 and 6.3 servers should show


The reason is that minor version of OS is treated as a string, because it can contain non-numerical characters, e.g. 2.1511 in case of CentOS. Therefore we can only compare these value lexically. And 10 is lexically lower than 6, since 1 is earlier in alphabet than 6. For search purposes we could break all numbers apart and store them in DB as integers.