### PR TITLE
Fixes #28391 - fix failing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^3.3.2",
+    "@theforeman/vendor": "^3.5.2",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -35,9 +35,9 @@
     "@storybook/addon-storysource": "^3.4.12",
     "@storybook/react": "~3.4.12",
     "@storybook/storybook-deployer": "^2.0.0",
-    "@theforeman/builder": "^3.3.2",
-    "@theforeman/env": "^3.3.2",
-    "@theforeman/vendor-dev": "^3.3.2",
+    "@theforeman/builder": "^3.5.2",
+    "@theforeman/env": "^3.5.2",
+    "@theforeman/vendor-dev": "^3.5.2",
     "argv-parse": "^1.0.1",
     "axios-mock-adapter": "^1.10.0",
     "babel-eslint": "^10.0.0",

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorSettings.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorSettings.test.js.snap
@@ -18,7 +18,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Syntax
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={false}
           id="mode-dropdown"
         >
@@ -100,7 +100,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Yaml
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -110,7 +110,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Keybind
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={false}
           id="keybindings-dropdown"
         >
@@ -156,7 +156,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Vim
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -166,7 +166,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Theme
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           id="themes-dropdown"
         >
           <DropdownToggle
@@ -202,7 +202,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Monokai
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
     </Popover>
   }
@@ -250,7 +250,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Syntax
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={true}
           id="mode-dropdown"
         >
@@ -332,7 +332,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Yaml
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -342,7 +342,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Keybind
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           disabled={true}
           id="keybindings-dropdown"
         >
@@ -388,7 +388,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Vim
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -398,7 +398,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Theme
         </div>
-        <ForwardRef
+        <Uncontrolled(Dropdown)
           id="themes-dropdown"
         >
           <DropdownToggle
@@ -434,7 +434,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Monokai
             </MenuItem>
           </DropdownMenu>
-        </ForwardRef>
+        </Uncontrolled(Dropdown)>
       </div>
     </Popover>
   }

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/NavDropdown.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/NavDropdown.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavDropdown rendering render NavDropdown 1`] = `
-<ForwardRef
+<Uncontrolled(Dropdown)
   className=""
   componentClass="li"
   id="account_menu"
@@ -11,5 +11,5 @@ exports[`NavDropdown rendering render NavDropdown 1`] = `
   >
     TEST
   </li>
-</ForwardRef>
+</Uncontrolled(Dropdown)>
 `;


### PR DESCRIPTION
After one of the latest patternfy-react version update with `react-bootstrap` update, tests started to fail.

opened issue to patternfly-react: https://github.com/patternfly/patternfly-react/issues/3364
opened issue to react-bootstrap: https://github.com/react-bootstrap/react-bootstrap/issues/4872

blocked by https://github.com/theforeman/foreman-js/pull/79
 