### PR TITLE
Fixes #28513 - downgrade storybook

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@storybook/addon-actions": "~3.4.12",
     "@storybook/addon-knobs": "~3.4.12",
     "@storybook/addon-storysource": "^3.4.12",
-    "@storybook/react": "~3.4.12",
+    "@storybook/react": "3.4.10",
     "@storybook/storybook-deployer": "^2.0.0",
     "@theforeman/builder": "^3.5.2",
     "@theforeman/env": "^3.5.2",


### PR DESCRIPTION
storybook fails on start with the error: "Module parse failed: 'return' outside of function (12:1)"

this seems to be an issue of @storybook/react, see: https://github.com/storybookjs/storybook/issues/9154
I downgraded to version 3.4.10 and the storybook works.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
