### PR TITLE
Fixes #27971 - Optimize reports/logs deletion task

### DIFF
--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -9,8 +9,9 @@ class ReportTest < ActiveSupport::TestCase
     report_count = 3
     Message.delete_all
     Source.delete_all
-    FactoryBot.create_list(:report, report_count, :with_logs)
+    # old reports must be created first (so database ID sequence is correct)
     FactoryBot.create_list(:report, report_count, :with_logs, :old_report)
+    FactoryBot.create_list(:report, report_count, :with_logs)
     assert_equal report_count * 2, Report.count
     assert_difference('Report.count', -1 * report_count) do
       assert_difference(['Log.count', 'Message.count', 'Source.count'], -1 * report_count * 5) do
@@ -23,8 +24,9 @@ class ReportTest < ActiveSupport::TestCase
     report_count = 3
     Message.delete_all
     Source.delete_all
-    FactoryBot.create_list(:report, report_count, :with_logs)
+    # old reports must be created first (so database ID sequence is correct)
     FactoryBot.create_list(:report, report_count, :with_logs, :old_report)
+    FactoryBot.create_list(:report, report_count, :with_logs)
     assert_equal report_count * 2, Report.count
     assert_difference('Report.count', -1 * report_count) do
       assert_difference(['Log.count', 'Message.count', 'Source.count'], -1 * report_count * 5) do


### PR DESCRIPTION
Instead of fetching all IDs individually which is very slow and creates
a lot of array allocations, we build on a fact that database sequence
IDs are monotonic increasing integers. Therefore we can simply delete
all reports and logs which has id/report_id LESS THAN expected one.

However to keep the batch deletion behevior we still delete them in
batches, instead 1k the default batch is now 100k because the query is
much more efficient. Yet deleting 50 millions of records in logs table
might take some time, thus the batching approach (exclusive lock
problem).

This replaces https://github.com/theforeman/foreman/pull/7072