### PR TITLE
Fixes #29973 - Move property docs next to the jail

### DIFF
--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -1,12 +1,6 @@
 require "resolv"
 # This models a DNS domain and so represents a site.
 class Domain < ApplicationRecord
-  apipie :class, desc: "A class representing #{model_name.human} object" do
-    sections only: %w[all additional]
-    prop_group :basic_model_props, ApplicationRecord, meta: { example: 'example.com' }
-    property :fullname, String, desc: 'User name for this domain, e.g. "Primary domain for our company"'
-  end
-
   audited
   include Authorizable
   extend FriendlyId
@@ -53,6 +47,11 @@ class Domain < ApplicationRecord
     end
   }
 
+  apipie :class, desc: "A class representing #{model_name.human} object" do
+    sections only: %w[all additional]
+    prop_group :basic_model_props, ApplicationRecord, meta: { example: 'example.com' }
+    property :fullname, String, desc: 'User name for this domain, e.g. "Primary domain for our company"'
+  end
   class Jail < Safemode::Jail
     allow :id, :name, :fullname
   end

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -1,18 +1,4 @@
 class SshKey < ApplicationRecord
-  apipie :class, desc: "A class representing #{model_name.human} object" do
-    sections only: %w[all additional]
-    prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'SSH key' }
-    property :user, User, desc: 'Returns the user object which is linked to the SSH key'
-    property :key, String, desc: 'Returns the SSH public key'
-    property :fingerprint, String, desc: 'Returns the fingerprint of the public key'
-    property :length, Integer, desc: 'Returns the length of the SSH public key'
-    property :ssh_key, String, desc: 'Returns the SSH public key'
-    property :type, String, desc: 'Returns the type of the of the SSH key, e.g. ssh-rsa, ssh-dsa',
-                            example: '@ssh_key.type # => "ssh-rsa"'
-    property :comment, String, desc: 'Returns a key comment. The comment is usually a user identifier',
-                               example: '@ssh-key.comment # => forman@foreman.example.com'
-  end
-
   audited :associated_with => :user
   include Authorizable
   extend FriendlyId
@@ -48,6 +34,20 @@ class SshKey < ApplicationRecord
 
   delegate :login, to: :user, prefix: true
 
+  apipie :class, desc: "A class representing #{model_name.human} object" do
+    sections only: %w[all additional]
+    prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'SSH key' }
+    property :user, User, desc: 'Returns the user object which is linked to the SSH key'
+    property :key, String, desc: 'Returns the SSH public key'
+    property :to_export, String, desc: 'Returns a string representing the key with its metadata (key, type and comment)'
+    property :fingerprint, String, desc: 'Returns the fingerprint of the public key'
+    property :length, Integer, desc: 'Returns the length of the SSH public key'
+    property :ssh_key, String, desc: 'Returns the SSH public key'
+    property :type, String, desc: 'Returns the type of the of the SSH key, e.g. ssh-rsa, ssh-dsa',
+                            example: '@ssh_key.type # => "ssh-rsa"'
+    property :comment, String, desc: 'Returns a key comment. The comment is usually a user identifier',
+                               example: '@ssh-key.comment # => forman@foreman.example.com'
+  end
   class Jail < ::Safemode::Jail
     allow :id, :name, :user, :key, :to_export, :fingerprint, :length, :ssh_key, :type, :comment
   end

--- a/app/models/taxonomies/location.rb
+++ b/app/models/taxonomies/location.rb
@@ -1,10 +1,4 @@
 class Location < Taxonomy
-  apipie :class, desc: "A class representing a Location object" do
-    sections only: %w[all additional]
-    prop_group :basic_model_props, ApplicationRecord, meta: { example: 'Europe' }
-    prop_group :taxonomy_props, Taxonomy, meta: { model_name: 'Location', example: 'Europe/Prague' }
-  end
-
   extend FriendlyId
   friendly_id :title
   include Foreman::ThreadSession::LocationModel
@@ -27,10 +21,6 @@ class Location < Taxonomy
   scope :my_locations, lambda { |user = User.current|
     user.admin? ? all : where(id: user.location_and_child_ids)
   }
-
-  class Jail < ::Safemode::Jail
-    allow :id, :name, :title, :created_at, :updated_at, :description
-  end
 
   def dup
     new = super

--- a/app/models/taxonomies/organization.rb
+++ b/app/models/taxonomies/organization.rb
@@ -1,10 +1,4 @@
 class Organization < Taxonomy
-  apipie :class, desc: "A class representing an Organization object" do
-    sections only: %w[all additional]
-    prop_group :basic_model_props, ApplicationRecord, meta: { example: 'Red Hat' }
-    prop_group :taxonomy_props, Taxonomy, meta: { model_name: 'Organization', example: 'Red Hat/Engineering' }
-  end
-
   extend FriendlyId
   friendly_id :title
   include Foreman::ThreadSession::OrganizationModel
@@ -27,10 +21,6 @@ class Organization < Taxonomy
   scope :my_organizations, lambda { |user = User.current|
     user.admin? ? all : where(id: user.organization_and_child_ids)
   }
-
-  class Jail < ::Safemode::Jail
-    allow :id, :name, :title, :created_at, :updated_at, :description
-  end
 
   def dup
     new = super


### PR DESCRIPTION
@tbrisker, as per discussion on IRC, moving property docs next to the Jail definitions.

Also contains refactored Jail for taxonomies: moved to the common `Taxonomy` class definition. It's still possible to re-open the Jail class and add new allowed methods (as Katello does).