### PR TITLE
Fixes #28733 - Editor allow refresh preview after error

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
@@ -134,6 +134,7 @@ export const previewTemplate = ({ host, renderPath }) => async (
     dispatch({
       type: EDITOR_SHOW_ERROR,
       payload: {
+        renderedEditorValue: templateValue,
         showError: true,
         errorText: error.response ? __(error.response.data) : '',
         previewResult: __('Error during rendering, Return to Editor tab.'),

--- a/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/EditorActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/EditorActions.test.js.snap
@@ -178,6 +178,7 @@ Array [
       "payload": Object {
         "errorText": "",
         "previewResult": "Error during rendering, Return to Editor tab.",
+        "renderedEditorValue": "value",
         "selectedHost": Object {
           "id": "1",
           "name": "host",

--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorNavbar.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorNavbar.js
@@ -103,8 +103,7 @@ const EditorNavbar = ({
           />
           {selectedView === 'preview' &&
             previewResult !== '' &&
-            renderedEditorValue !== value &&
-            !showError && (
+            renderedEditorValue !== value && (
               <div id="outdated-preview-alert">
                 <Alert type="warning">
                   {__('Preview is outdated.')}


### PR DESCRIPTION
After a user changes code in the editor there should always be `Preview is outdated.` notification with an option to load the new preview. But if there was an error loading the preview this notification will not show up after the user edits the code.