### PR TITLE
Fixes #28927 - Forget host status

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -27,7 +27,7 @@ class HostsController < ApplicationController
   before_action :find_resource, :only => [:show, :clone, :edit, :update, :destroy, :puppetrun, :review_before_build,
                                           :setBuild, :cancelBuild, :power, :overview, :bmc, :vm,
                                           :runtime, :resources, :nics, :ipmi_boot, :console,
-                                          :toggle_manage, :pxe_config, :disassociate, :build_errors]
+                                          :toggle_manage, :pxe_config, :disassociate, :build_errors, :forget_status]
 
   before_action :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
   before_action :set_host_type, :only => [:update]
@@ -310,6 +310,12 @@ class HostsController < ApplicationController
     render :partial => 'nics'
   rescue ActionView::Template::Error => exception
     process_ajax_error exception, 'fetch interfaces information'
+  end
+
+  def forget_status
+    status = @host.host_statuses.find(params[:status])
+    status.delete
+    redirect_to host_path(@host)
   end
 
   def ipmi_boot
@@ -651,7 +657,7 @@ class HostsController < ApplicationController
     'update_multiple_organization', 'select_multiple_organization',
     'update_multiple_location', 'select_multiple_location',
     'disassociate', 'update_multiple_disassociate', 'multiple_disassociate',
-    'select_multiple_owner', 'update_multiple_owner',
+    'select_multiple_owner', 'update_multiple_owner', 'forget_status',
     'select_multiple_power_state', 'update_multiple_power_state', 'random_name'
   ], :edit
   define_action_permission ['multiple_destroy', 'submit_multiple_destroy'], :destroy

--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -53,7 +53,8 @@ module HostDescriptionHelper
       { :field => [
         _(status.name),
         content_tag(:span, ' '.html_safe, :class => host_global_status_icon_class(status.to_global)) +
-          content_tag(:span, _(status.to_label), :class => host_global_status_class(status.to_global)),
+          content_tag(:span, _(status.to_label), :class => host_global_status_class(status.to_global)) +
+          content_tag(:span, link_to(_('clear'), forget_status_host_path(host, status: status), :class => 'pull-right', :method => 'post')),
       ], :priority => priority += 1 }
     end.compact
   end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -334,7 +334,7 @@ Foreman::AccessControl.map do |permission_set|
                                                :update_multiple_hostgroup, :update_multiple_parameters, :toggle_manage,
                                                :select_multiple_organization, :update_multiple_organization,
                                                :disassociate, :multiple_disassociate, :update_multiple_disassociate,
-                                               :select_multiple_owner, :update_multiple_owner,
+                                               :select_multiple_owner, :update_multiple_owner, :forget_status,
                                                :select_multiple_power_state, :update_multiple_power_state,
                                                :select_multiple_puppet_proxy, :update_multiple_puppet_proxy,
                                                :select_multiple_puppet_ca_proxy, :update_multiple_puppet_ca_proxy,
@@ -344,7 +344,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :puppetclasses => pc_ajax_actions,
                                     :subnets => subnets_ajax_actions,
                                     :interfaces => [:new, :random_name],
-                                    :"api/v2/hosts" => [:update, :disassociate],
+                                    :"api/v2/hosts" => [:update, :disassociate, :forget_status],
                                     :"api/v2/interfaces" => [:create, :update, :destroy],
                                     :"api/v2/compute_resources" => [:associate],
                                   }
@@ -363,6 +363,7 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :console_hosts, {:hosts => [:console] }
     map.permission :ipmi_boot_hosts, { :hosts          => [:ipmi_boot],
                                        :"api/v2/hosts" => [:boot] }
+    map.permission :forget_status_hosts, { :hosts => [:forget_status] }
     map.permission :puppetrun_hosts, {:hosts => [:puppetrun, :multiple_puppetrun, :update_multiple_puppetrun],
                                       :"api/v2/hosts" => [:puppetrun] }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Foreman::Application.routes.draw do
         get 'resources'
         get 'templates'
         get 'nics'
+        post 'forget_status'
         put 'ipmi_boot'
         put 'disassociate'
       end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -334,6 +334,7 @@ Foreman::Application.routes.draw do
           get :vm_compute_attributes, :on => :member
           get 'template/:kind', :on => :member, :action => :template
           put :disassociate, :on => :member
+          delete 'status/:type', :on => :member, :action => :forget_status
           put :boot, :on => :member
           get :power, :on => :member, :action => :power_status
           put :power, :on => :member

--- a/db/seeds.d/020-permissions_list.rb
+++ b/db/seeds.d/020-permissions_list.rb
@@ -72,6 +72,7 @@ class PermissionsList
         ['Host', 'console_hosts'],
         ['Host', 'ipmi_boot_hosts'],
         ['Host', 'puppetrun_hosts'],
+        ['Host', 'forget_status_hosts'],
         ['HttpProxy', 'view_http_proxies'],
         ['HttpProxy', 'create_http_proxies'],
         ['HttpProxy', 'edit_http_proxies'],

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1318,6 +1318,13 @@ class HostsControllerTest < ActionController::TestCase
     assert_not_nil flash[:error]
   end
 
+  test "#forget_status deletes a sub-status" do
+    host = FactoryBot.create(:host)
+    status = ::HostStatus::BuildStatus.create!(host_id: host.id)
+    post :forget_status, params: {:id => host.id, :status => status.id}, session: set_session_user
+    refute host.host_statuses.include?(status)
+  end
+
   test "#disassociate shows error when used on non-CR host" do
     host = FactoryBot.create(:host)
     @request.env["HTTP_REFERER"] = hosts_path


### PR DESCRIPTION
Adds the ability to remove an individual host status.  This is useful for old or unwanted warnings and errors.

At the moment it says "Forget Status", but there might be a better label, like "Clear Status" or something along those lines.  Perhaps even the clear button could be an icon, I'd be curious to hear what people have to say.  It'll make sense in the future for this action to be in the v2 API as well.

![forget_status](https://user-images.githubusercontent.com/14796566/73956428-f17c2b00-48d2-11ea-80a5-4a5ea86a3ec8.gif)

