### PR TITLE
Fixes #29416 - Trigger a full page reload on session expiration

### DIFF
--- a/webpack/assets/javascripts/react_app/components/notifications/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/helpers.js
@@ -1,3 +1,0 @@
-export const redirectToLogin = () => {
-  window.location.replace('/users/login');
-};

--- a/webpack/assets/javascripts/react_app/components/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/index.js
@@ -12,7 +12,7 @@ import { noop, translateObject } from '../../common/helpers';
 
 import './notifications.scss';
 import ToggleIcon from './ToggleIcon/ToggleIcon';
-import { redirectToLogin } from './helpers';
+import { reloadPage } from '../../../foreman_navigation';
 
 class notificationContainer extends React.Component {
   componentDidMount() {
@@ -33,11 +33,12 @@ class notificationContainer extends React.Component {
   }
 
   componentDidUpdate() {
-    const { error } = this.props;
+    const { error, stopNotificationsPolling } = this.props;
     if (error) {
       const { response: { status } = {} } = error;
+      stopNotificationsPolling();
       if (status === 401) {
-        redirectToLogin();
+        reloadPage();
       }
     }
   }


### PR DESCRIPTION
Continuing the discussion from https://github.com/theforeman/foreman/pull/7338/files, as @tbrisker suggested, we must handle the UI in a different PR.

Background: This PR makes sure that the looping of users is avoided while logging out during session expiration of external users. We handle the redirection on the server side as we have multiple type of users(internal, external and hidden) which have their own login pages that they must redirect to.