### PR TITLE
Refs #27708 - Fixes line chart test snapshots

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/charts/LineChart/LineChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/LineChart/LineChart.fixtures.js
@@ -3,13 +3,6 @@ export const data = [
   ['green', [2, 4, 6], '#89A54E'],
 ];
 
-const createDate = (year, month, day) => new Date(year, month, day).getTime();
+const dates = [1557014400000, 1559779200000, 1562457600000];
 
-export const timeseriesData = [
-  ...data,
-  [
-    'x',
-    [createDate(2019, 4, 5), createDate(2019, 5, 6), createDate(2019, 6, 7)],
-    null,
-  ],
-];
+export const timeseriesData = [...data, ['x', dates, null]];


### PR DESCRIPTION
the snapshot is changing every test,
instead of calling the `new date()` function, we can save these dates into:
`const dates = [1557014400000, 1559779200000, 1562457600000];`
