### PR TITLE
Fixes #29067 - extend ability to audits metadata

### DIFF
--- a/app/controllers/audits_controller.rb
+++ b/app/controllers/audits_controller.rb
@@ -5,10 +5,7 @@ class AuditsController < ApplicationController
 
   def index
     @audits = resource_base_search_and_page.preload(:user)
-    render :json => {
-      :audits => helpers.construct_additional_info(@audits),
-      :itemCount => @audits.count,
-    }
+    render :json => helpers.audits_metadata(@audits)
   end
 
   private

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -234,6 +234,13 @@ module AuditsHelper
     end
   end
 
+  def audits_metadata(audits)
+    {
+      :audits => construct_additional_info(audits),
+      :itemCount => audits.count,
+    }
+  end
+
   private
 
   def additional_details_if_any(audit, action_display_name)

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPage.fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPage.fixtures.js
@@ -22,6 +22,14 @@ export const getMock = {
   searchQuery: '',
 };
 
+const appMetadataState = {
+  app: {
+    metadata: {
+      version: '2.1',
+    },
+  },
+};
+
 export const state = {
   auditsPage: {
     data: {
@@ -29,20 +37,26 @@ export const state = {
       message: '',
       isLoading: false,
       hasError: false,
-      hasData: true,
+      itemCount: AuditsProps.audits.length,
     },
     query: {
       page: 1,
       perPage: 20,
-      itemCount: 0,
       searchQuery: '',
     },
   },
+  ...appMetadataState,
+};
+
+export const getStateWithDocumentationUrl = () => {
+  const modifiedState = { ...state };
+  modifiedState.auditsPage.data.documentationUrl = '/test';
+  return modifiedState;
 };
 
 export const auditsPageProps = {
   perPageOptions: [5, 10, 20, 50],
-  docURL: '/url',
+  documentationUrl: '/url',
   searchProps: SearchBarProps,
   searchable: true,
   location: {},

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPage.js
@@ -6,14 +6,14 @@ import './auditspage.scss';
 import { translate as __ } from '../../../common/I18n';
 import PageLayout from '../../common/PageLayout/PageLayout';
 import AuditsTable from './components/AuditsTable';
-import { AUDITS_SEARCH_PROPS, AUDITS_MANUAL_URL } from '../constants';
+import { AUDITS_SEARCH_PROPS } from '../constants';
 
 const AuditsPage = ({
   searchQuery,
   fetchAndPush,
-  version,
   isLoading,
   hasData,
+  documentationUrl,
   ...props
 }) => (
   <PageLayout
@@ -25,7 +25,7 @@ const AuditsPage = ({
     onSearch={search => fetchAndPush({ searchQuery: search, page: 1 })}
     onBookmarkClick={search => fetchAndPush({ searchQuery: search, page: 1 })}
     toolbarButtons={
-      <Button href={AUDITS_MANUAL_URL(version)} className="btn-docs">
+      <Button href={documentationUrl} className="btn-docs">
         <Icon type="pf" name="help" />
         {__(' Documentation')}
       </Button>
@@ -43,13 +43,9 @@ const AuditsPage = ({
 AuditsPage.propTypes = {
   searchQuery: PropTypes.string.isRequired,
   fetchAndPush: PropTypes.func.isRequired,
-  version: PropTypes.string,
   isLoading: PropTypes.bool.isRequired,
   hasData: PropTypes.bool.isRequired,
-};
-
-AuditsPage.defaultProps = {
-  version: '',
+  documentationUrl: PropTypes.string.isRequired,
 };
 
 export default AuditsPage;

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageActions.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageActions.js
@@ -41,7 +41,7 @@ export const fetchAudits = (
       type: AUDITS_PAGE_CLEAR_ERROR,
     });
 
-  const onRequestSuccess = ({ data: { audits, itemCount } }) => {
+  const onRequestSuccess = ({ data }) => {
     if (selectAuditsIsLoadingPage(getState()))
       dispatch({ type: AUDITS_PAGE_HIDE_LOADING });
 
@@ -51,16 +51,12 @@ export const fetchAudits = (
         page,
         perPage,
         searchQuery,
-        itemCount,
       },
     });
 
     dispatch({
       type: AUDITS_PAGE_DATA_RESOLVED,
-      payload: {
-        audits,
-        hasData: itemCount > 0,
-      },
+      payload: data,
     });
   };
   const onRequestFail = error => {

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageSelectors.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageSelectors.js
@@ -1,3 +1,7 @@
+import { createSelector } from 'reselect';
+import { AUDITS_MANUAL_URL } from '../constants';
+import { selectReactAppVersion } from '../../../ReactApp/ReactAppSelectors';
+
 export const selectAuditsPageData = state => state.auditsPage.data;
 export const selectAuditsPageQuery = state => state.auditsPage.query;
 
@@ -7,13 +11,18 @@ export const selectAuditsIsLoadingPage = state =>
   selectAuditsPageData(state).isLoading;
 export const selectAuditsHasError = state =>
   selectAuditsPageData(state).hasError;
-export const selectAuditsHasData = state => selectAuditsPageData(state).hasData;
+export const selectAuditsHasData = state => selectAuditsCount(state) > 0;
 
 export const selectAuditsSelectedPage = state =>
   selectAuditsPageQuery(state).page;
 export const selectAuditsPerPage = state =>
   selectAuditsPageQuery(state).perPage;
-export const selectAuditsCount = state =>
-  selectAuditsPageQuery(state).itemCount;
+export const selectAuditsCount = state => selectAuditsPageData(state).itemCount;
 export const selectAuditsSearch = state =>
   selectAuditsPageQuery(state).searchQuery;
+
+export const selectAuditDocumentationUrl = createSelector(
+  selectReactAppVersion,
+  state => selectAuditsPageData(state).documentationUrl,
+  (version, documentationUrl) => documentationUrl || AUDITS_MANUAL_URL(version)
+);

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/AuditsPageSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/AuditsPageSelectors.test.js
@@ -8,8 +8,9 @@ import {
   selectAuditsHasData,
   selectAuditsHasError,
   selectAuditsSearch,
+  selectAuditDocumentationUrl,
 } from '../AuditsPageSelectors';
-import { state } from '../AuditsPage.fixtures';
+import { state, getStateWithDocumentationUrl } from '../AuditsPage.fixtures';
 
 const fixtures = {
   'should return Audits array': () => selectAudits(state),
@@ -20,6 +21,10 @@ const fixtures = {
   'should return Audits hasData bool': () => selectAuditsHasData(state),
   'should return Audits message': () => selectAuditsMessage(state),
   'should return Audits Search Value': () => selectAuditsSearch(state),
+  'should return Audits default documentation url': () =>
+    selectAuditDocumentationUrl(state),
+  'should return Audits overridden documentation url ': () =>
+    selectAuditDocumentationUrl(getStateWithDocumentationUrl()),
 };
 
 describe('AuditsPage selectors', () =>

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -36,7 +36,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
       bsStyle="default"
       className="btn-docs"
       disabled={false}
-      href="https://theforeman.org/manuals/1.23/index.html#4.1.4Auditing"
+      href="/url"
     >
       <Icon
         name="help"
@@ -47,7 +47,6 @@ exports[`AuditsPage rendering render audits page 1`] = `
   }
 >
   <Component
-    docURL="/url"
     fetchAndPush={[Function]}
     hasData={true}
     initializeAudits={[Function]}
@@ -80,6 +79,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
       }
     }
     searchable={true}
+    version="1.23"
   />
 </PageLayout>
 `;
@@ -120,7 +120,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
       bsStyle="default"
       className="btn-docs"
       disabled={false}
-      href="https://theforeman.org/manuals/1.23/index.html#4.1.4Auditing"
+      href="/url"
     >
       <Icon
         name="help"
@@ -131,7 +131,6 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
   }
 >
   <Component
-    docURL="/url"
     fetchAndPush={[Function]}
     hasData={true}
     hasError={true}
@@ -166,6 +165,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
       }
     }
     searchable={true}
+    version="1.23"
   />
 </PageLayout>
 `;
@@ -206,7 +206,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
       bsStyle="default"
       className="btn-docs"
       disabled={false}
-      href="https://theforeman.org/manuals/1.23/index.html#4.1.4Auditing"
+      href="/url"
     >
       <Icon
         name="help"
@@ -217,7 +217,6 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
   }
 >
   <Component
-    docURL="/url"
     fetchAndPush={[Function]}
     hasData={true}
     hasError={true}
@@ -252,6 +251,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
       }
     }
     searchable={true}
+    version="1.23"
   />
 </PageLayout>
 `;
@@ -292,7 +292,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
       bsStyle="default"
       className="btn-docs"
       disabled={false}
-      href="https://theforeman.org/manuals/1.23/index.html#4.1.4Auditing"
+      href="/url"
     >
       <Icon
         name="help"
@@ -304,7 +304,6 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
 >
   <Component
     audits={Array []}
-    docURL="/url"
     fetchAndPush={[Function]}
     hasData={true}
     hasError={false}
@@ -338,6 +337,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
       }
     }
     searchable={true}
+    version="1.23"
   />
 </PageLayout>
 `;

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPageActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPageActions.test.js.snap
@@ -10,7 +10,6 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "itemCount": 1,
         "page": 1,
         "perPage": 20,
         "searchQuery": "",
@@ -124,7 +123,7 @@ Array [
             "version": 2,
           },
         ],
-        "hasData": true,
+        "itemCount": 1,
       },
       "type": "AUDITS_PAGE_DATA_RESOLVED",
     },
@@ -163,7 +162,6 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "itemCount": 1,
         "page": 1,
         "perPage": 20,
         "searchQuery": "",
@@ -277,7 +275,7 @@ Array [
             "version": 2,
           },
         ],
-        "hasData": true,
+        "itemCount": 1,
       },
       "type": "AUDITS_PAGE_DATA_RESOLVED",
     },
@@ -295,7 +293,6 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "itemCount": 0,
         "page": 1,
         "perPage": 20,
         "searchQuery": "no-such-audit",
@@ -307,7 +304,7 @@ Array [
     Object {
       "payload": Object {
         "audits": Array [],
-        "hasData": false,
+        "itemCount": 0,
       },
       "type": "AUDITS_PAGE_DATA_RESOLVED",
     },

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPageSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPageSelectors.test.js.snap
@@ -108,13 +108,17 @@ Array [
 ]
 `;
 
-exports[`AuditsPage selectors should return Audits array count 1`] = `0`;
+exports[`AuditsPage selectors should return Audits array count 1`] = `1`;
+
+exports[`AuditsPage selectors should return Audits default documentation url 1`] = `"https://theforeman.org/manuals/2.1/index.html#4.1.4Auditing"`;
 
 exports[`AuditsPage selectors should return Audits hasData bool 1`] = `true`;
 
 exports[`AuditsPage selectors should return Audits hasError bool 1`] = `false`;
 
 exports[`AuditsPage selectors should return Audits message 1`] = `""`;
+
+exports[`AuditsPage selectors should return Audits overridden documentation url  1`] = `"/test"`;
 
 exports[`AuditsPage selectors should return selected page 1`] = `1`;
 

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/index.js
@@ -14,11 +14,9 @@ import {
   selectAuditsHasData,
   selectAuditsHasError,
   selectAuditsIsLoadingPage,
+  selectAuditDocumentationUrl,
 } from './AuditsPageSelectors';
-import {
-  selectReactAppVersion,
-  selectReactAppPerPageOptions,
-} from '../../../ReactApp/ReactAppSelectors';
+import { selectReactAppPerPageOptions } from '../../../ReactApp/ReactAppSelectors';
 import { callOnMount, callOnPopState } from '../../../common/HOC';
 import withQueryReducer from '../../common/reducerHOC/withQueryReducer';
 import withDataReducer from '../../common/reducerHOC/withDataReducer';
@@ -33,8 +31,8 @@ const mapStateToProps = state => ({
   searchQuery: selectAuditsSearch(state),
   hasError: selectAuditsHasError(state),
   hasData: selectAuditsHasData(state),
-  version: selectReactAppVersion(state),
   perPageOptions: selectReactAppPerPageOptions(state),
+  documentationUrl: selectAuditDocumentationUrl(state),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);


### PR DESCRIPTION
moved `audits_metadata` into an helper 
so plugins could override it and extend the metadata.

in this PR I am giving the ability to amend the `documentationUrl`
so it could be used in plugins as:

```rb
module PluginAuditsHelper
  def audits_metadata(audits)
    super.merge(
      documentationUrl: '/test'
    )
  end
end
```

this is a patch to cherry pick also to 1.24
though after the context provider infrastructure will be ready, see #7139 ,
things like that can be treated in a global scope and get override in a single place in the backend.