### PR TITLE
Fixes #29049 - hide deprecated images & extends projects in GCE

### DIFF
--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -154,7 +154,18 @@ module Foreman::Model
     end
 
     def available_images
-      client.images
+      images_list = client.images.current
+      if image_families_to_filter.present?
+        images_list.select! {|img| img.family.match(/#{image_families_to_filter.join("|")}/)}
+      end
+      images_list
+    end
+
+    # Includes the ability to override the images list from Google Compute Engine
+    # override this method to filter list by adding image family names
+    # Example - ['rhel', 'centos']
+    def image_families_to_filter
+      []
     end
 
     def self.model_name
@@ -230,7 +241,8 @@ module Foreman::Model
         :provider => 'google',
         :google_project => project,
         :google_client_email => email,
-        :google_json_key_location => key_path
+        :google_json_key_location => key_path,
+        :google_extra_global_projects => ['rhel-sap-cloud']
       )
     end
 

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -157,16 +157,25 @@ module Foreman::Model
       images_list = client.images.current
       if image_families_to_filter.any?
         regexp = Setting.convert_array_to_regexp(image_families_to_filter, prefix: '', suffix: '')
-        images_list.select! {|img| img.family&.match(regexp)}
+        images_list.select! { |img| img.family&.match(regexp) }
       end
       images_list
     end
 
-    # Includes the ability to override the images list from Google Compute Engine
-    # override this method to filter list by adding image family names
-    # Example - ['rhel', 'centos']
     def image_families_to_filter
-      []
+      self.class.image_families_to_filter
+    end
+
+    def self.image_families_to_filter
+      @image_families_to_filter ||= []
+    end
+
+    # Becomes easy to filter the images list from Google Compute Engine
+    # Register an image family using this method to filter list
+    # Example - 'rhel', 'centos'
+    def self.register_family_for_image_filter(family)
+      image_families_to_filter << family
+      image_families_to_filter.uniq!
     end
 
     def self.model_name

--- a/app/models/compute_resources/foreman/model/gce.rb
+++ b/app/models/compute_resources/foreman/model/gce.rb
@@ -155,8 +155,9 @@ module Foreman::Model
 
     def available_images
       images_list = client.images.current
-      if image_families_to_filter.present?
-        images_list.select! {|img| img.family.match(/#{image_families_to_filter.join("|")}/)}
+      if image_families_to_filter.any?
+        regexp = Setting.convert_array_to_regexp(image_families_to_filter, prefix: '', suffix: '')
+        images_list.select! {|img| img.family&.match(regexp)}
       end
       images_list
     end


### PR DESCRIPTION
With this commit, it appends Google extra global projects list
with 'rhel-sap-cloud' project to show images as like Google
compute engine. Also, adds a method to override image list from
google compute by adding image family names to list.

+ adding @jyejare & @ares into the loop.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
