### PR TITLE
Fixes #29582 - Improve performance of externalNodes

### DIFF
--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -161,7 +161,9 @@ class String
   end
 
   def contains_erb?
-    self =~ /<%.*%>/
+    # minimum possible ERB is four characters '<%%>'
+    return false if size <= 4
+    index('<%')
   end
 
   # TODO Remove me after Rails 6 upgrade: https://github.com/rails/rails/commit/4940cc49ddb361d584d51bc3eb4675ff8ece4a2b

--- a/test/benchmark/host_info_benchmark.rb
+++ b/test/benchmark/host_info_benchmark.rb
@@ -1,0 +1,24 @@
+require File.expand_path('../../config/environment', __dir__)
+
+Rails.logger.level = Logger::ERROR
+
+Benchmark.ips do |x|
+  host = Host.find_or_create_by!(name: "benchmark-host-info-1")
+
+  (1..1000).each do |i|
+    name = FactName.find_or_create_by!(name: "benchmark-#{i}")
+    FactValue.find_or_create_by!(value: "some value", fact_name: name, host: host)
+  end
+
+  (1..1000).each do |i|
+    HostParameter.find_or_create_by!(name: "benchmark-param-#{i}", value: "<%= #{i} * 13 %>", host: host)
+  end
+
+  x.config(time: 10, warmup: 2)
+  # require 'profile'
+  x.report("Thousand") do
+    # Profiler__::start_profile
+    host.info
+    # Profiler__::stop_profile
+  end
+end

--- a/test/unit/parameter_safe_render_test.rb
+++ b/test/unit/parameter_safe_render_test.rb
@@ -6,6 +6,20 @@ class ParameterSafeRenderTest < ActiveSupport::TestCase
     @safe_render = ParameterSafeRender.new(@host)
   end
 
+  test 'safe_render should return empty string' do
+    Setting[:interpolate_erb_in_parameters] = true
+
+    s = @safe_render.render('')
+    assert_equal '', s
+  end
+
+  test 'safe_render should return long string' do
+    Setting[:interpolate_erb_in_parameters] = true
+
+    s = @safe_render.render('X' * 1024)
+    assert_equal 'X' * 1024, s
+  end
+
   test 'safe_render should return raw strings when interpolate is false' do
     Setting[:interpolate_erb_in_parameters] = false
 


### PR DESCRIPTION
This patch speeds up externalNodes action by 13 times: from 14 ops/s to 190 ops/s. You can test this on your setup, benchmark is included - it tests ENC with a host with 1000 facts and 1000 host parameters with a simple ERB block. To run it (I used Foreman develop with PostgreSQL from Fedora 31):

```
RAILS_ENV=production be ruby -Itest test/benchmark/host_info_benchmark.rb
```

Here is how I was researching the code and implementing changes and the gain I got from the change.

* Initial performance: 14 ops/second
* Removed deep_stringify_keys call: 14 ops/second
* Hash is passed as argument (less top level copying) 22 ops/second
* Skip ERB rendering when string does not contain `<%` 28 ops/second
* Memorized renderer scope 28 ops/second
* Moved interpolate_erb_in_parameters settings check out of the loop: 184 ops/second
* Introducing inplace parse!: 189 ops/second

So the biggest speedup is by simply moving this line out of the private method which is called many times to the entry method:

```
  return value unless (Setting[:interpolate_erb_in_parameters])
```

I do believe that our settings stack is ultra slow and if we refactor it in a way that a setting lookup is very fast it would boost other parts of Foreman too.