### PR TITLE
Fixes #29027 - session_id out of range error

### DIFF
--- a/db/migrate/20200217110708_alter_session_sequence_to_cycle.rb
+++ b/db/migrate/20200217110708_alter_session_sequence_to_cycle.rb
@@ -1,0 +1,13 @@
+class AlterSessionSequenceToCycle < ActiveRecord::Migration[5.2]
+  def up
+    change_column :sessions, :id, :bigint
+    if ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
+      ActiveRecord::Base.connection.execute(<<-SQL)
+        ALTER SEQUENCE sessions_id_seq MAXVALUE 9223372036854775807 CYCLE;
+      SQL
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
Session id is out of range for some users, probably because a lot of API requests.
This solves it for PostgreSQL and most likely even for MySQL (if we would get back to it in the future :upside_down_face:)