### PR TITLE
Fixes #24838 - Use integer representation for boolean on sqlite

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -136,6 +136,9 @@ module Foreman
     # Configure sensitive parameters which will be filtered from the log file.
     config.filter_parameters += [:password, :account_password, :facts, :root_pass, :value, :report, :password_confirmation, :secret]
 
+    # Since Rails 6 sqlite db must use integer representation for booleans
+    config.active_record.sqlite3.represent_boolean_as_integer = true
+
     # Enable escaping HTML in JSON.
     config.active_support.escape_html_entities_in_json = true
 

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -5,12 +5,6 @@
 - message: "`secrets.secret_token` is deprecated in favor of `secret_key_base` and
     will be removed in Rails 6.0."
 
-- message: |-
-    DEPRECATION WARNING: Leaving `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
-    set to false is deprecated. SQLite databases have used 't' and 'f' to serialize
-    boolean values and must have old data converted to 1 and 0 (its native boolean
-    serialization) before setting this flag to true.
-
 # https://projects.theforeman.org/issues/23300
 - message: 'Dangerous query method (method whose arguments are used as raw SQL) called
     with non-attribute argument(s):'

--- a/db/seeds.d/035-admin.rb
+++ b/db/seeds.d/035-admin.rb
@@ -42,11 +42,13 @@ unless User.unscoped.find_by_login(User::ANONYMOUS_API_ADMIN).present?
 end
 
 # First real admin user account
-unless User.unscoped.only_admin.except_hidden.present?
+admin_login = ENV['SEED_ADMIN_USER'].presence || 'admin'
+if User.unscoped.find_by_login(admin_login).present?
+  puts "User with login #{admin_login} already exists, not seeding as admin."
+elsif User.unscoped.only_admin.except_hidden.none?
   User.without_auditing do
     User.as_anonymous_admin do
-      admin_user = ENV['SEED_ADMIN_USER'].presence || 'admin'
-      user = User.new(:login     => admin_user,
+      user = User.new(:login     => admin_login,
                       :firstname => ENV['SEED_ADMIN_FIRST_NAME'] || "Admin",
                       :lastname  => ENV['SEED_ADMIN_LAST_NAME'] || "User",
                       :mail      => (ENV['SEED_ADMIN_EMAIL'] || Setting[:administrator]).try(:dup))
@@ -64,4 +66,6 @@ unless User.unscoped.only_admin.except_hidden.present?
       raise "Unable to create admin user: #{format_errors user}" unless user.save
     end
   end
+else
+  puts "An admin user already exists, not seeding a new one."
 end


### PR DESCRIPTION
We don't really need to migrate boolean fields as sqlite isn't supported
production database and is only used for running build tasks.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
