### PR TITLE
Fixes #28965 - calculate PXE UID from OS version

### DIFF
--- a/app/services/medium_providers/default.rb
+++ b/app/services/medium_providers/default.rb
@@ -26,7 +26,7 @@ module MediumProviders
 
     def unique_id
       @unique_id ||= begin
-        digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri(entity.operatingsystem.pxedir(self)).to_s), padding: false)
+        digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri(entity.operatingsystem.pxedir(self)).to_s + entity.operatingsystem.major + entity.operatingsystem.minor), padding: false)
         # return first 12 characters of encoded digest stripped down of non-alphanums for better readability
         "#{entity.medium.name.parameterize}-#{digest.gsub(/[-_]/, '')[1..12]}"
       end

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -90,6 +90,15 @@ FactoryBot.define do
       title { 'Debian Wheezy' }
     end
 
+    factory :debian7_1, class: Debian do
+      sequence(:name) { 'Debian' }
+      major { '7' }
+      minor { '1' }
+      type { 'Debian' }
+      release_name { 'wheezy' }
+      title { 'Debian Wheezy' }
+    end
+
     factory :suse, class: Suse do
       sequence(:name) { 'OpenSuse' }
       major { '11' }

--- a/test/models/operatingsystems/operatingsystems_test.rb
+++ b/test/models/operatingsystems/operatingsystems_test.rb
@@ -19,6 +19,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     :redhat      => { 'os' => :rhel7_5,     'arch' => :x86_64, 'expected' => 'images/pxeboot' },
     :redhat_ppc  => { 'os' => :rhel7_5,     'arch' => :ppc64, 'expected' => 'ppc/ppc64' },
     :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/debian-installer/$arch' },
+    :debian7_1   => { 'os' => :debian7_1,   'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/debian-installer/$arch' },
     :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'expected' => 'dists/$release/main/installer-$arch/current/images/netboot/ubuntu-installer/$arch' },
     :suse        => { 'os' => :suse,        'arch' => :x86_64, 'expected' => 'boot/$arch/loader' } }.
   each do |os, config|
@@ -38,10 +39,11 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-gomKIDxxXGyr-coreos_production_pxe.vmlinuz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-22gSejCmiWvb-linux' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-MISc0aOlWLr3-linux' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-n8xNOWMpKlrW-linux' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-ZX7K5DrIw8GD-coreos_production_pxe.vmlinuz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-zk3iA1lqbWLp-linux' },
+    :debian7_1   => { 'os' => :debian7_1,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-k1O72L6ktmiV-linux' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-nBGUKFMjrPYz-linux' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-51xY4YC2vskO-linux' } }.
   each do |os, config|
     test "kernel location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -58,10 +60,11 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-gomKIDxxXGyr-coreos_production_pxe_image.cpio.gz' },
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-22gSejCmiWvb-initrd.gz' },
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-MISc0aOlWLr3-initrd.gz' },
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-n8xNOWMpKlrW-initrd' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-ZX7K5DrIw8GD-coreos_production_pxe_image.cpio.gz' },
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-zk3iA1lqbWLp-initrd.gz' },
+    :debian7_1   => { 'os' => :debian7_1,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-k1O72L6ktmiV-initrd.gz' },
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-nBGUKFMjrPYz-initrd.gz' },
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-51xY4YC2vskO-initrd' } }.
   each do |os, config|
     test "initrd location for #{config['arch']} #{os}" do
       arch = architectures(config['arch'])
@@ -78,10 +81,11 @@ class OperatingsystemsTest < ActiveSupport::TestCase
     end
   end
 
-  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-gomKIDxxXGyr'},
-    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-22gSejCmiWvb'},
-    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-MISc0aOlWLr3'},
-    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-n8xNOWMpKlrW' } }.
+  { :coreos      => { 'os' => :coreos,      'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-ZX7K5DrIw8GD'},
+    :debian7_0   => { 'os' => :debian7_0,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-zk3iA1lqbWLp'},
+    :debian7_1   => { 'os' => :debian7_1,   'arch' => :x86_64, 'medium' => :unused, 'expected' => 'boot/unused-k1O72L6ktmiV'},
+    :ubuntu14_10 => { 'os' => :ubuntu14_10, 'arch' => :x86_64, 'medium' => :ubuntu, 'expected' => 'boot/ubuntu-mirror-nBGUKFMjrPYz'},
+    :suse        => { 'os' => :suse,        'arch' => :x86_64, 'medium' => :opensuse, 'expected' => 'boot/opensuse-51xY4YC2vskO' } }.
   each do |os, config|
     test "pxe prefix for #{os}" do
       arch = architectures(config['arch'])

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -198,8 +198,8 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     expected = <<~EXPECTED
       default linux
       label linux
-      kernel boot/centos-5-4-0hJnFEYDTkXX-vmlinuz
-      append initrd=boot/centos-5-4-0hJnFEYDTkXX-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
+      kernel boot/centos-5-4-uWCeq9vTUar3-vmlinuz
+      append initrd=boot/centos-5-4-uWCeq9vTUar3-initrd.img ks=http://ahost.com:3000/unattended/kickstart ksdevice=bootif network kssendmac
     EXPECTED
     assert_equal expected.strip, template
     assert h.build
@@ -372,8 +372,8 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     expected = <<~EXPECTED
       DEFAULT linux
       LABEL linux
-      KERNEL boot/opensuse-kAwuzwT2nvld-linux
-      APPEND initrd=boot/opensuse-kAwuzwT2nvld-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
+      KERNEL boot/opensuse-Ek8x7Rr7itxO-linux
+      APPEND initrd=boot/opensuse-Ek8x7Rr7itxO-initrd ramdisk_size=65536 install=http://download.opensuse.org/distribution/12.3/repo/oss autoyast=http://ahost.com:3000/unattended/provision textmode=1
     EXPECTED
     assert_equal expected.strip, template
     assert h.build

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -288,9 +288,9 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
         global_template_name = ProvisioningTemplate.global_template_name_for(kind)
         default_template = ProvisioningTemplate.find_global_default_template(global_template_name, kind)
         expected = {}
-        expected["PXELinux"] = [/combo_medium-8X6BsGonIA0A-(vmlinuz|initrd.img)/, /LABEL hg1 - ct[12]/, /LABEL hg2 - ct[23]/]
-        expected["PXEGrub"] = [/combo_medium-8X6BsGonIA0A-(vmlinuz|initrd.img)/, /title hg1 - ct[12]/, /title hg2 - ct[23]/]
-        expected["PXEGrub2"] = [/combo_medium-8X6BsGonIA0A-(vmlinuz|initrd.img)/, /hg1 - ct[12]/, /hg2 - ct[23]/]
+        expected["PXELinux"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /LABEL hg1 - ct[12]/, /LABEL hg2 - ct[23]/]
+        expected["PXEGrub"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /title hg1 - ct[12]/, /title hg2 - ct[23]/]
+        expected["PXEGrub2"] = [/combo_medium-[A-Za-z0-9_=]+-(vmlinuz|initrd.img)/, /hg1 - ct[12]/, /hg2 - ct[23]/]
         expected[kind].each do |match|
           assert_match match, default_template.render(variables: { profiles: ProvisioningTemplate.pxe_default_combos })
         end

--- a/test/unit/medium_providers/default_test.rb
+++ b/test/unit/medium_providers/default_test.rb
@@ -36,7 +36,7 @@ class DefaultMediumProviderTest < ActiveSupport::TestCase
       host = FactoryBot.build_stubbed(:host, :managed, :operatingsystem => Operatingsystem.find_by_name(osname))
       medium_uri_with_path = MediumProviders::Default.new(host).medium_uri(host.operatingsystem.pxedir).to_s
       assert_equal expected_uri, medium_uri_with_path
-      digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri_with_path), padding: false)
+      digest = Base64.urlsafe_encode64(Digest::SHA1.digest(medium_uri_with_path + host.operatingsystem.major + host.operatingsystem.minor), padding: false)
       expected_id = "#{host.medium.name.parameterize}-#{digest.gsub(/[-_]/, '')[1..12]}"
       assert_equal expected_id, MediumProviders::Default.new(host).unique_id.to_s
     end


### PR DESCRIPTION
When new Debian release comes out, the IM URL remains the same. We
calculate the unique id from the URL only, since it does not change
proxy has no reason to redownload the file. This patch adds OS version
to the hash so if OS version is bumped, it also triggers redownload of
the PXE files.

This patch will cause redownload of all PXE files but it's not a big
issue.