### PR TITLE
Fixes #28191 - add max-lines eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,6 +5,11 @@
     "./node_modules/@theforeman/vendor-dev/eslint.extends.js"
   ],
   "rules": {
+    "max-lines": ["error", {
+      "max": 300,
+      "skipBlankLines": true,
+      "skipComments": true
+    }],
     "promise/prefer-await-to-then": "error",
     "prettier/prettier": ["error", {
       "singleQuote": true,


### PR DESCRIPTION
Part of the `foreman-env` - to create an opinionated cross-plugins JS styling.
Recommendations usually range from 100 to 500 lines, **300** has been picked due to observing our existing files 
