### PR TITLE
[CP 1.24]Fixes #29049 - filter images & extends projects in GCE (#7463)

### DIFF
--- a/test/models/compute_resources/gce_test.rb
+++ b/test/models/compute_resources/gce_test.rb
@@ -176,6 +176,7 @@ class Foreman::Model::GCETest < ActiveSupport::TestCase
       mock_client = mock('client')
       mock_client.stubs(:images).returns(mock_images)
       cr.stubs(:client).returns(mock_client)
+      cr.stubs(:image_families_to_filter).returns([])
 
       gce_images = cr.send(:client).images
       current_images = cr.available_images.dup
@@ -192,13 +193,12 @@ class Foreman::Model::GCETest < ActiveSupport::TestCase
       mock_client = mock('client')
       mock_client.stubs(:images).returns(mock_images)
       cr.stubs(:client).returns(mock_client)
+      cr.stubs(:image_families_to_filter).returns(['rhel'])
 
       image1.expects(:family).returns('rhel-6')
       image3.expects(:family).returns('centos-6')
 
-      cr.class.register_family_for_image_filter('rhel')
       filtered_current_images = cr.available_images
-
       assert_includes filtered_current_images, image1
       assert_equal 1, filtered_current_images.count
     end


### PR DESCRIPTION
appends Google extra global projects list with 'rhel-sap-cloud' project
to show images as Google compute engine.
Also, adds a method to filter the image list from
google compute by adding image family names to filter list.

(cherry picked from commit d55f273f7d8d0dae621713d936d5a96ae474bdb4)

Blocked by #7524 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
