### PR TITLE
Fixes #29581 - Default search field type to string

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -465,7 +465,7 @@ module Api
           else
             # type is unknown for fields that are delegated to external methods
             # 'string' is a good guess in such cases
-            info[:type] = f.ext_method.nil? ? f.type.to_s : 'string' rescue ''
+            info[:type] = f.ext_method.nil? ? f.type.to_s : 'string' rescue 'string'
           end
           info
         end


### PR DESCRIPTION
When generating API cache without a migrated database, the scoped search
field definition cannot determine the field type. In that case we
default to `string` type which is always safe, as search parameters are
always sent as a string as part of url params.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
