### PR TITLE
Fixes #28857 - protect the Intl from code duplications

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -1,5 +1,6 @@
 import Jed from 'jed';
 import { addLocaleData } from 'react-intl';
+import forceSingleton from './forceSingleton';
 
 class IntlLoader {
   constructor(locale, timezone) {
@@ -34,7 +35,10 @@ const [htmlElemnt] = document.getElementsByTagName('html');
 const langAttr = htmlElemnt.getAttribute('lang') || 'en';
 const timezoneAttr = htmlElemnt.getAttribute('data-timezone') || 'UTC';
 
-export const intl = new IntlLoader(langAttr, timezoneAttr);
+export const intl = forceSingleton(
+  'Intl',
+  () => new IntlLoader(langAttr, timezoneAttr)
+);
 
 const cheveronPrefix = () => (window.I18N_MARK ? '\u00BB' : '');
 const cheveronSuffix = () => (window.I18N_MARK ? '\u00AB' : '');
@@ -56,7 +60,7 @@ const getLocaleData = () => {
   return locales[locale];
 };
 
-export const jed = new Jed(getLocaleData());
+export const jed = forceSingleton('Jed', () => new Jed(getLocaleData()));
 
 export const translate = (...args) =>
   `${cheveronPrefix()}${jed.gettext(...args)}${cheveronSuffix()}`;

--- a/webpack/assets/javascripts/react_app/common/forceSingleton.js
+++ b/webpack/assets/javascripts/react_app/common/forceSingleton.js
@@ -1,0 +1,23 @@
+/**
+ * Force a single instance to protect from code duplication.
+ *
+ * WARNING: Code duplications happen because of an issue with the build process,
+ *          so this method might be removed once the issue would be fixed.
+ *          See: https://projects.theforeman.org/issues/27195
+ *
+ * @param  {String}   key    A unique-key to save the instance.
+ * @param  {Function} create A function to create an instance.
+ * @return {*}               Single Instance,
+ *                           returned by the create method or from the cache.
+ */
+const forceSingleton = (key, create) => {
+  window.tfm_forced_singletons = window.tfm_forced_singletons || {};
+
+  if (!window.tfm_forced_singletons[key]) {
+    window.tfm_forced_singletons[key] = create();
+  }
+
+  return window.tfm_forced_singletons[key];
+};
+
+export default forceSingleton;

--- a/webpack/assets/javascripts/react_app/common/forceSingleton.test.js
+++ b/webpack/assets/javascripts/react_app/common/forceSingleton.test.js
@@ -1,0 +1,17 @@
+import forceSingleton from './forceSingleton';
+
+describe('forceSingleton', () => {
+  it('should force a single instance', () => {
+    const createInstance = () => ({});
+
+    expect(forceSingleton('key1', createInstance)).toBe(
+      forceSingleton('key1', createInstance)
+    );
+    expect(forceSingleton('key1', createInstance)).not.toBe(
+      forceSingleton('key2', createInstance)
+    );
+    expect(forceSingleton('key2', createInstance)).toBe(
+      forceSingleton('key2', createInstance)
+    );
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import forceSingleton from '../common/forceSingleton';
 
 import ReactApp from '../ReactApp';
 import DonutChart from './common/charts/DonutChart';
@@ -36,10 +37,8 @@ import LoginPage from './LoginPage';
 import ExternalLogout from './ExternalLogout';
 import Slot from './common/Slot';
 
-window.tfm_component_registry = window.tfm_component_registry || {};
-
 const componentRegistry = {
-  registry: window.tfm_component_registry,
+  registry: forceSingleton('component_registry', () => ({})),
 
   register({ name = null, type = null, store = true, data = true }) {
     if (!name || !type) {

--- a/webpack/assets/javascripts/react_app/redux/index.js
+++ b/webpack/assets/javascripts/react_app/redux/index.js
@@ -1,6 +1,7 @@
 import createLogger from 'redux-logger';
 import thunk from 'redux-thunk';
 import { applyMiddleware, createStore, compose } from 'redux';
+import forceSingleton from '../common/forceSingleton';
 
 import reducers from './reducers';
 
@@ -25,8 +26,6 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 export const generateStore = () =>
   createStore(reducers, composeEnhancers(applyMiddleware(...middleware)));
 
-window.tfm_redux_store = window.tfm_redux_store || generateStore();
-
-const store = window.tfm_redux_store;
+const store = forceSingleton('redux_store', generateStore);
 
 export default store;

--- a/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/registerReducer.js
@@ -1,11 +1,10 @@
+import forceSingleton from '../../common/forceSingleton';
 import store from '../index';
 import { combineReducersAsync } from './index';
 
-window.tfm_async_reducers = window.tfm_async_reducers || {};
+const asyncReducers = forceSingleton('async_reducers', () => ({}));
 
 export default (name, asyncReducer) => {
-  const asyncReducers = window.tfm_async_reducers;
-
   asyncReducers[name] = asyncReducer;
   store.replaceReducer(combineReducersAsync(asyncReducers));
 };


### PR DESCRIPTION
Protect the `Intl` from code duplications.
Also, provide a method to force singletons and migrate other places so it would be easier to replace it when/if needed.