### PR TITLE
Fixes #29974 - allow subnet helpers (CP 2.1)

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -228,9 +228,9 @@ class Operatingsystem < ApplicationRecord
     architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
     if host.subnet&.httpboot?
       if host.pxe_loader =~ /UEFI HTTPS/
-        port = host.subnet.httpboot.setting(:HTTPBoot, 'https_port') || raise(::Foreman::Exception.new(N_("HTTPS boot requires proxy with httpboot feature and https_port exposed setting")))
+        port = host.subnet.httpboot.httpboot_https_port
       else
-        port = host.subnet.httpboot.setting(:HTTPBoot, 'http_port') || raise(::Foreman::Exception.new(N_("HTTP boot requires proxy with httpboot feature and http_port exposed setting")))
+        port = host.subnet.httpboot.httpboot_http_port
       end
       hostname = URI.parse(host.subnet.httpboot.url).hostname
       self.class.all_loaders_map(architecture, "#{hostname}:#{port}")[host.pxe_loader]

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -100,6 +100,14 @@ class SmartProxy < ApplicationRecord
     smart_proxy_features.find_by(:feature_id => Feature.find_by(:name => feature)).try(:settings).try(:[], setting)
   end
 
+  def httpboot_http_port
+    setting(:HTTPBoot, 'http_port') || raise(::Foreman::Exception.new(N_("HTTP boot requires proxy with httpboot feature and http_port exposed setting")))
+  end
+
+  def httpboot_https_port
+    setting(:HTTPBoot, 'https_port') || raise(::Foreman::Exception.new(N_("HTTPS boot requires proxy with httpboot feature and https_port exposed setting")))
+  end
+
   def statuses
     return @statuses if @statuses
     @statuses = {}
@@ -172,6 +180,6 @@ class SmartProxy < ApplicationRecord
   end
 
   class Jail < ::Safemode::Jail
-    allow :id, :name
+    allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port
   end
 end

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -115,7 +115,8 @@ class Subnet < ApplicationRecord
 
   class Jail < ::Safemode::Jail
     allow :id, :name, :network, :mask, :cidr, :title, :to_label, :gateway, :dns_primary, :dns_secondary, :dns_servers,
-      :vlanid, :mtu, :nic_delay, :boot_mode, :dhcp?, :nil?, :has_vlanid?, :dhcp_boot_mode?, :description, :present?
+      :vlanid, :mtu, :nic_delay, :boot_mode, :dhcp?, :nil?, :has_vlanid?, :dhcp_boot_mode?, :description, :present?,
+      :dhcp, :dhcp?, :tftp, :tftp?, :dns, :dns?, :httpboot, :httpboot?, :template, :template?, :ipam, :ipam?
   end
 
   def self.network_reorder(order_string = 'network')

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -42,6 +42,10 @@ FactoryBot.define do
       name { 'BMC' }
     end
 
+    trait :httpboot do
+      name { 'HTTPBoot' }
+    end
+
     trait :external_ipam do
       name { 'External IPAM' }
     end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -49,6 +49,12 @@ FactoryBot.define do
       end
     end
 
+    factory :httpboot_smart_proxy do
+      after(:build) do |smart_proxy, _evaluator|
+        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :httpboot, :smart_proxy => smart_proxy)
+      end
+    end
+
     factory :puppet_smart_proxy do
       before(:create, :build, :build_stubbed) do
         ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:puppet => {'state' => 'running'})
@@ -116,6 +122,10 @@ FactoryBot.define do
 
     trait :external_ipam do
       association :feature, :external_ipam
+    end
+
+    trait :httpboot do
+      association :feature, :httpboot
     end
   end
 end

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -149,6 +149,24 @@ class SmartProxyTest < ActiveSupport::TestCase
       assert_equal 'bar', proxy.setting('TFTP', 'foo')
     end
 
+    test "can access httpboot_http_port exposed setting" do
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:httpboot => {:settings => {:http_port => 1234}, :state => 'running'})
+      proxy = FactoryBot.build(:httpboot_smart_proxy)
+      proxy.save!
+      proxy.reload
+
+      assert_equal 1234, proxy.httpboot_http_port
+    end
+
+    test "can access httpboot_https_port exposed setting" do
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:httpboot => {:settings => {:https_port => 1234}, :state => 'running'})
+      proxy = FactoryBot.build(:httpboot_smart_proxy)
+      proxy.save!
+      proxy.reload
+
+      assert_equal 1234, proxy.httpboot_https_port
+    end
+
     describe '#ping' do
       let(:proxy) { SmartProxy.new(name: 'Proxy', url: 'https://some.where.net:8443') }
 


### PR DESCRIPTION
(cherry picked from commit 89c1e286ec87831dfca343b092f1ba234608b460)
