### PR TITLE
Fixes #29056 - Fix API filter creation in case of organization_id exists

### DIFF
--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -36,7 +36,7 @@ module Api
       param_group :filter, :as => :create
 
       def create
-        @filter = nested_obj ? nested_obj.filters.build(filter_params) : Filter.new(filter_params)
+        @filter = nested_obj.respond_to?(:filters) ? nested_obj.filters.build(filter_params) : Filter.new(filter_params)
         process_response @filter.save
       end
 

--- a/test/controllers/api/v2/filters_controller_test.rb
+++ b/test/controllers/api/v2/filters_controller_test.rb
@@ -27,6 +27,18 @@ class Api::V2::FiltersControllerTest < ActionController::TestCase
     assert_equal show_response["permissions"].first["name"], "view_architectures"
   end
 
+  test "should create filter with scoped organization" do
+    role = FactoryBot.create(:role, :organization_ids => [taxonomies(:organization1).id], :name => "role_test")
+
+    filter = { :role_id => role.id, :permission_ids => [permissions(:view_architectures).id]}
+    assert_difference('Filter.count') do
+      post :create, params: { :filter => filter, :organization_id => taxonomies(:organization1).id}
+    end
+    assert_response :created
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal show_response["permissions"].first["name"], "view_architectures"
+  end
+
   test "should create non-overridable filter" do
     role = FactoryBot.create(:role, :name => 'New Role')
     assert_difference('Filter.count') do


### PR DESCRIPTION
When creating a filter with scoped organizaiton_id:

[ INFO 2020-02-18T17:44:45 API] Server: http://localhost:3000
[ INFO 2020-02-18T17:44:45 API] POST /api/filters
[DEBUG 2020-02-18T17:44:45 API] Params: {
    "organization_id" => "2",
             "filter" => {
               "role_id" => 18,
        "permission_ids" => [
            [0] 105
        ]
    }
}
we are getting the error: 
[ERROR 2020-02-18T17:44:45 API] 500 Internal Server Error
[DEBUG 2020-02-18T17:44:45 API] {
    "error" => {
        "message" => "Internal Server Error: the server was unable to finish the request. This may be caused by unavailability of some required service, incorrect API call or a server-side bug. There may be more information in the server's logs."
    }
}


the reason is nested_obj is found by the first parameter that contain _id" https://github.com/theforeman/foreman/blob/develop/app/controllers/api/base_controller.rb#L396

and this parameter is organiztion_id. 

