### PR TITLE
Fixes #28027 - resource pools needless fetch

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -171,8 +171,15 @@ module ComputeResourcesVmsHelper
   end
 
   def vsphere_resource_pools(form, compute_resource, disabled = false)
-    resource_pools = compute_resource.available_resource_pools(:cluster_id => form.object.cluster) rescue []
-    selectable_f form, :resource_pool, resource_pools, { }, :class => "col-md-2", :label => _('Resource pool'), :disabled => disabled
+    if form.object.cluster
+      options = {}
+      resource_pools = compute_resource.available_resource_pools(:cluster_id => form.object.cluster) rescue []
+    else
+      disabled = true
+      options = { include_blank: _('Please select a cluster') }
+      resource_pools = []
+    end
+    selectable_f form, :resource_pool, resource_pools, options, :class => "col-md-2", :label => _('Resource pool'), :disabled => disabled
   end
 
   def vms_table

--- a/webpack/assets/javascripts/compute_resource/vmware.js
+++ b/webpack/assets/javascripts/compute_resource/vmware.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import store from '../react_app/redux';
+import { translate as __ } from '../react_app/common/I18n';
 import { showSpinner, hideSpinner } from '../foreman_tools';
 import { changeCluster } from '../react_app/redux/actions/hosts/storage/vmware';
 
@@ -17,10 +18,19 @@ export function onClusterChange(item) {
 function fetchResourcePools(url, clusterId) {
   // eslint-disable-next-line camelcase
   const data = { cluster_id: clusterId };
+  const $selectbox = $('select[id$="resource_pool"]');
+
+  if (!clusterId) {
+    $selectbox.select2('destroy').empty();
+    $('<option>')
+      .text(__('Please select a cluster'))
+      .val('')
+      .appendTo($selectbox);
+    $selectbox.prop('disabled', true).select2();
+    return;
+  }
 
   showSpinner();
-  const selectbox = $('select[id$="resource_pool"]');
-
   $.ajax({
     type: 'get',
     url,
@@ -29,14 +39,17 @@ function fetchResourcePools(url, clusterId) {
       hideSpinner();
     },
     success(request) {
-      selectbox.select2('destroy').empty();
+      $selectbox
+        .select2('destroy')
+        .empty()
+        .prop('disabled', false);
       request.forEach(({ name }) => {
         $('<option>')
           .text(name)
           .val(name)
-          .appendTo(selectbox);
+          .appendTo($selectbox);
       });
-      $(selectbox).select2();
+      $selectbox.select2();
     },
   });
 }


### PR DESCRIPTION
This makes sure we don't do fetch of resource_pools if the cluster is `nil` as this fetch will fail anyway at that case (return empty array).

To reproduce:

1. start to provision vmware host
1. watch the network log in the browser/server
1. there should be no fetch to vmware resources at the begining
1. if we select cluster there should be fetches for resources - one of them resource_pools
1. if we deselect cluster, there should be no fetch and the resource_pool select should be empty.