### PR TITLE
Refs #28356 - revert api status code change

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -279,7 +279,7 @@ Return the host's compute attributes that can be used to create a clone of this 
           statusText: _("Failed to fetch power status: %s") % e,
         }
 
-        render json: resp.merge(PowerManager::PowerStatus::HOST_POWER[:na]), status: :internal_server_error
+        render json: resp.merge(PowerManager::PowerStatus::HOST_POWER[:na])
       end
 
       api :PUT, "/hosts/:id/boot", N_("Boot host from specified device")

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -1451,7 +1451,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       Host.any_instance.stubs(:supports_power?).returns(true)
       Host.any_instance.stubs(:power).raises(::Foreman::Exception.new(N_("Unknown power management support - can't continue")))
       get :power_status, params: { :id => host.id }, session: set_session_user, xhr: true
-      assert_response :internal_server_error
+      assert_response :success
       response = JSON.parse @response.body
       assert_equal(expected_resp.sort, response.sort)
     end


### PR DESCRIPTION
Revert the change to the API from #7210 
after discussing it on the PR and on [discourse](https://community.theforeman.org/t/what-error-status-code-should-we-return/16357?u=laviro)
