### PR TITLE
Fixes #30144 - use media_type check not content_type

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -42,7 +42,7 @@ module Api
       end
 
       before_action :setup_has_many_params, :only => [:create, :update]
-      before_action :check_content_type
+      before_action :check_media_type
       # ensure include_root_in_json = false for V2 only
       around_action :disable_json_root
 
@@ -144,9 +144,26 @@ module Api
         append_array_of_ids(params)             # unwrapped params
       end
 
+      def self.skip_before_action(*names)
+        names = names.map do |n|
+          if n == :check_content_type
+            Foreman::Deprecation.deprecation_warning('2.3', '#check_content_type is renamed to #check_media_type')
+            :check_media_type
+          else
+            n
+          end
+        end
+        super(*names)
+      end
+
       def check_content_type
-        if (request.post? || request.put?) && request.content_type != "application/json"
-          render_error(:unsupported_content_type, :status => :unsupported_media_type)
+        Foreman::Deprecation.deprecation_warning('2.3', '#check_content_type is renamed to #check_media_type')
+        check_media_type
+      end
+
+      def check_media_type
+        if (request.post? || request.put?) && request.media_type != "application/json"
+          render_error(:unsupported_media_type, :status => :unsupported_media_type)
         end
       end
 

--- a/app/views/api/v2/errors/unsupported_content_type.json.rabl
+++ b/app/views/api/v2/errors/unsupported_content_type.json.rabl
@@ -1,3 +1,0 @@
-object false
-
-node(:message) { _("'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'.") % request.content_type }

--- a/app/views/api/v2/errors/unsupported_media_type.json.rabl
+++ b/app/views/api/v2/errors/unsupported_media_type.json.rabl
@@ -1,0 +1,3 @@
+object false
+
+node(:message) { _("Media type in 'Content-Type: %s' is unsupported in API v2 for POST and PUT requests. Please use 'Content-Type: application/json'.") % request.content_type }


### PR DESCRIPTION
It should be the same ATM, but media_type should always stay only media_type, content_type can have more information. Maybe even some clients already may send such content_type headers.