### PR TITLE
Fixes #29857 - Add DSL docs for taxonomies

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,15 @@
 require_relative 'concerns/audit_associations'
 
 class ApplicationRecord < ActiveRecord::Base
+  extend ApipieDSL::Class
+
+  apipie :prop_group, name: :basic_model_props do
+    property :id, Integer, desc: "Numerical ID of the #{@meta[:friendly_name] || @meta[:class_scope]}"
+    meta_example = ", e.g. #{@meta[:example]}" if @meta[:example]
+    name_desc = @meta[:name_desc] || "Name of the #{@meta[:friendly_name] || @meta[:class_scope]}#{meta_example}"
+    property :name, String, desc: name_desc
+  end
+
   self.abstract_class = true
 
   extend AuditAssociations::AssociationsDefinitions

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -1,4 +1,10 @@
 class Location < Taxonomy
+  apipie :class, desc: "A class representing a Location object" do
+    sections only: %w[all additional]
+    prop_group :basic_model_props, ApplicationRecord, meta: { example: 'Europe' }
+    prop_group :taxonomy_props, Taxonomy, meta: { model_name: 'Location', example: 'Europe/Prague' }
+  end
+
   extend FriendlyId
   friendly_id :title
   include Foreman::ThreadSession::LocationModel

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -1,4 +1,10 @@
 class Organization < Taxonomy
+  apipie :class, desc: "A class representing an Organization object" do
+    sections only: %w[all additional]
+    prop_group :basic_model_props, ApplicationRecord, meta: { example: 'Red Hat' }
+    prop_group :taxonomy_props, Taxonomy, meta: { model_name: 'Organization', example: 'Red Hat/Engineering' }
+  end
+
   extend FriendlyId
   friendly_id :title
   include Foreman::ThreadSession::OrganizationModel

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,4 +1,11 @@
 class Taxonomy < ApplicationRecord
+  apipie :prop_group, name: :taxonomy_props do
+    property :title, String, desc: "Title of the #{@meta[:model_name]}. Comparing to the Name, Title contains also names of all parent #{@meta[:model_name]}s, e.g. #{@meta[:example]}"
+    property :description, String, desc: "Description of the #{@meta[:class_scope]}"
+    property :created_at, String, desc: "The time when the #{@meta[:class_scope]} was created"
+    property :updated_at, String, desc: "The last time when the #{@meta[:class_scope]} was updated"
+  end
+
   validates_lengths_from_database
 
   include Authorizable

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -9,8 +9,8 @@ ApipieDSL.configure do |config|
   config.dsl_classes_matchers = [
     "#{Rails.root}/lib/foreman/renderer/**/*.rb",
   ]
-  # TODO all provisioning reports jobs additional
-  config.sections = %w[basic_ruby_methods]
+  # TODO provisioning reports jobs
+  config.sections = %w[all additional basic_ruby_methods]
   # TODO enable?
   config.validate = false
 


### PR DESCRIPTION
Adds DSL docs for basic properties of taxonomy objects. The list is similar to the one we show in Help on the template creation page.

To test this I suggest to run `FOREMAN_APIPIE_LANGS=en bundle exec rake apipie_dsl:cache` at first, so the docs are being rendered from the cache. After go to `https://<fqdn>/templates_doc` (the redirecting button is in `About` section as well).