### PR TITLE
Fixes #28853 - Add NIC type to safemode methods

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -105,7 +105,7 @@ class Host::Managed < Host::Base
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
       :ssh_authorized_keys, :pxe_loader, :global_status, :get_status, :puppetca_token, :last_report, :build?, :smart_proxies, :host_param,
-      :virtual, :ram, :sockets, :cores, :params
+      :virtual, :ram, :sockets, :cores, :params, :pxe_loader_efi?
   end
 
   scope :recent, lambda { |interval = Setting[:outofsync_interval]|
@@ -738,6 +738,10 @@ class Host::Managed < Host::Base
 
   def pxe_loader
     explicit_pxe_loader || hostgroup.try(:pxe_loader)
+  end
+
+  def pxe_loader_efi?
+    pxe_loader.include?('EFI')
   end
 
   def image_build?

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -81,7 +81,7 @@ module Nic
       allow :id, :managed?, :subnet, :subnet6, :virtual?, :physical?, :mac, :ip, :ip6, :identifier, :attached_to,
         :link, :tag, :domain, :vlanid, :mtu, :bond_options, :attached_devices, :mode,
         :attached_devices_identifiers, :primary, :provision, :alias?, :inheriting_mac,
-        :children_mac_addresses, :nic_delay, :fqdn, :shortname
+        :children_mac_addresses, :nic_delay, :fqdn, :shortname, :type, :managed?, :bond?, :bridge?, :bmc?
     end
 
     # include STI inheritance column in audits
@@ -91,6 +91,18 @@ module Nic
 
     def physical?
       !virtual?
+    end
+
+    def bond?
+      type == 'Nic::Bond'
+    end
+
+    def bridge?
+      type == 'Nic::Bridge'
+    end
+
+    def bmc?
+      type == 'Nic::BMC'
     end
 
     def type_name


### PR DESCRIPTION
I'd appreciate quick merge, need this for IPv6 template changes.