### PR TITLE
Fixes #28563 - Be defensive about interface type in API

### DIFF
--- a/app/views/api/v2/interfaces/main.json.rabl
+++ b/app/views/api/v2/interfaces/main.json.rabl
@@ -6,5 +6,7 @@ attributes :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :domain_id, :do
            :managed, :identifier
 
 node do |interface|
-  partial("api/v2/interfaces/types/#{interface.type_name.downcase}.json", :object => interface)
+  unless interface.type.nil?
+    partial("api/v2/interfaces/types/#{interface.type_name.downcase}.json", :object => interface)
+  end
 end


### PR DESCRIPTION
It appears in some cases interfaces might be registered in the database
with `nil` type. While that is invalid, such interface's existance
causes the host/nic APIs to return an error instead of the requested
information.
This PR makes sure that such interfaces are still displayed in the API.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
