### PR TITLE
Fixes #29992 - pass stopInterval callback to handleError in API action

### DIFF
--- a/webpack/assets/javascripts/react_app/components/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/index.js
@@ -12,7 +12,6 @@ import { noop, translateObject } from '../../common/helpers';
 
 import './notifications.scss';
 import ToggleIcon from './ToggleIcon/ToggleIcon';
-import { reloadPage } from '../../../foreman_navigation';
 
 class notificationContainer extends React.Component {
   componentDidMount() {
@@ -29,17 +28,6 @@ class notificationContainer extends React.Component {
 
     if (isReady && isDrawerOpen) {
       toggleDrawer();
-    }
-  }
-
-  componentDidUpdate() {
-    const { error, stopNotificationsPolling } = this.props;
-    if (error) {
-      const { response: { status } = {} } = error;
-      stopNotificationsPolling();
-      if (status === 401) {
-        reloadPage();
-      }
     }
   }
 
@@ -126,13 +114,6 @@ notificationContainer.propTypes = {
     clearAll: PropTypes.string,
     deleteNotification: PropTypes.string,
   }),
-  error: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.shape({
-      message: PropTypes.string,
-      response: PropTypes.object,
-    }),
-  ]),
 };
 
 notificationContainer.defaultProps = {
@@ -150,7 +131,6 @@ notificationContainer.defaultProps = {
   clearNotification: noop,
   clearGroup: noop,
   stopNotificationsPolling: noop,
-  error: null,
   translations: NotificationDrawerPanelWrapper.defaultProps.translations,
 };
 
@@ -160,7 +140,6 @@ const mapStateToProps = state => {
     isDrawerOpen,
     expandedGroup,
     hasUnreadMessages,
-    error,
   } = state.notifications;
 
   return {
@@ -169,7 +148,6 @@ const mapStateToProps = state => {
     expandedGroup,
     isReady: !!notifications,
     hasUnreadMessages,
-    error,
   };
 };
 

--- a/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
@@ -1,6 +1,8 @@
 import { getApiResponse } from './APIHelpers';
 import { actionTypeGenerator } from './APIActionTypeGenerator';
 import { noop } from '../../common/helpers';
+import { stopInterval } from '../middlewares/IntervalMiddleware';
+import { selectDoesIntervalExist } from '../middlewares/IntervalMiddleware/IntervalSelectors';
 
 export const apiRequest = async (
   {
@@ -16,7 +18,7 @@ export const apiRequest = async (
       payload = {},
     },
   },
-  { dispatch }
+  { dispatch, getState }
 ) => {
   const { REQUEST, SUCCESS, FAILURE } = actionTypeGenerator(key, actionTypes);
   const modifiedPayload = { ...payload, url };
@@ -41,6 +43,9 @@ export const apiRequest = async (
       payload: modifiedPayload,
       response: error,
     });
-    handleError(error);
+    const stopIntervalCallback = selectDoesIntervalExist(getState(), key)
+      ? () => dispatch(stopInterval(key))
+      : noop;
+    handleError(error, stopIntervalCallback);
   }
 };

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APIRequest.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APIRequest.test.js
@@ -1,13 +1,16 @@
 import { API } from '../';
 import IntegrationTestHelper from '../../../common/IntegrationTestHelper';
-import { action } from '../APIFixtures';
+import { action, key } from '../APIFixtures';
 import { apiRequest } from '../APIRequest';
 
 const data = { results: [1] };
 jest.mock('../');
 
 describe('API get', () => {
-  const store = { dispatch: jest.fn() };
+  const store = {
+    dispatch: jest.fn(),
+    getState: jest.fn(() => ({ intervals: { [key]: 1 } })),
+  };
   beforeEach(() => {
     store.dispatch = jest.fn();
   });
@@ -42,9 +45,23 @@ describe('API get', () => {
     modifiedAction.payload.handleError = jest.fn();
     apiRequest(modifiedAction, store);
     await IntegrationTestHelper.flushAllPromises();
-    expect(modifiedAction.payload.handleError).toHaveBeenLastCalledWith(
-      apiError
+    expect(modifiedAction.payload.handleError.mock.calls).toMatchSnapshot();
+    expect(store.dispatch.mock.calls).toMatchSnapshot();
+  });
+
+  it('should dispatch stop interval on API error', async () => {
+    const apiError = new Error('bad request');
+    API.get.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          reject(apiError);
+        })
     );
+    const modifiedAction = { ...action };
+    modifiedAction.payload.handleError = jest.fn();
+    apiRequest(modifiedAction, store);
+    await IntegrationTestHelper.flushAllPromises();
+    expect(modifiedAction.payload.handleError.mock.calls).toMatchSnapshot();
     expect(store.dispatch.mock.calls).toMatchSnapshot();
   });
 });

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -3,6 +3,15 @@
 exports[`API get should dispatch request and failure actions on reject 1`] = `
 Array [
   Array [
+    [Error: bad request],
+    [Function],
+  ],
+]
+`;
+
+exports[`API get should dispatch request and failure actions on reject 2`] = `
+Array [
+  Array [
     Object {
       "key": "SOME_KEY",
       "payload": Object {
@@ -51,6 +60,41 @@ Array [
         ],
       },
       "type": "SOME_KEY_SUCCESS",
+    },
+  ],
+]
+`;
+
+exports[`API get should dispatch stop interval on API error 1`] = `
+Array [
+  Array [
+    [Error: bad request],
+    [Function],
+  ],
+]
+`;
+
+exports[`API get should dispatch stop interval on API error 2`] = `
+Array [
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "type": "SOME_KEY_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "response": [Error: bad request],
+      "type": "SOME_KEY_FAILURE",
     },
   ],
 ]

--- a/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/notifications/index.js
@@ -10,6 +10,7 @@ import {
 } from '../../consts';
 import * as sessionStorage from '../../../components/notifications/NotificationDrawerSessionStorage';
 import { API, get } from '../../API';
+import { reloadPage } from '../../../../foreman_navigation';
 import {
   stopInterval,
   withInterval,
@@ -18,10 +19,22 @@ import { DEFAULT_INTERVAL } from './constants';
 
 const interval = process.env.NOTIFICATIONS_POLLING || DEFAULT_INTERVAL;
 
-const getNotifications = url => get({ key: NOTIFICATIONS, url });
+const handleNotificationPollingError = (error, stopNotificationPolling) => {
+  if (error.response?.status === 401) {
+    stopNotificationPolling();
+    reloadPage();
+  }
+};
 
 export const startNotificationsPolling = url =>
-  withInterval(getNotifications(url), interval);
+  withInterval(
+    get({
+      key: NOTIFICATIONS,
+      url,
+      handleError: handleNotificationPollingError,
+    }),
+    interval
+  );
 
 export const stopNotificationsPolling = () => stopInterval(NOTIFICATIONS);
 

--- a/webpack/assets/javascripts/react_app/redux/actions/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/notifications/notifications.test.js
@@ -1,7 +1,7 @@
 import { API } from '../../../redux/API';
 import * as actions from './index';
 
-jest.mock('../../../redux/API');
+jest.mock('../../../redux/API/API');
 
 describe('Notification Drawer actions', () => {
   it('should make notification group read', () => {


### PR DESCRIPTION
Whenever an API polling encounters an error,
`stopInterval` for that specific key will be passed in the `handleError` callback,
so the consumer could stop it from the action, see how I implemented it in the notification in this PR.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
