### PR TITLE
Fixes #28639,#28640 - fix AWS deprecation and unrecognized args warnings

### DIFF
--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -154,7 +154,7 @@ module Foreman::Model
 
     def client
       self.url = region if gov_cloud
-      @client ||= ::Fog::Compute.new(:provider => "AWS", :aws_access_key_id => user, :aws_secret_access_key => password, :region => region, :connection_options => connection_options)
+      @client ||= Fog::AWS::Compute.new(:aws_access_key_id => user, :aws_secret_access_key => password, :region => region, :connection_options => connection_options)
     end
 
     def vm_instance_defaults


### PR DESCRIPTION
The intention in `fog-aws` was to deprecate the more generic `Fog::Compute.new` in favor of the more specific usage as per fog-aws maintainer explained in this [issue](https://github.com/fog/fog-aws/issues/565#issuecomment-631660289). Not sure, if other compute resources require similar changes, but if they do, I can update them too.