### PR TITLE
Fixes #28900 - Add search to Taxonomies in top navigation dropdowns

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -191,6 +191,15 @@ const organizations = {
     { id: 1, title: 'org1', href: '/organizations/1-org1/select' },
     { id: 2, title: 'org2', href: '/organizations/2-org2/select' },
   ],
+  many_organizations: [
+    { id: 1, title: 'org1', href: '/organizations/1-org1/select' },
+    { id: 2, title: 'org2', href: '/organizations/2-org2/select' },
+    { id: 3, title: 'org3', href: '/organizations/3-org3/select' },
+    { id: 4, title: 'org4', href: '/organizations/4-org4/select' },
+    { id: 5, title: 'org5', href: '/organizations/5-org5/select' },
+    { id: 6, title: 'org6', href: '/organizations/6-org6/select' },
+    { id: 7, title: 'org7', href: '/organizations/7-org7/select' },
+  ],
 };
 
 const locations = {

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -120,6 +120,43 @@ exports[`Layout rendering renders layout 1`] = `
             },
           ],
           "current_org": "org1",
+          "many_organizations": Array [
+            Object {
+              "href": "/organizations/1-org1/select",
+              "id": 1,
+              "title": "org1",
+            },
+            Object {
+              "href": "/organizations/2-org2/select",
+              "id": 2,
+              "title": "org2",
+            },
+            Object {
+              "href": "/organizations/3-org3/select",
+              "id": 3,
+              "title": "org3",
+            },
+            Object {
+              "href": "/organizations/4-org4/select",
+              "id": 4,
+              "title": "org4",
+            },
+            Object {
+              "href": "/organizations/5-org5/select",
+              "id": 5,
+              "title": "org5",
+            },
+            Object {
+              "href": "/organizations/6-org6/select",
+              "id": 6,
+              "title": "org6",
+            },
+            Object {
+              "href": "/organizations/7-org7/select",
+              "id": 7,
+              "title": "org7",
+            },
+          ],
         },
         "root": "/",
         "stop_impersonation_url": "/users/stop_impersonation",

--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomyDropdown.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomyDropdown.js
@@ -4,62 +4,98 @@ import NavItem from './NavItem';
 import { noop } from '../../../common/helpers';
 import { translate as __ } from '../../../common/I18n';
 
-const TaxonomyDropdown = ({
-  taxonomyType,
-  currentTaxonomy,
-  taxonomies,
-  id,
-  changeTaxonomy,
-  anyTaxonomyText,
-  manageTaxonomyText,
-  anyTaxonomyURL,
-  manageTaxonomyURL,
-}) => (
-  <NavItem className="dropdown org-switcher" id={id}>
-    <a
-      href="#"
-      className="dropdown-toggle nav-item-iconic"
-      data-toggle="dropdown"
-    >
-      {__(currentTaxonomy)}
-      <span className="caret" />
-    </a>
-    <ul className="dropdown-menu">
-      <li className="dropdown-header">{__(taxonomyType)}</li>
-      <li>
+class TaxonomyDropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { searchValue: '' };
+  }
+
+  render() {
+    const {
+      taxonomyType,
+      currentTaxonomy,
+      taxonomies,
+      id,
+      changeTaxonomy,
+      anyTaxonomyText,
+      manageTaxonomyText,
+      anyTaxonomyURL,
+      manageTaxonomyURL,
+    } = this.props;
+
+    const filteredTaxonomies = () => {
+      const { searchValue } = this.state;
+
+      if (searchValue === '') {
+        return this.props.taxonomies;
+      }
+
+      return this.props.taxonomies.filter(item =>
+        item.title.toLowerCase().includes(searchValue.toLowerCase())
+      );
+    };
+
+    return (
+      <NavItem className="dropdown org-switcher" id={id}>
         <a
-          className={`${taxonomyType.toLowerCase()}s_clear`}
-          href={anyTaxonomyURL}
-          onClick={() => {
-            changeTaxonomy({ title: anyTaxonomyText });
-          }}
+          href="#"
+          className="dropdown-toggle nav-item-iconic"
+          data-toggle="dropdown"
         >
-          {__(anyTaxonomyText)}
+          {__(currentTaxonomy)}
+          <span className="caret" />
         </a>
-      </li>
-      <li>
-        <a className={taxonomyType.toLowerCase()} href={manageTaxonomyURL}>
-          {__(manageTaxonomyText)}
-        </a>
-      </li>
-      <li className="divider" />
-      {taxonomies.map((taxonomy, i) => (
-        <li key={i}>
-          <a
-            className={`${taxonomyType.toLowerCase()}_menuitem`}
-            id={`select_taxonomy_${taxonomy.title}`}
-            href={taxonomy.href}
-            onClick={() => {
-              changeTaxonomy({ title: taxonomy.title, id: taxonomy.id });
-            }}
-          >
-            {__(taxonomy.title)}
-          </a>
-        </li>
-      ))}
-    </ul>
-  </NavItem>
-);
+        <ul className="dropdown-menu">
+          <li className="dropdown-header">{__(taxonomyType)}</li>
+          <li>
+            <a
+              className={`${taxonomyType.toLowerCase()}s_clear`}
+              href={anyTaxonomyURL}
+              onClick={() => {
+                changeTaxonomy({ title: anyTaxonomyText });
+              }}
+            >
+              {__(anyTaxonomyText)}
+            </a>
+          </li>
+          <li>
+            <a className={taxonomyType.toLowerCase()} href={manageTaxonomyURL}>
+              {__(manageTaxonomyText)}
+            </a>
+          </li>
+          <li className="divider" />
+          {taxonomies.length > 6 && (
+            <li>
+              <input
+                type="text"
+                className="form-control taxonomy_search"
+                id={`search_taxonomy_${taxonomyType.toLowerCase()}`}
+                placeholder="Filter ..."
+                onChange={e => {
+                  this.setState({ searchValue: e.target.value });
+                }}
+              />
+            </li>
+          )}
+          {filteredTaxonomies().map((taxonomy, i) => (
+            <li key={i}>
+              <a
+                className={`${taxonomyType.toLowerCase()}_menuitem`}
+                id={`select_taxonomy_${taxonomy.title}`}
+                href={taxonomy.href}
+                onClick={() => {
+                  changeTaxonomy({ title: taxonomy.title, id: taxonomy.id });
+                }}
+              >
+                {__(taxonomy.title)}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </NavItem>
+    );
+  }
+}
 
 TaxonomyDropdown.propTypes = {
   taxonomyType: PropTypes.string.isRequired,

--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomyDropdown.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomyDropdown.test.js
@@ -16,8 +16,14 @@ const props = {
   manageTaxonomyURL: '/organizations',
 };
 
+const propsSearch = {
+  ...props,
+  taxonomies: hasTaxonomiesMock.data.orgs.many_organizations,
+};
+
 const fixtures = {
   'render TaxonomyDropdown': { ...props },
+  'render TaxonomyDropdownWithSearch': { ...propsSearch },
 };
 
 describe('TaxonomyDropdown', () => {
@@ -36,5 +42,18 @@ describe('TaxonomyDropdown', () => {
       .simulate('click');
     wrapper.find('.organizations_clear').simulate('click');
     expect(changeTaxonomy).toHaveBeenCalledTimes(2);
+  });
+
+  it('Search items', () => {
+    const wrapper = shallow(<TaxonomyDropdown {...propsSearch} />);
+    const searchInput = wrapper.find('input.taxonomy_search');
+
+    expect(searchInput.exists()).toBeTruthy();
+
+    searchInput.simulate('change', { target: { value: 'org7' } });
+    expect(wrapper.find('a.organization_menuitem')).toHaveLength(1);
+
+    searchInput.simulate('change', { target: { value: '' } });
+    expect(wrapper.find('a.organization_menuitem')).toHaveLength(7);
   });
 });

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/TaxonomyDropdown.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/TaxonomyDropdown.test.js.snap
@@ -72,3 +72,145 @@ exports[`TaxonomyDropdown rendering render TaxonomyDropdown 1`] = `
   </ul>
 </NavItem>
 `;
+
+exports[`TaxonomyDropdown rendering render TaxonomyDropdownWithSearch 1`] = `
+<NavItem
+  activeHref=""
+  activeKey=""
+  className="dropdown org-switcher"
+  id="organization-dropdown"
+>
+  <a
+    className="dropdown-toggle nav-item-iconic"
+    data-toggle="dropdown"
+    href="#"
+  >
+    org1
+    <span
+      className="caret"
+    />
+  </a>
+  <ul
+    className="dropdown-menu"
+  >
+    <li
+      className="dropdown-header"
+    >
+      Organization
+    </li>
+    <li>
+      <a
+        className="organizations_clear"
+        href="/organizations/clear"
+        onClick={[Function]}
+      >
+        Any Organization
+      </a>
+    </li>
+    <li>
+      <a
+        className="organization"
+        href="/organizations"
+      >
+        Manage Organizations
+      </a>
+    </li>
+    <li
+      className="divider"
+    />
+    <li>
+      <input
+        className="form-control taxonomy_search"
+        id="search_taxonomy_organization"
+        onChange={[Function]}
+        placeholder="Filter ..."
+        type="text"
+      />
+    </li>
+    <li
+      key="0"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/1-org1/select"
+        id="select_taxonomy_org1"
+        onClick={[Function]}
+      >
+        org1
+      </a>
+    </li>
+    <li
+      key="1"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/2-org2/select"
+        id="select_taxonomy_org2"
+        onClick={[Function]}
+      >
+        org2
+      </a>
+    </li>
+    <li
+      key="2"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/3-org3/select"
+        id="select_taxonomy_org3"
+        onClick={[Function]}
+      >
+        org3
+      </a>
+    </li>
+    <li
+      key="3"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/4-org4/select"
+        id="select_taxonomy_org4"
+        onClick={[Function]}
+      >
+        org4
+      </a>
+    </li>
+    <li
+      key="4"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/5-org5/select"
+        id="select_taxonomy_org5"
+        onClick={[Function]}
+      >
+        org5
+      </a>
+    </li>
+    <li
+      key="5"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/6-org6/select"
+        id="select_taxonomy_org6"
+        onClick={[Function]}
+      >
+        org6
+      </a>
+    </li>
+    <li
+      key="6"
+    >
+      <a
+        className="organization_menuitem"
+        href="/organizations/7-org7/select"
+        id="select_taxonomy_org7"
+        onClick={[Function]}
+      >
+        org7
+      </a>
+    </li>
+  </ul>
+</NavItem>
+`;

--- a/webpack/assets/javascripts/react_app/components/Layout/layout.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/layout.scss
@@ -87,3 +87,8 @@
 .navbar-header {
   width: 221.22px;
 }
+
+.taxonomy_search {
+  max-width: 92%;
+  margin: 4px 0 4px 8px;
+}


### PR DESCRIPTION
**Description of problem:**
When a Satellite has many organizations and locations it can be time consuming to search and select the one you want from the context menu. I would like to be able to enter a name in a search field, and for auto-complete to be supported so that I can search by typing in the first part of the name.

**Fix**
If there are more than six Organizations or Locations in the top main menu, search input is displayed. Users then can filter items in dropdown (by it's name).

If there is six or less Org/Loc, search field is hidden.