### PR TITLE
Fixes #30080 - run plugins react tests in GH action

### DIFF
--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -1,0 +1,44 @@
+name: (non-blocking) React on plugins
+
+on:
+  pull_request:
+    branches: [develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - repo: katello
+            org: Katello
+          - repo: foreman-tasks
+            org: theforeman
+    steps:
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      # We could update the postinstall action for foreman to look for an environment variable for plugin webpack dirs
+      # before kicking off the ruby script to find them, this would eliminate the ruby dep and running `npm install` in plugins.
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Checkout Foreman
+        uses: actions/checkout@v2
+        with:
+          path: ./projects/foreman
+      - name: Install Foreman npm dependencies
+        run: npm install
+        working-directory: ${{ github.workspace }}/projects/foreman
+      - name: Checkout ${{ matrix.repo }}
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.org }}/${{ matrix.repo }}
+          path: ./projects/${{ matrix.repo }}
+      - name: Install ${{ matrix.repo }} npm dependencies
+        run: npm install
+        working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}
+      - name: Run ${{ matrix.plugin_repo }} tests
+        run: npm test
+        working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}


### PR DESCRIPTION
this will be a non-blocking test to see if some changes in Foreman broke the react tests in plugins.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
