### PR TITLE
Fixes #28624 - Scrolling in the editor scrolls the preview

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -147,9 +147,9 @@ class ActionDispatch::IntegrationTest
   # Works only with css locator
   def fill_in_editor_field(css_locator, text)
     # the input is not visible for chrome driver
-    find("#{css_locator} .ace_editor").click
-    has_css?("#{css_locator} .ace_editor")
-    find("#{css_locator} .ace_text-input", visible: :all).set text
+    find("#{css_locator} .ace_editor.ace_input").click
+    has_css?("#{css_locator} .ace_editor.ace_input")
+    find("#{css_locator} .ace_input .ace_text-input", visible: :all).set text
     # wait for the debounce
     has_editor_display?(css_locator, text)
   end

--- a/webpack/assets/javascripts/react_app/components/Editor/Editor.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/Editor.js
@@ -93,6 +93,21 @@ class Editor extends React.Component {
       toggleRenderView,
       value,
     } = this.props;
+
+    const editorViewProps = {
+      value: isRendering ? previewResult : value,
+      mode: isRendering ? 'Text' : mode,
+      theme,
+      keyBinding,
+      onChange: isRendering ? noop : changeEditorValue,
+      readOnly: readOnly || isRendering,
+      isMasked,
+    };
+    const editorNameTab = {
+      input: `${editorName}Code`,
+      preview: `${editorName}Preview`,
+    };
+
     return (
       <div id="editor-container">
         <ToastNotification
@@ -147,16 +162,18 @@ class Editor extends React.Component {
           fetchAndPreview={fetchAndPreview}
         />
         <EditorView
-          key="editorView"
-          value={isRendering ? previewResult : value}
-          name={editorName}
-          mode={isRendering ? 'Text' : mode}
-          theme={theme}
-          keyBinding={keyBinding}
-          onChange={isRendering ? noop : changeEditorValue}
-          readOnly={readOnly || isRendering}
-          className={selectedView !== 'diff' ? 'ace_editor_form' : 'hidden'}
-          isMasked={isMasked}
+          {...editorViewProps}
+          key="editorPreview"
+          name={editorNameTab.preview}
+          isSelected={selectedView === 'preview'}
+          className="ace_editor_form ace_preview"
+        />
+        <EditorView
+          {...editorViewProps}
+          key="editorCode"
+          name={editorNameTab.input}
+          isSelected={selectedView === 'input'}
+          className="ace_editor_form ace_input"
         />
         <div
           id="diff-table"

--- a/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/Editor.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/Editor.test.js.snap
@@ -91,12 +91,26 @@ exports[`Editor rendering renders editor 1`] = `
     value="value"
   />
   <EditorView
-    className="ace_editor_form"
+    className="ace_editor_form ace_preview"
     isMasked={false}
-    key="editorView"
+    isSelected={false}
+    key="editorPreview"
     keyBinding="Default"
     mode="Ruby"
-    name="editor"
+    name="editorPreview"
+    onChange={[Function]}
+    readOnly={false}
+    theme="Monokai"
+    value="value"
+  />
+  <EditorView
+    className="ace_editor_form ace_input"
+    isMasked={false}
+    isSelected={true}
+    key="editorCode"
+    keyBinding="Default"
+    mode="Ruby"
+    name="editorCode"
     onChange={[Function]}
     readOnly={false}
     theme="Monokai"

--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorView.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorView.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
+import classNames from 'classnames';
 
 import { noop } from '../../../common/helpers';
 
@@ -14,6 +15,7 @@ const EditorView = ({
   readOnly,
   theme,
   value,
+  isSelected,
 }) => (
   <AceEditor
     value={value}
@@ -22,7 +24,11 @@ const EditorView = ({
     keyboardHandler={keyBinding === 'Default' ? null : keyBinding.toLowerCase()}
     onChange={(editorValue, event) => onChange(editorValue)}
     name={name}
-    className={isMasked ? `${className} mask-editor` : className}
+    className={classNames({
+      [className]: isSelected,
+      'mask-editor': isMasked,
+      hidden: !isSelected,
+    })}
     readOnly={readOnly}
     editorProps={{ $blockScrolling: Infinity }}
     showPrintMargin={false}
@@ -39,10 +45,12 @@ EditorView.propTypes = {
   value: PropTypes.string,
   className: PropTypes.string,
   isMasked: PropTypes.bool.isRequired,
+  isSelected: PropTypes.bool,
 };
 EditorView.defaultProps = {
   className: '',
   onChange: noop,
   value: '</>',
+  isSelected: true,
 };
 export default EditorView;

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorModal.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorModal.test.js.snap
@@ -137,6 +137,7 @@ exports[`EditorModal should render renders EditorModal editor 1`] = `
     <EditorView
       className="editor ace_editor_modal"
       isMasked={false}
+      isSelected={true}
       keyBinding="Default"
       mode="Ruby"
       name="editor"


### PR DESCRIPTION
The code editor and preview were the same "TextBox" that only had different value in it, now they are 2 different text boxes that will "save" the scroll info per box.
The scroll info is not saved for the maximized version (The editor/preview modal) 