### PR TITLE
Refs #29038 - Generate a report by clicking a link in a notification email

### DIFF
--- a/app/controllers/report_templates_controller.rb
+++ b/app/controllers/report_templates_controller.rb
@@ -14,18 +14,12 @@ class ReportTemplatesController < TemplatesController
     @composer = ReportComposer.from_ui_params(params)
   end
 
-  def build_input_values_from_query(params)
-    @report_template = ReportTemplate.find(params[:id])
-    values = {}
-    @report_template.template_inputs.each do |template_input|
-      values[template_input.id.to_s] = { value: params[template_input.name] }
-    end
-    values
-  end
-
   def schedule_report
     if request.method == "GET"
-      params[:report_template_report] = { :input_values => build_input_values_from_query(params) }
+      params[:report_template_report] = {
+        :input_values => build_input_values_from_query(params),
+        :format => params['format'].downcase,
+      }
     end
     @composer = ReportComposer.from_ui_params(params)
     if @composer.valid?
@@ -59,5 +53,14 @@ class ReportTemplatesController < TemplatesController
       else
         super
     end
+  end
+
+  def build_input_values_from_query(params)
+    @report_template = ReportTemplate.find(params[:id])
+    values = {}
+    @report_template.template_inputs.each do |template_input|
+      values[template_input.id.to_s] = { value: params[template_input.name] }
+    end
+    values
   end
 end

--- a/app/controllers/report_templates_controller.rb
+++ b/app/controllers/report_templates_controller.rb
@@ -14,7 +14,19 @@ class ReportTemplatesController < TemplatesController
     @composer = ReportComposer.from_ui_params(params)
   end
 
+  def build_input_values_from_query(params)
+    @report_template = ReportTemplate.find(params[:id])
+    values = {}
+    @report_template.template_inputs.each do |template_input|
+      values[template_input.id.to_s] = { value: params[template_input.name] }
+    end
+    values
+  end
+
   def schedule_report
+    if request.method == "GET"
+      params[:report_template_report] = { :input_values => build_input_values_from_query(params) }
+    end
     @composer = ReportComposer.from_ui_params(params)
     if @composer.valid?
       job = @composer.schedule_rendering

--- a/app/controllers/report_templates_controller.rb
+++ b/app/controllers/report_templates_controller.rb
@@ -18,7 +18,7 @@ class ReportTemplatesController < TemplatesController
     if request.method == "GET"
       params[:report_template_report] = {
         :input_values => build_input_values_from_query(params),
-        :format => params['format'].downcase,
+        :format => params['format']&.downcase,
       }
     end
     @composer = ReportComposer.from_ui_params(params)

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -159,7 +159,6 @@ class ReportComposer
       val = input.default if val.blank?
       inputs[input.id.to_s] = InputValue.new(value: val, template_input: input)
     end
-
     inputs
   end
 

--- a/app/services/report_template_format.rb
+++ b/app/services/report_template_format.rb
@@ -14,7 +14,7 @@ class ReportTemplateFormat
   end
 
   def self.find(id)
-    all.find { |f| f.id.to_s == id.to_s }
+    all.find { |f| f.id.to_s == id.to_s.downcase }
   end
 
   # if the template does not support formats at all,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -365,6 +365,7 @@ Foreman::Application.routes.draw do
         get 'export'
         get 'generate'
         post 'schedule_report'
+        get 'schedule_report'
         post 'preview'
         get 'report_data'
       end

--- a/test/controllers/report_templates_controller_test.rb
+++ b/test/controllers/report_templates_controller_test.rb
@@ -179,6 +179,12 @@ class ReportTemplatesControllerTest < ActionController::TestCase
       assert_redirected_to report_data_report_template_url(@report_template, job_id: 'JOB-UNIQUE-IDENTIFIER')
     end
 
+    it "schedule report moves params from url query to report_template_report" do
+      expect_job_enque_with({ '1' => { 'value' => 'ohai' } }, format: 'html')
+      get :schedule_report, params: { :id => @report_template.to_param, :format => 'html', :input_values => { '1' => { :value => 'ohai' } } }, session: set_session_user
+      assert_redirected_to report_data_report_template_url(@report_template, job_id: 'JOB-UNIQUE-IDENTIFIER')
+    end
+
     it "schedule report delivery by e-mail" do
       expect_job_enque_with(nil, mail_to: 'this@email.cz')
       get :schedule_report, params: { :id => @report_template.to_param, :report_template_report => { send_mail: '1', mail_to: 'this@email.cz' } }, session: set_session_user


### PR DESCRIPTION
[SAT-E-459] 

This allows you to generate a report from a report template by visiting a link in the browser.

Instead of using form data from when the user clicked Submit on the Generate form, it uses regular URL query params from the GET request.

(This link will be incorporated into the Subscriptions Expiring Soon email notification.)

The URL format is
```
https://#{FOREMAN_URL}/templates/report-templates/#{REPORT_TEMPLATE_ID}/schedule_report?format=#{FORMAT}&#{USER_INPUT_KEY}=#{USER_INPUT_VALUE}
```

`REPORT_TEMPLATE_ID`: The ID of the ReportTemplate, for example `138-Subscription%20-%20Entitlement%20Report`
`FORMAT`: Case insensitive.  Can be any of the accepted report formats (`html`, `csv`, etc.)
`USER_INPUT_KEY` and `USER_INPUT_VALUE`: Keys are case sensitive.  Values must be one of the accepted values as defined in the user input.

Example url:
```
https://centos7-katello-devel.redhatlaptop.example.com/templates/report_templates/138-Subscription%20-%20Entitlement%20Report/schedule_report?format=HTML&Days%20from%20Now=180
```

* No other clicks are required - the report starts generating as soon as the browser loads the url
* The user will see the same download page as they would if they clicked Generate -> Submit
* If there is an error in one of the parameters, the user is taken to the Generate page to correct the error.