### PR TITLE
fixes #27931 - 'Could not match network interface'

### DIFF
--- a/app/models/concerns/fog_extensions/vsphere/server.rb
+++ b/app/models/concerns/fog_extensions/vsphere/server.rb
@@ -40,7 +40,7 @@ module FogExtensions
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
         all_networks = service.list_networks(datacenter: datacenter)
-        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network[:name], network[:id], network[:_ref]].compact.include?(nic_attrs['network']) }
+        vm_network = all_networks.detect { |network| nic_attrs['network'] && [network[:name], network[:id]].compact.include?(nic_attrs['network']) }
         vm_network ||= all_networks.detect { |network| network[:_ref] == nic_attrs['network'] }
         unless vm_network
           Rails.logger.info "Could not find Vsphere network for #{nic_attrs.inspect}"


### PR DESCRIPTION
This fixes failure creating a VMware backed host, possibly only where vCenter was upgraded from 6.0 or earlier.  The original issue is [#23909](https://projects.theforeman.org/issues/23909) which was fixed in f5ea70a and regressed in 5150a1d.