### PR TITLE
Fixes #28323 - Collect information about Dynflow sidekiq in f-debug

### DIFF
--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -354,6 +354,12 @@ add_files /var/log/foreman/production.log
 add_files /var/log/foreman/dynflow_executor.output*
 add_files /var/log/foreman-proxy-certs-generate.*log
 
+# Dynflow Sidekiq
+add_files /etc/foreman/dynflow/*
+add_cmd "systemctl list-units dynflow*" "dynflow_units"
+add_cmd "journalctl -u dynflow-sidekiq@*" "dynflow_sidekiq_logs"
+add_cmd 'systemctl status "system-dynflow\x2dsidekiq.slice"' "dynflow_sidekiq_status"
+
 # exclude *key.pem files and encryption_key.rb
 add_files /etc/foreman/*.{yml,yaml,conf} /etc/foreman/plugins/*.yaml
 


### PR DESCRIPTION
With this change foreman-debug will additionally collect:
- worker configuration from /etc/foreman/dynflow
- STDOUT from sidekiq processes
- current status of dynflow sidekiq services


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
