### PR TITLE
Fixes #28443 - use Layout.propTypes correctly

### DIFF
--- a/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/ReactApp/ReactApp.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Router } from 'react-router-dom';
 import history from '../history';
 
-import Layout from '../components/Layout';
+import Layout, { propTypes as LayoutPropTypes } from '../components/Layout';
 import AppSwitcher from '../routes';
 
 const ReactApp = ({ data: { layout } }) => (
@@ -16,7 +16,7 @@ const ReactApp = ({ data: { layout } }) => (
 
 ReactApp.propTypes = {
   data: PropTypes.shape({
-    layout: Layout.propTypes.data,
+    layout: LayoutPropTypes.data,
     metadata: PropTypes.object,
   }).isRequired,
 };

--- a/webpack/assets/javascripts/react_app/components/Layout/index.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/index.js
@@ -28,6 +28,9 @@ const mapStateToProps = state => ({
 // map action dispatchers to props
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 
+// export prop-types
+export const { propTypes } = Layout;
+
 // export reducers
 export const reducers = { layout: reducer };
 


### PR DESCRIPTION
Somehow with webpack-4 I am getting the `undefined is not an object` error when calling `Layout.propTypes.data`