### PR TITLE
Fixes #29670 - upgrade patternfly

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,6 +1,6 @@
 group :assets do
   gem 'jquery-ui-rails', '~> 6.0'
-  gem 'patternfly-sass', '>= 3.32.1', '< 3.38.0'
+  gem 'patternfly-sass', '~> 3.59.4'
   gem 'gettext_i18n_rails_js', '~> 1.0'
   gem 'execjs', '>= 1.4.0', '< 3.0'
   gem 'uglifier', '>= 1.0.3'


### PR DESCRIPTION
As #7187 - sprockets PR won't get it in for 2.1, this needs to go in, as packaging is already on this version.

Not sure who does the dep bump in packaging, in case it's not taken care of in other means: theforeman/foreman-packaging#4814. If it is, please close that one :)