### PR TITLE
Fixes #29792  - Add current taxonomies and user in react context

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -500,7 +500,12 @@ module ApplicationHelper
   end
 
   def app_metadata
-    { UISettings: ui_settings, version: SETTINGS[:version].short, docUrl: documentation_url }
+    {
+      UISettings: ui_settings, version: SETTINGS[:version].short, docUrl: documentation_url,
+      location: Location.current&.attributes&.slice('id', 'title'),
+      organization: Organization.current&.attributes&.slice('id', 'title'),
+      user: User.current&.attributes&.slice('id', 'login', 'firstname', 'lastname', 'admin')
+    }.compact
   end
 
   def ui_settings

--- a/webpack/assets/javascripts/react_app/Root/Context/ForemanContext.js
+++ b/webpack/assets/javascripts/react_app/Root/Context/ForemanContext.js
@@ -10,3 +10,6 @@ const useForemanMetadata = () => useForemanContext().metadata;
 export const useForemanVersion = () => useForemanMetadata().version;
 export const useForemanSettings = () => useForemanMetadata().UISettings;
 export const useForemanDocUrl = () => useForemanMetadata().docUrl;
+export const useForemanOrganization = () => useForemanMetadata().organization;
+export const useForemanLocation = () => useForemanMetadata().location;
+export const useForemanUser = () => useForemanMetadata().user;

--- a/webpack/stories/docs/foreman-context.stories.mdx
+++ b/webpack/stories/docs/foreman-context.stories.mdx
@@ -10,7 +10,7 @@ import { Meta } from '@theforeman/stories';
 # ForemanContext
 
 ForemanContext is an implementation of the new `React Context` API.
-Global metadata (such as version, pagination, theme, foreman's settings, etc...) can be shared over all react nodes
+Global metadata (such as version, pagination, user, taxonomies, theme, foreman's settings, etc...) can be shared over all react nodes
 without any redux integration nor API request.
 
 ### How to apply it
@@ -27,10 +27,16 @@ Like selectors, you can consume context values by custom hooks:
 import {
   useForemanSettings,
   useForemanVersion,
+  useForemanOrganization,
+  useForemanLocation,
+  useForemanUser
 } from '../../Root/Context/ForemanContext';
 
 const { perPage } = useForemanSettings();
 const foremanVersion = useForemanVersion();
+const { id, title } = useForemanLocation();
+const { id, title } = useForemanOrganization();
+const { id, login, firstname, lastname, admin } = useForemanUser();
 ```
 
 ### How to add a value to the context


### PR DESCRIPTION
current loc / org and user-id should be a single source of truth across core and plugins and react context may be the place. 
The need for this PR has been raised here:
https://github.com/theforeman/foreman_plugin_template/pull/32/files#diff-2ee0f3275ce16ab586fcec80d0b2124cR11