### PR TITLE
Fixes #30056 - Forcing Unicode in reports

### DIFF
--- a/app/models/stored_value.rb
+++ b/app/models/stored_value.rb
@@ -13,6 +13,6 @@ class StoredValue < ApplicationRecord
 
   def self.read(result_key)
     record = valid.find_by(key: result_key)
-    record&.value
+    record&.value&.force_encoding('UTF-8')
   end
 end

--- a/test/models/stored_value_test.rb
+++ b/test/models/stored_value_test.rb
@@ -47,5 +47,15 @@ class StoredValueTest < ActiveSupport::TestCase
       assert StoredValue.write('UNIQUE-KEY', "Hell\x00world")
       assert_equal StoredValue.read('UNIQUE-KEY'), "Hell\x00world"
     end
+
+    it 'handles special characters' do
+      assert StoredValue.write('UNIQUE-KEY', "šeď^světa")
+      assert_equal StoredValue.read('UNIQUE-KEY'), "šeď^světa"
+    end
+
+    it 'handles special characters in json' do
+      assert StoredValue.write('UNIQUE-KEY', '{ "name": "šeď^světa" }')
+      assert_equal StoredValue.read('UNIQUE-KEY').to_json, '{ "name": "šeď^světa" }'.to_json
+    end
   end
 end


### PR DESCRIPTION
This fixes problem where unicode characters broke generating of JSON report.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
