### PR TITLE
Fixes #25281,#27002 - support passing names in ovirt

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -37,7 +37,7 @@ module Api
           param :uuid, String, :desc => N_("Deprecated, please use datacenter") # FIXME: deprecated
           param :datacenter, String, :desc => N_("for oVirt, VMware Datacenter")
           param :use_v4, :bool, :desc => N_("for oVirt only")
-          param :ovirt_quota, String, :desc => N_("for oVirt only, ID of quota to use")
+          param :ovirt_quota, String, :desc => N_("for oVirt only, ID or Name of quota to use")
           param :public_key, String, :desc => N_("for oVirt only")
           param :region, String, :desc => N_("for EC2 only, use '%s' for GovCloud region") % Foreman::Model::EC2::GOV_CLOUD_REGION
           param :tenant, String, :desc => N_("for OpenStack and AzureRM only")

--- a/app/models/concerns/fog_extensions/ovirt/server.rb
+++ b/app/models/concerns/fog_extensions/ovirt/server.rb
@@ -34,7 +34,8 @@ module FogExtensions
       end
 
       def select_nic(fog_nics, nic)
-        fog_nics.detect {|fn| fn.network == nic.compute_attributes['network']} # grab any nic on the same network
+        nic_network = @service.list_networks(@attributes[:cluster]).detect { |n| n.name == nic.compute_attributes['network'] }.try(:id) || nic.compute_attributes['network']
+        fog_nics.detect {|fn| fn.network == nic_network} # grab any nic on the same network
       end
     end
   end


### PR DESCRIPTION
2 bugs were fixed in this pull request:
1. Added the possibility to enter name attributes (not only id) of quota, storage_domain, network and cluster in ovirt.
2. Validate quota so that a compute resource will not be created without a valid one.
3. fixed bug related to entering datacenter name as well. 

This PR is related to another fog-oVirt pr:
https://github.com/fog/fog-ovirt/pull/81

This pr can not be reviewed or merge before the fog-oVirt pr is merged and released.