### PR TITLE
Refs #29258 - Lazy initialize dynflow during rake tasks

### DIFF
--- a/lib/foreman/dynflow/configuration.rb
+++ b/lib/foreman/dynflow/configuration.rb
@@ -5,6 +5,7 @@ module Foreman
         super
         self.pool_size = SETTINGS.fetch(:dynflow, {})
                                  .fetch(:pool_size, pool_size)
+        self.lazy_initialization = rake_task_with_executor? || self.lazy_initialization
       end
 
       # Action related info such as exceptions raised inside the actions' methods


### PR DESCRIPTION
which need executor


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
