### PR TITLE
Refs #27995 - keep set_reported_data in Host::Base

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -192,7 +192,6 @@ module Host
       build_required_interfaces(managed: false, type: primary_interface_type(parser))
       set_non_empty_values(parser, attributes_to_import_from_facts)
       set_interfaces(parser) if parser.parse_interfaces?
-      set_reported_data(parser)
     end
 
     def set_non_empty_values(parser, methods)

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -414,6 +414,7 @@ class Host::Managed < Host::Base
 
   def populate_fields_from_facts(parser, type, source_proxy)
     super
+    set_reported_data(parser)
     update_os_from_facts if operatingsystem_id_changed?
     populate_facet_fields(parser, type, source_proxy)
   end


### PR DESCRIPTION
The patch broke discovery by moving a method from base class to host::managed. This fixes the problem.

Test failures are at: https://github.com/theforeman/foreman_discovery/pull/458