### PR TITLE
Fixes #28182 - fixing broken search bar in facts

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -198,7 +198,10 @@ class ApplicationController < ActionController::Base
       if param =~ /(\w+)_id$/
         if params[param].present?
           query = "#{Regexp.last_match(1)} = #{params[param]}"
-          params[:search] += query unless params[:search].include? query
+          unless params[:search].include? query
+            params[:search] += ' and ' if params[:search].present?
+            params[:search] += query
+          end
         end
       end
     end

--- a/test/controllers/fact_values_controller_test.rb
+++ b/test/controllers/fact_values_controller_test.rb
@@ -27,6 +27,12 @@ class FactValuesControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'when host-id is presented in params, it should be added to search with "and" operator' do
+    get :index, params: {host_id: host.id, search: 'location = a'}, session: set_session_user
+    assert_response :success
+    assert_match "location = a and host = #{host.id}", @controller.params[:search]
+  end
+
   def test_index_with_sort
     @request.env['HTTP_REFERER'] = fact_values_path
     get :index, params: {order: 'origin ASC'}, session: set_session_user


### PR DESCRIPTION
In Host -> Facts page the search bar contains `host = $fqdn`, and after cleaning it up and search for another query this happens:
![unspaced-search](https://user-images.githubusercontent.com/11807069/78061390-d9d29780-7395-11ea-8827-40ab0dac7fce.png)

it should add a separator " and ":
![fixed-search](https://user-images.githubusercontent.com/11807069/78061414-e35bff80-7395-11ea-8c91-2e6efc1c610f.png)

