### PR TITLE
WIP - Fixes #28382 - create high order API reducer

### DIFF
--- a/webpack/assets/javascripts/react_app/components/FactCharts/FactChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/FactChart.fixtures.js
@@ -7,7 +7,7 @@ export const chartDataValues = mockStoryData.data.columns;
 export const initialState = Immutable({
   modalToDisplay: {},
   chartData: [],
-  loaderStatus: '',
+  status: '',
 });
 
 export const modalOpenState = initialState.setIn(['modalToDisplay'], {
@@ -17,15 +17,15 @@ export const modalOpenState = initialState.setIn(['modalToDisplay'], {
 export const modalSuccessState = Immutable.merge(initialState, {
   modalToDisplay: { 1: true },
   chartData: chartDataValues,
-  loaderStatus: STATUS.RESOLVED,
+  status: STATUS.RESOLVED,
 });
 
 export const modalLoadingState = Immutable.merge(initialState, {
   modalToDisplay: { 1: true },
-  loaderStatus: STATUS.PENDING,
+  status: STATUS.PENDING,
 });
 
 export const modalErrorState = Immutable.merge(initialState, {
   modalToDisplay: { 1: true },
-  loaderStatus: STATUS.ERROR,
+  status: STATUS.ERROR,
 });

--- a/webpack/assets/javascripts/react_app/components/FactCharts/FactChart.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/FactChart.js
@@ -40,7 +40,6 @@ class FactChart extends React.Component {
       data: { id, title, search },
       modalToDisplay,
     } = this.props;
-
     const handleChartClick =
       search && search.match(/=$/) ? null : navigateToSearch.bind(null, search);
 
@@ -53,7 +52,7 @@ class FactChart extends React.Component {
     const chart = <DonutChart {...chartProps} config="large" />;
 
     const requestErrorMsg =
-      factChart.loaderStatus === STATUS.ERROR
+      factChart.status === STATUS.ERROR
         ? __('Request Failed')
         : __('No data available');
 
@@ -95,9 +94,7 @@ class FactChart extends React.Component {
             </Modal.Header>
             <Modal.Body>
               <div id="factChartModalBody">
-                <Loader status={factChart.loaderStatus}>
-                  {[chart, error]}
-                </Loader>
+                <Loader status={factChart.status}>{[chart, error]}</Loader>
               </div>
             </Modal.Body>
           </Modal>
@@ -116,7 +113,7 @@ FactChart.propTypes = {
   }).isRequired,
   factChart: PropTypes.shape({
     chartData: PropTypes.arrayOf(PropTypes.array),
-    loaderStatus: PropTypes.string,
+    status: PropTypes.string,
     modalToDisplay: PropTypes.object,
     title: PropTypes.string,
   }),

--- a/webpack/assets/javascripts/react_app/components/FactCharts/FactChartReducer.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/FactChartReducer.js
@@ -5,34 +5,34 @@ import {
   FACT_CHART_MODAL_OPEN,
 } from './FactChartConstants';
 
-import { actionTypeGenerator } from '../../redux/API';
+import { createAPIReducer } from '../../redux/API';
 
 const initialState = Immutable({
   modalToDisplay: {},
+  title: '',
+});
+
+const APIstate = Immutable({
   chartData: [],
-  loaderStatus: '',
+});
+
+const onSuccess = (state, payload) =>
+  state.set('chartData', payload.values).set('status', 'RESOLVED');
+
+export const apiReducer = createAPIReducer({
+  key: FACT_CHART,
+  initialState: APIstate,
+  onSuccess,
 });
 
 export default (state = initialState, action) => {
-  const { REQUEST, SUCCESS, FAILURE } = actionTypeGenerator(FACT_CHART);
   switch (action.type) {
-    case REQUEST:
-      return state.set('loaderStatus', 'PENDING');
-    case SUCCESS:
-      return state
-        .set('chartData', action.payload.values)
-        .set('loaderStatus', 'RESOLVED');
-    case FAILURE:
-      return state.set('loaderStatus', 'ERROR');
     case FACT_CHART_MODAL_OPEN:
       return state
         .set('title', action.payload.title)
         .set('modalToDisplay', { [action.payload.id]: true });
     case FACT_CHART_MODAL_CLOSE:
-      return state
-        .set('modalToDisplay', {})
-        .set('loaderStatus', '')
-        .set('chartData', []);
+      return state.set('modalToDisplay', {});
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/components/FactCharts/FactChartSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/FactChartSelectors.js
@@ -1,6 +1,8 @@
 import { createSelector } from 'reselect';
 
-export const selectFactChartData = state => selectFactChart(state).chartData;
+export const selectFactChartAPI = state => state.factChartAPI;
+
+export const selectFactChartData = state => selectFactChartAPI(state).chartData;
 
 const hostCounter = (accumulator, currentValue) => accumulator + currentValue;
 

--- a/webpack/assets/javascripts/react_app/components/FactCharts/__test__/FactChartReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/__test__/FactChartReducer.test.js
@@ -1,29 +1,10 @@
 import { testReducerSnapshotWithFixtures } from '../../../common/testHelpers';
-import { chartDataValues } from '../FactChart.fixtures';
 
 import reducer from '../FactChartReducer';
-import { FACT_CHART, FACT_CHART_MODAL_CLOSE } from '../FactChartConstants';
-import { actionTypeGenerator } from '../../../redux/API';
-
-const { REQUEST, SUCCESS, FAILURE } = actionTypeGenerator(FACT_CHART);
+import { FACT_CHART_MODAL_CLOSE } from '../FactChartConstants';
 
 const fixtures = {
   'initial state': {},
-  'should handle FACT_CHART_REQUEST action': {
-    action: { type: REQUEST, payload: { id: 1 } },
-  },
-  'should handle FACT_CHART_SUCCESS action': {
-    action: {
-      type: SUCCESS,
-      payload: { values: chartDataValues },
-    },
-  },
-  'should handle FACT_CHART_ERROR action': {
-    action: {
-      type: FAILURE,
-      payload: {},
-    },
-  },
   'should not display modal': {
     action: {
       type: FACT_CHART_MODAL_CLOSE,

--- a/webpack/assets/javascripts/react_app/components/FactCharts/__test__/FactChartSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/__test__/FactChartSelectors.test.js
@@ -8,7 +8,8 @@ import { chartDataValues } from '../FactChart.fixtures';
 
 describe('Fact Chart Selector', () => {
   const factChartState = {
-    factChart: { chartData: chartDataValues, modalToDisplay: { 1: true } },
+    factChart: { modalToDisplay: { 1: true } },
+    factChartAPI: { chartData: chartDataValues },
   };
 
   it('should count hosts', () => {

--- a/webpack/assets/javascripts/react_app/components/FactCharts/__test__/__snapshots__/FactChart.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/__test__/__snapshots__/FactChart.test.js.snap
@@ -12,8 +12,6 @@ exports[`factCharts should render closed 1`] = `
   factChart={
     Object {
       "chartData": Array [],
-      "loaderStatus": "",
-      "modalToDisplay": Object {},
     }
   }
   getChartData={[Function]}
@@ -64,8 +62,6 @@ exports[`factCharts should render open 1`] = `
   factChart={
     Object {
       "chartData": Array [],
-      "loaderStatus": "",
-      "modalToDisplay": Object {},
     }
   }
   getChartData={[Function]}

--- a/webpack/assets/javascripts/react_app/components/FactCharts/__test__/__snapshots__/FactChartReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/__test__/__snapshots__/FactChartReducer.test.js.snap
@@ -2,65 +2,14 @@
 
 exports[`FactChart reducer initial state 1`] = `
 Object {
-  "chartData": Array [],
-  "loaderStatus": "",
   "modalToDisplay": Object {},
-}
-`;
-
-exports[`FactChart reducer should handle FACT_CHART_ERROR action 1`] = `
-Object {
-  "chartData": Array [],
-  "loaderStatus": "ERROR",
-  "modalToDisplay": Object {},
-}
-`;
-
-exports[`FactChart reducer should handle FACT_CHART_REQUEST action 1`] = `
-Object {
-  "chartData": Array [],
-  "loaderStatus": "PENDING",
-  "modalToDisplay": Object {},
-}
-`;
-
-exports[`FactChart reducer should handle FACT_CHART_SUCCESS action 1`] = `
-Object {
-  "chartData": Array [
-    Array [
-      "Fedora 21 extra extra extra extra extra extra extra extra extra extra long label",
-      3,
-    ],
-    Array [
-      "Ubuntu 14.04",
-      4,
-    ],
-    Array [
-      "Centos 7 extra extra long label",
-      2,
-    ],
-    Array [
-      "Debian 8",
-      1,
-    ],
-    Array [
-      "Fedora 27",
-      2,
-    ],
-    Array [
-      "Fedora 26",
-      1,
-    ],
-  ],
-  "loaderStatus": "RESOLVED",
-  "modalToDisplay": Object {},
+  "title": "",
 }
 `;
 
 exports[`FactChart reducer should not display modal 1`] = `
 Object {
-  "chartData": Array [],
-  "loaderStatus": "",
   "modalToDisplay": Object {},
+  "title": "",
 }
 `;

--- a/webpack/assets/javascripts/react_app/components/FactCharts/__test__/__snapshots__/FactChartSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/__test__/__snapshots__/FactChartSelectors.test.js.snap
@@ -31,32 +31,6 @@ Array [
 
 exports[`Fact Chart Selector should return factChart object 1`] = `
 Object {
-  "chartData": Array [
-    Array [
-      "Fedora 21 extra extra extra extra extra extra extra extra extra extra long label",
-      3,
-    ],
-    Array [
-      "Ubuntu 14.04",
-      4,
-    ],
-    Array [
-      "Centos 7 extra extra long label",
-      2,
-    ],
-    Array [
-      "Debian 8",
-      1,
-    ],
-    Array [
-      "Fedora 27",
-      2,
-    ],
-    Array [
-      "Fedora 26",
-      1,
-    ],
-  ],
   "modalToDisplay": Object {
     "1": true,
   },

--- a/webpack/assets/javascripts/react_app/components/FactCharts/index.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/index.js
@@ -1,22 +1,22 @@
 import { connect } from 'react-redux';
 import {
   selectHostCount,
-  selectFactChart,
   selectDisplayModal,
+  selectFactChartAPI,
 } from './FactChartSelectors';
 
 import * as actions from './FactChartActions';
-import reducer from './FactChartReducer';
+import reducer, { apiReducer } from './FactChartReducer';
 
 import FactChart from './FactChart';
 
 const mapStateToProps = (state, ownProps) => ({
-  factChart: selectFactChart(state),
+  factChart: selectFactChartAPI(state),
   hostsCount: selectHostCount(state),
   modalToDisplay: selectDisplayModal(state, ownProps.data.id),
 });
 
 // export reducers
-export const reducers = { factChart: reducer };
+export const reducers = { factChart: reducer, factChartAPI: apiReducer };
 
 export default connect(mapStateToProps, actions)(FactChart);

--- a/webpack/assets/javascripts/react_app/redux/API/createAPIReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/API/createAPIReducer.js
@@ -1,0 +1,79 @@
+import Immutable from 'seamless-immutable';
+import { STATUS } from '../../constants';
+import { actionTypeGenerator } from './APIActionTypeGenerator';
+import { noop } from '../../common/helpers';
+
+const initState = Immutable({
+  error: null,
+  status: STATUS.PENDING,
+});
+
+const getModifiedState = (state, newState, payload, managedByID) => {
+  const { id } = payload;
+  const nextState = managedByID
+    ? state.set(id, { ...state[id], ...newState })
+    : state.merge(newState);
+
+  return nextState;
+};
+
+const handleRequest = (state, payload, managedByID) => {
+  const newState = {
+    error: null,
+    status: STATUS.PENDING,
+  };
+
+  return getModifiedState(state, newState, payload, managedByID);
+};
+
+const handleSuccess = (state, payload, managedByID) => {
+  const newState = {
+    error: null,
+    status: STATUS.RESOLVED,
+    ...payload,
+  };
+
+  return getModifiedState(state, newState, payload, managedByID);
+};
+
+const handleFailure = (state, payload, managedByID) => {
+  const newState = {
+    error: payload.error,
+    status: STATUS.ERROR,
+  };
+
+  return getModifiedState(state, newState, payload, managedByID);
+};
+
+const createAPIReducer = ({
+  key,
+  initialState: theirState,
+  managedByID = false,
+  onRequest = noop,
+  onSuccess = noop,
+  onFailure = noop,
+}) => (state = theirState || initState, action) => {
+  if (key === undefined) throw new Error('key is required');
+
+  const { REQUEST, FAILURE, SUCCESS } = actionTypeGenerator(key);
+  const { type, payload } = action;
+
+  switch (type) {
+    case REQUEST:
+      return (
+        onRequest(state, payload) || handleRequest(state, payload, managedByID)
+      );
+    case SUCCESS:
+      return (
+        onSuccess(state, payload) || handleSuccess(state, payload, managedByID)
+      );
+    case FAILURE:
+      return (
+        onFailure(state, payload) || handleFailure(state, payload, managedByID)
+      );
+    default:
+      return state;
+  }
+};
+
+export default createAPIReducer;

--- a/webpack/assets/javascripts/react_app/redux/API/index.js
+++ b/webpack/assets/javascripts/react_app/redux/API/index.js
@@ -1,4 +1,5 @@
 export { actionTypeGenerator } from './APIActionTypeGenerator';
 export { API_OPERATIONS } from './APIConstants';
 export { get, APIMiddleware } from './APIMiddleware';
+export { default as createAPIReducer } from './createAPIReducer';
 export { default as API } from './API';

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/__snapshots__/powerStatus.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/__snapshots__/powerStatus.test.js.snap
@@ -15,8 +15,8 @@ Object {
 exports[`powerStatus reducer should handle HOST_POWER_STATUS_REQUEST 1`] = `
 Object {
   "2": Object {
-    "id": "2",
-    "url": "test",
+    "error": null,
+    "status": "PENDING",
   },
 }
 `;
@@ -25,9 +25,17 @@ exports[`powerStatus reducer should handle HOST_POWER_STATUS_SUCCESS 1`] = `
 Object {
   "2": Object {
     "data": "data",
+    "error": null,
     "id": "2",
+    "status": "RESOLVED",
+    "url": "test",
   },
 }
 `;
 
-exports[`powerStatus reducer should return the initial state 1`] = `Object {}`;
+exports[`powerStatus reducer should return the initial state 1`] = `
+Object {
+  "error": null,
+  "status": "PENDING",
+}
+`;

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/index.js
@@ -1,28 +1,16 @@
-import Immutable from 'seamless-immutable';
-import {
-  HOST_POWER_STATUS_REQUEST,
-  HOST_POWER_STATUS_SUCCESS,
-  HOST_POWER_STATUS_FAILURE,
-} from '../../../consts';
+import { HOST_POWER_STATUS } from '../../../consts';
+import { createAPIReducer } from '../../../API';
 
-const initialState = Immutable({});
-
-export default (state = initialState, action) => {
-  const { payload } = action;
-
-  switch (action.type) {
-    case HOST_POWER_STATUS_REQUEST:
-    case HOST_POWER_STATUS_SUCCESS:
-      return state.set(payload.id, payload);
-    case HOST_POWER_STATUS_FAILURE: {
-      const {
-        message: errorMessage,
-        response: { data },
-      } = payload.error;
-
-      return state.set(data.id, { error: errorMessage, ...data });
-    }
-    default:
-      return state;
-  }
+const onFailure = (state, payload) => {
+  const {
+    message: errorMessage,
+    response: { data },
+  } = payload.error;
+  return state.set(data.id, { error: errorMessage, ...data });
 };
+
+export default createAPIReducer({
+  key: HOST_POWER_STATUS,
+  managedByID: true,
+  onFailure,
+});


### PR DESCRIPTION
in this POC I created an higher order API reducer which will maintain most of the common task a reducer for API request usually handles, with an option to override the default behavior.

just as an example I have used it in host power status and in facts and it worked well,
I didn't invest much in testing in facts, if we will decide that this is the direction to go I will provide a test helper for this scenario.

Discussing the best approach in: https://community.theforeman.org/t/managing-api-requests-reducers-in-the-best-way/16405