### PR TITLE
Fixes #27761 - EditorActions to use async/await

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/EditorActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/EditorActions.test.js.snap
@@ -168,6 +168,25 @@ Array [
       "type": "EDITOR_SHOW_LOADING",
     },
   ],
+  Array [
+    Object {
+      "type": "EDITOR_HIDE_LOADING",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "errorText": "",
+        "previewResult": "Error during rendering, Return to Editor tab.",
+        "selectedHost": Object {
+          "id": "1",
+          "name": "host",
+        },
+        "showError": true,
+      },
+      "type": "EDITOR_SHOW_ERROR",
+    },
+  ],
 ]
 `;
 


### PR DESCRIPTION
Update JavaScript code in Foreman to use async/await instead of .then
changed the test from `error.response.data` to `error.response ? __(error.response.data) : '',` as the test would show errors when error.response is undefined