### PR TITLE
Fixes #28154 - random name/description test failure fixed

### DIFF
--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -162,6 +162,33 @@ class String
   def contains_erb?
     self =~ /<%.*%>/
   end
+
+  # TODO Remove me after Rails 6 upgrade: https://github.com/rails/rails/commit/4940cc49ddb361d584d51bc3eb4675ff8ece4a2b
+  def truncate_bytes(truncate_at, omission: "…")
+    omission ||= ""
+
+    if bytesize <= truncate_at
+      dup
+    elsif omission.bytesize > truncate_at
+      raise ArgumentError, "Omission #{omission.inspect} is #{omission.bytesize}, larger than the truncation length of #{truncate_at} bytes"
+    elsif omission.bytesize == truncate_at
+      omission.dup
+    else
+      self.class.new.tap do |cut|
+        cut_at = truncate_at - omission.bytesize
+
+        scan(/\X/) do |grapheme|
+          if cut.bytesize + grapheme.bytesize <= cut_at
+            cut << grapheme
+          else
+            break
+          end
+        end
+
+        cut << omission
+      end
+    end
+  end
 end
 
 class Object

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,7 +47,7 @@ def valid_name_list
   [
     RFauxFactory.gen_alpha(1),
     RFauxFactory.gen_alpha(255),
-    *RFauxFactory.gen_strings(1..255, exclude: [:html]).values,
+    *RFauxFactory.gen_strings(1..255, exclude: [:html]).values.map {|x| x.truncate_bytes(255, omission: '')},
     RFauxFactory.gen_html(rand((1..230))),
   ]
 end


### PR DESCRIPTION
Due to generation of UTF8 Chinese characters up to 255 and storing them into name/description field with 255 bytes limit. This is UTF8 vs bytes problem, generated random UTF8 data must be truncated not to exceed the limit.