### PR TITLE
Fixes #30014 - set MALLOC_ARENA_MAX=2 for puma

### DIFF
--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -11,6 +11,7 @@ TimeoutSec=300
 WorkingDirectory=/usr/share/foreman
 ExecStart=/usr/share/foreman/bin/rails server --environment $FOREMAN_ENV --port $FOREMAN_PORT --binding $FOREMAN_BIND
 Environment=FOREMAN_ENV=production FOREMAN_PORT=3000 FOREMAN_BIND=0.0.0.0
+Environment=MALLOC_ARENA_MAX=2
 
 SyslogIdentifier=foreman
 


### PR DESCRIPTION
There is a lengthy discussion here:

https://community.theforeman.org/t/foreman-2-0-0-memory-leak/18953/37

But in short, we do this for dynflow and we should do the same. It
should lower memory consumption which was bumped a lot after migration
to puma. So we should try to surprise our users less.