### PR TITLE
Fixes #29402 - Add missing gov region for EC2

### DIFF
--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -17,14 +17,14 @@ module Foreman::Model
 
     def gov_cloud=(enable_gov_cloud)
       if enable_gov_cloud == '1'
-        self.url = GOV_CLOUD_REGION
+        self.url ||= GOV_CLOUD_REGION
       elsif gov_cloud?
         self.url = nil
       end
     end
 
     def gov_cloud
-      url == GOV_CLOUD_REGION
+      ['us-gov-west-1', 'us-gov-east-1'].include? url
     end
     alias_method :gov_cloud?, :gov_cloud
 
@@ -153,6 +153,7 @@ module Foreman::Model
     end
 
     def client
+      self.url = region if gov_cloud
       @client ||= ::Fog::Compute.new(:provider => "AWS", :aws_access_key_id => user, :aws_secret_access_key => password, :region => region, :connection_options => connection_options)
     end
 


### PR DESCRIPTION
With the addition of a new gov region `us-gov-east-1` in AWS, Foreman EC2 doesn't support it due to the hardcoded `GOV_CLOUD_REGION` in the model. 
If the API calls work for gov cloud as well, for example here: `[#describe_regions](https://github.com/theforeman/foreman/blob/develop/app/models/compute_resources/foreman/model/ec2.rb#L82)` then we can remove setting the `self.url` explicitly with hardcoded region.
Still considering it WIP.