### PR TITLE
Fixes #29292 - move pagination_options to the client

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -521,6 +521,6 @@ module ApplicationHelper
   end
 
   def ui_settings
-    { perPage: Setting['entries_per_page'], perPageOptions: per_page_options }
+    { perPage: Setting['entries_per_page'] }
   end
 end

--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -7,17 +7,10 @@ module PaginationHelper
     end
   end
 
-  def per_page_options(options = [5, 10, 15, 25, 50])
-    options << Setting[:entries_per_page].to_i
-    options << params[:per_page].to_i if params[:per_page].present?
-    options.uniq.sort
-  end
-
   def react_pagination_props(collection = nil, classname = nil)
     {
       viewType: 'table',
       itemCount: collection.total_entries,
-      perPageOptions: per_page_options,
       perPage: Setting[:entries_per_page],
       classNames: {pagination_classes: classname},
     }

--- a/webpack/assets/javascripts/react_app/Root/Context/ForemanContext.js
+++ b/webpack/assets/javascripts/react_app/Root/Context/ForemanContext.js
@@ -7,5 +7,4 @@ export const useForemanContext = () => React.useContext(getForemanContext());
 
 export const useForemanVersion = () => useForemanContext().version;
 export const useForemanSettings = () => useForemanContext().UISettings;
-export const usePaginationOptions = () => useForemanSettings().perPageOptions;
 export const useForemanDocUrl = () => useForemanContext().docUrl;

--- a/webpack/assets/javascripts/react_app/components/Pagination/Pagination.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/Pagination.js
@@ -3,15 +3,13 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { Paginator } from 'patternfly-react';
 import { translateObject } from '../../common/helpers';
+import { usePaginationOptions } from './PaginationHelper';
 import {
   getURIpage,
   getURIperPage,
   changeQuery,
 } from '../../common/urlHelpers';
-import {
-  useForemanSettings,
-  usePaginationOptions,
-} from '../../Root/Context/ForemanContext';
+import { useForemanSettings } from '../../Root/Context/ForemanContext';
 import './pagination.scss';
 
 const Pagination = props => {

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationHelper.js
@@ -1,0 +1,12 @@
+import { getURIperPage } from '../../common/urlHelpers';
+import { useForemanSettings } from '../../Root/Context/ForemanContext';
+
+export const usePaginationOptions = () => {
+  const perPageOptions = new Set([5, 10, 15, 25, 50]);
+  const { perPage } = useForemanSettings();
+  const URIPerPage = getURIperPage();
+
+  perPageOptions.add(perPage);
+  if (URIPerPage) perPageOptions.add(URIPerPage);
+  return [...perPageOptions].sort((a, b) => a - b);
+};

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationHelper.test.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationHelper.test.js
@@ -1,0 +1,12 @@
+import { usePaginationOptions } from './PaginationHelper';
+import * as helpers from '../../common/urlHelpers';
+
+describe('Pagination Helper', () => {
+  it('should render pagination options', () => {
+    expect(usePaginationOptions()).toMatchSnapshot();
+  });
+  it('should add per_page query to pagination options and sort it', () => {
+    helpers.getURIperPage = jest.fn().mockImplementation(() => 3);
+    expect(usePaginationOptions()).toMatchSnapshot();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/Pagination/__snapshots__/Pagination.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Pagination/__snapshots__/Pagination.test.js.snap
@@ -27,7 +27,8 @@ exports[`Pagination rendering from erb renders layout 1`] = `
       "perPageOptions": Array [
         5,
         10,
-        20,
+        15,
+        25,
         50,
       ],
     }

--- a/webpack/assets/javascripts/react_app/components/Pagination/__snapshots__/PaginationHelper.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Pagination/__snapshots__/PaginationHelper.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Pagination Helper should add per_page query to pagination options and sort it 1`] = `
+Array [
+  3,
+  5,
+  10,
+  15,
+  25,
+  50,
+]
+`;
+
+exports[`Pagination Helper should render pagination options 1`] = `
+Array [
+  5,
+  10,
+  15,
+  25,
+  50,
+]
+`;

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/components/AuditsTable.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/components/AuditsTable.js
@@ -4,7 +4,7 @@ import { withRenderHandler } from '../../../../common/HOC';
 import AuditsList from '../../../../components/AuditsList';
 import AuditsLoadingPage from './AuditsLoadingPage';
 import Pagination from '../../../../components/Pagination/Pagination';
-import { usePaginationOptions } from '../../../../Root/Context/ForemanContext';
+import { usePaginationOptions } from '../../../../components/Pagination/PaginationHelper';
 
 const AuditsTable = ({ audits, page, itemCount, fetchAndPush }) => {
   const perPageOptions = usePaginationOptions();


### PR DESCRIPTION
As it discussed here https://github.com/theforeman/foreman/pull/7139#discussion_r388370680, `pagination_options` can be computed directly in the client