### PR TITLE
Fixes #28838, #28931 - Safer seeding on initialization

### DIFF
--- a/config/initializers/seeds.rb
+++ b/config/initializers/seeds.rb
@@ -1,5 +1,10 @@
 return unless (ForemanInternal.table_exists? rescue(false)) && !Foreman.in_rake? && !Rails.env.test?
 
+if ActiveRecord::Base.connection.migration_context.needs_migration?
+  Rails.logger.warn("Migrations pending, skipping seeding. Please run `foreman-rake db:migrate` manually.")
+  return
+end
+
 Foreman::Application.configure do |app|
   config.after_initialize do
     seeder = ForemanSeeder.new
@@ -9,5 +14,8 @@ Foreman::Application.configure do |app|
     else
       Rails.logger.info("No new seed file updates found. Skipping")
     end
+  rescue StandardError => e
+    Rails.logger.error("Error while attempting to seed database, please run `foreman-rake db:seed` manually!")
+    Rails.logger.error(e.full_message)
   end
 end


### PR DESCRIPTION
Make sure that migartions have run before attempting to run seeds, to
ensure we don't get into a wierd state of the database if the app is
started before the db has been migrated.
Also, catch and log errors during seeding to prevent passanger from
failing to start if an error occurs.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
