### PR TITLE
Fixes #29523 - GraphQL collection preloading on Rails 6

### DIFF
--- a/config/initializers/z_rails_5_compatibility.rb
+++ b/config/initializers/z_rails_5_compatibility.rb
@@ -6,7 +6,16 @@ module Foreman
         super(template, source)
       end
     end
+
+    module CollectionLoaderAssocRead
+      def read_association(_preloader, record)
+        record.public_send(association_name)
+      end
+    end
   end
 end
 
 ActionView::Template::Handlers::Rabl.singleton_class.prepend Foreman::Rails5::RablTemplateHandlerExt
+if Rails.version.start_with?('5.2')
+  CollectionLoader.prepend Foreman::Rails5::CollectionLoaderAssocRead
+end


### PR DESCRIPTION
Custom preloading doesn't work as expected, details in the redmine ticket.