### PR TITLE
Fixes #29464 - plain inputs can be hidden

### DIFF
--- a/app/controllers/api/v2/template_inputs_controller.rb
+++ b/app/controllers/api/v2/template_inputs_controller.rb
@@ -36,6 +36,7 @@ module Api
           param :puppet_parameter_name, String, :required => false, :desc => N_('Puppet parameter name, used when input type is puppet_parameter')
           param :options, Array, :required => false, :desc => N_('Selectable values for user inputs')
           param :default, String, :required => false, :desc => N_('Default value for user input')
+          param :hidden_value, :bool, :required => false, :desc => N_('The value contains sensitive information and shouldn not be normally visible, useful e.g. for passwords')
           param :value_type, TemplateInput::VALUE_TYPE, :required => false, :desc => N_('Value type, defaults to plain')
           param :resource_type, Permission.resources, :required => false, :desc => N_('For values of type search, this is the resource the value searches in')
         end

--- a/app/controllers/concerns/foreman/controller/parameters/template_input.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template_input.rb
@@ -6,7 +6,7 @@ module Foreman::Controller::Parameters::TemplateInput
       Foreman::ParameterFilter.new(::TemplateInput).tap do |filter|
         filter.permit_by_context :id, :_destroy, :name, :required, :input_type, :fact_name, :resource_type, :value_type,
           :variable_name, :puppet_class_name, :puppet_parameter_name, :description, :template_id,
-          :options, :default, :advanced, :nested => true
+          :options, :default, :advanced, :hidden_value, :nested => true
       end
     end
   end

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -12,7 +12,7 @@ class TemplateInput < ApplicationRecord
 
   attr_exportable(:name, :required, :input_type, :fact_name, :variable_name, :puppet_class_name,
     :puppet_parameter_name, :description, :options, :advanced, :value_type,
-    :resource_type, :default)
+    :resource_type, :default, :hidden_value)
 
   belongs_to :template
 

--- a/app/views/api/v2/template_inputs/main.json.rabl
+++ b/app/views/api/v2/template_inputs/main.json.rabl
@@ -3,7 +3,7 @@ object @template_input
 extends 'api/v2/template_inputs/base'
 
 attributes :template_id, :fact_name, :variable_name, :puppet_parameter_name, :puppet_class_name,
-  :description, :required, :default
+  :description, :required, :default, :hidden_value
 
 node :options do |input|
   input.options.split(/\r?\n/) if input.options.present?

--- a/app/views/template_inputs/_form.html.erb
+++ b/app/views/template_inputs/_form.html.erb
@@ -18,6 +18,7 @@
       </div>
       <div class="user_input_type custom_input_type_fields" style="<%= (f.object.user_template_input? || f.object.new_record?) ? '' : 'display:none' %>">
         <%= checkbox_f f, :advanced, :disabled => @template.locked? %>
+        <%= checkbox_f f, :hidden_value, :disabled => @template.locked?, label_help: _('Should the value be hidden from users? Useful for sensitive input values such as passwords. Only applicable to Plain value types.'), wrapper_class: "form-group input-hidden-value-#{f.index || f.object_id}#{' hide' if f.object.value_type != 'plain'}" %>
         <%= textarea_f f, :options, :rows => 3, :class => 'user_input_type', :help_inline => _("A list of options the user can select from. If not provided, the user will be given a free-form field"),
                                     :disabled => @template.locked?, wrapper_class: "form-group input-options-#{f.index || f.object.id}#{' hide' if f.object.value_type != 'plain'}"  %>
         <%= text_f f, :default, :disabled => @template.locked? %>

--- a/app/views/template_inputs/_invocation_form.html.erb
+++ b/app/views/template_inputs/_invocation_form.html.erb
@@ -4,7 +4,14 @@
   <% else %>
     <%= content_tag :div, nil, id: "template-input-#{input.id}" %>
     <% if input.value_type == 'plain' || input.value_type.nil? %>
-      <%= textarea_f input_fields, :value, :label => input.name, :label_help => input.description, :required => input.required, :rows => 2, :onchange => local_assigns[:onchange], :id => input.name %>
+      <%= textarea_f input_fields, :value,
+        :label => input.name,
+        :label_help => input.description,
+        :required => input.required,
+        :rows => 2,
+        :onchange => local_assigns[:onchange],
+        :id => input.name,
+        :class => input.hidden_value? ? 'masked-input' : '' %>
     <% else %>
       <%= mount_report_template_input(input_fields.object) %>
     <% end %>

--- a/db/migrate/20200402190048_add_hidden_value_to_template_input.rb
+++ b/db/migrate/20200402190048_add_hidden_value_to_template_input.rb
@@ -1,0 +1,5 @@
+class AddHiddenValueToTemplateInput < ActiveRecord::Migration[5.2]
+  def change
+    add_column :template_inputs, :hidden_value, :boolean, default: false, null: false
+  end
+end

--- a/webpack/assets/javascripts/foreman_template_inputs.js
+++ b/webpack/assets/javascripts/foreman_template_inputs.js
@@ -55,7 +55,9 @@ export const inputValueOnchange = input => {
 
   $fields.find(`.resource-type-${inputId}`).toggle(searchValue);
   $fields.find(`.input-options-${inputId}`).toggle(plainValue);
+  $fields.find(`.input-hidden-value-${inputId}`).toggle(plainValue);
 };
+
 export function snippetChanged(item) {
   const checked = $(item).is(':checked');
 


### PR DESCRIPTION
Some inputs can be sensitive. Users typing such values would prefer to
have the value hidden in the form. The sensitive information can be a
password, private key or general multiline text. Therefore we aren't
limitting the input to type=password, but use text area with hiding
font, similarly to what we do for parameters.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
