### PR TITLE
Fixes #29258 - Initialize dynflow in puma workers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -330,7 +330,7 @@ module Foreman
     def init_dynflow
       dynflow.eager_load_actions!
 
-      if !dynflow.config.lazy_initialization && defined?(PhusionPassenger)
+      if defined?(PhusionPassenger) && !dynflow.config.lazy_initialization
         PhusionPassenger.on_event(:starting_worker_process) do |forked|
           dynflow.initialize! if forked
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -330,13 +330,9 @@ module Foreman
     def init_dynflow
       dynflow.eager_load_actions!
 
-      unless dynflow.config.lazy_initialization
-        if defined?(PhusionPassenger)
-          PhusionPassenger.on_event(:starting_worker_process) do |forked|
-            dynflow.initialize! if forked
-          end
-        else
-          dynflow.initialize!
+      if !dynflow.config.lazy_initialization && defined?(PhusionPassenger)
+        PhusionPassenger.on_event(:starting_worker_process) do |forked|
+          dynflow.initialize! if forked
         end
       end
     end

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -12,3 +12,8 @@ threads ENV.fetch('FOREMAN_PUMA_THREADS_MIN', 0).to_i, ENV.fetch('FOREMAN_PUMA_T
 # The default is "0" for puma. Recommending "2" for foreman
 #
 workers ENV.fetch('FOREMAN_PUMA_WORKERS', 2).to_i
+
+on_worker_boot do
+  dynflow = ::Rails.application.dynflow
+  dynflow.initialize! unless dynflow.config.lazy_initialization
+end


### PR DESCRIPTION
When running puma in clustered mode in production, Dynflow would get initialized
in the master process before workers were forked off and due to CoW the workers
would use the same world id.

With this commit we will eagerly initialize Dynflow only when running under
Passenger. When running under puma, we will initialize Dynflow in workers.

kudos to @ekohl for looking into this with me

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
