### PR TITLE
Fixes #28912 - Remove pointer from VM tab to interfaces

### DIFF
--- a/app/views/hosts/_compute_detail.html.erb
+++ b/app/views/hosts/_compute_detail.html.erb
@@ -1,16 +1,5 @@
-
 <%= render :partial => provider_partial(compute_resource, 'base'),
             :locals => { :f => f, :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm }.merge(args_for_compute_resource_partial(@host)) %>
-
-<!--NICS-->
-<% if provider_partial_exist?(compute_resource, 'network') %>
-  <fieldset>
-    <h2><%= _("Network interfaces") %></h2>
-    <p class="help-block">
-      <%= _("Network interfaces management has been moved to the Interfaces tab. Please set your interfaces there.") %>
-    </p>
-  </fieldset>
-<% end %>
 
 <!--Storage-->
 <%= render :partial => 'compute_resources_vms/form/volumes', :locals => { :f => f, :compute_resource => compute_resource, :new_host => new_vm, :new_vm => new_vm, :item_layout => 'removable' } %>


### PR DESCRIPTION
This help text was needed after moving the interface attributes into the
interfaces tab. It has been there for the past 5 years, so by now users
already know they should find it there.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
