### PR TITLE
Fixes #28325 - fix react-router & Turbolinks warning

### DIFF
--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -1,6 +1,9 @@
 import $ from 'jquery';
+import { push } from 'connected-react-router';
 import store from './react_app/redux';
 import * as LayoutActions from './react_app/components/Layout/LayoutActions';
+
+export const pushUrl = url => store.dispatch(push(url));
 
 export const showLoading = () => {
   store.dispatch(LayoutActions.showLoading());

--- a/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Router } from 'react-router-dom';
+import { ConnectedRouter } from 'connected-react-router';
 import history from '../history';
 
 import Layout, { propTypes as LayoutPropTypes } from '../components/Layout';
 import AppSwitcher from '../routes';
 
 const ReactApp = ({ data: { layout } }) => (
-  <Router history={history}>
+  <ConnectedRouter history={history}>
     <Layout data={layout}>
       <AppSwitcher />
     </Layout>
-  </Router>
+  </ConnectedRouter>
 );
 
 ReactApp.propTypes = {

--- a/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
@@ -4,7 +4,7 @@ import { ConnectedRouter } from 'connected-react-router';
 import history from '../history';
 
 import Layout, { propTypes as LayoutPropTypes } from '../components/Layout';
-import AppSwitcher from '../routes';
+import AppSwitcher from '../routes/AppSwitcher';
 
 const ReactApp = ({ data: { layout } }) => (
   <ConnectedRouter history={history}>

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorSettings.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorSettings.test.js.snap
@@ -18,7 +18,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Syntax
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={false}
           id="mode-dropdown"
         >
@@ -100,7 +100,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Yaml
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -110,7 +110,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Keybind
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={false}
           id="keybindings-dropdown"
         >
@@ -156,7 +156,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Vim
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -166,7 +166,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Theme
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           id="themes-dropdown"
         >
           <DropdownToggle
@@ -202,7 +202,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Monokai
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
     </Popover>
   }
@@ -250,7 +250,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Syntax
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={true}
           id="mode-dropdown"
         >
@@ -332,7 +332,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Yaml
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -342,7 +342,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Keybind
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={true}
           id="keybindings-dropdown"
         >
@@ -388,7 +388,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Vim
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -398,7 +398,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Theme
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           id="themes-dropdown"
         >
           <DropdownToggle
@@ -434,7 +434,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Monokai
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
     </Popover>
   }

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/NavDropdown.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/NavDropdown.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavDropdown rendering render NavDropdown 1`] = `
-<ForwardRef
+<Uncontrolled(Dropdown)
   className=""
   componentClass="li"
   id="account_menu"
@@ -11,5 +11,5 @@ exports[`NavDropdown rendering render NavDropdown 1`] = `
   >
     TEST
   </li>
-</ForwardRef>
+</Uncontrolled(Dropdown)>
 `;

--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -1,12 +1,19 @@
 import createLogger from 'redux-logger';
 import thunk from 'redux-thunk';
+import { routerMiddleware } from 'connected-react-router';
 import { applyMiddleware, createStore, compose } from 'redux';
 
+import history from '../history';
 import reducers from './reducers';
 
 import { IntervalMiddleware, APIMiddleware } from './middlewares';
 
-let middleware = [thunk, IntervalMiddleware, APIMiddleware];
+let middleware = [
+  thunk,
+  IntervalMiddleware,
+  APIMiddleware,
+  routerMiddleware(history),
+];
 
 const useLogger = () => {
   const isProduction = process.env.NODE_ENV === 'production';

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
+import { connectRouter } from 'connected-react-router';
 import { reducer as form } from 'redux-form';
 import bookmarks from './bookmarks';
 import statistics from './statistics';
 import hosts from './hosts';
 import notifications from './notifications';
 import toasts from './toasts';
+import history from '../../history';
 import { reducers as appReducers } from '../../ReactApp';
 import { reducers as passwordStrengthReducers } from '../../components/PasswordStrength';
 import { reducers as breadcrumbBarReducers } from '../../components/BreadcrumbBar';
@@ -40,6 +42,7 @@ export function combineReducersAsync(asyncReducers) {
     ...templateGenerationReducers,
     ...factChartReducers,
     ...intervalReducers,
+    router: connectRouter(history),
 
     // Pages
     ...statisticsPageReducers,

--- a/webpack/assets/javascripts/react_app/routes/AppSwitcher/index.js
+++ b/webpack/assets/javascripts/react_app/routes/AppSwitcher/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import AppSwitcher from './AppSwitcher';
+import { selectRouterLocation } from '../RouterSelector';
+
+const connectedAppSwitcher = () => {
+  const location = useSelector(selectRouterLocation);
+  return <AppSwitcher location={location} />;
+};
+
+export default connectedAppSwitcher;

--- a/webpack/assets/javascripts/react_app/routes/RouterSelector.js
+++ b/webpack/assets/javascripts/react_app/routes/RouterSelector.js
@@ -1,0 +1,5 @@
+export const selectRouterLocation = store => store.router.location;
+export const selectRouterPath = store => selectRouterLocation(store).pathname;
+export const selectRouterSearch = store => selectRouterLocation(store).search;
+export const selectRouterHash = store => selectRouterLocation(store).hash;
+export const lastHistoryAction = state => state.router.action;


### PR DESCRIPTION
React-router and turbolinks manipulate the `browserHistory`object on the same time.
It`s very risky and giving another reason to drop turbolinks, see #7158 and [discussion](https://community.theforeman.org/t/the-future-of-turbolinks/16149)

the warning that happens when moving between non-react-router pages:
```
Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state. 
    in Route (created by AppSwitcher)
    in AppSwitcher (created by ReactApp)
    in ReactApp (created by Anonymous)
    in Anonymous (created by Connect(Component))
    in Connect(Component) (created by I18nProviderWrapper(Connect(Component)))
    in I18nProviderWrapper(Connect(Component)) (created by StoreProvider(I18nProviderWrapper(Connect(Component))))
    in StoreProvider(I18nProviderWrapper(Connect(Component))) (created by DataProvider(StoreProvider(I18nProviderWrapper(Connect(Component)))))
    in DataProvider(StoreProvider(I18nProviderWrapper(Connect(Component))))
```

this PR is blocked by https://github.com/theforeman/foreman-js/pull/68
which bumps the version of react-router to `v5.1.2` which is fully backwards compatible with 4.x,
read about it here: https://reacttraining.com/blog/react-router-v5/. 
The upgrade bring us the ability to use router-hooks like: `useLocation` that helped to fix the current issue.

An alternative to hooks have been proposed in #7186 which will also bring the option to use `selectors` instead of `hooks`, though we could use both at the same time.