### PR TITLE
Fixes #29070 - HTTP Proxy taxonomy searching incorrect

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -20,6 +20,7 @@ class Taxonomy < ApplicationRecord
   has_many :ptables, -> { where(:type => 'Ptable') }, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'Ptable'
   has_many :report_templates, -> { where(:type => 'ReportTemplate') }, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'ReportTemplate'
   has_many :domains, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'Domain'
+  has_many :http_proxies, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'HttpProxy'
   has_many :realms, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'Realm'
   has_many :hostgroups, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'Hostgroup'
   has_many :environments, :through => :taxable_taxonomies, :source => :taxable, :source_type => 'Environment'

--- a/test/controllers/api/v2/http_proxies_controller_test.rb
+++ b/test/controllers/api/v2/http_proxies_controller_test.rb
@@ -4,6 +4,10 @@ module Api
   module V2
     class HttpProxiesControllerTest < ActionController::TestCase
       let(:model) { FactoryBot.create(:http_proxy) }
+      let (:myhttpproxy) { http_proxies(:myhttpproxy) }
+      let (:yourhttpproxy) { http_proxies(:yourhttpproxy) }
+      let (:loc) { FactoryBot.create(:location, http_proxies: [myhttpproxy, yourhttpproxy]) }
+      let (:org) { FactoryBot.create(:organization, http_proxies: [myhttpproxy]) }
 
       def test_index
         get :index, session: set_session_user
@@ -38,6 +42,13 @@ module Api
 
         assert_response :success
         assert_equal new_url, model.reload.url
+      end
+
+      def test_search_by_location
+        get :index, params: { :location_id => loc.id }
+        assert_response :success
+        assert_equal loc.http_proxies.length, assigns(:http_proxies).length
+        assert_same_elements assigns(:http_proxies), loc.http_proxies
       end
     end
   end

--- a/test/fixtures/http_proxies.yml
+++ b/test/fixtures/http_proxies.yml
@@ -1,0 +1,8 @@
+---
+myhttpproxy:
+  name: myhttpproxy
+  url: https://mytest.com
+
+yourhttpproxy:
+  name: yourhttpproxy
+  url: https://yourtest.com


### PR DESCRIPTION
This missing `has_many` relationship was causing scoped_searching by Organization or Location not to work for HTTP Proxies.