### PR TITLE
Fixes #29248 - add DNS stubs for all tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -92,9 +92,17 @@ end
 class ActiveSupport::TestCase
   extend Robottelo::Reporter::TestAttributes
   prepend TestCaseRailsLoggerExtensions
+  setup :setup_dns_stubs
 
   class << self
     alias_method :test, :it
+  end
+
+  def setup_dns_stubs
+    Resolv::DNS.any_instance.stubs(:getname).raises(Resolv::ResolvError, "DNS must be stub: Resolv::DNS.any_instance.stubs(:getname).returns('example.com')")
+    Resolv::DNS.any_instance.stubs(:getnames).raises(Resolv::ResolvError, "DNS must be stub: Resolv::DNS.any_instance.stubs(:getnames).returns(['example.com'])")
+    Resolv::DNS.any_instance.stubs(:getaddress).raises(Resolv::ResolvError, "DNS must be stub: Resolv::DNS.any_instance.stubs(:getaddress).returns('127.0.0.15')")
+    Resolv::DNS.any_instance.stubs(:getaddresses).raises(Resolv::ResolvError, "DNS must be stub: Resolv::DNS.any_instance.stubs(:getaddresses).returns(['127.0.0.15'])")
   end
 end
 


### PR DESCRIPTION
Some tests are randomly slow, this should help and also it should
prevent from relying on doing real DNS queries. I ran tests locally but
closed the window, need to see how CI confirms this. I expect errors.