### PR TITLE
Fixes #28921 - add updateURLQuery to urlHelpers

### DIFF
--- a/webpack/assets/javascripts/react_app/common/urlHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/urlHelpers.js
@@ -77,3 +77,14 @@ export const exportURL = () => {
   url.addQuery('format', 'csv');
   return `${url.pathname()}${url.search()}`;
 };
+
+/**
+ * merge current url with a new query
+ * @param {Object} query  - Query Object
+ * @param {Object} history  - React Router history object
+ */
+export const updateURLQuery = (query, history) => {
+  const uri = new URI(history.location.search);
+  uri.setSearch(query);
+  history.push(uri.search());
+};

--- a/webpack/assets/javascripts/react_app/common/urlHelpers.test.js
+++ b/webpack/assets/javascripts/react_app/common/urlHelpers.test.js
@@ -10,6 +10,7 @@ import {
   getURIperPage,
   getURIsearch,
   exportURL,
+  updateURLQuery,
 } from './urlHelpers';
 
 describe('urlBuilder', () => {
@@ -32,6 +33,16 @@ describe('urlWithSearch', () => {
   it('builds url with search', () => {
     expect(urlWithSearch(base, query)).toBe('/testBase?search=query=test');
   });
+});
+
+describe('updateURLQuery', () => {
+  const history = {
+    push: jest.fn(),
+    location: { search: '?a=1&b=c' },
+  };
+  const query = { query: 'test', b: 'd' };
+  updateURLQuery(query, history);
+  expect(history.push).toHaveBeenCalledWith('?a=1&b=d&query=test');
 });
 
 describe('URI query and stringify tests', () => {


### PR DESCRIPTION
updateURLQuery updates the url with a new query using the react router history object by merging the old query with the new