### PR TITLE
Refs #29027 - replace server_version with server_version_num

### DIFF
--- a/db/migrate/20200217110708_alter_session_sequence_to_cycle.rb
+++ b/db/migrate/20200217110708_alter_session_sequence_to_cycle.rb
@@ -2,8 +2,8 @@ class AlterSessionSequenceToCycle < ActiveRecord::Migration[5.2]
   def up
     if ActiveRecord::Base.connection.adapter_name.downcase == 'postgresql'
       change_column :sessions, :id, :bigint
-      version = Gem::Version.new(ActiveRecord::Base.connection.select_value('SHOW server_version'))
-      if version < Gem::Version.new('10')
+      pg_version = ActiveRecord::Base.connection.select_value('SHOW server_version_num').to_i
+      if pg_version < 100000
         sql = "ALTER SEQUENCE sessions_id_seq MAXVALUE 9223372036854775807 CYCLE"
       else
         sql = "ALTER SEQUENCE sessions_id_seq AS bigint CYCLE"


### PR DESCRIPTION
`SHOW server_version` returns `12.1 (Debian 12.1-1.pgdg100+1)`, which can't be parsed by  `Gem::Version.new`
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
