### PR TITLE
Fixes #28815 - keep .txt extension for text reports

### DIFF
--- a/app/services/report_template_format.rb
+++ b/app/services/report_template_format.rb
@@ -39,6 +39,7 @@ class ReportTemplateFormat
   end
 
   def extension
-    Mime::Type.lookup(@mime_type).symbol.to_s
+    suggested = Mime::Type.lookup(@mime_type).symbol.to_s
+    (suggested == 'text') ? 'txt' : suggested
   end
 end

--- a/test/models/report_template_format_test.rb
+++ b/test/models/report_template_format_test.rb
@@ -41,7 +41,7 @@ class ReportTemplateFormatTest < ActiveSupport::TestCase
   end
 
   test "#extension" do
-    assert_equal 'text', ReportTemplateFormat.find(:txt).extension
+    assert_equal 'txt', ReportTemplateFormat.find(:txt).extension
     assert_equal 'yaml', ReportTemplateFormat.find(:yaml).extension
     assert_equal 'csv', ReportTemplateFormat.find(:csv).extension
     assert_equal 'json', ReportTemplateFormat.find(:json).extension


### PR DESCRIPTION
If a report template does not use report_render macro, the output format
selection is disabled and it's considered a plain text. Mimetype symbol
in this case is text and we use it for suggested file extension. However
for plain text file, it's expected to be .txt. Therefore we need an
exception in the symbol to extension conversion for this case. Other
supported types work fine and we can rely on Mimetype symbols.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
