### PR TITLE
Fixes #29546 - External IPAM Dashboard Widget

### DIFF
--- a/app/controllers/external_ipam_controller.rb
+++ b/app/controllers/external_ipam_controller.rb
@@ -1,0 +1,15 @@
+class ExternalIpamController < ApplicationController
+  def show
+    @proxy = SmartProxy.with_features('External IPAM').first
+    @api = ProxyAPI::ExternalIpam.new({:url => @proxy.url}) if @proxy.present?
+
+    if @proxy
+      @subnets = @api.get_subnets_by_group(params[:group])
+      render :json => @subnets.to_json, :status => :ok
+    else
+      flash.now[:error] = "No External IPAM Proxy configured"
+    end
+  rescue => e
+    flash.now[:error] = e.message
+  end
+end

--- a/app/services/dashboard/manager.rb
+++ b/app/services/dashboard/manager.rb
@@ -70,6 +70,7 @@ module Dashboard
           {template: 'reports_widget', sizex: 6, sizey: 1, name: N_('Latest Events')},
           {template: 'new_hosts_widget', sizex: 8, sizey: 1, name: N_('New Hosts')},
           {template: 'hosts_in_build_mode_widget', sizex: 8, sizey: 1, name: N_('Hosts in build mode')},
+          {template: 'external_ipam_widget', sizex: 8, sizey: 1, name: N_('External IPAM Dashboard')},
         ].flatten.sort_by { |widget| widget['name'] }
       end
 

--- a/app/views/dashboard/_external_ipam_widget.html.erb
+++ b/app/views/dashboard/_external_ipam_widget.html.erb
@@ -1,0 +1,106 @@
+<% 
+  proxy = SmartProxy.with_features('External IPAM').first if proxy.nil?
+  api = ProxyAPI::ExternalIpam.new({:url => proxy.url}) if api.nil? && proxy.present?
+  groups = api.get_groups if api
+%>
+
+<h4 class="header">
+  <%= _('External IPAM Groups & Subnets') %>
+</h4>
+
+<% unless proxy %>
+  <div class="alert alert-warning ">
+    <span class="pficon pficon-warning-triangle-o "></span>
+    <span class="text"><%= _("No External IPAM Proxy configured") %></span>
+  </div>
+<% else %>
+  <% if groups['data'] && groups['data'].length == 0 %>
+    <div class="alert alert-warning ">
+      <span class="pficon pficon-warning-triangle-o "></span>
+      <span class="text"><%= _("No sections found in External IPAM.") %></span>
+    </div>
+  <% elsif groups['data'] && groups['data'].length > 0 %>
+    <div class='col-md-7'>
+      <h4>Groups</h4>
+      <div style="width:435px; height:209px; overflow:auto;">
+        <table class="<%= table_css_classes 'table-fixed' %>">
+          <thead>
+            <tr>
+              <th class="col-md-4"><%= s_("Name") %></th>
+              <th class="col-md-7"><%= s_("Description") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% groups['data'].each do |group| %>
+              <tr>
+                <td class="ellipsis">
+                  <a href="#" onclick="getSubnets('<%= group['name'] %>')"><%= group['name'] %></a>
+                </td>
+                <td class="ellipsis">
+                  <%= group['description'] %>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>  
+    </div>
+    <div class='col-md-5'>
+      <div id="subnet_header"></div>
+      <div style="height:209px; overflow:auto;">
+        <div id="subnet_container"><h4><i>Select a Group to display it's subnets</i></h4></div>      
+      </div>
+    </div>
+  <% end %>
+<% end %>
+
+<script>
+  function truncate(str, num) {
+    if (str.length <= num)
+      return str.toString();
+
+    return str.toString().slice(0, num) + "...";
+  }
+
+  function getSubnets(groupName) {
+    subnet_header.innerHTML = '<h4>Subnets in: <i><strong>' + truncate(groupName, 68) + '</strong></i></h4>';
+
+    $.ajax({
+      type: "GET", url: "/ipam/" + encodeURIComponent(groupName) + "/subnets",
+      data: {"group": groupName},
+      success: function(subnets) {
+        if (!subnets)
+          subnet_container.innerHTML = 'Cannot connect to External IPAM';
+        else 
+          renderSubnets(subnets);
+      }
+    });
+  }
+
+  function renderHeader(subnets) {
+    if (subnets['message'] === 'No subnets found') {
+      subnet_container.innerHTML = "<div class='col-sm'><i>No subnets found</i></div>"
+    }
+    else {
+      subnet_container.innerHTML = `
+        <div class='row'>
+          <div class='col col-md-4'><strong>Subnet</strong></div>
+          <div class='col'><strong>Description</strong></div>
+        </div>
+      `;
+    }
+  }
+
+  function renderSubnets(subnets) {
+    renderHeader(subnets);
+    subnets['data'].forEach(function(item) {
+      var desc = item['description'] == null ? "" : item['description'];
+      subnet_container.innerHTML += `
+        <div class='row'>
+          <div class='col col-md-4'>` + item['subnet'] + `/` + item['mask'] + `</div>
+          <div class='col'>` + truncate(desc, 34) + `</div>
+        </div>
+      `;
+    });
+  }
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,6 +166,7 @@ Foreman::Application.routes.draw do
     end
 
     get 'unattended/template/:id/*hostgroup', :to => "unattended#hostgroup_template", hostgroup: /.+/, :format => 'text'
+    get 'ipam/:group/subnets', to: 'external_ipam#show'
   end
 
   resources :settings, :only => [:index, :update] do

--- a/test/unit/dashboard_manager_test.rb
+++ b/test/unit/dashboard_manager_test.rb
@@ -33,7 +33,7 @@ class DashboardManagerTest < ActiveSupport::TestCase
   test '.default_widgets returns built-in widgets' do
     Dashboard::Manager.stubs(:registered_report_orgins).returns(['Puppet'])
     Foreman::Plugin.expects(:all).returns([])
-    assert_equal 8, Dashboard::Manager.default_widgets.count
+    assert_equal 9, Dashboard::Manager.default_widgets.count
   end
 
   test '.default_widgets adds plugin widgets' do


### PR DESCRIPTION
@lzap This PR is for the moving of the functionality from the [foreman_ipam](https://github.com/grizzthedj/foreman_ipam) plugin, into a widget in Foreman core. The widget will communicate with External IPAM via the proxy API, so this plugin will no longer be needed.

The design/layout has been modified slightly from that of the original plugin to accommodate the widget's smaller real estate. Both the Groups list(on left) and subnets list(on right) are scrollable, and strings are truncated to avoid text wrapping.

Here are a few screenshots:

Initial Load of widget:

<img width="1279" alt="initial-load" src="https://user-images.githubusercontent.com/9720835/79451666-e3264b80-7fb4-11ea-82cf-8262a693b3b1.png">

Click Group with no subnets:

<img width="1279" alt="group-with-no-subnets" src="https://user-images.githubusercontent.com/9720835/79451694-ef120d80-7fb4-11ea-9cfc-40eeb2801cbc.png">

Click Group with multiple subnets:

<img width="1280" alt="group-with-multiple-subnets" src="https://user-images.githubusercontent.com/9720835/79451720-fb966600-7fb4-11ea-9ead-80df5ee44c5b.png">
