### PR TITLE
Fixes #28606 - fix DecadeView test

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateComponents/DecadeView.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateComponents/DecadeView.test.js
@@ -4,7 +4,8 @@ import toJson from 'enzyme-to-json';
 import DecadeView from './DecadeView';
 
 test('DecadeView is working properly', () => {
-  const component = shallow(<DecadeView />);
+  const date = new Date('1/1/2020 , 2:22:31 PM');
+  const component = shallow(<DecadeView date={date} />);
 
   expect(toJson(component.render())).toMatchSnapshot();
 });


### PR DESCRIPTION
a test in `DecadeView.test.js` fails due to a real decade change (welcome 2020! :fireworks: )
 therefore, a date value should be given so it won't be dependant on real values