### PR TITLE
Fixes #28363 - Drop lookup key matcher length limit

### DIFF
--- a/db/migrate/20200311134414_change_match_to_text_in_lookupvalue.rb
+++ b/db/migrate/20200311134414_change_match_to_text_in_lookupvalue.rb
@@ -1,0 +1,5 @@
+class ChangeMatchToTextInLookupvalue < ActiveRecord::Migration[5.2]
+  def change
+    change_column :lookup_values, :match, :text, :limit => nil
+  end
+end

--- a/test/models/hostgroup_test.rb
+++ b/test/models/hostgroup_test.rb
@@ -373,26 +373,11 @@ class HostgroupTest < ActiveSupport::TestCase
     assert hostgroup.read_attribute(:root_pass).blank?, 'root_pass should not be copied and stored on child'
   end
 
-  test "hostgroup name can't be too big to create lookup value matcher over 255 characters" do
-    parent = FactoryBot.create(:hostgroup)
-    min_lookupvalue_length = "hostgroup=".length + parent.title.length + 1
-    hostgroup = Hostgroup.new :parent => parent, :name => 'a' * 256
-    refute_valid hostgroup
-    assert_equal "is too long (maximum is %s characters)" % (255 - min_lookupvalue_length), hostgroup.errors[:name].first
-  end
-
   test "hostgroup name can be up to 255 characters" do
     parent = FactoryBot.create(:hostgroup)
     min_lookupvalue_length = "hostgroup=".length + parent.title.length + 1
     hostgroup = Hostgroup.new :parent => parent, :name => 'a' * (255 - min_lookupvalue_length)
     assert_valid hostgroup
-  end
-
-  test "hostgroup should not save when matcher is exactly 256 characters" do
-    parent = FactoryBot.create(:hostgroup, :name => 'a' * 244)
-    hostgroup = Hostgroup.new :parent => parent, :name => 'b'
-    refute_valid hostgroup
-    assert_equal _("is too long (maximum is 0 characters)"), hostgroup.errors[:name].first
   end
 
   test "to_param" do

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -19,7 +19,6 @@ class LocationTest < ActiveSupport::TestCase
       '',
       ' ',
       "\t",
-      *RFauxFactory.gen_strings(247).values,
     ]
   end
 

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -23,7 +23,6 @@ class OrganizationTest < ActiveSupport::TestCase
       '',
       ' ',
       "\t",
-      *RFauxFactory.gen_strings(243).values,
     ]
   end
 

--- a/test/models/shared/taxonomies_base_test.rb
+++ b/test/models/shared/taxonomies_base_test.rb
@@ -392,27 +392,11 @@ module TaxonomiesBaseTest
       end
     end
 
-    test "taxonomy name can't be too big to create lookup value matcher over 255 characters" do
-      parent = FactoryBot.create(:"#{taxonomy_name}")
-      min_lookupvalue_length = "#{taxonomy_name}=".length + parent.title.length + 1
-      taxonomy = taxonomy_class.new :parent => parent, :name => 'a' * (256 - min_lookupvalue_length)
-      refute_valid taxonomy
-      assert_equal "is too long (maximum is %s characters)" % (255 - min_lookupvalue_length),
-        taxonomy.errors[:name].first
-    end
-
     test "taxonomy name can be up to 255 characters" do
       parent = FactoryBot.create(:"#{taxonomy_name}")
       min_lookupvalue_length = "#{taxonomy_name}=".length + parent.title.length + 1
       taxonomy = taxonomy_class.new :parent => parent, :name => 'a' * (255 - min_lookupvalue_length)
       assert_valid taxonomy
-    end
-
-    test "taxonomy should not save when matcher is exactly 256 characters" do
-      parent = FactoryBot.create(:"#{taxonomy_name}", :name => 'a' * (255 - taxonomy_name.length - 2))
-      taxonomy = taxonomy_class.new :parent => parent, :name => 'b'
-      refute_valid taxonomy
-      assert_equal _("is too long (maximum is 0 characters)"), taxonomy.errors[:name].first
     end
 
     test 'ignores the taxable_type if current taxonomy ignores it' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -59,7 +59,6 @@ def invalid_name_list
     ' ',
     '  ',
     "\t",
-    *RFauxFactory.gen_strings(256).values,
   ]
 end
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
