### PR TITLE
Fixes #29018 - Cherry pick to 1.22 - disabled buttons are still working

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -30,6 +30,18 @@ $(function() {
   $(document).trigger('ContentLoad');
 });
 
+// Prevents all links with the disabled attribute set to "disabled"
+// from being clicked.
+var handleDisabledClick = function(event, element){
+  var disabled = element.disabled || $(element).attr('disabled') === 'disabled';
+  if (disabled) event.preventDefault();
+  return !disabled;
+}
+
+$(document).on('click', 'a[disabled="disabled"]', function(event) {
+  return handleDisabledClick(event, this);
+});
+
 function onContentLoad(){
   tfm.store.observeStore('layout', tfm.nav.showContent);
   uninitialized_autocompletes = $.grep($('.autocomplete-input'), function(i){ return !$(i).next().hasClass('autocomplete-clear'); });
@@ -55,14 +67,8 @@ function onContentLoad(){
   tfm.tools.activateTooltips();
   tfm.tools.activateDatatables();
 
-  // Prevents all links with the disabled attribute set to "disabled"
-  // from being clicked.
-  $('a[disabled="disabled"]').click(function() {
-    // return false for actual disabled links, this is
-    // required in case the link was "enabled" after the
-    // function has registered.
-    var isDisabled = $(this).attr('disabled') === 'disabled';
-    return !isDisabled;
+  $('a[disabled="disabled"]').click(function(event) {
+    return handleDisabledClick(event, this);
   });
 
   // allow opening new window for selected links


### PR DESCRIPTION
(cherry picked from commit 3bc2e63109050069b5da08b59c11d04d6f592d65)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
