### PR TITLE
Refs #27719 - Specify the fog-vsphere dep clearer

### DIFF
--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,4 +1,4 @@
 group :vmware do
-  gem 'fog-vsphere', '~> 3.2', '>= 3.2.1'
+  gem 'fog-vsphere', '>= 3.2.1', '< 4.0'
   gem 'rbvmomi', '~> 2.0'
 end


### PR DESCRIPTION
Our gem to RPM dependency converter is not that smart and has a too
verbose output. Before this change:

```
Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 3.2
Requires: %{?scl_prefix}rubygem(fog-vsphere) < 4.0
Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 3.2.1
```

After:

```
Requires: %{?scl_prefix}rubygem(fog-vsphere) >= 3.2.1
Requires: %{?scl_prefix}rubygem(fog-vsphere) < 4.0
```