### PR TITLE
Fixes #28510 - mount_date_component doesnt mount correctly

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -54,7 +54,7 @@ module ApplicationHelper
   def mount_date_component(component, time, seconds)
     data = { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds }
 
-    react_component(component, data: data)
+    react_component(component, data)
   end
 
   def contract(model)


### PR DESCRIPTION
The React component is shown empty with no text
Can be seen in Fact charts, Dashboard ('Generated at ___'), templates history and more places.