### PR TITLE
Refs #30085 - pass stop_interval action to reducer

### DIFF
--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.test.js
@@ -4,9 +4,12 @@ import IntegrationTestHelper from '../../common/IntegrationTestHelper';
 import notificationReducer from '../../redux/reducers/notifications';
 import { componentMountData, serverResponse } from './notifications.fixtures';
 import Notifications from './';
-import { API, APIMiddleware } from '../../redux/API';
+import API from '../../redux/API/API';
 import { NOTIFICATIONS } from '../../redux/consts';
-import { IntervalMiddleware } from '../../redux/middlewares/IntervalMiddleware';
+import {
+  IntervalMiddleware,
+  reducers as intervalsReducer,
+} from '../../redux/middlewares/IntervalMiddleware';
 import { registeredIntervalException } from '../../redux/middlewares/IntervalMiddleware/IntervalHelpers';
 import { DEFAULT_INTERVAL } from '../../redux/actions/notifications/constants';
 
@@ -21,8 +24,11 @@ const notificationProps = {
 };
 
 const configureIntegrationHelper = () => {
-  const reducers = { notifications: notificationReducer };
-  const middlewares = [thunk, IntervalMiddleware, APIMiddleware];
+  const reducers = {
+    notifications: notificationReducer,
+    intervals: intervalsReducer,
+  };
+  const middlewares = [thunk, IntervalMiddleware];
   return new IntegrationTestHelper(reducers, middlewares);
 };
 

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalMiddleware.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/IntervalMiddleware.js
@@ -32,7 +32,7 @@ export const IntervalMiddleware = store => next => action => {
   if (type === STOP_INTERVAL) {
     const state = store.getState();
     const intervalID = selectIntervalID(state, intervalKey);
-    return intervalID && clearInterval(intervalID);
+    intervalID && clearInterval(intervalID);
   }
 
   return next(action);

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalMiddleware.test.js
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/IntervalMiddleware.test.js
@@ -5,10 +5,7 @@ import {
   stateWithKey,
   actionWithInterval,
 } from '../IntervalFixtures';
-import {
-  registeredIntervalException,
-  unregisteredIntervalException,
-} from '../IntervalHelpers';
+import { registeredIntervalException } from '../IntervalHelpers';
 import { stopInterval } from '../IntervalActions';
 
 jest.useFakeTimers();
@@ -57,20 +54,7 @@ describe('Interval Middleware', () => {
 
     IntervalMiddleware(fakeStore)(fakeNext)(stopAction);
     expect(clearInterval).toHaveBeenCalled();
-    expect(fakeNext.mock.calls).toHaveLength(0);
-  });
-
-  it('should handle STOP_INTERVAL action when key does not exist', () => {
-    const fakeStore = getFakeStore();
-    const fakeNext = jest.fn();
-    const stopAction = stopInterval(key);
-
-    try {
-      IntervalMiddleware(fakeStore)(fakeNext)(stopAction);
-    } catch (error) {
-      expect(error.message).toBe(unregisteredIntervalException(key).message);
-    }
-    expect(fakeNext).not.toBeCalled();
+    expect(fakeNext).toMatchSnapshot();
   });
 
   it('should pass action to next', () => {

--- a/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalMiddleware.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware/__tests__/__snapshots__/IntervalMiddleware.test.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Interval Middleware should handle STOP_INTERVAL action 1`] = `
+[MockFunction] {
+  "calls": Array [
+    Array [
+      Object {
+        "key": "SOME_KEY",
+        "type": "STOP_INTERVAL",
+      },
+    ],
+  ],
+  "results": Array [
+    Object {
+      "type": "return",
+      "value": undefined,
+    },
+  ],
+}
+`;
+
 exports[`Interval Middleware should handle an action with "interval" key 1`] = `
 [MockFunction] {
   "calls": Array [


### PR DESCRIPTION
last refactor did fix the severals warnings we got
but the action actually should not be stopped in the middleware
in order of the reducer to update the state correctly,
and removing that interval key from state.

@sharvit @stejskalleos 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
