### PR TITLE
Fixes #29578 - add sorting feature to reports

### DIFF
--- a/lib/foreman/renderer/errors.rb
+++ b/lib/foreman/renderer/errors.rb
@@ -38,6 +38,10 @@ module Foreman
       class UndefinedInput < RenderingError
         MESSAGE = N_('Rendering failed, no input with name "%{s}" for input macro found').freeze
       end
+
+      class UnknownReportColumn < RenderingError
+        MESSAGE = N_('Rendering failed, one or more unknown columns specified for ordering - "%{unknown}"').freeze
+      end
     end
   end
 end

--- a/test/unit/foreman/renderer/scope/report_test.rb
+++ b/test/unit/foreman/renderer/scope/report_test.rb
@@ -23,6 +23,31 @@ class ReportScopeTest < ActiveSupport::TestCase
       assert_equal expected_yaml, @scope.report_render(format: :yaml)
     end
 
+    test 'render report ordering' do
+      @scope.report_row(name: 'c', value: 1)
+      @scope.report_row(name: 'a', value: 3)
+      @scope.report_row(name: 'b', value: 22)
+      @scope.report_row(name: 'e', value: 0)
+      @scope.report_row(name: 'd', value: 5)
+
+      expected_csv = "name,value\na,3\nb,22\nc,1\nd,5\ne,0\n"
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: 'name')
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: :name)
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: ['name'])
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: ['name', 'value'])
+
+      expected_csv = "name,value\ne,0\nc,1\na,3\nd,5\nb,22\n"
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: 'value')
+
+      expected_csv = "name,value\ne,0\nd,5\nc,1\nb,22\na,3\n"
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: 'name', reverse_order: true)
+
+      @scope.report_row(name: 'a', value: 2)
+      @scope.report_row(name: 'b', value: 2)
+      expected_csv = "name,value\na,2\na,3\nb,2\nb,22\nc,1\nd,5\ne,0\n"
+      assert_equal expected_csv, @scope.report_render(format: :csv, order: ['name', 'value'])
+    end
+
     test 'empty report' do
       expected_csv = "\n"
       assert_equal expected_csv, @scope.report_render(format: :csv)


### PR DESCRIPTION
Reports usually generate a tabular data using the report_render
macro. There is no way to sort such output. This patch adds a new
parameter to report_render macro allowing to specify one or more
columns for sorting.

<%= report_render order: 'Name' -%>
<%= report_render order: [ 'Name', 'Age' ] -%>

Also it may be useful to reverse the order of the report. For this
purpose a second parameter was added

<%= report_render order: [ 'Name' ], :reverse_order: true -%>

Note that both can be used independently.

For unknown column, rendering error is presented calling out the values
that were not recognized. We support all headers registered using the
report_headers macro as well as names used when calling report_row
macro, as illustrated in the following example

<%- report_headers 'Name' -%>
<%- report_row Name: 'Ares', Age: 123 -%>
<%= report_render order: 'Age' %>

The performance impact was checked. Ordering roughly doubles the raw
rendering time, meaning the time the report_render method takes. The
order reversing is nearly instant.

On report with 10_000 rows, it added 0.05s which in such
big reports is marginal thing. Usually the report spend minutes on
parsing ActiveRecord data.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
