### PR TITLE
Fixes #30138 - report template download button

### DIFF
--- a/webpack/assets/javascripts/react_app/components/TemplateGenerator/TemplateGenerator.js
+++ b/webpack/assets/javascripts/react_app/components/TemplateGenerator/TemplateGenerator.js
@@ -2,7 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Alert, Button } from 'patternfly-react';
 
-import { sprintf, translate as __ } from '../../../react_app/common/I18n';
+import { noop } from '../../common/helpers';
+import { sprintf, translate as __ } from '../../common/I18n';
 import AlertBody from '../common/Alert/AlertBody';
 
 const pollingMsg = `
@@ -43,7 +44,7 @@ class TemplateGenerator extends React.Component {
   }
 
   render() {
-    const { polling, dataUrl, generatingError } = this.props;
+    const { polling, dataUrl, pollReportData, generatingError } = this.props;
 
     if (!dataUrl && !polling) return null;
 
@@ -51,7 +52,7 @@ class TemplateGenerator extends React.Component {
       <React.Fragment>
         {this.renderAlert()}
         {!polling && !generatingError && (
-          <Button bsStyle="primary" href={dataUrl} target="_blank">
+          <Button bsStyle="primary" onClick={() => pollReportData(dataUrl)}>
             {__('Download')}
           </Button>
         )}
@@ -65,6 +66,7 @@ TemplateGenerator.propTypes = {
     templateName: PropTypes.string.isRequired,
   }).isRequired,
   polling: PropTypes.bool,
+  pollReportData: PropTypes.func,
   dataUrl: PropTypes.string,
   generatingError: PropTypes.string,
   generatingErrorMessages: PropTypes.arrayOf(
@@ -74,6 +76,7 @@ TemplateGenerator.propTypes = {
 
 TemplateGenerator.defaultProps = {
   polling: false,
+  pollReportData: noop,
   dataUrl: null,
   generatingError: null,
   generatingErrorMessages: null,

--- a/webpack/assets/javascripts/react_app/components/TemplateGenerator/__tests__/__snapshots__/TemplateGenerator.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/TemplateGenerator/__tests__/__snapshots__/TemplateGenerator.test.js.snap
@@ -22,8 +22,7 @@ exports[`TemplateGenerator rendering render button if not polling and no errors 
     bsClass="btn"
     bsStyle="primary"
     disabled={false}
-    href="/data/IDENTIFIER.json"
-    target="_blank"
+    onClick={[Function]}
   >
     Download
   </Button>


### PR DESCRIPTION
Instead of downloading the file directly, let's use the same method for both download - automatical and manual.