### PR TITLE
Fixes #28737 - fix template assignment in OS form

### DIFF
--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -72,4 +72,12 @@ module OperatingsystemsHelper
     result = type.where(:os_family => obj.family)
     result.empty? ? type : result
   end
+
+  def os_default_templates_for_form(os)
+    if os.os_default_templates.any?(&:new_record?)
+      os.os_default_templates.sort_by { |o| o.template_kind.name.downcase }
+    else
+      os.os_default_templates.joins(:template_kind).order('LOWER(template_kinds.name)')
+    end
+  end
 end

--- a/app/views/operatingsystems/_template_defaults.html.erb
+++ b/app/views/operatingsystems/_template_defaults.html.erb
@@ -11,7 +11,7 @@
                 :text => (_("You probably need to configure your %s first.") %
                           link_to("templates", provisioning_templates_path)).html_safe) %>
     <% end %>
-    <%= f.fields_for :os_default_templates, @operatingsystem.os_default_templates.joins(:template_kind).order('LOWER(template_kinds.name)') do |builder| %>
+    <%= f.fields_for :os_default_templates, os_default_templates_for_form(@operatingsystem) do |builder| %>
       <%= render 'templates', :f => builder %>
     <% end %>
   <% end %>

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -50,7 +50,7 @@ pxeautoyast:
 pxe_menu:
   name: PXE Default Menu
   template: "FOO"
-  template_kind: PXELinux
+  template_kind: pxelinux
   operatingsystems: centos5_3
   locked: false
   type: ProvisioningTemplate


### PR DESCRIPTION
This fixes a regression introduced in #22269 when we started to sort
template kinds in OS form. It relied on sorting fields using database,
but for newly created OS, we build new objects in memory only, based on
which we generate the form.

This now checks if there's at least one unsaved OsDefaultTemplate object
in collection proxy and if it is, we sort template kinds in Ruby. If all
objects are persisted, we can improve efficiency by relying on SQL as we
did before.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
