### PR TITLE
Fixes #28727 - Correct dns_timeout setting value

### DIFF
--- a/db/migrate/20200112121946_fix_dns_timeout_setting.rb
+++ b/db/migrate/20200112121946_fix_dns_timeout_setting.rb
@@ -1,0 +1,7 @@
+class FixDnsTimeoutSetting < ActiveRecord::Migration[5.2]
+  def up
+    Rails.cache.delete(Setting.cache_key("dns_timeout"))
+    Setting.find_by_name('dns_timeout')&.update_column(:value, nil) if Setting[:dns_timeout] == [nil]
+    Rails.cache.delete(Setting.cache_key("dns_timeout"))
+  end
+end


### PR DESCRIPTION
The previous fix for the incorrect value did not include the possibility
of `[nil]` being the saved value for the setting.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
