### PR TITLE
Fixes #28520 - rake task for creation of external auth source

### DIFF
--- a/lib/tasks/auth_source_external.rake
+++ b/lib/tasks/auth_source_external.rake
@@ -1,0 +1,13 @@
+namespace :auth_source_external do
+  desc 'Creates an external authentication source named "External", if no external authentication source exists.'
+  task :create => :environment do
+    User.as_anonymous_admin do
+      if AuthSourceExternal.any?
+        puts "Failed to create external authentication source. External authentication source named '#{AuthSourceExternal.pluck(:name)}' with id '#{AuthSourceExternal.pluck(:id)}' is already present."
+      else
+        AuthSourceExternal.create!(name: 'External')
+        puts 'Successfully created external authentication source.'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch will create an external auth source and will add taxonomy to it. With conjunction to this patch, admins can use hammer to edit org/loc for the external auth source users.

@ares @ekohl @tbrisker let me know your thoughts on this one!