### PR TITLE
Fixes #27760 -  ImpersonateIconActions to use async/await

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
@@ -3,25 +3,22 @@ import { foremanUrl } from '../../../../../foreman_tools';
 
 import { addToast } from '../../../../redux/actions/toasts';
 
-export const stopImpersonating = (url, history) => dispatch =>
-  api
-    .delete(url)
-    // eslint-disable-next-line promise/prefer-await-to-then
-    .then(({ data }) => {
-      window.location.href = foremanUrl('/users');
-
-      dispatch(
-        addToast({
-          type: data.type,
-          message: data.message,
-        })
-      );
-    })
-    .catch(err => {
-      dispatch(
-        addToast({
-          type: 'error',
-          message: 'Failed to stop impersonation',
-        })
-      );
-    });
+export const stopImpersonating = url => async dispatch => {
+  try {
+    const { data } = await api.delete(url);
+    window.location.href = foremanUrl('/users');
+    return dispatch(
+      addToast({
+        type: data.type,
+        message: data.message,
+      })
+    );
+  } catch (error) {
+    return dispatch(
+      addToast({
+        type: 'error',
+        message: 'Failed to stop impersonation',
+      })
+    );
+  }
+};


### PR DESCRIPTION
Update JavaScript code in Foreman to use async/await instead of .then
History param isn't used anywhere in this function, and this function is never called with the history param so it's removed.