### PR TITLE
Fixes #29507 - Add puma-status for reporting

### DIFF
--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -2,6 +2,7 @@ run_dir = Rails.root.join('tmp')
 
 # Store server info state.
 state_path File.join(run_dir, 'puma.state')
+state_permission 0640
 
 # Configure "min" to be the minimum number of threads to use to answer
 # requests and "max" the maximum.

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -1,3 +1,8 @@
+run_dir = Rails.root.join('tmp')
+
+# Store server info state.
+state_path File.join(run_dir, 'puma.state')
+
 # Configure "min" to be the minimum number of threads to use to answer
 # requests and "max" the maximum.
 #
@@ -17,3 +22,6 @@ on_worker_boot do
   dynflow = ::Rails.application.dynflow
   dynflow.initialize! unless dynflow.config.lazy_initialization
 end
+
+# === Puma control rack application ===
+activate_control_app "unix://#{run_dir}/sockets/pumactl.sock"

--- a/script/foreman-puma-status
+++ b/script/foreman-puma-status
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Intended for a production environment only
+puma-status /run/foreman/puma.state


### PR DESCRIPTION
Note the foreman packaging change is still pending to include `puma-status` gem as rpm
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
