### PR TITLE
Fixes #29607 - warn early when cache does not work

### DIFF
--- a/app/services/ping.rb
+++ b/app/services/ping.rb
@@ -21,10 +21,16 @@ class Ping
           plugins: Foreman::Plugin.all,
           smart_proxies: statuses_smart_proxies,
           compute_resources: statuses_compute_resources,
+          rails_cache: rails_cache_check,
         },
       }.merge(plugins_statuses).merge(ping) do |_key, old_val, new_val|
         old_val.merge(new_val)
       end
+    end
+
+    def rails_cache_check
+      Rails.cache.write("foreman_rails_check", 1)
+      Rails.cache.fetch("foreman_rails_check") ? STATUS_OK : STATUS_FAIL
     end
 
     private

--- a/config/initializers/cache_check.rb
+++ b/config/initializers/cache_check.rb
@@ -1,0 +1,3 @@
+require_dependency "app/services/ping"
+
+Rails.logger.warn("Rails cache does not work or is misconfigured") if Ping.rails_cache_check != 'ok'


### PR DESCRIPTION
Foreman starts just fine when Rails cache is misconfigured (e.g. Redis incorrect URL or port blocked). Problem is, everything works fine except there is no caching at all. We need to prevent starting Rails without working cache and also add a ping check for that.

Adds also OK/FAIL into statuses controller.