### PR TITLE
Fixes #29275 - Documentation button for reports

### DIFF
--- a/app/views/report_templates/index.html.erb
+++ b/app/views/report_templates/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Report Templates") %>
 
 <% title_actions new_link(_("Create Template")),
-                 documentation_button('4.11ReportTemplates')
+                 documentation_button('4.11Reports')
 %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">


### PR DESCRIPTION
Fixes the documentation button linking to a none existing section.