### PR TITLE
Fixes #28295 - fact cleaner map error fixed

### DIFF
--- a/app/services/fact_cleaner.rb
+++ b/app/services/fact_cleaner.rb
@@ -51,7 +51,7 @@ class FactCleaner
     logger.debug "Cleaning facts mathing excluded pattern: #{excluded_facts_regex}"
 
     FactName.unscoped.reorder(nil).find_in_batches(:batch_size => @batch_size) do |names_batch|
-      fact_name_ids = names_batch.select! { |fact_name| fact_name.name.match(excluded_facts_regex) }.map(&:id)
+      fact_name_ids = names_batch.select { |fact_name| fact_name.name.match(excluded_facts_regex) }.map(&:id)
       @deleted_count += delete_facts_names_values(fact_name_ids)
     end
   end


### PR DESCRIPTION
Because `select!` returns `nil` when there was no change, the process
can sometimes fail with nil exception. This fixes it.