### PR TITLE
Fixes #29741 - Login background override

### DIFF
--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
@@ -1,4 +1,4 @@
-@import "~@theforeman/vendor/scss/variables";
+@import '~@theforeman/vendor/scss/variables';
 
 $caption_font_weight: 600;
 /* stylelint-disable-next-line */
@@ -15,6 +15,7 @@ $background_image: linear-gradient(
   height: 100%;
 
   .login-pf {
+    background: none;
     background-image: $background_image;
 
     .login-pf-header {


### PR DESCRIPTION
.login-pf style set `background: #005c7e url(/assets/bg-login-0ccfbfe….jpg) repeat-x 50% 0;`
currently no visible issue in foreman, but it can affect plugins that wants to override the login page too and count on our style to stay the same.

setting `background: none;` will reset PF login-pf background styles and we could use our styles with no interference.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
