### PR TITLE
Fixes #29324 - Adding head tags dynamically with react

### DIFF
--- a/webpack/assets/javascripts/react_app/common/document.js
+++ b/webpack/assets/javascripts/react_app/common/document.js
@@ -4,11 +4,3 @@
  */
 export const doesDocumentHasFocus = () =>
   document.hasFocus ? document.hasFocus() : true;
-
-/**
- * Update title of document
- * @param {String} title - the title
- */
-export const updateDocumentTitle = title => {
-  document.title = title;
-};

--- a/webpack/assets/javascripts/react_app/components/Head/index.js
+++ b/webpack/assets/javascripts/react_app/components/Head/index.js
@@ -1,0 +1,11 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Helmet } from 'react-helmet';
+
+const Head = ({ children }) => <Helmet>{children}</Helmet>;
+
+Head.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Head;

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.fixtures.js
@@ -2,7 +2,7 @@ import { breadcrumbBar } from '../../../components/BreadcrumbBar/BreadcrumbBar.f
 import { SearchBarProps } from '../../../components/SearchBar/SearchBar.fixtures';
 
 export const pageLayoutMock = {
-  header: 'Page',
+  headTags: { title: 'some title' },
   searchable: true,
   searchProps: SearchBarProps,
   customBreadcrumbs: null,

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -1,15 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col, Spinner } from 'patternfly-react';
-import { updateDocumentTitle } from '../../../common/document';
 import { changeQuery } from '../../../common/urlHelpers';
 
 import ToastsList from '../../../components/ToastsList';
 import BreadcrumbBar from '../../../components/BreadcrumbBar';
 import SearchBar from '../../../components/SearchBar';
+import Head from '../../../components/Head';
 
 const PageLayout = ({
-  header,
   searchable,
   searchProps,
   searchQuery,
@@ -18,55 +17,56 @@ const PageLayout = ({
   customBreadcrumbs,
   breadcrumbOptions,
   toolbarButtons,
+  header,
   toastNotifications,
   beforeToolbarComponent,
   isLoading,
   children,
-}) => {
-  updateDocumentTitle(header);
-  return (
-    <div id="main">
-      <div id="react-content">
-        <ToastsList railsMessages={toastNotifications} />
-        <div id="breadcrumb">
-          {!breadcrumbOptions && (
-            <div className="row form-group">
-              <h1 className="col-md-8">{header}</h1>
-            </div>
-          )}
-          {customBreadcrumbs
-            ? { customBreadcrumbs }
-            : breadcrumbOptions && <BreadcrumbBar {...breadcrumbOptions} />}
-        </div>
-        {beforeToolbarComponent}
-        <Row>
-          <Col className="title_filter" md={searchable ? 6 : 4}>
-            {searchable && (
-              <SearchBar
-                data={searchProps}
-                initialQuery={searchQuery}
-                onSearch={onSearch}
-                onBookmarkClick={onBookmarkClick}
-              />
-            )}
-            &nbsp;
-          </Col>
-          <Col id="title_action" md={searchable ? 6 : 8}>
-            <div className="btn-toolbar pull-right">
-              {isLoading && (
-                <div id="toolbar-spinner">
-                  <Spinner loading size="sm" />
-                </div>
-              )}
-              {toolbarButtons}
-            </div>
-          </Col>
-        </Row>
-        {children}
+}) => (
+  <div id="main">
+    <div id="react-content">
+      <Head>
+        <title>{header}</title>
+      </Head>
+      <ToastsList railsMessages={toastNotifications} />
+      <div id="breadcrumb">
+        {!breadcrumbOptions && (
+          <div className="row form-group">
+            <h1 className="col-md-8">{header}</h1>
+          </div>
+        )}
+        {customBreadcrumbs
+          ? { customBreadcrumbs }
+          : breadcrumbOptions && <BreadcrumbBar {...breadcrumbOptions} />}
       </div>
+      {beforeToolbarComponent}
+      <Row>
+        <Col className="title_filter" md={searchable ? 6 : 4}>
+          {searchable && (
+            <SearchBar
+              data={searchProps}
+              initialQuery={searchQuery}
+              onSearch={onSearch}
+              onBookmarkClick={onBookmarkClick}
+            />
+          )}
+          &nbsp;
+        </Col>
+        <Col id="title_action" md={searchable ? 6 : 8}>
+          <div className="btn-toolbar pull-right">
+            {isLoading && (
+              <div id="toolbar-spinner">
+                <Spinner loading size="sm" />
+              </div>
+            )}
+            {toolbarButtons}
+          </div>
+        </Col>
+      </Row>
+      {children}
     </div>
-  );
-};
+  </div>
+);
 
 PageLayout.propTypes = {
   children: PropTypes.node.isRequired,

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.test.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.test.js
@@ -3,6 +3,8 @@ import PageLayout from './PageLayout';
 import { pageLayoutMock } from './PageLayout.fixtures';
 import { toast } from '../../../components/ToastsList/ToastList.fixtures';
 
+jest.unmock('react-helmet');
+
 const pageLayoutFixtures = {
   'render pageLayout w/search': pageLayoutMock,
   'render pageLayout without search': { ...pageLayoutMock, searchable: false },

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -7,6 +7,9 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={Array []}
     />
@@ -98,6 +101,9 @@ exports[`render pageLayout w/search 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={Array []}
     />
@@ -188,6 +194,9 @@ exports[`render pageLayout w/toastNotifications 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={
         Array [
@@ -286,6 +295,9 @@ exports[`render pageLayout w/toolBar 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={Array []}
     />
@@ -378,6 +390,9 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={Array []}
     />
@@ -444,6 +459,9 @@ exports[`render pageLayout without breadcrumbs 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={Array []}
     />
@@ -455,9 +473,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
       >
         <h1
           className="col-md-8"
-        >
-          Page
-        </h1>
+        />
       </div>
     </div>
     <Row
@@ -518,6 +534,9 @@ exports[`render pageLayout without search 1`] = `
   <div
     id="react-content"
   >
+    <Head>
+      <title />
+    </Head>
     <Connect(ToastsList)
       railsMessages={Array []}
     />


### PR DESCRIPTION
With [react-helmet](https://github.com/nfl/react-helmet) react components can add head tags (title. meta, etc) dynamically. This package already exists in [katello](https://github.com/Katello/katello/blob/bc7a371aa24d2842a0ca0c8c4cd725fb7fd001be/webpack/containers/Application/Headers.js) but should be in implemented in foreman for reuse.