### PR TITLE
Fixes #28929 - allow complex types in settings api

### DIFF
--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -25,10 +25,20 @@ module Api
 
       def update
         value = params[:setting][:value]
-        if value.nil?
+        type = value.class.to_s.downcase
+        if type == "trueclass" || type == "falseclass"
+          type = "boolean"
+        end
+        case type
+        when "nilclass"
           render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => _("No setting value provided.") }
-        else
+        when "string"
           process_response (@setting.parse_string_value(value) && @setting.save)
+        when @setting.settings_type
+          @setting.value = value
+          process_response @setting.save
+        else
+          render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => _("expected a value of type %s") % @setting.settings_type}
         end
       end
     end

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -21,11 +21,32 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
     assert_response 422
   end
 
-  test "should parse string values" do
+  test "should parse string values to integers" do
     setting_id = Setting.where(:settings_type => 'integer').first.id
     put :update, params: { :id => setting_id, :setting => { :value => "100" } }
     assert_response :success
     assert_equal 100, Setting.find(setting_id).value
+  end
+
+  test "should accept integer values" do
+    setting_id = Setting.where(:settings_type => 'integer').first.id
+    put :update, params: { :id => setting_id, :setting => { :value => 120 } }
+    assert_response :success
+    assert_equal 120, Setting.find(setting_id).value
+  end
+
+  test "should parse string values to ararys" do
+    setting_id = Setting.where(:settings_type => 'array').first.id
+    put :update, params: { :id => setting_id, :setting => { :value => "['baz','foo']" } }
+    assert_response :success
+    assert_equal ['baz', 'foo'], Setting.find(setting_id).value
+  end
+
+  test "should accept array values" do
+    setting_id = Setting.where(:settings_type => 'array').first.id
+    put :update, params: { :id => setting_id, :setting => { :value => ['foo', 'bar'] } }
+    assert_response :success
+    assert_equal ['foo', 'bar'], Setting.find(setting_id).value
   end
 
   test_attributes :pid => 'fb8b0bf1-b475-435a-926b-861aa18d31f1'

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -146,6 +146,7 @@ attribute32:
   category: Setting::Auth
   default: []
   description: "Hosts that will be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
+  settings_type: array
 attribute36:
   name: puppetrun
   category: Setting::Puppet
@@ -354,6 +355,7 @@ attributes78:
   category: Setting::Provisioning
   default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
   description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
+  settings_type: 'array'
 attribute79:
   name: append_domain_name_for_hosts
   category: Setting::General


### PR DESCRIPTION
Previously the settings api only accepted stringified forms of complex
settings values, while returning the correctly typed ones.

This change allows setting both stringified and non stringified forms.

This Fixes the issue when mapping the api straight to puppet providers and trying to set a setting to an array:
```
/Stage[main]/Foreman_api/Foreman_setting[trusted_hosts]/value value changed ['puppet01.example.org', 'puppet02.example.org'] to '[puppet01.example.org, puppet02.example.org]' (corrective)
```
(since the api returns something different than what it expect to get written to it)
