### PR TITLE
Fixes #29110 - updated fact parser to handle v3 debian OS

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -261,7 +261,7 @@ class Operatingsystem < ApplicationRecord
     "Unknown"
   end
 
-  def self.shorten_description(description)
+  def shorten_description(description)
     # This method should be overridden in the OS subclass
     # to handle shortening the specific formats of lsbdistdescription
     # returned by Facter on that OS

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -43,13 +43,14 @@ class Debian < Operatingsystem
     "Debian"
   end
 
-  def self.shorten_description(description)
+  def shorten_description(description)
     return "" if description.blank?
     s = description.dup
     s.gsub!('GNU/Linux', '')
     s.gsub!(/\(.+?\)/, '')
     s.squeeze! " "
     s.strip!
+    s += '.' + minor unless s.include?('.')
     s.presence || description
   end
 

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -37,7 +37,7 @@ class Redhat < Operatingsystem
     "Red Hat"
   end
 
-  def self.shorten_description(description)
+  def shorten_description(description)
     return "" if description.blank?
     s = description.dup
     s.gsub!('Red Hat Enterprise Linux', 'RHEL')

--- a/app/models/operatingsystems/suse.rb
+++ b/app/models/operatingsystems/suse.rb
@@ -17,7 +17,7 @@ class Suse < Operatingsystem
     "SUSE"
   end
 
-  def self.shorten_description(description)
+  def shorten_description(description)
     return "" if description.blank?
     s = description.dup
     s.gsub!('SUSE Linux Enterprise Server', 'SLES')

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -26,7 +26,8 @@ class PuppetFactParser < FactParser
         os.description = os_name + ' ' + orel.gsub('.', ' SP')
       elsif facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription]
         family = os.deduce_family || 'Operatingsystem'
-        os.description = family.constantize.shorten_description(facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription])
+        os = os.becomes(family.constantize)
+        os.description = os.shorten_description(facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription])
       end
     end
 

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -11,8 +11,8 @@ class PuppetFactParser < FactParser
       args = {:name => os_name, :major => major, :minor => minor}
       os = Operatingsystem.find_or_initialize_by(args)
       if os_name[/debian|ubuntu/i] || os.family == 'Debian'
-        if facts[:lsbdistcodename]
-          os.release_name = facts[:lsbdistcodename]
+        if facts.dig(:os, :distro, :codename).presence || facts[:lsbdistcodename]
+          os.release_name = facts.dig(:os, :distro, :codename).presence || facts[:lsbdistcodename]
         elsif os.release_name.blank?
           os.release_name = 'unknown'
         end
@@ -24,9 +24,9 @@ class PuppetFactParser < FactParser
     if os.description.blank?
       if os_name == 'SLES'
         os.description = os_name + ' ' + orel.gsub('.', ' SP')
-      elsif facts[:lsbdistdescription]
+      elsif facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription]
         family = os.deduce_family || 'Operatingsystem'
-        os.description = family.constantize.shorten_description facts[:lsbdistdescription]
+        os.description = family.constantize.shorten_description(facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription])
       end
     end
 
@@ -185,7 +185,7 @@ class PuppetFactParser < FactParser
   end
 
   def os_name
-    os_name = facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
+    os_name = facts.dig(:os, :name).presence || facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
 
     if os_name == 'RedHat' && facts[:lsbdistid] == 'RedHatEnterpriseWorkstation'
       os_name += '_Workstation'
@@ -218,9 +218,9 @@ class PuppetFactParser < FactParser
       '1.0'
     when /Debian/i
       return "99" if facts[:lsbdistcodename] =~ /sid/
-      facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+      facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
     else
-      facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+      facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
     end
   end
 end

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -168,31 +168,31 @@ class OperatingsystemTest < ActiveSupport::TestCase
 
   describe "descriptions" do
     test "Redhat LSB description should be correctly shortened" do
-      assert_equal 'RHEL 6.4', Redhat.shorten_description("Red Hat Enterprise Linux release 6.4 (Santiago)")
+      assert_equal 'RHEL 6.4', Redhat.new.shorten_description("Red Hat Enterprise Linux release 6.4 (Santiago)")
     end
 
     test "Fedora LSB description should be correctly shortened" do
-      assert_equal 'Fedora 19', Redhat.shorten_description("Fedora release 19 (Schrodinger's Cat)")
+      assert_equal 'Fedora 19', Redhat.new.shorten_description("Fedora release 19 (Schrodinger's Cat)")
     end
 
     test "Debian LSB description should be correctly shortened" do
-      assert_equal 'Debian 7.1', Debian.shorten_description("Debian GNU/Linux 7.1 (wheezy)")
+      assert_equal 'Debian 7.1', Debian.new.shorten_description("Debian GNU/Linux 7.1 (wheezy)")
     end
 
     test "Ubuntu LSB is unaltered" do
-      assert_equal 'Ubuntu 12.04.3 LTS', Debian.shorten_description("Ubuntu 12.04.3 LTS")
+      assert_equal 'Ubuntu 12.04.3 LTS', Debian.new.shorten_description("Ubuntu 12.04.3 LTS")
     end
 
     test "SLES LSB description should be correctly shortened" do
-      assert_equal 'SLES 11', Suse.shorten_description("SUSE Linux Enterprise Server 11 (x86_64)")
+      assert_equal 'SLES 11', Suse.new.shorten_description("SUSE Linux Enterprise Server 11 (x86_64)")
     end
 
     test "openSUSE LSB description should be correctly shortened" do
-      assert_equal 'openSUSE 11.4', Suse.shorten_description("openSUSE 11.4 (x86_64)")
+      assert_equal 'openSUSE 11.4', Suse.new.shorten_description("openSUSE 11.4 (x86_64)")
     end
 
     test "OSes without a shorten_description method fall back to description" do
-      assert_equal 'Arch Linux', Archlinux.shorten_description("Arch Linux")
+      assert_equal 'Arch Linux', Archlinux.new.shorten_description("Arch Linux")
     end
   end
 

--- a/test/static_fixtures/facts/facts_v3_debian.json
+++ b/test/static_fixtures/facts/facts_v3_debian.json
@@ -1,0 +1,522 @@
+{
+    "aio_agent_version": "5.5.18",
+    "augeas": {
+      "version": "1.12.0"
+    },
+    "disks": {
+      "fd0": {
+        "size": "4.00 KiB",
+        "size_bytes": 4096
+      },
+      "sda": {
+        "model": "Virtual disk",
+        "size": "16.00 GiB",
+        "size_bytes": 17179869184,
+        "vendor": "VMware"
+      },
+      "sr0": {
+        "model": "VMware IDE CDR10",
+        "size": "1.00 GiB",
+        "size_bytes": 1073741312,
+        "vendor": "NECVMWar"
+      }
+    },
+    "dmi": {
+      "bios": {
+        "release_date": "04/14/2014",
+        "vendor": "Phoenix Technologies LTD",
+        "version": "6.00"
+      },
+      "board": {
+        "manufacturer": "Intel Corporation",
+        "product": "440BX Desktop Reference Platform"
+      },
+      "chassis": {
+        "asset_tag": "No Asset Tag",
+        "type": "Other"
+      },
+      "manufacturer": "VMware, Inc.",
+      "product": {
+        "name": "VMware Virtual Platform"
+      }
+    },
+    "facterversion": "3.11.11",
+    "filesystems": "ext2,ext3,ext4",
+    "fips_enabled": false,
+    "hypervisors": {
+      "vmware": {}
+    },
+    "identity": {
+      "gid": 1000,
+      "group": "someuser",
+      "privileged": false,
+      "uid": 1000,
+      "user": "someuser"
+    },
+    "is_virtual": true,
+    "kernel": "Linux",
+    "kernelmajversion": "4.19",
+    "kernelrelease": "4.19.0-8-amd64",
+    "kernelversion": "4.19.0",
+    "load_averages": {
+      "15m": 0.0,
+      "1m": 0.0,
+      "5m": 0.0
+    },
+    "memory": {
+      "swap": {
+        "available": "1.96 GiB",
+        "available_bytes": 2100293632,
+        "capacity": "0%",
+        "total": "1.96 GiB",
+        "total_bytes": 2100293632,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "system": {
+        "available": "1.64 GiB",
+        "available_bytes": 1757913088,
+        "capacity": "15.94%",
+        "total": "1.95 GiB",
+        "total_bytes": 2091294720,
+        "used": "317.94 MiB",
+        "used_bytes": 333381632
+      }
+    },
+    "mountpoints": {
+      "/": {
+        "available": "2.99 GiB",
+        "available_bytes": 3213406208,
+        "capacity": "32.24%",
+        "device": "/dev/mapper/vg0-root",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime",
+          "errors=remount-ro"
+        ],
+        "size": "4.42 GiB",
+        "size_bytes": 4742504448,
+        "used": "1.42 GiB",
+        "used_bytes": 1529098240
+      },
+      "/boot": {
+        "available": "100.83 MiB",
+        "available_bytes": 105726976,
+        "capacity": "45.20%",
+        "device": "/dev/sda1",
+        "filesystem": "ext2",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "183.99 MiB",
+        "size_bytes": 192924672,
+        "used": "83.16 MiB",
+        "used_bytes": 87197696
+      },
+      "/dev": {
+        "available": "981.63 MiB",
+        "available_bytes": 1029316608,
+        "capacity": "0%",
+        "device": "udev",
+        "filesystem": "devtmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "relatime",
+          "size=1005192k",
+          "nr_inodes=251298",
+          "mode=755"
+        ],
+        "size": "981.63 MiB",
+        "size_bytes": 1029316608,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/hugepages": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "hugetlbfs",
+        "filesystem": "hugetlbfs",
+        "options": [
+          "rw",
+          "relatime",
+          "pagesize=2M"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/mqueue": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "mqueue",
+        "filesystem": "mqueue",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/pts": {
+        "available": "0 bytes",
+        "available_bytes": 0,
+        "capacity": "100%",
+        "device": "devpts",
+        "filesystem": "devpts",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "size": "0 bytes",
+        "size_bytes": 0,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/dev/shm": {
+        "available": "997.21 MiB",
+        "available_bytes": 1045647360,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev"
+        ],
+        "size": "997.21 MiB",
+        "size_bytes": 1045647360,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/home": {
+        "available": "1.75 GiB",
+        "available_bytes": 1877663744,
+        "capacity": "2.79%",
+        "device": "/dev/mapper/vg0-home",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "1.80 GiB",
+        "size_bytes": 1931550720,
+        "used": "51.39 MiB",
+        "used_bytes": 53886976
+      },
+      "/opt": {
+        "available": "3.19 GiB",
+        "available_bytes": 3422388224,
+        "capacity": "3.80%",
+        "device": "/dev/mapper/vg0-opt",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "3.31 GiB",
+        "size_bytes": 3557621760,
+        "used": "128.97 MiB",
+        "used_bytes": 135233536
+      },
+      "/run": {
+        "available": "178.88 MiB",
+        "available_bytes": 187572224,
+        "capacity": "10.31%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "size=204228k",
+          "mode=755"
+        ],
+        "size": "199.44 MiB",
+        "size_bytes": 209129472,
+        "used": "20.56 MiB",
+        "used_bytes": 21557248
+      },
+      "/run/lock": {
+        "available": "5.00 MiB",
+        "available_bytes": 5242880,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "size=5120k"
+        ],
+        "size": "5.00 MiB",
+        "size_bytes": 5242880,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/run/user/1000": {
+        "available": "199.44 MiB",
+        "available_bytes": 209129472,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "size=204228k",
+          "mode=700",
+          "uid=1000",
+          "gid=1000"
+        ],
+        "size": "199.44 MiB",
+        "size_bytes": 209129472,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/sys/fs/cgroup": {
+        "available": "997.21 MiB",
+        "available_bytes": 1045647360,
+        "capacity": "0%",
+        "device": "tmpfs",
+        "filesystem": "tmpfs",
+        "options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "mode=755"
+        ],
+        "size": "997.21 MiB",
+        "size_bytes": 1045647360,
+        "used": "0 bytes",
+        "used_bytes": 0
+      },
+      "/tmp": {
+        "available": "280.49 MiB",
+        "available_bytes": 294116352,
+        "capacity": "0.71%",
+        "device": "/dev/mapper/vg0-tmp",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "282.50 MiB",
+        "size_bytes": 296227840,
+        "used": "2.01 MiB",
+        "used_bytes": 2111488
+      },
+      "/var": {
+        "available": "3.10 GiB",
+        "available_bytes": 3333681152,
+        "capacity": "13.80%",
+        "device": "/dev/mapper/vg0-var",
+        "filesystem": "ext4",
+        "options": [
+          "rw",
+          "relatime"
+        ],
+        "size": "3.60 GiB",
+        "size_bytes": 3867205632,
+        "used": "508.81 MiB",
+        "used_bytes": 533524480
+      }
+    },
+    "networking": {
+      "dhcp": "10.10.1.2",
+      "domain": "dmz-ext.example.org",
+      "fqdn": "freckles.dmz-ext.example.org",
+      "hostname": "freckles",
+      "interfaces": {
+        "ens160": {
+          "bindings": [
+            {
+              "address": "10.10.254.25",
+              "netmask": "255.255.255.0",
+              "network": "10.10.254.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "fe80::250:56ff:fe93:96d",
+              "netmask": "ffff:ffff:ffff:ffff::",
+              "network": "fe80::"
+            }
+          ],
+          "dhcp": "10.10.1.2",
+          "ip": "10.10.254.25",
+          "ip6": "fe80::250:56ff:fe93:96d",
+          "mac": "00:50:56:93:09:6d",
+          "mtu": 1500,
+          "netmask": "255.255.255.0",
+          "netmask6": "ffff:ffff:ffff:ffff::",
+          "network": "10.10.254.0",
+          "network6": "fe80::",
+          "scope6": "link"
+        },
+        "lo": {
+          "bindings": [
+            {
+              "address": "127.0.0.1",
+              "netmask": "255.0.0.0",
+              "network": "127.0.0.0"
+            }
+          ],
+          "bindings6": [
+            {
+              "address": "::1",
+              "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+              "network": "::1"
+            }
+          ],
+          "ip": "127.0.0.1",
+          "ip6": "::1",
+          "mtu": 65536,
+          "netmask": "255.0.0.0",
+          "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+          "network": "127.0.0.0",
+          "network6": "::1",
+          "scope6": "host"
+        }
+      },
+      "ip": "10.10.254.25",
+      "ip6": "fe80::250:56ff:fe93:96d",
+      "mac": "00:50:56:93:09:6d",
+      "mtu": 1500,
+      "netmask": "255.255.255.0",
+      "netmask6": "ffff:ffff:ffff:ffff::",
+      "network": "10.10.254.0",
+      "network6": "fe80::",
+      "primary": "ens160",
+      "scope6": "link"
+    },
+    "os": {
+      "architecture": "amd64",
+      "distro": {
+        "codename": "buster",
+        "description": "Debian GNU/Linux 10 (buster)",
+        "id": "Debian",
+        "release": {
+          "full": "10.3",
+          "major": "10",
+          "minor": "3"
+        }
+      },
+      "family": "Debian",
+      "hardware": "x86_64",
+      "name": "Debian",
+      "release": {
+        "full": "10.3",
+        "major": "10",
+        "minor": "3"
+      },
+      "selinux": {
+        "enabled": false
+      }
+    },
+    "partitions": {
+      "/dev/mapper/vg0-home": {
+        "mount": "/home",
+        "size": "1.86 GiB",
+        "size_bytes": 1996488704
+      },
+      "/dev/mapper/vg0-opt": {
+        "mount": "/opt",
+        "size": "3.43 GiB",
+        "size_bytes": 3682598912
+      },
+      "/dev/mapper/vg0-root": {
+        "mount": "/",
+        "size": "4.55 GiB",
+        "size_bytes": 4886364160
+      },
+      "/dev/mapper/vg0-tmp": {
+        "mount": "/tmp",
+        "size": "300.00 MiB",
+        "size_bytes": 314572800
+      },
+      "/dev/mapper/vg0-var": {
+        "mount": "/var",
+        "size": "3.72 GiB",
+        "size_bytes": 3997171712
+      },
+      "/dev/sda1": {
+        "mount": "/boot",
+        "size": "190.00 MiB",
+        "size_bytes": 199229440
+      },
+      "/dev/sda2": {
+        "size": "1.96 GiB",
+        "size_bytes": 2100297728
+      },
+      "/dev/sda3": {
+        "size": "13.86 GiB",
+        "size_bytes": 14878244864
+      }
+    },
+    "path": "/home/someuser/.rbenv/shims:/home/someuser/.rbenv/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games:/opt/puppetlabs/bin",
+    "processors": {
+      "count": 1,
+      "isa": "unknown",
+      "models": [
+        "Intel(R) Xeon(R) CPU           X5650  @ 2.67GHz"
+      ],
+      "physicalcount": 1
+    },
+    "ruby": {
+      "platform": "x86_64-linux",
+      "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.4.0",
+      "version": "2.4.9"
+    },
+    "ssh": {
+      "ecdsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 3 1 08293df4bbb9d95a8337ff385de",
+          "sha256": "SSHFP 3 2 5a3146d86ab15aed38650bcb4afefd99f0d0979"
+        },
+        "key": "AAAAE2VjZHNhLXNoZYH6AV5lb+aj7Z/eyBRWR8t0W3FoavNo0/7+4YrY8Fg=",
+        "type": "ecdsa-sha2-nistp256"
+      },
+      "ed25519": {
+        "fingerprints": {
+          "sha1": "SSHFP 4 1 b57950429bc4394c660c654",
+          "sha256": "SSHFP 4 2 2cc0994fb507b743a243df844"
+        },
+        "key": "AAAAC3NzaC1lZDI1NTE5AAA0HRpjc1j1EGv26Dgbc7y",
+        "type": "ssh-ed25519"
+      },
+      "rsa": {
+        "fingerprints": {
+          "sha1": "SSHFP 1 1 38793cc5e0fdfdd160",
+          "sha256": "SSHFP 1 2 7e2e81963832536153f8b3"
+        },
+        "key": "AAAAB3NzaC1yc2EAAAADxAO2hnKcfixSbA5ODpec3WT9wFipgfpnInRTiu2zCpX0PHvrnm6rZ0Cq4tZIrjQ+AhDLjHr6PinU1jvS08CUtx3sUjSMm7D",
+        "type": "ssh-rsa"
+      }
+    },
+    "system_uptime": {
+      "days": 11,
+      "hours": 268,
+      "seconds": 967720,
+      "uptime": "11 days"
+    },
+    "timezone": "GMT",
+    "virtual": "vmware"
+  }

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -91,6 +91,16 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
       assert_equal first_os, second_os
     end
 
+    test "should set os.release_name to the lsbdistcodename fact on Debian facter v3" do
+      @importer = PuppetFactParser.new(debian_facts_v3)
+      assert_equal 'Debian', os.name
+      assert_equal 'Debian 10', os.title
+      assert_equal 'Debian 10', os.description
+      assert_equal '10', os.major
+      assert_equal '3', os.minor
+      assert_equal 'buster', os.release_name
+    end
+
     test "should not set os.release_name to the lsbdistcodename on non-Debian OS" do
       assert_not_equal 'Santiago', os.release_name
     end
@@ -429,6 +439,10 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
 
   def debian_facts
     read_json_fixture('facts/facts_debian.json')['facts']
+  end
+
+  def debian_facts_v3
+    read_json_fixture('facts/facts_v3_debian.json')
   end
 
   def rhel_7_workstation_facts

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -94,8 +94,8 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     test "should set os.release_name to the lsbdistcodename fact on Debian facter v3" do
       @importer = PuppetFactParser.new(debian_facts_v3)
       assert_equal 'Debian', os.name
-      assert_equal 'Debian 10', os.title
-      assert_equal 'Debian 10', os.description
+      assert_equal 'Debian 10.3', os.title
+      assert_equal 'Debian 10.3', os.description
       assert_equal '10', os.major
       assert_equal '3', os.minor
       assert_equal 'buster', os.release_name


### PR DESCRIPTION
Added example JSON output from Facter v3 (VMWare, Debian 10.3) and
updated fact parser to handle LSB information from v3 "os" tree.

As part of this patch, I am adding stubbing of DNS calls as I noticed it
slows down fact tests 10x. Chances are there are other places in our
huge test codebase.