### PR TITLE
Fixes #28324 - Fix logout URL for OpenID connect users

### DIFF
--- a/app/models/setting/auth.rb
+++ b/app/models/setting/auth.rb
@@ -26,10 +26,10 @@ class Setting::Auth < Setting
       self.set('idle_timeout', N_("Log out idle users after a certain number of minutes"), 60, N_('Idle timeout')),
       self.set('bcrypt_cost', N_("Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."), 4, N_('BCrypt password cost')),
       self.set('bmc_credentials_accessible', N_("Permits access to BMC interface passwords through ENC YAML output and in templates"), true, N_('BMC credentials access')),
-      self.set('oidc_jwks_url', N_("OpenID Connect JSON Web Key Set(JWKS) URL. Typically https://keycloak.example.com/auth/realms/<realm name>/protocol/openid-connect/certs when using Keycloak as an IDP"), nil, N_('OIDC JWKs URL')),
+      self.set('oidc_jwks_url', N_("OpenID Connect JSON Web Key Set(JWKS) URL. Typically https://keycloak.example.com/auth/realms/<realm name>/protocol/openid-connect/certs when using Keycloak as an OpenID provider"), nil, N_('OIDC JWKs URL')),
       self.set('oidc_audience', N_("Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."), nil, N_('OIDC Audience')),
-      self.set('oidc_issuer', N_("The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the IDP's."), nil, N_('OIDC Issuer')),
-      self.set('oidc_algorithm', N_("The algorithm used to encode the JWT in the IDP."), nil, N_('OIDC Algorithm')),
+      self.set('oidc_issuer', N_("The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."), nil, N_('OIDC Issuer')),
+      self.set('oidc_algorithm', N_("The algorithm used to encode the JWT in the OpenID provider."), nil, N_('OIDC Algorithm')),
     ]
   end
 

--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -55,7 +55,8 @@ module SSO
     end
 
     def logout_url
-      Setting['login_delegation_logout_url'] || controller.extlogout_users_path
+      return Setting['login_delegation_logout_url'] if Setting['login_delegation_logout_url'].present?
+      controller.extlogout_users_path
     end
 
     def expiration_url

--- a/app/services/sso/openid_connect.rb
+++ b/app/services/sso/openid_connect.rb
@@ -20,6 +20,11 @@ module SSO
       self.user = User.current.presence || authenticate!
     end
 
+    def logout_url
+      return Setting['login_delegation_logout_url'] if Setting['login_delegation_logout_url'].present?
+      controller.extlogout_users_path
+    end
+
     private
 
     def jwt_token


### PR DESCRIPTION
This patch makes sure users logged in by OpenID Connect using an OpenID provider are loged out from the OpenID provider as well as from Foreman.

For the UI we use mod_auth_openidc, this patch makes sure that the user is logged out rightfully even when mod_auth_openidc is the user. In the case of mod_auth_openidc, a session is stored in the cookies which enables a user to login even when session from Foreman and OpenID provider is removed. Therefore, it is important to logout from the mod_auth_openidc!

@tbrisker @timogoebel @ares @ekohl @kgaikwad  can you please review this PR?