### PR TITLE
Fixes #28926 - Remove Parametrized_Classes_in_ENC setting

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -395,11 +395,6 @@ class Host::Managed < Host::Base
     hostgroup.all_config_groups
   end
 
-  # returns the list of puppetclasses a host is in.
-  def puppetclasses_names
-    all_puppetclasses.collect {|c| c.name}
-  end
-
   def attributes_to_import_from_facts
     attrs = [:architecture, :hostgroup]
     if !Setting[:ignore_facts_for_operatingsystem] || (Setting[:ignore_facts_for_operatingsystem] && operatingsystem.blank?)

--- a/app/models/host_info_providers/puppet_info.rb
+++ b/app/models/host_info_providers/puppet_info.rb
@@ -61,8 +61,7 @@ module HostInfoProviders
 
     def classes_info_hash
       return [] if host.environment.nil?
-      return puppetclass_parameters if Setting[:Parametrized_Classes_in_ENC]
-      host.puppetclasses_names
+      puppetclass_parameters
     end
 
     def smart_class_params_for(klass, key_hash, values)

--- a/app/models/setting/puppet.rb
+++ b/app/models/setting/puppet.rb
@@ -14,7 +14,6 @@ class Setting::Puppet < Setting
       self.set('default_puppet_environment', N_("Foreman will default to this puppet environment if it cannot auto detect one"), "production", N_('Default Puppet environment'), nil, { :collection => Proc.new {Hash[Environment.all.map {|env| [env[:name], env[:name]]}]} }),
       self.set('puppetrun', N_("Enable puppetrun support"), false, N_('Puppetrun')),
       self.set('Default_variables_Lookup_Path', N_("Foreman will evaluate host smart variables in this order by default"), ["fqdn", "hostgroup", "os", "domain"], N_('Default variables lookup path')),
-      self.set('Parametrized_Classes_in_ENC', N_("Foreman will use the new (2.6.5+) format for classes in the ENC yaml output"), true, N_('Parameterized classes in ENC')),
       self.set('interpolate_erb_in_parameters', N_("Foreman will parse ERB in parameters value in the ENC output"), true, N_('Interpolate ERB in parameters')),
       self.set('enc_environment', N_("Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"), true, N_('ENC environment')),
       self.set('use_uuid_for_certificates', N_("Foreman will use random UUIDs for certificate signing instead of hostnames"), false, N_('Use UUID for certificates')),

--- a/db/migrate/20200205105956_drop_parameterized_classes_setting.rb
+++ b/db/migrate/20200205105956_drop_parameterized_classes_setting.rb
@@ -1,0 +1,5 @@
+class DropParameterizedClassesSetting < ActiveRecord::Migration[5.2]
+  def up
+    Setting.where(name: 'Parametrized_Classes_in_ENC').delete_all
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -965,8 +965,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     get :enc, params: { :id => host.to_param }
     assert_response :success
     response = ActiveSupport::JSON.decode(@response.body)
-    puppet_class = response['data']['classes'].first rescue nil
-    assert_equal host.puppetclasses.first.name, puppet_class
+    puppet_class = response['data']['classes'].keys rescue nil
+    assert_equal host.puppetclasses.map(&:name), puppet_class
   end
 
   context 'parameters type' do

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -106,11 +106,6 @@ attributes24:
   category: Setting::General
   default: "false"
   description: "Setting::Authorize login delegation with REMOTE_USER environment variable for API calls"
-attributes25:
-  name: Parametrized_Classes_in_ENC
-  category: Setting::Puppet
-  default: "false"
-  description: "Should Foreman use the new format (2.6.5+) to answer Setting::Puppet in its ENC yaml output?"
 attribute26:
   name: token_duration
   category: Setting::Provisioning

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1131,7 +1131,6 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "should import from external nodes output" do
-    Setting[:Parametrized_Classes_in_ENC] = true
     # create a dummy node
     Parameter.destroy_all
     host = Host.create :name => "myfullhost", :mac => "aabbacddeeff", :ip => "3.3.4.12", :medium => media(:one),
@@ -1202,7 +1201,6 @@ class HostTest < ActiveSupport::TestCase
     host = FactoryBot.create(:host, :environment => environments(:production))
     host.importNode("environment" => "production", "classes" => ["apache", "base"], "parameters" => {})
 
-    Setting[:Parametrized_Classes_in_ENC] = true
     assert_equal ['apache', 'base'], host.info['classes'].keys
   end
 
@@ -2874,17 +2872,6 @@ class HostTest < ActiveSupport::TestCase
     refute_nil enc['parameters']['root_pw']
   end
 
-  test "#info ENC YAML uses all_puppetclasses for non-parameterized output" do
-    Setting[:Parametrized_Classes_in_ENC] = false
-    myclass = mock('myclass')
-    myclass.expects(:name).returns('myclass')
-    host = FactoryBot.build_stubbed(:host, :with_environment)
-    host.expects(:all_puppetclasses).returns([myclass])
-    enc = host.info
-    assert_kind_of Hash, enc
-    assert_equal ['myclass'], enc['classes']
-  end
-
   test "#info ENC YAML omits environment if not set" do
     host = FactoryBot.build_stubbed(:host)
     host.environment = nil
@@ -2907,7 +2894,6 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "#info ENC YAML uses Classification::ClassParam for parameterized output" do
-    Setting[:Parametrized_Classes_in_ENC] = true
     host = FactoryBot.build_stubbed(:host, :with_environment)
     classes = {'myclass' => {'myparam' => 'myvalue'}}
     HostInfoProviders::PuppetInfo.any_instance.expects(:puppetclass_parameters).returns(classes)


### PR DESCRIPTION
This setting was needed for Puppet <2.6.5 support, no point in keeping
it.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
