### PR TITLE
Fixes #29263 - catch permission error for hypervisor name

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -294,4 +294,14 @@ module ComputeResourcesVmsHelper
       }
     )
   end
+
+  def vmware_vm_hypervisor_name(vm)
+    vm.hypervisor&.name
+  rescue RbVmomi::Fault => e
+    if e.fault.instance_of?(RbVmomi::VIM::NoPermission)
+      "<#{_('Missing permission')} #{e.fault.privilegeId}>"
+    else
+      raise e
+    end
+  end
 end

--- a/app/views/compute_resources_vms/index/_vmware.html.erb
+++ b/app/views/compute_resources_vms/index/_vmware.html.erb
@@ -21,7 +21,7 @@
           <%= vm_state(vm) %></span>
       </td>
       <td><%= vm.operatingsystem %></td>
-      <td><%= vm.hypervisor&.name %></td>
+      <td><%= vmware_vm_hypervisor_name(vm) %></td>
       <td>
         <%= action_buttons(vm_power_action(vm, authorizer),
                          (display_link_if_authorized(_('Console'), hash_for_console_compute_resource_vm_path(:compute_resource_id => @compute_resource, :id => vm.identity).merge(:auth_object => @compute_resource, :authorizer => authorizer)) if vm.ready?),


### PR DESCRIPTION
This reverts commit b7d88a6c5c307312fae0404ceb1d5717e1cf313a (#6667)

@timogoebel unless you have an idea how to check permissions prior to showing this information, we should remove this as some users do not have access to the information.

Given this is only place where users need such permission, I suggest not to show it as an easy fix.