### PR TITLE
Fixes #28863 - upgrade tfm-builder to v4.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^4.0.2",
+    "@theforeman/vendor": "^4.0.7",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -30,11 +30,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": "^4.0.2",
-    "@theforeman/eslint-plugin-foreman": "^4.0.2",
-    "@theforeman/stories": "^4.0.2",
-    "@theforeman/test": "^4.0.2",
-    "@theforeman/vendor-dev": "^4.0.2",
+    "@theforeman/builder": "^4.0.7",
+    "@theforeman/eslint-plugin-foreman": "^4.0.7",
+    "@theforeman/stories": "^4.0.7",
+    "@theforeman/test": "^4.0.7",
+    "@theforeman/vendor-dev": "^4.0.7",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",


### PR DESCRIPTION
In order to prevent webpack to do tree-shaking,
tfm-builder v4.0.7 set modules to commonjs.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
