### PR TITLE
Fixes #26311 - graceful fail of external user creation

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -163,10 +163,27 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'login should also be unique across usergroups' do
-    Usergroup.expects(:where).with(:name => 'foo').returns(['fakeuser'])
+    Usergroup.expects(:where).with(:name => 'foo').returns(['fakeusergroup'])
     u = FactoryBot.build_stubbed(:user, :auth_source => auth_sources(:one),
                                  :login => "foo", :mail => "foo@bar.com")
     refute u.valid?
+    assert_includes u.errors.full_messages, 'A user group already exists with this name'
+  end
+
+  test 'external login should be unique across usergroups' do
+    Usergroup.expects(:where).with(:name => 'foo').returns(['fakeusergroup'])
+    u = FactoryBot.build_stubbed(:user, :auth_source => auth_sources(:external),
+                                 :login => "foo", :mail => "foo@bar.com")
+    refute u.valid?
+    assert_includes u.errors.full_messages, 'A user group already exists with this name'
+  end
+
+  test 'hidden login should be unique across usergroups' do
+    Usergroup.expects(:where).with(:name => 'foo').returns(['fakeusergroup'])
+    u = FactoryBot.build_stubbed(:user, :auth_source => auth_sources(:hidden),
+                                 :login => "foo", :mail => "foo@bar.com")
+    refute u.valid?
+    assert_includes u.errors.full_messages, 'A user group already exists with this name'
   end
 
   test "user should login case insensitively" do


### PR DESCRIPTION
Currently, the [`create!` ](https://github.com/theforeman/foreman/blob/develop/app/models/user.rb#L320) causes broken functionality during the external user login, in case of same user-group name present.

This PR makes sure that the error is logged. External must not be able to login if same user-group name exists.