### PR TITLE
Fixes #28758 - Editor modal is shown empty

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/editor.scss
+++ b/webpack/assets/javascripts/react_app/components/Editor/editor.scss
@@ -242,7 +242,7 @@
 
 .ace_editor_modal {
   width: 100% !important;
-  height: -webkit-fill-available !important;
+  height: 80vh !important;
 }
 
 #editor-container {


### PR DESCRIPTION
In report templates if you try to maximize the editor it only shows you its title and not its textarea, now it shows you the full modal that includes both