### PR TITLE
Fixes #29900 - Add Cpu/Cores react component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/CPUCoresInput.js
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/CPUCoresInput.js
@@ -1,0 +1,92 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { WarningTriangleIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
+import { HelpBlock, FormGroup, Grid, Col, Row } from 'patternfly-react';
+import { translate as __ } from '../../common/I18n';
+import NumericInput from '../common/forms/NumericInput';
+import './cpuCoresInput.scss';
+import { noop } from '../../common/helpers';
+
+const CPUCoresInput = ({
+  label,
+  recommendedMaxValue,
+  maxValue,
+  defaultValue,
+  onChange,
+  minValue,
+}) => {
+  const [value, setValue] = useState(defaultValue);
+
+  useEffect(() => {
+    setValue(defaultValue);
+  }, [defaultValue]);
+
+  const getValidationState = useCallback(() => {
+    if (value > maxValue && maxValue != null) return 'error';
+    else if (value > recommendedMaxValue && recommendedMaxValue != null)
+      return 'warning';
+    return null;
+  }, [recommendedMaxValue, maxValue, value]);
+
+  const handleChange = v => {
+    setValue(v);
+    onChange(v);
+  };
+
+  const validationState = getValidationState();
+
+  return (
+    <FormGroup validationState={validationState}>
+      <Grid>
+        <Row>
+          <Col>
+            <NumericInput
+              value={value}
+              minValue={minValue}
+              onChange={v => handleChange(v)}
+              label={label}
+            />
+          </Col>
+        </Row>
+        {validationState === 'warning' && (
+          <HelpBlock>
+            <WarningTriangleIcon className="help-block-icon" />
+            {__('Specified value is higher than recommended maximum')}
+          </HelpBlock>
+        )}
+        {validationState === 'error' && (
+          <HelpBlock>
+            <ErrorCircleOIcon className="help-block-icon" />
+            {__('Specified value is higher than maximum value')}
+          </HelpBlock>
+        )}
+      </Grid>
+    </FormGroup>
+  );
+};
+
+CPUCoresInput.propTypes = {
+  /** Set the label of the numeric input */
+  label: NumericInput.propTypes.label,
+  /** Set the default value of the numeric input */
+  defaultValue: PropTypes.number,
+  /** Set the recommended max value of the numeric input */
+  recommendedMaxValue: PropTypes.number,
+  /** Set the max value of the numeric input */
+  maxValue: PropTypes.number,
+  /** Set the min value of the numeric input */
+  minValue: PropTypes.number,
+  /** Set the onChange function of the numeric input */
+  onChange: PropTypes.func,
+};
+
+CPUCoresInput.defaultProps = {
+  label: __('CPUs'),
+  defaultValue: 1,
+  minValue: 1,
+  recommendedMaxValue: null,
+  maxValue: null,
+  onChange: noop,
+};
+
+export default CPUCoresInput;

--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/CPUCoresInput.stories.js
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/CPUCoresInput.stories.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { number, action, text } from '@theforeman/stories';
+import CPUCoresInput from './CPUCoresInput';
+
+export default {
+  title: 'Components|Form/CPUCoresInput',
+  component: CPUCoresInput,
+  parameters: {
+    centered: { disable: true },
+  },
+};
+
+export const UseCpuOrCoresInput = () => (
+  <CPUCoresInput
+    label={text('Label', 'CPUs')}
+    defaultValue={number('DefaultValue', 1)}
+    recommendedMaxValue={number('RecommendedMaxValue', 10)}
+    maxValue={number('MaxValue', 20)}
+    minValue={number('MinValue', 1)}
+    onChange={action('Value was changed')}
+  />
+);

--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/__tests__/CPUCoresInput.test.js
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/__tests__/CPUCoresInput.test.js
@@ -1,0 +1,17 @@
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+import CPUCoresInput from '../CPUCoresInput';
+
+const props = {
+  label: 'CPUs',
+};
+
+const fixtures = {
+  'should render with default props': {
+    ...props,
+  },
+};
+
+describe('CPUCoresInput', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(CPUCoresInput, fixtures));
+});

--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/__tests__/__snapshots__/CPUCoresInput.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/__tests__/__snapshots__/CPUCoresInput.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CPUCoresInput rendering should render with default props 1`] = `
+<FormGroup
+  bsClass="form-group"
+  validationState={null}
+>
+  <Grid
+    bsClass="container"
+    componentClass="div"
+    fluid={false}
+  >
+    <Row
+      bsClass="row"
+      componentClass="div"
+    >
+      <Col
+        bsClass="col"
+        componentClass="div"
+      >
+        <NumericInput
+          className=""
+          format={null}
+          label="CPUs"
+          minValue={1}
+          onChange={[Function]}
+          precision={0}
+          value={1}
+        />
+      </Col>
+    </Row>
+  </Grid>
+</FormGroup>
+`;

--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/cpuCoresInput.scss
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/cpuCoresInput.scss
@@ -1,0 +1,15 @@
+
+.help-block-icon {
+  margin-right: 3px;
+}
+
+.common-numericInput {
+  .react-numeric-input {
+    display: flex !important;
+
+    input {
+      flex: 1;
+      height: 28px;
+    }
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/index.js
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/index.js
@@ -1,0 +1,3 @@
+import CPUCoresInput from './CPUCoresInput';
+
+export default CPUCoresInput;


### PR DESCRIPTION
In order to eventually replace the jquery-ui-spinner, there is a need to add a component for the CPU/cores/sockets input in a form.
This issue is for the addition of the component.