### PR TITLE
Fixes #29708 - Remove internal use of deprecated JS API

### DIFF
--- a/webpack/assets/javascripts/react_app/API.js
+++ b/webpack/assets/javascripts/react_app/API.js
@@ -4,7 +4,7 @@ import { deprecate } from './common/DeprecationService';
 deprecate(
   'import API from webpack/assets/javascripts/react_app/API.js',
   "import { API } from 'webpack/assets/javascripts/react_app/redux/API.js'",
-  '1.26'
+  '2.2'
 );
 
 export default API;

--- a/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
@@ -1,11 +1,11 @@
-import api from '../../../../API';
+import { API } from '../../../../redux/API';
 import { foremanUrl } from '../../../../../foreman_tools';
 
 import { addToast } from '../../../../redux/actions/toasts';
 
 export const stopImpersonating = url => async dispatch => {
   try {
-    const { data } = await api.delete(url);
+    const { data } = await API.delete(url);
     window.location.href = foremanUrl('/users');
     return dispatch(
       addToast({

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -4,8 +4,7 @@ import IntegrationTestHelper from '../../common/IntegrationTestHelper';
 import notificationReducer from '../../redux/reducers/notifications';
 import { componentMountData, serverResponse } from './notifications.fixtures';
 import Notifications from './';
-import API from '../../redux/API/API';
-import { APIMiddleware } from '../../redux/API';
+import { API, APIMiddleware } from '../../redux/API';
 import { NOTIFICATIONS } from '../../redux/consts';
 import { IntervalMiddleware } from '../../redux/middlewares';
 import { registeredIntervalException } from '../../redux/middlewares/IntervalMiddleware/IntervalHelpers';
@@ -14,7 +13,7 @@ import { DEFAULT_INTERVAL } from '../../redux/actions/notifications/constants';
 jest.useFakeTimers();
 jest.mock('../../redux/API/API');
 jest.mock('../../redux/actions/notifications/constants', () => ({
-  DEFAULT_INTERVAL: 1,
+  DEFAULT_INTERVAL: 5000,
 }));
 
 const notificationProps = {

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageActions.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageActions.js
@@ -1,5 +1,5 @@
 import history from '../../../history';
-import API from '../../../API';
+import { API } from '../../../redux/API';
 import {
   AUDITS_PATH,
   AUDITS_PAGE_DATA_RESOLVED,

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/AuditsPageActions.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/AuditsPageActions.test.js
@@ -1,5 +1,4 @@
-import API from '../../../../API';
-
+import { API } from '../../../../redux/API';
 import { testActionSnapshotWithFixtures } from '../../../../common/testHelpers';
 import {
   fetchAudits,
@@ -13,7 +12,7 @@ import {
   state as stateMock,
 } from '../AuditsPage.fixtures';
 
-jest.mock('../../../../API');
+jest.mock('../../../../redux/API/API');
 
 const runWithGetState = (state, action, ...params) => async dispatch => {
   const getState = () => ({


### PR DESCRIPTION
The API module is deprecated and can be updated internally.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
