### PR TITLE
Fixes #28274 - refactor fallback route

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -1,43 +1,70 @@
 import React from 'react';
 import { Switch, Route } from 'react-router-dom';
+import URI from 'urijs';
 import { routes } from './routes';
 
-let currentLocation = null;
+let currentPath = null;
 
-const AppSwitcher = () => (
-  <Switch>
-    {routes.map(({ render, path, ...routeProps }) => (
-      <Route
-        path={path}
-        key={path}
-        {...routeProps}
-        render={renderProps => {
-          const railsContainer = document.getElementById('rails-app-content');
-          if (railsContainer) railsContainer.remove();
-          currentLocation = renderProps.location;
+const AppSwitcher = () => {
+  const updateCurrentPath = () => {
+    currentPath = getURIPath();
+  };
 
-          return render(renderProps);
-        }}
-      />
-    ))}
-    <Route
-      render={child => {
-        if (
-          currentLocation &&
-          currentLocation.pathname !== child.location.pathname
-        ) {
-          const useTurbolinks =
-            child.location.state &&
-            child.location.state.useTurbolinks &&
-            !window.history.state.turbolinks; // visit() already called
+  const getURIPath = () => {
+    /**
+      we decided to use URIjs to get the full path because 
+      turbolinks interpolates the window.location and sometimes instead of the full path,
+      e.g.: "/architectures/edit" we will get only "/architectures".
+     */
+    const uri = new URI();
+    return uri.pathname();
+  };
 
-          if (useTurbolinks) window.Turbolinks.visit(child.location.pathname);
-        }
-        currentLocation = child.location;
-        return null;
-      }}
-    />
-  </Switch>
-);
+  const handleRailsContainer = () => {
+    const railsContainer = document.getElementById('rails-app-content');
+    if (railsContainer) railsContainer.remove();
+  };
+
+  const handleTurbolinksVisit = (location, nextPath) => {
+    const { state: { useTurbolinks } = {} } = location;
+    /**
+      Couldn't use routeProps history because it's different than 
+      the window.history and sometimes doesn't contain the turbolinks object.
+    */
+    const turbolinksVisitCalled = !window.history.state.turbolinks;
+    if (useTurbolinks && turbolinksVisitCalled) {
+      window.Turbolinks.visit(nextPath);
+    }
+  };
+
+  const handleRoute = (Component, props) => {
+    handleRailsContainer();
+    updateCurrentPath();
+    return <Component {...props} />;
+  };
+
+  const handleFallbackRoute = ({ location }) => {
+    const nextPath = getURIPath();
+    if (currentPath !== nextPath) {
+      updateCurrentPath();
+      handleTurbolinksVisit(location, nextPath);
+    }
+    return null;
+  };
+
+  return (
+    <Switch>
+      {routes.map(({ render: Component, path, ...routeProps }) => (
+        <Route
+          path={path}
+          key={path}
+          {...routeProps}
+          render={props => handleRoute(Component, props)}
+        />
+      ))}
+      <Route render={handleFallbackRoute} />
+    </Switch>
+  );
+};
 
 export default AppSwitcher;


### PR DESCRIPTION
The problem is that the `routeProps.location.pathname`
doesn't include the whole URI path after `Turbolinks` manipulates it.

e.g:
while moving from "architectures" page to an architecture edit page,
the `pathname` which is provided by react-router is `/architecures` 
and not `/architectures/{ARCH_NAME}/edit` as expected.

this affects the condition that we had there to trigger turbolinks:
If we want to return to the main architectures page by clicking it in the menu,
it will look like we are already in it, therefore turbolinks won't get called.

got fixed by getting the correct URI full path with `urijs` and comparing it to the last saved path. 
