### PR TITLE
Fixes #2170 - Support custom AWS EC2 tags

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -353,7 +353,8 @@ module FormHelper
 
   def link_to_remove_fields(name, f, options = {})
     options[:title] ||= _("Remove Parameter")
-    f.hidden_field(:_destroy) + link_to_function(icon_text('remove', name, :kind => 'pficon'), "remove_fields(this)", options)
+    method_name = f.object.respond_to?(:_destroy) ? :_destroy : :_delete
+    f.hidden_field(method_name) + link_to_function(icon_text('remove', name, :kind => 'pficon'), "remove_fields(this)", options)
   end
 
   # Creates a link to a javascript function that creates field entries for the association on the web page
@@ -362,7 +363,7 @@ module FormHelper
   # +association : The field are created to allow entry into this association
   # +partial+    : String containing an optional partial into which we render
   def link_to_add_fields(name, f, association, partial = nil, options = {})
-    new_object = f.object.class.reflect_on_association(association).klass.new
+    new_object = options.delete(:object) || f.object.class.reflect_on_association(association).klass.new
     locals_option = options.delete(:locals) || {}
     fields = f.fields_for(association, new_object, :child_index => "new_#{association}") do |builder|
       render((partial.nil? ? association.to_s.singularize + "_fields" : partial),

--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -10,6 +10,8 @@ if Foreman::Model::EC2.available?
   require 'fog/aws'
   require 'fog/aws/models/compute/flavor'
   Fog::AWS::Compute::Flavor.include FogExtensions::AWS::Flavor
+  require 'fog/aws/models/compute/tag'
+  Fog::AWS::Compute::Tag.include FogExtensions::AWS::Tag
   require 'fog/aws/models/compute/server'
   Fog::AWS::Compute::Server.include FogExtensions::AWS::Server
 end

--- a/app/models/concerns/fog_extensions/aws/server.rb
+++ b/app/models/concerns/fog_extensions/aws/server.rb
@@ -2,8 +2,24 @@ module FogExtensions
   module AWS
     module Server
       extend ActiveSupport::Concern
+      extend Fog::Attributes::ClassMethods
 
       attr_accessor :managed_ip
+
+      def load_tags
+        list_of_tags = tags
+        return list_of_tags unless tags.present?
+
+        if list_of_tags.is_a?(Hash)
+          service.tags.all('key' => list_of_tags.keys, 'resource-id' => identity)
+        else
+          list_of_tags
+        end
+      end
+
+      # HACK: for tags form to work properly
+      def tags_attributes=(tags)
+      end
 
       def to_s
         tags.try(:[], 'Name') || identity

--- a/app/models/concerns/fog_extensions/aws/tag.rb
+++ b/app/models/concerns/fog_extensions/aws/tag.rb
@@ -1,0 +1,11 @@
+module FogExtensions
+  module AWS
+    module Tag
+      extend ActiveSupport::Concern
+
+      def id
+        "#{resource_id}-#{key}"
+      end
+    end
+  end
+end

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -16,7 +16,7 @@ attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :r
   :compute_resource_id, :compute_resource_name,
   :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
   :certname, :image_id, :image_name, :created_at, :updated_at,
-  :last_compile, :global_status, :global_status_label, :uptime_seconds
+  :last_compile, :global_status, :global_status_label, :uptime_seconds, :tags
 attributes :organization_id, :organization_name
 attributes :location_id, :location_name
 

--- a/app/views/compute_resources_vms/form/ec2/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ec2/_base.html.erb
@@ -31,3 +31,29 @@ images = possible_images(compute_resource, arch, os)
 
   <%= selectable_f f, :managed_ip, {_("Public")=>'public', _("Private")=>'private'}, {}, { :label => _("Managed IP"), :label_size => "col-md-2" } %>
 </div>
+
+<% if controller_name != "compute_attributes" %>
+  <div class="row">
+    <% tag = compute_resource.new_tag %>
+    <%= label_tag(:tags, _("Tags"), :class => 'col-md-2 control-label') %>
+    <div class="col-md-6">
+      <table id="ec2_tags" class="<%= table_css_classes %>">
+        <thead>
+          <th><%= _('Key') %></th>
+          <th><%= _('Value') %></th>
+          <% if new_vm %>
+            <th><%= _('Actions') %></th>
+          <% end %>
+        </thead>
+        <tbody>
+          <%= f.fields_for :tags, f.object.load_tags do |fields| %>
+            <%= render "compute_resources_vms/form/ec2/ec2_tag", f: fields, new_vm: new_vm %>
+          <% end %>
+        </tbody>
+      </table>
+      <% if new_vm %>
+       <%= link_to_add_fields('+ ' + _("Add tag"), f, :tags, "compute_resources_vms/form/ec2/ec2_tag", { :target => '#ec2_tags tbody', object: [tag], locals: { new_vm: new_vm } }) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/views/compute_resources_vms/form/ec2/_ec2_tag.html.erb
+++ b/app/views/compute_resources_vms/form/ec2/_ec2_tag.html.erb
@@ -1,0 +1,13 @@
+<tr class="fields">
+  <td>
+    <%= f.text_field(:key, class: "form-control", disabled: !new_vm, placeholder: _("Key")) %>
+  </td>
+  <td>
+    <%= f.text_field(:value, class: "form-control", disabled: !new_vm, placeholder: _("Value")) %>
+  </td>
+  <% if new_vm %>
+    <td>
+      <%= link_to_remove_fields(_('Remove'), f, title: _('Remove tag')) %>
+    </td>
+  <% end %>
+</tr>


### PR DESCRIPTION
Hello Foreman,

This feature as been asked for years and is actually quite important because many people work with Resources Groups and associated permissions profiles in AWS.
For this, you need to be allow to tag your AWS resources with custom rules.

Currently Foreman automatically create a Name tag with FQDN as value.
This PR add a free text field in the UI so you can add multiple Key=Val lines to generate customs tags. If you add Name=something it will override default Foreman tag.

This PR has been tested successfully and also works using API, I created custom tags by posting the following payload on /v2/hosts

```
{'host': {'name': 'test-foreman-api3', 'location_id': 2, 'organization_id': 1, 'hostgroup_id': 1, 'compute_resource_id': 1, 'compute_profile_id': 4, 'operatingsystem_id': 1, 'domain_name': 'foreman.dev.levert', 'compute_attributes': {'image_id': 'ami-0457476522c3d78c5', 'tags': 'Name=test-foreman-api3\nPlatform=Test'}, 'provision_method': 'image', 'managed': True, 'build': True}}
```

Just to be fully honest: It should probably be implemented as a {key, val} hashmap instead of multi-line string but this is my first time ever with Rails so it's the best I've been able to do.
At least it fixes the issue for me atm.

Would someone kind enough to look into it and finish proper work so it can be implemented properly for next Foreman releases ?

Thanks in advance,

Best regards, Adam.