### PR TITLE
Fixes #28620 - sqlite foreign_key removal

### DIFF
--- a/config/initializers/sqlite_hacks.rb
+++ b/config/initializers/sqlite_hacks.rb
@@ -1,0 +1,20 @@
+# Drops the support of foreign keys for sqlite as they do not support naming
+module Foreman
+  module DisableForeignKeys
+    def supports_foreign_keys?
+      false
+    end
+
+    def add_foreign_key(from_table, to_table, **options)
+      # pass
+    end
+
+    def remove_foreign_key(from_table, to_table = nil, **options)
+      # pass
+    end
+  end
+end
+
+ActiveSupport.on_load(:active_record_sqlite3adapter) do
+  prepend Foreman::DisableForeignKeys
+end


### PR DESCRIPTION
SQLite introduces a foreign keys, but it doesn't support foreign key naming.
It needs destinction of target table instead.