### PR TITLE
Fixes #29249 - Fix chartbox overflowed title

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Card, Modal } from 'patternfly-react';
 import { isEqual } from 'lodash';
 import classNames from 'classnames';
+import ElipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import DonutChart from '../common/charts/DonutChart';
 import BarChart from '../common/charts/BarChart';
 import { navigateToSearch } from '../../../services/charts/DonutChartService';
@@ -88,7 +89,7 @@ class ChartBox extends React.Component {
       >
         <Card.Heading>
           <Card.Title className="pointer panel-title" {...headerProps}>
-            {title}
+            <ElipsisWithTooltip> {title} </ElipsisWithTooltip>
           </Card.Title>
         </Card.Heading>
         <Card.Body>

--- a/webpack/assets/javascripts/react_app/components/ChartBox/__snapshots__/ChartBox.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/__snapshots__/ChartBox.test.js.snap
@@ -16,7 +16,11 @@ exports[`ChartBox error 1`] = `
     <CardTitle
       className="pointer panel-title"
     >
-      some title
+      <EllipisWithTooltip>
+         
+        some title
+         
+      </EllipisWithTooltip>
     </CardTitle>
   </CardHeading>
   <CardBody
@@ -64,7 +68,11 @@ exports[`ChartBox pending 1`] = `
     <CardTitle
       className="pointer panel-title"
     >
-      some title
+      <EllipisWithTooltip>
+         
+        some title
+         
+      </EllipisWithTooltip>
     </CardTitle>
   </CardHeading>
   <CardBody
@@ -116,7 +124,11 @@ exports[`ChartBox resolved 1`] = `
       onClick={[Function]}
       title="sone tooltip"
     >
-      some title
+      <EllipisWithTooltip>
+         
+        some title
+         
+      </EllipisWithTooltip>
     </CardTitle>
   </CardHeading>
   <CardBody


### PR DESCRIPTION
Before:
![overflow-chart-box](https://user-images.githubusercontent.com/11807069/75771413-9c58fb00-5d52-11ea-9a07-4dcad4771be1.png)

After:
![with-elipsis](https://user-images.githubusercontent.com/11807069/75771418-9fec8200-5d52-11ea-8360-e9a9da2e0dae.png)

