### PR TITLE
Fixes #28846 - PPC64 pxedir location

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -188,7 +188,7 @@ class Operatingsystem < ApplicationRecord
     end
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     ""
   end
 
@@ -288,7 +288,7 @@ class Operatingsystem < ApplicationRecord
 
   def boot_file_sources(medium_provider, &block)
     @boot_file_sources ||= self.family.constantize::PXEFILES.transform_values do |img|
-      "#{medium_provider.medium_uri(pxedir, &block)}/#{img}"
+      "#{medium_provider.medium_uri(pxedir(medium_provider), &block)}/#{img}"
     end
   end
 

--- a/app/models/operatingsystems/aix.rb
+++ b/app/models/operatingsystems/aix.rb
@@ -5,7 +5,7 @@ class AIX < Operatingsystem
     "nim"
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/loader"
   end
 

--- a/app/models/operatingsystems/altlinux.rb
+++ b/app/models/operatingsystems/altlinux.rb
@@ -11,7 +11,7 @@ class Altlinux < Operatingsystem
     "alterator"
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot"
   end
 

--- a/app/models/operatingsystems/archlinux.rb
+++ b/app/models/operatingsystems/archlinux.rb
@@ -10,7 +10,7 @@ class Archlinux < Operatingsystem
     "aif"
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/loader"
   end
 

--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -11,7 +11,7 @@ class Coreos < Operatingsystem
     end.to_s
   end
 
-  def pxedir(architecture = nil)
+  def pxedir(medium_provider = nil)
     '$arch-usr/$version'
   end
 

--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -11,7 +11,7 @@ class Coreos < Operatingsystem
     end.to_s
   end
 
-  def pxedir
+  def pxedir(architecture = nil)
     '$arch-usr/$version'
   end
 

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -1,7 +1,7 @@
 class Debian < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd.gz"}
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     'dists/$release/main/installer-$arch/current/images/netboot/' + guess_os + '-installer/$arch'
   end
 

--- a/app/models/operatingsystems/freebsd.rb
+++ b/app/models/operatingsystems/freebsd.rb
@@ -17,7 +17,7 @@ class Freebsd < Operatingsystem
     "memdisk"
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/images"
   end
 

--- a/app/models/operatingsystems/junos.rb
+++ b/app/models/operatingsystems/junos.rb
@@ -15,7 +15,7 @@ class Junos < Operatingsystem
     ["ZTP"]
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/images"
   end
 

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -10,7 +10,7 @@ class NXOS < Operatingsystem
     ["None"]
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/images"
   end
 

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -25,8 +25,12 @@ class Redhat < Operatingsystem
     "kickstart"
   end
 
-  def pxedir
-    "images/pxeboot"
+  def pxedir(medium_provider = nil)
+    if medium_provider.try(:architecture).try(:name) =~ /^ppc64/
+      "ppc/ppc64"
+    else
+      "images/pxeboot"
+    end
   end
 
   def display_family

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -31,7 +31,7 @@ class Solaris < Operatingsystem
     ["PXEGrub"]
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "Solaris_$minor/Tools/Boot"
   end
 

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -5,7 +5,7 @@ class Suse < Operatingsystem
     "yast"
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/loader"
   end
 

--- a/app/models/operatingsystems/vrp.rb
+++ b/app/models/operatingsystems/vrp.rb
@@ -22,7 +22,7 @@ class VRP < Operatingsystem
     ["ZTP"]
   end
 
-  def pxedir
+  def pxedir(medium_provider = nil)
     "boot/$arch/images"
   end
 

--- a/app/services/medium_providers/default.rb
+++ b/app/services/medium_providers/default.rb
@@ -26,7 +26,7 @@ module MediumProviders
 
     def unique_id
       @unique_id ||= begin
-        digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri(entity.operatingsystem.pxedir).to_s), padding: false)
+        digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri(entity.operatingsystem.pxedir(self)).to_s), padding: false)
         # return first 12 characters of encoded digest stripped down of non-alphanums for better readability
         "#{entity.medium.name.parameterize}-#{digest.gsub(/[-_]/, '')[1..12]}"
       end
@@ -34,6 +34,10 @@ module MediumProviders
 
     def valid?
       entity.respond_to?(:medium) && errors.empty?
+    end
+
+    def architecture
+      entity.try(:architecture)
     end
 
     private

--- a/test/fixtures/architectures.yml
+++ b/test/fixtures/architectures.yml
@@ -10,3 +10,6 @@ s390:
 
 ASIC:
   name: ASIC
+
+ppc64:
+  name: ppc64


### PR DESCRIPTION
It looks like PXE images for Red Hat systems are stored in a different subdirectory than on Intel. Foreman then tries to find them under wrong URL which leads to 404 when provisioning PPC64 machines.