### PR TITLE
Fixes #28932 - prevent ERROR: subquery has too many columns

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -215,7 +215,7 @@ module Hostext
       end
 
       def search_cast_facts(key, operator, value)
-        in_query = Host.joins(:fact_values => :fact_name).select(:id).
+        in_query = FactValue.joins(:fact_name).select(:host_id).
                     where("#{FactName.table_name}.name = ?", key.split('.', 2).last).
                     where(cast_facts(FactValue.table_name, key, operator, value)).to_sql
         {


### PR DESCRIPTION

Steps to reproduce:

Create a user role with the resource “Host” with any permissions and the search string of `
compute_resource = “Test”``
Assign the role to a user
Impersonate/login to the user
Search for some fact, like facts.certname ~ test

https://community.theforeman.org/t/role-filter-of-type-host-with-filter-for-compute-attribute-breaks-facts-search/17231
