### PR TITLE
Fixes #28357 - BMC Subnet-Proxy association

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -274,7 +274,14 @@ class HostsController < ApplicationController
   end
 
   def bmc
-    render :partial => 'bmc', :locals => { :host => @host }
+    render :partial => 'bmc', :locals => {
+      status: power_status(@host.power.state),
+      bmc_proxy: @host.bmc_proxy,
+    }
+  rescue Foreman::BMCFeatureException
+    render :partial => 'bmc_missing_proxy', locals: { bmc_proxy: @host.subnet.bmc, bmc_count: SmartProxy.with_features('BMC').count }
+  rescue Foreman::Exception => exception
+    process_ajax_error exception, 'fetch bmc information'
   rescue ActionView::Template::Error => exception
     process_ajax_error exception, 'fetch bmc information'
   end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -76,6 +76,12 @@ class Subnet < ApplicationRecord
     :api_description => N_('Template HTTP(S) Proxy ID to use within this subnet'),
     :description => N_('Template HTTP(S) Proxy to use within this subnet to allow access templating endpoint from isolated networks')
 
+  belongs_to_proxy :bmc,
+    :feature => N_('BMC'),
+    :label => N_('BMC Proxy'),
+    :api_description => N_('BMC Proxy ID to use within this subnet'),
+    :description => N_('BMC Proxy to use within this subnet for management access')
+
   has_many :hostgroups
   has_many :subnet_domains, :dependent => :destroy, :inverse_of => :subnet
   has_many :domains, :through => :subnet_domains
@@ -245,6 +251,10 @@ class Subnet < ApplicationRecord
 
   def template_proxy(attrs = {})
     @template_proxy ||= ProxyAPI::Template.new({:url => template.url}.merge(attrs)) if template?
+  end
+
+  def bmc?
+    !!(bmc && bmc.url && bmc.url.present?)
   end
 
   def external_ipam?

--- a/app/views/hosts/_bmc.html.erb
+++ b/app/views/hosts/_bmc.html.erb
@@ -7,7 +7,7 @@
   <tbody>
     <tr>
       <td><%= _('Status') %></td>
-      <td><%= power_status(@host.power.state) %></td>
+      <td><%= status %></td>
     </tr>
     <tr>
       <td><%= _('Boot device') %></td>
@@ -25,19 +25,19 @@
   <tbody>
     <tr>
       <td><%= _('IP') %></td>
-      <td><%= @host.bmc_proxy.lan(:action => 'ip') %></td>
+      <td><%= bmc_proxy.lan(:action => 'ip') %></td>
     </tr>
     <tr>
       <td><%= _('Netmask') %></td>
-      <td><%= @host.bmc_proxy.lan(:action => 'netmask') %></td>
+      <td><%= bmc_proxy.lan(:action => 'netmask') %></td>
     </tr>
     <tr>
       <td><%= _('MAC') %></td>
-      <td><%= @host.bmc_proxy.lan(:action => 'mac') %></td>
+      <td><%= bmc_proxy.lan(:action => 'mac') %></td>
     </tr>
     <tr>
       <td><%= _('Gateway') %></td>
-      <td><%= @host.bmc_proxy.lan(:action => 'gateway') %></td>
+      <td><%= bmc_proxy.lan(:action => 'gateway') %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/hosts/_bmc_missing_proxy.html.erb
+++ b/app/views/hosts/_bmc_missing_proxy.html.erb
@@ -1,0 +1,14 @@
+<div>
+<%
+  text = ''.html_safe
+  if bmc_count.zero?
+    text += _('No %s with BMC feature found, install one, enable BMC module and register it.').html_safe %
+      link_to(_("Smart Proxy"), smart_proxies_path)
+  end
+
+  if bmc_proxy.nil?
+      text += ' '.html_safe + _('Missing BMC feature associated with %s.').html_safe % link_to(_("Subnet"), subnets_path)
+  end
+%>
+  <%= alert :class => 'alert-warning', :header => '', :text => text %>
+</div>

--- a/db/migrate/20200615071719_add_bmc_to_subnet.rb
+++ b/db/migrate/20200615071719_add_bmc_to_subnet.rb
@@ -1,0 +1,16 @@
+class AddBmcToSubnet < ActiveRecord::Migration[6.0]
+  def change
+    add_column :subnets, :bmc_id, :integer
+
+    reversible do |dir|
+      dir.up do
+        Subnet.unscoped.each do |subnet|
+          candidate = subnet.proxies.find { |subnet_proxy| subnet_proxy.has_feature?('BMC') }
+          candidate ||= SmartProxy.unscoped.with_features("BMC").first
+          subnet.bmc = candidate
+          subnet.save!(validate: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -88,6 +88,9 @@ module Foreman
   class MaintenanceException < Foreman::Exception
   end
 
+  class BMCFeatureException < Foreman::Exception
+  end
+
   class PermissionMissingException < Foreman::Exception
   end
 

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -76,6 +76,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       :type => 'bmc',
       :provider => 'IPMI',
       :mac => '00:11:22:33:44:01',
+      :subnet_id => subnets(:one).id,
     }, {
       :mac => '00:11:22:33:44:02',
       :_destroy => 1,
@@ -830,7 +831,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
   test 'non-admin user with power_host permission can boot a vm' do
     @bmchost = FactoryBot.create(:host, :managed)
-    FactoryBot.create(:nic_bmc, :host => @bmchost)
+    FactoryBot.create(:nic_bmc, :host => @bmchost, :subnet => subnets(:one))
     ProxyAPI::BMC.any_instance.stubs(:power).with(:action => 'status').returns("on")
     role = FactoryBot.create(:role, :name => 'power_hosts')
     role.add_permissions!(['power_hosts'])
@@ -849,7 +850,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     def initialize_proxy_ops
       User.current = users(:apiadmin)
       @bmchost = FactoryBot.create(:host, :managed)
-      FactoryBot.create(:nic_bmc, :host => @bmchost)
+      @bmc_nic = FactoryBot.create(:nic_bmc, :host => @bmchost, :subnet => subnets(:one))
     end
 
     test "power call to interface" do
@@ -1435,7 +1436,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
     test 'shows power status for bmc hosts' do
       bmchost = FactoryBot.create(:host, :managed)
-      FactoryBot.create(:nic_bmc, :host => bmchost)
+      FactoryBot.create(:nic_bmc, :host => bmchost, :subnet => subnets(:one))
       ProxyAPI::BMC.any_instance.stubs(:power).with(:action => 'status').returns("on")
 
       expected_resp = {

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -338,7 +338,7 @@ FactoryBot.define do
         overrides[:locations] = [location] unless location.nil?
         overrides[:organizations] = [organization] unless organization.nil?
         FactoryBot.create(
-          :subnet_ipv4,
+          :subnet_ipv4_with_bmc,
           overrides
         )
       end

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -30,6 +30,10 @@ FactoryBot.define do
       association :dns, :factory => :dns_smart_proxy
     end
 
+    trait :bmc do
+      association :bmc, :factory => :bmc_smart_proxy
+    end
+
     trait :template do
       association :template, :factory => :template_smart_proxy
     end
@@ -58,6 +62,7 @@ FactoryBot.define do
       mask { '255.255.255.0' }
 
       factory :subnet_ipv4_with_domains, :traits => [:with_domains]
+      factory :subnet_ipv4_with_bmc, :traits => [:bmc]
 
       trait :ipam_dhcp do
         ipam { "DHCP" }

--- a/test/fixtures/subnets.yml
+++ b/test/fixtures/subnets.yml
@@ -7,6 +7,7 @@ one:
   dhcp: one
   tftp: two
   dns: three
+  bmc: bmc
   vlanid: 41
 
 two:
@@ -46,6 +47,7 @@ five:
   dhcp: one
   tftp: two
   dns: three
+  bmc: bmc
 
 six:
   name: six

--- a/test/fixtures/taxable_taxonomies.yml
+++ b/test/fixtures/taxable_taxonomies.yml
@@ -203,3 +203,13 @@ puppetmaster_organization2:
   taxonomy: organization2
   taxable: puppetmaster
   taxable_type: "SmartProxy"
+
+bmc_organization:
+  taxonomy: organization1
+  taxable: bmc
+  taxable_type: "SmartProxy"
+
+bmc_location1:
+  taxonomy: location1
+  taxable: bmc
+  taxable_type: "SmartProxy"

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2237,8 +2237,8 @@ class HostTest < ActiveSupport::TestCase
     end
     h = FactoryBot.create(:host, :managed)
     assert h.interfaces.create :mac => "cabbccddeeff", :host => h, :type => 'Nic::BMC',
-      :provider => "IPMI", :username => "root", :password => "secret", :ip => "10.35.19.35",
-      :identifier => 'eth2'
+      :provider => "IPMI", :username => "root", :password => "secret", :ip => "2.3.4.5",
+      :identifier => 'eth2', :subnet => subnets(:one)
     as_user :one do
       h.update!("interfaces_attributes" => {"0" => {"mac" => "00:52:10:1e:45:16"}})
       assert_empty h.errors

--- a/test/models/nic_test.rb
+++ b/test/models/nic_test.rb
@@ -272,13 +272,11 @@ class NicTest < ActiveSupport::TestCase
       assert_equal @interface.name, @interface.hostname
     end
 
-    test '.proxy uses any BMC SmartProxy if none is found in subnet' do
+    test '.proxy raises exception if BMC proxy is not set' do
       assert @subnet.proxies.select { |proxy| proxy.features.map(&:name).include?('BMC') }
-      assert_includes SmartProxy.with_features('BMC').map { |sp| sp.url + '/bmc' }, @interface.proxy.url
-    end
-
-    test '.proxy chooses BMC SmartProxy in Nic::BMC subnet if available' do
-      assert_equal @interface.proxy.url, @subnet.dhcp.url + '/bmc'
+      assert_raise Foreman::BMCFeatureException do
+        @interface.proxy.url
+      end
     end
 
     test '.proxy raises exception if BMC SmartProxy cannot be found' do

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -155,7 +155,7 @@ module TaxonomiesBaseTest
       assert_equal selected_ids[:domain_ids], [domains(:mydomain).id, domains(:yourdomain).id]
       assert_equal selected_ids[:medium_ids], [media(:one).id]
       assert_equal selected_ids[:user_ids], [users(:one).id, users(:scoped).id]
-      assert_equal selected_ids[:smart_proxy_ids].sort, [smart_proxies(:puppetmaster).id, smart_proxies(:one).id, smart_proxies(:two).id, smart_proxies(:three).id, smart_proxies(:realm).id].sort
+      assert_equal selected_ids[:smart_proxy_ids].sort, [smart_proxies(:bmc).id, smart_proxies(:puppetmaster).id, smart_proxies(:one).id, smart_proxies(:two).id, smart_proxies(:three).id, smart_proxies(:realm).id].sort
       assert_equal selected_ids[:provisioning_template_ids], [templates(:mystring2).id]
       assert_equal selected_ids[:compute_resource_ids], [compute_resources(:one).id, compute_resources(:mycompute).id]
     end


### PR DESCRIPTION
Subnet has no association with Proxy, therefore Foreman picks up proxies with BMC features "randomly". When there is nothing found, it uses first proxy with BMC feature available. This is based on an assumption that all BMC proxies has direct access to all servers which is not the case.

The solution is to create new BMC association so Foreman uses the correct BMC proxy for operations associated with the BMC interface. To prevent confusion, I suggest also to remove the fallback mechanism - if no association is found than use the "first" proxy available. We should explicitly error out instead.