### PR TITLE
Fixes #30205 - smart proxies statuses with logs feature disabled

### DIFF
--- a/app/services/ping.rb
+++ b/app/services/ping.rb
@@ -63,7 +63,7 @@ class Ping
         begin
           version = proxy.statuses[:version].version['version']
           features = proxy.statuses[:version].version['modules']
-          failed_features = proxy.statuses[:logs].logs.failed_modules
+          failed_features = ProxyAPI::V2::Features.new(:url => proxy.url).features.select { |f, p| p['state'] == 'failed' }
           status = STATUS_OK
         rescue ::Foreman::WrappedException => error
           version ||= 'N/A'


### PR DESCRIPTION
Let be more robust when a smart proxy has "logs" feature disabled.

Signed-off-by: Pavel Moravec <pmoravec@redhat.com>


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
