### PR TITLE
Fixes #7570 - Replace `secret_token` with `secret_key_base`

### DIFF
--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -1,10 +1,4 @@
 ---
-# https://projects.theforeman.org/issues/7570
-- message: You didn't set `secret_key_base`. Read the upgrade documentation to learn
-    more about this new config option.
-- message: "`secrets.secret_token` is deprecated in favor of `secret_key_base` and
-    will be removed in Rails 6.0."
-
 # https://projects.theforeman.org/issues/23300
 - message: 'Dangerous query method (method whose arguments are used as raw SQL) called
     with non-attribute argument(s):'

--- a/config/initializers/local_secret_token.rb.example
+++ b/config/initializers/local_secret_token.rb.example
@@ -7,4 +7,4 @@
 
 # You can use `rake security:generate_token` to regenerate this file.
 
-#Foreman::Application.config.secret_token = 'uncomment and insert token here'
+#Foreman::Application.config.secret_key_base = 'uncomment and insert token here'

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,7 +1,7 @@
 require_dependency 'foreman/util'
 include Foreman::Util
 
-unless Foreman::Application.config.secret_token
+unless Foreman::Application.config.secret_key_base
   tmp = Rails.root.join("tmp")
   Dir.mkdir(tmp) unless File.exist? tmp
 
@@ -11,5 +11,5 @@ unless Foreman::Application.config.secret_token
     token = secure_token
     File.open(token_store, "w", 0600) { |f| f.write(token) }
   end
-  Foreman::Application.config.secret_token = token
+  Foreman::Application.config.secret_key_base = token
 end

--- a/lib/tasks/security.rake
+++ b/lib/tasks/security.rake
@@ -15,7 +15,7 @@ namespace :security do
 
 # You can use `rake security:generate_token` to regenerate this file.
 
-Foreman::Application.config.secret_token = '#{secure_token}'
+Foreman::Application.config.secret_key_base = '#{secure_token}'
 ")
     end
   end


### PR DESCRIPTION
This new config setting was introduced in Rails 4 to allow encrypting
cookies. The old setting is being removed in Rails 6.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
