### PR TITLE
Fixes #29362 - Include templates in seed hash calculation

### DIFF
--- a/app/services/foreman_seeder.rb
+++ b/app/services/foreman_seeder.rb
@@ -11,6 +11,7 @@ class ForemanSeeder
 
   def initialize
     @seeds = (foreman_seeds + plugin_seeds).sort_by { |seed| seed.split("/").last }
+    @hashed_files = @seeds + templates
   end
 
   def foreman_seeds
@@ -27,8 +28,12 @@ class ForemanSeeder
     end.flatten.compact
   end
 
+  def templates
+    SeedHelper.report_templates + SeedHelper.provisioning_templates + SeedHelper.partition_tables_templates
+  end
+
   def hash
-    hashes = @seeds.collect { |seed| Digest::SHA256.file(seed).base64digest }
+    hashes = @hashed_files.collect { |seed| Digest::SHA256.file(seed).base64digest }
     Digest::SHA256.base64digest(hashes.join)
   end
 


### PR DESCRIPTION
Otherwise, changes to default templates will not trigger a seeding on
startup if no other seeds have changed.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
