### PR TITLE
Fixes #29369 - Add support for URL with parameters in Hosts bulk actions

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -415,6 +415,21 @@ class HostJSTest < IntegrationTestWithJavascript
       page.execute_script("tfm.hosts.table.buildRedirect('#{select_multiple_environment_hosts_path}')")
       assert_current_path(select_multiple_environment_hosts_path, :ignore_query => true)
     end
+
+    test 'redirect js with parameter in URL' do
+      path1 = hosts_path(param1: 'val1')
+      path2 = hosts_path(param1: 'val1', param2: 'val2')
+
+      visit hosts_path
+      check 'check_all'
+      page.execute_script("tfm.hosts.table.buildRedirect('#{path1}')")
+      assert(current_url.include?("#{path1}&host_ids"))
+
+      visit hosts_path
+      check 'check_all'
+      page.execute_script("tfm.hosts.table.buildRedirect('#{path2}')")
+      assert(current_url.include?("#{path2}&host_ids"))
+    end
   end
 
   describe 'edit page' do

--- a/webpack/assets/javascripts/hosts/tableCheckboxes.js
+++ b/webpack/assets/javascripts/hosts/tableCheckboxes.js
@@ -256,7 +256,9 @@ export function buildModal(element, url) {
 
 export function buildRedirect(url) {
   const data = getBulkParam();
-  const redirectUrl = url.includes('?') ? `${url}&${$.param(data)}` : `${url}?${$.param(data)}`;
+  const redirectUrl = url.includes('?')
+    ? `${url}&${$.param(data)}`
+    : `${url}?${$.param(data)}`;
 
   window.location.replace(redirectUrl);
 }

--- a/webpack/assets/javascripts/hosts/tableCheckboxes.js
+++ b/webpack/assets/javascripts/hosts/tableCheckboxes.js
@@ -256,8 +256,9 @@ export function buildModal(element, url) {
 
 export function buildRedirect(url) {
   const data = getBulkParam();
-  const uri = `${url}?${$.param(data)}`;
-  window.location.replace(uri);
+  const redirectUrl = url.includes('?') ? `${url}&${$.param(data)}` : `${url}?${$.param(data)}`;
+
+  window.location.replace(redirectUrl);
 }
 
 function paginationMetaData() {


### PR DESCRIPTION
If URL in bulk actions contains parameter (like: `/job_invocations/new?feature=leapp_preupgrade`), JS method `buildRedirect()` will add `hosts_id` parameter like this:

`/job_invocations/new?feature=leapp_preupgrade?host_ids=1,2,3`

But the correct URL should be:
`/job_invocations/new?feature=leapp_preupgrade&host_ids=1,2,3`
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
