### PR TITLE
Fixes #30080 - run katello JS tests from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ node_js:
   - '10'
   - '12'
 cache:
-  npm: false  
+  npm: false
 script: ./script/travis_run_js_tests.sh

--- a/script/travis_run_js_tests.sh
+++ b/script/travis_run_js_tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -ev
-if [[ $( git diff --name-only HEAD~1..HEAD config/webpack.config.js webpack/ .travis.yml package.json | wc -l ) -ne 0 ]]; then
+if [[ $( git diff --name-only origin/develop..HEAD config/webpack.config.js webpack/ .travis.yml package.json | wc -l ) -ne 0 ]]; then
   npm run test;
   npm run publish-coverage;
   npm run lint;
+  bash ./script/travis_run_katello_js_tests.sh
 fi

--- a/script/travis_run_katello_js_tests.sh
+++ b/script/travis_run_katello_js_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ev
+
+cd ..
+git clone https://github.com/Katello/katello.git
+cd katello;
+npm install;
+npm run test;
+npm run lint;


### PR DESCRIPTION
as Katello are pointing to the actual code in Foreman and not just mocking tests,
we can test to see if PRs on Foreman actually affect the JS stack of Katello.

cc @johnpmitsch
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
