### PR TITLE
Fixes #29427 - change breadcrumbs path in compute resources

### DIFF
--- a/app/views/compute_resources_vms/index.html.erb
+++ b/app/views/compute_resources_vms/index.html.erb
@@ -7,7 +7,7 @@
         url: compute_resources_path
       },
       {
-        caption: @compute_resource.provider,
+        caption: @compute_resource.name,
         url: compute_resource_path(@compute_resource)
       },
       {

--- a/app/views/compute_resources_vms/show.html.erb
+++ b/app/views/compute_resources_vms/show.html.erb
@@ -6,7 +6,7 @@
         url: compute_resources_path
       },
       {
-        caption: @compute_resource.provider,
+        caption: @compute_resource.name,
         url: compute_resource_path(@compute_resource)
       },
       {


### PR DESCRIPTION
breadcrumb path is shown as "Compute Resources -> $RESOURCE_TYPE -> VMs -> $VM_NAME", (e.g. "Compute Resources -> Ovirt -> VMs -> vm1.rhev1.example.com").
`$RESOURCE_TYPE` shuold be replaced by `$RESOURCE_NAME`