### PR TITLE
Fixes #30102 - ability to override test logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config/settings.plugins.d
 config/database.yml
 config/initializers/local_secret_token.rb
 config/initializers/encryption_key.rb
+config/*.yaml*local
 Gemfile.lock
 bundler.d/*.local.rb
 *.sw?

--- a/config/application.rb
+++ b/config/application.rb
@@ -218,7 +218,7 @@ module Foreman
     config.active_job.queue_adapter = :dynflow
 
     Foreman::Logging.configure(
-      :log_directory => "#{Rails.root}/log",
+      :log_directory => SETTINGS.dig(:logging, :log_directory) || "#{Rails.root}/log",
       :environment => Rails.env,
       :config_overrides => SETTINGS[:logging]
     )

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -3,9 +3,11 @@ require_relative '../app/services/foreman/version'
 require_relative '../app/services/foreman/env_settings_loader'
 
 root = File.expand_path(File.dirname(__FILE__) + "/..")
-settings_file = Rails.env.test? ? 'config/settings.yaml.test' : 'config/settings.yaml'
+settings_files = Rails.env.test? ? ['config/settings.yaml.test', 'config/settings.yaml.test.local'] : ['config/settings.yaml', 'config/settings.yaml.local']
 
-SETTINGS.merge! YAML.load(ERB.new(File.read("#{root}/#{settings_file}")).result) if File.exist?(settings_file)
+settings_files.each do |settings_file|
+  SETTINGS.merge! YAML.load(ERB.new(File.read("#{root}/#{settings_file}")).result) if File.exist?(settings_file)
+end
 SETTINGS[:version] = Foreman::Version.new
 
 # Load settings from env variables

--- a/config/settings.yaml.test
+++ b/config/settings.yaml.test
@@ -3,3 +3,5 @@
 :require_ssl: false
 :fqdn: foreman.example.com
 :domain: example.com
+
+# Do not change this file, create config/settings.yaml.test.local instead.


### PR DESCRIPTION
We have a `config/logging.yaml` file which defines the default values
for logging, however this file is commited into git. It supports
overriding values in `config/settings.yaml` via "logging" key, however
this is never picked up in case of "test" Rails environment because it
has a special behavior: `config/settings.yaml.test` file is picked
instead.

This file has the same problem, it is commited into git, therefore any
changes for logging I want to apply in my development environment would
be commited.

This patch adds reading of `config/settings.yaml.test.local` which is
also excluded from git which can be used to override some values.
Example:

```
$ cat config/settings.yaml.test.local
:logging:
  :level: debug
  :pattern: "%m\n"
  :type: file
  :log_directory: /tmp
  :filename: foreman-test.log
:loggers:
  :app:
    :enabled: true
  :ldap:
    :enabled: true
  :permissions:
    :enabled: true
  :sql:
    :enabled: true
  :templates:
    :enabled: true
  :audit:
    :enabled: true
  :telemetry:
    :enabled: true
  :notifications:
    :enabled: true
  :blob:
    :enabled: true
  :callbacks:
    :enabled: true

```

In my case, I want all loggers to be enabled and debug level into tmpfs
folder with slightly simplified patter for better readability.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->