### PR TITLE
Fixes #28849 - Long role names are cut off in the roles UI

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -680,13 +680,3 @@ code.transparent {
   overflow-y: auto;
   max-width: 175px;
 }
-
-.table-locked-col {
-  text-align: center;
-  width: 70px;
-}
-
-.table-actions-col {
-  text-align: center;
-  width: 90px;
-}

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -680,3 +680,13 @@ code.transparent {
   overflow-y: auto;
   max-width: 175px;
 }
+
+.table-locked-col {
+  text-align: center;
+  width: 70px;
+}
+
+.table-actions-col {
+  text-align: center;
+  width: 90px;
+}

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -8,8 +8,8 @@
     <tr>
       <th class="col-md-2"><%= sort :name, :as => s_("Role|Name") %></th>
       <th class="col-md-8"><%= sort :description, :as => s_("Role|Description") %></th>
-      <th class="table-locked-col"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
-      <th class="table-actions-col"><%= _('Actions') %></th>
+      <th class="col-md-1"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
+      <th><%= _('Actions') %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -8,14 +8,14 @@
     <tr>
       <th class="col-md-2"><%= sort :name, :as => s_("Role|Name") %></th>
       <th class="col-md-8"><%= sort :description, :as => s_("Role|Description") %></th>
-      <th class="col-md-1"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
-      <th><%= _('Actions') %></th>
+      <th class="table-locked-col"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
+      <th class="table-actions-col"><%= _('Actions') %></th>
     </tr>
   </thead>
   <tbody>
     <% for role in @roles %>
       <tr>
-        <td class="ellipsis">
+        <td>
           <%= role_link(role) %>
         </td>
         <td class="ellipsis">


### PR DESCRIPTION
**Description of problem:**
If role names are long then they are cut off, the names should take a higher priority than the description.

**Steps to Reproduce:**
1. Create a role with a long name
2. look at the list of roles
3. profit

**Actual results:**
see attached screenshot

**Expected results:**
More or all of the role name should be shown, we should cut more ofthe Description before the Name.