### PR TITLE
Fixes #28205 - manifest action progress not tracked

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -5,10 +5,12 @@ Object {
   "action": Array [
     Array [
       Object {
+        "key": "BOOKMARKS",
         "payload": Object {
           "controller": "models",
         },
-        "type": "BOOKMARKS_REQUEST",
+        "type": "API_GET",
+        "url": "/api/bookmarks?search=controller%3Dmodels&per_page=100",
       },
     ],
   ],

--- a/webpack/assets/javascripts/react_app/redux/API/APIMiddleware.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIMiddleware.js
@@ -5,7 +5,7 @@ export const APIMiddleware = store => next => action => {
   const { type, key, payload = {}, url, actionTypes = {} } = action;
   if (type === API_OPERATIONS.GET) {
     get(payload, url, store, actionTypeGenerator(key, actionTypes));
-  } else {
-    next(action);
   }
+
+  return next(action);
 };

--- a/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/bookmarks/bookmarks.fixtures.js
@@ -21,8 +21,16 @@ const requestAction = {
   payload: { controller: 'hosts' },
 };
 
+const apiAction = {
+  key: 'BOOKMARKS',
+  payload: { controller: 'hosts' },
+  type: 'API_GET',
+  url: '/api/bookmarks?search=controller%3Dhosts&per_page=100',
+};
+
 export const onFailureActions = [
   requestAction,
+  apiAction,
   {
     payload: {
       error: new Error('Request failed with status code 422'),
@@ -34,6 +42,7 @@ export const onFailureActions = [
 
 export const onSuccessActions = [
   requestAction,
+  apiAction,
   {
     payload: {
       results: bookmarks,

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
@@ -18,6 +18,12 @@ export const requestData = {
 export const onFailureActions = [
   { payload: { id: 0 }, type: 'HOST_POWER_STATUS_REQUEST' },
   {
+    key: 'HOST_POWER_STATUS',
+    payload: { id: 0 },
+    type: 'API_GET',
+    url: '/hosts/0/power',
+  },
+  {
     payload: {
       error: new Error('Request failed with status code 500'),
       payload: { id: 0 },
@@ -28,6 +34,12 @@ export const onFailureActions = [
 
 export const onSuccessActions = [
   { payload: { id: 1 }, type: 'HOST_POWER_STATUS_REQUEST' },
+  {
+    key: 'HOST_POWER_STATUS',
+    payload: { id: 1 },
+    type: 'API_GET',
+    url: '/hosts/1/power',
+  },
   {
     payload: mockSuccessRequests[0].response,
     type: 'HOST_POWER_STATUS_SUCCESS',

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
@@ -29,8 +29,20 @@ export const onSuccessActions = [
     type: 'STATISTICS_DATA_REQUEST',
   },
   {
+    key: 'STATISTICS_DATA',
+    payload: payloads.operatingsystem,
+    type: 'API_GET',
+    url: 'statistics/operatingsystem',
+  },
+  {
     payload: payloads.architecture,
     type: 'STATISTICS_DATA_REQUEST',
+  },
+  {
+    key: 'STATISTICS_DATA',
+    payload: payloads.architecture,
+    type: 'API_GET',
+    url: 'statistics/architecture',
   },
   {
     payload: {
@@ -54,8 +66,20 @@ export const onFailureActions = [
     type: 'STATISTICS_DATA_REQUEST',
   },
   {
+    key: 'STATISTICS_DATA',
+    payload: payloads.operatingsystem,
+    type: 'API_GET',
+    url: 'statistics/operatingsystem',
+  },
+  {
     payload: payloads.architecture,
     type: 'STATISTICS_DATA_REQUEST',
+  },
+  {
+    key: 'STATISTICS_DATA',
+    payload: payloads.architecture,
+    type: 'API_GET',
+    url: 'statistics/architecture',
   },
   {
     payload: {


### PR DESCRIPTION
The community post here explains the issue in detail: https://community.theforeman.org/t/change-in-foreman-react-code-affecting-katello-manifest-refresh-ui/16184

The gist of it is that there was a change to the React middleware recently in Foreman that broke the Katello Manifest-related UI.  Adding the return here fixes it.