### PR TITLE
Fixes #29636 - Add BMC support for Redfish.

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -791,7 +791,7 @@ autopart"', desc: 'to render the content of host partition table'
   def bmc_available?
     ipmi = bmc_nic
     return false if ipmi.nil?
-    (ipmi.password.present? && ipmi.username.present? && ipmi.provider == 'IPMI') || ipmi.provider == 'SSH'
+    (ipmi.password.present? && ipmi.username.present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
   end
 
   def ipmi_boot(booting_device)

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -1,8 +1,8 @@
 module Nic
   class BMC < Managed
-    PROVIDERS = %w(IPMI SSH)
+    PROVIDERS = %w(IPMI Redfish SSH)
     before_validation :ensure_physical
-    before_validation { |nic| nic.provider.try(:upcase!) }
+    before_validation { |nic| nic.provider == 'Redfish' || nic.provider.try(:upcase!) }
     validates :provider, :presence => true, :inclusion => { :in => PROVIDERS }
     validates :mac, :presence => true, :if => :managed?
     validate :validate_bmc_proxy


### PR DESCRIPTION
Includes changes to enforce BMC provider selection for front-end
tasks. Previously, all Foreman UI requests to the BMC smart proxy
used the proxy's default provider, regardless of BMC NIC setting.

There is a corresponding pull request in the Smart Proxy project
to implement the Redfish BMC provider.

Fixes #29636

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
