### PR TITLE
Fixes #28580 - enable assignment of external users(via oidc) to userg…

### DIFF
--- a/app/services/sso/openid_connect.rb
+++ b/app/services/sso/openid_connect.rb
@@ -56,11 +56,14 @@ module SSO
     end
 
     def find_or_create_user_from_jwt(payload)
+      attrs = { login: payload['preferred_username'],
+                mail: payload['email'],
+                firstname: payload['given_name'],
+                lastname: payload['family_name'],
+              }
+      attrs[:groups] = payload['groups'] if payload['groups'].present?
       User.find_or_create_external_user(
-        { login: payload['preferred_username'],
-          mail: payload['email'],
-          firstname: payload['given_name'],
-          lastname: payload['family_name']},
+        attrs,
         Setting['authorize_login_delegation_auth_source_user_autocreate']
       )
     end

--- a/test/unit/sso/openid_connect_test.rb
+++ b/test/unit/sso/openid_connect_test.rb
@@ -77,6 +77,20 @@ class OpenidConnectTest < ActiveSupport::TestCase
         assert_equal users(:one), subject.authenticated?
       end
     end
+
+    test "it accepts group parameter in payload and authenticates the user" do
+      oidc_source = AuthSourceExternal.where(:name => 'External').first_or_create
+      external = FactoryBot.create(:external_usergroup, :auth_source => oidc_source)
+      usergroup = FactoryBot.create(:usergroup, :admin => true)
+      external.update(:usergroup => usergroup, :name => usergroup.name)
+
+      User.current = nil
+      payload['groups'] = [usergroup.name]
+      OidcJwt.any_instance.stubs(:decode).returns(payload.with_indifferent_access)
+      assert subject.authenticated?
+
+      assert_equal payload['groups'].first, subject.current_user.usergroups.first.name
+    end
   end
 
   private


### PR DESCRIPTION
External users logged in via OpenID Connect are unable to be assigned to an external usergroup because of which assignment of roles to users is not possible. This patch makes sure that the external usergroup is identified and assigned correctly with appropriate roles.