### PR TITLE
Fixes #28093 - Wrong host ownership in UserMailNotifications

### DIFF
--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -6,8 +6,9 @@ class HostMailer < ApplicationMailer
   # sends out a summary email of hosts and their metrics (e.g. how many changes failures etc).
   def summary(options = {})
     raise ::Foreman::Exception.new(N_("Must specify a valid user with email enabled")) unless (user = User.find(options[:user]))
-    User.current = user
-    hosts = Host::Managed.authorized_as(user, :view_hosts, Host)
+    hosts = User.as user do
+        Host::Managed.authorized_as(user, :view_hosts, Host)
+    end
     time = options[:time] || 1.day.ago
     host_data = ConfigReport.summarise(time, hosts.all).sort
 

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -7,7 +7,7 @@ class HostMailer < ApplicationMailer
   def summary(options = {})
     raise ::Foreman::Exception.new(N_("Must specify a valid user with email enabled")) unless (user = User.find(options[:user]))
     hosts = User.as user do
-        Host::Managed.authorized_as(user, :view_hosts, Host)
+      Host::Managed.authorized_as(user, :view_hosts, Host)
     end
     time = options[:time] || 1.day.ago
     host_data = ConfigReport.summarise(time, hosts.all).sort

--- a/app/mailers/host_mailer.rb
+++ b/app/mailers/host_mailer.rb
@@ -6,6 +6,7 @@ class HostMailer < ApplicationMailer
   # sends out a summary email of hosts and their metrics (e.g. how many changes failures etc).
   def summary(options = {})
     raise ::Foreman::Exception.new(N_("Must specify a valid user with email enabled")) unless (user = User.find(options[:user]))
+    User.current = user
     hosts = Host::Managed.authorized_as(user, :view_hosts, Host)
     time = options[:time] || 1.day.ago
     host_data = ConfigReport.summarise(time, hosts.all).sort

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -119,15 +119,15 @@ class ReportImporter
 
       owners = host.owner.present? ? host.owner.recipients_for(:config_error_state) : []
       users = ConfigManagementError.all_hosts.flat_map(&:users)
-      users.select { |user|
+      users = users.select do |user|
         begin
           User.as user do
             Host.authorized_as(user, :view_hosts).find(host.id).present?
           end
-        rescue ActiveRecord::RecordNotFound => e
+        rescue ActiveRecord::RecordNotFound
           nil
         end
-      }
+      end
       owners.concat users
       if owners.present?
         logger.debug { "sending alert to #{owners.map(&:login).join(',')}" }

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -120,10 +120,8 @@ class ReportImporter
       owners = host.owner.present? ? host.owner.recipients_for(:config_error_state) : []
       users = ConfigManagementError.all_hosts.flat_map(&:users)
       users = users.select do |user|
-        begin
-          User.as user do
-            Host.authorized_as(user, :view_hosts).find(host.id).present?
-          end
+        User.as user do
+          Host.authorized_as(user, :view_hosts).find(host.id).present?
         rescue ActiveRecord::RecordNotFound
           nil
         end


### PR DESCRIPTION
Wrong list of hosts in "Configuration Management Summary Report" when view_host permission
 is used with filter "owner = current_user"


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
