### PR TITLE
Fixes #28379 - remove unexist export

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/index.js
+++ b/webpack/assets/javascripts/react_app/redux/API/index.js
@@ -1,4 +1,4 @@
 export { actionTypeGenerator } from './APIActionTypeGenerator';
 export { API_OPERATIONS } from './APIConstants';
-export { get, APIMiddleware } from './APIMiddleware';
+export { APIMiddleware } from './APIMiddleware';
 export { default as API } from './API';


### PR DESCRIPTION
export 'get' was not found in './APIMiddleware'