### PR TITLE
Fixes #28821 - Make component registry resiliant to duplication

### DIFF
--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -36,18 +36,22 @@ import LoginPage from './LoginPage';
 import ExternalLogout from './ExternalLogout';
 import Slot from './common/Slot';
 
+window.tfm_component_registry = window.tfm_component_registry || {};
+
 const componentRegistry = {
-  registry: {},
+  registry: window.tfm_component_registry,
 
   register({ name = null, type = null, store = true, data = true }) {
     if (!name || !type) {
       throw new Error('Component name or type is missing');
     }
     if (this.registry[name]) {
-      throw new Error(`Component name already taken: ${name}`);
+      // eslint-disable-next-line no-console
+      console.warn(`Component name already taken: ${name}`);
+    } else {
+      this.registry[name] = { type, store, data };
     }
 
-    this.registry[name] = { type, store, data };
     return this.registry;
   },
 

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.test.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.test.js
@@ -17,13 +17,12 @@ describe('Component registry', () => {
     expect(comp.data).toBeTruthy();
   });
 
-  it('should not register a component twice', () => {
+  it('should not error when register same component twice', () => {
     const name = 'TwiceComponent';
 
     componentRegistry.register({ name, type: FakeComponent });
-    expect(() =>
-      componentRegistry.register({ name, type: FakeComponent })
-    ).toThrow('Component name already taken: TwiceComponent');
+    componentRegistry.register({ name, type: FakeComponent });
+    expect(componentRegistry.getComponent(name)).toBeTruthy();
   });
 
   it('should not register a component without a name', () => {


### PR DESCRIPTION
Some plugins might create a new registry or try to register a component
that is already registered. This moved the actual registry to the window
object and makes the ComponentRegistry class an interface for it. It
also allows registering the same component multiple times without
erroring.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
