### PR TITLE
Fixes #28845 When generating custom report, leave output format field empty

### DIFF
--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -28,14 +28,8 @@
 
   <% render_present = @composer.template.supports_format_selection?
      output_formats = render_present ? ReportTemplateFormat.selectable : []
-     label_help = 'If the template supports format selection, user can choose preferred format.<br>
-                   Typically the template needs to use report_render macro.<br><br>
-                   If usage of this macro is not found in the template,<br>
-                   this field is disabled and the output format defaults to plain text.<br><br>
-                   If the template supports filter selection, but does not use the report_render macro,<br>
-                   in order to enable this field, add a comment to the template mentioning report_render macro name.'
   %>
-  <%= select_f f, :format, output_formats, :id, :human_name, {}, :label => _('Output format'), :label_help => _(label_help), :disabled => !render_present %>
+  <%= select_f f, :format, output_formats, :id, :human_name, {}, :label => _('Output format'), :label_help => _('If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name.'), :disabled => !render_present %>
 
   <%= f.fields_for :input_values do |input_values_fields| %>
     <% inputs = @template.template_inputs.select {|input| input.input_type == 'user'} %>

--- a/app/views/report_templates/generate.html.erb
+++ b/app/views/report_templates/generate.html.erb
@@ -26,7 +26,16 @@
       label_help: _('Valid e-mail addresses delimited by "%s"') % ReportComposer::MailToValidator::MAIL_DELIMITER %>
   </div>
 
-  <%= select_f f, :format, ReportTemplateFormat.selectable, :id, :human_name, {}, :label => _('Output format'), :label_help => _('If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name.'), :disabled => !@composer.template.supports_format_selection? %>
+  <% render_present = @composer.template.supports_format_selection?
+     output_formats = render_present ? ReportTemplateFormat.selectable : []
+     label_help = 'If the template supports format selection, user can choose preferred format.<br>
+                   Typically the template needs to use report_render macro.<br><br>
+                   If usage of this macro is not found in the template,<br>
+                   this field is disabled and the output format defaults to plain text.<br><br>
+                   If the template supports filter selection, but does not use the report_render macro,<br>
+                   in order to enable this field, add a comment to the template mentioning report_render macro name.'
+  %>
+  <%= select_f f, :format, output_formats, :id, :human_name, {}, :label => _('Output format'), :label_help => _(label_help), :disabled => !render_present %>
 
   <%= f.fields_for :input_values do |input_values_fields| %>
     <% inputs = @template.template_inputs.select {|input| input.input_type == 'user'} %>

--- a/test/factories/report_template.rb
+++ b/test/factories/report_template.rb
@@ -12,5 +12,9 @@ FactoryBot.define do
     trait :snippet do
       snippet { true }
     end
+
+    trait :with_report_render do
+      template { "<%= report_render -%>"}
+    end
   end
 end

--- a/test/integration/report_template_js_test.rb
+++ b/test/integration/report_template_js_test.rb
@@ -57,4 +57,24 @@ class ReportTemplateJSIntegrationTest < IntegrationTestWithJavascript
       assert page.has_no_content? input.name
     end
   end
+
+  test "ouput options for templates with report_render method" do
+    template = FactoryBot.create(:report_template, :with_report_render)
+    output_options = ['CSV', 'JSON', 'YAML', 'HTML']
+
+    visit generate_report_template_path(template)
+    find('#s2id_report_template_report_format').click
+
+    output_options.each { |opt| assert page.has_content? opt }
+  end
+
+  test "ouput options for templates without report_render method" do
+    template = FactoryBot.create(:report_template)
+
+    visit generate_report_template_path(template)
+    select = find('#s2id_report_template_report_format')
+
+    assert select.text ''
+    assert select[:class].include?('select2-container-disabled'), true
+  end
 end


### PR DESCRIPTION
**Description of problem:**
When generating a report template that doesn't contain report_render string in template, the Output Format field is greyed out but contains the value of "CSV". This is misleading because the resulting file is a text file, according both to MIME type and to its extension.

**Steps to Reproduce:**
1. Create a report template that doesn't contain report_render string in template
2. Monitor -> Report Templates -> Generate

**Actual results:**
Output Format field greyed out, containing "CSV"

**Expected results:**
Something that is not misleading, e.g. empty value