### PR TITLE
Fixes #28448 - Use Intl npm modules from vendor

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,7 +32,6 @@
     </script>
     <%= javascript_include_tag "locale/#{FastGettext.locale}/app" %>
     <%= javascript_include_tag *webpack_asset_paths('foreman-vendor', :extension => 'js') %>
-    <%= javascript_include_tag *webpack_asset_paths('vendor', :extension => 'js') %>
     <%= javascript_include_tag *webpack_asset_paths('bundle', :extension => 'js') %>
     <%= javascript_include_tag 'application' %>
     <%= webpacked_plugins_with_global_js %>

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -9,11 +9,8 @@ var StatsWriterPlugin = require("webpack-stats-plugin").StatsWriterPlugin;
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var CompressionPlugin = require('compression-webpack-plugin');
 var pluginUtils = require('../script/plugin_webpack_directories');
-var vendorEntry = require('./webpack.vendor');
 var SimpleNamedModulesPlugin = require('../webpack/simple_named_modules');
 var argvParse = require('argv-parse');
-var fs = require('fs');
-var { execSync } = require('child_process');
 
 var args = argvParse({
   port: {
@@ -22,22 +19,7 @@ var args = argvParse({
   host: {
     type: 'string',
   }
-})
-
-const supportedLocales = () => {
-  const localeDir = path.join(__dirname, '..', 'locale');
-
-  // Find all files in ./locale/*
-  const localesFiles = fs.readdirSync(localeDir)
-
-  // Return only folders
-  return localesFiles.filter(f => fs.statSync(path.join(localeDir, f)).isDirectory());
-}
-
-const supportedLanguages = () => {
-  // Extract extract languages from the language tags (strip off dialects)
-  return [ ...new Set(supportedLocales().map(d => d.split('_')[0]))];
-}
+});
 
 const devServerConfig = () => {
   const result = require('dotenv').config();
@@ -94,12 +76,9 @@ module.exports = env => {
   var entry = Object.assign(
     {
       bundle: bundleEntry,
-      vendor: vendorEntry,
     },
     pluginEntries
   );
-
-  const supportedLanguagesRE = new RegExp(`/(${supportedLanguages().join('|')})$`);
 
   var config = {
     entry: entry,
@@ -184,23 +163,8 @@ module.exports = env => {
           REDUX_LOGGER: process.env.REDUX_LOGGER
         }
       }),
-      // limit locales from intl only to supported ones
-      new webpack.ContextReplacementPlugin(
-        /intl\/locale-data\/jsonp/,
-        supportedLanguagesRE
-      ),
-      // limit locales from react-intl only to supported ones
-      new webpack.ContextReplacementPlugin(
-        /react-intl\/locale-data/,
-        supportedLanguagesRE
-      ),
     ]
   };
-
-  config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
-    name: 'vendor',
-    minChunks: Infinity,
-  }))
 
   if (production) {
     config.plugins.push(

--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -1,1 +1,0 @@
-module.exports = ['react-intl', 'intl'];

--- a/package.json
+++ b/package.json
@@ -20,21 +20,18 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^4.0.2",
-    "intl": "~1.2.5",
-    "jed": "^1.1.1",
-    "react-intl": "^2.8.0"
+    "@theforeman/vendor": "4.0.6-intl.0"
   },
   "optionalDependencies": {
     "chromedriver": "79.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^4.0.2",
-    "@theforeman/eslint-plugin-foreman": "^4.0.2",
-    "@theforeman/stories": "^4.0.2",
-    "@theforeman/test": "^4.0.2",
-    "@theforeman/vendor-dev": "^4.0.2",
+    "@theforeman/builder": "4.0.6-intl.0",
+    "@theforeman/eslint-plugin-foreman": "4.0.6-intl.0",
+    "@theforeman/stories": "4.0.6-intl.0",
+    "@theforeman/test": "4.0.6-intl.0",
+    "@theforeman/vendor-dev": "4.0.6-intl.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -29,12 +29,6 @@ import * as spice from './spice';
 import * as autocomplete from './foreman_autocomplete';
 import './bundle_novnc';
 
-// Set the public path for dynamic imports
-if (process.env.NODE_ENV !== 'production') {
-  /* eslint-disable-next-line */
-  __webpack_public_path__ = `${window.location.protocol}//${window.location.hostname}:3808/webpack/`;
-}
-
 window.tfm = Object.assign(window.tfm || {}, {
   authSource,
   tools,

--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -1,5 +1,10 @@
 import Jed from 'jed';
 import { addLocaleData } from 'react-intl';
+import {
+  loadVendorIntl,
+  loadVendorIntlLocale,
+  loadReactIntlLocale,
+} from 'vendor-intl';
 
 class IntlLoader {
   constructor(locale, timezone) {
@@ -12,20 +17,18 @@ class IntlLoader {
 
   async init() {
     await this.fetchIntl();
-    addLocaleData(
-      await import(
-        /* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${this.locale}`
-      )
-    );
+    const { default: localeData } = await loadReactIntlLocale(this.locale);
+
+    addLocaleData(localeData);
     return true;
   }
 
   async fetchIntl() {
     if (this.fallbackIntl) {
-      global.Intl = await import(/* webpackChunkName: "intl" */ 'intl');
-      await import(
-        /* webpackChunkName: 'intl/locale/[request]' */ `intl/locale-data/jsonp/${this.locale}`
-      );
+      const { default: Intl } = await loadVendorIntl();
+
+      global.Intl = Intl;
+      await loadVendorIntlLocale(this.locale);
     }
   }
 }


### PR DESCRIPTION
Load `jed`, `intl` and `react-intl` from `@theforeman/vendor`.
Support async import.

Work with: https://github.com/theforeman/foreman-js/pull/81