### PR TITLE
Fixes #29796 - trends extraction warning

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -10,6 +10,8 @@ class LinksController < ApplicationController
     case type
     when 'manual'
       documentation_url(options['section'], options)
+    when 'plugin_manual'
+      plugin_documentation_url(options['name'])
     when 'feed'
       Setting['rss_url']
     when 'wiki'
@@ -25,6 +27,8 @@ class LinksController < ApplicationController
     end
   end
 
+  private
+
   def documentation_url(section = "", options = {})
     root_url = options[:root_url] || "https://theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#"
     if section.empty?
@@ -32,6 +36,12 @@ class LinksController < ApplicationController
     else
       root_url + section
     end
+  end
+
+  def plugin_documentation_url(plugin_name, version: nil, options: {})
+    root_url = options[:root_url] || "https://theforeman.org/plugins"
+    path = version ? "#{plugin_name}/#{version}" : plugin_name
+    "#{root_url}/#{path}"
   end
 
   def wiki_url(section: '')

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -19,7 +19,7 @@ class LinksController < ApplicationController
     when 'chat'
       'https://freenode.net'
     when 'forums'
-      'https://community.theforeman.org'
+      forum_url(options['post'])
     when 'issues'
       'https://projects.theforeman.org/projects/foreman/issues'
     when 'vmrc'
@@ -42,6 +42,11 @@ class LinksController < ApplicationController
     root_url = options[:root_url] || "https://theforeman.org/plugins"
     path = version ? "#{plugin_name}/#{version}" : plugin_name
     "#{root_url}/#{path}"
+  end
+
+  def forum_url(post_path = nil, options: {})
+    root = options[:root] || 'https://community.theforeman.org'
+    post_path ? "#{root}/#{post_path}" : root
   end
 
   def wiki_url(section: '')

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -2,7 +2,7 @@ class StatisticsController < ApplicationController
   before_action :find_stat, :only => [:show]
 
   def index
-    render :json => charts.map(&:metadata)
+    render :json => { :charts => charts.map(&:metadata), discussion_url: external_link_path(type: 'forums', post: 't/trends-and-statistics-plugin/18745') }
   end
 
   def show

--- a/app/views/trends/_extraction_warning.html.erb
+++ b/app/views/trends/_extraction_warning.html.erb
@@ -1,0 +1,8 @@
+<% if User.current.admin? %>
+  <%= alert :class => 'alert-warning', :header => _("This funcionality is deprecated"),
+            :text => ("and will be removed in version 2.2. "\
+                       "If you wish continue using it, please install a plugin Foreman Statistics. "\
+                       "For instructions follow " +
+                       link_to('Statistics Plugin manual', external_link_path(type: 'plugin_manual', name: 'foreman_statistics', version: '1.0'))
+                     ).html_safe %>
+<% end %>

--- a/app/views/trends/_extraction_warning.html.erb
+++ b/app/views/trends/_extraction_warning.html.erb
@@ -1,8 +1,5 @@
-<% if User.current.admin? %>
-  <%= alert :class => 'alert-warning', :header => _("This funcionality is deprecated"),
-            :text => ("and will be removed in version 2.2. "\
-                       "If you wish continue using it, please install a plugin Foreman Statistics. "\
-                       "For instructions follow " +
-                       link_to('Statistics Plugin manual', external_link_path(type: 'plugin_manual', name: 'foreman_statistics', version: '1.0'))
-                     ).html_safe %>
-<% end %>
+<%= alert :class => 'alert-warning', :header => _("This functionality is deprecated"),
+          :text => ("and will be removed in version 2.2. "\
+                     "If you wish continue using it, you will need to install the Foreman Statistics plugin when upgrading to 2.2. " +
+                     link_to('Join discussion', external_link_path(type: 'forums', post: 't/trends-and-statistics-plugin/18745'), :target => '_blank')
+                   ).html_safe %>

--- a/app/views/trends/index.html.erb
+++ b/app/views/trends/index.html.erb
@@ -2,6 +2,7 @@
 <% title _("Trends") %>
 <% title_actions new_link(_("Add Trend Counter")),
                  documentation_button('4.1.3Trends') %>
+<%= render 'trends/extraction_warning' %>
 <% if @trends.empty? %>
   <%= alert :class => 'alert-info', :header => _("No trend counter defined"),
             :text => (_("To define trend counters, use the Add Trend Counter button.</br> To start collecting trend data, set a cron job to execute 'foreman-rake trends:counter' at least every %s minutes.") % Setting[:outofsync_interval]).html_safe %>

--- a/app/views/trends/welcome.html.erb
+++ b/app/views/trends/welcome.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, _("Trends")) %>
+<%= render 'trends/extraction_warning' %>
 <div class="blank-slate-pf">
   <div class="blank-slate-pf-icon">
     <%= icon_text("area-chart", "", :kind => "fa") %>

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPage.fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPage.fixtures.js
@@ -1,8 +1,12 @@
 import { statisticsMeta } from '../../../components/StatisticsChartsList/StatisticsChartsList.fixtures';
 import { noop } from '../../../common/helpers';
 
+export const discussionUrl =
+  '/links/forums?post=t/trends-and-statistics-plugin/18745/4';
+
 export const statisticsProps = {
   statisticsMeta,
+  discussionUrl,
   isLoading: false,
   hasData: true,
   hasError: false,

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPage.js
@@ -1,21 +1,36 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Alert } from 'patternfly-react';
 import PageLayout from '../../common/PageLayout/PageLayout';
 import Statistics from './Statistics/Statistics';
 import { translate as __ } from '../../../common/I18n';
 
-const StatisticsPage = ({ statisticsMeta, ...props }) => (
+const StatisticsPage = ({ statisticsMeta, discussionUrl, ...props }) => (
   <PageLayout header={__('Statistics')} searchable={false}>
+    <Alert type="warning">
+      <span className="pficon pficon-warning-triangle-o" />
+      <strong>This functionality is deprecated </strong>
+      <span className="text">
+        and will be removed in version 2.2. If you wish continue using it, you
+        will need to install the Foreman Statistics plugin when upgrading to
+        2.2.
+        <a href={discussionUrl} target="_blank" rel="noreferrer">
+          Join discussion
+        </a>
+      </span>
+    </Alert>
     <Statistics statisticsMeta={statisticsMeta} {...props} />
   </PageLayout>
 );
 
 StatisticsPage.propTypes = {
   statisticsMeta: PropTypes.array,
+  discussionUrl: PropTypes.string,
 };
 
 StatisticsPage.defaultProps = {
   statisticsMeta: [],
+  discussionUrl: '',
 };
 
 export default StatisticsPage;

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPageActions.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPageActions.js
@@ -14,7 +14,11 @@ export const getStatisticsMeta = (
     dispatch(hideLoading());
     dispatch({
       type: STATISTICS_PAGE_DATA_RESOLVED,
-      payload: { metadata: data, hasData: data.length > 0 },
+      payload: {
+        metadata: data.charts,
+        hasData: data.charts.length > 0,
+        discussionUrl: data.discussion_url,
+      },
     });
   };
 

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPageSelectors.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/StatisticsPageSelectors.js
@@ -2,6 +2,8 @@ export const selectStatisticsPage = state => state.statisticsPage;
 
 export const selectStatisticsMetadata = state =>
   selectStatisticsPage(state).metadata;
+export const selectStatisticsDiscussionUrl = state =>
+  selectStatisticsPage(state).discussionUrl;
 export const selectStatisticsIsLoading = state =>
   selectStatisticsPage(state).isLoading;
 export const selectStatisticsMessage = state =>

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/StatisticsPageActions.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/StatisticsPageActions.test.js
@@ -2,7 +2,7 @@ import API from '../../../../redux/API/API';
 
 import { testActionSnapshotWithFixtures } from '../../../../common/testHelpers';
 import { getStatisticsMeta } from '../StatisticsPageActions';
-import { statisticsProps } from '../StatisticsPage.fixtures';
+import { statisticsProps, discussionUrl } from '../StatisticsPage.fixtures';
 
 jest.mock('../../../../redux/API/API');
 
@@ -15,7 +15,10 @@ const runStatisticsAction = (callback, props, serverMock) => {
 const fixtures = {
   'should fetch statisticsMeta': () =>
     runStatisticsAction(getStatisticsMeta, {}, async () => ({
-      data: statisticsProps.statisticsMeta,
+      data: {
+        charts: statisticsProps.statisticsMeta,
+        discussion_url: discussionUrl,
+      },
     })),
   'should fetch statisticsMeta and fail': () =>
     runStatisticsAction(getStatisticsMeta, {}, async () => {

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPage.test.js.snap
@@ -15,6 +15,30 @@ exports[`StatisticsPage rendering render with props 1`] = `
   toastNotifications={null}
   toolbarButtons={null}
 >
+  <Alert
+    className=""
+    onDismiss={null}
+    type="warning"
+  >
+    <span
+      className="pficon pficon-warning-triangle-o"
+    />
+    <strong>
+      This functionality is deprecated 
+    </strong>
+    <span
+      className="text"
+    >
+      and will be removed in version 2.2. If you wish continue using it, you will need to install the Foreman Statistics plugin when upgrading to 2.2.
+      <a
+        href="/links/forums?post=t/trends-and-statistics-plugin/18745/4"
+        rel="noreferrer"
+        target="_blank"
+      >
+        Join discussion
+      </a>
+    </span>
+  </Alert>
   <Component
     getStatisticsMeta={[Function]}
     hasData={true}

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPageActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPageActions.test.js.snap
@@ -10,6 +10,7 @@ Array [
   Array [
     Object {
       "payload": Object {
+        "discussionUrl": "/links/forums?post=t/trends-and-statistics-plugin/18745/4",
         "hasData": true,
         "metadata": Array [
           Object {

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPageSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/__tests__/__snapshots__/StatisticsPageSelectors.test.js.snap
@@ -4,6 +4,7 @@ exports[`StatisticsPage selectors should return StatisticsHasMetadata 1`] = `tru
 
 exports[`StatisticsPage selectors should return StatisticsPage 1`] = `
 Object {
+  "discussionUrl": "/links/forums?post=t/trends-and-statistics-plugin/18745/4",
   "getStatisticsMeta": [Function],
   "hasData": true,
   "hasError": false,

--- a/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Statistics/StatisticsPage/index.js
@@ -6,6 +6,7 @@ import * as actions from './StatisticsPageActions';
 import withDataReducer from '../../common/reducerHOC/withDataReducer';
 import {
   selectStatisticsMetadata,
+  selectStatisticsDiscussionUrl,
   selectStatisticsMessage,
   selectStatisticsIsLoading,
   selectStatisticsHasMetadata,
@@ -17,6 +18,7 @@ import StatisticsPage from './StatisticsPage';
 // map state to props
 const mapStateToProps = state => ({
   statisticsMeta: selectStatisticsMetadata(state),
+  discussionUrl: selectStatisticsDiscussionUrl(state),
   isLoading: selectStatisticsIsLoading(state),
   message: selectStatisticsMessage(state),
   hasData: selectStatisticsHasMetadata(state),


### PR DESCRIPTION
Trends and statistics extraction warning.

Unfortunatelly both pages use diferent technology, so there is no easy way for both be using the same snipet, but it should be living just one version, so it should not be a big issue.

Relies on theforeman/theforeman.org#1585 being merged first.