### PR TITLE
Fixes #27067 - IPAM Integration with phpIPAM

### DIFF
--- a/app/assets/javascripts/subnets.js
+++ b/app/assets/javascripts/subnets.js
@@ -2,6 +2,10 @@ function showSubnetIPAM(element) {
   if ($.inArray(element.val(), element.data('disable-auto-suggest-on')) !== -1)
     $('#ipam_options').hide();
   else $('#ipam_options').show();
+
+  if ($.inArray(element.val(), element.data('enable-ipam-group-on')) >= 0)
+    $('#external_ipam_options').show();
+  else $('#external_ipam_options').hide();
 }
 
 function checkedRelatedRadioButton(element) {

--- a/app/controllers/concerns/foreman/controller/parameters/subnet.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/subnet.rb
@@ -12,6 +12,7 @@ module Foreman::Controller::Parameters::Subnet
           :description,
           :dns_primary,
           :dns_secondary,
+          :externalipam_group,
           :from,
           :gateway,
           :ipam,

--- a/app/helpers/subnets_helper.rb
+++ b/app/helpers/subnets_helper.rb
@@ -33,4 +33,8 @@ module SubnetsHelper
     return [] unless Subnet::SUBNET_TYPES.key?(type.to_sym)
     type.safe_constantize.supported_ipam_modes_with_translations
   end
+
+  def external_ipam?(subnet)
+    subnet&.ipam == IPAM::MODES[:external_ipam]
+  end
 end

--- a/app/models/concerns/orchestration/external_ipam.rb
+++ b/app/models/concerns/orchestration/external_ipam.rb
@@ -1,0 +1,147 @@
+module Orchestration::ExternalIPAM
+  extend ActiveSupport::Concern
+  include Orchestration::Common
+  include SubnetsHelper
+
+  included do
+    after_validation :queue_external_ipam
+    before_destroy :queue_external_ipam_destroy
+  end
+
+  def generate_external_ipam_task_id(action, network_type, interface = self)
+    id = [interface.mac, interface.ip, interface.identifier, interface.id].find { |x| x&.present? }
+    "external_ipam_#{action}_#{id}_#{network_type}"
+  end
+
+  protected
+
+  def set_add_external_ip(params)
+    ip, subnet = params[:ip], params[:subnet]
+
+    if ip_is_available?(ip, subnet)
+      subnet.external_ipam_proxy.add_ip_to_subnet(ip, subnet.network_address, subnet.externalipam_group)
+    else
+      errors.add :ip, _('This IP address has already been reserved in External IPAM') if subnet.network_type == "IPv4"
+      errors.add :ip6, _('This IP address has already been reserved in External IPAM') if subnet.network_type == "IPv6"
+      errors.add :interfaces, _('Some interfaces are invalid')
+    end
+  end
+
+  def set_remove_external_ip(params)
+    ip, subnet = params[:ip], params[:subnet]
+    subnet.external_ipam_proxy.delete_ip_from_subnet(ip, subnet.network_address, subnet.externalipam_group)
+  end
+
+  def del_add_external_ip(params)
+    new_record? ? rollback_on_add : rollback_on_update
+  end
+
+  def del_remove_external_ip(params)
+    logger.warn "IP address deletion failed in External IPAM, and it cannot be compensated."
+  end
+
+  def rollback_on_add
+    if ipv4_errors_not_ipv6? && !ip_is_available?(ip6, subnet6)
+      subnet.external_ipam_proxy.delete_ip_from_subnet(ip6, subnet6.network_address, subnet6.externalipam_group)
+    elsif ipv6_errors_not_ipv4? && !ip_is_available?(ip, subnet)
+      subnet.external_ipam_proxy.delete_ip_from_subnet(ip, subnet.network_address, subnet.externalipam_group)
+    end
+  end
+
+  def rollback_on_update
+    if ipv4_errors_not_ipv6? && ip_is_available?(old.ip, old.subnet)
+      subnet.external_ipam_proxy.add_ip_to_subnet(old.ip, old.subnet.network_address, old.subnet.externalipam_group)
+    elsif ipv6_errors_not_ipv4? && ip_is_available?(old.ip6, old.subnet6)
+      subnet.external_ipam_proxy.add_ip_to_subnet(old.ip6, old.subnet6.network_address, old.subnet6.externalipam_group)
+    end
+  end
+
+  def requires_update?
+    return false if new_record?
+    old.ip != ip
+  end
+
+  def requires_update6?
+    return false if new_record?
+    old.ip6 != ip6
+  end
+
+  def requires_delete?
+    old_nic = Nic::Base.find(id)
+    !old_nic.ip.nil? && !old_nic.subnet_id.nil?
+  end
+
+  def requires_delete6?
+    old_nic = Nic::Base.find(id)
+    !old_nic.ip6.nil? && !old_nic.subnet6_id.nil?
+  end
+
+  def ip_is_available?(ip, subnet)
+    !subnet.external_ipam_proxy.ip_exists(ip, subnet.network_address, subnet.externalipam_group)
+  end
+
+  def ipv4_errors_not_ipv6?
+    !errors[:ip].empty? && errors[:ip6].empty? && ip6.present?
+  end
+
+  def ipv6_errors_not_ipv4?
+    !errors[:ip6].empty? && errors[:ip].empty? && ip.present?
+  end
+
+  def ipv4_removed?
+    old.ip.present? && ip.blank?
+  end
+
+  def ipv6_removed?
+    old.ip6.present? && ip6.blank?
+  end
+
+  def ipv4_added?
+    old.ip.blank? && ip.present?
+  end
+
+  def ipv6_added?
+    old.ip6.blank? && ip6.present?
+  end
+
+  def ipv4_changed?
+    old.ip.present? && ip.present? && old.ip != ip
+  end
+
+  def ipv6_changed?
+    old.ip6.present? && ip6.present? && old.ip6 != ip6
+  end
+
+  private
+
+  def queue_external_ipam
+    new_record? ? queue_external_ipam_create : queue_external_ipam_update
+  end
+
+  def queue_external_ipam_create
+    return unless (external_ipam?(subnet) || external_ipam?(subnet6)) && errors.empty?
+    logger.debug "Scheduling new IP reservation(s) in external IPAM for #{self}"
+    queue.create(id: generate_external_ipam_task_id("create", subnet.network_type), name: _("Creating IPv4 in External IPAM for %s") % self, priority: 10, action: [self, :set_add_external_ip, {:ip => ip, :subnet => subnet}]) if ip.present? && subnet.present? && external_ipam?(subnet)
+    queue.create(id: generate_external_ipam_task_id("create", subnet6.network_type), name: _("Creating IPv6 in External IPAM for %s") % self, priority: 10, action: [self, :set_add_external_ip, {:ip => ip6, :subnet => subnet6}]) if ip6.present? && subnet6.present? && external_ipam?(subnet6)
+    true
+  end
+
+  def queue_external_ipam_destroy
+    return unless (external_ipam?(subnet) || external_ipam?(subnet6)) && errors.empty?
+    logger.debug "Removing IP reservation(s) in external IPAM for #{self}"
+    queue.create(id: generate_external_ipam_task_id("remove", "IPv4"), name: _("Removing IPv4 in External IPAM for %s") % self, priority: 5, action: [self, :set_remove_external_ip, {:ip => ip, :subnet => subnet}]) if requires_delete? && external_ipam?(subnet)
+    queue.create(id: generate_external_ipam_task_id("remove", "IPv6"), name: _("Removing IPv6 in External IPAM for %s") % self, priority: 5, action: [self, :set_remove_external_ip, {:ip => ip6, :subnet => subnet6}]) if requires_delete6? && external_ipam?(subnet6)
+    true
+  end
+
+  def queue_external_ipam_update
+    return false if old.nil?
+    return unless (external_ipam?(subnet) || external_ipam?(subnet6) || external_ipam?(old.subnet) || external_ipam?(old.subnet6)) && errors.empty?
+    logger.debug "Updating IP reservation in external IPAM for #{self}"
+    queue.create(id: generate_external_ipam_task_id("create", subnet.network_type), name: _("Creating IPv4 in External IPAM for %s") % self, priority: 10, action: [self, :set_add_external_ip, {:ip => ip, :subnet => subnet}]) if (ipv4_added? || ipv4_changed?) && external_ipam?(subnet)
+    queue.create(id: generate_external_ipam_task_id("remove", old.subnet.network_type), name: _("Removing IPv4 in External IPAM for %s") % self, priority: 5, action: [old, :set_remove_external_ip, {:ip => old.ip, :subnet => old.subnet}]) if (ipv4_removed? || ipv4_changed?) && external_ipam?(old.subnet)
+    queue.create(id: generate_external_ipam_task_id("create", subnet6.network_type), name: _("Creating IPv6 in External IPAM for %s") % self, priority: 10, action: [self, :set_add_external_ip, {:ip => ip6, :subnet => subnet6}]) if (ipv6_added? || ipv6_changed?) && external_ipam?(subnet6)
+    queue.create(id: generate_external_ipam_task_id("remove", old.subnet6.network_type), name: _("Removing IPv6 in External IPAM for %s") % self, priority: 5, action: [old, :set_remove_external_ip, {:ip => old.ip6, :subnet => old.subnet6}]) if (ipv6_removed? || ipv6_changed?) && external_ipam?(old.subnet6)
+    true
+  end
+end

--- a/app/models/nic/managed.rb
+++ b/app/models/nic/managed.rb
@@ -4,6 +4,7 @@ module Nic
     include Orchestration::DHCP
     include Orchestration::DNS
     include Orchestration::TFTP
+    include Orchestration::ExternalIPAM
     include DnsInterface
     include InterfaceCloning
 

--- a/app/models/subnet/ipv4.rb
+++ b/app/models/subnet/ipv4.rb
@@ -26,7 +26,7 @@ class Subnet::Ipv4 < Subnet
   end
 
   def self.supported_ipam_modes
-    [:dhcp, :db, :random_db, :none]
+    [:dhcp, :db, :random_db, :external_ipam, :none]
   end
 
   def self.show_mask?

--- a/app/models/subnet/ipv6.rb
+++ b/app/models/subnet/ipv6.rb
@@ -24,7 +24,7 @@ class Subnet::Ipv6 < Subnet
   end
 
   def self.supported_ipam_modes
-    [:eui64, :db, :none]
+    [:eui64, :db, :external_ipam, :none]
   end
 
   def self.show_mask?

--- a/app/services/ipam.rb
+++ b/app/services/ipam.rb
@@ -1,5 +1,5 @@
 module IPAM
-  MODES = {:dhcp => N_('DHCP'), :db => N_('Internal DB'), :random_db => N_('Random DB'), :eui64 => N_('EUI-64'), :none => N_('None')}
+  MODES = {:dhcp => N_('DHCP'), :db => N_('Internal DB'), :random_db => N_('Random DB'), :eui64 => N_('EUI-64'), :external_ipam => N_('External IPAM'), :none => N_('None')}
 
   def self.new(type, *args)
     case type
@@ -13,6 +13,8 @@ module IPAM
       IPAM::RandomDb.new(*args)
     when IPAM::MODES[:eui64]
       IPAM::Eui64.new(*args)
+    when IPAM::MODES[:external_ipam]
+      IPAM::ExternalIpam.new(*args)
     else
       raise ::Foreman::Exception.new(N_("Unknown IPAM type - can't continue"))
     end

--- a/app/services/ipam/external_ipam.rb
+++ b/app/services/ipam/external_ipam.rb
@@ -1,0 +1,20 @@
+module IPAM
+  class ExternalIpam < Base
+    delegate :external_ipam_proxy, :to => :subnet
+
+    def suggest_ip
+      logger.debug("Obtaining next available IP from IPAM for subnet #{@subnet.network_address}")
+      next_ip = external_ipam_proxy.next_ip(@subnet.network_address, mac, @subnet.externalipam_group)
+      logger.debug("IPAM returned #{next_ip} as the next available IP in subnet #{@subnet.network_address}")
+      next_ip
+    rescue => e
+      logger.warn "Failed to fetch the next available IP address from IPAM: #{e}"
+      errors.add(:subnet, _(e.message))
+      nil
+    end
+
+    def suggest_new?
+      false
+    end
+  end
+end

--- a/app/views/subnets/_fields.html.erb
+++ b/app/views/subnets/_fields.html.erb
@@ -8,19 +8,25 @@
 <%= text_f f, :gateway, :label => _("Gateway Address"), :help_inline => _("Optional: Gateway for this subnet") %>
 <%= text_f f, :dns_primary, :label => _("Primary DNS Server"), :help_inline => _("Optional: Primary DNS for this subnet") %>
 <%= text_f f, :dns_secondary, :label => _("Secondary DNS Server"), :help_inline => _("Optional: Secondary DNS for this subnet") %>
-<%= selectable_f f, :ipam, subnet_ipam_modes(f.object.type), {}, :data => {'disable-auto-suggest-on' => [IPAM::MODES[:none], IPAM::MODES[:eui64]]},
+<%= selectable_f f, :ipam, subnet_ipam_modes(f.object.type), {}, :data => {'disable-auto-suggest-on' => [IPAM::MODES[:none], IPAM::MODES[:eui64], IPAM::MODES[:external_ipam]], 'enable-ipam-group-on' => [IPAM::MODES[:external_ipam]]},
                  :label => _('IPAM'),
                  :label_help => _("You can select one of the IPAM modes supported by the selected IP protocol:<br/>" +
                                    "<ul><li><strong>DHCP</strong> - will manage the IP on DHCP through assigned DHCP proxy, auto-suggested IPs come from DHCP <em>(IPv4)</em></li>" +
                                    "<li><strong>Internal DB</strong> - use internal DB to auto-suggest free IP based on other interfaces on same subnet respecting range if specified, useful mainly with static boot mode <em>(IPv4, IPv6)</em>, preserves natural ordering</li>" +
                                    "<li><strong>Random DB</strong> - same as Internal DB but randomizes results to prevent race conditions <em>(IPv4)</em></li>" +
                                    "<li><strong>EUI-64</strong> - will assign the IPv6 address based on the MAC address of the interface <em>(IPv6)</em></li>" +
+                                   "<li><strong>External IPAM</strong> - will auto-suggest the next available address via an External IPAM Smart-proxy plugin (IPv4, IPv6)</li>" +
                                    "<li><strong>None</strong> - leave IP management solely on user, no auto-suggestion <em>(IPv4, IPv6)</em></li></ul>").html_safe,
                  :label_help_options => { :title => _("IP Address Management"), :'data-placement' => 'top' }%>
 <div id='ipam_options' class ='<%= f.object.ipam_needs_range? ? "" : "hide" %>'>
   <%= text_f f, :from, :help_inline => _("Optional: Starting IP Address for IP auto suggestion") %>
   <%= text_f f, :to,   :help_inline => _("Optional: Ending IP Address for IP auto suggestion") %>
 </div>
+
+<div id='external_ipam_options' class='<%= f.object.ipam_needs_group? ? "" : "hide" %>'>
+  <%= text_f f, :externalipam_group, :label => _("External IPAM Group"), :help_inline => _("Optional: The group/section of subnets in External IPAM to associate this subnet with") %>
+</div>
+
 <%= number_f f, :vlanid, :min => 0, :max => 4095, :help_inline => _("Optional: VLAN ID for this subnet") %>
 <%= number_f f, :mtu, :label => _('MTU'), :min => 68, :max => 4294967295, :help_inline => _('MTU for this subnet') %>
 <%= number_f f, :nic_delay, :label => _('Link Delay'), :min => 0, :max => 900, :help_inline => _('Delay network activity during install for X seconds') %>

--- a/db/migrate/20191017151119_add_external_ipam_id_to_subnets.rb
+++ b/db/migrate/20191017151119_add_external_ipam_id_to_subnets.rb
@@ -1,0 +1,13 @@
+class AddExternalIpamIdToSubnets < ActiveRecord::Migration[5.2]
+  def up
+    add_column :subnets, :externalipam_id, :integer
+    add_column :subnets, :externalipam_group, :text
+    add_index(:subnets, :externalipam_id)
+  end
+
+  def down
+    remove_column :subnets, :externalipam_id
+    remove_column :subnets, :externalipam_group
+    remove_index(:subnets, :externalipam_id)
+  end
+end

--- a/db/seeds.d/110-smart_proxy_features.rb
+++ b/db/seeds.d/110-smart_proxy_features.rb
@@ -1,5 +1,5 @@
 # Proxy features
-["TFTP", "DNS", "DHCP", "Puppet", "Puppet CA", "BMC", "Realm", "Facts", "Logs", "HTTPBoot"].each do |input|
+["TFTP", "DNS", "DHCP", "Puppet", "Puppet CA", "BMC", "Realm", "Facts", "Logs", "HTTPBoot", "External IPAM"].each do |input|
   f = Feature.where(:name => input).first_or_create
   raise "Unable to create proxy feature: #{format_errors f}" if f.nil? || f.errors.any?
 end

--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -1,0 +1,287 @@
+require 'uri'
+
+module ProxyAPI
+  class ExternalIpam < ProxyAPI::Resource
+    def initialize(args)
+      @url = args[:url] + "/ipam"
+      super args
+    end
+
+    # Queries External IPAM and retrieves the next available IP address for the given subnet.
+    # The IP returned is NOT reserved in External IPAM database. It is however written to an in-memory,
+    # thread safe cache, on the proxy side, with the subnet CIDR/mac address as the key(see
+    # IP cache structure below). This will prevent the same IP being suggested for different mac addresses,
+    # and will handle race condition scenarios where multiple hosts are being provisioned simultaneously.
+    #
+    # Groups of subnets are cached under the External IPAM Group name. "IPAM Group" in the snippet below is
+    # the 'section' in phpIPAM. For subnets that have an External IPAM group specified(e.g. "IPAM Group"),
+    # the IP's/mac are cached under the "IPAM Group" key. If External IPAM group is not defined, then they
+    # are cached under the "" key.
+    #
+    # The IP address is only actually reserved in the External IPAM database upon successful host
+    # and/or interface creation.
+    #
+    # In-memory IP cache structure(IPv4 and IPv6):
+    # ===============================
+    # {
+    #   "": {
+    #     "100.55.55.0/24":{
+    #       "00:0a:95:9d:68:10": {"ip": "100.55.55.1", "timestamp": "2019-09-17 12:03:43 -D400"}
+    #     },
+    #   },
+    #   "IPAM Group": {
+    #     "123.11.33.0/24":{
+    #       "00:0a:95:9d:68:33": {"ip": "123.11.33.1", "timestamp": "2019-09-17 12:04:43 -0400"},
+    #       "00:0a:95:9d:68:34": {"ip": "123.11.33.2", "timestamp": "2019-09-17 12:05:48 -0400"},
+    #       "00:0a:95:9d:68:35": {"ip": "123.11.33.3", "timestamp:: "2019-09-17 12:06:50 -0400"}
+    #     }
+    #   },
+    #   "Another IPAM Group": {
+    #     "185.45.39.0/24":{
+    #       "00:0a:95:9d:68:55": {"ip": "185.45.39.1", "timestamp": "2019-09-17 12:04:43 -0400"},
+    #       "00:0a:95:9d:68:56": {"ip": "185.45.39.2", "timestamp": "2019-09-17 12:05:48 -0400"}
+    #     }
+    #   }
+    # }
+    #
+    # Params: 1. subnet:  The IPv4 or IPv6 subnet CIDR. (Examples: IPv4 - "100.10.10.0/24", IPv6 - "2001:db8:abcd:12::/124")
+    #         2. mac:     The mac address of the interface obtaining the IP address for
+    #         3. group:   The group in External IPAM that the subnet belongs to(e.g. This would be "Section" in phpIPAM)
+    #
+    # Returns: A hash with the next available IP in the "data" field, or a hash with "error" key
+    #          containing error message
+    #
+    # Examples:
+    #   Responses if success:
+    #     IPv4: {"data": "100.55.55.3"}
+    #     IPv6: {"data": "2001:db8:abcd:12::1"}
+    #   Response if missing required params:
+    #     {"error": ["A 'cidr' parameter for the subnet must be provided(e.g. 100.10.10.0/24)","A 'mac' address must be provided(e.g. 00:0a:95:9d:68:10)"]}
+    #   Response if subnet does not exist:
+    #     {"error": "The specified subnet does not exist in External IPAM."}
+    #   Response if there are no free addresses:
+    #     {"error": "No free addresses found"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def next_ip(subnet, mac, group = "")
+      raise "subnet cannot be nil" if subnet.nil?
+      response = parse get("/subnet/#{subnet}/next_ip?mac=#{mac}&group=#{URI.escape(group.to_s)}")
+      raise(response['error']) if response['error'].present?
+      response['data']
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to retrieve the next available IP for subnet %{subnet} External IPAM."), subnet: subnet)
+    end
+
+    # Adds an IP address to the specified subnet in External IPAM. This will reserve the IP in the
+    # External IPAM database. If group is specified, the IP will be added to the subnet within the
+    # given group.
+    #
+    # Params: 1. ip:               IP address to be added
+    #         2. subnet:           The IPv4 or IPv6 subnet CIDR. (Examples: IPv4 - "100.10.10.0/24",
+    #                              IPv6 - "2001:db8:abcd:12::/124")
+    #         3. group(optional):  The name of the External IPAM group containing the subnet.
+    #
+    # Returns: true if IP was added successfully to External IPAM, otherwise false
+    #
+    # Responses from Proxy plugin:
+    #   Response if success:
+    #     Net::HTTPCreated
+    #   Response if IP already reserved:
+    #     {"error": "IP address already exists"}
+    #   Response if subnet error:
+    #     {"error": "The specified subnet does not exist in External IPAM."}
+    #   Response if missing required params:
+    #     {"error": ["A 'cidr' parameter for the subnet must be provided(e.g. 100.10.10.0/24)","Missing 'ip' parameter. An IPv4 address must be provided(e.g. 100.10.10.22)"]}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def add_ip_to_subnet(ip, subnet, group = "")
+      raise "subnet cannot be nil" if subnet.nil?
+      response = parse post({}, "/subnet/#{subnet}/#{ip}?group=#{URI.escape(group.to_s)}")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to add IP %{ip} to the subnet %{subnet} in External IPAM."), ip: ip, subnet: subnet)
+    end
+
+    # Get a list of groups from External IPAM. A group is analagous to a 'section' in phpIPAM, and
+    # is a logical grouping of subnets/ips.
+    #
+    # Params: None
+    #
+    # Returns: An array of groups on success, or a hash with a "error" key
+    #          containing error on failure.
+    #
+    # Responses from Proxy plugin:
+    #   Response if success:
+    #     {"data": [
+    #       {name":"Test Group","description": "A Test Group"},
+    #       {name":"Awesome Group","description": "A totally awesome Group"}
+    #     ]}
+    #   Response if no groups exist:
+    #     {"data": []}
+    #   Response if groups are not supported:
+    #     {"error": "Groups are not supported"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def get_groups
+      response = parse get("/groups")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain groups from External IPAM."))
+    end
+
+    # Get a group from External IPAM. A group is analagous to a 'section' in phpIPAM, and
+    # is a logical grouping of subnets/ips.
+    #
+    # Params: group: The name of the External IPAM group
+    #
+    # Returns: An External IPAM group on success, or a hash with an "error" key on failure.
+    #
+    # Responses from Proxy plugin:
+    #   Response if success:
+    #     {"data": {"name":"Awesome Section", "description": "Awesome Section"}}
+    #   Response if group doesn't exist:
+    #     {"error": "Not found"}
+    #   Response if groups are not supported:
+    #     {"error": "Groups are not supported"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def get_group(group)
+      raise "group must be provided" if group.blank?
+      response = parse get("/groups/#{URI.escape(group)}")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain group %{group} from External IPAM."), group: group)
+    end
+
+    # Get a list of subnets for the given External IPAM group.
+    #
+    # Params:  1. group:  The name of the External IPAM group containing the subnet.
+    #
+    # Returns: An array of subnets on success, or a hash with an "error" key on failure.
+    #
+    # Responses from Proxy plugin:
+    #   Response if success: {"data": [
+    #     {subnet":"100.10.10.0","mask":"24","description":"Test Subnet 1"},
+    #     {subnet":"100.20.20.0","mask":"24","description":"Test Subnet 2"}
+    #   ]}
+    #   Response if no subnets exist in section.
+    #     {"data": []}
+    #   Response if section not found:
+    #     {"error": "Group not found in External IPAM"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM"}
+    def get_subnets_by_group(group)
+      raise "group must be provided" if group.blank?
+      response = parse get("/groups/#{URI.escape(group)}/subnets")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain subnets in group %{group} from External IPAM."), group: group)
+    end
+
+    # Returns an array of subnets from External IPAM matching the given subnet.
+    #
+    # Params:  1. subnet:           The IPv4 or IPv6 subnet CIDR. (Examples: IPv4 - "100.10.10.0/24",
+    #                               IPv6 - "2001:db8:abcd:12::/124")
+    #          2. group(optional):  The name of the External IPAM group containing the subnet.
+    #
+    # Returns: A subnet on success, or a hash with an "error" key on failure.
+    #
+    # Responses from Proxy plugin:
+    #   Response if subnet(s) exists:
+    #     {"data": {"subnet": "44.44.44.0", "description": "", "mask":"29"}}
+    #   Response if subnet not exists:
+    #     {"error": "No subnets found"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def get_subnet(subnet, group = "")
+      raise "subnet cannot be nil" if subnet.nil?
+      response = parse get("/subnet/#{subnet}?group=#{URI.escape(group.to_s)}")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain subnet %{subnet} from External IPAM."), subnet: subnet)
+    end
+
+    # Checks whether an IP address has already been reserved in External IPAM.
+    #
+    # Inputs: 1. ip:               IP address to be checked
+    #         2. subnet:           The IPv4 or IPv6 subnet CIDR. (Examples: IPv4 - "100.10.10.0/24",
+    #                              IPv6 - "2001:db8:abcd:12::/124")
+    #         3. group(optional):  The name of the External IPAM group containing the subnet to pull IP from
+    #
+    # Returns: true if IP exists in External IPAM, otherwise false.
+    #
+    # Responses from Proxy plugin:
+    #   Response if IP is already reserved:
+    #     Net::HTTPFound
+    #   Response if IP address is available
+    #     Net::HTTPNotFound
+    #   Response if missing required parameters:
+    #     {"error": ["A 'cidr' parameter for the subnet must be provided(e.g. 100.10.10.0/24)", "Missing 'ip' parameter. An IPv4 address must be provided(e.g. 100.10.10.22)"]}
+    #   Response if subnet not exists:
+    #     {"error": "No subnets found"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def ip_exists(ip, subnet, group = "")
+      raise "subnet cannot be nil" if subnet.nil?
+      response = parse get("/subnet/#{subnet}/#{ip}?group=#{URI.escape(group.to_s)}")
+      raise(response['error']) if response['error'].present?
+      response.include? "Net::HTTPFound"
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to obtain IP address for subnet_id %{subnet} from External IPAM."), subnet: subnet)
+    end
+
+    # Deletes an IP address from a given subnet in External IPAM.
+    #
+    # Inputs: 1. ip:               IP address to be freed up
+    #         2. subnet:           The IPv4 or IPv6 subnet CIDR. (Examples: IPv4 - "100.10.10.0/24",
+    #                              IPv6 - "2001:db8:abcd:12::/124")
+    #         3. group(optional):  The name of the External IPAM group containing the subnet.
+    #
+    # Returns: true if IP is deleted successfully from External IPAM, otherwise false.
+    #
+    # Proxy responses:
+    #   Response if success:
+    #     Net::HTTPOK
+    #   Response if subnet error:
+    #     {"error": "The specified subnet does not exist in External IPAM."}
+    #   Response if IP already deleted:
+    #     {"error": "No addresses found"}
+    #   Response if can't connect to External IPAM server
+    #     {"error": "Unable to connect to External IPAM server"}
+    def delete_ip_from_subnet(ip, subnet, group = "")
+      raise "subnet cannot be nil" if subnet.nil?
+      response = parse delete("/subnet/#{subnet}/#{ip}?group=#{URI.escape(group.to_s)}")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to delete IP %{ip} from the subnet %{subnet} in External IPAM."), ip: ip, subnet: subnet)
+    end
+
+    # Gets a subnet from a specific External IPAM group.
+    #
+    # Inputs: 1. subnet: The IPv4 or IPv6 subnet CIDR. (Examples: IPv4 - "100.10.10.0/24", IPv6 - "2001:db8:abcd:12::/124")
+    #         2. group: The name of the External IPAM group containing the subnet.
+    #
+    # Returns: A subnet with a "data" key, or a hash with a "message" key containing error.
+    #
+    # Proxy responses:
+    #   Response if exists:
+    #     {"data": {"subnet":"172.55.55.0", "mask":"24", "description":"My subnet"}
+    #   Response if not exists:
+    #     {"error": "No subnet 172.55.66.0/29 found in section '<:group>'"}
+    def get_subnet_from_group(subnet, group)
+      raise "subnet must be provided" if subnet.blank?
+      raise "group must be provided" if group.blank?
+      response = parse get("/group/#{URI.escape(group.to_s)}/subnet/#{subnet}")
+      raise(response['error']) if response['error'].present?
+      response
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to check if subnet %{subnet} exists in the External IPAM group %{group}."), subnet: subnet, group: group)
+    end
+  end
+end

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -41,5 +41,9 @@ FactoryBot.define do
     trait :bmc do
       name { 'BMC' }
     end
+
+    trait :external_ipam do
+      name { 'External IPAM' }
+    end
   end
 end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -43,6 +43,12 @@ FactoryBot.define do
       end
     end
 
+    factory :ipam_smart_proxy do
+      after(:build) do |smart_proxy, _evaluator|
+        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :external_ipam, :smart_proxy => smart_proxy)
+      end
+    end
+
     factory :puppet_smart_proxy do
       before(:create, :build, :build_stubbed) do
         ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:puppet => {'state' => 'running'})
@@ -106,6 +112,10 @@ FactoryBot.define do
 
     trait :bmc do
       association :feature, :bmc
+    end
+
+    trait :external_ipam do
+      association :feature, :external_ipam
     end
   end
 end

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
     organizations { [Organization.find_by_name('Organization 1')] }
     locations { [Location.find_by_name('Location 1')] }
 
+    # Skip the Subnet.after_validation hook that validates against External IPAM API
+    after(:build) do |subnet|
+      subnet.class.skip_callback(:validation, :after, :validate_against_external_ipam, raise: false)
+    end
+
     trait :tftp do
       association :tftp, :factory => :template_smart_proxy
     end

--- a/test/helpers/subnets_helper_test.rb
+++ b/test/helpers/subnets_helper_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class SubnetsHelperTest < ActionView::TestCase
+  include SubnetsHelper
+
+  let(:ipam_proxy) do
+    FactoryBot.create(:smart_proxy,
+      :features => [FactoryBot.create(:feature, :name => 'External IPAM')])
+  end
+
+  test "external_ipam? method should return true for external ipam subnets" do
+    ipam_subnet = FactoryBot.create(:subnet,
+      :ipam => "External IPAM",
+      :network => '100.25.25.0',
+      :mask => '255.255.255.0',
+      :externalipam => ipam_proxy)
+    assert external_ipam?(ipam_subnet)
+  end
+
+  test "external_ipam? method should return false for non external ipam subnets" do
+    non_ipam_subnet = FactoryBot.create(:subnet,
+      :ipam => "None",
+      :network => '100.25.25.0',
+      :mask => '255.255.255.0')
+    refute external_ipam?(non_ipam_subnet)
+  end
+end

--- a/test/models/orchestration/external_ipam_test.rb
+++ b/test/models/orchestration/external_ipam_test.rb
@@ -1,0 +1,247 @@
+require 'test_helper'
+
+class ExternalIPAMOrchestrationTest < ActiveSupport::TestCase
+  let(:ipam_proxy) do
+    FactoryBot.create(:smart_proxy,
+      :features => [FactoryBot.create(:feature, :name => 'External IPAM')])
+  end
+
+  context 'host with IPv4 interface using external ipam' do
+    let(:subnet) do
+      FactoryBot.create(:subnet,
+        :ipam => IPAM::MODES[:external_ipam],
+        :network => '100.25.25.0',
+        :mask => '255.255.255.0',
+        :externalipam => ipam_proxy)
+    end
+
+    let(:interfaces) do
+      [FactoryBot.build(:nic_managed,
+        :ip => '100.25.25.1',
+        :mac => '00:53:67:ab:dd:00',
+        :subnet => subnet,
+        :domain => FactoryBot.create(:domain))]
+    end
+
+    test "host with IPv4 interface should be valid" do
+      host = FactoryBot.create(:host, :managed, :interfaces => interfaces)
+      assert host.valid?
+    end
+
+    test "should queue a create task when new host created" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      assert host.new_record?
+      assert host.valid?
+      host.save
+      assert_equal ["external_ipam_create_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+    end
+
+    test "should queue a remove task when host is destroyed" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.destroy
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+    end
+
+    test 'should queue an update task when interface ip is updated in host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip = '100.25.25.2'
+      host.save!
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4", "external_ipam_create_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+    end
+  end
+
+  context 'host with IPv6 interface using external ipam' do
+    let(:subnet) do
+      FactoryBot.create(:subnet_ipv6,
+        :ipam => IPAM::MODES[:external_ipam],
+        :network => '2001:db8::',
+        :cidr => "64",
+        :externalipam => ipam_proxy)
+    end
+
+    let(:interfaces) do
+      [FactoryBot.build(:nic_managed,
+        :ip6 => '2001:db8::1',
+        :mac => '00:53:67:ab:dd:00',
+        :subnet6 => subnet,
+        :domain => FactoryBot.create(:domain))]
+    end
+
+    test "host with IPv6 interface should be valid" do
+      host = FactoryBot.create(:host, :managed, :interfaces => interfaces)
+      assert host.valid?
+    end
+
+    test "should queue a create task when new host created" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      assert host.new_record?
+      assert host.valid?
+      host.save
+      assert_equal ["external_ipam_create_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+
+    test "should queue a remove task when host is destroyed" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.destroy
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+
+    test 'should queue an update task when interface ip is updated in host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip6 = '2001:db8::2'
+      host.save!
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv6", "external_ipam_create_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+  end
+
+  context 'host with dual stack interface(IPv4 & IPv6) using external ipam' do
+    let(:subnet) do
+      FactoryBot.create(:subnet,
+        :ipam => IPAM::MODES[:external_ipam],
+        :network => '100.25.25.0',
+        :mask => '255.255.255.0',
+        :externalipam => ipam_proxy)
+    end
+
+    let(:subnet6) do
+      FactoryBot.create(:subnet_ipv6,
+        :ipam => IPAM::MODES[:external_ipam],
+        :network => '2001:db8::',
+        :cidr => "64",
+        :externalipam => ipam_proxy)
+    end
+
+    let(:interfaces) do
+      [FactoryBot.build(:nic_managed,
+        :ip => '100.25.25.1',
+        :ip6 => '2001:db8::1',
+        :mac => '00:53:67:ab:dd:00',
+        :subnet => subnet,
+        :subnet6 => subnet6,
+        :domain => FactoryBot.create(:domain))]
+    end
+
+    test "host with dual stack interface should be valid" do
+      host = FactoryBot.create(:host, :managed, :interfaces => interfaces)
+      assert host.valid?
+    end
+
+    test "should queue 2 create tasks when new host created" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      assert host.new_record?
+      assert host.valid?
+      host.save
+      assert_equal ["external_ipam_create_00:53:67:ab:dd:00_IPv4", "external_ipam_create_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+
+    test "should queue 2 remove tasks when host is destroyed" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.destroy
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4", "external_ipam_remove_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+
+    test 'should queue 2 update tasks when both ips in dual stack interface are updated on host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip = '100.25.25.2'
+      host.interfaces.first.ip6 = '2001:db8::2'
+      host.save!
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4", "external_ipam_remove_00:53:67:ab:dd:00_IPv6", "external_ipam_create_00:53:67:ab:dd:00_IPv4", "external_ipam_create_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+
+    test 'should queue only 1 update tasks when IPv4 address in dual stack interface is updated on host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip = '100.25.25.2'
+      host.save!
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4", "external_ipam_create_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4").action[-2].to_sym
+    end
+
+    test 'should queue only 1 update tasks when IPv6 address in dual stack interface is updated on host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip6 = '2001:db8::2'
+      host.save!
+      assert_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv6", "external_ipam_create_00:53:67:ab:dd:00_IPv6"], host.queue.task_ids
+      assert_equal :set_remove_external_ip, host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+      assert_equal :set_add_external_ip, host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv6").action[-2].to_sym
+    end
+  end
+
+  context 'host with interface not using external ipam' do
+    let(:subnet) do
+      FactoryBot.create(:subnet,
+        :ipam => "None",
+        :network => '100.25.25.0',
+        :mask => '255.255.255.0')
+    end
+
+    let(:interfaces) do
+      [FactoryBot.build(:nic_managed,
+        :ip => '100.25.25.1',
+        :mac => '00:53:67:ab:dd:00',
+        :subnet => subnet,
+        :domain => FactoryBot.create(:domain))]
+    end
+
+    test "should not queue an external ipam create task when new host created" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      assert host.new_record?
+      assert host.valid?
+      host.save
+      assert_not_equal ["external_ipam_create_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_nil host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4")
+    end
+
+    test "should not queue an external ipam remove task when host is destroyed" do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.destroy
+      assert_not_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_nil host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4")
+    end
+
+    test 'should not queue an external ipam update task when interface ip is updated in host' do
+      host = FactoryBot.build(:host, :managed, :interfaces => interfaces)
+      host.save
+      host.queue.clear
+      host.interfaces.first.ip = '100.25.25.2'
+      host.save!
+      assert_not_equal ["external_ipam_remove_00:53:67:ab:dd:00_IPv4", "external_ipam_create_00:53:67:ab:dd:00_IPv4"], host.queue.task_ids
+      assert_nil host.queue.find_by_id("external_ipam_remove_00:53:67:ab:dd:00_IPv4")
+      assert_nil host.queue.find_by_id("external_ipam_create_00:53:67:ab:dd:00_IPv4")
+    end
+  end
+end

--- a/test/models/subnet/external_ipam_test.rb
+++ b/test/models/subnet/external_ipam_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class Subnet::ExternalIpamTest < ActiveSupport::TestCase
+  test 'external ipam is supported for IPv4' do
+    subnet = FactoryBot.build(:subnet_ipv4)
+    assert subnet.supports_ipam_mode?(:external_ipam)
+  end
+
+  test 'external ipam is supported for IPv6' do
+    subnet = FactoryBot.build(:subnet_ipv6)
+    assert subnet.supports_ipam_mode?(:external_ipam)
+  end
+
+  test 'subnet with external ipam does not need IP range' do
+    subnet = FactoryBot.build(:subnet_ipv4)
+    subnet.ipam = IPAM::MODES[:external_ipam]
+    refute subnet.ipam_needs_range?
+  end
+end


### PR DESCRIPTION
NOTE: Submitting a new PR for "Fixes #27067 - IPAM Integration with phpIPAM" using a new branch named: feature/ipam_integration. 

There were some issues with the previous branch(plugin/foreman_ipam), that I was not able to recover from. We can use the old PR(which is now closed) as a reference to the code review history.

https://github.com/theforeman/foreman/pull/6847

===========================================

This PR is a patch to support of the use of plugins for external IPAM use, with opensource provider phpIPAM(https://phpipam.net). The primary use case is to provide the next available IPv4 address from phpIPAM, for a given phpIPAM subnet. 

The functionality that Foreman will use for external IPAM is encompassed in the below plugins(which are both new).

**foreman_ipam(v0.0.10)**
**Git:** https://github.com/grizzthedj/foreman_ipam
**Gem:** https://rubygems.org/gems/foreman_ipam

**smart_proxy_ipam(v0.0.15)**
**Git:** https://github.com/grizzthedj/smart_proxy_ipam
**Gem:** https://rubygems.org/gems/smart_proxy_ipam

The `foreman_ipam` plugin provides a very basic dashboard to display sections and subnets from phpIPAM, and the `smart_proxy_ipam` plugin communicates with the phpIPAM API.

Features and functionality

* Simple IPAM Dashboard page(Infrastructure => IPAM Dashboard) to view sections and subnets for phpIPAM. More features will be added here based on internal user feedback and from the community.
* When creating a phpIPAM subnet(IPAM type = External IPAM) in Foreman, subnet/mask must exist in phpIPAM, or error will be thrown
* When creating a new host in Foreman, auto suggested IP's from phpIPAM will be persisted back to phpIPAM on Host submit.
* When updating the IP address on a NIC that uses a phpIPAM subnet, the old IP will be deleted from phpIPAM, and new one will be added.
* Deleting a host in Foreman will delete all NIC ip's that used a phpIPAM subnet
* Deleting a NIC from a host will also delete the IP from phpIPAM
* Deleting a subnet in Foreman will NOT delete the associated subnet in phpIPAM. This could easily be added later if it makes sense to the community, however initial thoughts are to not delete it. 

Prerequisites for testing:
* Working Foreman environment.
* A phpIPAM instance that at least one Forman Smart Proxy has network connectivity to.
* The API must be enabled in phpIPAM settings, and `Prettify Links` should also be enabled.
* An API user in phpIPAM must be created. The credentials for this user are to be put in the `config/settings.d/externalipam.yml` file in the Smart Proxy core
