### PR TITLE
Fixes #29352 - Create action_buttons in react

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.fixtures.js
@@ -1,0 +1,7 @@
+import { noop } from '../../../common/helpers';
+
+export const buttons = [
+  { title: 'first', action: { onClick: noop } },
+  { title: 'second', action: { href: 'some-url2', 'data-method': 'put' } },
+  { title: 'third', action: { onClick: noop } },
+];

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SplitButton, MenuItem, Button } from 'patternfly-react';
+
+/**
+ * Generate a button or a dropdown of buttons
+ * @param  {String} title The title of the button for the title and text inside the button
+ * @param  {Object} action action to preform when the button is click can be href with data-method or Onclick
+ * @return {Function} button component or splitbutton component
+ */
+export const ActionButtons = ({ buttons }) => {
+  if (!buttons.length) return null;
+  if (buttons.length === 1)
+    return (
+      <Button bsSize="small" {...buttons[0].action}>
+        {buttons[0].title}
+      </Button>
+    );
+  const firstButton = buttons.shift();
+  return (
+    <SplitButton
+      title={firstButton.title}
+      {...firstButton.action}
+      bsSize="small"
+    >
+      {buttons.map(button => (
+        <MenuItem key={button.title} title={button.title} {...button.action}>
+          {button.title}
+        </MenuItem>
+      ))}
+    </SplitButton>
+  );
+};
+
+ActionButtons.propTypes = {
+  buttons: PropTypes.arrayOf(
+    PropTypes.shape({
+      action: PropTypes.object,
+      title: PropTypes.string,
+    })
+  ),
+};
+
+ActionButtons.defaultProps = {
+  buttons: [],
+};

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.stories.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ActionButtons } from './ActionButtons';
+import Story from '../../../../../../stories/components/Story';
+import Text from '../../../../../../stories/components/Text';
+
+import { buttons } from './ActionButtons.fixtures';
+
+export default {
+  title: 'Components|Common|ActionButtons',
+};
+
+export const ButtonsStory = () => (
+  <Story>
+    <Text>
+      <u>Input</u>: an array of button props each contaning: a title string and
+      an action object. <br />
+      action can be <strong> href</strong> with <strong>data-method</strong> or
+      <strong> onClick</strong>
+      <br />
+      <u>Output</u>: a button or drop down of buttons
+      <br />
+      <br />
+    </Text>
+    <Text>No buttons</Text>
+    <ActionButtons buttons={[]} />
+    <br />
+    <Text>One button</Text>
+    <ActionButtons buttons={[buttons[0]]} />
+    <br />
+    <Text>Three buttons</Text>
+    <ActionButtons buttons={buttons} />
+  </Story>
+);
+
+ButtonsStory.story = {
+  name: 'ActionButtons',
+};

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.test.js
@@ -1,0 +1,12 @@
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+import { ActionButtons } from './ActionButtons';
+import { buttons } from './ActionButtons.fixtures';
+
+const fixtures = {
+  'renders ActionButtons with 0 button': { buttons: [] },
+  'renders ActionButtons with 1 button': { buttons: [buttons[0]] },
+  'renders ActionButtons with 3 button': { buttons },
+};
+
+describe('ActionButtons', () =>
+  testComponentSnapshotsWithFixtures(ActionButtons, fixtures));

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/__snapshots__/ActionButtons.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/__snapshots__/ActionButtons.test.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionButtons renders ActionButtons with 0 button 1`] = `""`;
+
+exports[`ActionButtons renders ActionButtons with 1 button 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsSize="small"
+  bsStyle="default"
+  disabled={false}
+  onClick={[Function]}
+>
+  first
+</Button>
+`;
+
+exports[`ActionButtons renders ActionButtons with 3 button 1`] = `
+<SplitButton
+  bsSize="small"
+  onClick={[Function]}
+  title="first"
+>
+  <MenuItem
+    bsClass="dropdown"
+    data-method="put"
+    disabled={false}
+    divider={false}
+    header={false}
+    href="some-url2"
+    key="second"
+    title="second"
+  >
+    second
+  </MenuItem>
+  <MenuItem
+    bsClass="dropdown"
+    disabled={false}
+    divider={false}
+    header={false}
+    key="third"
+    onClick={[Function]}
+    title="third"
+  >
+    third
+  </MenuItem>
+</SplitButton>
+`;


### PR DESCRIPTION
A component to group one or more buttons into a drop down like Rubys action_buttons.
gets an array or buttons and returns a button or a dropdown of buttons depending on the number of buttons