### PR TITLE
Fixes #29272 - add template locked error only in not seeding

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -11,8 +11,8 @@ class Template < ApplicationRecord
   validates :name, :presence => true
   validates :template, :presence => true
   validates :audit_comment, :length => {:maximum => 255}
-  validate :template_changes, :if => ->(template) { (template.locked? || template.locked_changed?) && template.persisted? && !Foreman.in_rake? }
-  validate :inputs_unchanged_when_locked, :if => ->(template) { (template.locked? || template.locked_changed?) && template.persisted? && !Foreman.in_rake? }
+  validate :template_changes, :if => :run_template_changes_validation?
+  validate :inputs_unchanged_when_locked, :if => :run_template_changes_validation?
   validate do
     validate_unique_inputs!
   rescue Foreman::Exception => e
@@ -297,6 +297,10 @@ class Template < ApplicationRecord
 
   def remove_trailing_chars
     self.template = template.tr("\r", '') if template.present?
+  end
+
+  def run_template_changes_validation?
+    (locked? || locked_changed?) && persisted? && !ForemanSeeder.is_seeding
   end
 
   def inputs_unchanged_when_locked


### PR DESCRIPTION
otherwise, running the server will fail while seeding (In case a template Input was changed)
stepes to reprodcue :
1. run :  Template.find_by_name("Registered users").template_inputs.first.update_column(:value_type, "plain")
2. run rails server


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
