### PR TITLE
Fixes #28227 - drop support of node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 script: ./script/travis_run_js_tests.sh


### PR DESCRIPTION
The Node.js 8.x Maintenance LTS cycle will expire on December 31, 2019,
and it seem that already there are differences in tests snapshots and linting rules because of it.