### PR TITLE
Fixes #29008 - consider locked templates valid in seed

### DIFF
--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -126,7 +126,7 @@ class SeedHelper
         t.locations = Location.unscoped.all if t.respond_to?(:locations=)
         raise "Unable to create template #{t.name}: #{format_errors t}" unless t.valid?
       else
-        raise "Unable to update template #{t.name}: #{format_errors t}" unless t.valid?
+        raise "Unable to update template #{t.name}: #{format_errors t}" unless t.ignore_locking { t.valid? }
       end
 
       t.ignore_locking { t.save! }


### PR DESCRIPTION
When a template is already persisted, it's considered invalid when
changed, if it's locked, however seeding should update default template.
When we call save, we ignore locking, but we also need to ignore it when
checking for errors on few lines above. This is I believe a regression
caused by running seed checks.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
