### PR TITLE
[CP 1.24]Fixes #28725 - prevent image field from disabling on host form

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -147,6 +147,9 @@ function update_capabilities(capabilities) {
   } else if (capabilities.length > 0) {
     $('#manage_network_build').hide();
     $('#host_provision_method_' + capabilities[0]).click();
+    if (capabilities[0].toLowerCase() === 'image') {
+      image_provision_method_selected();
+    }
   }
 
   if (capabilities.length >= 2) {


### PR DESCRIPTION
While creating a host using compute_profile, the image field
under OS tab remain disabled & user won't be able to select
image for provisioning.
With this commit, it prevents this behavior on host form.

(cherry picked from commit 6bad7d9958d536ef4190d79af8ac3a97b2a16c25)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
