### PR TITLE
Fixes #27982 - Update desc for compute resource api 'tenant' param

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -40,7 +40,7 @@ module Api
           param :ovirt_quota, String, :desc => N_("for oVirt only, ID of quota to use")
           param :public_key, String, :desc => N_("for oVirt only")
           param :region, String, :desc => N_("for EC2 only, use '%s' for GovCloud region") % Foreman::Model::EC2::GOV_CLOUD_REGION
-          param :tenant, String, :desc => N_("for OpenStack only")
+          param :tenant, String, :desc => N_("for OpenStack and AzureRM only")
           param :domain, String, :desc => N_("for OpenStack (v3) only")
           param :project_domain_name, String, :desc => N_("for OpenStack (v3) only")
           param :project_domain_id, String, :desc => N_("for OpenStack (v3) only")


### PR DESCRIPTION
The `tenant` api param is used currently by openstack. But, it is also used by `foreman_azure_rm` plugin to create compute resource on Azure public cloud. Therefore, this PR simply updates the description specified for the tenant param for the apidoc in order to indicate it is used by AzureRM too.