### PR TITLE
Fixes #28768 - always export metadata first

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -48,16 +48,11 @@ class Template < ApplicationRecord
   end
 
   def metadata
-    "<%#\n#{to_export(false).to_yaml.sub(/\A---$/, '').strip}\n%>\n"
+    "<%#\n#{to_export(false).to_yaml.sub(/\A---$/, '').strip}\n-%>\n"
   end
 
   def to_erb
-    if self.template.start_with?('<%#')
-      metadata + template_without_metadata
-    else
-      lines = template_without_metadata.split("\n")
-      [ lines[0], metadata.chomp, lines[1..-1] ].flatten.join("\n")
-    end
+    metadata + template_without_metadata
   end
 
   def template_without_metadata

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -108,13 +108,6 @@ data"
         assert_equal "METADATA\ndata", @template.to_erb
       end
     end
-
-    test "it keeps data that present before original metadata" do
-      @template.template = "<?xml ...>\n" + @template.template
-      @template.stub(:metadata, "METADATA") do
-        assert_equal "<?xml ...>\nMETADATA\ndata", @template.to_erb
-      end
-    end
   end
 
   context "importing" do


### PR DESCRIPTION
The old behavior was needed for templates that required <?xml directive
to be the first thing in rendered result. Turns our metadata specified
before don't cause problems as long as they are correctly closed by -%>.
Community templates are updated in separate PR.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
