### PR TITLE
Fixes #28987 - Fix report_templates API taxonomies routing

### DIFF
--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -396,6 +396,7 @@ Foreman::Application.routes.draw do
         resources :smart_proxies, :only => [:index, :show]
         resources :filters, :only => [:index, :show]
         resources :hosts, :except => [:new, :edit]
+        resources :report_templates, :only => [:index, :show]
         resources :parameters, :except => [:new, :edit] do
           collection do
             delete '/', :action => :reset
@@ -420,6 +421,7 @@ Foreman::Application.routes.draw do
           resources :smart_proxies, :only => [:index, :show]
           resources :filters, :only => [:index, :show]
           resources :hosts, :except => [:new, :edit]
+          resources :report_templates, :only => [:index, :show]
         end
       end
 
@@ -441,6 +443,7 @@ Foreman::Application.routes.draw do
         resources :smart_proxies, :only => [:index, :show]
         resources :filters, :only => [:index, :show]
         resources :hosts, :except => [:new, :edit]
+        resources :report_templates, :only => [:index, :show]
         resources :parameters, :except => [:new, :edit] do
           collection do
             delete '/', :action => :reset
@@ -465,6 +468,7 @@ Foreman::Application.routes.draw do
           resources :smart_proxies, :only => [:index, :show]
           resources :filters, :only => [:index, :show]
           resources :hosts, :except => [:new, :edit]
+          resources :report_templates, :only => [:index, :show]
         end
       end
 


### PR DESCRIPTION
Fixed the routing of:  
GET http://localhost:3000/api/organizations/2/report_templates
GET http://localhost:3000/api/locations/1/report_templates