### PR TITLE
Fixes #28552 - update http_proxy model to filter/scope by taxonomy

### DIFF
--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -17,6 +17,14 @@ class HttpProxy < ApplicationRecord
   validates :url, :presence => true
   validates :url, :format => URI.regexp(["http", "https"])
 
+  # with proc support, default_scope can no longer be chained
+  # include all default scoping here
+  default_scope lambda {
+    with_taxonomy_scope do
+      order("#{self.table_name}.name")
+    end
+  }
+
   scoped_search :on => :name
   scoped_search :on => :url
 

--- a/test/controllers/api/v2/http_proxies_controller_test.rb
+++ b/test/controllers/api/v2/http_proxies_controller_test.rb
@@ -28,8 +28,8 @@ module Api
         name = 'http_proxy_is_smart'
         post :create, params: { :http_proxy => { :name => name, :url => 'http://what????:5000' } }, session: set_session_user
 
-        assert_response :success
-        assert HttpProxy.find_by(:name => name)
+        assert_response :created
+        assert_equal JSON.parse(@response.body)['name'], name
       end
 
       def test_update

--- a/test/controllers/http_proxies_controller_test.rb
+++ b/test/controllers/http_proxies_controller_test.rb
@@ -28,8 +28,7 @@ class HttpProxiesControllerTest < ActionController::TestCase
     name = 'http_proxy_is_smart'
     post :create, params: { :http_proxy => { :name => name, :url => 'http://what????:5000' } }, session: set_session_user
 
-    assert_response :found
-    assert HttpProxy.find_by(:name => name)
+    assert_redirected_to http_proxies_url
   end
 
   def test_update


### PR DESCRIPTION
The http_proxy model doesn't currently provide the default scoping
by taxonomy (e.g. organization/location).  As a result, without
this fix, the user will see all proxies listed.