### PR TITLE
Fixes #26562 - Test smart proxy graphql on hosts with env

### DIFF
--- a/test/graphql/queries/smart_proxy_query_test.rb
+++ b/test/graphql/queries/smart_proxy_query_test.rb
@@ -26,7 +26,7 @@ module Queries
       GRAPHQL
     end
 
-    let(:hosts) { FactoryBot.create_list(:host, 2) }
+    let(:hosts) { FactoryBot.create_list(:host, 2, :with_environment) }
     let(:smart_proxy) { FactoryBot.create(:smart_proxy, hosts: hosts) }
 
     let(:global_id) { Foreman::GlobalId.for(smart_proxy) }


### PR DESCRIPTION
Due to a change in Rails (https://github.com/rails/rails/pull/33673/),
when factory bot creates a smart proxy with child hosts it now triggers
a save on the hosts, which in this test fails because hosts validate
that they have an environment set if they have a puppet proxy assigned.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
