### PR TITLE
Fixes #29525 - Use model name from global id to load object

### DIFF
--- a/app/graphql/foreman_graphql_schema.rb
+++ b/app/graphql/foreman_graphql_schema.rb
@@ -19,10 +19,8 @@ class ForemanGraphqlSchema < GraphQL::Schema
   def self.object_from_id(id, query_ctx)
     return unless id.present?
 
-    _, type_name, item_id = Foreman::GlobalId.decode(id)
-    type_class = "::Types::#{type_name}".safe_constantize
-
-    model_class = type_class&.model_class
+    _, model_class_name, item_id = Foreman::GlobalId.decode(id)
+    model_class = ForemanGraphqlSchema.types.keys.find { |t| t == model_class_name }&.safe_constantize
 
     return unless model_class
 


### PR DESCRIPTION
we can use the model name encoded in GlobalId to load the object

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
