### PR TITLE
Fixes #26729 - add polling to API middleware

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -5,10 +5,12 @@ Object {
   "action": Array [
     Array [
       Object {
+        "key": "BOOKMARKS",
         "payload": Object {
           "controller": "models",
         },
-        "type": "BOOKMARKS_REQUEST",
+        "type": "API_GET",
+        "url": "/api/bookmarks?search=controller%3Dmodels&per_page=100",
       },
     ],
   ],

--- a/webpack/assets/javascripts/react_app/redux/API/APIMiddleware.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIMiddleware.js
@@ -1,11 +1,16 @@
 import { API_OPERATIONS, actionTypeGenerator } from './';
 import { get } from './APIRequest';
+import { startInterval } from '../middlewares/IntervalMiddleware';
 
 export const APIMiddleware = store => next => action => {
-  const { type, key, payload = {}, url, actionTypes = {} } = action;
+  const { type, key, payload = {}, url, actionTypes = {}, polling } = action;
   if (type === API_OPERATIONS.GET) {
-    get(payload, url, store, actionTypeGenerator(key, actionTypes));
-  } else {
-    next(action);
+    const APIActionTypes = actionTypeGenerator(key, actionTypes);
+    const APIRequest = () => get(payload, url, store, APIActionTypes);
+    if (polling) {
+      return store.dispatch(startInterval(key, APIRequest, polling));
+    }
+    APIRequest();
   }
+  return next(action);
 };

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APIMiddleware.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APIMiddleware.test.js
@@ -9,9 +9,19 @@ describe('APIMiddleware', () => {
     APIMiddleware()(jest.fn())({ type: 'TEST' });
     expect(get.mock.calls).toHaveLength(0);
   });
+
   it('should call get request', async () => {
     get.mockImplementation(jest.fn());
     APIMiddleware()(jest.fn())({ type: API_OPERATIONS.GET });
     expect(get).toBeCalled();
+  });
+
+  it('should pass the API action to next', () => {
+    const fakeStore = {};
+    const fakeNext = jest.fn();
+
+    const action = { type: API_OPERATIONS.GET };
+    APIMiddleware(fakeStore)(fakeNext)(action);
+    expect(fakeNext).toHaveBeenCalledWith(action);
   });
 });

--- a/webpack/assets/javascripts/react_app/redux/API/index.js
+++ b/webpack/assets/javascripts/react_app/redux/API/index.js
@@ -1,4 +1,4 @@
 export { actionTypeGenerator } from './APIActionTypeGenerator';
 export { API_OPERATIONS } from './APIConstants';
-export { get, APIMiddleware } from './APIMiddleware';
+export { APIMiddleware } from './APIMiddleware';
 export { default as API } from './API';

--- a/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.fixtures.js
@@ -1,5 +1,9 @@
 import immutable from 'seamless-immutable';
-import { BOOKMARKS_REQUEST, BOOKMARKS_SUCCESS } from '../../consts';
+import {
+  BOOKMARKS_REQUEST,
+  BOOKMARKS_SUCCESS,
+  BOOKMARKS_FAILURE,
+} from '../../consts';
 import { bookmarks } from '../../reducers/bookmarks/bookmarks.fixtures';
 
 export const initialState = immutable({
@@ -16,6 +20,13 @@ export const requestData = {
   response: { results: bookmarks },
 };
 
+const APIMiddlewareAction = {
+  key: 'BOOKMARKS',
+  payload: { controller: 'hosts' },
+  type: 'API_GET',
+  url: '/api/bookmarks?search=controller%3Dhosts&per_page=100',
+};
+
 const requestAction = {
   type: BOOKMARKS_REQUEST,
   payload: { controller: 'hosts' },
@@ -23,21 +34,23 @@ const requestAction = {
 
 export const onFailureActions = [
   requestAction,
+  APIMiddlewareAction,
   {
     payload: {
       error: new Error('Request failed with status code 422'),
       payload: { controller: 'hosts' },
     },
-    type: 'BOOKMARKS_FAILURE',
+    type: BOOKMARKS_FAILURE,
   },
 ];
 
 export const onSuccessActions = [
   requestAction,
+  APIMiddlewareAction,
   {
     payload: {
-      results: bookmarks,
       controller: 'hosts',
+      results: bookmarks,
     },
     type: BOOKMARKS_SUCCESS,
   },

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
@@ -1,15 +1,3 @@
-const mockSuccessRequests = [
-  {
-    path: '/hosts/:id/power',
-    searchRegex: '/hosts/1/power',
-    response: {
-      id: 1,
-      state: 'na',
-      title: 'N/A',
-    },
-  },
-];
-
 export const requestData = {
   failRequest: { id: 0, url: '/hosts/0/power' },
   successRequest: { id: 1, url: '/hosts/1/power' },
@@ -17,6 +5,12 @@ export const requestData = {
 
 export const onFailureActions = [
   { payload: { id: 0 }, type: 'HOST_POWER_STATUS_REQUEST' },
+  {
+    key: 'HOST_POWER_STATUS',
+    payload: { id: 0 },
+    type: 'API_GET',
+    url: '/hosts/0/power',
+  },
   {
     payload: {
       error: new Error('Request failed with status code 500'),
@@ -29,7 +23,13 @@ export const onFailureActions = [
 export const onSuccessActions = [
   { payload: { id: 1 }, type: 'HOST_POWER_STATUS_REQUEST' },
   {
-    payload: mockSuccessRequests[0].response,
+    key: 'HOST_POWER_STATUS',
+    payload: { id: 1 },
+    type: 'API_GET',
+    url: '/hosts/1/power',
+  },
+  {
+    payload: { id: 1, state: 'na', title: 'N/A' },
     type: 'HOST_POWER_STATUS_SUCCESS',
   },
 ];

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
@@ -23,52 +23,75 @@ export const successRequestData = [
   payloads.architecture,
 ];
 
+const actions = {
+  architectures: {
+    REQUEST: {
+      payload: payloads.architecture,
+      type: 'STATISTICS_DATA_REQUEST',
+    },
+    SUCCESS: {
+      payload: {
+        data: [['x86_64', 6]],
+        ...payloads.architecture,
+      },
+      type: 'STATISTICS_DATA_SUCCESS',
+    },
+    FAILURE: {
+      payload: {
+        error: new Error('Request failed with status code 422'),
+        payload: payloads.architecture,
+      },
+      type: 'STATISTICS_DATA_FAILURE',
+    },
+    API_MIDDLEWARE: {
+      key: 'STATISTICS_DATA',
+      payload: payloads.architecture,
+      type: 'API_GET',
+      url: 'statistics/architecture',
+    },
+  },
+  operatingsystem: {
+    REQUEST: {
+      payload: payloads.operatingsystem,
+      type: 'STATISTICS_DATA_REQUEST',
+    },
+    SUCCESS: {
+      payload: {
+        data: [['centOS 7.1', 6]],
+        ...payloads.operatingsystem,
+      },
+      type: 'STATISTICS_DATA_SUCCESS',
+    },
+    FAILURE: {
+      payload: {
+        error: new Error('Request failed with status code 422'),
+        payload: payloads.operatingsystem,
+      },
+      type: 'STATISTICS_DATA_FAILURE',
+    },
+    API_MIDDLEWARE: {
+      key: 'STATISTICS_DATA',
+      payload: payloads.operatingsystem,
+      type: 'API_GET',
+      url: 'statistics/operatingsystem',
+    },
+  },
+};
+
 export const onSuccessActions = [
-  {
-    payload: payloads.operatingsystem,
-    type: 'STATISTICS_DATA_REQUEST',
-  },
-  {
-    payload: payloads.architecture,
-    type: 'STATISTICS_DATA_REQUEST',
-  },
-  {
-    payload: {
-      data: [['centOS 7.1', 6]],
-      ...payloads.operatingsystem,
-    },
-    type: 'STATISTICS_DATA_SUCCESS',
-  },
-  {
-    payload: {
-      data: [['x86_64', 6]],
-      ...payloads.architecture,
-    },
-    type: 'STATISTICS_DATA_SUCCESS',
-  },
+  actions.operatingsystem.REQUEST,
+  actions.operatingsystem.API_MIDDLEWARE,
+  actions.architectures.REQUEST,
+  actions.architectures.API_MIDDLEWARE,
+  actions.operatingsystem.SUCCESS,
+  actions.architectures.SUCCESS,
 ];
 
 export const onFailureActions = [
-  {
-    payload: payloads.operatingsystem,
-    type: 'STATISTICS_DATA_REQUEST',
-  },
-  {
-    payload: payloads.architecture,
-    type: 'STATISTICS_DATA_REQUEST',
-  },
-  {
-    payload: {
-      error: new Error('Request failed with status code 422'),
-      payload: payloads.operatingsystem,
-    },
-    type: 'STATISTICS_DATA_FAILURE',
-  },
-  {
-    payload: {
-      error: new Error('Request failed with status code 422'),
-      payload: payloads.architecture,
-    },
-    type: 'STATISTICS_DATA_FAILURE',
-  },
+  actions.operatingsystem.REQUEST,
+  actions.operatingsystem.API_MIDDLEWARE,
+  actions.architectures.REQUEST,
+  actions.architectures.API_MIDDLEWARE,
+  actions.operatingsystem.FAILURE,
+  actions.architectures.FAILURE,
 ];

--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -4,9 +4,9 @@ import { applyMiddleware, createStore, compose } from 'redux';
 
 import reducers from './reducers';
 
-import { APIMiddleware } from './API';
+import { IntervalMiddleware, APIMiddleware } from './middlewares';
 
-let middleware = [thunk, APIMiddleware];
+let middleware = [thunk, APIMiddleware, IntervalMiddleware];
 
 const useLogger = () => {
   const isProduction = process.env.NODE_ENV === 'production';

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalActions.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalActions.js
@@ -1,0 +1,18 @@
+import { STOP_INTERVAL, START_INTERVAL } from './IntervalConstants';
+
+export const stopInterval = key => ({
+  type: STOP_INTERVAL,
+  payload: {
+    key,
+  },
+});
+
+export const startInterval = (key, method, interval, ...args) => ({
+  type: START_INTERVAL,
+  payload: {
+    key,
+    method,
+    interval,
+    args: [...args],
+  },
+});

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalConstants.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalConstants.js
@@ -1,0 +1,3 @@
+export const START_INTERVAL = 'START_INTERVAL';
+export const STOP_INTERVAL = 'STOP_INTERVAL';
+export const DEFAULT_INTERVAL = 5000;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalFixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalFixtures.js
@@ -1,0 +1,8 @@
+import { noop } from '../../../common/helpers';
+
+export const key = 'SOME_KEY';
+export const method = noop;
+export const interval = 3000;
+export const intervalID = 1212;
+export const initialState = {};
+export const stateWithKey = { [key]: intervalID };

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalHelpers.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalHelpers.js
@@ -1,0 +1,5 @@
+export const registeredIntervalException = key =>
+  new Error(`There is already an interval running and registered for: ${key}.`);
+
+export const unregisteredIntervalException = key =>
+  new Error(`Can't find a registered interval process for: ${key}`);

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalMiddleware.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalMiddleware.js
@@ -1,0 +1,36 @@
+import { START_INTERVAL, STOP_INTERVAL } from './IntervalConstants';
+import { selectIntervalID } from './IntervalSelectors';
+import { amendActionsPayload } from '../common/helpers';
+import {
+  registeredIntervalException,
+  unregisteredIntervalException,
+} from './IntervalHelpers';
+
+export const IntervalMiddleware = store => next => action => {
+  const { type, payload: { key, method, interval, args } = {} } = action;
+  const state = store.getState();
+
+  if (type === START_INTERVAL) {
+    const intervalAlreadyExist = !!selectIntervalID(state, key);
+
+    if (intervalAlreadyExist) {
+      throw registeredIntervalException(key);
+    }
+
+    method(); // force the method to run for the first time.
+    const intervalID = setInterval(method, interval, ...args);
+    return next(amendActionsPayload(action, { intervalID }));
+  }
+
+  if (type === STOP_INTERVAL) {
+    const intervalID = selectIntervalID(state, key);
+
+    if (!intervalID) {
+      throw unregisteredIntervalException(key);
+    }
+    clearInterval(intervalID);
+  }
+  return next(action);
+};
+
+export default IntervalMiddleware;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalReducer.js
@@ -1,0 +1,20 @@
+import Immutable from 'seamless-immutable';
+import { START_INTERVAL, STOP_INTERVAL } from './IntervalConstants';
+
+const initialState = Immutable({});
+
+export const reducer = (state = initialState, action) => {
+  const { type, payload: { key, intervalID } = {} } = action;
+  switch (type) {
+    case START_INTERVAL:
+      return state.merge({ [key]: intervalID });
+    case STOP_INTERVAL:
+      return state.without(key);
+    default:
+      return state;
+  }
+};
+
+export const reducers = { intervals: reducer };
+
+export default reducer;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalSelectors.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalSelectors.js
@@ -1,0 +1,2 @@
+export const selectIntervals = state => state.intervals || {};
+export const selectIntervalID = (state, key) => selectIntervals(state)[key];

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalActions.test.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalActions.test.js
@@ -1,0 +1,10 @@
+import { testActionSnapshotWithFixtures } from '../../../../common/testHelpers';
+import { startInterval, stopInterval } from '../IntervalActions';
+import { key, method, interval } from '../IntervalFixtures';
+
+const fixtures = {
+  'should start interval': () => startInterval(key, method, interval),
+  'should stop interval': () => stopInterval(key),
+};
+
+describe('API actions', () => testActionSnapshotWithFixtures(fixtures));

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalReducer.test.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalReducer.test.js
@@ -1,0 +1,40 @@
+import Immutable from 'seamless-immutable';
+import { START_INTERVAL, STOP_INTERVAL } from '../IntervalConstants';
+import { reducer } from '../IntervalReducer';
+
+import { testReducerSnapshotWithFixtures } from '../../../../common/testHelpers';
+import {
+  key,
+  intervalID,
+  stateWithKey,
+  initialState,
+} from '../IntervalFixtures';
+
+const fixtures = {
+  'should return the initial state': initialState,
+  'should handle START_INTERVAL': {
+    action: {
+      type: START_INTERVAL,
+      payload: {
+        key,
+        intervalID,
+      },
+    },
+  },
+};
+
+describe('API reducer', () => {
+  testReducerSnapshotWithFixtures(reducer, fixtures);
+
+  it('Should handle STOP_INTERVAL', () => {
+    const state = Immutable(stateWithKey);
+    const stopAction = {
+      type: STOP_INTERVAL,
+      payload: {
+        key,
+      },
+    };
+
+    expect(reducer(state, stopAction)).toMatchSnapshot();
+  });
+});

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalSelectors.test.js
@@ -1,0 +1,15 @@
+import { testSelectorsSnapshotWithFixtures } from '../../../../common/testHelpers';
+import { selectIntervals, selectIntervalID } from '../IntervalSelectors';
+import { key, stateWithKey } from '../IntervalFixtures';
+
+const state = {
+  intervals: stateWithKey,
+};
+
+const fixtures = {
+  'should return the intervals wrapper': () => selectIntervals(state),
+  'should return the interval ID': () => selectIntervalID(state, key),
+};
+
+describe('intervals selectors', () =>
+  testSelectorsSnapshotWithFixtures(fixtures));

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalActions.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`API actions should start interval 1`] = `
+Object {
+  "payload": Object {
+    "args": Array [],
+    "interval": 3000,
+    "key": "SOME_KEY",
+    "method": [Function],
+  },
+  "type": "START_INTERVAL",
+}
+`;
+
+exports[`API actions should stop interval 1`] = `
+Object {
+  "payload": Object {
+    "key": "SOME_KEY",
+  },
+  "type": "STOP_INTERVAL",
+}
+`;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalReducer.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`API reducer Should handle STOP_INTERVAL 1`] = `Object {}`;
+
+exports[`API reducer should handle START_INTERVAL 1`] = `
+Object {
+  "SOME_KEY": 1212,
+}
+`;
+
+exports[`API reducer should return the initial state 1`] = `Object {}`;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalSelectors.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`intervals selectors should return the interval ID 1`] = `1212`;
+
+exports[`intervals selectors should return the intervals wrapper 1`] = `
+Object {
+  "SOME_KEY": 1212,
+}
+`;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/index.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/index.js
@@ -1,0 +1,3 @@
+export { IntervalMiddleware } from './IntervalMiddleware';
+export { reducers } from './IntervalReducer';
+export { startInterval, stopInterval } from './IntervalActions';

--- a/webpack/assets/javascripts/react_app/redux/middlewares/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/common/helpers.js
@@ -1,0 +1,7 @@
+export const amendActionsPayload = (action, extPayload) => ({
+  ...action,
+  payload: {
+    ...action.payload,
+    ...extPayload,
+  },
+});

--- a/webpack/assets/javascripts/react_app/redux/middlewares/index.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/index.js
@@ -1,0 +1,2 @@
+export { APIMiddleware } from '../API';
+export { IntervalMiddleware } from './IntervalMiddleware';

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -18,6 +18,7 @@ import { reducers as factChartReducers } from '../../components/FactCharts';
 import { reducers as statisticsPageReducers } from '../../routes/Statistics/StatisticsPage';
 import { reducers as fillReducers } from '../../components/common/Fill';
 import { reducers as auditsPageReducers } from '../../routes/Audits/AuditsPage';
+import { reducers as intervalReducers } from '../middlewares/IntervalMiddleware';
 
 export function combineReducersAsync(asyncReducers) {
   return combineReducers({
@@ -38,6 +39,7 @@ export function combineReducersAsync(asyncReducers) {
     ...modelsReducers,
     ...templateGenerationReducers,
     ...factChartReducers,
+    ...intervalReducers,
 
     // Pages
     ...statisticsPageReducers,

--- a/webpack/stories/docs/APIPollingMiddleware.md
+++ b/webpack/stories/docs/APIPollingMiddleware.md
@@ -1,0 +1,55 @@
+# API Middleware with polling
+
+current generic API action looks like this:
+
+```js
+const some_API_action = payload => ({
+  type: API_OPERATIONS.GET,
+  key: MY_API_REQUEST_SPECIAL_KEY,
+  payload,
+});
+```
+
+To use polling, we will need to add the "polling" key:
+
+```js
+const some_API_action = payload => ({
+  type: API_OPERATIONS.GET,
+  key: MY_API_REQUEST_SPECIAL_KEY,
+  polling: 3000, /** value in ms, or true which will use the default values. */  
+  payload,
+});
+```
+
+To stop the polling, we will need to use the "stopPolling" Action from APIActions:
+```js
+// MyComponent/index.js
+import { APIActions } from "../../redux/API";
+// import { APIActions } from "foremanReact/redux/API"; in plugins
+...
+const mapDispatchToProps = dispatch => bindActionCreators( { ...actions, ...APIActions }, dispatch)
+```
+
+Then it will be available in your component:
+```js
+// MyComponent/MyComponent.js
+handlePolling = () => {
+  /**use the same key that was used to create the API request with polling.*/
+  this.props.stopPolling(MY_API_REQUEST_SPECIAL_KEY) 
+}
+```
+
+Instead of adding the APIActions to mapDispatchToProps,
+you could also use the redux-hook to fire the action:
+```js
+// MyComponent/MyComponent.js
+import { useDispatch } from 'react-redux'
+import { stopPolling } from "../../redux/API/APIActions";
+// import { APIActions } from "foremanReact/redux/API/APIActions"; in plugins
+...
+handlePolling = () => {
+  const dispatch = useDispatch()
+  /**use the same key that was used to create the API request with polling.*/
+  dispatch(stopPolling(MY_API_REQUEST_SPECIAL_KEY))
+}
+```

--- a/webpack/stories/index.js
+++ b/webpack/stories/index.js
@@ -10,6 +10,7 @@ import hoc from './docs/hoc.md';
 import addingDependencies from './docs/addingDependencies.md';
 import internationalization from './docs/internationalization.md';
 import APIMiddleware from './docs/APIMiddleware.md';
+import APIPollingMiddleware from './docs/APIPollingMiddleware.md';
 import plugins from './docs/plugins.md';
 import SlotAndFill from './docs/SlotAndFill.md';
 import LegacyJs from './docs/LegacyJs.md';
@@ -71,6 +72,11 @@ storiesOf('Introduction', module)
   .add('API Middleware', () => (
     <Story>
       <Markdown source={APIMiddleware} />
+    </Story>
+  ))
+  .add('API Middleware with polling', () => (
+    <Story>
+      <Markdown source={APIPollingMiddleware} />
     </Story>
   ));
 


### PR DESCRIPTION
current API action looks like this:
```
const some_action = payload => ({
  type: API_OPERATIONS.GET,
  key: MY_API_REQUEST_SPECIAL_KEY,
  payload,
});
```
with polling:
```
const some_action = payload => ({
  type: API_OPERATIONS.GET,
  key: MY_API_REQUEST_SPECIAL_KEY,
  polling: 3000, /** value in ms, or true which will use the default values. */  
  payload,
});
```
How to stop the polling?
_index.js_
```
import { APIActions } from "../../redux/API";
...
const mapDispatchToProps = dispatch => bindActionCreators( { ...actions, ...APIActions }, dispatch);
```
and then use it in your component:
```
handlePolling = () => {
  this.props.stopPolling(MY_API_REQUEST_SPECIAL_KEY)
}
```