### PR TITLE
Fixes #29859 - Add DSL docs for SSH keys

### DIFF
--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -1,4 +1,18 @@
 class SshKey < ApplicationRecord
+  apipie :class, desc: "A class representing #{model_name.human} object" do
+    sections only: %w[all additional]
+    prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'SSH key' }
+    property :user, User, desc: 'Returns the user object which is linked to the SSH key'
+    property :key, String, desc: 'Returns the SSH public key'
+    property :fingerprint, String, desc: 'Returns the fingerprint of the public key'
+    property :length, Integer, desc: 'Returns the length of the SSH public key'
+    property :ssh_key, String, desc: 'Returns the SSH public key'
+    property :type, String, desc: 'Returns the type of the of the SSH key, e.g. ssh-rsa, ssh-dsa',
+                            example: '@ssh_key.type # => "ssh-rsa"'
+    property :comment, String, desc: 'Returns a key comment. The comment is usually a user identifier',
+                               example: '@ssh-key.comment # => forman@foreman.example.com'
+  end
+
   audited :associated_with => :user
   include Authorizable
   extend FriendlyId

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -7,6 +7,7 @@ ApipieDSL.configure do |config|
   config.doc_base_url = '/templates_doc'
   config.markup = ApipieDSL::Markup::Markdown.new if Rails.env.development? && defined? Maruku
   config.dsl_classes_matchers = [
+    "#{Rails.root}/app/models/**/*.rb",
     "#{Rails.root}/lib/foreman/renderer/**/*.rb",
   ]
   # TODO provisioning reports jobs


### PR DESCRIPTION
Unfortunately, examples for properties are not being shown for now, I'll add it in the next version of apipie-dsl. Although I've kept them here, they don't break anything, just ignored.