### PR TITLE
Fixes #28380 - Use Github Actions for path based labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+UI:
+  - webpack/**/*
+Legacy JS:
+  - app/assets/javascripts/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,11 @@
+name: "Pull Request Labeler"
+on:
+- pull_request
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v2
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Previously we had our own implementation in our PRProcessor but this allows dropping that code in favor of a generic implementation.