### PR TITLE
fixes #28078 - add event subscribers api

### DIFF
--- a/app/models/concerns/foreman/event_subscribers/observable.rb
+++ b/app/models/concerns/foreman/event_subscribers/observable.rb
@@ -1,0 +1,36 @@
+module Foreman
+  module EventSubscribers
+    module Observable
+      extend ActiveSupport::Concern
+
+      included do
+        class_attribute :event_subscription_hooks
+        self.event_subscription_hooks ||= []
+      end
+
+      module ClassMethods
+        def notify_event_observers(on:, with:, payload: nil, &blk)
+          event_name = "#{event_subscription_namespace}_#{with}"
+          self.event_subscription_hooks |= [event_name]
+          after_commit on: on do
+            actual_payload = blk&.call(self) || payload || { id: id }
+            do_notify_event_observers(with, payload: actual_payload)
+          end
+        end
+
+        def event_subscription_namespace
+          name.underscore
+        end
+      end
+
+      private
+
+      def do_notify_event_observers(action, payload:)
+        event_name = "#{self.class.event_subscription_namespace}_#{action}"
+        Foreman::Plugin.all.map(&:event_observers).flatten.uniq.compact.map(&:constantize).each do |observer|
+          observer.new.notify(event_name: event_name, payload: payload)
+        end
+      end
+    end
+  end
+end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -4,6 +4,13 @@ class Model < ApplicationRecord
   extend FriendlyId
   friendly_id :name
   include Parameterizable::ByIdName
+  include ::Foreman::EventSubscribers::Observable
+
+  notify_event_observers on: :create, with: :created
+  notify_event_observers on: :update, with: :updated
+  notify_event_observers on: :destroy, with: :destroyed do |model|
+    { id: model.id, name: model.name }
+  end
 
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many_hosts

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -21,6 +21,7 @@ require_dependency 'foreman/plugin/rbac_support'
 require_dependency 'foreman/plugin/report_scanner_registry'
 require_dependency 'foreman/plugin/report_origin_registry'
 require_dependency 'foreman/plugin/medium_providers_registry'
+require_dependency 'foreman/plugin/event_observers_registry'
 
 module Foreman #:nodoc:
   class PluginNotFound < Foreman::Exception; end
@@ -43,12 +44,13 @@ module Foreman #:nodoc:
     @report_origin_registry = Plugin::ReportOriginRegistry.new
     @medium_providers = Plugin::MediumProvidersRegistry.new
     @graphql_types_registry = Plugin::GraphqlTypesRegistry.new
+    @event_observers_registry = Plugin::EventObserversRegistry.new
 
     class << self
       attr_reader   :registered_plugins
       attr_accessor :tests_to_skip, :report_scanner_registry,
                     :report_origin_registry, :medium_providers,
-                    :graphql_types_registry
+                    :graphql_types_registry, :event_observers_registry
       private :new
 
       def def_field(*names)
@@ -557,6 +559,11 @@ module Foreman #:nodoc:
     def describe_host(&block)
       @host_ui_description = UI.describe_host(&block)
     end
+
+    delegate :event_observers_registry, to: :class
+    delegate :event_observers, to: :event_observers_registry
+    delegate :register_event_observer, to: :event_observers_registry
+    delegate :unregister_event_observer, to: :event_observers_registry
 
     private
 

--- a/app/registries/foreman/plugin/event_observers_registry.rb
+++ b/app/registries/foreman/plugin/event_observers_registry.rb
@@ -1,0 +1,20 @@
+module Foreman
+  class Plugin
+    class EventObserversRegistry
+      delegate :logger, to: Rails
+      attr_reader :event_observers
+
+      def initialize
+        @event_observers = []
+      end
+
+      def register_event_observer(klass)
+        @event_observers << klass
+      end
+
+      def unregister_event_observer(klass)
+        @event_observers.delete(klass)
+      end
+    end
+  end
+end

--- a/lib/foreman/event_subscribers.rb
+++ b/lib/foreman/event_subscribers.rb
@@ -1,0 +1,7 @@
+module Foreman
+  module EventSubscribers
+    def self.all_observable_events
+      ActiveRecord::Base.descendants.select { |klass| klass <= ::Foreman::EventSubscribers::Observable }.map(&:event_subscription_hooks).flatten.uniq
+    end
+  end
+end


### PR DESCRIPTION
This PR adds

- a DSL so models can define events and payload
- a plugin DSL so plugins can ask to be notified when such an event happens

https://community.theforeman.org/t/the-future-of-foreman-hooks-plugin/15772

This has still some rough edges. Opening for more visibility.

Reference Implementation:
https://github.com/timogoebel/foreman_webhooks