### PR TITLE
Fixes #27927 - allow taxonomy inheritance

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -40,10 +40,10 @@ module Nic
     validate :validate_updating_types
 
     # Validate that subnet's taxonomies are defined for nic's host
-    validates :subnet, :belongs_to_host_taxonomy => {:taxonomy => :location }
-    validates :subnet6, :belongs_to_host_taxonomy => {:taxonomy => :location }
-    validates :subnet, :belongs_to_host_taxonomy => {:taxonomy => :organization }
-    validates :subnet6, :belongs_to_host_taxonomy => {:taxonomy => :organization }
+    validates :subnet, :belongs_to_host_taxonomy => { :taxonomy => :location }
+    validates :subnet6, :belongs_to_host_taxonomy => { :taxonomy => :location }
+    validates :subnet, :belongs_to_host_taxonomy => { :taxonomy => :organization }
+    validates :subnet6, :belongs_to_host_taxonomy => { :taxonomy => :organization }
 
     scope :bmc, -> { where(:type => "Nic::BMC") }
     scope :bonds, -> { where(:type => "Nic::Bond") }

--- a/app/validators/belongs_to_host_taxonomy_validator.rb
+++ b/app/validators/belongs_to_host_taxonomy_validator.rb
@@ -9,17 +9,14 @@ class BelongsToHostTaxonomyValidator < ActiveModel::EachValidator
     return unless record.host.present? && value.present?
 
     host_taxonomy = record.host.public_send(taxonomy)
-    attribute_taxonomies = value.public_send(taxonomy.to_s.pluralize.to_sym)
+    return if host_taxonomy.nil?
 
-    return if host_taxonomy.nil? && attribute_taxonomies.empty?
+    host_taxonomy_ids = host_taxonomy.path_ids
+    attribute_taxonomy_ids = value.public_send("#{taxonomy}_ids")
 
-    attribute_name = attribute.to_s.end_with?('_id') ? attribute : "#{attribute}_id"
-    record.errors.add(attribute_name, _("is not defined for host's %s") % _(taxonomy)) unless include_or_empty?(attribute_taxonomies, host_taxonomy)
-  end
-
-  private
-
-  def include_or_empty?(list, item)
-    (list.empty? && item.nil?) || list.include?(item)
+    unless (attribute_taxonomy_ids & host_taxonomy_ids).any?
+      attribute_name = attribute.to_s.end_with?('_id') ? attribute : "#{attribute}_id"
+      record.errors.add(attribute_name, _("is not defined for host's %s") % _(taxonomy))
+    end
   end
 end

--- a/test/validators/belongs_to_host_taxonomy_validator_test.rb
+++ b/test/validators/belongs_to_host_taxonomy_validator_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class BelongsToHostTaxonomyValidatorTest < ActiveSupport::TestCase
+  class Validatable
+    include ActiveModel::Validations
+    validates :subnet, :belongs_to_host_taxonomy => { :taxonomy => :location }
+    attr_accessor :host, :subnet
+  end
+
+  it 'passes if host belongs_to child location' do
+    parent = FactoryBot.create(:location)
+    child = FactoryBot.create(:location)
+    child.update(parent_id: parent.id)
+    obj = Validatable.new
+    obj.host = FactoryBot.build(:host, location: child)
+    obj.subnet = FactoryBot.create(:subnet_ipv4, locations: [parent])
+    assert obj.valid?
+  end
+end


### PR DESCRIPTION
Enable host in child taxonomies to have assigned objects from parent taxonomies.