### PR TITLE
Fixes #28116 - AppStream additional media for RHEL8

### DIFF
--- a/db/migrate/20200521082853_rename_cent_os7_install_media.rb
+++ b/db/migrate/20200521082853_rename_cent_os7_install_media.rb
@@ -1,0 +1,9 @@
+class RenameCentOs7InstallMedia < ActiveRecord::Migration[6.0]
+  def up
+    Medium.where(name: "CentOS mirror").update_all(name: "CentOS 7 mirror")
+  end
+
+  def down
+    Medium.where(name: "CentOS 7 mirror").update_all(name: "CentOS mirror")
+  end
+end

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -5,7 +5,8 @@ os_suse = Operatingsystem.unscoped.where(:type => "Suse") || Operatingsystem.uns
 # Installation media: default mirrors
 Medium.without_auditing do
   [
-    { :name => "CentOS mirror",        :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major/os/$arch" },
+    { :name => "CentOS 7 mirror",      :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major/os/$arch" },
+    { :name => "CentOS 8 mirror",      :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major/BaseOS/$arch/kickstart" },
     { :name => "Debian mirror",        :os_family => "Debian",  :path => "http://ftp.debian.org/debian" },
     { :name => "Fedora mirror",        :os_family => "Redhat",  :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Server/$arch/os/" },
     { :name => "Fedora Atomic mirror", :os_family => "Redhat",  :path => "http://dl.fedoraproject.org/pub/alt/atomic/stable/Cloud_Atomic/$arch/os/" },


### PR DESCRIPTION
Katello automatically adds BaseOS and AppStream as additional media so RHEL8 provisioning works. There is currently an issue with that tracked as #27948 but the feature works with RHEL8.

For Foreman core (normal Installation media provisioning) however, there is no such a feature. This is my attempt to fill the gap - if user adds repo containing /BaseOS/ and it is redhat family with major version 8 or higher, Foreman will add new repository named "AppStream" with the same URL but with BaseOS replaced with AppStream which matches all CentOS mirrors as well as RHEL8 CDN. This enables seamless CentOS8 provisioning with Foreman core, installation media must be set to: http://mirror.centos.org/centos/$major/BaseOS/$arch/kickstart/ in order to work.