### PR TITLE
Fixes #27946 - fix redux devtools setup

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -1,6 +1,6 @@
 import createLogger from 'redux-logger';
 import thunk from 'redux-thunk';
-import { applyMiddleware, createStore } from 'redux';
+import { applyMiddleware, createStore, compose } from 'redux';
 
 import reducers from './reducers';
 
@@ -18,13 +18,10 @@ const useLogger = () => {
 
 if (useLogger()) middleware = [...middleware, createLogger()];
 
+const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
+
 export const generateStore = () =>
-  createStore(
-    reducers,
-    window.__REDUX_DEVTOOLS_EXTENSION__ &&
-      window.__REDUX_DEVTOOLS_EXTENSION__(),
-    applyMiddleware(...middleware)
-  );
+  createStore(reducers, composeEnhancers(applyMiddleware(...middleware)));
 
 const store = generateStore();
 


### PR DESCRIPTION
According to [Redux Devtools](https://github.com/zalmoxisus/redux-devtools-extension) the setup for an advanced store (store with middleware) should be different.

After upgrading redux ([here](https://github.com/theforeman/foreman/pull/6981)) an error appeared which is related to the `createStore` setup, this PR fixes that error as well