### PR TITLE
Fixes #28028 - Drop chromedriver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
   },
-  "optionalDependencies": {
-    "chromedriver": "81.0.0"
-  },
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@babel/preset-env": "7.9.5",

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -19,7 +19,7 @@ Minitest::Retry.on_consistent_failure do |klass, test_name|
   Rails.logger.error("DO NOT IGNORE - Consistent failure - #{klass} #{test_name}")
 end
 
-Selenium::WebDriver::Chrome::Service.driver_path = ENV['TESTDRIVER_PATH'] || File.join(Rails.root, 'node_modules', '.bin', 'chromedriver')
+Selenium::WebDriver::Chrome::Service.driver_path = ENV['TESTDRIVER_PATH'] || Foreman::Util.which('chromedriver', Rails.root.join('node_modules', '.bin'))
 Capybara.register_driver :selenium_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.args << '--disable-gpu'


### PR DESCRIPTION
This prefers the NPM path it used to look at, but falls back to looking in `$PATH`.

Right now I don't know if we should keep looking at the NPM path or just limit to `$PATH`. This is also untested so I'll see what CI tells me about it.