### PR TITLE
Fixes #29092 - Set Active Tab for AuthSourceExternal form

### DIFF
--- a/app/helpers/auth_source_external_helper.rb
+++ b/app/helpers/auth_source_external_helper.rb
@@ -1,0 +1,11 @@
+module AuthSourceExternalHelper
+  def tab_classes_for_edit_auth_source_external
+    if show_location_tab?
+      { :location => 'active' }
+    elsif show_organization_tab?
+      { :organization => 'active' }
+    else
+      {}
+    end
+  end
+end

--- a/app/views/auth_source_externals/_form.html.erb
+++ b/app/views/auth_source_externals/_form.html.erb
@@ -1,17 +1,23 @@
 <%= form_for @auth_source_external do |f| %>
   <%= base_errors_for @auth_source_external %>
   <ul class="nav nav-tabs" data-tabs="tabs">
+    <% tab_classes = tab_classes_for_edit_auth_source_external %>
     <% if show_location_tab? %>
-      <li><a href="#locations" data-toggle="tab"><%= _("Locations") %></a></li>
+      <li class="active">
+        <a href="#locations" data-toggle="tab"><%= _("Locations") %></a>
+      </li>
     <% end %>
     <% if show_organization_tab? %>
-      <li><a href="#organizations" data-toggle="tab"><%= _("Organizations") %></a></li>
+      <li class="<%= tab_classes[:organization] %>">
+        <a href="#organizations" data-toggle="tab"><%= _("Organizations") %></a>
+      </li>
     <% end %>
   </ul>
 
   <div class="tab-content">
-    <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @auth_source_external %>
-</div>
+    <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @auth_source_external,
+      :html_options => { :tab_classes => tab_classes } %>
+  </div>
 
-  <%= submit_or_cancel f, false, :cancel_path => auth_sources_path%>
+  <%= submit_or_cancel f, false, :cancel_path => auth_sources_path %>
 <% end %>

--- a/app/views/taxonomies/_loc_org_tabs.html.erb
+++ b/app/views/taxonomies/_loc_org_tabs.html.erb
@@ -1,10 +1,11 @@
 <% select_options ||= {} %>
 <% html_options ||= {} %>
+<% html_options[:tab_classes] ||= {} %>
 <% html_options[:location] ||= {} %>
 <% html_options[:organization] ||= {} %>
 
 <% if show_location_tab? %>
-  <div class="tab-pane" id="locations">
+  <div class="tab-pane <%= html_options[:tab_classes][:location] %>" id="locations">
     <%= location_selects f, obj.used_or_selected_location_ids,
             {:disabled => obj.used_location_ids }.merge!(select_options),
             {'data-descendants' => obj.children_of_selected_location_ids.to_json,
@@ -17,7 +18,7 @@
 <% end %>
 
 <% if show_organization_tab? %>
-  <div class="tab-pane" id="organizations">
+  <div class="tab-pane <%= html_options[:tab_classes][:organization] %>" id="organizations">
     <%= organization_selects f, obj.used_or_selected_organization_ids,
             {:disabled => obj.used_organization_ids }.merge!(select_options),
             {'data-descendants' => obj.children_of_selected_organization_ids.to_json,

--- a/test/helpers/auth_source_external_helper_test.rb
+++ b/test/helpers/auth_source_external_helper_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class AuthSourceExternalHelperTest < ActionView::TestCase
+  include AuthSourceExternalHelper
+  include TaxonomyHelper
+
+  describe 'tab_classes_for_edit_auth_source_external' do
+    context 'user with view_locations and view_organizations permission' do
+      it 'returns class for location tab' do
+        as_admin do
+          assert_equal ({ :location => 'active' }), tab_classes_for_edit_auth_source_external
+        end
+      end
+    end
+
+    context 'user with view_locations permission only' do
+      it 'returns class for location tab' do
+        setup_user 'view', 'locations'
+        assert_equal ({ :location => 'active' }), tab_classes_for_edit_auth_source_external
+      end
+    end
+
+    context 'user with view_organizations permission only' do
+      it 'returns class for organization tab' do
+        setup_user 'view', 'organizations'
+        assert_equal ({ :organization => 'active' }), tab_classes_for_edit_auth_source_external
+      end
+    end
+
+    context 'user with neither view_locations nor view_organization access' do
+      it 'returns a empty hash' do
+        setup_user 'none'
+        assert_empty tab_classes_for_edit_auth_source_external
+      end
+    end
+  end
+end


### PR DESCRIPTION
Bug:
https://projects.theforeman.org/issues/29092

Steps to reproduce bug:
1. log in to the dashboard as a administrator user   
1. On the dashboard, click on 'Administrator' in the left nav-bar and then click on 'Authentication sources'  
1. Then on the card titled as 'External', click on the icon at top-right  
1. Click on the 'edit' option from the dropdown
1. You will notice that on the page that loads (/auth_source_externals/{:id}/edit), there is no active tab and the tab contents are empty

Before Fix Screenshot:

![29092_before](https://user-images.githubusercontent.com/1745111/79999101-24e55380-84d9-11ea-82a5-9b1595586985.png)

After Fix Screenshot:

![29092 _after](https://user-images.githubusercontent.com/1745111/79999043-1434dd80-84d9-11ea-8b2c-9a4fcc398e2b.png)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
