### PR TITLE
Refs #28857 - do not let webpack to treeShake helpers

### DIFF
--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -1,6 +1,7 @@
 import 'core-js/shim';
 import 'regenerator-runtime/runtime';
 
+import helpers from './react_app/common/helpers';
 import compute from './foreman_compute_resource';
 import componentRegistry from './react_app/components/componentRegistry';
 import i18n from './react_app/common/I18n';
@@ -62,4 +63,8 @@ window.tfm = Object.assign(window.tfm || {}, {
   componentRegistry,
   store,
   autocomplete,
+  // The `helpers` imported here and lives in the window object
+  // to make sure webpack include it when doing treeShaking.
+  // If you need to use an helper method, import it from foremanReact/common/helpers
+  helpers,
 });


### PR DESCRIPTION
Import common/helpers in the main bundle so they won't
removed in the webpack tree-shaking process.
This would ensure plugins can import methods from the common/helpers.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
