### PR TITLE
Refs #29738 - Fix string extraction for plugins

### DIFF
--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -32,7 +32,7 @@ begin
       end
 
       def files_to_translate
-        @engine.root.glob(FILE_GLOB)
+        @engine.root.glob(FILE_GLOB).map(&:to_s)
       end
 
       def text_domain


### PR DESCRIPTION
The `files_to_translate` method was returning an array of Pathname objects which broke gettext