### PR TITLE
Fixes #28585 - Drop host status api without type

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -179,36 +179,17 @@ module Api
         render :json => { :data => @host.info }
       end
 
-      api :GET, "/hosts/:id/status", N_("Get configuration status of host")
-      param :id, :identifier_dottable, :required => true
-      description <<~EOS
-        Return value may either be one of the following:
-
-        * Alerts disabled
-        * No reports
-        * Error
-        * Out of sync
-        * Active
-        * Pending
-        * No changes
-      EOS
-
-      def status
-        Foreman::Deprecation.api_deprecation_warning('The /status route is deprecated, please use the new /status/configuration instead')
-        render :json => { :status => @host.get_status(HostStatus::ConfigurationStatus).to_label }.to_json if @host
-      end
-
       api :GET, "/hosts/:id/status/:type", N_("Get status of host")
       param :id, :identifier_dottable, :required => true
-      param :type, [ HostStatus::Global ] + HostStatus.status_registry.to_a.map { |s| s.humanized_name }, :required => true, :desc => N_(<<~EOS
-        status type, can be one of
-        * global
-        * configuration
-        * build
-      EOS
-  # rubocop:disable Layout/ClosingParenthesisIndentation
-)
-      # rubocop:enable Layout/ClosingParenthesisIndentation
+      param :type, [ HostStatus::Global ] + HostStatus.status_registry.to_a.map { |s| s.humanized_name }, :required => true, :desc => N_(
+        <<~EOS
+          status type, can be one of
+          * global
+          * configuration
+          * build
+        EOS
+      )
+
       description N_('Returns string representing a host status of a given type')
       def get_status
         case params[:type]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -345,7 +345,6 @@ Foreman::Application.routes.draw do
         end
         resources :hosts, :except => [:new, :edit] do
           get :enc, :on => :member
-          get :status, :on => :member
           get 'status/:type', :on => :member, :action => :get_status
           get :vm_compute_attributes, :on => :member
           get 'template/:kind', :on => :member, :action => :template

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -460,12 +460,6 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should show status hosts" do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/status route is deprecated}))
-    get :status, params: { :id => @host.to_param }
-    assert_response :success
-  end
-
   test "should show specific status hosts" do
     get :get_status, params: { :id => @host.to_param, :type => 'global' }
     assert_response :success
@@ -504,10 +498,9 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   test "should allow show status for restricted user who owns the hosts" do
-    Foreman::Deprecation.expects(:api_deprecation_warning).with(regexp_matches(%r{/status route is deprecated}))
     host = FactoryBot.create(:host, :owner => users(:scoped), :organization => taxonomies(:organization1), :location => taxonomies(:location1))
     setup_user 'view', 'hosts', "owner_type = User and owner_id = #{users(:scoped).id}", :scoped
-    get :status, params: { :id => host.to_param }
+    get :get_status, params: { :id => host.to_param, :type => 'configuration' }
     assert_response :success
   end
 
@@ -542,7 +535,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should not show status of hosts out of users hosts scope" do
     setup_user 'view', 'hosts', "owner_type = User and owner_id = #{users(:restricted).id}", :restricted
-    get :status, params: { :id => @host.to_param }
+    get :get_status, params: { :id => @host.to_param, :type => 'configuration' }
     assert_response :not_found
   end
 


### PR DESCRIPTION
The `hosts/<id>/status` api endpoint has been deprecated in favor of
more specific status types.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
