### PR TITLE
Fixes #29043 - Add name to 'generate_at' field

### DIFF
--- a/app/helpers/tags/react_input.rb
+++ b/app/helpers/tags/react_input.rb
@@ -27,6 +27,7 @@ module Tags
       react_opts['inputSizeClass'] = options.delete('size') if options.key?('size')
       react_opts['labelSizeClass'] = options.delete('label_size') if options.key?('label_size')
       react_opts.merge! deep_camelize_keys(options)
+      react_opts['inputProps']['name'] = options['name'] if options['name'] && react_opts['inputProps']
       react_opts
     end
 

--- a/test/integration/report_template_js_test.rb
+++ b/test/integration/report_template_js_test.rb
@@ -77,4 +77,11 @@ class ReportTemplateJSIntegrationTest < IntegrationTestWithJavascript
     assert select.text ''
     assert select[:class].include?('select2-container-disabled'), true
   end
+
+  test "should have correct generate_at field" do
+    template = FactoryBot.create(:report_template)
+    visit generate_report_template_path(template)
+
+    assert_equal 'report_template_report[generate_at]', find('#report_template_report_generate_at')['name']
+  end
 end

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -50,7 +50,14 @@ class DateTimePicker extends React.Component {
   };
 
   render() {
-    const { locale, weekStartsOn, inputProps, id, placement } = this.props;
+    const {
+      locale,
+      weekStartsOn,
+      inputProps,
+      id,
+      placement,
+      name,
+    } = this.props;
     const { value, typeOfDateInput, isTimeTableOpen, hiddenValue } = this.state;
     const popover = (
       <Popover
@@ -85,6 +92,7 @@ class DateTimePicker extends React.Component {
             aria-label="date-picker-input"
             type="text"
             className="date-time-input"
+            name={name}
             value={hiddenValue ? '' : this.formatDate()}
             onChange={e => this.setSelected(e.target.value)}
           />
@@ -124,6 +132,7 @@ DateTimePicker.propTypes = {
   id: PropTypes.string,
   hiddenValue: PropTypes.bool,
   placement: OverlayTrigger.propTypes.placement,
+  name: PropTypes.string,
 };
 DateTimePicker.defaultProps = {
   value: new Date(),
@@ -133,5 +142,6 @@ DateTimePicker.defaultProps = {
   id: 'datetime-picker-popover',
   hiddenValue: true,
   placement: 'top',
+  name: undefined,
 };
 export default DateTimePicker;


### PR DESCRIPTION
The field value is now correctly submitted. Even though I see the jobs in dynflow console, they seem to be 'scheduled pending' forever. I am not sure if there is something wrong in my setup or if it is actually another bug. It would be nice if someone dynflow savvy could test.
 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
