### PR TITLE
Fixes #29265 - do not cache datacenters list

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -79,9 +79,7 @@ module Foreman::Model
     end
 
     def datacenters
-      cache.cache(:datacenters) do
-        name_sort(client.datacenters.all)
-      end
+      name_sort(client.datacenters.all)
     end
 
     def cluster(cluster)


### PR DESCRIPTION
Datacenters are being cached, even though they are used only while creating compute resource.
That makes them being cached under cache key with empty `cr_id` and it reuses the cache on next CR creation.

### Problem

I have two users every user has access to one datacenter, I create CR_one with first user and first DC, everything works as expected.
I go ahead and try to create CR_second with second user and second DC, but I can only see the previously cached DCs, what is incorrectly only first DC.