### PR TITLE
Fixes #29733 - deprecate foreman_url without arguments

### DIFF
--- a/lib/foreman/foreman_url_renderer.rb
+++ b/lib/foreman/foreman_url_renderer.rb
@@ -9,7 +9,12 @@ module Foreman
     end
 
     # returns the URL for Foreman based on the required action
-    def foreman_url(action = 'provision', params = {})
+    def foreman_url(action = nil, params = {})
+      if action.nil?
+        Foreman::Deprecation.deprecation_warning('2.3', 'Do not call foreman_url macro without arguments, use foreman_url("provision") instead.')
+        action = 'provision'
+      end
+
       # Get basic stuff
       config = URI.parse(Setting[:unattended_url])
       url_options = foreman_url_options_from_settings_or_request(config)

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -49,13 +49,13 @@ class BaseMacrosTest < ActiveSupport::TestCase
 
     @scope.instance_variable_set('@host', host)
 
-    assert_match(host.provision_interface.subnet.template.url, @scope.foreman_url)
+    assert_match(host.provision_interface.subnet.template.url, @scope.foreman_url('provision'))
   end
 
   test "foreman_url should run with @host as nil" do
     @scope.instance_variable_set('@host', nil)
 
-    assert_nothing_raised { @scope.foreman_url }
+    assert_nothing_raised { @scope.foreman_url('provision') }
   end
 
   test "pxe_kernel_options are not set when no OS is set" do


### PR DESCRIPTION
Probably cleaner. We do not call foreman_url without arguments anymore
after https://github.com/theforeman/community-templates/pull/570 is
merged.