### PR TITLE
Fixes #28007 - Remove taxonomies from parameter params

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/parameter.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/parameter.rb
@@ -8,8 +8,6 @@ module Foreman::Controller::Parameters::Parameter
           :hostgroup_id,
           :domain_id,
           :operatingsystem_id,
-          :location_id,
-          :organization_id,
           :subnet_id
 
         filter.permit_by_context :hidden_value,


### PR DESCRIPTION
After https://github.com/theforeman/foreman/pull/6878 we cannot create/update (global) parameters for any resource (loc/org/hostgroup/etc).

I'm afraid this is not the best solution, so adding @tbrisker, @kgaikwad to the loop.

This fix doesn't permit `location_id` and `organization_id` which are set by default under `parameter` params.

If there is a better way to ensure that `loc/org_id` is not being set under `parameter` params, please point me :)