### PR TITLE
Fixes #29761 - correct config status chart layout

### DIFF
--- a/app/assets/stylesheets/charts.scss
+++ b/app/assets/stylesheets/charts.scss
@@ -155,8 +155,7 @@
 
 .host-configuration-chart {
   width: 240px;
-  margin: 25px auto 12px;
-  padding-bottom: 40px;
+  margin: 25px auto;
 }
 
 #host-show {

--- a/app/services/dashboard/manager.rb
+++ b/app/services/dashboard/manager.rb
@@ -50,7 +50,7 @@ module Dashboard
                 name: N_('Host Configuration Chart for %s') % origin,
                 settings: {
                   origin: origin,
-                  class_name: 'host-configuration-chart',
+                  class_name: 'host-configuration-chart-widget',
                 },
               },
             ]

--- a/db/migrate/20200513092446_change_config_chart_class.rb
+++ b/db/migrate/20200513092446_change_config_chart_class.rb
@@ -1,0 +1,10 @@
+class ChangeConfigChartClass < ActiveRecord::Migration[6.0]
+  def up
+    Widget.where(template: 'status_chart_widget').find_each do |widget|
+      widget.data ||= {}
+      widget.data[:settings] ||= {}
+      widget.data[:settings][:class_name] = 'host-configuration-chart-widget'
+      widget.save
+    end
+  end
+end


### PR DESCRIPTION
`host-configuration-chart` class was used for both the widget and the
chart iteslf, causing the title to be displayed with incorrect margins.
Since widget classes are saved to the database, a migration was added to
update the class name in the db as well. Some styling cleanup was done
as well.

Before:
![Screenshot from 2020-05-13 12-11-10](https://user-images.githubusercontent.com/1540531/81798235-79984f00-9518-11ea-8d5c-2e82acf3e9cf.png)

After:
![image](https://user-images.githubusercontent.com/1540531/81798305-8ddc4c00-9518-11ea-981b-56f5019605f9.png)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
