### PR TITLE
Fixes #28783 - Update CR api 'region' description for AzureRm

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -38,8 +38,8 @@ module Api
           param :use_v4, :bool, :desc => N_("for oVirt only")
           param :ovirt_quota, String, :desc => N_("for oVirt only, ID or Name of quota to use")
           param :public_key, String, :desc => N_("for oVirt only")
-          param :region, String, :desc => N_("for EC2 only, use '%s' for GovCloud region") % Foreman::Model::EC2::GOV_CLOUD_REGION
-          param :tenant, String, :desc => N_("for OpenStack and AzureRM only")
+          param :region, String, :desc => N_("for AzureRm eg. 'eastus' and for EC2 only. Use '%s' for EC2 GovCloud region") % Foreman::Model::EC2::GOV_CLOUD_REGION
+          param :tenant, String, :desc => N_("for OpenStack and AzureRm only")
           param :domain, String, :desc => N_("for OpenStack (v3) only")
           param :project_domain_name, String, :desc => N_("for OpenStack (v3) only")
           param :project_domain_id, String, :desc => N_("for OpenStack (v3) only")


### PR DESCRIPTION
Updating the `region` parameter description to contain AzureRm for --help option in hammer.