### PR TITLE
Fixes #29251 - Multiple templates deletion support

### DIFF
--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -80,4 +80,24 @@ module TemplatesHelper
       resourceTypes: Hash[Permission.resources.map { |d| [d.tableize.to_s, d] }],
     }.to_json)
   end
+
+  def multiple_template_actions(templates)
+    actions = []
+    actions << [_('Delete Templates'), send("multiple_destroy_#{templates}_path"), true] if authorized_for(controller: :templates, action: :destroy)
+    actions
+  end
+
+  def multiple_template_actions_select(templates)
+    select_action_button(_('Select Action'), { id: 'submit_multiple' },
+      multiple_template_actions(templates).map do |action|
+        # If the action array has 3 entries, the third one is whether to use a modal dialog or not
+        modal = (action.size == 3) ? action[2] : true
+        if modal
+          link_to_function(action[0], "tfm.templates.table.buildModal(this, '#{action[1]}')", :'data-dialog-title' => _("%s - The following templates are about to be changed") % action[0])
+        else
+          link_to_function(action[0], "tfm.templates.table.buildRedirect('#{action[1]}')")
+        end
+      end.flatten
+    )
+  end
 end

--- a/app/views/report_templates/_selected_templates.html.erb
+++ b/app/views/report_templates/_selected_templates.html.erb
@@ -1,0 +1,35 @@
+<div class="row">
+  <%= alert(class: 'alert-info hide', id: 'multiple-modal-alert', close: true, header: '',
+            text: multiple_filter(templates)) %>
+  <% unless multiple_with_filter? %>
+    <div class="col-md-12">
+      <table class="<%= table_css_classes %>">
+        <thead>
+          <tr>
+            <th>
+              <%= _('Name') %>
+            </th>
+            <th>
+              <%= _('Snippet') %>
+            </th>
+            <th>
+              <%= _('Locked') %>
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <% templates.each do |template| %>
+            <tr>
+              <td><%=h template %>
+              </td>
+              <td><%= checked_icon template.snippet %></td>
+              <td><%= locked_icon template.locked?, _('This template is locked for editing.') %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <%= check_box_tag 'keep_selected', '', false, title: _('Remember templates selection for the next bulk action') %>
+      <%= _('Remember templates selection for the next bulk action') %><br/><br/>
+    </div>
+  <% end %>
+</div>

--- a/app/views/report_templates/index.html.erb
+++ b/app/views/report_templates/index.html.erb
@@ -1,12 +1,24 @@
 <% title _("Report Templates") %>
 
-<% title_actions new_link(_("Create Template")),
+<% title_actions multiple_template_actions_select('report_templates'),
+                 new_link(_("Create Template")),
                  documentation_button('4.11Reports')
 %>
-
+<%= alert(class: 'alert-info hide', id: 'multiple-alert', close: false, header: '',
+          text: n_('Single template on this page is selected.',
+                   "All %{per_page} templates on this page are selected.", per_page(@templates)).html_safe % { per_page: per_page(@templates) } + ' ' +
+                   link_to_function(n_("Select this template",
+                                       "Select all <b> %{total} </b> templates", @templates.total_entries).html_safe % { total: @templates.total_entries },
+                                       "tfm.templates.table.multipleSelection()")) %>
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
+      <th class='ca' width='40px'>
+        <%= check_box_tag 'check_all', '', false,
+                          { onchange: 'tfm.templates.table.toggleCheck()',
+                            :'check-title' => _('Select all items on this page'),
+                            :'uncheck-title'=> _('items selected. Uncheck to clear') } %>
+      </th>
       <th class="col-md-3"><%= sort :name, :as => s_("ReportTemplate|Name") %></th>
       <th class="col-md-1"><%= sort :snippet, :as => s_("ReportTemplate|Snippet") %></th>
       <th class="col-md-1"><%= sort :locked, :as => s_("ReportTemplate|Locked"), :default => "DESC" %></th>
@@ -16,6 +28,12 @@
   <tbody>
     <% for report_template in @templates %>
     <tr>
+        <td align='center' class='ca'>
+          <%= check_box_tag 'template_ids[]', nil, false,
+                            id: "template_ids_#{report_template.id}",
+                            class: 'template_select_boxes',
+                            onclick: 'tfm.templates.table.templateChecked(this)' %>
+        </td>
         <td class="ellipsis"><%= link_to_if_authorized report_template,
                                          hash_for_edit_report_template_path(:id => report_template.to_param).
                                          merge(:auth_object => report_template, :authorizer => authorizer,
@@ -30,3 +48,19 @@
   </tbody>
 </table>
 <%= will_paginate_with_info @templates %>
+<div id="confirmation-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title"><%= _('Please Confirm') %></h4>
+      </div>
+      <div class="modal-body">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= _('Cancel') %></button>
+        <button type="button" class="btn btn-primary" onclick='tfm.templates.table.submitModalForm()'><%= _('Submit') %></button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/report_templates/multiple_destroy.html.erb
+++ b/app/views/report_templates/multiple_destroy.html.erb
@@ -1,0 +1,7 @@
+<%= form_tag submit_multiple_destroy_report_templates_path(template_ids: params[:template_ids]), onsubmit: 'tfm.templates.table.resetSelection()' do %>
+  <%= alert class: 'alert-warning',
+    text: (_('This is irreversible.')).html_safe,
+    header: '' %>
+<% end %>
+
+<%= render 'selected_templates', templates: @templates %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -372,6 +372,8 @@ Foreman::Application.routes.draw do
         post 'preview'
         get 'revision'
         get 'auto_complete_search'
+        post 'multiple_destroy'
+        post 'submit_multiple_destroy'
       end
     end
   end

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -6,6 +6,7 @@ import componentRegistry from './react_app/components/componentRegistry';
 import i18n from './react_app/common/I18n';
 import * as document from './react_app/common/document';
 import hosts from './foreman_hosts';
+import templates from './foreman_templates';
 import * as store from './foreman_store';
 import * as authSource from './foreman_auth_source';
 import * as tools from './foreman_tools';
@@ -64,4 +65,5 @@ window.tfm = Object.assign(window.tfm || {}, {
   store,
   autocomplete,
   typeAheadSelect,
+  templates,
 });

--- a/webpack/assets/javascripts/foreman_templates.js
+++ b/webpack/assets/javascripts/foreman_templates.js
@@ -1,0 +1,5 @@
+import * as table from './templates/tableCheckboxes';
+
+export default {
+  table,
+};

--- a/webpack/assets/javascripts/templates/tableCheckboxes.js
+++ b/webpack/assets/javascripts/templates/tableCheckboxes.js
@@ -1,0 +1,291 @@
+/* eslint-disable jquery/no-param */
+/* eslint-disable jquery/no-load */
+/* eslint-disable jquery/no-hide */
+/* eslint-disable jquery/no-show */
+/* eslint-disable jquery/no-find */
+/* eslint-disable jquery/no-text */
+/* eslint-disable jquery/no-data */
+/* eslint-disable jquery/no-val */
+/* eslint-disable jquery/no-attr */
+/* eslint-disable jquery/no-is */
+/* eslint-disable jquery/no-html */
+/* eslint-disable jquery/no-each */
+/* eslint-disable jquery/no-submit */
+/* eslint-disable jquery/no-in-array */
+
+import $ from 'jquery';
+
+import {
+  sprintf,
+  ngettext as n__,
+  translate as __,
+} from '../react_app/common/I18n';
+import { getURIsearch } from '../react_app/common/urlHelpers';
+import { foremanUrl } from '../foreman_tools';
+
+// Array contains list of template ids
+const cookieName = `_ForemanSelected${window.location.pathname.replace(
+  /\//,
+  ''
+)}`;
+let foremanSelectedTemplates = readFromCookie();
+
+// triggered by a template checkbox change
+export function templateChecked({ id, checked }) {
+  const multipleAlert = $('#multiple-alert');
+  const cid = parseInt(id.replace('template_ids_', ''), 10);
+  if (checked) addTemplateId(cid);
+  else {
+    rmTemplateId(cid);
+    if (multipleAlert.length) {
+      multipleAlert.hide('slow');
+      multipleAlert.data('multiple', false);
+    }
+  }
+  $.cookie(cookieName, JSON.stringify(foremanSelectedTemplates), {
+    secure: window.location.protocol === 'https:',
+  });
+  toggleActions();
+  updateCounter();
+  return false;
+}
+
+function addTemplateId(id) {
+  if ($.inArray(id, foremanSelectedTemplates) === -1) foremanSelectedTemplates.push(id);
+}
+
+function rmTemplateId(id) {
+  const pos = $.inArray(id, foremanSelectedTemplates);
+  if (pos >= 0) foremanSelectedTemplates.splice(pos, 1);
+}
+
+function readFromCookie() {
+  try {
+    const r = $.cookie(cookieName);
+    if (r) return $.parseJSON(r);
+    return [];
+  } catch (err) {
+    removeForemanTemplatesCookie();
+    return [];
+  }
+}
+
+function toggleActions() {
+  const dropDownContainer = $('#submit_multiple');
+  const dropdown = dropDownContainer.find('a');
+  const disabledMessage = __('Please select templates to perform action on.');
+  if (foremanSelectedTemplates.length === 0) {
+    dropdown.addClass('disabled');
+    dropdown.attr('disabled', 'disabled');
+    dropDownContainer.attr('title', disabledMessage);
+  } else {
+    dropdown.removeClass('disabled');
+    dropdown.removeAttr('disabled');
+    dropDownContainer.removeAttr('title');
+  }
+}
+
+// setups checkbox values upon document load
+$(document).on('ContentLoad', () => {
+  //                                           TODO: generic
+  if (window.location.pathname !== foremanUrl('/templates/report_templates')) return;
+
+  const templateQuery = sessionStorage.getItem('templateQuery');
+  const uriSearch = getURIsearch();
+
+  // clear selected templates if new search occurs
+  if (uriSearch !== '' && templateQuery !== uriSearch) {
+    cleanTemplatesSelection();
+    sessionStorage.setItem('templateQuery', uriSearch);
+    return;
+  }
+  sessionStorage.setItem('templateQuery', uriSearch);
+
+  for (let i = 0; i < foremanSelectedTemplates.length; i++) {
+    const cid = `template_ids_${foremanSelectedTemplates[i]}`;
+    const boxes = $(`#${cid}`);
+    if (boxes && boxes[0]) boxes[0].checked = true;
+  }
+  toggleActions();
+  updateCounter();
+  $('#search-form').submit(() => {
+    resetSelection();
+  });
+
+  // updates the form URL based on the action selection
+  $('#confirmation-modal .secondary').click(() => {
+    $('#confirmation-modal').modal('hide');
+  });
+});
+
+function removeForemanTemplatesCookie() {
+  $.removeCookie(cookieName);
+}
+
+export function resetSelection() {
+  removeForemanTemplatesCookie();
+  foremanSelectedTemplates = [];
+}
+
+function cleanTemplatesSelection() {
+  $('.template_select_boxes').each((index, box) => {
+    box.checked = false;
+    templateChecked(box);
+  });
+  resetSelection();
+  toggleActions();
+  updateCounter();
+  return false;
+}
+
+export function multipleSelection() {
+  const { total } = paginationMetaData();
+  const alertText = sprintf(
+    n__(
+      'Single template is selected in total',
+      'All <b> %d </b> templates are selected.',
+      total
+    ),
+    total
+  );
+  const undoText = __('Undo selection');
+  const multpleAlert = $('#multiple-alert');
+  multpleAlert
+    .find('.text')
+    .html(
+      `${alertText} <a href="#" onclick="tfm.templates.table.undoMultipleSelection();">${undoText}</a>`
+    );
+  multpleAlert.data('multiple', true);
+  $('.select_count').html(total);
+}
+
+export function undoMultipleSelection() {
+  const pagination = paginationMetaData();
+  const alertText = sprintf(
+    n__(
+      'Single template on this page is selected.',
+      'All %s templates on this page are selected.',
+      pagination.perPage
+    ),
+    pagination.perPage
+  );
+  const selectText = sprintf(
+    n__('Select this template', 'Select all<b> %s </b> templates', pagination.total),
+    pagination.total
+  );
+  const multpleAlert = $('#multiple-alert');
+  multpleAlert
+    .find('.text')
+    .html(
+      `${alertText} <a href="#" onclick="tfm.templates.table.multipleSelection();">${selectText}</a>`
+    );
+  multpleAlert.data('multiple', false);
+  $('.select_count').html(pagination.perPage);
+}
+
+export function toggleCheck() {
+  const pagination = paginationMetaData();
+  const multpleAlert = $('#multiple-alert');
+  const checked = $('#check_all').is(':checked');
+  $('.template_select_boxes').each((index, box) => {
+    box.checked = checked;
+    templateChecked(box);
+  });
+  if (checked && pagination.perPage - pagination.total < 0) {
+    multpleAlert.show('slow');
+    multpleAlert.data('multiple', false);
+  } else if (!checked) {
+    multpleAlert.hide('slow');
+    multpleAlert.data('multiple', false);
+    cleanTemplatesSelection();
+  }
+  return false;
+}
+
+export function toggleMultipleOkButton({ value }) {
+  const btn = $('#confirmation-modal .btn-primary');
+  if (value !== 'disabled') btn.removeClass('disabled').attr('disabled', false);
+  else btn.addClass('disabled').attr('disabled', true);
+}
+
+export function submitModalForm() {
+  if (!$('#keep_selected').is(':checked')) removeForemanTemplatesCookie();
+  if (isMultple()) {
+    const query = $('<input>')
+      .attr('type', 'hidden')
+      .attr('name', 'search')
+      .val(getURIsearch());
+    $('#confirmation-modal form').append(query);
+  }
+  $('#confirmation-modal form').submit();
+  $('#confirmation-modal').modal('hide');
+}
+
+function isMultple() {
+  return $('#multiple-alert').data('multiple');
+}
+
+function getBulkParam() {
+  return isMultple()
+    ? { search: getURIsearch() }
+    : { template_ids: foremanSelectedTemplates };
+}
+
+export function buildModal(element, url) {
+  const data = getBulkParam();
+  const title = $(element).attr('data-dialog-title');
+  $('#confirmation-modal .modal-header h4').text(title);
+  $('#confirmation-modal .modal-body')
+    .empty()
+    .append("<div class='modal-spinner spinner spinner-lg'></div>");
+  $('#confirmation-modal').modal();
+  $('#confirmation-modal .modal-body').load(
+    `${url} #content`,
+    data,
+    (response, status, xhr) => {
+      $('#loading').hide();
+      $('#submit_multiple').val('');
+      if (isMultple()) $('#multiple-modal-alert').show();
+      const b = $('#confirmation-modal .btn-primary');
+      if ($(response).find('#content form select').length > 0)
+        b.addClass('disabled').attr('disabled', true);
+      else b.removeClass('disabled').attr('disabled', false);
+    }
+  );
+  return false;
+}
+
+export function buildRedirect(url) {
+  const data = getBulkParam();
+  const redirectUrl = url.includes('?')
+    ? `${url}&${$.param(data)}`
+    : `${url}?${$.param(data)}`;
+
+  window.location.replace(redirectUrl);
+}
+
+function paginationMetaData() {
+  const total = Number(
+    document.getElementsByClassName('pagination-pf-items-total')[0].textContent
+  );
+  const perPage = Number(
+    document.getElementById('pagination-row-dropdown').textContent
+  );
+  return { total, perPage };
+}
+
+function updateCounter() {
+  const item = $('#check_all');
+  if (foremanSelectedTemplates)
+    $('.select_count').text(foremanSelectedTemplates.length);
+  let title = '';
+  if (item.prop('checked') && foremanSelectedTemplates)
+    title = `${foremanSelectedTemplates.length} - ${item.attr('uncheck-title')}`;
+  else title = item.attr('check-title');
+
+  item.attr('data-original-title', title);
+  item.tooltip({
+    trigger: 'hover',
+  });
+  return false;
+}


### PR DESCRIPTION
Adds a possibility to delete multiple report templates at once through UI:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/32508194/80022630-a5598380-84dc-11ea-95aa-b9930a1f946e.gif)

Actually the logic is copy-pasted and somehow adjusted from hosts page checkbox. I've tried to do changes in more general way so it can be extended for other templates. I hope that it's possible to add bulk actions (e.g. multiple lock/unlock) easier now.

Also, I wanted to ask maybe someone from @theforeman/ui-ux team could give me some advises on how to do `tableCheckboxes.js` more general, so it could be used for other templates.

Anyway, I'm open to any kind of advises :)

