### PR TITLE
fixes #27740 - Add taxonomy to parameters

### DIFF
--- a/db/migrate/20191007163620_add_taxonomy_ids_to_parameters.rb
+++ b/db/migrate/20191007163620_add_taxonomy_ids_to_parameters.rb
@@ -1,0 +1,14 @@
+class AddTaxonomyIdsToParameters < ActiveRecord::Migration[5.2]
+  def up
+    add_column :parameters, :organization_id, :integer
+    add_column :parameters, :location_id, :integer
+
+    add_index :parameters, [:type, :organization_id, :location_id]
+    add_index :parameters, [:type, :location_id]
+  end
+
+  def down
+    remove_column :parameters, :organization_id
+    remove_column :parameters, :location_id
+  end
+end


### PR DESCRIPTION
REST calls to add parameters to hosts, host groups, etc fail with (amon others) this
message:
`ActiveModel::UnknownAttributeError: unknown attribute 'location_id' for HostParameter`

Ref: https://projects.theforeman.org/issues/27740

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>