### PR TITLE
Fixes #28359 - Added Provisioning Template to auditable_types

### DIFF
--- a/app/models/concerns/audit_search.rb
+++ b/app/models/concerns/audit_search.rb
@@ -65,7 +65,8 @@ module AuditSearch
         :setting => 'Setting',
         :smart_class_parameter => 'PuppetclassLookupKey',
         :smart_variable => 'VariableLookupKey',
-        :subnet => 'Subnet'
+        :subnet => 'Subnet',
+        :provisioning_template => 'ProvisioningTemplate'
       )
     end
 


### PR DESCRIPTION
I have to explicitly add provisioning template to list because at production environment causes error during search. Reason is simple - Provisioning template has a successor (see `ProvisioningTemplateFromFolder`) and thanks to that this model was not included at list (see `audited_classes_without_sti` method). This bug occur also only at production environment due to eager (prod) vs lazy (dev) loading. 