### PR TITLE
Fixes #29474 - remove :on from save callbacks

### DIFF
--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -7,8 +7,8 @@ module NestedAncestryCommon
     has_ancestry :orphan_strategy => :restrict
 
     before_validation :set_title
-    after_save :set_other_titles, :on => [:update, :destroy]
-    after_save :update_matchers, :on => :update, :if => proc { |obj| obj.saved_change_to_title? }
+    after_update :set_other_titles
+    after_update :update_matchers, :if => proc { |obj| obj.saved_change_to_title? }
 
     # attribute used by *_names and *_name methods.  default is :name
     attr_name :title

--- a/app/models/jwt_secret.rb
+++ b/app/models/jwt_secret.rb
@@ -8,7 +8,7 @@ class JwtSecret < ApplicationRecord
   validates :token, uniqueness: true
   validates :user, presence: true
 
-  before_save :generate_token, on: :create, prepend: true, :unless => proc { |j| j.token.present? }
+  before_create :generate_token, prepend: true, :unless => proc { |j| j.token.present? }
 
   private
 


### PR DESCRIPTION
This was silently ignored, and will fail in rails 6. Changing the
callbacks to the correct ones intended according to the :on option.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
