### PR TITLE
Fixes #29700 - bold table headers

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -22,6 +22,18 @@ body {
   }
 }
 
+// fix pf3 tables to have bold headers
+// when mixing with pf4 styles
+.table {
+  & > thead,
+  & > tbody,
+  & > tfoot {
+    & > tr > th a {
+      font-weight: 600;
+    }
+  }
+}
+
 .base li {
   list-style: none;
   margin-left: 20px;


### PR DESCRIPTION
Make the table headers bold again, after the latest vendor upgrade.