### PR TITLE
Fixes #28405 - Missing permissions to Table Preferences

### DIFF
--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -6,7 +6,8 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :user_logout, { :users => [:logout] }, :public => true
     map.permission :view_current_user, { :"api/v2/users" => [:show_current] }, public: :true
     map.permission :my_account, { :users => [:edit],
-      :notification_recipients => [:index, :update, :destroy, :update_group_as_read, :destroy_group ] }, :public => true
+      :notification_recipients => [:index, :update, :destroy, :update_group_as_read, :destroy_group ],
+      :"api/v2/table_preferences" => [:show, :create, :edit, :delete, :index]}, :public => true
     map.permission :api_status, { :"api/v2/home" => [:status]}, :public => true
     map.permission :about_index, { :about => [:index] }, :public => true
     map.permission :user_menu, { :user_menus => [:menu] }, :public => true

--- a/db/seeds.d/020-roles_list.rb
+++ b/db/seeds.d/020-roles_list.rb
@@ -41,7 +41,9 @@ class RolesList
 
     def default_role
       {
-        'Default role' => { :permissions => [:view_bookmarks, :view_tasks], :description => 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody' },
+        'Default role' => { permissions: [:view_bookmarks, :view_tasks],
+                            description: 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody',
+        },
       }
     end
 

--- a/test/controllers/api/v2/table_preferences_controller_test.rb
+++ b/test/controllers/api/v2/table_preferences_controller_test.rb
@@ -73,4 +73,12 @@ class Api::V2::TablePreferencesControllerTest < ActionController::TestCase
     assert_equal(1, columns.size)
     assert_equal(resource2, columns.first.name)
   end
+
+  def test_should_get_index_non_admin_user
+    setup_user 'view', 'table_preferences'
+    get :index, params: {user_id: User.current.id}
+    assert_response :success
+    columns = ActiveSupport::JSON.decode(@response.body)["results"]
+    assert_equal(columns.length, 0)
+  end
 end


### PR DESCRIPTION
Fixing bug where user was unable to see own table preferences via API. 
