### PR TITLE
Fixes #28468 - Misspelling on login page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js
@@ -26,7 +26,7 @@ const LoginPage = ({
         caption: <LoginPageCaption version={version} caption={caption} />,
       }}
       card={{
-        title: __('Log Into Your Account'),
+        title: __('Log in to your account'),
         form: {
           ...defaultFormProps,
           submitError: submitErrors,

--- a/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/__snapshots__/LoginPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/__snapshots__/LoginPage.test.js.snap
@@ -42,7 +42,7 @@ exports[`AutoComplete rendering renders LoginPage 1`] = `
         },
         "validate": true,
       },
-      "title": "Log Into Your Account",
+      "title": "Log in to your account",
     }
   }
   container={


### PR DESCRIPTION
Note the card title misspelling.

Before:
![screencapture-localhost-5000-users-login-1575973025581](https://user-images.githubusercontent.com/26363699/70521012-26743780-1b47-11ea-873b-4d1b9a1d3836.png)

After:
![screencapture-localhost-5000-users-login-1575972962424](https://user-images.githubusercontent.com/26363699/70521017-283dfb00-1b47-11ea-9c5e-326517c5c5d4.png)

Needs ack from @rohoover
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
