### PR TITLE
Fixes #28858 - allow delete user with multiple groups

### DIFF
--- a/app/models/usergroup_member.rb
+++ b/app/models/usergroup_member.rb
@@ -96,7 +96,7 @@ class UsergroupMember < ApplicationRecord
 
   def recache_memberships
     memberships = find_all_affected_memberships
-    memberships = memberships.without(self) if self.destroyed?
+    memberships = memberships.reject(&:destroyed?)
     memberships.each(&:save!)
   end
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1107,6 +1107,15 @@ class UserTest < ActiveSupport::TestCase
     assert jwt_secret.persisted?
   end
 
+  describe '#destroy' do
+    it 'works for user with two groups' do
+      user = users(:one)
+      FactoryBot.create_list(:user_usergroup_member, 2, member: user)
+      user.reload.destroy
+      assert user.destroyed?
+    end
+  end
+
   context 'Jail' do
     test 'should allow methods' do
       allowed = [:login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail]


### PR DESCRIPTION
User with multiple groups can not be deleted.