### PR TITLE
Fixes #28167 - fix parent permission for reports

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -202,6 +202,15 @@ module Api
         end
       end
 
+      def parent_permission(child_permission)
+        case child_permission.to_s
+        when 'generate', 'schedule_report', 'report_data'
+          'view'
+        else
+          super
+        end
+      end
+
       def load_and_authorize_plan
         @plan = load_dynflow_plan(params[:job_id])
         return not_found(_('Report not found, please ensure you used the correct job_id')) if @plan.nil?

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -282,6 +282,21 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
       assert_response :success
       assert_equal '2 ohai', response.body
     end
+
+    it "should generate report with in organization scope" do
+      organization = Organization.first
+      location = Location.first
+      report_template = FactoryBot.create(:report_template, :template => '<%= 1 + 1 %>', :organization_ids => [organization.id], :location_ids => [location.id])
+
+      setup_user('generate', 'report_templates')
+      setup_user('view', 'organizations')
+      setup_user('view', 'locations')
+      users(:one).organizations << organization
+
+      post :generate, params: { id: report_template.id, organization_id: organization.id }, session: set_session_user(:one)
+      assert_response :success
+      assert_equal '2', response.body
+    end
   end
 
   describe '#schedule_report' do


### PR DESCRIPTION
When report is generate in scope of some taxonomy, the parent permission
can't be derived for customer action name - 'generate'. We need to
provide a definition for all non-standard action names.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
