### PR TITLE
Fixes #1513 - distinguish between RHEL 7 Server and Workstation

### DIFF
--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -185,7 +185,13 @@ class PuppetFactParser < FactParser
   end
 
   def os_name
-    facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
+    os_name = facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
+
+    if os_name == 'RedHat' && facts[:lsbdistid] == 'RedHatEnterpriseWorkstation'
+      os_name += '_Workstation'
+    end
+
+    os_name
   end
 
   def os_release

--- a/test/static_fixtures/facts/facts_rhel_7_server.json
+++ b/test/static_fixtures/facts/facts_rhel_7_server.json
@@ -1,0 +1,521 @@
+{
+  "aio_agent_version": "5.5.19",
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.12.0"
+  },
+  "augeasversion": "1.12.0",
+  "bios_release_date": "04/01/2014",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "?-20190727_073836-buildvm-ppc64le-16.ppc.fedoraproject.org-3.fc31",
+  "blockdevice_vda_size": 10737418240,
+  "blockdevice_vda_vendor": "0x1af4",
+  "blockdevices": "vda",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "192.168.122.1",
+    "system": "192.168.122.1"
+  },
+  "disks": {
+    "vda": {
+      "size": "10.00 GiB",
+      "size_bytes": 10737418240,
+      "vendor": "0x1af4"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "04/01/2014",
+      "vendor": "SeaBIOS",
+      "version": "?-20190727_073836-buildvm-ppc64le-16.ppc.fedoraproject.org-3.fc31"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "QEMU",
+    "product": {
+      "name": "Standard PC (i440FX + PIIX, 1996)",
+      "uuid": "D018231B-9254-4F37-9FD1-52F4F39CFFB2"
+    }
+  },
+  "domain": "example.tst",
+  "facterversion": "3.11.12",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "fqdn": "adele-segur.example.tst",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "adele-segur",
+  "hypervisors": {
+    "kvm": {}
+  },
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "192.168.122.101",
+  "ipaddress6": "fe80::5054:ff:feab:15f2",
+  "ipaddress6_eth0": "fe80::5054:ff:feab:15f2",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "192.168.122.101",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "3.10",
+  "kernelrelease": "3.10.0-1062.el7.x86_64",
+  "kernelversion": "3.10.0",
+  "load_averages": {
+    "15m": 0.05,
+    "1m": 0.0,
+    "5m": 0.01
+  },
+  "lsbdistcodename": "Maipo",
+  "lsbdistdescription": "Red Hat Enterprise Linux Server release 7.7 (Maipo)",
+  "lsbdistid": "RedHatEnterpriseServer",
+  "lsbdistrelease": "7.7",
+  "lsbmajdistrelease": "7",
+  "lsbminordistrelease": "7",
+  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
+  "macaddress": "52:54:00:ab:15:f2",
+  "macaddress_eth0": "52:54:00:ab:15:f2",
+  "manufacturer": "QEMU",
+  "memory": {
+    "swap": {
+      "available": "1.00 GiB",
+      "available_bytes": 1073737728,
+      "capacity": "0%",
+      "total": "1.00 GiB",
+      "total_bytes": 1073737728,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.54 GiB",
+      "available_bytes": 1652846592,
+      "capacity": "14.24%",
+      "total": "1.79 GiB",
+      "total_bytes": 1927241728,
+      "used": "261.68 MiB",
+      "used_bytes": 274395136
+    }
+  },
+  "memoryfree": "1.54 GiB",
+  "memoryfree_mb": 1576.27734375,
+  "memorysize": "1.79 GiB",
+  "memorysize_mb": 1837.9609375,
+  "mountpoints": {
+    "/": {
+      "available": "6.16 GiB",
+      "available_bytes": 6612844544,
+      "capacity": "22.88%",
+      "device": "/dev/mapper/rhel_adele--segur-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "size": "7.99 GiB",
+      "size_bytes": 8575254528,
+      "used": "1.83 GiB",
+      "used_bytes": 1962409984
+    },
+    "/boot": {
+      "available": "865.13 MiB",
+      "available_bytes": 907157504,
+      "capacity": "14.68%",
+      "device": "/dev/vda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "148.87 MiB",
+      "used_bytes": 156098560
+    },
+    "/dev": {
+      "available": "907.30 MiB",
+      "available_bytes": 951373824,
+      "capacity": "0%",
+      "device": "devtmpfs",
+      "filesystem": "devtmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "size=929076k",
+        "nr_inodes=232269",
+        "mode=755"
+      ],
+      "size": "907.30 MiB",
+      "size_bytes": 951373824,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/hugepages": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "hugetlbfs",
+      "filesystem": "hugetlbfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/mqueue": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "mqueue",
+      "filesystem": "mqueue",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/pts": {
+      "available": "0 bytes",
+      "available_bytes": 0,
+      "capacity": "100%",
+      "device": "devpts",
+      "filesystem": "devpts",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "noexec",
+        "relatime",
+        "gid=5",
+        "mode=620",
+        "ptmxmode=000"
+      ],
+      "size": "0 bytes",
+      "size_bytes": 0,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/dev/shm": {
+      "available": "918.98 MiB",
+      "available_bytes": 963620864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "918.98 MiB",
+      "size_bytes": 963620864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "910.44 MiB",
+      "available_bytes": 954667008,
+      "capacity": "0.93%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "918.98 MiB",
+      "size_bytes": 963620864,
+      "used": "8.54 MiB",
+      "used_bytes": 8953856
+    },
+    "/run/user/0": {
+      "available": "183.80 MiB",
+      "available_bytes": 192724992,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=188208k",
+        "mode=700"
+      ],
+      "size": "183.80 MiB",
+      "size_bytes": 192724992,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "918.98 MiB",
+      "available_bytes": 963620864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "918.98 MiB",
+      "size_bytes": 963620864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "192.168.122.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "192.168.122.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "dhcp": "192.168.122.1",
+    "domain": "example.tst",
+    "fqdn": "adele-segur.example.tst",
+    "hostname": "adele-segur",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "192.168.122.101",
+            "netmask": "255.255.255.0",
+            "network": "192.168.122.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::5054:ff:feab:15f2",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "dhcp": "192.168.122.1",
+        "ip": "192.168.122.101",
+        "ip6": "fe80::5054:ff:feab:15f2",
+        "mac": "52:54:00:ab:15:f2",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "192.168.122.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1"
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "192.168.122.101",
+    "ip6": "fe80::5054:ff:feab:15f2",
+    "mac": "52:54:00:ab:15:f2",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "192.168.122.0",
+    "network6": "fe80::",
+    "primary": "eth0",
+    "scope6": "link"
+  },
+  "operatingsystem": "RedHat",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7.7",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Maipo",
+      "description": "Red Hat Enterprise Linux Server release 7.7 (Maipo)",
+      "id": "RedHatEnterpriseServer",
+      "release": {
+        "full": "7.7",
+        "major": "7",
+        "minor": "7"
+      },
+      "specification": ":core-4.1-amd64:core-4.1-noarch"
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "RedHat",
+    "release": {
+      "full": "7.7",
+      "major": "7",
+      "minor": "7"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "31"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/mapper/rhel_adele--segur-root": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "size": "8.00 GiB",
+      "size_bytes": 8585740288,
+      "uuid": "3d6b8a2d-f8c2-464e-84a7-1f9dea341d8b"
+    },
+    "/dev/mapper/rhel_adele--segur-swap": {
+      "filesystem": "swap",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "4f661cd2-95bf-4bc7-8a99-4de8c4d26563"
+    },
+    "/dev/vda1": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "d92de42c-9ccc-4a9a-9a5b-25ef6308d5a8"
+    },
+    "/dev/vda2": {
+      "filesystem": "LVM2_member",
+      "size": "9.00 GiB",
+      "size_bytes": 9662627840,
+      "uuid": "SVRQm6-HCCn-jIZq-dznZ-ptsv-EJhp-xQ0xpr"
+    }
+  },
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "QEMU Virtual CPU version 2.5+",
+  "processorcount": 1,
+  "processors": {
+    "count": 1,
+    "isa": "x86_64",
+    "models": [
+      "QEMU Virtual CPU version 2.5+"
+    ],
+    "physicalcount": 1
+  },
+  "productname": "Standard PC (i440FX + PIIX, 1996)",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.4.0",
+    "version": "2.4.9"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.4.0",
+  "rubyversion": "2.4.9",
+  "scope6": "link",
+  "scope6_eth0": "link",
+  "scope6_lo": "host",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "31",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 c3e23b70b57f2238ae30514f2fd865e788462986",
+        "sha256": "SSHFP 3 2 6b6c9c6beb998c1ec16d584d5808d877a7628db9bd69053603ed386a3f3c9369"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC2CeSgYEf8j+TtwPzGNyBXFNyi9kxbRpW3gQCYkkGRs/5LxkLWdCiKlOn77+X7Ku9kuu9t/ysBvrf0rmxy/YCw=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 9cfc041484f84519666b71c02e5e7833f6fdb149",
+        "sha256": "SSHFP 4 2 e29a092db2c9e4552d5414cdbe0105854a9c9156a1bddd2d96fd8b6f659a81bf"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIGQ09bOzMUm4ZAnI2BMnD54TD+1Q33f9HHf8iTMyup4F",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 221dfeab8a2245b8475b7ec786566435a85106e7",
+        "sha256": "SSHFP 1 2 f1f04bc0f5a50e3ee54f340161e691905e5d14501f6a001a340e557c8efd0ccb"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDlUyZp3QjyQZ1ooZklknk0yGsFrEL2Fio2UJaq7TVbfDAYOB7GflrhDj435WkUFDooRLXSQS3dQ0DaJ3kNQqRZTNcRqdN3L1yYsd0tp6Oth5lm8+mTOPaVDV/XDT06FJeHUTRPn/WEpEqFYIIOgFH3f7s+2lpHc8zcJMQlWYqfxUA6yFu4644sd55tk9V9R85EJj2TIyR/FP0IYZTaSW3bS323CvIs5B5XRlMKMeILlX83zrUE200cT64KI4yxXqvCdZfx04QK5evILcvxRplbV1Pm8GP/ac/1blrX/9d+up4IhoedUlYwgiSSHvJjhe22hPJ2ApcPxYrBA05wY1Kn",
+      "type": "ssh-rsa"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBC2CeSgYEf8j+TtwPzGNyBXFNyi9kxbRpW3gQCYkkGRs/5LxkLWdCiKlOn77+X7Ku9kuu9t/ysBvrf0rmxy/YCw=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIGQ09bOzMUm4ZAnI2BMnD54TD+1Q33f9HHf8iTMyup4F",
+  "sshfp_ecdsa": "SSHFP 3 1 c3e23b70b57f2238ae30514f2fd865e788462986\nSSHFP 3 2 6b6c9c6beb998c1ec16d584d5808d877a7628db9bd69053603ed386a3f3c9369",
+  "sshfp_ed25519": "SSHFP 4 1 9cfc041484f84519666b71c02e5e7833f6fdb149\nSSHFP 4 2 e29a092db2c9e4552d5414cdbe0105854a9c9156a1bddd2d96fd8b6f659a81bf",
+  "sshfp_rsa": "SSHFP 1 1 221dfeab8a2245b8475b7ec786566435a85106e7\nSSHFP 1 2 f1f04bc0f5a50e3ee54f340161e691905e5d14501f6a001a340e557c8efd0ccb",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDlUyZp3QjyQZ1ooZklknk0yGsFrEL2Fio2UJaq7TVbfDAYOB7GflrhDj435WkUFDooRLXSQS3dQ0DaJ3kNQqRZTNcRqdN3L1yYsd0tp6Oth5lm8+mTOPaVDV/XDT06FJeHUTRPn/WEpEqFYIIOgFH3f7s+2lpHc8zcJMQlWYqfxUA6yFu4644sd55tk9V9R85EJj2TIyR/FP0IYZTaSW3bS323CvIs5B5XRlMKMeILlX83zrUE200cT64KI4yxXqvCdZfx04QK5evILcvxRplbV1Pm8GP/ac/1blrX/9d+up4IhoedUlYwgiSSHvJjhe22hPJ2ApcPxYrBA05wY1Kn",
+  "swapfree": "1.00 GiB",
+  "swapfree_mb": 1023.99609375,
+  "swapsize": "1.00 GiB",
+  "swapsize_mb": 1023.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 1,
+    "seconds": 4236,
+    "uptime": "1:10 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "1:10 hours",
+  "uptime_days": 0,
+  "uptime_hours": 1,
+  "uptime_seconds": 4236,
+  "uuid": "D018231B-9254-4F37-9FD1-52F4F39CFFB2",
+  "virtual": "kvm"
+}

--- a/test/static_fixtures/facts/facts_rhel_7_workstation.json
+++ b/test/static_fixtures/facts/facts_rhel_7_workstation.json
@@ -1,0 +1,436 @@
+{
+  "aio_agent_version": "1.10.14",
+  "architecture": "x86_64",
+  "augeas": {
+    "version": "1.4.0"
+  },
+  "augeasversion": "1.4.0",
+  "bios_release_date": "04/01/2014",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "?-20190727_073836-buildvm-ppc64le-16.ppc.fedoraproject.org-3.fc31",
+  "blockdevice_vda_size": 10737418240,
+  "blockdevice_vda_vendor": "0x1af4",
+  "blockdevices": "vda",
+  "chassistype": "Other",
+  "dhcp_servers": {
+    "eth0": "192.168.122.1",
+    "system": "192.168.122.1"
+  },
+  "disks": {
+    "vda": {
+      "size": "10.00 GiB",
+      "size_bytes": 10737418240,
+      "vendor": "0x1af4"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "04/01/2014",
+      "vendor": "SeaBIOS",
+      "version": "?-20190727_073836-buildvm-ppc64le-16.ppc.fedoraproject.org-3.fc31"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "QEMU",
+    "product": {
+      "name": "Standard PC (i440FX + PIIX, 1996)",
+      "uuid": "14AC41B1-7452-4899-A1C9-FB08C419C6B4"
+    }
+  },
+  "domain": "example.tst",
+  "facterversion": "3.6.10",
+  "filesystems": "xfs",
+  "fqdn": "rhel7ws.example.tst",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hardwaremodel": "x86_64",
+  "hostname": "rhel7ws",
+  "id": "root",
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "interfaces": "eth0,lo",
+  "ipaddress": "192.168.122.218",
+  "ipaddress6": "fe80::5054:ff:fe84:461e",
+  "ipaddress6_eth0": "fe80::5054:ff:fe84:461e",
+  "ipaddress6_lo": "::1",
+  "ipaddress_eth0": "192.168.122.218",
+  "ipaddress_lo": "127.0.0.1",
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "3.10",
+  "kernelrelease": "3.10.0-1062.el7.x86_64",
+  "kernelversion": "3.10.0",
+  "load_averages": {
+    "15m": 0.05,
+    "1m": 0.0,
+    "5m": 0.01
+  },
+  "lsbdistcodename": "Maipo",
+  "lsbdistdescription": "Red Hat Enterprise Linux Workstation release 7.7 (Maipo)",
+  "lsbdistid": "RedHatEnterpriseWorkstation",
+  "lsbdistrelease": "7.7",
+  "lsbmajdistrelease": "7",
+  "lsbminordistrelease": "7",
+  "lsbrelease": ":core-4.1-amd64:core-4.1-noarch",
+  "macaddress": "52:54:00:84:46:1e",
+  "macaddress_eth0": "52:54:00:84:46:1e",
+  "manufacturer": "QEMU",
+  "memory": {
+    "swap": {
+      "available": "1.00 GiB",
+      "available_bytes": 1073737728,
+      "capacity": "0%",
+      "total": "1.00 GiB",
+      "total_bytes": 1073737728,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "system": {
+      "available": "1.47 GiB",
+      "available_bytes": 1581314048,
+      "capacity": "17.95%",
+      "total": "1.79 GiB",
+      "total_bytes": 1927241728,
+      "used": "329.90 MiB",
+      "used_bytes": 345927680
+    }
+  },
+  "memoryfree": "1.47 GiB",
+  "memoryfree_mb": 1508.05859375,
+  "memorysize": "1.79 GiB",
+  "memorysize_mb": 1837.9609375,
+  "mountpoints": {
+    "/": {
+      "available": "5.99 GiB",
+      "available_bytes": 6436794368,
+      "capacity": "24.94%",
+      "device": "/dev/mapper/rhel_rhel7ws-root",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "size": "7.99 GiB",
+      "size_bytes": 8575254528,
+      "used": "1.99 GiB",
+      "used_bytes": 2138460160
+    },
+    "/boot": {
+      "available": "865.14 MiB",
+      "available_bytes": 907165696,
+      "capacity": "14.68%",
+      "device": "/dev/vda1",
+      "filesystem": "xfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "relatime",
+        "attr2",
+        "inode64",
+        "noquota"
+      ],
+      "size": "1014.00 MiB",
+      "size_bytes": 1063256064,
+      "used": "148.86 MiB",
+      "used_bytes": 156090368
+    },
+    "/dev/shm": {
+      "available": "918.98 MiB",
+      "available_bytes": 963620864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev"
+      ],
+      "size": "918.98 MiB",
+      "size_bytes": 963620864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/run": {
+      "available": "910.50 MiB",
+      "available_bytes": 954724352,
+      "capacity": "0.92%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "mode=755"
+      ],
+      "size": "918.98 MiB",
+      "size_bytes": 963620864,
+      "used": "8.48 MiB",
+      "used_bytes": 8896512
+    },
+    "/run/user/0": {
+      "available": "183.80 MiB",
+      "available_bytes": 192724992,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "rw",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "relatime",
+        "size=188208k",
+        "mode=700"
+      ],
+      "size": "183.80 MiB",
+      "size_bytes": 192724992,
+      "used": "0 bytes",
+      "used_bytes": 0
+    },
+    "/sys/fs/cgroup": {
+      "available": "918.98 MiB",
+      "available_bytes": 963620864,
+      "capacity": "0%",
+      "device": "tmpfs",
+      "filesystem": "tmpfs",
+      "options": [
+        "ro",
+        "seclabel",
+        "nosuid",
+        "nodev",
+        "noexec",
+        "mode=755"
+      ],
+      "size": "918.98 MiB",
+      "size_bytes": 963620864,
+      "used": "0 bytes",
+      "used_bytes": 0
+    }
+  },
+  "mtu_eth0": 1500,
+  "mtu_lo": 65536,
+  "netmask": "255.255.255.0",
+  "netmask6": "ffff:ffff:ffff:ffff::",
+  "netmask6_eth0": "ffff:ffff:ffff:ffff::",
+  "netmask6_lo": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+  "netmask_eth0": "255.255.255.0",
+  "netmask_lo": "255.0.0.0",
+  "network": "192.168.122.0",
+  "network6": "fe80::",
+  "network6_eth0": "fe80::",
+  "network6_lo": "::1",
+  "network_eth0": "192.168.122.0",
+  "network_lo": "127.0.0.0",
+  "networking": {
+    "dhcp": "192.168.122.1",
+    "domain": "example.tst",
+    "fqdn": "rhel7ws.example.tst",
+    "hostname": "rhel7ws",
+    "interfaces": {
+      "eth0": {
+        "bindings": [
+          {
+            "address": "192.168.122.218",
+            "netmask": "255.255.255.0",
+            "network": "192.168.122.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::5054:ff:fe84:461e",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "dhcp": "192.168.122.1",
+        "ip": "192.168.122.218",
+        "ip6": "fe80::5054:ff:fe84:461e",
+        "mac": "52:54:00:84:46:1e",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "192.168.122.0",
+        "network6": "fe80::"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1"
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1"
+      }
+    },
+    "ip": "192.168.122.218",
+    "ip6": "fe80::5054:ff:fe84:461e",
+    "mac": "52:54:00:84:46:1e",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "192.168.122.0",
+    "network6": "fe80::",
+    "primary": "eth0"
+  },
+  "operatingsystem": "RedHat",
+  "operatingsystemmajrelease": "7",
+  "operatingsystemrelease": "7.7",
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "codename": "Maipo",
+      "description": "Red Hat Enterprise Linux Workstation release 7.7 (Maipo)",
+      "id": "RedHatEnterpriseWorkstation",
+      "release": {
+        "full": "7.7",
+        "major": "7",
+        "minor": "7"
+      },
+      "specification": ":core-4.1-amd64:core-4.1-noarch"
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "RedHat",
+    "release": {
+      "full": "7.7",
+      "major": "7",
+      "minor": "7"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "31"
+    }
+  },
+  "osfamily": "RedHat",
+  "partitions": {
+    "/dev/mapper/rhel_rhel7ws-root": {
+      "filesystem": "xfs",
+      "mount": "/",
+      "size": "8.00 GiB",
+      "size_bytes": 8585740288,
+      "uuid": "ef7d23a5-e7e9-4f5c-9d21-67e75b8c04e4"
+    },
+    "/dev/mapper/rhel_rhel7ws-swap": {
+      "filesystem": "swap",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "a134ef8b-3027-4ef9-91d7-2f00e79b946c"
+    },
+    "/dev/vda1": {
+      "filesystem": "xfs",
+      "mount": "/boot",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "d2cee6e5-d109-49e8-8c2b-c017cb8e39fd"
+    },
+    "/dev/vda2": {
+      "filesystem": "LVM2_member",
+      "size": "9.00 GiB",
+      "size_bytes": 9662627840,
+      "uuid": "r0yvHr-spS9-GsP1-UTP1-DOda-sYTh-xC2ANJ"
+    }
+  },
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
+  "physicalprocessorcount": 1,
+  "processor0": "QEMU Virtual CPU version 2.5+",
+  "processorcount": 1,
+  "processors": {
+    "count": 1,
+    "isa": "x86_64",
+    "models": [
+      "QEMU Virtual CPU version 2.5+"
+    ],
+    "physicalcount": 1
+  },
+  "productname": "Standard PC (i440FX + PIIX, 1996)",
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0",
+    "version": "2.1.9"
+  },
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.1.0",
+  "rubyversion": "2.1.9",
+  "selinux": true,
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "selinux_current_mode": "enforcing",
+  "selinux_enforced": true,
+  "selinux_policyversion": "31",
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 10c3750ebeed1c4c0050de8ad38dbf5e3725236b",
+        "sha256": "SSHFP 3 2 c92359cba84d11169eca41a79f5ec3ca5a18fbce3e9e8f28a7cbc12e0830fd09"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNVVapbdQyt0EDdiMChknswkz2xMcYKJAJz+UwsamlZ/aUwQZtmSRPoqgD6g33vVF/FOBPcJV1+HvVQiTUgPIIE="
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 806d100c003fdedf5808702f19f068e043f7d4ce",
+        "sha256": "SSHFP 4 2 64850f9d384f5076da921b8786359bb36190ac0bdf404be8973ffd5421545d07"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIM36dlCVEfNg9OvyPvCNxo0A+gXrq5pY0Fuj9o2oGKhR"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 823e2038481d3f07d77228bc079feaf7869c81e0",
+        "sha256": "SSHFP 1 2 921c917b104cc6fb6ba235993bd25f6a526f07ec36f4728551689419cc69c953"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC1w8LQjlsRo3r0UHmltMZc4VdlEPKaKel2O2xo8j1Y4k/7B6n6C7gB+9nZrZ3j9kiqEoc9TfGILZbLSvB7Wmo51+IN/oK1F+jXEKJVzdPJ1gXYuuyeiTvRGCoi5bpP0rDtq48klObYC3S0Lc3XQb0lCxBjAgO4E8yH8qNmXNbHXQLtQjfxQxQeIJYiZdedSOz7oC2JHLnzuvgaPCF9kWo0T8dgV5pzlMRPwNBoSs6CwMfpg8Lc4F0yAsx5GSgZIG2+ZVAzwPXvonsdv7MW6QScHSXtlAdfKF3UN7bMhUAEwZqUciczLgcnrKO4dgnsbj5lNP455b93CVd22EyLbtxF"
+    }
+  },
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBNVVapbdQyt0EDdiMChknswkz2xMcYKJAJz+UwsamlZ/aUwQZtmSRPoqgD6g33vVF/FOBPcJV1+HvVQiTUgPIIE=",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIM36dlCVEfNg9OvyPvCNxo0A+gXrq5pY0Fuj9o2oGKhR",
+  "sshfp_ecdsa": "SSHFP 3 1 10c3750ebeed1c4c0050de8ad38dbf5e3725236b\nSSHFP 3 2 c92359cba84d11169eca41a79f5ec3ca5a18fbce3e9e8f28a7cbc12e0830fd09",
+  "sshfp_ed25519": "SSHFP 4 1 806d100c003fdedf5808702f19f068e043f7d4ce\nSSHFP 4 2 64850f9d384f5076da921b8786359bb36190ac0bdf404be8973ffd5421545d07",
+  "sshfp_rsa": "SSHFP 1 1 823e2038481d3f07d77228bc079feaf7869c81e0\nSSHFP 1 2 921c917b104cc6fb6ba235993bd25f6a526f07ec36f4728551689419cc69c953",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC1w8LQjlsRo3r0UHmltMZc4VdlEPKaKel2O2xo8j1Y4k/7B6n6C7gB+9nZrZ3j9kiqEoc9TfGILZbLSvB7Wmo51+IN/oK1F+jXEKJVzdPJ1gXYuuyeiTvRGCoi5bpP0rDtq48klObYC3S0Lc3XQb0lCxBjAgO4E8yH8qNmXNbHXQLtQjfxQxQeIJYiZdedSOz7oC2JHLnzuvgaPCF9kWo0T8dgV5pzlMRPwNBoSs6CwMfpg8Lc4F0yAsx5GSgZIG2+ZVAzwPXvonsdv7MW6QScHSXtlAdfKF3UN7bMhUAEwZqUciczLgcnrKO4dgnsbj5lNP455b93CVd22EyLbtxF",
+  "swapfree": "1.00 GiB",
+  "swapfree_mb": 1023.99609375,
+  "swapsize": "1.00 GiB",
+  "swapsize_mb": 1023.99609375,
+  "system_uptime": {
+    "days": 0,
+    "hours": 6,
+    "seconds": 24859,
+    "uptime": "6:54 hours"
+  },
+  "timezone": "UTC",
+  "uptime": "6:54 hours",
+  "uptime_days": 0,
+  "uptime_hours": 6,
+  "uptime_seconds": 24859,
+  "uuid": "14AC41B1-7452-4899-A1C9-FB08C419C6B4",
+  "virtual": "kvm"
+}

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -99,6 +99,18 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
       assert_equal "RHEL Server 6.2", os.description
     end
 
+    test "should not mix Workstation with Server on RHEL7" do
+      @importer = PuppetFactParser.new(rhel_7_workstation_facts)
+      first_os = @importer.operatingsystem
+      assert first_os.present?
+      assert_equal "RedHat_Workstation", first_os.name
+
+      @importer = PuppetFactParser.new(rhel_7_server_facts)
+      first_os = @importer.operatingsystem
+      assert first_os.present?
+      assert_equal "RedHat", first_os.name
+    end
+
     test "should not alter description field if already set" do
       # Need to instantiate @importer once with normal facts
       first_os = @importer.operatingsystem
@@ -417,6 +429,14 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
 
   def debian_facts
     read_json_fixture('facts/facts_debian.json')['facts']
+  end
+
+  def rhel_7_workstation_facts
+    read_json_fixture('facts/facts_rhel_7_workstation.json').with_indifferent_access
+  end
+
+  def rhel_7_server_facts
+    read_json_fixture('facts/facts_rhel_7_server.json').with_indifferent_access
   end
 
   def sles_facts


### PR DESCRIPTION
When facts are received we parse them and create/assign the operating
system of a host accordingly. We didn't correctly detect the right RHEL
7 distribution and considered every RHEL 7 as Server. For people having
both variants in their infrastructure, this caused problems.

With this patch, RHEL 7 Workstations is recognized as
RedHat_Workstation, the OS can't contain spaces. We don't have other
attribute to distinguish these distributions and it's not worth
introducing it as a separate attribute, since this concept was replaced
by system purpose in RHEL 8.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
