### PR TITLE
Fixes #28767: Drop extra transaction from plugin Role creation

### DIFF
--- a/app/services/foreman/plugin/role_lock.rb
+++ b/app/services/foreman/plugin/role_lock.rb
@@ -9,17 +9,15 @@ module Foreman
 
       def register_role(name, permissions, role_registry, description = '')
         User.as_anonymous_admin do
-          Role.transaction do
-            role = process_role name, permissions, description
-            role_registry.role_ids << role.id
-          end
+          role = process_role name, permissions, description
+          role_registry.role_ids << role.id
         end
       end
 
       def process_role(name, permissions, description = '')
         role = Role.find_by :name => name
         if role
-          role.update_attribute(:description, description) if role.description != description
+          role.update_column(:description, description) if role.description != description
 
           if role&.origin && role.permission_diff(permissions).present?
             return update_plugin_role_permissions role, permissions

--- a/test/unit/role_lock_test.rb
+++ b/test/unit/role_lock_test.rb
@@ -135,7 +135,7 @@ class RoleLockTest < ActiveSupport::TestCase
     assert_empty role.description
 
     @role_lock.register_role name, @permissions, registry, 'new description'
-    role.reload
+    role = Role.find(registry.role_ids.first)
     assert_equal 'new description', role.description
   end
 end


### PR DESCRIPTION
See Redmine issue for error seen in installer. This is how I was able to reproduce this issue reliably.

 1. Spin up katello nightly: `vagrant up centos7-katello-nightly`
 2. Open two separate terminals via SSH into nightly box: `vagrant ssh centos7-katello-nightly`
 3. In Terminal 1, delete all roles:

```
[root@dynflow vagrant]# foreman-rake console
Tasks Manager
Tasks Reader
Register hosts
Loading production environment (Rails 5.2.1)
irb(main):001:0> Role.all.each { |role| role.destroy }
=> [#<Role id: 1, name: "Default role", builtin: 2, description: "Role that is automatically assigned to every user ...", origin: nil, cloned_from_id: nil>, #<Role id: 39, name: "Tasks Manager", builtin: 0, description: "", origin: "foreman-tasks", cloned_from_id: nil>, #<Role id: 40, name: "Tasks Reader", builtin: 0, description: "", origin: "foreman-tasks", cloned_from_id: nil>, #<Role id: 41, name: "Register hosts", builtin: 0, description: "", origin: "katello", cloned_from_id: nil>]
irb(main):002:0> exit
```

4. A command will need to be run in each terminal nearly simultaneously. In Terminal 1, queue up `foreman-rake apipie:cache:index`. In Terminal 2, queue up `foreman-rake db:seed`.

5. Now, press enter on Terminal 1 then immediately press Enter in Terminal 2. You should see the failure without this patch applied in Terminal 2.

Rinse and repeat to reproduce the issue (deleting the Roles each time) or to test the patch.