### PR TITLE
Revert "Fixes #28945 - Taxonomy scope for interfaces action"

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -12,7 +12,7 @@ class HostsController < ApplicationController
   include Foreman::Controller::ConsoleCommon
 
   SEARCHABLE_ACTIONS = %w[index active errors out_of_sync pending disabled]
-  AJAX_REQUESTS = %w{compute_resource_selected current_parameters process_hostgroup process_taxonomy review_before_build scheduler_hint_selected interfaces}
+  AJAX_REQUESTS = %w{compute_resource_selected current_parameters process_hostgroup process_taxonomy review_before_build scheduler_hint_selected}
   BOOT_DEVICES = { :disk => N_('Disk'), :cdrom => N_('CDROM'), :pxe => N_('PXE'), :bios => N_('BIOS') }
   MULTIPLE_ACTIONS = %w(multiple_parameters update_multiple_parameters select_multiple_hostgroup
                         update_multiple_hostgroup

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1844,21 +1844,6 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
 
-  context 'interfaces' do
-    test 'Taxonomy scope for interfaces' do
-      post :interfaces, params: { host: { organization_id: taxonomies(:organization1).id,
-                                          location_id: taxonomies(:location1).id }},
-           session: set_session_user, xhr: true
-      assert_response :success
-
-      options = Nokogiri::HTML(@response.body).css('select.interface_domain > option').map(&:text).uniq.reject(&:blank?)
-
-      assert_includes options, domains(:mydomain).name
-      assert_includes options, domains(:yourdomain).name
-      refute_includes options, domains(:useless).name
-    end
-  end
-
   private
 
   def initialize_host


### PR DESCRIPTION
Reverts GH-7468