### PR TITLE
Fixes #29356 - Ship puma-plugin-systemd in production

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,3 +1,4 @@
 group :service do
   gem 'puma'
+  gem 'puma-plugin-systemd'
 end

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -17,3 +17,5 @@ on_worker_boot do
   dynflow = ::Rails.application.dynflow
   dynflow.initialize! unless dynflow.config.lazy_initialization
 end
+
+plugin :systemd

--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -4,11 +4,16 @@ Documentation=https://theforeman.org
 After=network.target remote-fs.target nss-lookup.target
 
 [Service]
-Type=simple
+Type=notify
 User=foreman
 TimeoutSec=300
 WorkingDirectory=/usr/share/foreman
 ExecStart=/usr/bin/rails server --environment $FOREMAN_ENV --port $FOREMAN_PORT --binding $FOREMAN_BIND
+ExecReload=/bin/kill -USR1 $MAINPID
+ExecRestart=/bin/kill -USR2 $MAINPID
+Restart=Always
+KillMode=mixed
+WatchdogSec=30
 Environment=FOREMAN_ENV=production FOREMAN_PORT=3000 FOREMAN_BIND=0.0.0.0
 
 SyslogIdentifier=foreman


### PR DESCRIPTION
The Puma systemd plugin exposes Puma information to systemd via the sd_notify protocol giving notify, status and watchdog.

RPM packaging PR incoming.