### PR TITLE
Fixes #28334 - change documentation button for domains (CP 1.24)

### DIFF
--- a/app/views/domains/welcome.html.erb
+++ b/app/views/domains/welcome.html.erb
@@ -11,7 +11,7 @@
     <%= _("The <b>fullname</b> field is used for human readability in reports and other pages that refer to domains,
     and also available as an external node parameter").html_safe %></br>
   </p>
-  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4Provisioning")%></p>
+  <p><%= link_to _('Learn more about this in the documentation.'), documentation_url("4.4.7Networking")%></p>
   <div class="blank-slate-pf-main-action">
       <%= new_link(_("Create Domain"), {}, { :class => "btn-lg" }) %>
   </div>


### PR DESCRIPTION
Change documentation button for the /domains/help page to be the same as or subnets - 4.4.7Networking

(cherry picked from commit 878e140da553d7cfe4c5942bf284369a6a09eaa9)
