### PR TITLE
Fixes #27195 - react_app folder as a common chunk

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -11,6 +11,7 @@
     <%= favicon_link_tag "favicon.ico"%>
 
     <%= stylesheet_link_tag *webpack_asset_paths('foreman-vendor', :extension => 'css'), "data-turbolinks-track" => true %>
+    <%= stylesheet_link_tag *webpack_asset_paths('foreman-react', :extension => 'css'), "data-turbolinks-track" => true %>
     <%= stylesheet_link_tag *webpack_asset_paths('bundle', :extension => 'css'), "data-turbolinks-track" => true %>
     <%= stylesheet_link_tag 'application', "data-turbolinks-track" => true %>
     <%= yield(:stylesheets) %>
@@ -33,6 +34,7 @@
     <%= javascript_include_tag "locale/#{FastGettext.locale}/app", "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('foreman-vendor', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('vendor', :extension => 'js'), "data-turbolinks-track" => true %>
+    <%= javascript_include_tag *webpack_asset_paths('foreman-react', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag *webpack_asset_paths('bundle', :extension => 'js'), "data-turbolinks-track" => true %>
     <%= javascript_include_tag 'application', "data-turbolinks-track" => true %>
     <%= webpacked_plugins_with_global_js %>

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -194,13 +194,18 @@ module.exports = env => {
         /react-intl\/locale-data/,
         supportedLanguagesRE
       ),
+      new webpack.optimize.CommonsChunkPlugin({
+        name: 'vendor',
+        minChunks: Infinity,
+      }),
+      new webpack.optimize.CommonsChunkPlugin({
+        name: 'foreman-react',
+        chunks: ['bundle', ...Object.keys(pluginEntries)],
+        minChunks: (module) =>
+        module.resource && (/(foremanReact|react_app)/).test(module.resource),
+      }),
     ]
   };
-
-  config.plugins.push(new webpack.optimize.CommonsChunkPlugin({
-    name: 'vendor',
-    minChunks: Infinity,
-  }))
 
   if (production) {
     config.plugins.push(


### PR DESCRIPTION
This will change the webpack build to produce a `foreman-react.js` file with everything from `./webpack/assets/javascripts/react_app` so we won't end up with the `react_app` in every plugin bundle.

**Before the change: `28.3MB`**
http://foreman-webpack-report-before-react-app-common.surge.sh/report.html
![screenshot-foreman-webpack-report-before-react-app-common surge sh-2020 01 02-11_41_04](https://user-images.githubusercontent.com/1262502/71660853-022a0600-2d55-11ea-9e37-fb907117d861.png)


**After the change: `15.54MB`**
http://foreman-webpack-report-after-react-app-common.surge.sh/report.html
![screenshot-foreman-webpack-report-after-react-app-common surge sh-2020 01 02-13_48_27](https://user-images.githubusercontent.com/1262502/71665721-9cdf1080-2d66-11ea-8d38-06bfe0b33c1d.png)

