### PR TITLE
Fixes #29219 - Provide Storybook deployment

### DIFF
--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy Storybook
+
+on:
+  pull_request:
+    paths:
+      - '**[Ss]tories**'
+
+jobs:
+  deploy_storybook:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        clean: false
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+    - name: Fetch all branches
+      run: 'git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*'
+    - name: Run npm install
+      run: npm install
+    - name: Build Storybook in temporary folder
+      run: npm run build-storybook -- --output-dir=tmp/storybooks/${{ github.event.pull_request.number }}
+    - name: Checkout gh-pages
+      run: |
+        git checkout gh-pages
+        ls tmp/storybooks/${{ github.event.pull_request.number }}
+    - name: Move files to storybooks/${{ github.event.pull_request.number }}
+      run: |
+        mkdir -p storybooks/${{ github.event.pull_request.number }}
+        rm -rf storybooks/${{ github.event.pull_request.number }}/*
+        mv tmp/storybooks/${{ github.event.pull_request.number }}/* storybooks/${{ github.event.pull_request.number }}
+        ls storybooks/${{ github.event.pull_request.number }}
+        git status
+    - name: Tell Github not to use jekyll
+      run: touch .nojekyll
+    - name: Update gh-pages branch
+      run: git pull --rebase origin gh-pages
+    - name: Commit files
+      continue-on-error: true
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "Foreman Storybook Bot"
+        echo 'git add .'
+        git add .
+        git status
+        git commit -m "Storybook build for PR #${{ github.event.pull_request.number }}"
+    - name: Deploy Storybook to gh-pages branch
+      if: success()
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        force: false
+        branch: gh-pages
+    - name: Comment PR with new Storybook location
+      if: success()
+      uses: thollander/actions-comment-pull-request@master
+      with:
+        message: "Deployed the [Storybook](https://${{ github.event.pull_request.base.repo.owner.login }}.github.io/foreman/storybooks/${{ github.event.pull_request.number }}/) for this PR to the `gh-pages` branch."
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -23,10 +23,6 @@ jobs:
       run: npm install
     - name: Build Storybook in temporary folder
       run: npm run build-storybook -- --output-dir=tmp/storybooks/${{ github.event.pull_request.number }}
-    - name: Checkout gh-pages
-      run: |
-        git checkout gh-pages
-        ls tmp/storybooks/${{ github.event.pull_request.number }}
     - name: Move files to storybooks/${{ github.event.pull_request.number }}
       run: |
         mkdir -p storybooks/${{ github.event.pull_request.number }}
@@ -34,29 +30,17 @@ jobs:
         mv tmp/storybooks/${{ github.event.pull_request.number }}/* storybooks/${{ github.event.pull_request.number }}
         ls storybooks/${{ github.event.pull_request.number }}
         git status
-    - name: Tell Github not to use jekyll
-      run: touch .nojekyll
-    - name: Update gh-pages branch
-      run: git pull origin gh-pages
-    - name: Commit files
-      continue-on-error: true
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "Foreman Storybook Bot"
-        echo 'git add .'
-        git add .
-        git status
-        git commit -m "Storybook build for PR #${{ github.event.pull_request.number }}"
-    - name: Deploy Storybook to gh-pages branch
+    - name: Deploy Storybook to surge
       if: success()
-      uses: ad-m/github-push-action@master
       with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        force: false
-        branch: gh-pages
+        SURGE_LOGIN: jlenz@redhat.com
+        SURGE_TOKEN: b541d1ed09a6655320d49757721024ae
+      run: |
+        npm install --save-dev surge
+        surge --project tmp/storybooks/${{ github.event.pull_request.number }} --domain foreman-{{ github.event.pull_request.number }}.surge.sh
     - name: Comment PR with new Storybook location
       if: success()
       uses: thollander/actions-comment-pull-request@master
       with:
-        message: "Deployed the [Storybook](https://${{ github.event.pull_request.base.repo.owner.login }}.github.io/foreman/storybooks/${{ github.event.pull_request.number }}/) for this PR to the `gh-pages` branch."
+        message: "Deployed the [Storybook](https://foreman-{{ github.event.pull_request.number }}.surge.sh) for this PR to surge.sh"
         GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -18,7 +18,9 @@ jobs:
     - name: Fetch all branches
       run: 'git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*'
     - name: Run npm install
-      run: npm install
+      run: |
+        npm install
+        npm install terser@4.6.7
     - name: Build Storybook in temporary folder
       run: npm run build-storybook -- --output-dir=tmp/storybooks/${{ github.event.pull_request.number }}
     - name: Move files to storybooks/${{ github.event.pull_request.number }}
@@ -32,7 +34,6 @@ jobs:
       if: success()
       run: |
         npm install surge
-        npm install terser@4.6.7
         SURGE_LOGIN=jlenz@redhat.com SURGE_TOKEN=b541d1ed09a6655320d49757721024ae surge --project tmp/storybooks/${{ github.event.pull_request.number }} --domain foreman-{{ github.event.pull_request.number }}.surge.sh
     - name: Comment PR with new Storybook location
       if: success()

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -32,12 +32,9 @@ jobs:
         git status
     - name: Deploy Storybook to surge
       if: success()
-      with:
-        SURGE_LOGIN: jlenz@redhat.com
-        SURGE_TOKEN: b541d1ed09a6655320d49757721024ae
       run: |
         npm install --save-dev surge
-        surge --project tmp/storybooks/${{ github.event.pull_request.number }} --domain foreman-{{ github.event.pull_request.number }}.surge.sh
+        SURGE_LOGIN=jlenz@redhat.com SURGE_TOKEN=b541d1ed09a6655320d49757721024ae surge --project tmp/storybooks/${{ github.event.pull_request.number }} --domain foreman-{{ github.event.pull_request.number }}.surge.sh
     - name: Comment PR with new Storybook location
       if: success()
       uses: thollander/actions-comment-pull-request@master

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Tell Github not to use jekyll
       run: touch .nojekyll
     - name: Update gh-pages branch
-      run: git pull --rebase origin gh-pages
+      run: git pull origin gh-pages
     - name: Commit files
       continue-on-error: true
       run: |

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: '12.x'
     - name: Fetch all branches
       run: 'git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*'
     - name: Run npm install

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: test GITHUB_TOKEN
+      run: echo "${{ secrets.GITHUB_TOKEN }}"
     - uses: actions/checkout@v2
       with:
         clean: false

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Deploy Storybook to surge
       if: success()
       run: |
-        npm install --save-dev surge
+        npm install surge
         SURGE_LOGIN=jlenz@redhat.com SURGE_TOKEN=b541d1ed09a6655320d49757721024ae surge --project tmp/storybooks/${{ github.event.pull_request.number }} --domain foreman-{{ github.event.pull_request.number }}.surge.sh
     - name: Comment PR with new Storybook location
       if: success()

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -32,6 +32,7 @@ jobs:
       if: success()
       run: |
         npm install surge
+        npm install terser@4.6.7
         SURGE_LOGIN=jlenz@redhat.com SURGE_TOKEN=b541d1ed09a6655320d49757721024ae surge --project tmp/storybooks/${{ github.event.pull_request.number }} --domain foreman-{{ github.event.pull_request.number }}.surge.sh
     - name: Comment PR with new Storybook location
       if: success()

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -11,8 +11,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: test GITHUB_TOKEN
-      run: echo "${{ secrets.GITHUB_TOKEN }}"
     - uses: actions/checkout@v2
       with:
         clean: false

--- a/.github/workflows/storybook_deploy.yml
+++ b/.github/workflows/storybook_deploy.yml
@@ -12,8 +12,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        clean: false
     - uses: actions/setup-node@v1
       with:
         node-version: '10.x'

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -1,0 +1,61 @@
+name: Deploy Main Storybook
+
+on:
+  pull_request:
+    paths:
+      - '**[Ss]tories**'
+    types: [closed]
+
+jobs:
+  deploy_main_storybook:
+
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        clean: false
+    - name: Fetch all branches
+      run: 'git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*'
+    - name: Run npm install
+      run: npm install
+    - name: Build Storybook in temporary folder
+      run: npm run build-storybook -- --output-dir=tmp/storybooks/main
+    - name: Checkout gh-pages
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "Foreman Storybook Bot"
+        git checkout gh-pages
+    - name: Move files to storybooks/main
+      run: |
+        mkdir -p storybooks/main
+        rm -rf storybooks/main/*
+        mv tmp/storybooks/main/* storybooks/main
+        ls storybooks/main
+        git status
+    - name: Tell Github not to use jekyll
+      run: touch .nojekyll
+    - name: Update gh-pages branch
+      run: git pull --rebase origin gh-pages
+    - name: Commit files
+      continue-on-error: true
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "Foreman Storybook Bot"
+        echo 'git add .'
+        git add .
+        git status
+        git commit -m "Update storybooks/main after PR #${{ github.event.pull_request.number }} merged"
+    - name: Deploy Storybook to gh-pages branch
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        force: false
+        branch: gh-pages
+    - name: Comment PR with new Storybook location
+      if: success()
+      uses: thollander/actions-comment-pull-request@master
+      with:
+        message: "PR merged succesfully; Main [Storybook](https://${{ github.event.pull_request.base.repo.owner.login }}.github.io/foreman/storybooks/main/) deployed to the `gh-pages` branch."
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Tell Github not to use jekyll
       run: touch .nojekyll
     - name: Update gh-pages branch
-      run: git pull --rebase origin gh-pages
+      run: git pull origin gh-pages
     - name: Commit files
       continue-on-error: true
       run: |

--- a/.github/workflows/storybook_reminder.yml
+++ b/.github/workflows/storybook_reminder.yml
@@ -1,0 +1,21 @@
+name: Storybook Reminder
+
+on:
+  pull_request:
+    paths:
+      - '**/react_app/**js'
+      - '!**.stories.js'
+    types: opened
+
+jobs:
+  storybook_reminder:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: thollander/actions-comment-pull-request@master
+      name: Comment PR with Storybook reminder
+    # if the list of changed files contains react_app, comment the PR
+      with:
+        message: If you've added or modified React components, don't forget to update the Storybook!
+        GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/storybook_remove_after_merge.yml
+++ b/.github/workflows/storybook_remove_after_merge.yml
@@ -1,0 +1,39 @@
+name: Remove Storybook after PR is merged or closed
+
+on:
+  pull_request:
+    paths:
+      - '**[Ss]tories**'
+    types: [closed]
+
+jobs:
+  remove_storybook:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: gh-pages
+    - name: Remove files from storybooks/:pr_num/
+      run: |
+        mkdir -p storybooks/${{ github.event.pull_request.number }}
+        rm -rf storybooks/${{ github.event.pull_request.number }}
+        git status
+    - name: Tell Github not to use jekyll
+      run: touch .nojekyll
+    - name: Commit changes
+      continue-on-error: true
+      run: |
+        git config --local user.email "action@github.com"
+        git config --local user.name "Foreman Storybook Bot"
+        echo 'git add .'
+        git add .
+        git status
+        git commit -m "Remove storybooks/${{ github.event.pull_request.number }} after PR #${{ github.event.pull_request.number }} closed"
+    - name: Deploy to gh-pages branch
+      uses: ad-m/github-push-action@master
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        force: false
+        branch: gh-pages

--- a/webpack/stories/docs/getting-started.stories.mdx
+++ b/webpack/stories/docs/getting-started.stories.mdx
@@ -11,7 +11,7 @@ import { Meta } from '@theforeman/stories';
 
 ## Development setup
 
-Following steps are required to setup a webpack development environment:
+Following steps are required to set up a webpack development environment:
 
 1. **Settings**
    There are 2 relevant settings in `config/settings.yml`. At least `webpack_dev_server` should be set to true:


### PR DESCRIPTION
Uses Github Actions to deploy the React Storybook to the `gh-pages` branch.

#### On PR open, if `js` files have changed
* Comments the PR reminding you to update the Storybook if necessary

#### On PR open / update when `**stories**` files changed
* Checks out the PR
* Runs `npm build storybook`, which builds the Storybook static site inside the Github action runner
* Switches to `gh-pages` branch
* Copies Storybook static files from temp location to `/storybooks/:pr_number`
* Deploys the storybook to the `gh-pages` branch at `/storybooks/:pr_number/`.  It will be accessible at `https://theforeman.github.io/storybooks/:pr_number/`
* Comments the PR with a link to the storybook.

#### On PR merge or close without merge
* Removes the previously-deployed Storybook at `/storybooks/:pr_number/`

#### On PR merge
* Deploys the Storybook to `/storybooks/main`
* Comments the PR with a link to the main storybook

#### Current status: 
Works on my fork.  To work on `theforeman/foreman`, may require a repo settings change and/or a Github token providing access.

#### To test the PR:  
* Fork `jeremylenz/29219-storybook-deploy`
* Make a branch based off `29219-storybook-deploy`
* Change at least one `stories` file
* Make a pull request comparing YOUR `29219-storybook-deploy` and YOUR new branch
* View output on the Actions tab


