### PR TITLE
Fixes #27971 - cleanup logs table during expiration

### DIFF
--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -14,7 +14,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal report_count * 2, Report.count
     assert_difference('Report.count', -1 * report_count) do
       assert_difference(['Log.count', 'Message.count', 'Source.count'], -1 * report_count * 5) do
-        Report.expire({}, 1000, 0.2)
+        Report.expire({}, 1000, 0.2, 0)
       end
     end
   end
@@ -28,7 +28,7 @@ class ReportTest < ActiveSupport::TestCase
     assert_equal report_count * 2, Report.count
     assert_difference('Report.count', -1 * report_count) do
       assert_difference(['Log.count', 'Message.count', 'Source.count'], -1 * report_count * 5) do
-        Report.expire({}, 2, 0.0001)
+        Report.expire({}, 2, 0.0001, 0)
       end
     end
   end
@@ -111,7 +111,7 @@ class ReportTest < ActiveSupport::TestCase
     test '.expire should delete only the class which calls it' do
       FactoryBot.create_list(:config_report, 5, :old_report)
       FactoryBot.create_list(:report, 5, :old_report, :type => 'TestReport')
-      TestReport.expire({}, 1000, 0.2)
+      TestReport.expire({}, 1000, 0.2, 0)
       refute(TestReport.all.any?)
       assert(ConfigReport.all.any?)
     end


### PR DESCRIPTION
Customers with large deployments on puppet or OpenSCAP are suffering
from expiration task not being able to catch up with incoming reports.
It looks like the offender is the "logs" join SQL table which grows up
to 40 GB data + 40 GB indices for about 500k records for a busy
instance.

Deletion of reports is a slow process of deleting records from various
tables joined via "logs". We've identified that if records are deleted
in more straightforward way deletion of reports is much quicker. The
sweet-spot seems to be 50k records. So a query is added to the
expiration rake task to first perform deletion of "old" logs and then
deletion of reports is performed in a much faster fashion.

There must be no join during the logs deletion, thus the query is
"heuristic" and tries to identify last 50k records via primary key which
works great in postgresql. The key is to delete them fast which can be
only achieved with this.

Result is that on instances with many reports, contents of old reports
will be deleted (reports themselves are kept and deleted according to
the standard plan of one week).