### PR TITLE
Fixes #29010 - graphql: fix creating object by user with create perission

### DIFF
--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -33,11 +33,12 @@ module Mutations
       authorizer = Authorizer.new(user)
       permission_name = resource.permission_name(action)
 
-      unless authorizer.can?(permission_name, resource)
-        raise GraphQL::ExecutionError.new(
-          _('Unauthorized. You do not have the required permission %s.') % permission_name
-        )
-      end
+      return if action == :create && authorizer.can?(permission_name)
+      return if action != :create && authorizer.can?(permission_name, resource)
+
+      raise GraphQL::ExecutionError.new(
+        _('Unauthorized. You do not have the required permission %s.') % permission_name
+      )
     end
 
     def validate_object(resource)

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -368,6 +368,9 @@ viewer_23_0:
 viewer_24_0:
   filter: viewer_24
   permission: view_external_parameters
+viewer_25_0:
+  filter: viewer_25
+  permission: view_subnets
 default_role_1_0:
   filter: default_role_1
   permission: view_tasks

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -103,6 +103,8 @@ viewer_23:
   role_id: 5
 viewer_24:
   role_id: 5
+viewer_25:
+  role_id: 5
 default_role_1:
   role_id: 7
 destroy_hosts_1:

--- a/test/graphql/mutations/models/update_mutation_test.rb
+++ b/test/graphql/mutations/models/update_mutation_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Mutations
   module Models
-    class UpdateMutationTest < ActiveSupport::TestCase
+    class UpdateMutationTest < GraphQLQueryTestCase
       let(:model) { FactoryBot.create(:model) }
       let(:model_id) { Foreman::GlobalId.for(model) }
       let(:variables) do
@@ -47,35 +47,47 @@ module Mutations
       end
 
       context 'with admin user' do
-        let(:user) { FactoryBot.create(:user, :admin) }
+        let(:context_user) { FactoryBot.create(:user, :admin) }
 
-        test 'updates a model' do
-          context = { current_user: user }
-
+        test 'update a model' do
           model
 
-          assert_difference('::Model.count', 0) do
-            result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+          assert_difference(-> {::Model.count}, 0) do
             assert_empty result['errors']
             assert_empty result['data']['updateModel']['errors']
           end
-          assert_equal user.id, Audit.last.user_id
+          assert_equal context_user.id, Audit.last.user_id
+          model.reload
+          assert_equal 'SUN T2000', model.name
+        end
+      end
+
+      context 'with edit permission' do
+        let(:context_user) do
+          setup_user('edit', 'models') do |user|
+            user.roles << Role.find_by(name: 'Viewer')
+          end
+        end
+
+        test 'update a model' do
+          model
+
+          assert_difference(-> {::Model.count}, 0) do
+            assert_empty result['errors']
+          end
+          assert_equal context_user.id, Audit.last.user_id
           model.reload
           assert_equal 'SUN T2000', model.name
         end
       end
 
       context 'with user with view permissions' do
-        setup do
-          model
-          @user = setup_user 'view', 'models'
-        end
+        let(:context_user) { setup_user('view', 'models') }
 
         test 'cannot update a model' do
-          context = { current_user: @user }
+          model
 
-          assert_difference('Model.count', 0) do
-            result = ForemanGraphqlSchema.execute(query, variables: variables, context: context)
+          assert_difference(-> {::Model.count}, 0) do
             assert_not_empty result['errors']
           end
         end


### PR DESCRIPTION
(cherry picked from commit 276240d2d36670aa90f161e08ea1df355bbdaf3c)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
