### PR TITLE
Fixes #28315 - allow autocomplete without form scope

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -180,6 +180,19 @@ module ApplicationHelper
     controller.respond_to?(:auto_complete_controller_name) ? controller.auto_complete_controller_name : controller_name
   end
 
+  def auto_complete_search(name, val, options = {})
+    Foreman::Deprecation.deprecation_warning('1.27', 'use #auto_complete_f, possibly with #form_with if you need to avoid of object scope')
+    options.merge!(
+      {
+        url: options[:full_path] || (options[:path] || send("#{auto_complete_controller_name}_path")) + "/auto_complete_#{name}",
+        controller: options[:path] || auto_complete_controller_name,
+        search_query: '',
+        use_key_shortcuts: options[:use_key_shortcuts] || false,
+      }
+    )
+    Tags::ReactInput.new(nil, name, self, options.merge(value: val, type: 'autocomplete', only_input: true)).render
+  end
+
   def sort(field, permitted: [], **kwargs)
     kwargs[:url_options] ||= current_url_params(permitted: permitted)
     super(field, kwargs)

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -416,7 +416,7 @@ module FormHelper
   def react_form_input(type, f, attr, options = {})
     options[:label] ||= get_attr_label(f, attr)
     options[:error] ||= get_attr_error(f, attr)
-    options[:error] = options[:error].to_sentence if options[:error]
+    options[:error] = options[:error]&.to_sentence
     options[:required] = is_required?(f, attr) unless options.key?(:required)
 
     Tags::ReactInput.new(f.object_name, attr, self, options.merge(type: type, object: f.object)).render

--- a/app/helpers/tags/react_input.rb
+++ b/app/helpers/tags/react_input.rb
@@ -1,10 +1,23 @@
 module Tags
   class ReactInput < ActionView::Helpers::Tags::Base
+    def initialize(*attr)
+      super
+      @only_input = @options.delete(:only_input)
+    end
+
+    def only_input?
+      !!@only_input
+    end
+
+    def component_name
+      only_input? ? 'InputFactory' : 'FormField'
+    end
+
     def render
       options = @options.stringify_keys
       options['value'] = options.fetch('value') { value_before_type_cast }
       add_default_name_and_id(options)
-      @template_object.react_component('FormField', reactify_options(options))
+      @template_object.react_component(component_name, reactify_options(options))
     end
 
     private

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.js
@@ -178,6 +178,7 @@ class AutoComplete extends React.Component {
       id,
       error,
       name,
+      value,
       searchQuery,
       inputProps,
       placeholder,
@@ -195,7 +196,7 @@ class AutoComplete extends React.Component {
         <TypeAheadSelect
           id={id}
           ref={this._typeahead}
-          defaultInputValue={searchQuery}
+          defaultInputValue={value || searchQuery}
           options={options}
           onInputChange={this.handleInputChange}
           onChange={this.handleResultsChange}
@@ -230,6 +231,7 @@ AutoComplete.propTypes = {
   id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   url: PropTypes.string.isRequired,
   name: PropTypes.string,
+  value: PropTypes.string,
   results: PropTypes.array,
   searchQuery: PropTypes.string,
   inputProps: PropTypes.object,
@@ -249,6 +251,7 @@ AutoComplete.propTypes = {
 
 AutoComplete.defaultProps = {
   name: null,
+  value: null,
   results: [],
   searchQuery: '',
   inputProps: {},

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/auto-complete.scss
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/auto-complete.scss
@@ -1,9 +1,11 @@
 @import "~@theforeman/vendor/scss/variables";
 
 .foreman-autocomplete {
+  position: relative;
+
   .autocomplete-aux {
     position: absolute;
-    right: 25px;
+    right: 4px;
     top: 4px;
     z-index: 10;
 

--- a/webpack/assets/javascripts/react_app/components/SearchBar/search-bar.scss
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/search-bar.scss
@@ -1,15 +1,6 @@
 @import "../AutoComplete/auto-complete.scss";
-@import "~@theforeman/vendor/scss/variables";
 
 .search-bar {
-  .autocomplete-aux {
-    right: 108px;
-    // Keeps in position when screen size is xs and search button shrinks.
-    @media screen and (max-width: $screen-sm-min) {
-      right: 65px;
-    }
-  }
-
   .autocomplete-search-btn-text {
     display: inline;
   }

--- a/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
@@ -1,48 +1,15 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
   Col,
   FormGroup,
-  FormControl,
   ControlLabel,
   HelpBlock,
   FieldLevelHelp,
 } from 'patternfly-react';
+import InputFactory from './InputFactory';
 import { noop } from '../../../common/helpers';
-
-import AutoComplete from '../../AutoComplete';
-import DateTimePicker from '../DateTimePicker/DateTimePicker';
-import DatePicker from '../DateTimePicker/DatePicker';
-import TimePicker from '../DateTimePicker/TimePicker';
-import OrderableSelect from './OrderableSelect';
-
-const inputComponents = {
-  date: DatePicker,
-  dateTime: DateTimePicker,
-  time: TimePicker,
-  autocomplete: AutoComplete,
-  orderableSelect: OrderableSelect,
-};
-
-export const registerInputComponent = (name, Component) => {
-  inputComponents[name] = Component;
-};
-export const ControlContext = React.createContext();
-
-const InputFactory = ({ type }) => {
-  const controlProps = useContext(ControlContext);
-
-  if (inputComponents[type]) {
-    return (
-      <FormControl componentClass={inputComponents[type]} {...controlProps} />
-    );
-  }
-  return <FormControl type={type} {...controlProps} />;
-};
-InputFactory.propTypes = {
-  type: PropTypes.string.isRequired,
-};
 
 const InlineMessage = ({ error, helpInline }) => {
   if (!error && !helpInline) {
@@ -113,9 +80,7 @@ const FormField = ({
         )}
       </ControlLabel>
       <Col className={inputSizeClass}>
-        <ControlContext.Provider value={controlProps}>
-          {children || <InputFactory type={type} />}
-        </ControlContext.Provider>
+        {children || <InputFactory type={type} {...controlProps} />}
       </Col>
       <InlineMessage error={error} helpInline={helpInline} />
     </FormGroup>

--- a/webpack/assets/javascripts/react_app/components/common/forms/InputFactory.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/InputFactory.js
@@ -1,0 +1,56 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormControl } from 'patternfly-react';
+
+import { noop } from '../../../common/helpers';
+import AutoComplete from '../../AutoComplete';
+import DateTimePicker from '../DateTimePicker/DateTimePicker';
+import DatePicker from '../DateTimePicker/DatePicker';
+import OrderableSelect from './OrderableSelect';
+import TimePicker from '../DateTimePicker/TimePicker';
+
+const inputComponents = {
+  autocomplete: AutoComplete,
+  date: DatePicker,
+  dateTime: DateTimePicker,
+  orderableSelect: OrderableSelect,
+  time: TimePicker,
+};
+
+export const registerInputComponent = (name, Component) => {
+  inputComponents[name] = Component;
+};
+
+const InputFactory = ({ type, ...controlProps }) => {
+  if (inputComponents[type]) {
+    return (
+      <FormControl componentClass={inputComponents[type]} {...controlProps} />
+    );
+  }
+  return <FormControl type={type} {...controlProps} />;
+};
+
+InputFactory.propTypes = {
+  type: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.instanceOf(Date),
+  ]),
+  name: PropTypes.string,
+  disabled: PropTypes.bool,
+  required: PropTypes.bool,
+  className: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+InputFactory.defaultProps = {
+  name: undefined,
+  value: undefined,
+  className: '',
+  required: false,
+  disabled: false,
+  onChange: noop,
+};
+
+export default InputFactory;

--- a/webpack/assets/javascripts/react_app/components/common/forms/__tests__/FormField.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__tests__/FormField.test.js
@@ -1,15 +1,10 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { shallow } from 'enzyme';
-import toJson from 'enzyme-to-json';
 import { testComponentSnapshotsWithFixtures } from '../../../../common/testHelpers';
 import {
   dateTimeWithErrorProps,
   textFieldWithHelpProps,
-  ownComponentFieldProps,
   formAutocompleteDataProps,
 } from '../FormField.fixtures';
-import FormField, { registerInputComponent } from '../FormField';
+import FormField from '../FormField';
 
 const fixtures = {
   'renders text input': { type: 'text', name: 'a' },
@@ -18,31 +13,11 @@ const fixtures = {
   'renders DateTime input': { type: 'dateTime', name: 'a' },
   'renders text complex options and help': textFieldWithHelpProps,
   'renders DateTime complex options and error': dateTimeWithErrorProps,
-  'renders AutoComplete': formAutocompleteDataProps,
-};
-
-const Abc = props => <input type="hidden" id={props.id} name={props.name} />;
-Abc.propTypes = {
-  id: PropTypes.string,
-  name: PropTypes.string,
-};
-Abc.defaultProps = {
-  id: undefined,
-  name: null,
+  'renders AutoComplete': { type: 'autocomplete', formAutocompleteDataProps },
 };
 
 describe('FormField', () => {
   describe('rendering', () => {
     testComponentSnapshotsWithFixtures(FormField, fixtures);
-  });
-
-  describe('register own component', () => {
-    it('renders registered component', () => {
-      registerInputComponent('ownInput', Abc);
-
-      expect(
-        toJson(shallow(<FormField {...ownComponentFieldProps} />))
-      ).toMatchSnapshot();
-    });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/common/forms/__tests__/InputFactory.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__tests__/InputFactory.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { testComponentSnapshotsWithFixtures } from '../../../../common/testHelpers';
+import {
+  ownComponentFieldProps,
+  formAutocompleteDataProps,
+} from '../FormField.fixtures';
+import InputFactory, { registerInputComponent } from '../InputFactory';
+
+const fixtures = {
+  'renders text input': { type: 'text', name: 'a' },
+  'renders DateTime input': { type: 'dateTime', name: 'a' },
+  'renders AutoComplete': {
+    type: 'autocomplete',
+    ...formAutocompleteDataProps,
+  },
+  'renders custom registered component': ownComponentFieldProps,
+};
+
+const Abc = props => <input type="hidden" id={props.id} name={props.name} />;
+Abc.propTypes = {
+  id: PropTypes.string,
+  name: PropTypes.string,
+};
+Abc.defaultProps = {
+  id: undefined,
+  name: null,
+};
+
+describe('InputFactory', () => {
+  describe('rendering', () => {
+    registerInputComponent('ownInput', Abc);
+    testComponentSnapshotsWithFixtures(InputFactory, fixtures);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/common/forms/__tests__/__snapshots__/FormField.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__tests__/__snapshots__/FormField.test.js.snap
@@ -1,52 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`FormField register own component renders registered component 1`] = `
-<FormGroup
-  bsClass="form-group"
-  controlId="own-field"
-  disabled={false}
-  validationState={null}
->
-  <ControlLabel
-    bsClass="control-label"
-    className="col-md-2"
-    srOnly={false}
-  >
-    ownField
-  </ControlLabel>
-  <Col
-    bsClass="col"
-    className="col-md-4"
-    componentClass="div"
-  >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "group[ownfield]",
-          "onChange": [Function],
-          "required": false,
-          "value": undefined,
-        }
-      }
-    >
-      <InputFactory
-        type="ownInput"
-      />
-    </ContextProvider>
-  </Col>
-  <InlineMessage
-    error={null}
-    helpInline={null}
-  />
-</FormGroup>
-`;
-
 exports[`FormField rendering renders AutoComplete 1`] = `
 <FormGroup
   bsClass="form-group"
-  controlId="form-search"
+  controlId={null}
   disabled={false}
   validationState={null}
 >
@@ -60,26 +17,24 @@ exports[`FormField rendering renders AutoComplete 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
+    <InputFactory
+      className=""
+      disabled={false}
+      formAutocompleteDataProps={
         Object {
-          "className": "",
           "controller": "bookmarks",
           "disabled": false,
+          "id": "form-search",
           "name": "Filter[search]",
-          "onChange": [Function],
-          "required": false,
           "searchQuery": "",
           "url": "bookmarks/auto_complete",
           "useKeyShortcuts": false,
-          "value": undefined,
         }
       }
-    >
-      <InputFactory
-        type="text"
-      />
-    </ContextProvider>
+      onChange={[Function]}
+      required={false}
+      type="autocomplete"
+    />
   </Col>
   <InlineMessage
     error={null}
@@ -105,22 +60,14 @@ exports[`FormField rendering renders Date input 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "a",
-          "onChange": [Function],
-          "required": false,
-          "value": undefined,
-        }
-      }
-    >
-      <InputFactory
-        type="date"
-      />
-    </ContextProvider>
+    <InputFactory
+      className=""
+      disabled={false}
+      name="a"
+      onChange={[Function]}
+      required={false}
+      type="date"
+    />
   </Col>
   <InlineMessage
     error={null}
@@ -148,22 +95,15 @@ exports[`FormField rendering renders DateTime complex options and error 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "group[datetime]",
-          "onChange": [Function],
-          "required": false,
-          "value": 1991-01-01T01:12:01.000Z,
-        }
-      }
-    >
-      <InputFactory
-        type="dateTime"
-      />
-    </ContextProvider>
+    <InputFactory
+      className=""
+      disabled={false}
+      name="group[datetime]"
+      onChange={[Function]}
+      required={false}
+      type="dateTime"
+      value={1991-01-01T01:12:01.000Z}
+    />
   </Col>
   <InlineMessage
     error="can not be in the past"
@@ -189,22 +129,14 @@ exports[`FormField rendering renders DateTime input 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "a",
-          "onChange": [Function],
-          "required": false,
-          "value": undefined,
-        }
-      }
-    >
-      <InputFactory
-        type="dateTime"
-      />
-    </ContextProvider>
+    <InputFactory
+      className=""
+      disabled={false}
+      name="a"
+      onChange={[Function]}
+      required={false}
+      type="dateTime"
+    />
   </Col>
   <InlineMessage
     error={null}
@@ -230,22 +162,14 @@ exports[`FormField rendering renders Time input 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "a",
-          "onChange": [Function],
-          "required": false,
-          "value": undefined,
-        }
-      }
-    >
-      <InputFactory
-        type="time"
-      />
-    </ContextProvider>
+    <InputFactory
+      className=""
+      disabled={false}
+      name="a"
+      onChange={[Function]}
+      required={false}
+      type="time"
+    />
   </Col>
   <InlineMessage
     error={null}
@@ -283,22 +207,14 @@ exports[`FormField rendering renders text complex options and help 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "group[textfield]",
-          "onChange": [Function],
-          "required": false,
-          "value": undefined,
-        }
-      }
-    >
-      <InputFactory
-        type="text"
-      />
-    </ContextProvider>
+    <InputFactory
+      className=""
+      disabled={false}
+      name="group[textfield]"
+      onChange={[Function]}
+      required={false}
+      type="text"
+    />
   </Col>
   <InlineMessage
     error={null}
@@ -324,22 +240,14 @@ exports[`FormField rendering renders text input 1`] = `
     className="col-md-4"
     componentClass="div"
   >
-    <ContextProvider
-      value={
-        Object {
-          "className": "",
-          "disabled": false,
-          "name": "a",
-          "onChange": [Function],
-          "required": false,
-          "value": undefined,
-        }
-      }
-    >
-      <InputFactory
-        type="text"
-      />
-    </ContextProvider>
+    <InputFactory
+      className=""
+      disabled={false}
+      name="a"
+      onChange={[Function]}
+      required={false}
+      type="text"
+    />
   </Col>
   <InlineMessage
     error={null}

--- a/webpack/assets/javascripts/react_app/components/common/forms/__tests__/__snapshots__/InputFactory.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__tests__/__snapshots__/InputFactory.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InputFactory rendering renders AutoComplete 1`] = `
+<FormControl
+  bsClass="form-control"
+  className=""
+  componentClass={
+    Object {
+      "$$typeof": Symbol(react.memo),
+      "Error": [Function],
+      "SearchButton": [Function],
+      "WrappedComponent": [Function],
+      "compare": null,
+      "displayName": "Connect(AutoComplete)",
+      "type": [Function],
+    }
+  }
+  controller="bookmarks"
+  disabled={false}
+  id="form-search"
+  name="Filter[search]"
+  onChange={[Function]}
+  required={false}
+  searchQuery=""
+  url="bookmarks/auto_complete"
+  useKeyShortcuts={false}
+/>
+`;
+
+exports[`InputFactory rendering renders DateTime input 1`] = `
+<FormControl
+  bsClass="form-control"
+  className=""
+  componentClass={[Function]}
+  disabled={false}
+  name="a"
+  onChange={[Function]}
+  required={false}
+/>
+`;
+
+exports[`InputFactory rendering renders custom registered component 1`] = `
+<FormControl
+  bsClass="form-control"
+  className=""
+  componentClass={[Function]}
+  disabled={false}
+  id="own-field"
+  label="ownField"
+  name="group[ownfield]"
+  onChange={[Function]}
+  required={false}
+/>
+`;
+
+exports[`InputFactory rendering renders text input 1`] = `
+<FormControl
+  bsClass="form-control"
+  className=""
+  componentClass="input"
+  disabled={false}
+  name="a"
+  onChange={[Function]}
+  required={false}
+  type="text"
+/>
+`;

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -13,6 +13,7 @@ import LongDateTime from './common/dates/LongDateTime';
 import ShortDateTime from './common/dates/ShortDateTime';
 import IsoDate from './common/dates/IsoDate';
 import FormField from './common/forms/FormField';
+import InputFactory from './common/forms/InputFactory';
 import StorageContainer from './hosts/storage/vmware/';
 import PasswordStrength from './PasswordStrength';
 import BreadcrumbBar from './BreadcrumbBar';
@@ -152,6 +153,7 @@ const coreComponets = [
     store: false,
   },
   { name: 'FormField', type: FormField },
+  { name: 'InputFactory', type: InputFactory },
   { name: 'ModelsTable', type: ModelsTable },
   { name: 'Editor', type: Editor },
 


### PR DESCRIPTION
This is follow up for #6980 where we forgot that `auto_complete_search` is part of an API for plugins and should have some deprecation period.
This deprecates the method and allows following:

```erb
<%= form_with url: '/hola_amigos' do |f| %>
  <%= autocomplete_f(f, :search, value: 'default') %>
<% end %>
```
What should allow the transfer path for autocompletes, which needs `name="search"` without scope.