### PR TITLE
Fixes #29744 - Consistent session expiration for oidc ext. users

### DIFF
--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -76,26 +76,15 @@ module Foreman::Controller::Authentication
     # such sessions aren't checked for CSRF
     # UI access resets only session ID
     if api_request?
-      # When authenticating using SSO::OpenidConnect, upon successful authentication, we refresh the
-      # :sso_method values in the session (in OpenidConnect#update_session).
-      # Hence when we reset_session for SSO::OpenidConnect here, we do not reset the sso_method value in session
-      oidc_session? ? reset_oidc_session : reset_session
+      reset_session
       session[:user] = user.id
       session[:api_authenticated_session] = true
       set_activity_time
     else
-      oidc_session? ? reset_oidc_session : backup_session_content { reset_session }
+      backup_session_content { reset_session }
       session[:user] = user.id
       update_activity_time
     end
     user.present?
-  end
-
-  def reset_oidc_session
-    backup_session_content { reset_session }
-  end
-
-  def oidc_session?
-    session[:sso_method] == "SSO::OpenidConnect"
   end
 end

--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -77,8 +77,8 @@ module Foreman::Controller::Authentication
     # UI access resets only session ID
     if api_request?
       # When authenticating using SSO::OpenidConnect, upon successful authentication, we refresh the
-      # :expires_at and :sso_method values in the session (in OpenidConnect#update_session).
-      # Hence when we reset_session for SSO::OpenidConnect here, we do not reset the expires_at for session.
+      # :sso_method values in the session (in OpenidConnect#update_session).
+      # Hence when we reset_session for SSO::OpenidConnect here, we do not reset the sso_method value in session
       oidc_session? ? reset_oidc_session : reset_session
       session[:user] = user.id
       session[:api_authenticated_session] = true
@@ -92,7 +92,7 @@ module Foreman::Controller::Authentication
   end
 
   def reset_oidc_session
-    backup_session_content([:sso_method, :expires_at]) { reset_session }
+    backup_session_content { reset_session }
   end
 
   def oidc_session?

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -25,11 +25,7 @@ module Foreman::Controller::Session
     set_activity_time
   end
 
-  # In case of SSO::OpenidConnect Foreman will use :expiry_at from the token. This is
-  # set when the current user is set (in Authentication#set_current_user method)
-  # For other SSO types like basic_auth we use expiry at from the Settings
   def set_activity_time
-    return if session[:sso_method] == "SSO::OpenidConnect"
     session[:expires_at] = Setting[:idle_timeout].minutes.from_now.to_i
   end
 

--- a/app/services/sso/openid_connect.rb
+++ b/app/services/sso/openid_connect.rb
@@ -80,7 +80,6 @@ module SSO
 
     def update_session(payload)
       session[:sso_method] = self.class.to_s
-      session[:expires_at] = payload['exp']
     end
 
     def find_or_create_user_from_jwt(payload)


### PR DESCRIPTION
Currently the session expiration time is taken from the access token.
Since we use the idle session time out setting for all auth sources,
it would be nice to have this consistent.

For further reference: https://community.theforeman.org/t/external-authentication-session-expiration/18417