### PR TITLE
fixes #28735 - Audits page causes endless loop of calls

### DIFF
--- a/webpack/assets/javascripts/react_app/common/HOC.js
+++ b/webpack/assets/javascripts/react_app/common/HOC.js
@@ -33,7 +33,7 @@ export const callOnPopState = callback => WrappedComponent => props => {
     } else {
       didMount.current = true;
     }
-  }, [search, action, props]);
+  }, [search, action]);
 
   return <WrappedComponent {...props} />;
 };


### PR DESCRIPTION
`useEffect` ran when props object was changed
but the `useEffect` changed the props which caused the loop