### PR TITLE
Fixes #28014 - graphql: add puppetclasses field to Environment type

### DIFF
--- a/app/graphql/types/environment.rb
+++ b/app/graphql/types/environment.rb
@@ -8,5 +8,6 @@ module Types
 
     has_many :locations, Types::Location
     has_many :organizations, Types::Organization
+    has_many :puppetclasses, Types::Puppetclass
   end
 end

--- a/test/graphql/queries/environment_query_test.rb
+++ b/test/graphql/queries/environment_query_test.rb
@@ -28,12 +28,21 @@ module Queries
               }
             }
           }
+          puppetclasses {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
         }
       }
       GRAPHQL
     end
 
-    let(:environment) { FactoryBot.create(:environment) }
+    let(:puppetclass) { FactoryBot.create(:puppetclass, environments: [FactoryBot.create(:environment)]) }
+    let(:environment) { puppetclass.environments.first }
 
     let(:global_id) { Foreman::GlobalId.for(environment) }
     let(:variables) {{ id: global_id }}
@@ -49,6 +58,7 @@ module Queries
 
       assert_collection environment.locations, data['locations']
       assert_collection environment.organizations, data['organizations']
+      assert_collection environment.puppetclasses, data['puppetclasses']
     end
   end
 end


### PR DESCRIPTION
allow to query environment puppetclasses
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
