### PR TITLE
Fixes #28347 - Add default LDAP attributes mapping

### DIFF
--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -36,11 +36,11 @@ module Api
           param :account, String
           param :base_dn, String
           param :account_password, String, :desc => N_("required if onthefly_register is true")
-          param :attr_login, String, :desc => N_("required if onthefly_register is true")
-          param :attr_firstname, String, :desc => N_("required if onthefly_register is true")
-          param :attr_lastname, String, :desc => N_("required if onthefly_register is true")
-          param :attr_mail, String, :desc => N_("required if onthefly_register is true")
-          param :attr_photo, String
+          param :attr_login, String, :desc => N_("required if onthefly_register is true"), :default_value => 'uid'
+          param :attr_firstname, String, :desc => N_("required if onthefly_register is true"), :default_value => 'givenName'
+          param :attr_lastname, String, :desc => N_("required if onthefly_register is true"), :default_value => 'sn'
+          param :attr_mail, String, :desc => N_("required if onthefly_register is true"), :default_value => 'mail'
+          param :attr_photo, String, :default_value => 'jpegPhoto'
           param :onthefly_register, :bool
           param :usergroup_sync, :bool, :desc => N_("sync external user groups on login")
           param :tls, :bool

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -205,6 +205,11 @@ class AuthSourceLdap < AuthSource
 
   def set_defaults
     self.port ||= DEFAULT_PORTS[:ldap]
+    self.attr_login ||= 'uid'
+    self.attr_firstname ||= 'givenName'
+    self.attr_lastname ||= 'sn'
+    self.attr_mail ||= 'mail'
+    self.attr_photo ||= 'jpegPhoto'
   end
 
   def required_ldap_attributes

--- a/test/models/auth_sources/auth_source_ldap_test.rb
+++ b/test/models/auth_sources/auth_source_ldap_test.rb
@@ -35,6 +35,16 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
     assert_equal 389, other_auth_source_ldap.port
   end
 
+  test "after initialize should set default ldap attributes" do
+    auth_source_ldap = AuthSourceLdap.new
+
+    assert_equal 'uid', auth_source_ldap.attr_login
+    assert_equal 'givenName', auth_source_ldap.attr_firstname
+    assert_equal 'sn', auth_source_ldap.attr_lastname
+    assert_equal 'mail', auth_source_ldap.attr_mail
+    assert_equal 'jpegPhoto', auth_source_ldap.attr_photo
+  end
+
   test "should strip the ldap attributes before validate" do
     @auth_source_ldap.attr_login = "following spaces    "
     @auth_source_ldap.attr_firstname = "following spaces    "


### PR DESCRIPTION
**Description of problem:**
Currently, there are some different values that can be defined specifically to "Login Name Attribute". That said, still necessary add that information manually all the time when proceeding with ldap authentication configuration.

**Version-Release number of selected component (if applicable):**
6.6.z

**How reproducible:**
100%

**Steps to Reproduce:**
1. Configure ldap authentication
2. Check Attribute Mappings tab

**Actual results:**
Empty fields

**Expected results:**
Filled fields according to the selection on "server type" (Free IPA, AD or POSIX).