### PR TITLE
Fixes #28734 - Add hostgroup inherited parameters in GET

### DIFF
--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -37,8 +37,10 @@ module NestedAncestryCommon
   end
 
   module ClassMethods
-    def nested_attribute_for(*opts)
-      opts.each do |field|
+    attr_reader :nested_attribute_fields
+    def nested_attribute_for(*fields)
+      @nested_attribute_fields = fields
+      @nested_attribute_fields.each do |field|
         # Example method
         # def inherited_compute_profile_id
         #   read_attribute(:compute_profile_id) || nested_compute_profile_id

--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -9,6 +9,10 @@ attributes :subnet_id, :subnet_name, :operatingsystem_id, :operatingsystem_name,
   :subnet6_id, :subnet6_name, :compute_resource_id, :compute_resource_name,
   :architecture_id, :architecture_name, :realm_id, :realm_name, :created_at, :updated_at
 
+Hostgroup.nested_attribute_fields.each do |nested_field|
+  node(:"inherited_#{nested_field}") { |hostgroup| hostgroup.nested(nested_field) if hostgroup[nested_field].nil? }
+end
+
 if @parameters
   node do |hostgroup|
     { :parameters => partial("api/v2/parameters/index", :object => hostgroup.group_parameters.authorized) }

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -43,6 +43,16 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert show_response.has_key?('parameters')
   end
 
+  test "should show inherited parameters" do
+    get :show, params: { :id => hostgroups(:inherited).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal environments(:production).id, show_response['environment_id']
+    assert_nil show_response['inherited_environment_id']
+    assert_nil show_response['ptable_id']
+    assert_equal templates(:autopart).id, show_response['inherited_ptable_id']
+  end
+
   test "should show all puppet clases for individual record" do
     hostgroup = FactoryBot.create(:hostgroup, :with_config_group)
     get :show, params: { :id => hostgroup.id }


### PR DESCRIPTION
This PR was created because Hammer relies on hostgroup compute_resource_id, 
The problem begins when a certain hostgroup has a parent, then the compute_resource_id will be nil, as expected. 
in that case, I have no way to get the inherited_compute_resource_id or any inherited value. so I have added the option for it in this PR. 
@orrabin mentioned it should be the default behavior, @ShimShtein mentioned it might cost a lot to do so.
@tbrisker we would like to hear your opinion :) 