### PR TITLE
Fixes #28769 - add more loader macros

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -48,7 +48,7 @@ class Domain < ApplicationRecord
   }
 
   class Jail < Safemode::Jail
-    allow :name, :fullname
+    allow :id, :name, :fullname
   end
 
   # return the primary name server for our domain based on DNS lookup

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -104,7 +104,7 @@ class Hostgroup < ApplicationRecord
   }
 
   class Jail < Safemode::Jail
-    allow :name, :diskLayout, :puppetmaster, :operatingsystem, :architecture,
+    allow :id, :name, :diskLayout, :puppetmaster, :operatingsystem, :architecture,
       :environment, :ptable, :url_for_boot, :params, :puppetproxy,
       :puppet_ca_server, :indent, :os, :arch, :domain, :subnet,
       :subnet6, :realm, :root_pass, :description, :pxe_loader, :title

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -78,7 +78,7 @@ module Nic
     serialize :compute_attributes, Hash
 
     class Jail < ::Safemode::Jail
-      allow :managed?, :subnet, :subnet6, :virtual?, :physical?, :mac, :ip, :ip6, :identifier, :attached_to,
+      allow :id, :managed?, :subnet, :subnet6, :virtual?, :physical?, :mac, :ip, :ip6, :identifier, :attached_to,
         :link, :tag, :domain, :vlanid, :mtu, :bond_options, :attached_devices, :mode,
         :attached_devices_identifiers, :primary, :provision, :alias?, :inheriting_mac,
         :children_mac_addresses, :nic_delay, :fqdn, :shortname

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -76,7 +76,7 @@ class Operatingsystem < ApplicationRecord
   graphql_type '::Types::Operatingsystem'
 
   class Jail < Safemode::Jail
-    allow :name, :media_url, :major, :minor, :family, :to_s, :==, :release, :release_name, :kernel, :initrd, :pxe_type, :boot_files_uri, :password_hash, :mediumpath
+    allow :id, :name, :media_url, :major, :minor, :family, :to_s, :==, :release, :release_name, :kernel, :initrd, :pxe_type, :boot_files_uri, :password_hash, :mediumpath
   end
 
   def self.title_name

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -35,6 +35,6 @@ class Realm < ApplicationRecord
   }
 
   class Jail < ::Safemode::Jail
-    allow :name, :realm_type
+    allow :id, :name, :realm_type
   end
 end

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -172,6 +172,6 @@ class SmartProxy < ApplicationRecord
   end
 
   class Jail < ::Safemode::Jail
-    allow :name
+    allow :id, :name
   end
 end

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -35,7 +35,7 @@ class SshKey < ApplicationRecord
   delegate :login, to: :user, prefix: true
 
   class Jail < ::Safemode::Jail
-    allow :name, :user, :key, :to_export, :fingerprint, :length, :ssh_key, :type, :comment
+    allow :id, :name, :user, :key, :to_export, :fingerprint, :length, :ssh_key, :type, :comment
   end
 
   def to_export

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -107,7 +107,7 @@ class Subnet < ApplicationRecord
   delegate :supports_ipam_mode?, :supported_ipam_modes, :show_mask?, to: 'self.class'
 
   class Jail < ::Safemode::Jail
-    allow :name, :network, :mask, :cidr, :title, :to_label, :gateway, :dns_primary, :dns_secondary, :dns_servers,
+    allow :id, :name, :network, :mask, :cidr, :title, :to_label, :gateway, :dns_primary, :dns_secondary, :dns_servers,
       :vlanid, :mtu, :nic_delay, :boot_mode, :dhcp?, :nil?, :has_vlanid?, :dhcp_boot_mode?, :description, :present?
   end
 

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -22,6 +22,10 @@ class Location < Taxonomy
     user.admin? ? all : where(id: user.location_and_child_ids)
   }
 
+  class Jail < ::Safemode::Jail
+    allow :id, :name, :title, :created_at, :updated_at, :description
+  end
+
   def dup
     new = super
     new.organizations = organizations

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -22,6 +22,10 @@ class Organization < Taxonomy
     user.admin? ? all : where(id: user.organization_and_child_ids)
   }
 
+  class Jail < ::Safemode::Jail
+    allow :id, :name, :title, :created_at, :updated_at, :description
+  end
+
   def dup
     new = super
     new.locations = locations

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -26,7 +26,7 @@ class Template < ApplicationRecord
   attr_exportable :name, :description, :snippet, :template_inputs, :model => ->(template) { template.class.to_s }
 
   class Jail < Safemode::Jail
-    allow :name
+    allow :id, :name
   end
 
   def skip_strip_attrs

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -5,7 +5,7 @@ class Token < ApplicationRecord
   validates :value, :host_id, :presence => true
 
   class Jail < ::Safemode::Jail
-    allow :host, :value, :expires, :nil?, :present?
+    allow :id, :host, :value, :expires, :nil?, :present?
   end
 
   def to_s

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -143,7 +143,7 @@ class User < ApplicationRecord
   end
 
   class Jail < ::Safemode::Jail
-    allow :login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail, :last_login_on
+    allow :id, :login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail, :last_login_on
   end
 
   # we need to allow self-editing and self-updating

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -43,7 +43,7 @@ class Usergroup < ApplicationRecord
   accepts_nested_attributes_for :external_usergroups, :reject_if => ->(a) { a[:name].blank? }, :allow_destroy => true
 
   class Jail < ::Safemode::Jail
-    allow :ssh_keys, :all_users, :ssh_authorized_keys
+    allow :id, :ssh_keys, :all_users, :ssh_authorized_keys
   end
 
   # This methods retrieves all user addresses in a usergroup

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -95,18 +95,21 @@ module Foreman
         :update_ip_from_built_request,
       ]
 
+      DEFAULT_ALLOWED_LOADERS = Foreman::Renderer::Scope::Macros::Loaders::LOADERS.map(&:first)
+
       def initialize
         @allowed_variables = DEFAULT_ALLOWED_VARIABLES
         @allowed_global_settings = DEFAULT_ALLOWED_GLOBAL_SETTINGS
         @allowed_generic_helpers = DEFAULT_ALLOWED_GENERIC_HELPERS
         @allowed_host_helpers = DEFAULT_ALLOWED_HOST_HELPERS
+        @allowed_loaders = DEFAULT_ALLOWED_LOADERS
       end
 
       attr_accessor :allowed_variables, :allowed_global_settings,
-        :allowed_generic_helpers, :allowed_host_helpers
+        :allowed_generic_helpers, :allowed_host_helpers, :allowed_loaders
 
       def allowed_helpers
-        allowed_generic_helpers + allowed_host_helpers
+        allowed_generic_helpers + allowed_host_helpers + allowed_loaders
       end
     end
   end

--- a/lib/foreman/renderer/scope/base.rb
+++ b/lib/foreman/renderer/scope/base.rb
@@ -4,6 +4,7 @@ module Foreman
       class Base
         include Foreman::Renderer::Scope::Variables
         include Foreman::Renderer::Scope::Macros::Base
+        include Foreman::Renderer::Scope::Macros::Loaders
         include Foreman::Renderer::Scope::Macros::TemplateLogging
         include Foreman::Renderer::Scope::Macros::SnippetRendering
 

--- a/lib/foreman/renderer/scope/macros/loaders.rb
+++ b/lib/foreman/renderer/scope/macros/loaders.rb
@@ -1,0 +1,52 @@
+module Foreman
+  module Renderer
+    module Scope
+      module Macros
+        module Loaders
+          include Foreman::Renderer::Errors
+
+          LOADERS = [
+            [ :load_organizations, Organization, :view_organizations ],
+            [ :load_locations, Location, :view_locations ],
+            [ :load_hosts, Host, :view_hosts ],
+            [ :load_operating_systems, Operatingsystem, :view_operatingsystems ],
+            [ :load_subnets, Subnet, :view_subnets ],
+            [ :load_smart_proxies, SmartProxy, :view_smart_proxies ],
+            [ :load_user_groups, Usergroup, :view_usergroups ],
+            [ :load_host_groups, Hostgroup, :view_hostgroups ],
+            [ :load_domains, Domain, :view_domains ],
+            [ :load_realms, Realm, :view_realms ],
+            [ :load_users, User, :view_users ],
+          ]
+
+          LOADERS.each do |name, model, permission|
+            define_method name do |search: '', includes: nil, preload: nil, joins: nil, select: nil, batch: 1_000, limit: nil|
+              load_resource(klass: model, search: search, permission: permission, includes: includes, preload: preload, joins: joins, select: select, batch: batch, limit: limit)
+            end
+          end
+
+          private
+
+          # returns a batched relation, use either
+          #   .each { |batch| batch.each { |record| record.name }}
+          # or
+          #   .each_record { |record| record.name }
+          def load_resource(klass:, search:, permission:, batch: 1_000, includes: nil, limit: nil, select: nil, joins: nil, where: nil, preload: nil)
+            limit ||= 10 if preview?
+
+            base = klass
+            base = base.search_for(search)
+            base = base.preload(preload) unless preload.nil?
+            base = base.includes(includes) unless includes.nil?
+            base = base.joins(joins) unless joins.nil?
+            base = base.authorized(permission) unless permission.nil?
+            base = base.limit(limit) unless limit.nil?
+            base = base.where(where) unless where.nil?
+            base = base.select(select) unless select.nil?
+            base.in_batches(of: batch)
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are multiple objects that has Jail defined but can't be loaded in
a sane way. This patch adds load_* macros for all such objects. It also
extracts loaders from base macros to separate file. Load macros are
defined dynamically to avoid repetition of definition and to unify
capabilities of all such macros.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
