### PR TITLE
Fixes #27740 - Allow creating parameters with lone taxonomies

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -243,6 +243,8 @@ module Api
 
     def assign_lone_taxonomies
       return unless resource_class_for(resource_name)
+      # parameters aren't taxable but have a relation to taxonomies because of location and organization params
+      return if resource_name == 'parameter'
       Taxonomy.types.each do |taxonomy|
         tax_name = taxonomy.to_s.downcase
         if resource_class.reflections.has_key? tax_name.pluralize

--- a/test/controllers/api/v2/parameters_controller_test.rb
+++ b/test/controllers/api/v2/parameters_controller_test.rb
@@ -122,6 +122,14 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
     assert_response :created
   end
 
+  test "should create host parameter with lone taxonomies" do
+    Location.stubs(:one?).returns(true)
+    assert_difference('@host.parameters.count') do
+      post :create, params: { :host_id => @host.to_param, :parameter => valid_attrs }
+    end
+    assert_response :created
+  end
+
   test "should create domain parameter" do
     domain = domains(:mydomain)
     assert_difference('domain.parameters.count') do
@@ -184,6 +192,15 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
   end
 
   test "should create hostgroup parameter" do
+    hostgroup = hostgroups(:common)
+    assert_difference('hostgroup.group_parameters.count') do
+      post :create, params: { :hostgroup_id => hostgroup.to_param, :parameter => valid_attrs }
+    end
+    assert_response :created
+  end
+
+  test "should create hostgroup parameter with lone taxonomies" do
+    Organization.stubs(:one?).returns(true)
     hostgroup = hostgroups(:common)
     assert_difference('hostgroup.group_parameters.count') do
       post :create, params: { :hostgroup_id => hostgroup.to_param, :parameter => valid_attrs }


### PR DESCRIPTION
Parameter has a relation to taxonomies due to Location and
Organization params.
However, we shouldn't set location_id or organization_id on parameters
even if only one taxonomy is present as they are not taxable.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
