### PR TITLE
Fixes #27941 - Set timezone based on browser timezone

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -53,7 +53,7 @@ module ApplicationHelper
   end
 
   def iana_timezone
-    ActiveSupport::TimeZone::MAPPING[Time.zone.try(:name)] || 'UTC'
+    Time.zone&.tzinfo&.name || 'UTC'
   end
 
   protected


### PR DESCRIPTION
The date/time displays in katello pages uses react components which aren't handling timezones correctly based on browser timezone. 
From what I found, https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/common/I18n.js#L35 uses attribute 'data-timezone' which is set in https://github.com/theforeman/foreman/search?q=iana_timezone&unscoped_q=iana_timezone with the timezone of the server.
We should ideally fetch user's browser timezone to display dates.

