### PR TITLE
Fixes #28308 - ignore prerelease tags in dependencies

### DIFF
--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -169,7 +169,7 @@ class SeedHelper
         if plugin.nil?
           logger.info("Template #{template_name} requires plugin #{r['plugin']}, skipping import.")
           return false
-        elsif r['version'] && (Gem::Version.new(plugin.version) < Gem::Version.new(r['version']))
+        elsif r['version'] && (Gem::Version.new(plugin.version).release < Gem::Version.new(r['version']))
           logger.info("Template #{template_name} requires plugin #{r['plugin']} >= #{r['version']}, skipping import.")
           return false
         end

--- a/test/unit/seed_helper_test.rb
+++ b/test/unit/seed_helper_test.rb
@@ -152,6 +152,17 @@ class SeedHelperTest < ActiveSupport::TestCase
       assert_nil SeedHelper.import_raw_template(get_template(metadata.merge(requirements)))
     end
 
+    it 'accepts prereleases to satisty version condition ' do
+      requirements = {
+        'require' => [{
+          'plugin' => 'some_plugin',
+          'version' => '2.0.1',
+        }],
+      }
+      Foreman::Plugin.expects(:find).with('some_plugin').returns(mock(:version => '2.0.1.rc2'))
+      refute_nil SeedHelper.import_raw_template(get_template(metadata.merge(requirements)))
+    end
+
     it 'imports the template and sets taxonomies' do
       orgs = [taxonomies(:organization1), taxonomies(:organization2)]
       locs = [taxonomies(:location1), taxonomies(:location2)]


### PR DESCRIPTION
Templates with requirements specifying plugins that contains .rc in their
versions are skipped. E.g. a template needs katello 3.14.0 but 3.14.0.rc1
s installed. The comparison does not work and template is ignored.

We should ignore the .rc tag as 3.14.0.rc1 has all functionality already
and should be only receiving bug fixes. That makes tester life easier,
they don't have to hack templates in order to seed them.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
