### PR TITLE
Fixes #20832 - allow deletion of unkown STI records

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -3,12 +3,6 @@ class SettingsController < ApplicationController
 
   helper_method :xeditable?
 
-  # This can happen in development when removing a plugin
-  rescue_from ActiveRecord::SubclassNotFound do |e|
-    type = (e.to_s =~ /\'(Setting::.*)\'\./) ? Regexp.last_match(1) : 'STI-Type'
-    render :plain => (e.to_s + "<br><b>run Setting.where(:category=>'#{type}').delete_all to recover.</b>").html_safe, :status => :internal_server_error
-  end
-
   def index
     @settings = Setting.live_descendants.search_for(params[:search])
   end

--- a/app/views/common/class_clean_up_failed.html.erb
+++ b/app/views/common/class_clean_up_failed.html.erb
@@ -1,0 +1,7 @@
+<h1><%= _('Unknown records found in the database') %></h1>
+
+<%= (_('Foreman has detected definitions of unknown classes in your database. This can happen after a plugin removal which did not properly cleaned up data it created. Would you like to delete all records from SQL table <b>"%{table}"</b> with column <b>"%{column}"</b> having the value <b>"%{value}"</b>') % { table: @parent_class.table_name, column: @parent_class.inheritance_column, value: @unknown_class_name}).html_safe %>
+
+<br><br>
+
+<%= alert(text: _('Automatic cleanup has failed, there are probably other records still referencing this data, please do the clean up manually in the database and then refresh this page.'), class: 'alert-warning', close: false) %>

--- a/app/views/common/confirm_class_clean_up.html.erb
+++ b/app/views/common/confirm_class_clean_up.html.erb
@@ -1,0 +1,8 @@
+<h1><%= _('Unknown records found in the database') %></h1>
+
+<%= alert(text: _('Creating a DB backup before proceeding is highly recommended!'), class: 'alert-danger', close: false) %>
+
+<%= (_('Foreman has detected definitions of unknown classes in your database. This can happen after a plugin removal which did not properly cleaned up data it created. Would you like to delete all records from SQL table <b>"%{table}"</b> with column <b>"%{column}"</b> having the value <b>"%{value}"</b>') % { table: @parent_class.table_name, column: @parent_class.inheritance_column, value: @unknown_class_name}).html_safe %>
+
+<br><br>
+<%= link_to 'Delete', '?confirm_data_deletion=yes', class: 'btn btn-danger', data: { confirm: 'The data deletion can not be undone, are you sure you want to proceed?' } %>


### PR DESCRIPTION
When a plugin that adds to STI table is uninstalled, Foreman fails with
500 when we list records that no longer has a class definition present.
On settings page we display a command to delete such records, however we
could do better and allow cleaning up such data from the app itself.

This patch adds a check for this kind of exception. In production
environment, we rescue from any error, however we can detect the wrapped
exception type. We parse the affected class name and its STI parent from
the exception message. Then we offer user to delete such records.

This can still fail in case some foreign key prevents the deletion. In
such case we inform the user auto-clean up is impossible and they need
to do the proper clean up themselves.

The change does not replace the need for plugin clean up scripts,
however should help desperate users who don't know how to clean up
settings, custom host statuses and perhaps some other STI data.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
