### PR TITLE
Refs #28320 - Allow sass-rails 5.x again

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -4,7 +4,7 @@ group :assets do
   gem 'gettext_i18n_rails_js', '~> 1.0'
   gem 'execjs', '>= 1.4.0', '< 3.0'
   gem 'uglifier', '>= 1.0.3'
-  gem 'sass-rails', '~> 6.0'
+  gem 'sass-rails', '>= 5.0', '< 7.0'
   # this one is a dependecy for x-editable-rails
   case SETTINGS[:rails]
   when '5.2'


### PR DESCRIPTION
This partially reverts 26dda8dbbf32d357657c3d22018c9d247fb0cb4e. The reason is that the sassc RPM packaging was broken. However, there's nothing (yet) that really needs it. This allows testing with the newer version wil allowing the older one as well.