### PR TITLE
Fixes #27943 - oVirt instance type throw error on vm creation

### DIFF
--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -21,7 +21,7 @@
              { :disabled    => !new_vm, :'data-url' => instance_type_selected_compute_resource_path(compute_resource),
                :onchange    => 'tfm.computeResource.ovirt.instanceTypeSelected(this);',
                :help_inline => :indicator,
-               :help_block  => _("oVirt/RHEV instance type"),
+               :help_block  => _("oVirt/RHEV instance type. Provided memory, sockets and cores values will be overriden by instance types values"),
                :label       => _('Instance type'), :label_size => "col-md-2" } %>
 <%= f.hidden_field :instance_type if !new_vm %>
 
@@ -38,13 +38,13 @@
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2" } if new_vm && controller_name != "compute_attributes" %>
 
 <%= f.fields_for :display, OpenStruct.new(f.object.display) do |display_f| %>
-  <%= select_f display_f, :type, compute_resource.display_types, :downcase, :upcase, 
+  <%= select_f display_f, :type, compute_resource.display_types, :downcase, :upcase,
                 { },
                 { :label_size => "col-md-2",
                   :label => _("Display Type"),
                   :class => 'display_type',
                   :disabled => f.object.status != "down" && !new_vm } %>
-  <%= select_f display_f, :keyboard_layout, compute_resource.keyboard_layouts, :downcase, :to_s, 
+  <%= select_f display_f, :keyboard_layout, compute_resource.keyboard_layouts, :downcase, :to_s,
                 { },
                 { :label_size => "col-md-2",
                   :label => _("Keyboard"),


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Align VM memory/cpus to templates/instance type ones (if no values found)