### PR TITLE
Refs #29483 - remove unecessary use of implicit scopes

### DIFF
--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -20,7 +20,7 @@ class Bookmark < ApplicationRecord
   scoped_search :on => :name, :complete_value => true
 
   scope :my_bookmarks, lambda {
-    where(public: true).or(Bookmark.where(owner: User.current))
+    where(public: true).or(where(owner: User.current))
   }
 
   scope :controller, ->(*args) { where("controller = ?", (args.first || '')) }

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -202,7 +202,7 @@ module AuditExtensions
     # If the label changed we want to record the old one, not the new one.
     # We need to load old version from db since the auditable in memory is the
     # updated version that hasn't been saved yet.
-    previous_state = auditable.class.find_by(id: auditable_id) if auditable
+    previous_state = auditable.class.unscoped.find_by(id: auditable_id) if auditable
     previous_state ||= auditable
     self.auditable_name ||= previous_state.try(:to_label)
     self.associated_name ||= associated.try(:to_label)

--- a/app/models/mail_notifications/config_management_error.rb
+++ b/app/models/mail_notifications/config_management_error.rb
@@ -1,6 +1,6 @@
 class ConfigManagementError < MailNotification
   scope :all_hosts, lambda {
-    ConfigManagementError.includes(:user_mail_notifications).
+    includes(:user_mail_notifications).
     where(:user_mail_notifications => {:interval => 'Subscribe to all hosts'})
   }
 


### PR DESCRIPTION
This is not exhaustive list, probably there are other places we will need to address, this is example and it's the low hanging fruit before we will be forced to do it for Rails 6.1 :upside_down_face: 