### PR TITLE
Fixes #29447 - Build more efficient taxonomy search for filters

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -181,10 +181,10 @@ class Filter < ApplicationRecord
   end
 
   def build_taxonomy_search_string(name)
-    relation = name.pluralize
-    taxes = send(relation).empty? ? [] : send(relation).map { |t| "#{name}_id = #{t.id}" }
-    taxes = taxes.join(' or ')
-    parenthesize(taxes)
+    relation = send(name.pluralize).pluck(:id)
+    return '' if relation.empty?
+
+    parenthesize("#{name}_id ^ (#{relation.join(',')})")
   end
 
   def nilify_empty_searches

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -117,7 +117,7 @@ class FilterTest < ActiveSupport::TestCase
       f = FactoryBot.build_stubbed(:filter, :search => '', :unlimited => '1', :organization_ids => [@organization.id])
       assert f.valid?
       assert f.limited?
-      assert_include f.taxonomy_search, "(organization_id = #{@organization.id})"
+      assert_include f.taxonomy_search, "(organization_id ^ (#{@organization.id}))"
       assert_not_include f.taxonomy_search, ' and '
       assert_not_include f.taxonomy_search, ' or '
     end
@@ -126,7 +126,7 @@ class FilterTest < ActiveSupport::TestCase
       f = FactoryBot.build_stubbed(:filter, :search => '', :unlimited => '1', :location_ids => [@location.id])
       assert f.valid?
       assert f.limited?
-      assert_include f.taxonomy_search, "(location_id = #{@location.id})"
+      assert_include f.taxonomy_search, "(location_id ^ (#{@location.id}))"
     end
 
     test "filter with location set is always limited before validation" do
@@ -134,9 +134,7 @@ class FilterTest < ActiveSupport::TestCase
                          :organization_ids => [@organization.id, @organization1.id], :location_ids => [@location.id])
       assert f.valid?
       assert f.limited?
-      assert_include f.taxonomy_search, "(location_id = #{@location.id})"
-      assert_include f.taxonomy_search, "organization_id = #{@organization.id}"
-      assert_include f.taxonomy_search, "organization_id = #{@organization1.id}"
+      assert_equal "(organization_id ^ (#{@organization.id},#{@organization1.id})) and (location_id ^ (#{@location.id}))", f.taxonomy_search
     end
 
     test "removing all organizations and locations from filter nilify taxonomy search" do
@@ -241,6 +239,6 @@ class FilterTest < ActiveSupport::TestCase
     f.role = FactoryBot.build(:role, :organizations => [FactoryBot.build(:organization)])
     f.save # we need ids
     f.enforce_inherited_taxonomies
-    assert_equal "(organization_id = #{f.organizations.first.id})", f.taxonomy_search
+    assert_equal "(organization_id ^ (#{f.organizations.first.id}))", f.taxonomy_search
   end
 end


### PR DESCRIPTION
If a filter supported taxonomy filtering and the role had many taxonomies
assigned then the resulting search query consisted of many id comparisons joined
together with `OR`s. This commit generates more efficient query by performing the
search as `id IN (...)`.

Requires:
- [x] https://github.com/wvanbergen/scoped_search/pull/191


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
