### PR TITLE
Fixes #29877 - sidekiq wrapper for SELinux

### DIFF
--- a/extras/sidekiq
+++ b/extras/sidekiq
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec /usr/bin/sidekiq "$@"

--- a/extras/systemd/dynflow-sidekiq@.service
+++ b/extras/systemd/dynflow-sidekiq@.service
@@ -15,7 +15,7 @@ Environment=REDIS_PROVIDER=DYNFLOW_REDIS_URL
 # https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
 Environment=MALLOC_ARENA_MAX=2
 WorkingDirectory=/usr/share/foreman
-ExecStart=/usr/bin/sidekiq -e ${RAILS_ENV} -r ${DYNFLOW_SIDEKIQ_SCRIPT} -C /etc/foreman/dynflow/%i.yml
+ExecStart=/usr/share/foreman/bin/sidekiq -e ${RAILS_ENV} -r ${DYNFLOW_SIDEKIQ_SCRIPT} -C /etc/foreman/dynflow/%i.yml
 ExecReload=/usr/bin/kill -TSTP $MAINPID
 
 SyslogIdentifier=dynflow-sidekiq@%i


### PR DESCRIPTION
There is no other reason for this than new executable which can be
assigned with a SELinux label for domain transition.

Packaging PRs:

* https://github.com/theforeman/foreman-packaging/pull/5255
* @mmoll can you help me with Debian? this is a new file actually which
needs to go into `/usr/share/foreman/bin/foreman-sidekiq`