### PR TITLE
Fixes #28457 - bookmarks, statistics api reducers object fix

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksReducer.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksReducer.js
@@ -54,8 +54,8 @@ export default (state = initialState, action) => {
       return state.set('showModal', false);
     case BOOKMARKS_FAILURE:
       return state
-        .setIn([payload.item.controller, 'errors'], payload.error)
-        .setIn([payload.item.controller, 'status'], STATUS.ERROR);
+        .setIn([payload.controller, 'errors'], payload.error)
+        .setIn([payload.controller, 'status'], STATUS.ERROR);
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/BookmarksReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/BookmarksReducer.test.js
@@ -78,7 +78,7 @@ const fixtures = {
       type: BOOKMARKS_FAILURE,
       payload: {
         error: 'This is error',
-        item: { controller: 'architectures' },
+        controller: 'architectures',
       },
     },
   },

--- a/webpack/assets/javascripts/react_app/redux/reducers/statistics/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/statistics/index.js
@@ -21,8 +21,8 @@ export default (state = initialState, action) => {
         data: payload.data,
       });
     case STATISTICS_DATA_FAILURE:
-      return state.setIn(['charts', payload.item.id], {
-        ...state.charts[payload.item.id],
+      return state.setIn(['charts', payload.id], {
+        ...state.charts[payload.id],
         error: payload.error,
       });
     default:

--- a/webpack/assets/javascripts/react_app/redux/reducers/statistics/statistics.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/statistics/statistics.test.js
@@ -35,7 +35,7 @@ describe('statistics reducer', () => {
       prev: stateBeforeResponse,
       action: {
         type: types.STATISTICS_DATA_FAILURE,
-        payload: { error, item: request },
+        payload: { error, ...request },
       },
     },
   };


### PR DESCRIPTION
Both use payload.item.controller instead of payload.controller from the new API middle-ware
Blocked by: https://github.com/theforeman/foreman/pull/7211
