### PR TITLE
Fixes #25925 - Disable autocomplete for password input on User Edit page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js
+++ b/webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js
@@ -40,7 +40,7 @@ const PasswordStrength = ({
             __('Strong'),
             __('Very strong'),
           ]}
-          inputProps={{ name, id, className }}
+          inputProps={{ name, id, className, autoComplete: 'new-password' }}
         />
       </CommonForm>
       {verify && (

--- a/webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/__snapshots__/PasswordStrength.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/PasswordStrength/__tests__/__snapshots__/PasswordStrength.test.js.snap
@@ -17,6 +17,7 @@ exports[`PasswordStrength component rendering renders password-strength 1`] = `
       defaultValue=""
       inputProps={
         Object {
+          "autoComplete": "new-password",
           "className": "some-class-name",
           "id": "some-id",
           "name": "some-name",
@@ -58,6 +59,7 @@ exports[`PasswordStrength component rendering renders password-strength with pas
       defaultValue=""
       inputProps={
         Object {
+          "autoComplete": "new-password",
           "className": "some-class-name",
           "id": "some-id",
           "name": "some-name",
@@ -116,6 +118,7 @@ exports[`PasswordStrength component rendering renders password-strength with unm
       defaultValue=""
       inputProps={
         Object {
+          "autoComplete": "new-password",
           "className": "some-class-name",
           "id": "some-id",
           "name": "some-name",
@@ -174,6 +177,7 @@ exports[`PasswordStrength component rendering renders password-strength with use
       defaultValue=""
       inputProps={
         Object {
+          "autoComplete": "new-password",
           "className": "some-class-name",
           "id": "some-id",
           "name": "some-name",


### PR DESCRIPTION
**Issue:**
Admin's password saved in browser is populated to New password input field on Edit user page in administration.

**Step to reproduce:**
* Save credentials in browser
* Login as admin and go to /users
* Edit any user (except yourself)

New password field is filled with admin's password.

**Fix:**
Added `autocomplete="new-password"` to `input` element.

More information at [The HTML autocomplete attribute (MDN)](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete)