### PR TITLE
Fixes #23234 - Simplify parent scope lookup

### DIFF
--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -189,11 +189,25 @@ class String
       end
     end
   end
+
+  def integer?
+    self.to_i.to_s == self
+  end
 end
 
 class Object
   def contains_erb?
     false
+  end
+
+  def integer?
+    false
+  end
+end
+
+class Integer
+  def integer?
+    true
   end
 end
 


### PR DESCRIPTION
Knowing the id format allows us to know which field we should search by,
no need to try both id and friendly_id and use conditional order to
pick the friendly id first.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
