### PR TITLE
Fixes #28651 - changes http proxy id description

### DIFF
--- a/app/controllers/api/v2/http_proxies_controller.rb
+++ b/app/controllers/api/v2/http_proxies_controller.rb
@@ -15,7 +15,7 @@ module Api
       end
 
       api :GET, '/http_proxies/:id/', N_('Show an HTTP Proxy')
-      param :id, :identifier, :required => true, :desc => N_('Numerical ID or HTTP Proxy name')
+      param :id, :identifier, :required => true, :desc => N_('Identifier of the HTTP Proxy')
       def show
       end
 


### PR DESCRIPTION
This PR updates the HTTP proxy id parameter description to support a request for hammer-cli-foreman help output.

Noe that this only works with a hammer client communicating foreman v1.24 until https://github.com/theforeman/hammer-cli-foreman/pull/477 is completed. Otherwise, the hammer client will attempt to use removed api resources in 1.25, etc, and produce an error.

After the change, the following should be the observed:
```
[vagrant@centos7-hammer-devel2 hammer-cli-katello]$ hammer repository create --help | grep "HTTP Proxy"
 --http-proxy-id HTTP_PROXY_ID                                     Identifier of the HTTP Proxy
```
