### PR TITLE
Fixes #28844 - protect the state from  duplication

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -25,6 +25,8 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export const generateStore = () =>
   createStore(reducers, composeEnhancers(applyMiddleware(...middleware)));
 
-const store = generateStore();
+window.tfm_redux_store = window.tfm_redux_store || generateStore();
+
+const store = window.tfm_redux_store;
 
 export default store;

--- a/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.js
@@ -1,9 +1,11 @@
 import store from '../index';
 import { combineReducersAsync } from './index';
 
-const asyncReducers = {};
+window.tfm_async_reducers = window.tfm_async_reducers || {};
 
 export default (name, asyncReducer) => {
+  const asyncReducers = window.tfm_async_reducers;
+
   asyncReducers[name] = asyncReducer;
   store.replaceReducer(combineReducersAsync(asyncReducers));
 };


### PR DESCRIPTION
Make the redux state resiliant to code duplication
by saving the state globally on the window object.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
