### PR TITLE
Fixes #28280 - fixed ssl cert compute in ovirt cr create

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -494,7 +494,8 @@ module Foreman::Model
       @client = client
     rescue => e
       if e.message =~ /SSL_connect.*certificate verify failed/ ||
-          e.message =~ /Peer certificate cannot be authenticated with given CA certificates/
+          e.message =~ /Peer certificate cannot be authenticated with given CA certificates/ ||
+           e.message =~ /SSL peer certificate or SSH remote key was not OK/
         raise Foreman::FingerprintException.new(
           N_("The remote system presented a public key signed by an unidentified certificate authority. If you are sure the remote system is authentic, go to the compute resource edit page, press the 'Test Connection' or 'Load Datacenters' button and submit"),
           ca_cert


### PR DESCRIPTION
Fixed this bug:

An error appears when trying to load datacenters when creating a new oVirt compute resource using apiv4.
Error message: Can't send request: SSL peer certificate or SSH remote key was not OK

The reason for this error is a different message error that is returned from a newer version of libcurl package which is used by oVirtsdk.
This libcurl package is apparently used in the newest versions of fedora.