### PR TITLE
Fixes #28509 - relative time tooltip is optional in dates

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,21 +15,22 @@ module ApplicationHelper
   end
 
   # this helper should be used to print date time in absolute form
-  # it will also define a title with relative time information
+  # It will also define a title with relative time information,
+  # unless you pass show_relative_time_tooltip = false.
   # it supports two formats :short and :long
   # example of long is February 12, 2021 17:13
   # example of short is Aug 31, 12:52
-  def date_time_absolute(time, format = :short, seconds = false)
+  def date_time_absolute(time, format = :short, seconds = false, show_relative_time_tooltip = true)
     raise ArgumentError, "unsupported format '#{format}', use :long or :short" unless %w(long short).include?(format.to_s)
 
     component = (format == :short) ? 'ShortDateTime' : 'LongDateTime'
-    mount_date_component(component, time, seconds)
+    mount_date_component(component, time, seconds, show_relative_time_tooltip)
   end
 
   # this helper should be used to print date time in relative form, e.g. "10 days ago",
   # it will also define a title with absolute time information
   def date_time_relative(time)
-    mount_date_component('RelativeDateTime', time, false)
+    mount_date_component('RelativeDateTime', time, false, false)
   end
 
   def date_time_absolute_value(time, format = :short)
@@ -51,8 +52,8 @@ module ApplicationHelper
     "datetime_#{timestamp}"
   end
 
-  def mount_date_component(component, time, seconds)
-    data = { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds }
+  def mount_date_component(component, time, seconds, show_relative_time_tooltip)
+    data = { date: time.try(:iso8601), defaultValue: _('N/A'), seconds: seconds, showRelativeTimeTooltip: show_relative_time_tooltip}
 
     react_component(component, data)
   end

--- a/webpack/assets/javascripts/react_app/components/AuditsList/__tests__/__snapshots__/AuditsList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/__tests__/__snapshots__/AuditsList.test.js.snap
@@ -13,6 +13,7 @@ exports[`AuditsList rendering render resources list 1`] = `
           date="2018-08-13 00:34:55 -1100"
           defaultValue="N/A"
           seconds={false}
+          showRelativeTimeTooltip={true}
         />
       </span>
     }

--- a/webpack/assets/javascripts/react_app/components/AuditsList/index.js
+++ b/webpack/assets/javascripts/react_app/components/AuditsList/index.js
@@ -34,7 +34,11 @@ const renderAdditionalInfoItems = items =>
 
 const renderTimestamp = date => (
   <span className="gray-text">
-    <ShortDateTime date={date} defaultValue={__('N/A')} />
+    <ShortDateTime
+      date={date}
+      defaultValue={__('N/A')}
+      showRelativeTimeTooltip
+    />
   </span>
 );
 

--- a/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.js
@@ -7,7 +7,9 @@ const LongDateTime = (props, context) => {
   const { date, defaultValue } = props;
   if (date) {
     const isoDate = isoCompatibleDate(date);
-    const title = context.intl.formatRelative(isoDate);
+    const title = props.showRelativeTimeTooltip
+      ? context.intl.formatRelative(isoDate)
+      : undefined;
     const seconds = props.seconds ? '2-digit' : undefined;
 
     return (
@@ -35,12 +37,14 @@ LongDateTime.propTypes = {
   date: PropTypes.any,
   defaultValue: PropTypes.string,
   seconds: PropTypes.bool,
+  showRelativeTimeTooltip: PropTypes.bool,
 };
 
 LongDateTime.defaultProps = {
   date: null,
   defaultValue: '',
   seconds: false,
+  showRelativeTimeTooltip: false,
 };
 
 export default LongDateTime;

--- a/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/LongDateTime.test.js
@@ -23,6 +23,21 @@ describe('LongDateTime', () => {
     });
   });
 
+  it('formats date with relative tooltip', () => {
+    const wrapper = mount(
+      <IntlDate
+        date={date}
+        defaultValue="Default value"
+        showRelativeTimeTooltip
+      />
+    );
+
+    intl.ready.then(() => {
+      wrapper.update();
+      expect(toJson(wrapper.find('LongDateTime'))).toMatchSnapshot();
+    });
+  });
+
   it('formats date with seconds', () => {
     const wrapper = mount(
       <IntlDate date={date} seconds defaultValue="Default value" />

--- a/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.js
@@ -7,9 +7,10 @@ const ShortDateTime = (props, context) => {
   const { date, defaultValue, seconds } = props;
   if (date) {
     const isoDate = isoCompatibleDate(date);
-    const title = context.intl.formatRelative(isoDate);
+    const title = props.showRelativeTimeTooltip
+      ? context.intl.formatRelative(isoDate)
+      : undefined;
     const secondsFormat = seconds ? '2-digit' : undefined;
-
     return (
       <span title={title}>
         <FormattedDate
@@ -34,12 +35,14 @@ ShortDateTime.propTypes = {
   date: PropTypes.any,
   defaultValue: PropTypes.string,
   seconds: PropTypes.bool,
+  showRelativeTimeTooltip: PropTypes.bool,
 };
 
 ShortDateTime.defaultProps = {
   date: null,
   defaultValue: '',
   seconds: false,
+  showRelativeTimeTooltip: false,
 };
 
 export default ShortDateTime;

--- a/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/ShortDateTime.test.js
@@ -23,6 +23,21 @@ describe('ShortDateTime', () => {
     });
   });
 
+  it('formats date with relative tooltip', () => {
+    const wrapper = mount(
+      <IntlDate
+        date={date}
+        defaultValue="Default value"
+        showRelativeTimeTooltip
+      />
+    );
+
+    intl.ready.then(() => {
+      wrapper.update();
+      expect(toJson(wrapper.find('ShortDateTime'))).toMatchSnapshot();
+    });
+  });
+
   it('formats date with seconds', () => {
     const wrapper = mount(
       <IntlDate date={date} seconds defaultValue="Default value" />

--- a/webpack/assets/javascripts/react_app/components/common/dates/__snapshots__/LongDateTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/dates/__snapshots__/LongDateTime.test.js.snap
@@ -5,6 +5,31 @@ exports[`LongDateTime formats date 1`] = `
   date={2017-10-13T11:54:55.000Z}
   defaultValue="Default value"
   seconds={false}
+  showRelativeTimeTooltip={false}
+>
+  <span>
+    <FormattedDate
+      day="2-digit"
+      hour="2-digit"
+      minute="2-digit"
+      month="long"
+      value={2017-10-13T11:54:55.000Z}
+      year="numeric"
+    >
+      <span>
+        October 13, 2017, 11:54 AM
+      </span>
+    </FormattedDate>
+  </span>
+</LongDateTime>
+`;
+
+exports[`LongDateTime formats date with relative tooltip 1`] = `
+<LongDateTime
+  date={2017-10-13T11:54:55.000Z}
+  defaultValue="Default value"
+  seconds={false}
+  showRelativeTimeTooltip={true}
 >
   <span
     title="15 days ago"
@@ -30,10 +55,9 @@ exports[`LongDateTime formats date with seconds 1`] = `
   date={2017-10-13T11:54:55.000Z}
   defaultValue="Default value"
   seconds={true}
+  showRelativeTimeTooltip={false}
 >
-  <span
-    title="15 days ago"
-  >
+  <span>
     <FormattedDate
       day="2-digit"
       hour="2-digit"
@@ -56,6 +80,7 @@ exports[`LongDateTime renders default value 1`] = `
   date={null}
   defaultValue="Default value"
   seconds={false}
+  showRelativeTimeTooltip={false}
 >
   <span>
     Default value

--- a/webpack/assets/javascripts/react_app/components/common/dates/__snapshots__/ShortDateTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/dates/__snapshots__/ShortDateTime.test.js.snap
@@ -5,6 +5,30 @@ exports[`ShortDateTime formats date 1`] = `
   date={2017-10-13T11:54:55.000Z}
   defaultValue="Default value"
   seconds={false}
+  showRelativeTimeTooltip={false}
+>
+  <span>
+    <FormattedDate
+      day="2-digit"
+      hour="2-digit"
+      minute="2-digit"
+      month="short"
+      value={2017-10-13T11:54:55.000Z}
+    >
+      <span>
+        Oct 13, 11:54 AM
+      </span>
+    </FormattedDate>
+  </span>
+</ShortDateTime>
+`;
+
+exports[`ShortDateTime formats date with relative tooltip 1`] = `
+<ShortDateTime
+  date={2017-10-13T11:54:55.000Z}
+  defaultValue="Default value"
+  seconds={false}
+  showRelativeTimeTooltip={true}
 >
   <span
     title="15 days ago"
@@ -29,10 +53,9 @@ exports[`ShortDateTime formats date with seconds 1`] = `
   date={2017-10-13T11:54:55.000Z}
   defaultValue="Default value"
   seconds={true}
+  showRelativeTimeTooltip={false}
 >
-  <span
-    title="15 days ago"
-  >
+  <span>
     <FormattedDate
       day="2-digit"
       hour="2-digit"
@@ -54,6 +77,7 @@ exports[`ShortDateTime renders default value 1`] = `
   date={null}
   defaultValue="Default value"
   seconds={false}
+  showRelativeTimeTooltip={false}
 >
   <span>
     Default value

--- a/webpack/assets/javascripts/react_app/components/common/dates/dates.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/dates.stories.js
@@ -20,6 +20,7 @@ storiesOf('Components/Common', module)
       date('Date and time in your time zone', defaultValue)
     );
     const showSeconds = boolean('Show seconds');
+    const showRelativeTimeTooltip = boolean('Show relative time');
 
     const timezoneOptions = [
       'America/Phoenix',
@@ -54,30 +55,38 @@ storiesOf('Components/Common', module)
             <IsoDate date={dateToShow} defaultValue="N/A" />
           </pre>
           <h3>LongDateTime</h3>
-          Renders full date with time, seconds can be displyed optionally:
+          Renders full date with time. Relative time tooltip and seconds can be
+          displyed optionally :
           <pre>
             <LongDateTime
               date={dateToShow}
               defaultValue="N/A"
               seconds={showSeconds}
+              showRelativeTimeTooltip={showRelativeTimeTooltip}
             />
           </pre>
-          There&apos;s an erb helper alernative for rendering the same format:
+          There&apos;s an erb helper alernative for rendering the same format
+          with relative time tooltip true as a default:
           <Code lang="ruby">
-            date_time_absolute(time, :short, seconds = false)
+            date_time_absolute(time, :short, seconds = false,
+            show_relative_time_tooltip = true)
           </Code>
           <h3>ShortDateTime</h3>
-          Renders shortened date with time, seconds can be displyed optionally:
+          Renders shortened date with time. Relative time tooltip and seconds
+          can be displyed optionally :
           <pre>
             <ShortDateTime
               date={dateToShow}
               defaultValue="N/A"
               seconds={showSeconds}
+              showRelativeTimeTooltip={showRelativeTimeTooltip}
             />
           </pre>
-          There&apos;s an erb helper alernative for rendering the same format:
+          There&apos;s an erb helper alernative for rendering the same format
+          with relative time tooltip true as a default:
           <Code lang="ruby">
-            date_time_absolute(time, :long, seconds = false)
+            date_time_absolute(time, :long, seconds = false,
+            show_relative_time_tooltip = true)
           </Code>
           <h3>RelativeDateTime</h3>
           Renders relative date with long date in a tooltop:


### PR DESCRIPTION
Date Time components should show only the date-time and be the foreman standard.
Not all date-time usages require relative time tooltip so now it's optional.  