### PR TITLE
Refs #29605 - pin babel-plugin-dynamic-import-node

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",
+    "babel-plugin-dynamic-import-node": "2.3.0",
     "compression-webpack-plugin": "~1.1.11",
     "cross-env": "^5.2.0",
     "css-loader": "^0.23.1",


### PR DESCRIPTION
Release 2.3.3 of this plugin causes webpack compile to fail on dynamic
imports in I18n.js. Pinning to known good version.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
