### PR TITLE
Fixes #30143 - passing root_url without section to documentation_url

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -31,11 +31,7 @@ class LinksController < ApplicationController
 
   def documentation_url(section = "", options = {})
     root_url = options[:root_url] || "https://theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#"
-    if section.empty?
-      "https://theforeman.org/documentation.html##{SETTINGS[:version].short}"
-    else
-      root_url + section
-    end
+    root_url + (section || '')
   end
 
   def plugin_documentation_url(plugin_name, version: nil, options: {})

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -5,7 +5,7 @@ class LinksControllerTest < ActionController::TestCase
     test '#documentation_url returns global url if no section specified' do
       get :show, params: { type: 'manual' }
 
-      assert_redirected_to /documentation.html/
+      assert_redirected_to /index.html/
     end
 
     test '#documentation_url returns foreman docs url with a given section' do


### PR DESCRIPTION
`documentation_url` expect section to be provided
also when only using `root_url`


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
