### PR TITLE
Fixes #28584 - refactor API middleware payload

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.fixtures.js
@@ -1,8 +1,9 @@
+export const controller = 'hosts';
 /* eslint-disable camelcase */
 export const bookmarks = [
   {
     name: '1111',
-    controller: 'hosts',
+    controller,
     query: 'abc',
     public: true,
     id: 52,
@@ -11,7 +12,7 @@ export const bookmarks = [
   },
   {
     name: '1122',
-    controller: 'hosts',
+    controller,
     query: 'abc',
     public: true,
     id: 54,
@@ -22,7 +23,6 @@ export const bookmarks = [
 
 export const response = {
   data: {
-    controller: 'hosts',
     results: bookmarks,
   },
 };
@@ -36,7 +36,7 @@ export const submitResponse = {
   data: {
     name,
     query: search,
-    controller: 'hosts',
+    controller,
     public: publik,
   },
   item,

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksReducer.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksReducer.js
@@ -25,10 +25,8 @@ const sortByName = (a, b) => {
   return 0;
 };
 
-export default (state = initialState, action) => {
-  const { payload } = action;
-
-  switch (action.type) {
+export default (state = initialState, { type, payload, response }) => {
+  switch (type) {
     case BOOKMARKS_REQUEST:
       return state.set(payload.controller, {
         results: [],
@@ -37,7 +35,7 @@ export default (state = initialState, action) => {
       });
     case BOOKMARKS_SUCCESS:
       return state
-        .setIn([payload.controller, 'results'], payload.results)
+        .setIn([payload.controller, 'results'], response.results)
         .setIn([payload.controller, 'status'], STATUS.RESOLVED);
     case BOOKMARKS_MODAL_OPENED:
       return state.set('currentQuery', payload.query).set('showModal', true);
@@ -54,7 +52,7 @@ export default (state = initialState, action) => {
       return state.set('showModal', false);
     case BOOKMARKS_FAILURE:
       return state
-        .setIn([payload.controller, 'errors'], payload.error)
+        .setIn([payload.controller, 'errors'], response)
         .setIn([payload.controller, 'status'], STATUS.ERROR);
     default:
       return state;

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/BookmarksReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/BookmarksReducer.test.js
@@ -52,8 +52,10 @@ const fixtures = {
     action: {
       type: BOOKMARKS_SUCCESS,
       payload: {
-        results: [bookmarkItem],
         controller: 'architectures',
+      },
+      response: {
+        results: [bookmarkItem],
       },
     },
   },
@@ -77,9 +79,9 @@ const fixtures = {
     action: {
       type: BOOKMARKS_FAILURE,
       payload: {
-        error: 'This is error',
         controller: 'architectures',
       },
+      response: 'This is error',
     },
   },
   'should update after form submission': {

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/integration.test.js.snap
@@ -35,6 +35,8 @@ Object {
       Object {
         "payload": Object {
           "controller": "hosts",
+        },
+        "response": Object {
           "results": Array [
             Object {
               "controller": "hosts",

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/integration.test.js
@@ -13,6 +13,7 @@ import {
   publik,
   item,
   submitResponse,
+  controller,
 } from '../../../Bookmarks.fixtures';
 import { BOOKMARKS_SUCCESS } from '../../../BookmarksConstants';
 
@@ -28,7 +29,11 @@ describe('Bookmark form integration test', () => {
     const testHelper = new IntegrationTestHelper(reducers);
     testHelper.store.dispatch({
       type: BOOKMARKS_SUCCESS,
-      payload: { ...response.data, item },
+      payload: {
+        controller,
+        item,
+      },
+      response: response.data,
     });
 
     const component = testHelper.mount(<BookmarkForm {...props} />);

--- a/webpack/assets/javascripts/react_app/components/FactCharts/FactChartReducer.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/FactChartReducer.js
@@ -13,21 +13,21 @@ const initialState = Immutable({
   loaderStatus: '',
 });
 
-export default (state = initialState, action) => {
+export default (state = initialState, { type, payload, response }) => {
   const { REQUEST, SUCCESS, FAILURE } = actionTypeGenerator(FACT_CHART);
-  switch (action.type) {
+  switch (type) {
     case REQUEST:
       return state.set('loaderStatus', 'PENDING');
     case SUCCESS:
       return state
-        .set('chartData', action.payload.values)
+        .set('chartData', response.values)
         .set('loaderStatus', 'RESOLVED');
     case FAILURE:
       return state.set('loaderStatus', 'ERROR');
     case FACT_CHART_MODAL_OPEN:
       return state
-        .set('title', action.payload.title)
-        .set('modalToDisplay', { [action.payload.id]: true });
+        .set('title', payload.title)
+        .set('modalToDisplay', { [payload.id]: true });
     case FACT_CHART_MODAL_CLOSE:
       return state
         .set('modalToDisplay', {})

--- a/webpack/assets/javascripts/react_app/components/FactCharts/__test__/FactChartReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/__test__/FactChartReducer.test.js
@@ -15,7 +15,8 @@ const fixtures = {
   'should handle FACT_CHART_SUCCESS action': {
     action: {
       type: SUCCESS,
-      payload: { values: chartDataValues },
+      payload: { id: 1 },
+      response: { values: chartDataValues },
     },
   },
   'should handle FACT_CHART_ERROR action': {

--- a/webpack/assets/javascripts/react_app/components/common/table/reducers/createTableReducer.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/reducers/createTableReducer.js
@@ -10,23 +10,26 @@ const initState = Immutable({
   status: STATUS.PENDING,
 });
 
-const createTableReducer = tableID => (state = initState, action) => {
+const createTableReducer = tableID => (
+  state = initState,
+  { type, payload, response }
+) => {
   const { REQUEST, FAILURE, SUCCESS } = createTableActionTypes(tableID);
 
-  switch (action.type) {
+  switch (type) {
     case REQUEST:
       return state.set('status', STATUS.PENDING);
     case SUCCESS:
       return Immutable.merge(state, {
         error: null,
         status: STATUS.RESOLVED,
-        results: action.payload.results,
-        sortBy: action.payload.sort.by,
-        sortOrder: action.payload.sort.order,
+        results: response.results,
+        sortBy: response.sort.by,
+        sortOrder: response.sort.order,
       });
     case FAILURE:
       return Immutable.merge(state, {
-        error: action.payload.error,
+        error: response,
         status: STATUS.ERROR,
         results: [],
       });

--- a/webpack/assets/javascripts/react_app/components/common/table/reducers/createTableReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/reducers/createTableReducer.test.js
@@ -18,8 +18,12 @@ const fixtures = {
     action: {
       type: ACTION_TYPES.SUCCESS,
       payload: {
-        search: 'name=model',
+        url: 'some_url',
+        tableID: 'some_ID',
+      },
+      response: {
         results: [{ id: 23, name: 'model' }],
+        search: 'name=model',
         page: 1,
         per_page: 5,
         total: 20,
@@ -31,8 +35,10 @@ const fixtures = {
     action: {
       type: ACTION_TYPES.FAILURE,
       payload: {
-        error: new Error('ooops!'),
+        url: 'some_url',
+        tableID: 'some_ID',
       },
+      response: new Error('ooops!'),
     },
   },
 };

--- a/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
@@ -13,12 +13,14 @@ export const get = async (payload, url, store, actionTypes) => {
     );
     store.dispatch({
       type: actionTypes.SUCCESS,
-      payload: { ...payload, ...data },
+      payload,
+      response: data,
     });
   } catch (error) {
     store.dispatch({
       type: actionTypes.FAILURE,
-      payload: { ...payload, error },
+      payload,
+      response: error,
     });
   }
 };

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -14,10 +14,10 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "error": [Error: bad request],
         "id": "myid",
         "name": "test",
       },
+      "response": [Error: bad request],
       "type": "TEST_FAILURE",
     },
   ],
@@ -40,6 +40,8 @@ Array [
       "payload": Object {
         "id": "myid",
         "name": "test",
+      },
+      "response": Object {
         "results": Array [
           1,
         ],

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/__snapshots__/powerStatus.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/powerStatus/__snapshots__/powerStatus.test.js.snap
@@ -18,9 +18,9 @@ Array [
   },
   Object {
     "payload": Object {
-      "error": [Error: Request failed with status code 500],
       "id": 0,
     },
+    "response": [Error: Request failed with status code 500],
     "type": "HOST_POWER_STATUS_FAILURE",
   },
 ]
@@ -44,6 +44,9 @@ Array [
   },
   Object {
     "payload": Object {
+      "id": 1,
+    },
+    "response": Object {
       "id": 1,
       "state": "na",
       "title": "N/A",

--- a/webpack/assets/javascripts/react_app/redux/actions/statistics/__snapshots__/statistics.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/actions/statistics/__snapshots__/statistics.test.js.snap
@@ -44,6 +44,12 @@ Array [
   },
   Object {
     "payload": Object {
+      "id": "operatingsystem",
+      "search": "/hosts?search=os_title=~VAL~",
+      "title": "OS Distribution",
+      "url": "statistics/operatingsystem",
+    },
+    "response": Object {
       "data": Array [
         Array [
           "centOS 7.1",
@@ -51,14 +57,17 @@ Array [
         ],
       ],
       "id": "operatingsystem",
-      "search": "/hosts?search=os_title=~VAL~",
-      "title": "OS Distribution",
-      "url": "statistics/operatingsystem",
     },
     "type": "STATISTICS_DATA_SUCCESS",
   },
   Object {
     "payload": Object {
+      "id": "architecture",
+      "search": "/hosts?search=facts.architecture=~VAL~",
+      "title": "Architecture Distribution",
+      "url": "statistics/architecture",
+    },
+    "response": Object {
       "data": Array [
         Array [
           "x86_64",
@@ -66,9 +75,6 @@ Array [
         ],
       ],
       "id": "architecture",
-      "search": "/hosts?search=facts.architecture=~VAL~",
-      "title": "Architecture Distribution",
-      "url": "statistics/architecture",
     },
     "type": "STATISTICS_DATA_SUCCESS",
   },
@@ -119,22 +125,22 @@ Array [
   },
   Object {
     "payload": Object {
-      "error": [Error: Request failed with status code 422],
       "id": "operatingsystem",
       "search": "/hosts?search=os_title=~VAL~",
       "title": "OS Distribution",
       "url": "statistics/operatingsystem",
     },
+    "response": [Error: Request failed with status code 422],
     "type": "STATISTICS_DATA_FAILURE",
   },
   Object {
     "payload": Object {
-      "error": [Error: Request failed with status code 422],
       "id": "architecture",
       "search": "/hosts?search=facts.architecture=~VAL~",
       "title": "Architecture Distribution",
       "url": "statistics/architecture",
     },
+    "response": [Error: Request failed with status code 422],
     "type": "STATISTICS_DATA_FAILURE",
   },
 ]

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/index.js
@@ -7,18 +7,17 @@ import {
 
 const initialState = Immutable({});
 
-export default (state = initialState, action) => {
-  const { payload } = action;
-
-  switch (action.type) {
+export default (state = initialState, { type, payload, response }) => {
+  switch (type) {
     case HOST_POWER_STATUS_REQUEST:
-    case HOST_POWER_STATUS_SUCCESS:
       return state.set(payload.id, payload);
+    case HOST_POWER_STATUS_SUCCESS:
+      return state.set(payload.id, response);
     case HOST_POWER_STATUS_FAILURE: {
       const {
         message: errorMessage,
         response: { data },
-      } = payload.error;
+      } = response;
 
       return state.set(data.id, { error: errorMessage, ...data });
     }

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/powerStatus.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/powerStatus/powerStatus.test.js
@@ -28,16 +28,16 @@ describe('powerStatus reducer', () => {
       state: stateBeforeResponse,
       action: {
         type: types.HOST_POWER_STATUS_SUCCESS,
-        payload: response,
+        payload: request,
+        response,
       },
     },
     'should handle HOST_POWER_STATUS_FAILURE': {
       state: stateBeforeResponse,
       action: {
         type: types.HOST_POWER_STATUS_FAILURE,
-        payload: {
-          error,
-        },
+        payload: request,
+        response: error,
       },
     },
   };

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.js
@@ -36,7 +36,7 @@ const getAvailableKey = controllers =>
     )
   );
 
-export default (state = initialState, { type, payload }) => {
+export default (state = initialState, { type, payload, response }) => {
   switch (type) {
     case VMWARE_CLUSTER_CHANGE:
       return state.set('cluster', payload.cluster);
@@ -123,10 +123,10 @@ export default (state = initialState, { type, payload }) => {
       });
     case STORAGE_VMWARE_DATASTORES_SUCCESS:
       return state
-        .set('datastores', payload.results)
+        .set('datastores', response.results)
         .set('datastoresLoading', false);
     case STORAGE_VMWARE_DATASTORES_FAILURE:
-      return state.set('datastoresError', payload.error.message);
+      return state.set('datastoresError', response.message);
     case STORAGE_VMWARE_STORAGEPODS_REQUEST:
       return state.merge({
         storagePodsError: undefined,
@@ -135,11 +135,11 @@ export default (state = initialState, { type, payload }) => {
       });
     case STORAGE_VMWARE_STORAGEPODS_SUCCESS:
       return state.merge({
-        storagePods: payload.results,
+        storagePods: response.results,
         storagePodsLoading: false,
       });
     case STORAGE_VMWARE_STORAGEPODS_FAILURE:
-      return state.set('storagePodsError', payload.error.message);
+      return state.set('storagePodsError', response.message);
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/redux/reducers/statistics/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/statistics/index.js
@@ -9,21 +9,19 @@ const initialState = Immutable({
   charts: Immutable({}),
 });
 
-export default (state = initialState, action) => {
-  const { payload } = action;
-
-  switch (action.type) {
+export default (state = initialState, { type, payload, response }) => {
+  switch (type) {
     case STATISTICS_DATA_REQUEST:
       return state.setIn(['charts', payload.id], payload);
     case STATISTICS_DATA_SUCCESS:
       return state.setIn(['charts', payload.id], {
         ...state.charts[payload.id],
-        data: payload.data,
+        data: response.data,
       });
     case STATISTICS_DATA_FAILURE:
       return state.setIn(['charts', payload.id], {
         ...state.charts[payload.id],
-        error: payload.error,
+        error: response,
       });
     default:
       return state;

--- a/webpack/assets/javascripts/react_app/redux/reducers/statistics/statistics.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/statistics/statistics.test.js
@@ -28,14 +28,16 @@ describe('statistics reducer', () => {
       prev: stateBeforeResponse,
       action: {
         type: types.STATISTICS_DATA_SUCCESS,
-        payload: response,
+        payload: request,
+        response,
       },
     },
     'should handle STATISTICS_DATA_FAILURE': {
       prev: stateBeforeResponse,
       action: {
         type: types.STATISTICS_DATA_FAILURE,
-        payload: { error, ...request },
+        payload: request,
+        response: error,
       },
     },
   };


### PR DESCRIPTION
currently the returned payload is a mix of data and payload, looks like: 
`payload: { ...payload, ...data }`
which is quite risky and may not be the best approach to handle API responses,

in this refactor I will split it into `response` which will store the API's success or error responses, and `payload` which will pass the same payload that was passed to the API action.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
