### PR TITLE
Fixes #29433 - seeding with scope

### DIFF
--- a/db/seeds.d/150-bookmarks.rb
+++ b/db/seeds.d/150-bookmarks.rb
@@ -8,7 +8,7 @@ Bookmark.without_auditing do
     { :name => "disabled", :query => 'status.enabled = false', :controller => "hosts" },
     { :name => "ok hosts", :query => 'last_report > "35 minutes ago" and status.enabled = true and status.applied = 0 and status.failed = 0 and status.pending = 0', :controller => "hosts" },
   ].each do |input|
-    next if Bookmark.where(:controller => input[:controller], :name => input[:name]).first
+    next if Bookmark.where(:controller => input[:controller], :name => input[:name]).exists?
     next if SeedHelper.audit_modified? Bookmark, input[:name], :controller => input[:controller]
     b = Bookmark.create({ :public => true }.merge(input))
     raise "Unable to create bookmark: #{format_errors b}" if b.nil? || b.errors.any?

--- a/test/factories/bookmark.rb
+++ b/test/factories/bookmark.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :bookmark do
     sequence(:name) { |n| "bookmark_#{n}" }
     query { "bar" }
+    controller { 'hosts' }
     # rubocop:disable Layout/EmptyLinesAroundAccessModifier
     public { false }
     # rubocop:enable Layout/EmptyLinesAroundAccessModifier


### PR DESCRIPTION
the seeding filter is broken if there is unexpected change to the checked resource.
Update audit contains only changed attributes
