### PR TITLE
Fixes #29445 - restrict STI deletion to admin

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -122,9 +122,10 @@ class ApplicationController < ActionController::Base
   end
 
   def sti_clean_up(e)
+    require_login rescue false
     @unknown_class_name = e.message.match(/subclass: '(.*)'\./)[1]
     @parent_class = e.message.match(/overwrite (.*)\.inheritance_column/)[1].constantize
-    if params[:confirm_data_deletion] == 'yes'
+    if params[:confirm_data_deletion] == 'yes' && User.current&.admin?
       begin
         @parent_class.where(@parent_class.inheritance_column => @unknown_class_name).delete_all
       rescue ActiveRecord::InvalidForeignKey => e

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,6 +123,7 @@ class ApplicationController < ActionController::Base
 
   def sti_clean_up(e)
     require_login rescue false
+    Foreman::Logging.exception("Action failed", e) unless User.current&.admin?
     @unknown_class_name = e.message.match(/subclass: '(.*)'\./)[1]
     @parent_class = e.message.match(/overwrite (.*)\.inheritance_column/)[1].constantize
     if params[:confirm_data_deletion] == 'yes' && User.current&.admin?

--- a/app/views/common/confirm_class_clean_up.html.erb
+++ b/app/views/common/confirm_class_clean_up.html.erb
@@ -1,8 +1,11 @@
 <h1><%= _('Unknown records found in the database') %></h1>
-
-<%= alert(text: _('Creating a DB backup before proceeding is highly recommended!'), class: 'alert-danger', close: false) %>
-
-<%= (_('Foreman has detected definitions of unknown classes in your database. This can happen after a plugin removal which did not properly cleaned up data it created. Would you like to delete all records from SQL table <b>"%{table}"</b> with column <b>"%{column}"</b> having the value <b>"%{value}"</b>') % { table: @parent_class.table_name, column: @parent_class.inheritance_column, value: @unknown_class_name}).html_safe %>
-
-<br><br>
-<%= link_to _('Delete'), '?confirm_data_deletion=yes', class: 'btn btn-danger', data: { confirm: _('The data deletion can not be undone, are you sure you want to proceed?') } %>
+<% if User.current&.admin? %>
+  <%= alert(text: _('Creating a DB backup before proceeding is highly recommended!'), class: 'alert-danger', close: false) %>
+  
+  <%= (_('Foreman has detected definitions of unknown classes in your database. This can happen after a plugin removal which did not properly cleaned up data it created. Would you like to delete all records from SQL table <b>"%{table}"</b> with column <b>"%{column}"</b> having the value <b>"%{value}"</b>') % { table: @parent_class.table_name, column: @parent_class.inheritance_column, value: @unknown_class_name}).html_safe %>
+  
+  <br><br>
+  <%= link_to _('Delete'), '?confirm_data_deletion=yes', class: 'btn btn-danger', data: { confirm: _('The data deletion can not be undone, are you sure you want to proceed?') } %>
+<% else %>
+  <%= (_('Please contact your administrator, the request id for finding the logs: "%s"') % request.uuid) %>
+<% end %>


### PR DESCRIPTION
When obsolete STI records deletion was introduced, we allowed even
non-admin users to delete that. This patch makes it possible only for
admins to delete records from the database. Non-admin users only see a
short message explaining what happened, that they should contact
administrator and request ID that can help administrator to figure out
what happened.

It was also necessary to add explicit require_login call, otherwise
User.current was nil in case the stack failed before user was loaded.
This also made the page looks much nicer, becase the menu can be
properly rendered.

For the reviewer - under admin account
![0admin](https://user-images.githubusercontent.com/109773/82806133-76408400-9e85-11ea-866d-24f979d7a845.png)
non-admin account
![0nonadmin](https://user-images.githubusercontent.com/109773/82806135-76d91a80-9e85-11ea-89e7-39b23fb10b2a.png)

to reproduce, install a plugin, e.g. discovery, change some discovery setting and then comment it in Gemfile. After server restart, enter setting page under non-admin user. You shouldn't be able to delete records even if you know the magic parameter. Pinging @tbrisker as he was who pointed this weakness out.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
