### PR TITLE
[WIP] Fixes #28217 - dropping turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'fast_gettext', '~> 1.4'
 gem 'gettext_i18n_rails', '~> 1.8'
 gem 'rails-i18n', '~> 5.0'
 gem 'i18n', '~> 1.1'
-gem 'turbolinks', '>= 2.5.4', '< 3'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
 gem 'fog-core', '2.1.0'
 gem 'net-scp'
@@ -56,6 +55,9 @@ gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
 gem 'jwt', '~> 2.2.1'
 gem 'graphql', '~> 1.8.0'
 gem 'graphql-batch'
+# this one is a dependecy for x-editable-rails
+# when removing turbolinks, coffee-script is removed as well
+gem 'coffee-rails', '~> 5.0.0' 
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,3 @@
-//= require jquery.turbolinks
-//= require turbolinks
 //= require jquery.ui.autocomplete
 //= require jquery.ui.spinner
 //= require scoped_search
@@ -22,9 +20,6 @@ $(document).on('page:fetch', function() {
 $(document).on('page:change', tfm.tools.hideSpinner);
 
 $(function() {
-  // turbolinks classic cached pages have an issue with react integration
-  // https://github.com/reactjs/react-rails/blob/18a4f5b4c44ab58ad0dd77c5e9315e3cb0edba1f/react_ujs/src/events/turbolinksClassicDeprecated.js#L4
-  Turbolinks.pagesCached(0);
   $(document).trigger('ContentLoad');
 });
 

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,5 +1,4 @@
 group :assets do
-  gem 'jquery-turbolinks', '~> 2.1'
   gem 'jquery-ui-rails', '< 5.0.0'
   gem 'patternfly-sass', '>= 3.32.1', '< 3.38.0'
   gem 'gettext_i18n_rails_js', '~> 1.0'

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -1,6 +1,19 @@
 import $ from 'jquery';
+import { contentSwaping } from './services/InternalAjax';
 import store from './react_app/redux';
 import * as LayoutActions from './react_app/components/Layout/LayoutActions';
+import { deprecateObjectProperty } from './foreman_tools';
+
+export const ApplyLinks = () => {
+  const anchorTags = document.querySelectorAll('a[data-ajax-loading]');
+  anchorTags.forEach(elem => {
+    elem.onclick = () => {
+      const { text, href } = elem;
+      visit(text, href);
+      return false;
+    };
+  });
+};
 
 export const showLoading = () => {
   store.dispatch(LayoutActions.showLoading());
@@ -32,3 +45,12 @@ export function showContent(layout, unsubscribe) {
     content();
   } else if ($('#layout').length === 0) content();
 }
+
+export const visit = (url, name = null) => {
+  window.history.pushState({}, name || url, url);
+  contentSwaping(url);
+};
+
+window.Turbolinks = { visit };
+// eslint-disable-next-line no-undef
+deprecateObjectProperty(Turbolinks, 'visit', 'tfm.nav.visit');

--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
 import { routes } from './routes';
+import { contentSwaping } from '../../services/InternalAjax';
 
 let currentLocation = null;
 
@@ -31,7 +32,7 @@ const AppSwitcher = () => (
             child.location.state.useTurbolinks &&
             !window.history.state.turbolinks; // visit() already called
 
-          if (useTurbolinks) window.Turbolinks.visit(child.location.pathname);
+          if (useTurbolinks) contentSwaping(child.location.pathname);
         }
         currentLocation = child.location;
         return null;
@@ -39,5 +40,4 @@ const AppSwitcher = () => (
     />
   </Switch>
 );
-
 export default AppSwitcher;

--- a/webpack/assets/javascripts/services/InternalAjax/index.js
+++ b/webpack/assets/javascripts/services/InternalAjax/index.js
@@ -1,0 +1,60 @@
+import $ from 'jquery';
+import API from '../../react_app/API';
+import { showSpinner, hideSpinner } from '../../foreman_tools';
+import { ApplyLinks } from '../../foreman_navigation';
+
+let cachedHead = null;
+
+export const contentSwaping = async url => {
+  cachedHead = cachedHead || getInitialHead();
+  let response = null;
+  showSpinner();
+  try {
+    response = await API.get(url, { Accept: 'text/html' });
+  } catch ({ response: { status } }) {
+    window.location.assign(status);
+  }
+
+  const { data } = response;
+  const railsContent = $('#content');
+  const [parsedContent, parsedHead] = parsingHTML(data);
+
+  if (compareHeads(parsedHead, cachedHead)) {
+    railsContent.replaceWith(parsedContent);
+    // eslint-disable-next-line jquery/no-show
+    $('#content').show();
+  } else {
+    window.location.assign(url);
+  }
+  hideSpinner();
+  cachedHead = parsedHead;
+  ApplyLinks();
+  $(document.body).trigger('ContentLoad');
+};
+
+const parsingHTML = html => {
+  // eslint-disable-next-line jquery/no-parse-html
+  const domParser = new DOMParser();
+  const parsed = $($.parseHTML(html, document, true));
+  const parsedContent = parsed.find('#content')[0];
+
+  const doc = domParser.parseFromString(html, 'text/html');
+  const trackedHead = getTrackedTags(doc.head);
+  return [parsedContent, trackedHead];
+};
+
+const getTrackedTags = document =>
+  document.querySelectorAll('[data-turbolinks-track]');
+
+const compareHeads = (newHead, currentHead) => {
+  if (newHead.length !== currentHead.length) return false;
+  let isEqual = true;
+  currentHead.forEach((elm, index) => {
+    if (!newHead[index].isEqualNode(elm)) {
+      isEqual = false;
+    }
+  });
+  return isEqual;
+};
+
+const getInitialHead = () => getTrackedTags($('head')[0]);

--- a/webpack/test_setup.js
+++ b/webpack/test_setup.js
@@ -2,6 +2,9 @@ import 'babel-polyfill';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
+jest.mock('./assets/javascripts/foreman_navigation', () => ({
+  deprecateObjectProperty: jest.fn,
+}));
 jest.mock('jed');
 jest.mock('./assets/javascripts/react_app/common/I18n');
 jest.mock('./assets/javascripts/foreman_tools', () => ({


### PR DESCRIPTION
Foreman uses turbolinks classic, which won't be supported (rails 6)
This PR is a POC for removing it from foreman and using other solution