### PR TITLE
Fixes #29379 - don't try to load removed widget

### DIFF
--- a/app/models/widget.rb
+++ b/app/models/widget.rb
@@ -8,6 +8,8 @@ class Widget < ApplicationRecord
 
   before_validation :default_values
 
+  scope :available, -> { where(template: Dashboard::Manager.default_widgets.map { |w| w[:template] }) }
+
   def default_values
     self.sizex ||= 4
     self.sizey ||= 1

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -10,7 +10,7 @@
   <% else %>
     <div id='dashboard' class="dashboard gridster col-md-12">
       <ul>
-        <% User.current.widgets.order(:id).each do |widget| %>
+        <% User.current.widgets.available.order(:id).each do |widget| %>
           <%= content_tag(:li, widget_data(widget)) do %>
             <div class='widget_control'>
               <a class='remove' data-url='<%= widget_path(widget) %>' onclick='tfm.dashboard.removeWidget(this)' >&times;</a>


### PR DESCRIPTION
After a plugin removal, its widgets are still stored for user dashboard.
We can detect the widget won't be able to be rendered and skip it, to
avoid ugly red boxes on dashboard.

With this patch, widget model gets a new scope that can filter only
widget that are known. Records remain in the database in case the plugin
is reinstalled later however it's silently ignored on the dashboard.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
