### PR TITLE
Fixes #28137 - Fix generating global id for operatingsystems

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -73,6 +73,8 @@ class Operatingsystem < ApplicationRecord
                'NXOS'      => %r{NX-OS}i,
                'Xenserver' => %r{XenServer}i }
 
+  graphql_type '::Types::Operatingsystem'
+
   class Jail < Safemode::Jail
     allow :name, :media_url, :major, :minor, :family, :to_s, :==, :release, :release_name, :kernel, :initrd, :pxe_type, :boot_files_uri, :password_hash, :mediumpath
   end

--- a/test/unit/foreman/global_id_test.rb
+++ b/test/unit/foreman/global_id_test.rb
@@ -19,9 +19,16 @@ module Foreman
       end
     end
 
-    test 'generates id for object' do
-      model = FactoryBot.create(:model)
-      assert_equal Foreman::GlobalId.encode('Model', model.id), Foreman::GlobalId.for(model)
+    describe '.for' do
+      test 'generates id for object' do
+        model = FactoryBot.create(:model)
+        assert_equal Foreman::GlobalId.encode('Model', model.id), Foreman::GlobalId.for(model)
+      end
+
+      test 'generates id for Redhat OS' do
+        os = FactoryBot.create(:rhel7_5)
+        assert_equal Foreman::GlobalId.encode('Operatingsystem', os.id), Foreman::GlobalId.for(os)
+      end
     end
   end
 end


### PR DESCRIPTION
It allows to generate global id for operatingsystems
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
