### PR TITLE
Fixes #28499 - bump vendor to ^3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^3.5.2",
+    "@theforeman/vendor": "^3.8.0",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -35,9 +35,9 @@
     "@storybook/addon-storysource": "^3.4.12",
     "@storybook/react": "~3.4.12",
     "@storybook/storybook-deployer": "^2.0.0",
-    "@theforeman/builder": "^3.5.2",
-    "@theforeman/env": "^3.5.2",
-    "@theforeman/vendor-dev": "^3.5.2",
+    "@theforeman/builder": "^3.8.0",
+    "@theforeman/env": "^3.8.0",
+    "@theforeman/vendor-dev": "^3.8.0",
     "argv-parse": "^1.0.1",
     "axios-mock-adapter": "^1.10.0",
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
Includes `react-router-bootstrap@0.25.0` which fixes an issue in Katello that prevented the subscriptions page from loading.

See [discussion on Katello #8476](https://github.com/Katello/katello/pull/8476)
