### PR TITLE
Fixes #29044 - Hide values of encrypted settings in API

### DIFF
--- a/app/views/api/v2/settings/main.json.rabl
+++ b/app/views/api/v2/settings/main.json.rabl
@@ -2,7 +2,10 @@ object @setting
 
 extends "api/v2/settings/base"
 
-attributes :value, :description, :category, :settings_type, :default, :created_at, :updated_at
+attributes :description, :category, :settings_type, :default, :created_at, :updated_at
+node :value do |s|
+  s.safe_value
+end
 
 node :category_name do |s|
   _(s.class.humanized_category || s.category.gsub(/Setting::/, ''))


### PR DESCRIPTION
Settings which have their value stored encrypted in the DB are write-only in the
Web UI since dad774bbf was merged. This is intended to make the API behave the
same way.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
