### PR TITLE
Fixes #28070 - host param fallback parameter

### DIFF
--- a/lib/foreman/renderer/scope/macros/host_template.rb
+++ b/lib/foreman/renderer/scope/macros/host_template.rb
@@ -30,14 +30,22 @@ module Foreman
             host.puppetclasses
           end
 
-          def host_param_true?(name)
+          def host_param_true?(name, default_value = false)
             check_host
-            host.params.has_key?(name) && Foreman::Cast.to_bool(host.params[name])
+            if host.params.has_key?(name)
+              Foreman::Cast.to_bool(host.params[name])
+            else
+              default_value
+            end
           end
 
-          def host_param_false?(name)
+          def host_param_false?(name, default_value = false)
             check_host
-            host.params.has_key?(name) && Foreman::Cast.to_bool(host.params[name]) == false
+            if host.params.has_key?(name)
+              Foreman::Cast.to_bool(host.params[name]) == false
+            else
+              default_value
+            end
           end
 
           def root_pass

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -95,6 +95,7 @@ class HostTemplateTest < ActiveSupport::TestCase
       @scope.instance_variable_set('@host', host)
       FactoryBot.create(:parameter, :name => 'true_param', :value => "true")
       assert @scope.host_param_true?('true_param')
+      refute @scope.host_param_true?('false_param')
     end
   end
 
@@ -104,6 +105,7 @@ class HostTemplateTest < ActiveSupport::TestCase
       @scope.instance_variable_set('@host', host)
       FactoryBot.create(:parameter, :name => 'false_param', :value => "false")
       assert @scope.host_param_false?('false_param')
+      refute @scope.host_param_false?('true_param')
     end
   end
 


### PR DESCRIPTION
This statement in our kickstart template does not work correctly:

    use_ntp = host_param_true?('use-ntp') || (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7

In order to avoid three liner, I am introducing a default value option, so it can be shortened to:

    use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7))