### PR TITLE
Fixes #28484 - Pass hostname to GCP API

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -82,8 +82,12 @@ module Foreman::Model
         args[collection] = nested_attributes_for(collection, nested_attrs.deep_symbolize_keys) if nested_attrs
       end
 
-      # Dots are not allowed in names
-      args[:name] = args[:name].parameterize if args[:name].present?
+      if args[:name].present?
+        # With google-api-client >= 0.27.3, this will trigger custom hostname in GCP
+        args[:hostname] = args[:name]
+        # Dots are not allowed in names
+        args[:name] = args[:name].parameterize
+      end
 
       # GCE network interfaces cannot be defined though Foreman yet
       if args[:network]

--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,3 +1,3 @@
 group :gce do
-  gem 'fog-google', '~> 1.8.2'
+  gem 'fog-google', '~> 1.11.0'
 end


### PR DESCRIPTION
Needs an update from fog-google to use recent enought google-api-client but that should not be an issue if enable before, just no-oop.

I asked for a fog-google update here
https://github.com/fog/fog-google/issues/479