### PR TITLE
Fixes #28075 - Ping endpoints apidoc should be explicit

### DIFF
--- a/app/controllers/api/v2/ping_controller.rb
+++ b/app/controllers/api/v2/ping_controller.rb
@@ -1,15 +1,20 @@
 module Api
   module V2
     class PingController < BaseController
+      resource_description do
+        api_version 'v2'
+        api_base_url ''
+      end
+
       skip_before_action :authorize, only: [:ping]
 
-      api :GET, '/ping', N_("Shows status of Foreman system and it's subcomponents")
+      api :GET, '/api/ping', N_("Shows status of Foreman system and it's subcomponents")
       description N_('This service is available for unauthenticated users')
       def ping
         @results = Ping.ping
       end
 
-      api :GET, '/statuses', N_("Shows status and version information of Foreman system and it's subcomponents")
+      api :GET, '/api/statuses', N_("Shows status and version information of Foreman system and it's subcomponents")
       description N_('This service is only available for authenticated users')
       def statuses
         @results = Ping.statuses


### PR DESCRIPTION
This is required to save backwards compatibility of usage ping endpoint in hammer.

Since hammer commands rely on API documentation there appears a problem if we suddenly change resource documentation. E.g. previously hammer ping command came from hammer-cli-katello plugin and used :ping resource which was defined in Katello plugin. But due to some changes Katello has now :katello_ping resource and thus older versions of hammer-cli-katello plugin will not work.

This change will allow Katello ping reuse :ping resource from Foreman to add its documentation (see: https://github.com/Katello/katello/pull/8386).