### PR TITLE
Fixes #28458 - Don't allow images from gravatar

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,6 +10,6 @@
     :connect_src => ["'self'", 'ws:', 'wss:'],
     :style_src   => ["'unsafe-inline'", "'self'"],
     :script_src  => ["'unsafe-eval'", "'unsafe-inline'", "'self'"],
-    :img_src     => ["'self'", 'data:', '*.gravatar.com'],
+    :img_src     => ["'self'", 'data:'],
   }
 end

--- a/test/integration/middleware_test.rb
+++ b/test/integration/middleware_test.rb
@@ -8,7 +8,7 @@ class MiddlewareIntegrationTest < ActionDispatch::IntegrationTest
     assert_equal page.response_headers['X-Content-Type-Options'], 'nosniff'
     assert_equal page.response_headers['Content-Security-Policy'], \
       "default-src 'self'; child-src 'self'; connect-src 'self' ws: wss:; " +
-      "img-src 'self' data: *.gravatar.com; script-src 'unsafe-eval' 'unsafe-inline' " +
+      "img-src 'self' data:; script-src 'unsafe-eval' 'unsafe-inline' " +
       "'self'; style-src 'unsafe-inline' 'self'"
   end
 


### PR DESCRIPTION
In the past users could have images from gravater. This has been removed
almost two years ago due to FIPS hardening, but the secure headers
weren't updated.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
