### PR TITLE
Fixes #30085 - return after interval middleware stop action

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalHelpers.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalHelpers.js
@@ -3,9 +3,6 @@ import { DEFAULT_INTERVAL } from './IntervalConstants';
 export const registeredIntervalException = key =>
   new Error(`There is already an interval running and registered for: ${key}.`);
 
-export const unregisteredIntervalException = key =>
-  new Error(`Can't find a registered interval process for: ${key}`);
-
 export const withInterval = (action, interval = getDefaultInterval()) => ({
   ...action,
   interval,

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalMiddleware.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalMiddleware.js
@@ -3,7 +3,6 @@ import { STOP_INTERVAL } from './IntervalConstants';
 import { selectDoesIntervalExist, selectIntervalID } from './IntervalSelectors';
 import {
   registeredIntervalException,
-  unregisteredIntervalException,
   getDefaultInterval,
 } from './IntervalHelpers';
 import { startInterval as startIntervalAction } from './IntervalActions';
@@ -32,13 +31,8 @@ export const IntervalMiddleware = store => next => action => {
 
   if (type === STOP_INTERVAL) {
     const state = store.getState();
-
-    if (!selectDoesIntervalExist(state, intervalKey)) {
-      throw unregisteredIntervalException(intervalKey);
-    }
-
     const intervalID = selectIntervalID(state, intervalKey);
-    clearInterval(intervalID);
+    return intervalID && clearInterval(intervalID);
   }
 
   return next(action);

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalHelpers.test.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalHelpers.test.js
@@ -1,6 +1,5 @@
 import {
   registeredIntervalException,
-  unregisteredIntervalException,
   withInterval,
   getDefaultInterval,
 } from '../IntervalHelpers';
@@ -10,10 +9,6 @@ import { DEFAULT_INTERVAL } from '../IntervalConstants';
 describe('Interval Helpers', () => {
   it('return registeredIntervalException error', () => {
     expect(registeredIntervalException(key)).toMatchSnapshot();
-  });
-
-  it('return unregisteredIntervalException error', () => {
-    expect(unregisteredIntervalException(key)).toMatchSnapshot();
   });
 
   it('return withInterval modified action', () => {

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalMiddleware.test.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalMiddleware.test.js
@@ -11,6 +11,8 @@ import {
 } from '../IntervalHelpers';
 import { stopInterval } from '../IntervalActions';
 
+jest.useFakeTimers();
+
 describe('Interval Middleware', () => {
   const getFakeStore = () => ({
     getState: () => ({
@@ -54,7 +56,8 @@ describe('Interval Middleware', () => {
     const stopAction = stopInterval(key);
 
     IntervalMiddleware(fakeStore)(fakeNext)(stopAction);
-    expect(fakeNext).toMatchSnapshot();
+    expect(clearInterval).toHaveBeenCalled();
+    expect(fakeNext.mock.calls).toHaveLength(0);
   });
 
   it('should handle STOP_INTERVAL action when key does not exist', () => {
@@ -73,9 +76,9 @@ describe('Interval Middleware', () => {
   it('should pass action to next', () => {
     const fakeStore = getFakeStoreWithKey();
     const fakeNext = jest.fn();
-    const stopAction = stopInterval(key);
+    const action = { type: 'SOME_TYPE' };
 
-    IntervalMiddleware(fakeStore)(fakeNext)(stopAction);
+    IntervalMiddleware(fakeStore)(fakeNext)(action);
     expect(fakeNext).toMatchSnapshot();
   });
 });

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalHelpers.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalHelpers.test.js.snap
@@ -1,5 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Interval Helpers return registeredIntervalException error 1`] = `[Error: There is already an interval running and registered for: SOME_KEY.]`;
-
-exports[`Interval Helpers return unregisteredIntervalException error 1`] = `[Error: Can't find a registered interval process for: SOME_KEY]`;

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalMiddleware.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalMiddleware.test.js.snap
@@ -1,24 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Interval Middleware should handle STOP_INTERVAL action 1`] = `
-[MockFunction] {
-  "calls": Array [
-    Array [
-      Object {
-        "key": "SOME_KEY",
-        "type": "STOP_INTERVAL",
-      },
-    ],
-  ],
-  "results": Array [
-    Object {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`Interval Middleware should handle an action with "interval" key 1`] = `
 [MockFunction] {
   "calls": Array [
@@ -33,7 +14,7 @@ exports[`Interval Middleware should handle an action with "interval" key 1`] = `
     ],
     Array [
       Object {
-        "intervalID": 2,
+        "intervalID": 1,
         "key": "SOME_KEY",
         "type": "START_INTERVAL",
       },
@@ -57,8 +38,7 @@ exports[`Interval Middleware should pass action to next 1`] = `
   "calls": Array [
     Array [
       Object {
-        "key": "SOME_KEY",
-        "type": "STOP_INTERVAL",
+        "type": "SOME_TYPE",
       },
     ],
   ],


### PR DESCRIPTION
- when stopping an interval, the action shouldn't be passed to the next middleware
- there was a strange warning ( test wasn't failing ) when the notification used the middleware,
as the `STOP_INTERVAL` action was triggered twice. to prevent double errors, I removed the throw error on the `STOP_INTERVAL` and instead used:
```js
return intervalID && clearInterval(intervalID);
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
