### PR TITLE
Fixes #28802 - lint issue in empty state component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/DefaultEmptyState.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/DefaultEmptyState.js
@@ -5,30 +5,29 @@ import SecondaryActionButtons from './EmptyStateSecondaryActionButtons';
 import { defaultEmptyStatePropTypes } from './EmptyStatePropTypes';
 import { translate as __ } from '../../../common/I18n';
 
-const documentationBlock = ({
-  url,
-  label = __('For more information please see'),
-  buttonLabel = __('Documentation'),
-}) =>
-  url && (
-    <React.Fragment>
-      {label}{' '}
-      <a href={url} target="_blank" rel="noopener noreferrer">
-        {buttonLabel}
-      </a>
-    </React.Fragment>
-  );
-
 const DefaultEmptyState = props => {
   const {
     icon,
     iconType,
     header,
     description,
-    documentation,
+    documentation: {
+      url,
+      label = __('For more information please see'),
+      buttonLabel = __('Documentation'),
+    } = {},
     action,
     secondaryActions,
   } = props;
+
+  const documentationBlock = url ? (
+    <React.Fragment>
+      {label}{' '}
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        {buttonLabel}
+      </a>
+    </React.Fragment>
+  ) : null;
 
   return (
     <EmptyStatePattern
@@ -36,7 +35,7 @@ const DefaultEmptyState = props => {
       iconType={iconType}
       header={header}
       description={description}
-      documentation={documentation ? documentationBlock(documentation) : null}
+      documentation={documentationBlock}
       action={action ? <PrimaryActionButton action={action} /> : null}
       secondaryActions={<SecondaryActionButtons actions={secondaryActions} />}
     />


### PR DESCRIPTION
the inner component of documentationBlock proptypes are missing:
```
9:3  error  'url' is missing in props validation          react/prop-types
10:3  error  'label' is missing in props validation        react/prop-types
11:3  error  'buttonLabel' is missing in props validation  react/prop-types
```

a small refactor fixed it.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
