### PR TITLE
Fixes #29470 - Rails 6 compatible method calls

### DIFF
--- a/config/initializers/rabl_init.rb
+++ b/config/initializers/rabl_init.rb
@@ -55,9 +55,7 @@ module Foreman
     # while initializing the engine.
     # This allows us to find extension template from plugins
     # that match the template name
-    def call(template)
-      source = template.source
-
+    def call(template, source)
       %{ ::Rabl::Engine.new(#{source.inspect}, :template => '#{template.virtual_path}').
                                           apply(self, assigns.merge(local_assigns)).
                                                         render }

--- a/config/initializers/z_rails_5_compatibility.rb
+++ b/config/initializers/z_rails_5_compatibility.rb
@@ -1,0 +1,12 @@
+module Foreman
+  module Rails5
+    module RablTemplateHandlerExt
+      def call(template, source = nil)
+        source ||= template.source
+        super(template, source)
+      end
+    end
+  end
+end
+
+ActionView::Template::Handlers::Rabl.singleton_class.prepend Foreman::Rails5::RablTemplateHandlerExt


### PR DESCRIPTION
Moves to rails 6 syntax and adds a patch file to keep compatibility to Rails 5.2