### PR TITLE
Fixes #28755 - fix chart stories titles

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
@@ -4,7 +4,7 @@ import mockStoryData from './ChartBox.fixtures';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|Charts|ChartBox',
+  title: 'Components|Charts/ChartBox',
   component: ChartBox,
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/charts/BarChart/BarChart.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/BarChart/BarChart.stories.js
@@ -1,14 +1,20 @@
 import React from 'react';
 import BarChart from './';
-import { barChartData } from './BarChart.fixtures';
-import Story from '../../../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|Charts|BarChart',
+  title: 'Components|Charts/BarChart',
+  component: BarChart,
 };
 
 export const barChart = () => (
-  <Story>
-    <BarChart {...barChartData} />
-  </Story>
+  <BarChart
+    data={[
+      ['Fedora 21', 3],
+      ['Ubuntu 14.04', 4],
+      ['Centos 7', 2],
+      ['Debian 8', 1],
+    ]}
+    xAxisLabel="OS"
+    yAxisLabel="COUNT"
+  />
 );

--- a/webpack/assets/javascripts/react_app/components/common/charts/LineChart/LineChart.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/LineChart/LineChart.stories.js
@@ -1,25 +1,29 @@
 import React from 'react';
 
 import LineChart from './index';
-import { data, timeseriesData } from './LineChart.fixtures';
-import Story from '../../../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|Charts|LineChart',
+  title: 'Components|Charts/LineChart',
+  component: LineChart,
 };
 
 export const lineChart = () => (
-  <Story>
-    <LineChart data={data} />
-  </Story>
+  <LineChart
+    data={[
+      ['red', [5, 7, 9], '#AA4643'],
+      ['green', [2, 4, 6], '#89A54E'],
+    ]}
+  />
 );
 
 export const lineChartTimeseries = () => (
-  <Story>
-    <LineChart data={timeseriesData} config="timeseries" xAxisDataLabel="x" />
-  </Story>
+  <LineChart
+    data={[
+      ['red', [5, 7, 9], '#AA4643'],
+      ['green', [2, 4, 6], '#89A54E'],
+      ['x', [1557014400000, 1559779200000, 1562457600000], null],
+    ]}
+    config="timeseries"
+    xAxisDataLabel="x"
+  />
 );
-
-lineChartTimeseries.story = {
-  name: 'Line Chart timeseries',
-};


### PR DESCRIPTION
**Before:**
![screenshot-localhost_6006-2020 01 15-13_21_17](https://user-images.githubusercontent.com/1262502/72430333-be92bb80-379a-11ea-9ef1-e9a792cbe3d2.png)

**After:**
![screenshot-localhost_6006-2020 01 15-13_25_02](https://user-images.githubusercontent.com/1262502/72430309-b0dd3600-379a-11ea-9cef-7577867a73e5.png)

Other changes
1. Add prop-tables to the doc-page by adding `component` field to the story default export.
2. Stop using the `Story` component, not sure why it is needed.
3. Instead of importing `fixtures` use `hard-coded` props so they would be visible when clicking **Show Source**