### PR TITLE
Fixes #29893 - using properly prefixed URL in React

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -188,7 +188,7 @@ function submit_with_all_params() {
       stop_pooling = true;
       $('body').css('cursor', 'auto');
       $('form input[type="submit"]').attr('disabled', false);
-      if (window.location.pathname !== tfm.tools.foremanUrl('/hosts/new')) {
+      if (window.location.pathname !== tfm.nav.foremanUrl('/hosts/new')) {
         // We got redirected to the show page, need to clear the title override
         tfm.store.dispatch('updateBreadcrumbTitle');
       }
@@ -451,7 +451,7 @@ function update_provisioning_image() {
   $.ajax({
     data: { operatingsystem_id: os_id, architecture_id: arch_id },
     type: 'get',
-    url: tfm.tools.foremanUrl('/compute_resources/' + compute_id + '/images'),
+    url: tfm.nav.foremanUrl('/compute_resources/' + compute_id + '/images'),
     dataType: 'json',
     success: function(result) {
       $.each(result, function() {

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -395,7 +395,7 @@ function update_fqdn() {
     .text();
   var pathname = window.location.pathname;
   var name = fqdn(host_name, domain_name);
-  if (name.length > 0 && pathname === tfm.tools.foremanUrl('/hosts/new')) {
+  if (name.length > 0 && pathname === tfm.nav.foremanUrl('/hosts/new')) {
     name = __('Create Host') + ' | ' + name;
     tfm.store.dispatch('updateBreadcrumbTitle', name);
   }

--- a/webpack/assets/javascripts/dashboard/index.js
+++ b/webpack/assets/javascripts/dashboard/index.js
@@ -7,8 +7,8 @@
 import $ from 'jquery';
 import { doesDocumentHasFocus } from '../react_app/common/document';
 import { notify } from '../foreman_toast_notifications';
-import { activateTooltips, foremanUrl } from '../foreman_tools';
-import { reloadPage } from '../foreman_navigation';
+import { activateTooltips } from '../foreman_tools';
+import { foremanUrl, reloadPage } from '../foreman_navigation';
 import { translate as __ } from '../react_app/common/I18n';
 import './index.scss';
 

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -6,10 +6,9 @@ import { push } from 'connected-react-router';
 import store from './react_app/redux';
 import * as LayoutActions from './react_app/components/Layout/LayoutActions';
 import { deprecate } from './react_app/common/DeprecationService';
+import { foremanUrl, visit } from './react_app/common/urlHelpers';
 
-export const visit = url => {
-  window.location.href = url;
-};
+export { visit, foremanUrl };
 
 export const reloadPage = () => {
   window.location.reload();

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -7,10 +7,20 @@
 
 import $ from 'jquery';
 import { translate as __ } from './react_app/common/I18n';
-
-import { showLoading, hideLoading } from './foreman_navigation';
+import { deprecate } from './react_app/common/DeprecationService';
+import {
+  showLoading,
+  hideLoading,
+  foremanUrl as _foremanUrl
+} from './foreman_navigation';
 
 export * from './react_app/common/DeprecationService';
+
+export function foremanUrl(path) {
+  // Katello is using this method as of now
+  deprecate('tfm.tools.foremanUrl', 'tfm.navigation.foremanUrl', '2.4');
+  return _foremanUrl(path);
+}
 
 export function showSpinner() {
   showLoading();

--- a/webpack/assets/javascripts/hosts/tableCheckboxes.js
+++ b/webpack/assets/javascripts/hosts/tableCheckboxes.js
@@ -20,8 +20,7 @@ import {
   ngettext as n__,
   translate as __,
 } from '../react_app/common/I18n';
-import { getURIsearch } from '../react_app/common/urlHelpers';
-import { foremanUrl } from '../foreman_tools';
+import { foremanUrl, getURIsearch } from '../react_app/common/urlHelpers';
 import * as sessionStorage from './HostsSessionStorage';
 
 // Array contains list of host ids

--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -1,6 +1,7 @@
 import { snakeCase, camelCase, debounce } from 'lodash';
 import URI from 'urijs';
 import { translate as __ } from './I18n';
+import { foremanUrl } from './urlHelpers';
 
 /**
  * Our API returns non-ISO8601 dates
@@ -187,9 +188,6 @@ export const formatDateTime = date => {
   return `${year}-${month}-${day} ${hour}:${minutes}:00`;
 };
 
-// generates an absolute, needed in case of running Foreman from a subpath
-export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
-
 export default {
   isoCompatibleDate,
   bindMethods,
@@ -208,5 +206,4 @@ export default {
   getManualURL,
   formatDate,
   formatDateTime,
-  foremanUrl,
 };

--- a/webpack/assets/javascripts/react_app/common/urlHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/urlHelpers.js
@@ -1,6 +1,11 @@
 import URI from 'urijs';
 
-import { visit } from '../../foreman_navigation';
+export const visit = url => {
+  window.location.href = url;
+};
+
+// generates an absolute, needed in case of running Foreman from a subpath
+export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
 
 /**
  * Build a url from given controller, action and id
@@ -8,7 +13,7 @@ import { visit } from '../../foreman_navigation';
  * @param {String} action - the action
  */
 export const urlBuilder = (controller, action, id = undefined) =>
-  `/${controller}/${id ? `${id}/` : ''}${action}`;
+  foremanUrl(`/${controller}/${id ? `${id}/` : ''}${action}`);
 
 /**
  * Build a url with search query

--- a/webpack/assets/javascripts/react_app/common/urlHelpers.test.js
+++ b/webpack/assets/javascripts/react_app/common/urlHelpers.test.js
@@ -1,5 +1,4 @@
 import { mockWindowLocation } from './testHelpers';
-import { visit } from '../../foreman_navigation';
 import {
   urlBuilder,
   urlWithSearch,
@@ -48,7 +47,7 @@ describe('URI query and stringify tests', () => {
     const newQuery = { search: 'some-new-search', per_page: 10 };
 
     changeQuery(newQuery);
-    expect(visit).toHaveBeenCalledWith(
+    expect(global.window.location.href).toEqual(
       `${baseHref}?search=some-new-search&page=1&per_page=10&order=name+ASC`
     );
 

--- a/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
@@ -1,6 +1,7 @@
 import { debounce, toString } from 'lodash';
 import { API } from '../../redux/API';
 import { translate as __ } from '../../common/I18n';
+import { urlBuilder } from '../../common/urlHelpers';
 
 import {
   EDITOR_CHANGE_DIFF_VIEW,
@@ -18,7 +19,6 @@ import {
   EDITOR_REVERT_CHANGES,
   EDITOR_TOGGLE_MASK,
   EDITOR_TOGGLE_RENDER_VIEW,
-  EDITOR_HOSTS_URL,
   EDITOR_HOST_SELECT_TOGGLE,
   EDITOR_HOST_SELECT_CLEAR,
   EDITOR_FETCH_HOST_PENDING,
@@ -149,6 +149,8 @@ export const previewTemplate = ({ host, renderPath }) => async (
 
 export const fetchTemplatePreview = (renderPath, params) =>
   API.post(renderPath, params);
+
+const EDITOR_HOSTS_URL = urlBuilder('hosts', 'preview_host_collection.json');
 
 // fetch & debounced fetch
 const fetchHosts = (

--- a/webpack/assets/javascripts/react_app/components/Editor/EditorConstants.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/EditorConstants.js
@@ -20,7 +20,6 @@ export const EDITOR_HOST_SELECT_CLEAR = 'EDITOR_HOST_SELECT_CLEAR';
 export const EDITOR_HOST_SELECT_RESET = 'EDITOR_HOST_SELECT_RESET';
 export const EDITOR_HOST_INITIAL_FETCH = 'EDITOR_HOST_INITIAL_FETCH';
 
-export const EDITOR_HOSTS_URL = '/hosts/preview_host_collection.json';
 export const EDITOR_HOST_ARR = 'hosts';
 export const EDITOR_HOST_FILTERED_ARR = 'filteredHosts';
 export const EDITOR_KEYBINDINGS = ['Default', 'Emacs', 'Vim'];

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -4,11 +4,13 @@
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { translate as __ } from '../../common/I18n';
+<<<<<<< HEAD
 import {
   removeLastSlashFromPath,
   noop,
   foremanUrl,
 } from '../../common/helpers';
+import { urlBuilder } from '../../common/urlHelpers';
 
 export const createInitialTaxonomy = (currentTaxonomy, availableTaxonomies) => {
   const taxonomyId = availableTaxonomies.find(
@@ -67,7 +69,7 @@ const createOrgItem = orgs => {
   const anyOrg = {
     name: __('Any Organization'),
     onClick: () => {
-      window.location.assign(foremanUrl('/organizations/clear'));
+      window.location.assign(urlBuilder('organizations', 'clear'));
     },
   };
   const childrenArray = [anyOrg];
@@ -98,7 +100,7 @@ const createLocationItem = locations => {
   const anyLoc = {
     name: __('Any Location'),
     onClick: () => {
-      window.location.assign(foremanUrl('/locations/clear'));
+      window.location.assign(urlBuilder('locations', 'clear'));
     },
   };
   const childrenArray = [anyLoc];

--- a/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
@@ -1,5 +1,5 @@
 import { API } from '../../../../redux/API';
-import { foremanUrl } from '../../../../../foreman_tools';
+import { foremanUrl } from '../../../../common/urlHelpers';
 
 import { addToast } from '../../../../redux/actions/toasts';
 

--- a/webpack/assets/javascripts/react_app/components/LoginPage/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/helpers.js
@@ -1,4 +1,5 @@
 import { translate as __ } from '../../common/I18n';
+import { urlBuilder } from '../../common/urlHelpers';
 
 export const adjustAlerts = alerts => {
   const submitErrors = [];
@@ -26,7 +27,7 @@ export const adjustAlerts = alerts => {
 
 export const defaultFormProps = {
   attributes: {
-    action: '/users/login',
+    action: urlBuilder('users', 'login'),
     method: 'post',
   },
   validate: true,

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/integration.test.js
@@ -8,9 +8,10 @@ import { reducers } from '../../AutoComplete';
 import bookmarksReducer from '../../Bookmarks/BookmarksReducer';
 import foremanModalsReducer from '../../ForemanModal/ForemanModalReducer';
 import { APIMiddleware } from '../../../redux/API';
-import { visit } from '../../../../foreman_navigation';
+import { changeQuery } from '../../../common/urlHelpers';
 
 jest.mock('../../../redux/API/API');
+jest.mock('../../../common/urlHelpers');
 jest.mock('lodash/debounce', () => jest.fn(fn => fn));
 
 const combinedReducers = {
@@ -38,10 +39,10 @@ describe('SearchBar integration test', () => {
       .find('.autocomplete-search-btn')
       .first()
       .simulate('click');
-    expect(visit).toHaveBeenCalledTimes(1);
+    expect(changeQuery).toHaveBeenCalledTimes(1);
     const event = new KeyboardEvent('keypress', { charCode: KEYCODES.ENTER });
     global.dispatchEvent(event);
-    expect(visit).toHaveBeenCalledTimes(2);
+    expect(changeQuery).toHaveBeenCalledTimes(2);
     // bookmark this page:
     // click on bookmark button
     wrapper

--- a/webpack/assets/javascripts/react_app/components/common/table/components/NameCell.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/components/NameCell.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
+import { urlBuilder } from '../../../../common/urlHelpers';
 
 const NameCell = ({ active, id, name, controller, children }) =>
   active ? (
-    <Link to={`/${controller}/${id}-${name}/edit`}>{children}</Link>
+    <Link to={urlBuilder(controller, 'edit', `${id}-${encodeURI(name)}`)}>
+      {children}
+    </Link>
   ) : (
     <a href="#" className="disabled" disabled="disabled" onClick={() => {}}>
       {children}

--- a/webpack/assets/javascripts/react_app/constants.js
+++ b/webpack/assets/javascripts/react_app/constants.js
@@ -3,22 +3,3 @@ export const STATUS = {
   RESOLVED: 'RESOLVED',
   ERROR: 'ERROR',
 };
-
-export const getControllerSearchProps = (
-  controller,
-  id = 'searchBar',
-  canCreate = true
-) => ({
-  controller,
-  autocomplete: {
-    id,
-    searchQuery: '',
-    url: `${controller}/auto_complete_search`,
-    useKeyShortcuts: true,
-  },
-  bookmarks: {
-    url: '/api/bookmarks',
-    canCreate,
-    documentationUrl: `4.1.5Searching`,
-  },
-});

--- a/webpack/assets/javascripts/react_app/redux/API/API.js
+++ b/webpack/assets/javascripts/react_app/redux/API/API.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import './APITestSetup';
-import { foremanUrl } from '../../../foreman_tools';
 
 const getcsrfToken = () => {
   const token = document.querySelector('meta[name="csrf-token"]');
@@ -13,28 +12,28 @@ axios.defaults.headers.common['X-CSRF-Token'] = getcsrfToken();
 
 export default {
   get(url, headers = {}, params = {}) {
-    return axios.get(foremanUrl(url), {
+    return axios.get(url, {
       headers,
       params,
     });
   },
   put(url, data = {}, headers = {}) {
-    return axios.put(foremanUrl(url), data, {
+    return axios.put(url, data, {
       headers,
     });
   },
   post(url, data = {}, headers = {}) {
-    return axios.post(foremanUrl(url), data, {
+    return axios.post(url, data, {
       headers,
     });
   },
   delete(url, headers = {}) {
-    return axios.delete(foremanUrl(url), {
+    return axios.delete(url, {
       headers,
     });
   },
   patch(url, data = {}, headers = {}) {
-    return axios.patch(foremanUrl(url), data, {
+    return axios.patch(url, data, {
       headers,
     });
   },

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPage.js
@@ -6,8 +6,11 @@ import './auditspage.scss';
 import { translate as __ } from '../../../common/I18n';
 import PageLayout from '../../common/PageLayout/PageLayout';
 import AuditsTable from './components/AuditsTable';
-import { AUDITS_SEARCH_PROPS, AUDITS_MANUAL_URL } from '../constants';
+import { AUDITS_MANUAL_URL } from '../constants';
 import { useForemanVersion } from '../../../Root/Context/ForemanContext';
+import { getControllerSearchProps } from '../../common/helpers';
+
+const SEARCH_PROPS = getControllerSearchProps('audits');
 
 const AuditsPage = ({
   searchQuery,
@@ -21,7 +24,7 @@ const AuditsPage = ({
     <PageLayout
       header={__('Audits')}
       searchable
-      searchProps={AUDITS_SEARCH_PROPS}
+      searchProps={SEARCH_PROPS}
       searchQuery={searchQuery}
       isLoading={isLoading && hasData}
       onSearch={search => fetchAndPush({ searchQuery: search, page: 1 })}

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageActions.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/AuditsPageActions.js
@@ -16,7 +16,11 @@ import {
   selectAuditsSearch,
   selectAuditsIsLoadingPage,
 } from './AuditsPageSelectors';
-import { stringifyParams, getParams } from '../../../common/urlHelpers';
+import {
+  foremanUrl,
+  stringifyParams,
+  getParams,
+} from '../../../common/urlHelpers';
 import { translate as __ } from '../../../common/I18n';
 
 // on didMount or popstatee
@@ -25,7 +29,7 @@ export const initializeAudits = () => dispatch => {
   dispatch(fetchAudits(params));
   if (!history.action === 'POP') {
     history.replace({
-      pathname: AUDITS_PATH,
+      pathname: foremanUrl(AUDITS_PATH),
       search: stringifyParams(params),
     });
   }
@@ -33,7 +37,7 @@ export const initializeAudits = () => dispatch => {
 
 export const fetchAudits = (
   { page, perPage, searchQuery },
-  url = AUDITS_PATH
+  url = foremanUrl(AUDITS_PATH)
 ) => async (dispatch, getState) => {
   dispatch({ type: AUDITS_PAGE_SHOW_LOADING });
   if (selectAuditsHasError(getState()))
@@ -97,7 +101,7 @@ export const fetchAndPush = params => (dispatch, getState) => {
   const query = buildQuery(params, getState());
   dispatch(fetchAudits(query));
   history.push({
-    pathname: AUDITS_PATH,
+    pathname: foremanUrl(AUDITS_PATH),
     search: stringifyParams(query),
   });
 };

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -14,7 +14,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
       "autocomplete": Object {
         "id": "searchBar",
         "searchQuery": "",
-        "url": "audits/auto_complete_search",
+        "url": "/audits/auto_complete_search",
         "useKeyShortcuts": true,
       },
       "bookmarks": Object {
@@ -89,7 +89,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
       "autocomplete": Object {
         "id": "searchBar",
         "searchQuery": "",
-        "url": "audits/auto_complete_search",
+        "url": "/audits/auto_complete_search",
         "useKeyShortcuts": true,
       },
       "bookmarks": Object {
@@ -166,7 +166,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
       "autocomplete": Object {
         "id": "searchBar",
         "searchQuery": "",
-        "url": "audits/auto_complete_search",
+        "url": "/audits/auto_complete_search",
         "useKeyShortcuts": true,
       },
       "bookmarks": Object {
@@ -243,7 +243,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
       "autocomplete": Object {
         "id": "searchBar",
         "searchQuery": "",
-        "url": "audits/auto_complete_search",
+        "url": "/audits/auto_complete_search",
         "useKeyShortcuts": true,
       },
       "bookmarks": Object {

--- a/webpack/assets/javascripts/react_app/routes/Audits/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/Audits/constants.js
@@ -1,5 +1,4 @@
 import { getManualURL } from '../../common/helpers';
-import { getControllerSearchProps } from '../../constants';
 
 export const AUDITS_PAGE_DATA_RESOLVED = 'AUDITS_PAGE_DATA_RESOLVED';
 export const AUDITS_PAGE_DATA_FAILED = 'AUDITS_PAGE_DATA_FAILED';
@@ -9,5 +8,4 @@ export const AUDITS_PAGE_UPDATE_QUERY = 'AUDITS_PAGE_UPDATE_QUERY';
 export const AUDITS_PAGE_CLEAR_ERROR = 'AUDITS_PAGE_CLEAR_ERROR';
 
 export const AUDITS_PATH = '/audits';
-export const AUDITS_SEARCH_PROPS = getControllerSearchProps('audits');
 export const AUDITS_MANUAL_URL = () => getManualURL('4.1.4Auditing');

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
@@ -6,7 +6,11 @@ import { Link } from 'react-router-dom';
 import { translate as __ } from '../../../common/I18n';
 import PageLayout from '../../common/PageLayout/PageLayout';
 import ModelsPageContent from './components/ModelsPageContent';
-import { MODELS_SEARCH_PROPS } from '../constants';
+import { getControllerSearchProps } from '../../common/helpers';
+
+import './ModelsPage.scss';
+
+const SEARCH_PROPS = getControllerSearchProps('models');
 
 const ModelsPage = ({
   fetchAndPush,
@@ -35,7 +39,7 @@ const ModelsPage = ({
     <PageLayout
       header={__('Hardware Models')}
       searchable={!isLoading}
-      searchProps={MODELS_SEARCH_PROPS}
+      searchProps={SEARCH_PROPS}
       searchQuery={search}
       isLoading={isLoading && hasData}
       onSearch={handleSearch}

--- a/webpack/assets/javascripts/react_app/routes/Models/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/constants.js
@@ -6,7 +6,6 @@ export const MODELS_PAGE_HIDE_LOADING = 'MODELS_PAGE_HIDE_LOADING';
 export const MODELS_PAGE_SHOW_LOADING = 'MODELS_PAGE_SHOW_LOADING';
 export const MODELS_PAGE_CLEAR_ERROR = 'MODELS_PAGE_CLEAR_ERROR';
 
-export const MODELS_SEARCH_PROPS = getControllerSearchProps('models');
 export const MODELS_API_PATH = '/api/models?include_permissions=true';
 export const MODELS_PATH = '/models';
 export const MODEL_DELETE_MODAL_ID = 'modelDeleteModal';

--- a/webpack/assets/javascripts/react_app/routes/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/routes/common/helpers.js
@@ -1,0 +1,20 @@
+import { foremanUrl, urlBuilder } from '../../common/urlHelpers';
+
+export const getControllerSearchProps = (
+  controller,
+  id = 'searchBar',
+  canCreate = true
+) => ({
+  controller,
+  autocomplete: {
+    id,
+    searchQuery: '',
+    url: urlBuilder(controller, 'auto_complete_search'),
+    useKeyShortcuts: true,
+  },
+  bookmarks: {
+    url: foremanUrl('/api/bookmarks'),
+    canCreate,
+    documentationUrl: `4.1.5Searching`,
+  },
+});


### PR DESCRIPTION
@amirfefer @MariaAga if I have got correctly what the `foremanUrl()` should do, we are not using it correctly. URLs that comes from server, are already prefixed by the subdirectory, so we can't just prefix all of them, only the ones build on client.

To test locally, run foreman by: `RAILS_RELATIVE_URL_ROOT='/foreman' bundle exec foreman start`

I'm fixing what I found, please if anyone know about another place we build URLs on client statically, please come forward now :thinking: xD

Note: `Statistics` are gonna be droped, no point of fixing here.