### PR TITLE
Fixes #28343 - fixed order info example for multiple attributes

### DIFF
--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -56,7 +56,7 @@
       <h2><%= _("Prioritize Attribute Order") %></h2>
       <h6><%= _("Set the order in which values are resolved.") %></h6>
       <%= textarea_f f, :path, :rows => :auto, :label => _("Order"), :id => 'order', :size => "col-md-8", :onchange => 'fill_in_matchers()', :value => f.object.path, :class => "no-stretch",
-                        :label_help => _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>host group, environment</code> would expect a matcher such as <code>hostgroup = \"web servers\", environment = production</code>").html_safe %>
+                        :label_help => _("The order in which matchers keys are processed, first match wins.<br> You may use multiple attributes as a matcher key, for example, an order of <code>hostgroup,environment</code> would expect a matcher such as <code>hostgroup,environment = example-group,production</code>").html_safe %>
       <%= checkbox_f(f, :merge_overrides, :onchange => 'mergeOverridesChanged(this)', :table_field => true,
                         :disabled => !f.object.supports_merge?, :size => "col-md-1", :label_size => "col-md-2",
                         :label_help => _("Continue to look for matches after first find (only array/hash type)? Note: merging overrides ignores all matchers that are omitted.")) %>


### PR DESCRIPTION
Fixed incorrect example to use multiple attributes as a matcher key in the info for Order.