### PR TITLE
[WIP] Fixes #24907 - PatternFly DualList - replacement for JQuery multi-select

### DIFF
--- a/app/assets/javascripts/jquery.multi-select.js
+++ b/app/assets/javascripts/jquery.multi-select.js
@@ -19,7 +19,7 @@ function multiSelectOnLoad(){
 }
 
 function multiSelectToolTips(){
-  $('select[multiple]').each(function(i,item){
+  $('select[multiple]:not(.without_jquery_multiselect)').each(function(i,item){
     var mismatches = $(item).attr('data-mismatches');
     var inheriteds = $(item).attr('data-inheriteds');
     var descendants = $(item).attr('data-descendants');

--- a/app/assets/javascripts/taxonomy_edit.js
+++ b/app/assets/javascripts/taxonomy_edit.js
@@ -1,23 +1,34 @@
 $(function() {
-  $(':checkbox').each(function(i, item) {
-    ignore_checked(item);
+  $("input.ignore_types:not(.dual_list)").each(function(i, item) {
+    ignore_checked(item, false);
   });
 });
 
-function ignore_checked(item) {
-  var current_select = $(item)
-    .closest('.tab-pane')
-    .find('select');
+function ignore_checked(item, dual_list) {
+  if(dual_list){
+    var checkBox = $(item);
+    var dualList = checkBox.closest('.tab-pane').find('.dual-list');
 
-  if ($(item).is(':checked')) {
-    current_select.attr('disabled', 'disabled');
-  } else {
-    current_select.removeAttr('disabled');
+    if (checkBox.is(':checked')) {
+      dualList.addClass('disabled');
+    } else {
+      dualList.removeClass('disabled');
+    }
+  }else{
+    var current_select = $(item)
+      .closest('.tab-pane')
+      .find('select');
+
+    if ($(item).is(':checked')) {
+      current_select.attr('disabled', 'disabled');
+    } else {
+      current_select.removeAttr('disabled');
+    }
+    if (!$(current_select).hasClass('parameter_type_selection')) {
+      $(current_select).multiSelect('refresh');
+    }
+    multiSelectToolTips();
   }
-  if (!$(current_select).hasClass('parameter_type_selection')) {
-    $(current_select).multiSelect('refresh');
-  }
-  multiSelectToolTips();
 }
 
 function parent_taxonomy_changed(element) {

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -114,41 +114,39 @@ module FormHelper
 
     items += unauthorized.map do |unauthorized_value|
       {
-        value: '',
-        label: unauthorized_value.to_s,
+        value: unauthorized_value,
+        label: '',
         hidden: true,
       }
     end
 
-    if (html_options["data-useds"])
-      JSON.parse(html_options["data-useds"]).map do |disabled_value|
-        items.each do |item|
-          item[:disabled] = true if item[:value] == disabled_value
-        end
-      end
-    end
+   items.each do |item|
+     if options[:mismatches] && options[:mismatches].include?(item[:value])
+       item[:disabled] = true
+       item[:tooltip] = __("Select this since it belongs to a host")
+     elsif options[:useds] && options[:useds].include? ...
+       item[:disabled] = true
+       item[:tooltip] = __("This is used by a host")
+     elsif ....
+     end
+   end
 
     input_id = "#{f.object_name}_#{attr_ids}"
     error_messages = f.object.errors[attr].map(&:inspect).join(', ')
-    props = {
+    props = options.merge({
       id: "dual_list_#{input_id}",
-      label: options[:label],
-      error: error_messages,
       items: items,
-      selectedIDs: selected_ids,
+      value: selected_ids,
       inputProps: {
         name: "#{f.object_name}[#{attr_ids}][]",
         id: input_id,
         className: class_name,
         form: f.options[:html][:id],
       },
-      disabled: html_options['disabled'],
     }.to_json
 
-    field(f, attr, options) do
-      f.hidden_field(attr_ids, multiple: true, :value => nil, :id => '') +
-      react_component('DualList', props)
-    end
+    f.hidden_field(attr_ids, multiple: true, :value => nil, :id => '') +
+    react_form_input('dualList', f, attr, props)
   end
 
   def line_count(f, attr)

--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -141,17 +141,26 @@ module TaxonomyHelper
     content_tag(:div, :id => resource, :class => "tab-pane") do
       attr = association.where(nil).klass.to_s.underscore.pluralize.to_sym
       selected_ids = taxonomy.selected_or_inherited_ids[ids]
-      opts = options.merge({:disabled => taxonomy.used_and_selected_or_inherited_ids[ids], :label => translated_label(resource, :select)})
-      html_opts = {'data-mismatches' => taxonomy.need_to_be_selected_ids[ids].to_json, 'data-inheriteds' => taxonomy.inherited_ids[ids].to_json,
-                   'data-useds' => taxonomy.used_ids[ids].to_json,
-                   'disabled' => (taxonomy.ignore_types.any? resource.to_s.singularize.capitalize)
-      }
+      options[:label] = translated_label(resource, :select)
+      mismatches = taxonomy.need_to_by_selected_ids[ids]
+      inheriteds = ...
+      useds = ....
       result = all_checkbox(f, resource, dual_list)
 
       if dual_list
-        result += dual_list(f, attr, association, selected_ids, opts, html_opts)
+        opts = options.merge({
+                       disabled: (taxonomy.ignore_types.any? resource.to_s.singularize.capitalize),
+                       used: used,
+                       inheriteds: inheriteds,
+                       mismatches: mismatches
+        })
+        result += dual_list(f, attr, association, selected_ids, opts)
       else
-        result += multiple_selects(f, attr, association, selected_ids, opts, html_opts)
+        html_opts = {'data-mismatches' => mismatches.to_json, 'data-inheriteds' => inheriteds.to_json,
+                   'data-useds' => useds.to_json,
+                   'disabled' => (taxonomy.ignore_types.any? resource.to_s.singularize.capitalize)
+      }
+        result += multiple_selects(f, attr, association, selected_ids, options.merge(:disabled => taxonomy.used_and_selected_or_inherited_ids[ids]), html_opts)
       end
 
       result.html_safe

--- a/app/views/subnets/_form.html.erb
+++ b/app/views/subnets/_form.html.erb
@@ -22,7 +22,10 @@
       <%= render 'fields', :f => f %>
     </div>
     <div class="tab-pane" id="domains">
-      <%= multiple_checkboxes f, :domains, f.object, Domain, {:help_inline => _("Domains in which this subnet is part"), :size => 'col-md-6', :prefix => f.object_name}, { :label => _("Domain")} %>
+      <%= multiple_checkboxes f, :domains, f.object, Domain, { :help_inline => _("Domains in which this subnet is part"),
+                                                               :size => 'col-md-10',
+                                                               :prefix => f.object_name,
+                                                               :dual_list => true }, { :label => _("Domain")} %>
     </div>
     <div class="tab-pane" id="proxies">
       <%= smart_proxy_fields f %>

--- a/app/views/taxonomies/_form.html.erb
+++ b/app/views/taxonomies/_form.html.erb
@@ -68,12 +68,12 @@
       <%= show_resource_if_allowed(f, taxonomy, :smart_proxies) %>
 
       <% if SETTINGS[:unattended] %>
-        <%= show_resource_if_allowed(f, taxonomy, :subnets) %>
+        <%= show_resource_if_allowed(f, taxonomy, :subnets, { dual_list: true }) %>
         <%= show_resource_if_allowed(f, taxonomy, :compute_resources) %>
         <%= show_resource_if_allowed(f, taxonomy, :media) %>
         <%= show_resource_if_allowed(f, taxonomy, :provisioning_templates) %>
         <%= show_resource_if_allowed(f, taxonomy, :ptables) %>
-        <%= show_resource_if_allowed(f, taxonomy, :domains) %>
+        <%= show_resource_if_allowed(f, taxonomy, :domains, { dual_list: true }) %>
         <%= show_resource_if_allowed(f, taxonomy, :realms) %>
       <% end %>
 

--- a/test/helpers/taxonomy_helper_test.rb
+++ b/test/helpers/taxonomy_helper_test.rb
@@ -27,5 +27,15 @@ class TaxonomyHelperTest < ActionView::TestCase
         end
       end
     end
+
+    it "with dual list" do
+      as_admin do
+        form = form_for(taxonomies(:organization1)) do |f|
+          all_checkbox(f, :domains, true)
+        end
+        html = Nokogiri::HTML(form)
+        assert html.css("input.ignore_types.dual_list").any?
+      end
+    end
   end
 end

--- a/webpack/assets/javascripts/react_app/components/DualList/DualList.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/DualList/DualList.fixtures.js
@@ -1,0 +1,11 @@
+export const props = {
+  id: '123',
+  items: [
+    { label: 'location_01', value: '1' },
+    { label: 'location_02', value: '2' },
+    { label: 'location_03', value: '3' },
+    { label: 'location_04', value: '4' },
+  ],
+  selectedIDs: [4],
+  disabled: false,
+};

--- a/webpack/assets/javascripts/react_app/components/DualList/DualList.js
+++ b/webpack/assets/javascripts/react_app/components/DualList/DualList.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DualListControlled as PfDualList } from 'patternfly-react';
+import { arrangeItemsBySelectedIDs } from './DualListHelper';
+
+import './DualList.scss';
+
+const DualList = props => {
+  const { id, items, selectedIDs, inputProps, disabled, error } = props;
+  const { selectedList, unselectedlist } = arrangeItemsBySelectedIDs(
+    items,
+    selectedIDs
+  );
+
+  return (
+    <div id={id} className={`dual-list ${disabled ? 'disabled' : ''}`}>
+      <PfDualList
+        allowHiddenInputs
+        left={{
+          items: unselectedlist,
+          inputProps,
+        }}
+        right={{
+          items: selectedList,
+          inputProps,
+        }}
+      />
+      <div className="dual_list_error">{error}</div>
+    </div>
+  );
+};
+
+DualList.propTypes = {
+  id: PropTypes.string,
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
+    })
+  ),
+  selectedIDs: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+  ),
+  inputProps: PropTypes.object,
+  disabled: PropTypes.bool,
+  error: PropTypes.string,
+};
+
+DualList.defaultProps = {
+  id: null,
+  items: [],
+  selectedIDs: [],
+  inputProps: {},
+  disabled: false,
+  error: null,
+};
+
+export default DualList;

--- a/webpack/assets/javascripts/react_app/components/DualList/DualList.scss
+++ b/webpack/assets/javascripts/react_app/components/DualList/DualList.scss
@@ -1,0 +1,9 @@
+.dual-list.disabled {
+  pointer-events: none;
+  cursor: not-allowed;
+
+  .dual-list-pf-item {
+    background: #f5f5f5;
+    color: #8b8d8f;
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/DualList/DualList.test.js
+++ b/webpack/assets/javascripts/react_app/components/DualList/DualList.test.js
@@ -1,0 +1,12 @@
+import { testComponentSnapshotsWithFixtures } from '../../common/testHelpers';
+import DualList from './DualList';
+import { props } from './DualList.fixtures';
+
+const fixtures = {
+  'renders DualList': props,
+};
+
+describe('DualList', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(DualList, fixtures));
+});

--- a/webpack/assets/javascripts/react_app/components/DualList/DualListConstants.js
+++ b/webpack/assets/javascripts/react_app/components/DualList/DualListConstants.js
@@ -1,0 +1,2 @@
+export const DUAL_LIST_INIT = 'DUAL_LIST_INIT';
+export const DUAL_LIST_CHANGE = 'DUAL_LIST_CHANGE';

--- a/webpack/assets/javascripts/react_app/components/DualList/DualListHelper.js
+++ b/webpack/assets/javascripts/react_app/components/DualList/DualListHelper.js
@@ -1,0 +1,10 @@
+export const arrangeItemsBySelectedIDs = (items, selectedIDs) => {
+  const selectedList = [];
+  const unselectedlist = [];
+  items.forEach(item => {
+    const selectedIDIndex = selectedIDs.indexOf(item.value);
+    const whichlist = selectedIDIndex !== -1 ? selectedList : unselectedlist;
+    whichlist.push(item);
+  });
+  return { selectedList, unselectedlist };
+};

--- a/webpack/assets/javascripts/react_app/components/DualList/__snapshots__/DualList.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/DualList/__snapshots__/DualList.test.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DualList rendering renders DualList 1`] = `
+<div
+  className="dual-list "
+  id="123"
+>
+  <DualListControlled
+    allowHiddenInputs={true}
+    left={
+      Object {
+        "inputProps": Object {},
+        "items": Array [
+          Object {
+            "label": "location_01",
+            "value": "1",
+          },
+          Object {
+            "label": "location_02",
+            "value": "2",
+          },
+          Object {
+            "label": "location_03",
+            "value": "3",
+          },
+          Object {
+            "label": "location_04",
+            "value": "4",
+          },
+        ],
+      }
+    }
+    onChange={[Function]}
+    onComponentInit={[Function]}
+    onFilterChange={[Function]}
+    onItemChange={[Function]}
+    onMainCheckboxChange={[Function]}
+    onSortClick={[Function]}
+    right={
+      Object {
+        "inputProps": Object {},
+        "items": Array [],
+      }
+    }
+  />
+  <div
+    className="dual_list_error"
+  />
+</div>
+`;

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -38,6 +38,7 @@ import ExternalLogout from './ExternalLogout';
 import Slot from './common/Slot';
 import TypeAheadSelect from './common/TypeAheadSelect';
 import DatePicker from './common/DateTimePicker/DatePicker';
+import DualList from './DualList/DualList';
 
 const componentRegistry = {
   registry: forceSingleton('component_registry', () => ({})),
@@ -134,6 +135,7 @@ const coreComponets = [
   { name: 'Slot', type: Slot },
   { name: 'TypeAheadSelect', type: TypeAheadSelect },
   { name: 'DatePicker', type: DatePicker },
+  { name: 'DualList', type: DualList },
 
   {
     name: 'RelativeDateTime',


### PR DESCRIPTION
* Added React component `DualList` for future replacement of JQuery multi-select
* Updated `multi-select` methods to work along with `DualList` component on same page.
* Fixed [#24907](https://projects.theforeman.org/issues/24907)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
