### PR TITLE
[CP 1.24]Fixes #29183 - hide image selection from compute-profile in GCE

### DIFF
--- a/app/views/compute_resources_vms/form/gce/_base.html.erb
+++ b/app/views/compute_resources_vms/form/gce/_base.html.erb
@@ -1,15 +1,18 @@
 <%= select_f f, :machine_type, compute_resource.machine_types, :name, :name,
 			{ :selected => f.object.pretty_machine_type },
 			{ :label => _('Machine type'), :label_size => "col-md-2" } %>
-<%
-   arch ||= nil ; os ||= nil
-   images = possible_images(compute_resource, arch, os)
-%>
-<div id='image_selection'>
-  <%= select_f f, :image_id, images, :uuid, :name,
-               { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },
-               { :disabled => images.empty?, :label => _('Image'), :label_size => "col-md-2" } %>
-</div>
+
+<% if controller_name != "compute_attributes" %>
+	<%
+	  arch ||= nil ; os ||= nil
+	  images = possible_images(compute_resource, arch, os)
+	%>
+	<div id='image_selection'>
+	  <%= select_f f, :image_id, images, :uuid, :name,
+	               { :include_blank => (images.empty? || images.size == 1) ? false : _('Please select an image') },
+	               { :disabled => images.empty?, :label => _('Image'), :label_size => "col-md-2" } %>
+	</div>
+<% end %>
 
 <%= selectable_f f, :network, compute_resource.networks, {}, :label => _('Network'), :label_size => "col-md-2" %>
 <%= checkbox_f f, :associate_external_ip, :label => _('Associate Ephemeral External IP'), :label_size => "col-md-2" %>


### PR DESCRIPTION
(cherry picked from commit 79b4b12d365389c8beac7762ebcf1d2c64b68d66)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
