### PR TITLE
Fixes #28583 - Drop `use_puppet_default` API params

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -11,7 +11,6 @@ module Api
       before_action :return_if_smart_mismatch, :only => [:create, :show, :update, :destroy]
       before_action :return_if_override_mismatch, :only => [:show, :update, :destroy]
 
-      before_action :rename_use_puppet_default, :only => [:create, :update]
       before_action :cast_value, :only => [:create, :update]
 
       api :GET, "/smart_class_parameters/:smart_class_parameter_id/override_values", N_("List of override values for a specific smart class parameter")
@@ -34,8 +33,7 @@ module Api
         param :override_value, Hash, :required => true, :action_aware => true do
           param :match, String, :required => true, :desc => N_("Override match")
           param :value, :any_type, :of => LookupKey::KEY_TYPES, :required => false, :desc => N_("Override value, required if omit is false")
-          param :use_puppet_default, :bool, :required => false, :desc => N_("Deprecated, please use omit")
-          param :omit, :bool, :required => false, :desc => N_("Foreman will not send this parameter in classification output, replaces use_puppet_default")
+          param :omit, :bool, :required => false, :desc => N_("Foreman will not send this parameter in classification output")
         end
       end
 
@@ -92,13 +90,6 @@ module Api
       # overwrite Api::BaseController
       def resource_class
         LookupValue
-      end
-
-      def rename_use_puppet_default
-        return unless params[:override_value]&.key?(:use_puppet_default)
-
-        params[:override_value][:omit] = params[:override_value].delete(:use_puppet_default)
-        Foreman::Deprecation.api_deprecation_warning('"use_puppet_default" was renamed to "omit"')
       end
     end
   end

--- a/app/controllers/api/v2/smart_class_parameters_controller.rb
+++ b/app/controllers/api/v2/smart_class_parameters_controller.rb
@@ -5,8 +5,6 @@ module Api
       include Api::V2::LookupKeysCommonController
       include Foreman::Controller::Parameters::PuppetclassLookupKey
 
-      before_action :rename_use_puppet_default, :only => [:update]
-
       alias_method :resource_scope, :smart_class_parameters_resource_scope
 
       api :GET, "/smart_class_parameters", N_("List all smart class parameters")
@@ -44,7 +42,6 @@ module Api
         param :description, String, :desc => N_("Description of smart class")
         param :default_value, :any_type, :of => LookupKey::KEY_TYPES, :desc => N_("Value to use when there is no match")
         param :hidden_value, :bool, :desc => N_("When enabled the parameter is hidden in the UI")
-        param :use_puppet_default, :bool, :desc => N_("Deprecated, please use omit")
         param :omit, :bool, :desc => N_("Foreman will not send this parameter in classification output. Puppet will use the value defined in the Puppet manifest for this parameter")
         param :path, String, :desc => N_("The order in which values are resolved")
         param :validator_type, LookupKey::VALIDATOR_TYPES, :desc => N_("Types of validation values")
@@ -66,13 +63,6 @@ module Api
       # overwrite Api::BaseController
       def resource_class
         LookupKey
-      end
-
-      def rename_use_puppet_default
-        return unless params[:smart_class_parameter]&.key?(:use_puppet_default)
-
-        params[:smart_class_parameter][:omit] = params[:smart_class_parameter].delete(:use_puppet_default)
-        Foreman::Deprecation.api_deprecation_warning('"use_puppet_default" was renamed to "omit"')
       end
     end
   end

--- a/app/views/api/v2/override_values/base.json.rabl
+++ b/app/views/api/v2/override_values/base.json.rabl
@@ -1,8 +1,6 @@
 object @override_value
 
 attributes :id, :match, :value, :omit
-# compatibility
-attribute :omit => :use_puppet_default
 
 node do
   partial("api/v2/common/show_hidden", :locals => { :value => :value }, :object => @object)

--- a/app/views/api/v2/smart_class_parameters/main.json.rabl
+++ b/app/views/api/v2/smart_class_parameters/main.json.rabl
@@ -18,9 +18,6 @@ node do
   partial("api/v2/common/show_hidden", :locals => { :value => :default_value }, :object => @object)
 end
 
-# compatibility
-attribute :omit => :use_puppet_default
-
 node :puppetclass_name do |lk|
   lk.param_class.name
 end

--- a/test/controllers/api/v2/override_values_controller_test.rb
+++ b/test/controllers/api/v2/override_values_controller_test.rb
@@ -85,26 +85,6 @@ class Api::V2::OverrideValuesControllerTest < ActionController::TestCase
     assert_equal lookup_key.override_values.first.omit, true
   end
 
-  test "should create override value without when use_puppet_default is true (compatibility test)" do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with('"use_puppet_default" was renamed to "omit"')
-    lookup_key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
-
-    assert_difference('LookupValue.count', 1) do
-      post :create, params: { :smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :use_puppet_default => true} }
-    end
-    assert_response :success
-  end
-
-  test "should create override value when use_puppet_default is false (compatibility test)" do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with('"use_puppet_default" was renamed to "omit"')
-    lookup_key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two), :omit => true)
-
-    assert_difference('LookupValue.count', 1) do
-      post :create, params: { :smart_class_parameter_id => lookup_key.id, :override_value =>  { :match => 'os=string', :use_puppet_default => false, :value => 'test_val'} }
-    end
-    assert_response :success
-  end
-
   test "should not create override value without when omit is false" do
     lookup_key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :override => true, :puppetclass => puppetclasses(:two))
 

--- a/test/controllers/api/v2/smart_class_parameters_controller_test.rb
+++ b/test/controllers/api/v2/smart_class_parameters_controller_test.rb
@@ -187,27 +187,6 @@ class Api::V2::SmartClassParametersControllerTest < ActionController::TestCase
     refute_equal orig_parameter_type, lookup_key.parameter_type
   end
 
-  test "should update smart class parameter with use_puppet_default (compatibility test)" do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with('"use_puppet_default" was renamed to "omit"')
-    orig_value = lookup_keys(:five).omit
-    refute lookup_keys(:five).omit # check that the initial value is false
-    put :update, params: { :id => lookup_keys(:five).to_param, :smart_class_parameter => { :use_puppet_default => "true" } }
-    assert_response :success
-    new_value = lookup_keys(:five).reload.omit
-    refute_equal orig_value, new_value
-  end
-
-  test "should update smart class parameter with use_puppet_default (compatibility test)" do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with('"use_puppet_default" was renamed to "omit"')
-    key = lookup_keys(:five)
-    key.omit = true
-    key.save!
-    put :update, params: { :id => lookup_keys(:five).to_param, :smart_class_parameter => { :use_puppet_default => "false" } }
-    assert_response :success
-    new_value = lookup_keys(:five).reload.omit
-    refute new_value
-  end
-
   test_attributes :pid => '11d75f6d-7105-4ee8-b147-b8329cae4156'
   test "should not set avoid duplicates for non supported types" do
     lookup_key = lookup_keys(:five)


### PR DESCRIPTION
These have been deprecated for over 3 years.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
