### PR TITLE
Fixes #27585 - default dns timeout value is nil

### DIFF
--- a/db/migrate/20200107154252_correct_dns_timeout_setting.rb
+++ b/db/migrate/20200107154252_correct_dns_timeout_setting.rb
@@ -1,0 +1,7 @@
+class CorrectDnsTimeoutSetting < ActiveRecord::Migration[5.2]
+  def up
+    unless Setting[:dns_timeout].is_a?(Integer) || Setting[:dns_timeout].is_a?(Array)
+      Setting.find_by_name('dns_timeout')&.update_column(:value, nil)
+    end
+  end
+end


### PR DESCRIPTION
This should fix the issue and sets up a new way we should be "migrating"
settings. These settings operations are usually:

* rename a setting
* change type of a setting

In my case this is both, but the idea is to simply do this during seed
instead of Rails migration which is very clunky because Rails
migrations:

* happen before setting are populated for new deployments
* happen with old values on existing deployments or upgrades
* are the wrong tool for the job

A seed script will always happen after settings are initialized and are
the right tool for the job. Migrations should manipulate schemas, seed
scripts should manipulate data.