### PR TITLE
Fixes #29719 - Hostgroup facet inheritance error

### DIFF
--- a/app/models/concerns/facets/hostgroup_extensions.rb
+++ b/app/models/concerns/facets/hostgroup_extensions.rb
@@ -22,7 +22,7 @@ module Facets
     end
 
     def inherited_facet_attributes(facet_config)
-      inherited_attributes = send(facet_config.name).inherited_attributes
+      inherited_attributes = send(facet_config.name)&.inherited_attributes || {}
       hostgroup_ancestry_cache.reverse_each do |hostgroup|
         hg_facet = hostgroup.send(facet_config.name)
         next unless hg_facet

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -252,6 +252,21 @@ class FacetTest < ActiveSupport::TestCase
       assert_equal({grand_only: 'grand', parent: 'parent', local: 'local'}, actual)
     end
 
+    test 'attributes inherited from leaf without facet' do
+      parent = Hostgroup.new
+      parent_facet = parent.build_hostgroup_facet
+      parent_facet.expects(:inherited_attributes).returns(parent: 'parent', local: 'parent')
+      @facet.expects(:inherited_attributes).returns(parent: nil, local: 'local')
+
+      # Hostgroup without facet attached
+      child = Hostgroup.new
+
+      child.expects(:hostgroup_ancestry_cache).returns([parent, @hostgroup])
+      actual = child.inherited_facet_attributes(Facets.registered_facets[:hostgroup_facet])
+
+      assert_equal({parent: 'parent', local: 'local'}, actual)
+    end
+
     test 'hostgroup and facet are connected two-way' do
       assert_equal @hostgroup, @facet.hostgroup
     end


### PR DESCRIPTION
As the method for `Hostgroup#inherited_facet_attributes` - and methods that call it - include no checks for _if_ a hostgroup includes an instance of the requested facet before trying to read attributes from it, this can lead to a NoMethodError here.

Wrapping it in a safe accessor and a fallback to an empty hash means that such calls will no longer error, and will still read attributes correctly from the ancestry as well.