### PR TITLE
Fixes #28861 - Use sha256 fingerprints for SSH keys due to FIPS

### DIFF
--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -6,7 +6,7 @@ class SshKey < ApplicationRecord
   include Parameterizable::ByIdName
 
   belongs_to :user
-  before_validation :generate_fingerprint
+  before_validation :generate_fingerprint, on: :create
   before_validation :calculate_length
 
   scoped_search :on => :name
@@ -72,7 +72,7 @@ class SshKey < ApplicationRecord
   def generate_fingerprint
     self.fingerprint = nil
     return unless self.key.present?
-    self.fingerprint = SSHKey.fingerprint(self.key)
+    self.fingerprint = SSHKey.sha256_fingerprint(self.key)
     true
   rescue SSHKey::PublicKeyError => exception
     Foreman::Logging.exception("Could not calculate SSH key fingerprint", exception)

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -6,7 +6,7 @@ class SshKey < ApplicationRecord
   include Parameterizable::ByIdName
 
   belongs_to :user
-  before_validation :generate_fingerprint, on: :create
+  before_validation :generate_fingerprint
   before_validation :calculate_length
 
   scoped_search :on => :name

--- a/db/migrate/20200127103144_ssh_keys_fingerprints_sha1.rb
+++ b/db/migrate/20200127103144_ssh_keys_fingerprints_sha1.rb
@@ -1,0 +1,9 @@
+class SshKeysFingerprintsSha1 < ActiveRecord::Migration[5.2]
+  def up
+    SshKey.all.each { |ssh_key| ssh_key.update(fingerprint: SSHKey.sha256_fingerprint(ssh_key.key)) }
+  end
+
+  def down
+    SshKey.all.each { |ssh_key| ssh_key.update(fingerprint: SSHKey.fingerprint(ssh_key.key)) }
+  end
+end

--- a/db/migrate/20200127103144_ssh_keys_fingerprints_sha1.rb
+++ b/db/migrate/20200127103144_ssh_keys_fingerprints_sha1.rb
@@ -1,9 +1,9 @@
 class SshKeysFingerprintsSha1 < ActiveRecord::Migration[5.2]
   def up
-    SshKey.all.each { |ssh_key| ssh_key.update(fingerprint: SSHKey.sha256_fingerprint(ssh_key.key)) }
+    SshKey.all.each { |ssh_key| ssh_key.update_column('fingerprint', SSHKey.sha256_fingerprint(ssh_key.key)) }
   end
 
   def down
-    SshKey.all.each { |ssh_key| ssh_key.update(fingerprint: SSHKey.fingerprint(ssh_key.key)) }
+    SshKey.all.each { |ssh_key| ssh_key.update_column('fingerprint', SSHKey.fingerprint(ssh_key.key)) }
   end
 end


### PR DESCRIPTION
**Description of problem:** 
When FIPS is enabled and customer will try to add SSH key for user, `500 internal server error` appear. It's caused by using `MD5` for generating ssh key fingerprints.

**Steps to reproduce**
Steps to Reproduce:
(Enable FIPS)
1. Create new user
2. generate new key
3. Edit user -> SSH Keys -> Add SSH Keys
4. Fill new SSH key & Save

**Actual results:**
500 Internal server error

**Expected results:**
Key added

**Solution:**
Generate ssh key fingerprint with `SHA256` instead of `MD5`