### PR TITLE
Fixes #25723 - Prevent AJ.spawn_if_missing from creating duplicates

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -6,15 +6,21 @@ class ApplicationJob < ActiveJob::Base
   def self.spawn_if_missing(world)
     return if (Foreman.in_rake? && !Foreman.in_rake?('dynflow:executor')) || Rails.env.test?
 
-    pending_jobs = world.persistence.find_execution_plans(filters: { :state => 'scheduled' })
-    scheduled_job = pending_jobs.select do |job|
-      delayed_plan = world.persistence.load_delayed_plan job.id
-      next unless delayed_plan.present?
-      arg = delayed_plan.to_hash[:serialized_args].first
-      arg.is_a?(Hash) && arg['job_class'] == to_s
-    end
+    # While in scheduled and planning, the execution plan still doesn't have its label set, but it could have
+    # a delayed plan record, which should contain the data we need to match
+    scheduled_plans = world.persistence.find_execution_plans(filters: { :state => %w(planning scheduled) })
+                           .select do |job|
+                             delayed_plan = world.persistence.load_delayed_plan job.id
+                             next unless delayed_plan.present?
+                             arg = delayed_plan.to_hash[:serialized_args].first
+                             arg.is_a?(Hash) && arg['job_class'] == to_s
+                           end
+
+    # The delayed plan record gets deleted somewhere during the planned -> running transition so we cannot use it anymore
+    # However when a plan gets planned, its label gets set and we can use that instead
+    in_progress_plans = world.persistence.find_execution_plans(filters: { :state => %w(planned running), :label => name })
 
     # Schedule the job only if it doesn't exit yet
-    perform_later if scheduled_job.blank?
+    perform_later if (scheduled_plans + in_progress_plans).blank?
   end
 end


### PR DESCRIPTION
Previously we only checked execution plans which were in scheduled state. This left us with a small window where the ActiveJob was actually present, but we didn't detect it so we spawned a new one.

With this patch, we consider execution plans in states scheduled, planning, planned and running as present and plans in paused and stopped states as missing. The only state which is not covered is pending, but in that state the execution plan doesn't have enough data and we cannot reliably identify it.

This is not perfect, it can still happen that two processes get initialized at roughly the same time, go through all the checks and then both create a new job. We cannot solve this with the data we already store and we would have to introduce some kind of locking, similar to what we did for singleton actions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
