### PR TITLE
Fixes #28566 - add organizations and locations to http proxy show api

### DIFF
--- a/app/views/api/v2/http_proxies/show.json.rabl
+++ b/app/views/api/v2/http_proxies/show.json.rabl
@@ -1,3 +1,11 @@
 object @http_proxy
 
 extends "api/v2/http_proxies/main"
+
+child :locations => :locations do
+  attributes :id, :name, :title
+end
+
+child :organizations => :organizations do
+  attributes :id, :name, :title
+end


### PR DESCRIPTION
Adding organizations and locations to the show/GET API for the
http proxy.  This will be added to the CLI as well and is to
provide consistency with the information shown on the UI.