### PR TITLE
Fixes #28222: Stabilize React Storybook

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,2 +1,3 @@
 import '@storybook/addon-actions/register';
 import '@storybook/addon-knobs/register';
+import '@storybook/addon-storysource/register';

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -40,6 +40,20 @@ module.exports = (baseConfig, env, defaultConfig) => {
       test: /(\.ttf|\.woff|\.woff2|\.eot|\.svg|\.jpg)$/,
       loaders: ['url-loader']
     },
+    {
+      test: /\.stories\.js$/,
+      loaders: [
+        {
+          loader: require.resolve('@storybook/addon-storysource/loader'),
+          options: {
+              prettierConfig: {
+                parser: "babel" //The default prettier parser
+              },
+            },
+        }
+      ],
+      enforce: 'pre',
+    },
   ]
 
   defaultConfig.resolve = {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "devDependencies": {
     "@storybook/addon-actions": "~3.4.12",
     "@storybook/addon-knobs": "~3.4.12",
+    "@storybook/addon-storysource": "^3.4.12",
     "@storybook/react": "~3.4.12",
     "@storybook/storybook-deployer": "^2.0.0",
     "@theforeman/vendor-dev": "^1.7.0",

--- a/webpack/stories/index.js
+++ b/webpack/stories/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { configure, storiesOf } from '@storybook/react';
+import 'babel-polyfill';
 import Markdown from './components/Markdown';
 import Story from './components/Story';
 
@@ -14,9 +15,6 @@ import plugins from './docs/plugins.md';
 import SlotAndFill from './docs/SlotAndFill.md';
 import LegacyJs from './docs/LegacyJs.md';
 import ForemanFrontendDiagram from './docs/foreman-frontend-infra.png';
-
-require('../assets/javascripts/bundle');
-require('../../app/assets/javascripts/application');
 
 const req = require.context(
   '../assets/javascripts/react_app',


### PR DESCRIPTION
* Refactor `stories/index.js` to remove unnecessary `require`s
* Add `storysource` add-on to Storybook: Adds a __Story__ tab to show the code of each story.