### PR TITLE
Fixes #28596 - remove smart variables from LookupKeysCommonController

### DIFF
--- a/app/controllers/api/v2/override_values_controller.rb
+++ b/app/controllers/api/v2/override_values_controller.rb
@@ -42,8 +42,8 @@ module Api
       param_group :override_value, :as => :create
 
       def create
-        @override_value = @smart.lookup_values.create!(lookup_value_params)
-        @smart.update_attribute(:override, true)
+        @override_value = @smart_class_parameter.lookup_values.create!(lookup_value_params)
+        @smart_class_parameter.update_attribute(:override, true)
         process_response @override_value
       end
 
@@ -68,16 +68,16 @@ module Api
       private
 
       def find_override_values
-        if @smart
-          @override_values = @smart.lookup_values.paginate(paginate_options)
+        if @smart_class_parameter
+          @override_values = @smart_class_parameter.lookup_values.paginate(paginate_options)
           @total = @override_values.count
         end
       end
 
       def find_override_value
         @override_value = LookupValue.find_by_id(params[:id])
-        if @smart
-          @override_value ||= @smart.lookup_values.friendly.find(params[:id])
+        if @smart_class_parameter
+          @override_value ||= @smart_class_parameter.lookup_values.friendly.find(params[:id])
         end
       end
 

--- a/test/controllers/concerns/lookup_keys_common_controller_test.rb
+++ b/test/controllers/concerns/lookup_keys_common_controller_test.rb
@@ -16,12 +16,6 @@ class Api::V2::LookupKeysCommonControllerTest < ActiveSupport::TestCase
     @dummy = DummyController.new
   end
 
-  test "should cast default_value from smart variable" do
-    @dummy.params = {:smart_variable => { :default_value => true }}
-    @dummy.cast_value(:smart_variable, :default_value)
-    assert_equal "true", @dummy.params[:smart_variable][:default_value]
-  end
-
   test "should cast default_value from smart class parameter" do
     @dummy.params = {:smart_class_parameter => { :default_value => ['a', 'b'] }}
     @dummy.cast_value(:smart_class_parameter, :default_value)


### PR DESCRIPTION
Cleaning `smart variables` leftovers
`LookupKeysCommonController` is also used by `OverrideValuesController` therefore I left it as a concern