### PR TITLE
[WIP] Fixes #28936 - Add default descriptions to all roles added from plugins

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -288,7 +288,9 @@ module Foreman #:nodoc:
     # Add a new role if it doesn't exist
     def role(name, permissions, description = '')
       default_roles[name] = permissions
+      description = (_("Role from plugin %{plugin}") % { :plugin => self.name }) if description == ''
       return false if pending_migrations || Rails.env.test? || User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).nil?
+
       Role.without_auditing do
         Filter.without_auditing do
           Plugin::RoleLock.new(self.id).register_role name, permissions, rbac_registry, description


### PR DESCRIPTION
Default description:

> "Role from plugin [plugin_name]"


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
