### PR TITLE
Fixes #28362 - fix API middleware failure payload

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
@@ -18,7 +18,7 @@ export const get = async (payload, url, store, actionTypes) => {
   } catch (error) {
     store.dispatch({
       type: actionTypes.FAILURE,
-      payload: { error, payload },
+      payload: { ...payload, error },
     });
   }
 };

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -15,10 +15,8 @@ Array [
     Object {
       "payload": Object {
         "error": [Error: bad request],
-        "payload": Object {
-          "id": "myid",
-          "name": "test",
-        },
+        "id": "myid",
+        "name": "test",
       },
       "type": "TEST_FAILURE",
     },

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/powerStatus.fixtures.js
@@ -26,7 +26,7 @@ export const onFailureActions = [
   {
     payload: {
       error: new Error('Request failed with status code 500'),
-      payload: { id: 0 },
+      id: 0,
     },
     type: 'HOST_POWER_STATUS_FAILURE',
   },

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/statistics.fixtures.js
@@ -84,14 +84,14 @@ export const onFailureActions = [
   {
     payload: {
       error: new Error('Request failed with status code 422'),
-      payload: payloads.operatingsystem,
+      ...payloads.operatingsystem,
     },
     type: 'STATISTICS_DATA_FAILURE',
   },
   {
     payload: {
       error: new Error('Request failed with status code 422'),
-      payload: payloads.architecture,
+      ...payloads.architecture,
     },
     type: 'STATISTICS_DATA_FAILURE',
   },


### PR DESCRIPTION
From: `payload: { error, payload }`
To: `payload: { ...payload, error }`

the `payload` data will be accessed in the `reducer` as `payload` instead of `payload.payload`