### PR TITLE
Fixes #29219 - Deploy Storybook to surge.sh

### DIFF
--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -5,12 +5,13 @@ on:
     branches:
       - develop
     paths:
-      - '**[Ss]tories**'
+      - 'webpack/**'
 
 jobs:
   deploy_main_storybook:
 
     runs-on: ubuntu-latest
+    if: github.repository == 'theforeman/foreman'
 
     steps:
     - uses: actions/checkout@v2
@@ -22,6 +23,6 @@ jobs:
       name: Deploy Storybook to surge.sh
       with:
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-        DOMAIN_NAME: foreman.surge.sh
+        DOMAIN_NAME: ${{ secrets.SURGE_DOMAIN }}
         BUILD_DIRECTORY: storybooks/main
       id: surge_deploy

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -18,12 +18,10 @@ jobs:
       run: npm install
     - name: Build Storybook
       run: npm run build-storybook -- --output-dir=storybooks/main
-    - name: Deploy Storybook to surge.sh
-      id: surge_deploy
-      env:
-        SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+    - uses: yg/deploy-surge@v1.0.1
+      name: Deploy Storybook to surge.sh
+      with:
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
-      if: ${{ env.SURGE_TOKEN }}
-      run: |
-        npm install --save-dev surge
-        node_modules/.bin/surge --project storybooks/main --domain foreman.surge.sh
+        DOMAIN_NAME: foreman.surge.sh
+        BUILD_DIRECTORY: storybooks/main
+      id: surge_deploy

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -19,8 +19,8 @@ jobs:
       run: npm install
     - name: Build Storybook
       run: npm run build-storybook -- --output-dir=storybooks/main
-    - uses: yg/deploy-surge@v1.0.1
-      name: Deploy Storybook to surge.sh
+    - name: Deploy Storybook to surge.sh
+      uses: yg/deploy-surge@v1.0.1
       with:
         SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
         DOMAIN_NAME: ${{ secrets.SURGE_DOMAIN }}

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -1,8 +1,11 @@
 name: Deploy Main Storybook
 
 on:
-  schedule:
-    - cron: '0 7 * * *'
+  push:
+    branches:
+      - develop
+    paths:
+      - '**[Ss]tories**'
 
 jobs:
   deploy_main_storybook:
@@ -11,8 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        clean: false
     - name: Run npm install
       run: npm install
     - name: Build Storybook

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -1,0 +1,28 @@
+name: Deploy Main Storybook
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  deploy_main_storybook:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        clean: false
+    - name: Run npm install
+      run: npm install
+    - name: Build Storybook
+      run: npm run build-storybook -- --output-dir=storybooks/main
+    - name: Deploy Storybook to surge.sh
+      id: surge_deploy
+      env:
+        SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
+        SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
+      if: ${{ env.SURGE_TOKEN }}
+      run: |
+        npm install --save-dev surge
+        node_modules/.bin/surge --project storybooks/main --domain foreman.surge.sh

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/theforeman/foreman/badge.svg?branch=develop)](https://coveralls.io/github/theforeman/foreman?branch=develop)
 [![Reviewed by Hound](https://img.shields.io/badge/Reviewed_by-Hound-8E64B0.svg)](https://houndci.com)
 [![Support IRC channel](https://kiwiirc.com/buttons/irc.freenode.net/theforeman.png)](https://kiwiirc.com/client/irc.freenode.net/?#theforeman)
-[![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg)](http://theforeman.github.io/foreman)
+[![Storybook](https://raw.githubusercontent.com/storybooks/brand/master/badge/badge-storybook.svg)](https://foreman-storybook.surge.sh)
 
 [Foreman](https://theforeman.org) is a free open source project that gives you the power to easily **automate repetitive tasks**, quickly **deploy applications**, and proactively **manage your servers life cycle**, on-premises or in the cloud.
 

--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
@@ -12,7 +12,7 @@ export const Loading = () => (
   <Story narrow>
     <ChartBox
       chart={{ data: [] }}
-      noDataMsg="No data here"
+      noDataMsg="No data here."
       title="Title"
       status="PENDING"
     />

--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
@@ -12,7 +12,7 @@ export const Loading = () => (
   <Story narrow>
     <ChartBox
       chart={{ data: [] }}
-      noDataMsg="No data here."
+      noDataMsg="No data here"
       title="Title"
       status="PENDING"
     />


### PR DESCRIPTION
Github secrets (and some other features) are not available for Github `pull_request` actions from PR's in forked repos.  So, this action runs instead on the `push` event on the `develop` branch.

The React storybook is deployed from the `develop` branch to https://foreman.surge.sh.

Requires the secrets `SURGE_TOKEN` and `SURGE_DOMAIN` (foreman.surge.sh) to be set on Github (Settings tab -> Secrets).  Secrets are properly stored and are not hard-coded.

You can check the status in the Actions tab.  To test the PR on a fork, comment out line 14:
```yaml
if: github.repository == 'theforeman/foreman'
```
