### PR TITLE
Fixes #28855 - enforce taxonomy in template renderer

### DIFF
--- a/app/controllers/concerns/foreman/controller/template_rendering.rb
+++ b/app/controllers/concerns/foreman/controller/template_rendering.rb
@@ -6,10 +6,12 @@ module Foreman
       private
 
       def render_template(template:, type:)
-        return safe_render(template) if template
+        Taxonomy.as_taxonomy(@host&.organization, @host&.location) do
+          return safe_render(template) if template
 
-        error_message = N_("unable to find %{type} template for %{host} running %{os}")
-        render_error(error_message, type: type, host: @host.name, os: @host.operatingsystem, status: :not_found)
+          error_message = N_("unable to find %{type} template for %{host} running %{os}")
+          render_error(error_message, type: type, host: @host.name, os: @host.operatingsystem, status: :not_found)
+        end
       end
 
       def safe_render(template)

--- a/lib/foreman/renderer/scope/macros/snippet_rendering.rb
+++ b/lib/foreman/renderer/scope/macros/snippet_rendering.rb
@@ -10,7 +10,7 @@ module Foreman
           def snippet(name, options = {}, variables: {})
             template = source.find_snippet(name)
             unless template
-              raise "The specified snippet '#{name}' does not exist, or is not a snippet." unless options[:silent]
+              raise "The specified snippet '#{name}' does not exist in context org=#{Organization.current}/loc=#{Location.current}, or is not a snippet." unless options[:silent]
               return
             end
 


### PR DESCRIPTION
When unattended controller renders a template, it finds it in a correct
taxonomy in method provisioning_template, but then it is passed into the
renderer outside of the taxonomy block in
TemplateRendering#render_template. Therefore all snippets being loaded
via SnippetRendering#snippet (source.find_snippet(name)) is called
without Taxonomy handling (basically unscoped SQL query). This is
possibly a security issue as well when all snippets are essentially
shared across all organizations even when taxonomy is not set like that.

There are two options to solve this, only add taxonomy scope in
find_template method used to load snippets OR perform whole rendering in
the taxonomy scoped block. I am proposing the latter, it is more secure
but it will have big impact on upgrading users - after the patch all SQL
queries performed in templates (e.g. loading a subnet associated from a
host) can now return `nil` if taxonomy is not correct. Which is the
wanted behavior but it can create regressions.