### PR TITLE
Fixes #28600 - don't change encoding of empty strings

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -71,7 +71,7 @@ class AuthSourceLdap < AuthSource
       return
     end
 
-    attrs.each { |k, v| attrs[k] = v.force_encoding('UTF-8') }
+    attrs.each { |k, v| attrs[k] = v.force_encoding('UTF-8') unless v == ''}
 
     logger.debug "Retrieved LDAP Attributes for #{login}: #{attrs}"
 


### PR DESCRIPTION
Ruby 2.7 freezes generated empty strings by default.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
