### PR TITLE
Fixes #28591 - Drop deprecated permissions api params

### DIFF
--- a/app/controllers/api/v2/permissions_controller.rb
+++ b/app/controllers/api/v2/permissions_controller.rb
@@ -4,25 +4,13 @@ module Api
       include Api::Version2
 
       before_action :find_resource, :only => %w{show}
-      before_action :parameter_deprecation, :only => %w(index)
 
       api :GET, "/permissions/", N_("List all permissions")
       param_group :search_and_pagination, ::Api::V2::BaseController
-      param :resource_type, String
-      param :name, String
       add_scoped_search_description_for(Permission)
 
       def index
-        type = params[:resource_type].presence
-        name = params[:name].presence
-        if type
-          @permissions = Permission.where(:resource_type => type).paginate(paginate_options)
-        elsif name
-          @permissions = Permission.where(:name => name).paginate(paginate_options)
-        else
-          @permissions = resource_scope_for_index
-        end
-        @permissions
+        @permissions = resource_scope_for_index
       end
 
       api :GET, "/permissions/:id/", N_("Show a permission")
@@ -36,15 +24,6 @@ module Api
         @resource_types = Permission.resources
         @total = @resource_types.size
         render :resource_types, :layout => 'api/v2/layouts/index_layout'
-      end
-
-      private
-
-      def parameter_deprecation
-        return true unless params[:resource_type] || params[:name]
-        Foreman::Deprecation.api_deprecation_warning(
-          "The name and resource_type parameters are deprecated, use search syntax to search by those parameters."
-        )
       end
     end
   end


### PR DESCRIPTION
These params have been deprecated since Foreman 1.10.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
