### PR TITLE
Fixes #29144 - Use systemd socket activation

### DIFF
--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -2,13 +2,14 @@
 Description=Foreman
 Documentation=https://theforeman.org
 After=network.target remote-fs.target nss-lookup.target
+Requires=foreman.socket
 
 [Service]
 Type=simple
 User=foreman
 TimeoutSec=300
 WorkingDirectory=/usr/share/foreman
-ExecStart=/usr/bin/rails server --environment $FOREMAN_ENV --port $FOREMAN_PORT --binding $FOREMAN_BIND
+ExecStart=/usr/share/foreman/bin/rails server --environment $FOREMAN_ENV --port $FOREMAN_PORT --binding $FOREMAN_BIND
 Environment=FOREMAN_ENV=production FOREMAN_PORT=3000 FOREMAN_BIND=0.0.0.0
 
 SyslogIdentifier=foreman

--- a/extras/systemd/foreman.socket
+++ b/extras/systemd/foreman.socket
@@ -1,0 +1,17 @@
+[Unit]
+Description=Foreman HTTP Server Accept Sockets
+
+[Socket]
+# Note Puma must be configured to listen on the same IP/port. If there's a
+# mismatch, it will bind again. The port can already be in use, for example when
+# systemd is configured with [::]:3000 but Puma with 0.0.0.0:3000. The port is
+# then already in use.
+ListenStream=0.0.0.0:3000
+
+# Socket options matching Puma defaults
+NoDelay=true
+ReusePort=true
+Backlog=1024
+
+[Install]
+WantedBy=sockets.target


### PR DESCRIPTION
From https://github.com/puma/puma/blob/master/docs/systemd.md#socket-activation
> systemd and puma also support socket activation, where systemd opens the listening socket(s) in advance and provides them to the puma master process on startup. Among other advantages, this keeps listening sockets open across puma restarts and achieves graceful restarts, including when upgraded puma, and is compatible with both clustered mode and application preload.

When using unix sockets, it should also increase security since only the webserver can connect to it. This is not configured by default since the webserver is not assumed to be present. However, it can be deployed via overrides.

This also needs a packaging change for ExecStart. Currently RPM and Deb packaging change this, but the wrappers break the passing on the socket. That part is currently untested so this is still a draft.