### PR TITLE
Fixes #28519: Hash and run database seeds on startup 

### DIFF
--- a/app/models/foreman_internal.rb
+++ b/app/models/foreman_internal.rb
@@ -1,0 +1,4 @@
+# Used for storing non-user facing key-value data
+# For example, the current hash of known database seed files
+class ForemanInternal < ApplicationRecord
+end

--- a/app/services/foreman_seeder.rb
+++ b/app/services/foreman_seeder.rb
@@ -1,0 +1,62 @@
+require 'digest'
+
+class ForemanSeeder
+  FOREMAN_INTERNAL_KEY = 'database_seed'.freeze
+
+  attr_reader :seeds
+
+  def initialize
+    @seeds = (foreman_seeds + plugin_seeds).sort_by { |seed| seed.split("/").last }
+  end
+
+  def foreman_seeds
+    Dir.glob(Rails.root + 'db/seeds.d/*.rb')
+  end
+
+  def plugin_seeds
+    Foreman::Plugin.registered_plugins.collect do |name, plugin|
+      engine = (name.to_s.tr('-', '_').camelize + '::Engine').constantize
+      Dir.glob(engine.root + 'db/seeds.d/*.rb')
+    rescue NameError => e
+      Foreman::Logging.exception("Failed to register plugin #{name}", e)
+      nil
+    end.flatten.compact
+  end
+
+  def hash
+    hashes = @seeds.collect { |seed| Digest::SHA256.file(seed).base64digest }
+    Digest::SHA256.base64digest(hashes.join)
+  end
+
+  def execute
+    @seeds.each do |seed|
+      Rails.logger.info("Seeding #{seed}") unless Rails.env.test?
+
+      admin = User.unscoped.find_by_login(User::ANONYMOUS_ADMIN)
+      # anonymous admin does not exist until some of seed step creates it, therefore we use it only when it exists
+      if admin.present?
+        User.as_anonymous_admin do
+          load seed
+        end
+      else
+        load seed
+      end
+    end
+
+    save_hash
+
+    Rails.logger.info("All seed files executed") unless Rails.env.test?
+  end
+
+  def save_hash
+    ForemanInternal.find_or_create_by(key: FOREMAN_INTERNAL_KEY).update_attribute(:value, hash)
+  end
+
+  def old_hash
+    ForemanInternal.find_or_create_by(key: FOREMAN_INTERNAL_KEY).value
+  end
+
+  def hash_changed?
+    old_hash != hash
+  end
+end

--- a/config/initializers/seeds.rb
+++ b/config/initializers/seeds.rb
@@ -1,0 +1,13 @@
+return unless (ForemanInternal.table_exists? rescue(false)) && !Foreman.in_rake? && !Rails.env.test?
+
+Foreman::Application.configure do |app|
+  config.after_initialize do
+    seeder = ForemanSeeder.new
+
+    if seeder.hash_changed?
+      seeder.execute
+    else
+      Rails.logger.info("No new seed file updates found. Skipping")
+    end
+  end
+end

--- a/db/migrate/20200107181613_add_foreman_internal_table.rb
+++ b/db/migrate/20200107181613_add_foreman_internal_table.rb
@@ -1,0 +1,9 @@
+class AddForemanInternalTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :foreman_internals do |t|
+      t.string :key
+      t.string :value
+      t.timestamps
+    end
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,31 +10,5 @@ def format_errors(model = nil)
   SeedHelper.format_errors(model)
 end
 
-# now we load all seed files
-foreman_seeds = Dir.glob(Rails.root + 'db/seeds.d/*.rb')
-
-Foreman::Plugin.registered_plugins.each do |name, plugin|
-  engine = (name.to_s.tr('-', '_').camelize + '::Engine').constantize
-  foreman_seeds += Dir.glob(engine.root + 'db/seeds.d/*.rb')
-rescue NameError => e
-  Foreman::Logging.exception("Failed to register plugin #{name}", e)
-end
-
-foreman_seeds = foreman_seeds.sort do |a, b|
-  a.split('/').last <=> b.split('/').last
-end
-
-foreman_seeds.each do |seed|
-  puts "Seeding #{seed}" unless Rails.env.test?
-
-  admin = User.unscoped.find_by_login(User::ANONYMOUS_ADMIN)
-  # anonymous admin does not exist until some of seed step creates it, therefore we use it only when it exists
-  if admin.present?
-    User.as_anonymous_admin do
-      load seed
-    end
-  else
-    load seed
-  end
-end
-puts "All seed files executed" unless Rails.env.test?
+seeder = ForemanSeeder.new
+seeder.execute

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -115,7 +115,7 @@ class SeedsTest < ActiveSupport::TestCase
 
   test 'is idempotent' do
     seed
-    ActiveRecord::Base.any_instance.expects(:save).never
+    ActiveRecord::Base.any_instance.expects(:save).once
     seed
   end
 


### PR DESCRIPTION
This is part of moving to a model where packaging can remove this file to indicate seeding needed and the installer can trigger if the file does not exist.
