### PR TITLE
Fixes #28005 - using git hooks before pushing a commit.

### DIFF
--- a/.huskyrc
+++ b/.huskyrc
@@ -1,0 +1,8 @@
+{
+  "hooks": {
+    "pre-push": "if [[ $( git diff --name-only HEAD~1..HEAD config/webpack.config.js webpack/ .travis.yml package.json | wc -l ) -ne 0 ]]; then
+      npm run lint;
+      npm run test;
+    fi"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.9.0",
     "highlight.js": "~9.14.0",
+    "husky": "^3.0.8",
     "identity-obj-proxy": "^3.0.0",
     "jest-cli": "^23.6.0",
     "jest-prop-type-error": "^1.1.0",


### PR DESCRIPTION
Using git-hooks will prevent us from pushing a bad commit.
it will run `npm run lint && npm test` before you push the commit.

To prevent it, you can add the variable `HUSKY_SKIP_HOOKS=1`, for example:
`HUSKY_SKIP_HOOKS=1 git push origin branch_name`

it should work only when a file in the `webpack` will changed.