### PR TITLE
Fixes #26312 - fix default taxonomy for external users

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -12,7 +12,7 @@ class Setting < ApplicationRecord
   TYPES = %w{integer boolean hash array string}
   FROZEN_ATTRS = %w{name category full_name}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page max_trend outofsync_interval}
-  BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url authorize_login_delegation_auth_source_user_autocreate root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text oidc_audience oidc_issuer oidc_algorithm
+  BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text oidc_audience oidc_issuer oidc_algorithm
                     smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list default_locale default_timezone ssl_certificate ssl_ca_file ssl_priv_key default_pxe_item_global default_pxe_item_local oidc_jwks_url }
   ARRAY_HOSTNAMES = %w{trusted_hosts}
   URI_ATTRS = %w{foreman_url unattended_url}

--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -20,7 +20,7 @@ class Setting::Auth < Setting
       # websockets_encrypt depends on key/cert when true, so initialize it last
       self.set('websockets_encrypt', N_("VNC/SPICE websocket proxy console access encryption (websockets_ssl_key/cert setting required)"), !!SETTINGS[:require_ssl], N_('Websockets encryption')),
       self.set('login_delegation_logout_url', N_('Redirect your users to this url on logout (authorize_login_delegation should also be enabled)'), nil, N_('Login delegation logout URL')),
-      self.set('authorize_login_delegation_auth_source_user_autocreate', N_('Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)'), nil, N_('Authorize login delegation auth source user autocreate')),
+      self.set('authorize_login_delegation_auth_source_user_autocreate', N_('Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)'), 'External', N_('Authorize login delegation auth source user autocreate')),
       self.set('authorize_login_delegation', N_("Authorize login delegation with REMOTE_USER environment variable"), false, N_('Authorize login delegation')),
       self.set('authorize_login_delegation_api', N_("Authorize login delegation with REMOTE_USER environment variable for API calls too"), false, N_('Authorize login delegation API')),
       self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60, N_('Idle timeout')),

--- a/db/migrate/20191128172542_set_default_authsource_external_setting.rb
+++ b/db/migrate/20191128172542_set_default_authsource_external_setting.rb
@@ -1,0 +1,13 @@
+class SetDefaultAuthsourceExternalSetting < ActiveRecord::Migration[5.2]
+  def up
+    Setting.where(:name => 'authorize_login_delegation_auth_source_user_autocreate').set('authorize_login_delegation_auth_source_user_autocreate',
+    'Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)',
+    'External', 'Authorize login delegation auth source user autocreate')
+  end
+
+  def down
+    Setting.where(:name => 'authorize_login_delegation_auth_source_user_autocreate').set('authorize_login_delegation_auth_source_user_autocreate',
+     'Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (keep unset to prevent the autocreation)',
+     nil, 'Authorize login delegation auth source user autocreate')
+  end
+end


### PR DESCRIPTION
This PR makes sure that the external users are assigned default taxonomy on creation.

@tbrisker can you please take a look at this one?