### PR TITLE
Fixes #28820 - protect registering the react-component

### DIFF
--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -71,4 +71,6 @@ class ReactComponentElement extends HTMLElement {
   }
 }
 
-window.customElements.define('react-component', ReactComponentElement);
+if (!window.customElements.get('react-component')) {
+  window.customElements.define('react-component', ReactComponentElement);
+}


### PR DESCRIPTION
Hope it would fix the nightly issue, ATM we have this error in katello nightly:
```
katello:fills-ccdbc5a5bf8461855f61.js:1 Uncaught DOMException: Failed to execute 'define' on 'CustomElementRegistry': the name "react-component" has already been used with this registry
    at Object../webpack/assets/javascripts/react_app/common/MountingService.js (https://centos7-katello-nightly.sharvit-fedorabook-t480s.example.com/webpack/katello/katello:fills-ccdbc5a5bf8461855f61.js:1:27287)
    at o (https://centos7-katello-nightly.sharvit-fedorabook-t480s.example.com/webpack/vendor-4f7f4f3563d146a3e24d.js:1:411)
    at Object.../../../../../BUILDROOT/tfm-rubygem-katello-3.15.0-0.4.pre.master.20200119210854git796b07d.el7.noarch/opt/theforeman/tfm/root/usr/share/gems/gems/katello-3.15.0.pre.master/webpack/fills_index.js (https://centos7-katello-nightly.sharvit-fedorabook-t480s.example.com/webpack/katello/katello:fills-ccdbc5a5bf8461855f61.js:1:6343)
    at o (https://centos7-katello-nightly.sharvit-fedorabook-t480s.example.com/webpack/vendor-4f7f4f3563d146a3e24d.js:1:411)
    at window.webpackJsonp (https://centos7-katello-nightly.sharvit-fedorabook-t480s.example.com/webpack/vendor-4f7f4f3563d146a3e24d.js:1:284)
    at https://centos7-katello-nightly.sharvit-fedorabook-t480s.example.com/webpack/katello/katello:fills-ccdbc5a5bf8461855f61.js:1:1
```

See: https://community.theforeman.org/t/attempt-to-fix-the-broken-katello-nightly/17058