### PR TITLE
Fixes #28480 - Raise exception for non-existing image in GCE

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -101,7 +101,11 @@ module Foreman::Model
 
       if args[:volumes].present?
         if args[:image_id].to_i > 0
-          args[:volumes].first[:source_image] = client.images.find { |i| i.id == args[:image_id].to_i }.name
+          image = client.images.find { |i| i.id == args[:image_id].to_i }
+          if image.nil?
+            raise ::Foreman::Exception.new(N_("selected image does not exist"))
+          end
+          args[:volumes].first[:source_image] = image.name
         end
         args[:disks] = []
         args[:volumes].each_with_index do |vol_args, i|


### PR DESCRIPTION
I use custom images and deleted the one associated to the selected operating system.
End up with nil related issue and had to look into the code to figure out what was going so here's a PR raising a custom exception with better error message