### PR TITLE
Fixes #28017 - graphql: fix creating host with puppetclasses

### DIFF
--- a/app/graphql/mutations/hosts/create.rb
+++ b/app/graphql/mutations/hosts/create.rb
@@ -29,7 +29,7 @@ module Mutations
       argument :hostgroup_id, ID, loads: Types::Hostgroup
       argument :puppet_proxy_id, ID, loads: Types::SmartProxy
       argument :puppet_ca_proxy_id, ID, loads: Types::SmartProxy
-      argument :puppetclass_ids, [ID], loads: Types::Puppetclass
+      argument :puppetclass_ids, [ID], loads: Types::Puppetclass, as: :puppetclasses
       argument :compute_attributes, Types::RawJson, required: false
       argument :interfaces_attributes, [Types::InterfaceAttributesInput], required: false
 

--- a/test/graphql/mutations/hosts/create_mutation_test.rb
+++ b/test/graphql/mutations/hosts/create_mutation_test.rb
@@ -25,6 +25,8 @@ module Mutations
       let(:ptable_id) { Foreman::GlobalId.for(ptable) }
       let(:owner) { FactoryBot.create(:user, locations: [tax_location], organizations: [organization]) }
       let(:owner_id) { Foreman::GlobalId.for(owner) }
+      let(:puppetclass) { FactoryBot.create(:puppetclass) }
+      let(:puppetclass_id) { Foreman::GlobalId.for(puppetclass) }
       let(:mac) { '00:11:22:33:44:55' }
       let(:ip) { '192.0.2.1' }
       let(:root_pass) { 'graphql-is-great' }
@@ -45,6 +47,7 @@ module Mutations
           ownerId: owner_id,
           rootPass: root_pass,
           build: true,
+          puppetclassIds: [puppetclass_id],
         }
       end
       let(:variables) do
@@ -73,6 +76,7 @@ module Mutations
               $ptableId: ID!,
               $rootPass: String,
               $subnetId: ID,
+              $puppetclassIds: [ID!]
             ) {
             createHost(input: {
               architectureId: $architectureId,
@@ -93,6 +97,7 @@ module Mutations
               ptableId: $ptableId,
               rootPass: $rootPass,
               subnetId: $subnetId,
+              puppetclassIds: $puppetclassIds,
             }) {
               host {
                 id,


### PR DESCRIPTION
It fixes `ActiveModel::UnknownAttributeError (unknown attribute 'puppetclass' for Host::Managed.)` error, when trying to create a host with `puppetclassIds`
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
