### PR TITLE
Fixes #29018 - disabled buttons are still working

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,12 +17,14 @@ $(function() {
 
 // Prevents all links with the disabled attribute set to "disabled"
 // from being clicked.
-$(document).on('click', 'a[disabled="disabled"]', function(evt) {
-  // this check is required in case the link was "enabled" after the
-  // function has registered.
-  var disabled = this.disabled || $(this).attr('disabled') === 'disabled';
-  if (disabled) evt.preventDefault();
+var handleDisabledClick = function(event, element){
+  var disabled = element.disabled || $(element).attr('disabled') === 'disabled';
+  if (disabled) event.preventDefault();
   return !disabled;
+}
+
+$(document).on('click', 'a[disabled="disabled"]', function(event) {
+  return handleDisabledClick(event, this);
 });
 
 function onContentLoad() {
@@ -53,6 +55,10 @@ function onContentLoad() {
   $('a[rel="popover"]').popover();
   tfm.tools.activateTooltips();
   tfm.tools.activateDatatables();
+
+  $('a[disabled="disabled"]').click(function(event) {
+    return handleDisabledClick(event, this);
+  });
 
   // allow opening new window for selected links
   $('a[rel="external"]').attr('target', '_blank');


### PR DESCRIPTION
Bug that was found several times in different places,
and it seem that combination of things didn't solve all of the issues,
some examples:
Have remote execution that succeeded.
1. Go to Monitor -> Jobs
2. Select job that succeeded
3. 'Rerun failed' is disabled
4. Click 'Rerun failed'

Another example:
Have remote execution that succeeded and has hosts.
1. Go to Monitor -> Jobs
2. Select job that succeeded
3. Select host from table
4. 'Cancel Job' and 'Abort Job' are disabled
5. Click on 'Cancel Job' or 'Abort Job'

Another example:
Have host that cannot be build
1. Navigate to host details
2. Click on disabled button 'Build'

I think it should move back to be called `onContentLoad` as it seem to affect better,
and I also reverted to the older selector that was used..

This needs to be cherry picked to 1.24 and 1.22