### PR TITLE
Fixes #28868 - Add location inherited parameters

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -3,12 +3,6 @@ class SettingsController < ApplicationController
 
   helper_method :xeditable?
 
-  # This can happen in development when removing a plugin
-  rescue_from ActiveRecord::SubclassNotFound do |e|
-    type = (e.to_s =~ /\'(Setting::.*)\'\./) ? Regexp.last_match(1) : 'STI-Type'
-    render :plain => (e.to_s + "<br><b>run Setting.where(:category=>'#{type}').delete_all to recover.</b>").html_safe, :status => :internal_server_error
-  end
-
   def index
     @settings = Setting.live_descendants.search_for(params[:search])
   end

--- a/app/views/api/v2/taxonomies/show.json.rabl
+++ b/app/views/api/v2/taxonomies/show.json.rabl
@@ -6,52 +6,89 @@ attribute :ignore_types => :select_all_types
 
 attributes :description, :created_at, :updated_at
 
+ancestors = @taxonomy.ancestors.preload(
+  :users, :smart_proxies, :subnets, :compute_resources, :media, :ptables,
+  :provisioning_templates, :domains, :realms, :environments, :hostgroups
+)
 node :hosts_count do |taxonomy|
   hosts_count[taxonomy]
 end
 
-child :users do
+child (@taxonomy.users + ancestors.map(&:users).flatten).uniq => :users do
   extends "api/v2/users/base"
+  node :inherited do |user|
+    !@taxonomy.users.include?(user)
+  end
 end
 
-child :smart_proxies do
+child (@taxonomy.smart_proxies + ancestors.map(&:smart_proxies).flatten).uniq => :smart_proxies do
   extends "api/v2/smart_proxies/base"
+  node :inherited do |smart_proxy|
+    !@taxonomy.smart_proxies.include?(smart_proxy)
+  end
 end
 
-child :subnets do
+child (@taxonomy.subnets + ancestors.map(&:subnets).flatten).uniq => :subnets do
   extends "api/v2/subnets/base"
+  node :inherited do |subnet|
+    !@taxonomy.subnets.include?(subnet)
+  end
 end
 
-child :compute_resources do
+child (@taxonomy.compute_resources + ancestors.map(&:compute_resources).flatten).uniq => :compute_resources do
   extends "api/v2/compute_resources/base"
+  node :inherited do |compute_resource|
+    !@taxonomy.compute_resources.include?(compute_resource)
+  end
 end
 
-child :media do
+child (@taxonomy.media + ancestors.map(&:media).flatten).uniq => :media do
   extends "api/v2/media/base"
+  node :inherited do |current_media|
+    !@taxonomy.media.include?(current_media)
+  end
 end
 
-child :ptables => :ptables do
+child (@taxonomy.ptables + ancestors.map(&:ptables).flatten).uniq => :ptables do
   extends "api/v2/ptables/main"
+  node :inherited do |ptable|
+    !@taxonomy.ptables.include?(ptable)
+  end
 end
 
-child :provisioning_templates => :provisioning_templates do
+child (@taxonomy.provisioning_templates + ancestors.map(&:provisioning_templates).flatten).uniq => :provisioning_templates do
   extends "api/v2/provisioning_templates/base"
+  node :inherited do |provisioning_template|
+    !@taxonomy.provisioning_templates.include?(provisioning_template)
+  end
 end
 
-child :domains do
+child (@taxonomy.domains + ancestors.map(&:domains).flatten).uniq => :domains do
   extends "api/v2/domains/base"
+  node :inherited do |domain|
+    !@taxonomy.domains.include?(domain)
+  end
 end
 
-child :realms do
+child (@taxonomy.realms + ancestors.map(&:realms).flatten).uniq => :realms do
   extends "api/v2/realms/base"
+  node :inherited do |realm|
+    !@taxonomy.realms.include?(realm)
+  end
 end
 
-child :environments do
+child (@taxonomy.environments + ancestors.map(&:environments).flatten).uniq => :environments do
   extends "api/v2/environments/base"
+  node :inherited do |environment|
+    !@taxonomy.environments.include?(environment)
+  end
 end
 
-child :hostgroups do
+child (@taxonomy.hostgroups + ancestors.map(&:hostgroups).flatten).uniq => :hostgroups do
   extends "api/v2/hostgroups/base"
+  node :inherited do |hostgroup|
+    !@taxonomy.hostgroups.include?(hostgroup)
+  end
 end
 
 if @taxonomy.is_a?(Location)

--- a/app/views/common/class_clean_up_failed.html.erb
+++ b/app/views/common/class_clean_up_failed.html.erb
@@ -1,0 +1,7 @@
+<h1><%= _('Unknown records found in the database') %></h1>
+
+<%= (_('Foreman has detected definitions of unknown classes in your database. This can happen after a plugin removal which did not properly cleaned up data it created. Would you like to delete all records from SQL table <b>"%{table}"</b> with column <b>"%{column}"</b> having the value <b>"%{value}"</b>') % { table: @parent_class.table_name, column: @parent_class.inheritance_column, value: @unknown_class_name}).html_safe %>
+
+<br><br>
+
+<%= alert(text: _('Automatic cleanup has failed, there are probably other records still referencing this data, please do the clean up manually in the database and then refresh this page.'), class: 'alert-warning', close: false) %>

--- a/app/views/common/confirm_class_clean_up.html.erb
+++ b/app/views/common/confirm_class_clean_up.html.erb
@@ -1,0 +1,8 @@
+<h1><%= _('Unknown records found in the database') %></h1>
+
+<%= alert(text: _('Creating a DB backup before proceeding is highly recommended!'), class: 'alert-danger', close: false) %>
+
+<%= (_('Foreman has detected definitions of unknown classes in your database. This can happen after a plugin removal which did not properly cleaned up data it created. Would you like to delete all records from SQL table <b>"%{table}"</b> with column <b>"%{column}"</b> having the value <b>"%{value}"</b>') % { table: @parent_class.table_name, column: @parent_class.inheritance_column, value: @unknown_class_name}).html_safe %>
+
+<br><br>
+<%= link_to 'Delete', '?confirm_data_deletion=yes', class: 'btn btn-danger', data: { confirm: 'The data deletion can not be undone, are you sure you want to proceed?' } %>


### PR DESCRIPTION
When a plugin that adds to STI table is uninstalled, Foreman fails with
500 when we list records that no longer has a class definition present.
On settings page we display a command to delete such records, however we
could do better and allow cleaning up such data from the app itself.

This patch adds a check for this kind of exception. In production
environment, we rescue from any error, however we can detect the wrapped
exception type. We parse the affected class name and its STI parent from
the exception message. Then we offer user to delete such records.

This can still fail in case some foreign key prevents the deletion. In
such case we inform the user auto-clean up is impossible and they need
to do the proper clean up themselves.

The change does not replace the need for plugin clean up scripts,
however should help desperate users who don't know how to clean up
settings, custom host statuses and perhaps some other STI data.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
