### PR TITLE
Fixes #29990 - stop clear API response on polling

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APIReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIReducer.js
@@ -14,8 +14,9 @@ const apiReducer = (state = initialState, { type, key, payload, response }) => {
     case REQUEST:
       return state.merge({
         [key]: {
-          payload,
           response: null,
+          ...state[key],
+          payload,
           status: PENDING,
         },
       });


### PR DESCRIPTION
Each polling response is getting reset on every new request
since initially in the APIReducer we set response to null.

Thanks @MariaAga for bringing that up :)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
