### PR TITLE
Refs #28391 - snapshots update after vendor 3.9.0 upgrade with patternfly-react 2.39.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^3.5.2",
+    "@theforeman/vendor": "^3.9.0",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -35,9 +35,9 @@
     "@storybook/addon-storysource": "^3.4.12",
     "@storybook/react": "3.4.10",
     "@storybook/storybook-deployer": "^2.0.0",
-    "@theforeman/builder": "^3.5.2",
-    "@theforeman/env": "^3.5.2",
-    "@theforeman/vendor-dev": "^3.5.2",
+    "@theforeman/builder": "^3.9.0",
+    "@theforeman/env": "^3.9.0",
+    "@theforeman/vendor-dev": "^3.9.0",
     "argv-parse": "^1.0.1",
     "axios-mock-adapter": "^1.10.0",
     "babel-eslint": "^10.0.0",

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   id="architectures"
   onClick={[Function]}
   pullRight={true}
@@ -61,11 +61,11 @@ exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
       text="my-bookmark"
     />
   </DropdownMenu>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;
 
 exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   id="architectures"
   onClick={[Function]}
   pullRight={true}
@@ -130,11 +130,11 @@ exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
       />
     </li>
   </DropdownMenu>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;
 
 exports[`Bookmarks should render when no bookmarks loaded 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   id="architectures"
   onClick={[Function]}
   pullRight={true}
@@ -197,11 +197,11 @@ exports[`Bookmarks should render when no bookmarks loaded 1`] = `
       None found
     </MenuItem>
   </DropdownMenu>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;
 
 exports[`Bookmarks should show error 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   id="architectures"
   onClick={[Function]}
   pullRight={true}
@@ -266,5 +266,5 @@ exports[`Bookmarks should show error 1`] = `
       </EllipisWithTooltip>
     </MenuItem>
   </DropdownMenu>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorSettings.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorSettings.test.js.snap
@@ -18,7 +18,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Syntax
         </div>
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={false}
           id="mode-dropdown"
         >
@@ -100,7 +100,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Yaml
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -110,7 +110,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Keybind
         </div>
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={false}
           id="keybindings-dropdown"
         >
@@ -156,7 +156,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Vim
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -166,7 +166,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
         >
           Theme
         </div>
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           id="themes-dropdown"
         >
           <DropdownToggle
@@ -202,7 +202,7 @@ exports[`EditorSettings renders EditorSettings 1`] = `
               Monokai
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </div>
     </Popover>
   }
@@ -250,7 +250,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Syntax
         </div>
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={true}
           id="mode-dropdown"
         >
@@ -332,7 +332,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Yaml
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -342,7 +342,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Keybind
         </div>
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           disabled={true}
           id="keybindings-dropdown"
         >
@@ -388,7 +388,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Vim
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </div>
       <div
         className="cog-popover-dropdown"
@@ -398,7 +398,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
         >
           Theme
         </div>
-        <Uncontrolled(Dropdown)
+        <ForwardRef
           id="themes-dropdown"
         >
           <DropdownToggle
@@ -434,7 +434,7 @@ exports[`EditorSettings renders EditorSettings w/preview 1`] = `
               Monokai
             </MenuItem>
           </DropdownMenu>
-        </Uncontrolled(Dropdown)>
+        </ForwardRef>
       </div>
     </Popover>
   }

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/NavDropdown.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/NavDropdown.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NavDropdown rendering render NavDropdown 1`] = `
-<Uncontrolled(Dropdown)
+<ForwardRef
   className=""
   componentClass="li"
   id="account_menu"
@@ -11,5 +11,5 @@ exports[`NavDropdown rendering render NavDropdown 1`] = `
   >
     TEST
   </li>
-</Uncontrolled(Dropdown)>
+</ForwardRef>
 `;


### PR DESCRIPTION
patternfly fixed their modal issue which broke our tests
updated the PF version in foreman-vendor-core, blocked by https://github.com/theforeman/foreman-js/pull/98
modal tests forward-ref snapshots need to be updated.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
