### PR TITLE
Fixes #25602 - Correct tests for user role audits

### DIFF
--- a/test/models/concerns/audit_associations_test.rb
+++ b/test/models/concerns/audit_associations_test.rb
@@ -20,11 +20,14 @@ class AuditAssociationsTest < ActiveSupport::TestCase
     @user.save!
     assert_empty @user.audits.last.audited_changes['role_ids']
 
+    # Ensure the default role is loaded when creating the audit, Rails 5.2.1 workaround (https://projects.theforeman.org/issues/25602)
+    @user.reload
+
     @user.role_ids = [role.id]
     @user.save!
 
     audit = @user.audits.last
-    assert_equal [[], [role.id]], audit.audited_changes['role_ids']
+    assert_equal [[Role.default.id], [role.id]], audit.audited_changes['role_ids']
     assert_equal 'update', audit.action
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1227,6 +1227,9 @@ class UserTest < ActiveSupport::TestCase
     end
 
     test 'should audit when a role is assigned to a user' do
+      # Ensure the default role is loaded when creating the audit, Rails 5.2.1 workaround (https://projects.theforeman.org/issues/25602)
+      @user.reload
+
       @user.role_ids = [@role.id]
       @user.save
 
@@ -1234,7 +1237,7 @@ class UserTest < ActiveSupport::TestCase
       audited_changes = recent_audit.audited_changes['role_ids']
 
       assert audited_changes, 'No audits found for user-roles'
-      assert_empty audited_changes.first
+      assert_equal [Role.default.id], audited_changes.first
       assert_equal [@role.id], audited_changes.last
     end
 


### PR DESCRIPTION
Auditing user role changes should show the default role in the previous
version. Due to a bug in Rails 5.2.1 which is fixed in 5.2.2, this was
not showing up when the object was saved without reloading. We now
reload explicitly to allow backward compatibility for both Rails
versions, the reload can be removed once we upgrade to newer Rails.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
