### PR TITLE
Fixes #29936 - Bump fog-aws version to 3.6.5

### DIFF
--- a/bundler.d/ec2.rb
+++ b/bundler.d/ec2.rb
@@ -1,3 +1,3 @@
 group :ec2 do
-  gem 'fog-aws', '< 4'
+  gem 'fog-aws', '>= 3.6.2', '< 4'
 end


### PR DESCRIPTION
Packaging PR: [foreman-packaging/5296](https://github.com/theforeman/foreman-packaging/pull/5296).
The minimum required `fog-aws` to support #7585 is `3.6.2` and the latest fog-aws released is `3.6.5`. So, the packaging PR has been opened to update to `3.6.5` while here, in foreman, setting minimum required version to `3.6.2`. 