### PR TITLE
Fixes #29710 - Clean up .where conditions

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -70,7 +70,7 @@ module Api
     def parent_scope
       parent_name, scope = parent_resource_details
 
-      return resource_class.where(nil) unless scope
+      return resource_class.all unless scope
 
       association = resource_class.reflect_on_all_associations.detect { |assoc| assoc.plural_name == parent_name.pluralize }
       # if couldn't find an association by name, try to find one by class

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -186,7 +186,7 @@ class ApplicationController < ActionController::Base
     @resource_base ||= if model_of_controller.respond_to?(:authorized)
                          model_of_controller.authorized(current_permission)
                        else
-                         model_of_controller.where(nil)
+                         model_of_controller.all
                        end
   end
 

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -67,14 +67,6 @@ class FiltersController < ApplicationController
     @role = Role.find_by_id(role_id)
   end
 
-  def resource_base
-    @resource_base ||= if @role.present?
-                         Filter.authorized(current_permission)
-                       else
-                         Filter.where(nil).authorized(current_permission)
-                       end
-  end
-
   def role_id
     params[:role_id]
   end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -363,7 +363,7 @@ class HostsController < ApplicationController
   # multiple host selection methods
 
   def multiple_parameters
-    @parameters = HostParameter.where(:reference_id => @hosts).select("distinct name")
+    @parameters = HostParameter.where(:reference_id => @hosts).distinct.select("name")
   end
 
   def update_multiple_parameters
@@ -713,7 +713,7 @@ class HostsController < ApplicationController
     # Lets search by name or id and make sure one of them exists first
     if params.key?(:host_names) || params.key?(:host_ids) || multiple_with_filter?
       @hosts = resource_base.search_for(params[:search]) if multiple_with_filter?
-      @hosts ||= resource_base.where("hosts.id IN (?) or hosts.name IN (?)", params[:host_ids], params[:host_names])
+      @hosts ||= resource_base.merge(Host.where(id: params[:host_ids]).or(Host.where(name: params[:host_names])))
       if @hosts.empty?
         error _('No hosts were found with that id, name or query filter')
         redirect_to(hosts_path)

--- a/app/helpers/common_parameters_helper.rb
+++ b/app/helpers/common_parameters_helper.rb
@@ -84,7 +84,7 @@ module CommonParametersHelper
 
   def find_parameters_to_view(params_authorizer, parameters_by_type, user = User.current)
     return parameters_by_type.none if user.nil?
-    return parameters_by_type.where(nil) if user.admin?
+    return parameters_by_type.all if user.admin?
     params_authorizer.find_collection(parameters_by_type.klass, :permission => :view_params)
   end
 

--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -63,11 +63,11 @@ module SmartProxiesHelper
   end
 
   def services_tab_features(proxy)
-    proxy.features.where('features.name NOT IN (?)', TABBED_FEATURES).distinct.pluck("name").sort
+    proxy.features.where.not(name: TABBED_FEATURES).distinct.pluck("name").sort
   end
 
   def tabbed_features(proxy)
-    proxy.features.where('features.name IN (?)', TABBED_FEATURES).distinct.pluck("name").sort
+    proxy.features.where(name: TABBED_FEATURES).distinct.pluck("name").sort
   end
 
   def show_feature_version(feature)

--- a/app/helpers/taxonomy_helper.rb
+++ b/app/helpers/taxonomy_helper.rb
@@ -135,11 +135,11 @@ module TaxonomyHelper
       association = resource.to_s.classify.constantize
     end
     return unless User.current.allowed_to?("view_#{resource}".to_sym)
-    ids = "#{association.where(nil).klass.to_s.underscore.singularize}_ids".to_sym
+    ids = "#{association.all.klass.to_s.underscore.singularize}_ids".to_sym
 
     content_tag(:div, :id => resource, :class => "tab-pane") do
       all_checkbox(f, resource) +
-      multiple_selects(f, association.where(nil).klass.to_s.underscore.pluralize.to_sym, association, taxonomy.selected_or_inherited_ids[ids],
+      multiple_selects(f, association.all.klass.to_s.underscore.pluralize.to_sym, association, taxonomy.selected_or_inherited_ids[ids],
         {:disabled => taxonomy.used_and_selected_or_inherited_ids[ids],
          :label => translated_label(resource, :select)},
         {'data-mismatches' => taxonomy.need_to_be_selected_ids[ids].to_json,

--- a/app/models/concerns/authorizable.rb
+++ b/app/models/concerns/authorizable.rb
@@ -49,9 +49,9 @@ module Authorizable
     # Or you may simply use authorized for User.current
     def authorized_as(user, permission, resource = nil)
       if user.nil? || user.disabled?
-        where('1=0')
+        none
       elsif user.admin?
-        where(nil)
+        all
       else
         Authorizer.new(user).find_collection(resource || self, :permission => permission)
       end
@@ -72,7 +72,7 @@ module Authorizable
     #
     def joins_authorized_as(user, resource, permission, opts = {})
       if user.nil? || user.disabled?
-        where('1=0')
+        none
       else
         Authorizer.new(user).find_collection(resource, {:permission => permission, :joined_on => self}.merge(opts))
       end

--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -244,7 +244,7 @@ module HostCommon
   end
 
   def available_puppetclasses
-    return Puppetclass.where(nil).authorized(:view_puppetclasses) if environment.blank?
+    return Puppetclass.all.authorized(:view_puppetclasses) if environment.blank?
     environment.puppetclasses - parent_classes
   end
 

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -145,7 +145,7 @@ module Hostext
         host_ids         = Host.authorized(:view_hosts, Host).where(conditions).joins(:puppetclasses).distinct.pluck('hosts.id')
         host_ids        += HostConfigGroup.where(:host_type => 'Host::Base').where(:config_group_id => config_group_ids).pluck(:host_id)
         hostgroups       = Hostgroup.unscoped.with_taxonomy_scope.where(conditions).joins(:puppetclasses)
-        hostgroups      += Hostgroup.unscoped.with_taxonomy_scope.joins(:host_config_groups).where("host_config_groups.config_group_id IN (#{config_group_ids.join(',')})") if config_group_ids.any?
+        hostgroups      += Hostgroup.unscoped.with_taxonomy_scope.joins(:host_config_groups).where(host_config_groups: {config_group_id: config_group_ids}) if config_group_ids.any?
         hostgroup_ids    = hostgroups.map(&:subtree_ids).flatten.uniq
 
         opts  = ''

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -74,7 +74,7 @@ module NestedAncestryCommon
   end
 
   def nested(attr)
-    self.class.sort_by_ancestry(ancestors.where("#{attr} is not NULL")).last.try(attr) if ancestry.present?
+    self.class.sort_by_ancestry(ancestors.where.not(attr => nil)).last.try(attr) if ancestry.present?
   end
 
   private
@@ -85,7 +85,7 @@ module NestedAncestryCommon
 
   def set_other_titles
     if saved_change_to_name? || saved_change_to_ancestry?
-      self.class.where('ancestry IS NOT NULL').find_each do |obj|
+      self.class.where.not(ancestry: nil).find_each do |obj|
         if obj.path_ids.include?(id)
           obj.update(:title => obj.get_title)
         end

--- a/app/models/concerns/smart_proxy_host_extensions.rb
+++ b/app/models/concerns/smart_proxy_host_extensions.rb
@@ -7,7 +7,7 @@ module SmartProxyHostExtensions
       ProxyReferenceRegistry.add_smart_proxy_reference hash
     end
 
-    def smart_proxy_ids(hosts_scope = Host::Managed.where(nil))
+    def smart_proxy_ids(hosts_scope = Host::Managed.all)
       hosts_scope.eager_load(proxy_join_tables).pluck(proxy_column_list).flatten.uniq.compact
     end
 

--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -124,7 +124,7 @@ module Taxonomix
         scope
       when []
         # If *no* taxable ids were found, then don't show any resources
-        scope.where('1=0')
+        scope.none
       else
         # We need to generate the WHERE part of the SQL query as a string,
         # otherwise the default scope would set id on each new instance

--- a/app/models/config_group.rb
+++ b/app/models/config_group.rb
@@ -23,7 +23,7 @@ class ConfigGroup < ApplicationRecord
   alias_method :individual_puppetclasses, :puppetclasses
 
   def available_puppetclasses
-    Puppetclass.where(nil)
+    Puppetclass.all
   end
 
   # for auditing

--- a/app/models/environment_class.rb
+++ b/app/models/environment_class.rb
@@ -23,7 +23,7 @@ class EnvironmentClass < ApplicationRecord
 
   # TODO move these into scopes?
   def self.is_in_any_environment(puppetclass, puppetclass_lookup_key)
-    EnvironmentClass.where(:puppetclass_id => puppetclass, :puppetclass_lookup_key_id => puppetclass_lookup_key).count > 0
+    EnvironmentClass.where(:puppetclass_id => puppetclass, :puppetclass_lookup_key_id => puppetclass_lookup_key).any?
   end
 
   def self.key_in_environment(env, puppetclass, puppetclass_lookup_key)

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -190,7 +190,7 @@ class Host::Managed < Host::Base
   }
 
   scope :not_disabled, lambda {
-    where(["#{Host.table_name}.enabled != ?", false])
+    where.not(enabled: false)
   }
 
   scope :with_last_report_within, lambda { |minutes|
@@ -206,7 +206,7 @@ class Host::Managed < Host::Base
   }
 
   scope :with_status, lambda { |status_type|
-    eager_load(:host_statuses).where("host_status.type = '#{status_type}'")
+    eager_load(:host_statuses).where(host_status: {type: status_type})
   }
 
   scope :with_config_status, lambda {
@@ -368,12 +368,12 @@ class Host::Managed < Host::Base
 
   def clear_reports
     # Remove any reports that may be held against this host
-    Report.where("host_id = #{id}").delete_all
+    Report.where(host_id: id).delete_all
     self.last_report = nil
   end
 
   def clear_facts
-    FactValue.where("host_id = #{id}").delete_all
+    FactValue.where(host_id: id).delete_all
   end
 
   def clear_data_on_build

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -214,7 +214,7 @@ class Hostgroup < ApplicationRecord
   def params
     parameters = {}
     # read common parameters
-    CommonParameter.where(nil).find_each { |p| parameters.update Hash[p.name => p.value] }
+    CommonParameter.find_each { |p| parameters.update Hash[p.name => p.value] }
     # read OS parameters
     operatingsystem&.os_parameters&.each { |p| parameters.update Hash[p.name => p.value] }
     # read group parameters only if a host belongs to a group

--- a/app/models/lookup_value.rb
+++ b/app/models/lookup_value.rb
@@ -130,6 +130,6 @@ class LookupValue < ApplicationRecord
   end
 
   def host_with_fqdn_exists?(fqdn)
-    Host.unscoped.left_joins(:primary_interface).where("nics.name = ?", fqdn).any?
+    Host.unscoped.left_joins(:primary_interface).where(nics: {name: fqdn}).any?
   end
 end

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -354,7 +354,7 @@ module Nic
 
     private
 
-    def interface_attribute_uniqueness(attr, base = Nic::Base.where(nil))
+    def interface_attribute_uniqueness(attr, base = Nic::Base)
       in_memory_candidates = host.present? ? host.interfaces.select { |i| i.persisted? && !i.marked_for_destruction? } : [self]
       db_candidates = base.where(attr => public_send(attr))
       db_candidates = db_candidates.select { |c| c.id != id && in_memory_candidates.map(&:id).include?(c.id) }

--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -20,9 +20,8 @@ class Puppetclass < ApplicationRecord
   has_many_hosts :through => :host_classes, :dependent => :destroy
   has_many :config_group_classes
   has_many :config_groups, :through => :config_group_classes, :dependent => :destroy
-  # param classes
-  has_many :class_params, -> { where('environment_classes.puppetclass_lookup_key_id is NOT NULL').distinct },
-    :through => :environment_classes, :source => :puppetclass_lookup_key
+
+  has_many :class_params, :through => :environment_classes, :source => :puppetclass_lookup_key
   accepts_nested_attributes_for :class_params, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
 
   validates :name, :uniqueness => true, :presence => true, :no_whitespace => true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -100,8 +100,8 @@ class Report < ApplicationRecord
       end
       # Delete orphan messages/sources when no reports are left
       if report_ids.blank?
-        message_count = Message.unscoped.where("id not IN (#{Log.unscoped.select('DISTINCT message_id').to_sql})").delete_all
-        source_count = Source.unscoped.where("id not IN (#{Log.unscoped.select('DISTINCT source_id').to_sql})").delete_all
+        message_count = Message.unscoped.where.not(id: Log.unscoped.distinct.select('message_id')).delete_all
+        source_count = Source.unscoped.where.not(id: Log.unscoped.distinct.select('source_id')).delete_all
         Foreman::Logging.with_fields(deleted_messages: message_count, expired_sources: source_count) do
           logger.info "Expired #{message_count} messages and #{source_count} sources"
         end

--- a/app/registries/foreman/plugin/rbac_support.rb
+++ b/app/registries/foreman/plugin/rbac_support.rb
@@ -6,7 +6,7 @@ module Foreman
 
       def add_all_permissions_to_default_roles(all_permissions)
         view_permissions = all_permissions.where("name LIKE :name", :name => "view_%")
-        org_admin_permissions = all_permissions.where('resource_type <> :resource_type OR resource_type IS NULL', { :resource_type => "Organization" })
+        org_admin_permissions = all_permissions.merge(Permission.where.not(resource_type: 'Organization').or(Permission.where(resource_type: nil)))
         Role.transaction do
           add_all_permissions_to_role(Role::MANAGER, all_permissions)
           add_all_permissions_to_role(Role::ORG_ADMIN, org_admin_permissions)

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -31,8 +31,8 @@ class Authorizer
     Foreman::Logging.logger('permissions').debug "checking permission #{permission} for class #{resource_class}"
 
     # retrieve all filters relevant to this permission for the user
-    base = user.filters.joins(:permissions).where(["#{Permission.table_name}.resource_type = ?", resource_name(resource_class)])
-    all_filters = permission.nil? ? base : base.where(["#{Permission.table_name}.name = ?", permission])
+    base = user.filters.joins(:permissions).where(permissions: {resource_type: resource_name(resource_class)})
+    all_filters = permission.nil? ? base : base.where(permissions: {name: permission})
 
     organization_ids = allowed_organizations(resource_class)
     Foreman::Logging.logger('permissions').debug "organization_ids: #{organization_ids.inspect}"

--- a/app/services/foreman/unattended_installation/host_finder.rb
+++ b/app/services/foreman/unattended_installation/host_finder.rb
@@ -22,7 +22,7 @@ module Foreman
       private
 
       def find_host_by_spoof
-        host = Host.authorized('view_hosts').joins(:primary_interface).where("#{Nic::Base.table_name}.ip" => query_params['spoof']).first if query_params['spoof'].present?
+        host = Host.authorized('view_hosts').joins(:primary_interface).where(nics: {ip: query_params['spoof']}).first if query_params['spoof'].present?
         host ||= Host.authorized('view_hosts').find_by_name(query_params['hostname']) if query_params['hostname'].present?
         @spoof = host.present?
         host

--- a/app/views/taxonomies/_form.html.erb
+++ b/app/views/taxonomies/_form.html.erb
@@ -54,7 +54,7 @@
       <div class="tab-pane active" id="primary">
         <%= base_errors_for taxonomy %>
         <% taxonomy_name = taxonomy.class.to_s.underscore %>
-        <%= select_f(f, :parent_id, taxonomy.class.completer_scope(nil).authorized("edit_#{taxonomy_name.pluralize}").where("id NOT IN (#{taxonomy.subtree_ids.join(',')})").order(:title), :id, :title, { :include_blank => true },
+        <%= select_f(f, :parent_id, taxonomy.class.completer_scope(nil).authorized("edit_#{taxonomy_name.pluralize}").where.not(id: taxonomy.subtree_ids).order(:title), :id, :title, { :include_blank => true },
                      { :label => _('Parent'), :onchange => 'parent_taxonomy_changed(this);',
                        :help_inline => :indicator,
                        :'data-url' => (controller_name == 'organizations' ? parent_taxonomy_selected_organization_path(taxonomy.id) :

--- a/db/migrate/20150525081931_remove_duplicate_tokens.rb
+++ b/db/migrate/20150525081931_remove_duplicate_tokens.rb
@@ -8,9 +8,9 @@ class RemoveDuplicateTokens < ActiveRecord::Migration[4.2]
     hosts_with_duplicate_tokens = Token.having('count(*) > 1').group(:host_id).pluck('host_id')
     existing_tokens = Host.where(:id => hosts_with_duplicate_tokens).map(&:token).compact
     if existing_tokens.empty?
-      Token.where(:id => Token.where(:host_id => hosts_with_duplicate_tokens).pluck('tokens.id')).delete_all
+      Token.where(host_id: hosts_with_duplicate_tokens).delete_all
     else
-      Token.where(:id => Token.where('host_id in (?) and id not in (?)', hosts_with_duplicate_tokens, existing_tokens).pluck('tokens.id')).delete_all
+      Token.where(host_id: hosts_with_duplicate_tokens).where.not(id: existing_tokens).delete_all
     end
 
     remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, { :name => "tokens_host_id_fk" })

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -253,7 +253,7 @@ class LocationsControllerTest < ActionController::TestCase
       host = FactoryBot.create(:host)
       host.update(:location => nil)
 
-      Host.stubs(:authorized).returns(Host.where('1=0'))
+      Host.stubs(:authorized).returns(Host.none)
 
       post :create, params: { :location => {:name => "test_loc"} }, session: set_session_user
 

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -257,7 +257,7 @@ class OrganizationsControllerTest < ActionController::TestCase
       host = FactoryBot.create(:host)
       host.update(:organization => nil)
 
-      Host.stubs(:authorized).returns(Host.where('1=0'))
+      Host.stubs(:authorized).returns(Host.none)
 
       post :create, params: { :organization => {:name => "test_org"} }, session: set_session_user
 

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -169,7 +169,7 @@ class RoleTest < ActiveSupport::TestCase
 
     context "with a missing default role" do
       setup do
-        role_ids = Role.where("builtin = #{Role::BUILTIN_DEFAULT_ROLE}").pluck(:id)
+        role_ids = Role.where(builtin: Role::BUILTIN_DEFAULT_ROLE).pluck(:id)
         UserRole.where(:role_id => role_ids).destroy_all
         roles = Role.where(:id => role_ids)
         roles.each do |found_role|

--- a/test/models/usergroup_member_test.rb
+++ b/test/models/usergroup_member_test.rb
@@ -38,12 +38,12 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   test "searching for affected users memberships" do
     setup_admins_scenario
 
-    found = @semiadmins.usergroup_members.where("member_type = 'Usergroup'").first.send :find_all_affected_users
+    found = @semiadmins.usergroup_members.where(member_type: 'Usergroup').first.send :find_all_affected_users
     assert_includes found, @admin_user
     assert_includes found, @superadmin_user
     assert_not_includes found, @semiadmin_user
 
-    found = @superadmins.usergroup_members.where("member_type = 'User'").first.send :find_all_affected_users
+    found = @superadmins.usergroup_members.where(member_type: 'User').first.send :find_all_affected_users
     assert_not_includes found, @admin_user
     assert_not_includes found, @semiadmin_user
     assert_includes found, @superadmin_user

--- a/test/models/usergroup_test.rb
+++ b/test/models/usergroup_test.rb
@@ -176,7 +176,7 @@ class UsergroupTest < ActiveSupport::TestCase
     admin2 = FactoryBot.create(:user, :admin => true)
     usergroup.users = [admin1]
 
-    User.unscoped.except_hidden.only_admin.where('login NOT IN (?)', [admin1.login, admin2.login]).destroy_all
+    User.unscoped.except_hidden.only_admin.where.not(login: [admin1.login, admin2.login]).destroy_all
     usergroup.admin = false
     assert_valid usergroup
   end
@@ -186,7 +186,7 @@ class UsergroupTest < ActiveSupport::TestCase
     admin = FactoryBot.create(:user)
     usergroup.users = [admin]
 
-    User.unscoped.except_hidden.only_admin.where('login <> ?', admin.login).destroy_all
+    User.unscoped.except_hidden.only_admin.where.not(login: admin.login).destroy_all
     usergroup.admin = false
     refute_valid usergroup, :admin, /last admin account/
   end
@@ -196,7 +196,7 @@ class UsergroupTest < ActiveSupport::TestCase
     admin = FactoryBot.create(:user)
     usergroup.users = [admin]
 
-    User.unscoped.except_hidden.only_admin.where('login <> ?', admin.login).destroy_all
+    User.unscoped.except_hidden.only_admin.where.not(login: admin.login).destroy_all
     refute_with_errors usergroup.destroy, usergroup, :base, /last admin user group/
   end
 


### PR DESCRIPTION
Using methods such as `none`, `not`, `or`, or `all`, we can simplify
some `.where` calls in ways that weren't possible in some very old rails
versions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
