### PR TITLE
Fixes #28269 - Remove translation from table column

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/table/schemaHelpers/column.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/schemaHelpers/column.js
@@ -1,4 +1,3 @@
-import { translate as __ } from '../../../../common/I18n';
 /**
  * Generate a column for a patternfly-3 table.
  * See more in http://patternfly-react.surge.sh/patternfly-3/
@@ -25,7 +24,7 @@ export const column = (
 ) => ({
   property,
   header: {
-    label: __(label),
+    label,
     props: headProps,
     formatters: headFormat,
   },


### PR DESCRIPTION
The column should not do that because we have a script that searches for the __ in order to extract all the strings needs to be translated and upload them to the translation service.
All '__' instances should be hard coded strings and not variables so the script will only send strings to translate (and not variable name)

Models table already translates the label so no changes needed there