### PR TITLE
Fixes #29612 - Update debian.rb to support Ubuntu 20 legacy pxe

### DIFF
--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -2,7 +2,12 @@ class Debian < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd.gz"}
 
   def pxedir(medium_provider = nil)
-    'dists/$release/main/installer-$arch/current/images/netboot/' + guess_os + '-installer/$arch'
+    # support ubuntu focal(20), which moved pxe files to legacy_image
+    if (guess_os == 'ubuntu' && major.to_i >= 20)
+      'dists/$release/main/installer-$arch/current/legacy-images/netboot/' + guess_os + '-installer/$arch'
+    else
+      'dists/$release/main/installer-$arch/current/images/netboot/' + guess_os + '-installer/$arch'
+    end
   end
 
   def preseed_server(medium_provider)


### PR DESCRIPTION
Starting Ubuntu 20.04 LTS the PXE files (linux & initrd.gz) have moved from images to legacy-images
this PR adds an if contition to weather ubuntu major ver is over 20 and changes the pxe path