### PR TITLE
Fixes #28945 - Taxonomy scope for interfaces action

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -12,7 +12,7 @@ class HostsController < ApplicationController
   include Foreman::Controller::ConsoleCommon
 
   SEARCHABLE_ACTIONS = %w[index active errors out_of_sync pending disabled]
-  AJAX_REQUESTS = %w{compute_resource_selected current_parameters process_hostgroup process_taxonomy review_before_build scheduler_hint_selected}
+  AJAX_REQUESTS = %w{compute_resource_selected current_parameters process_hostgroup process_taxonomy review_before_build scheduler_hint_selected interfaces}
   BOOT_DEVICES = { :disk => N_('Disk'), :cdrom => N_('CDROM'), :pxe => N_('PXE'), :bios => N_('BIOS') }
   MULTIPLE_ACTIONS = %w(multiple_parameters update_multiple_parameters select_multiple_hostgroup
                         update_multiple_hostgroup

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1844,6 +1844,21 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
 
+  context 'interfaces' do
+    test 'Taxonomy scope for interfaces' do
+      post :interfaces, params: { host: { organization_id: taxonomies(:organization1).id,
+                                          location_id: taxonomies(:location1).id }},
+           session: set_session_user, xhr: true
+      assert_response :success
+
+      options = Nokogiri::HTML(@response.body).css('select.interface_domain > option').map(&:text).uniq.reject(&:blank?)
+
+      assert_includes options, domains(:mydomain).name
+      assert_includes options, domains(:yourdomain).name
+      refute_includes options, domains(:useless).name
+    end
+  end
+
   private
 
   def initialize_host


### PR DESCRIPTION
**Description of problem:**
Even though a location only has one domain selected, when creating Hosts for that location all domains are in the pull down list, but only the Subnets assigned to the location are in the pull down list.

**Steps to Reproduce:**
- Create multiple domains.
- Associate only a single domain with the location.
- While creating a host via provisioning, select the appropriate location and notice the availability of multiple domains on the "Interface" tab even when a particular location has been selected, which should only show one single domain associated with that location.

**Actual results:**
The domains that have not even been tied to the location are being shown on the "Interface" tab while creating a host on Satellite Web UI.

**Expected results:**
When a location is selected, only the domain/s associated with that location should be shown/displayed.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
