### PR TITLE
Fixes #30086 - move foremanUrl into ReactApp

### DIFF
--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -133,6 +133,4 @@ export function updateTable(element) {
 }
 
 // generates an absolute, needed in case of running Foreman from a subpath
-export function foremanUrl(path) {
-  return window.URL_PREFIX + path;
-}
+export { foremanUrl } from './react_app/common/helpers';

--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -1,7 +1,6 @@
 import { snakeCase, camelCase, debounce } from 'lodash';
 import URI from 'urijs';
 import { translate as __ } from './I18n';
-import { foremanUrl } from '../../foreman_tools';
 
 /**
  * Our API returns non-ISO8601 dates
@@ -188,6 +187,9 @@ export const formatDateTime = date => {
   return `${year}-${month}-${day} ${hour}:${minutes}:00`;
 };
 
+// generates an absolute, needed in case of running Foreman from a subpath
+export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
+
 export default {
   isoCompatibleDate,
   bindMethods,
@@ -206,4 +208,5 @@ export default {
   getManualURL,
   formatDate,
   formatDateTime,
+  foremanUrl,
 };


### PR DESCRIPTION
plugins JS tests have access only to the ReactApp folder in Foreman,
it means that when trying to import something out of the folder,
jest can't handle it.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
