### PR TITLE
Fixes #30052 - Do not dump dynflow tables when dumping db schema

### DIFF
--- a/config/initializers/dynflow.rb
+++ b/config/initializers/dynflow.rb
@@ -1,0 +1,2 @@
+# Ignore Dynflow tables when schema-dumping. Dynflow tables are handled automatically by Dynflow.
+ActiveRecord::SchemaDumper.ignore_tables << /^dynflow_.*$/


### PR DESCRIPTION
This should fix `PG::InvalidForeignKey: ERROR: there is no unique constraint matching given keys for referenced table "dynflow_actions"` error appearing in plugin tests.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
