### PR TITLE
Fixes #30207 - isolate LookupKeysControllerTest

### DIFF
--- a/app/controllers/lookup_keys_controller.rb
+++ b/app/controllers/lookup_keys_controller.rb
@@ -1,12 +1,9 @@
+# Base class for all LookupKeys descendants controllers
+# The index method needs to be always implemented in the subclass
 class LookupKeysController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   before_action :setup_search_options, :only => :index
   before_action :find_resource, :only => [:edit, :update, :destroy], :if => proc { params[:id] }
-
-  def index
-    @lookup_keys = resource_base_search_and_page(:puppetclass)
-    @puppetclass_authorizer = Authorizer.new(User.current, :collection => @lookup_keys.map(&:puppetclass_id).compact.uniq)
-  end
 
   def edit
   end
@@ -25,6 +22,16 @@ class LookupKeysController < ApplicationController
     else
       process_error
     end
+  end
+
+  protected
+
+  def resource
+    instance_variable_get("@#{resource_name}")
+  end
+
+  def resource_params
+    send("#{resource_name}_params")
   end
 
   private

--- a/db/migrate/20200625081552_add_unique_index_to_lookup_value.rb
+++ b/db/migrate/20200625081552_add_unique_index_to_lookup_value.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToLookupValue < ActiveRecord::Migration[6.0]
+  def change
+    add_index :lookup_values, [:lookup_key_id, :match], unique: true
+  end
+end

--- a/test/factories/lookups.rb
+++ b/test/factories/lookups.rb
@@ -1,0 +1,74 @@
+FactoryBot.define do
+  factory :lookup_key, class: 'LookupKey' do
+    transient do
+      overrides { {} }
+    end
+
+    sequence(:key) { |n| "param#{n}" }
+    key_type { 'string' }
+    path { nil }
+    default_value { 'default' }
+
+    trait :integer do
+      key_type { 'integer' }
+      default_value { 1 }
+    end
+
+    trait :boolean do
+      key_type { 'boolean' }
+      default_value { true }
+    end
+
+    trait :yaml do
+      key_type { 'yaml' }
+      default_value { '--- \nfoo: bar\n' }
+    end
+
+    trait :array do
+      key_type { 'array' }
+      default_value { '[{"hostname": "test.example.com"}]' }
+    end
+
+    trait :with_omit do
+      omit { true }
+    end
+
+    trait :with_override do
+      override { true }
+      path { 'comment' }
+      overrides do
+        {
+          'comment=override' => case key_type
+                                when 'integer'
+                                  2
+                                when 'boolean'
+                                  false
+                                when 'yaml'
+                                  '--- \nfoo: overridden\n'
+                                when 'array'
+                                  '[{"overridden": "value"}]'
+                                else
+                                  'overridden value'
+                                end,
+        }
+      end
+    end
+
+    after(:create) do |lkey, evaluator|
+      evaluator.overrides.each do |match, value|
+        FactoryBot.create :lookup_value, :lookup_key => lkey, :value => value, :match => match, :omit => false
+      end
+      lkey.reload
+    end
+  end
+
+  factory :lookup_value do
+    association :lookup_key
+    sequence(:value) { |n| "value#{n}" }
+    omit { false }
+
+    trait :with_omit do
+      omit { true }
+    end
+  end
+end

--- a/test/factories/puppet_related.rb
+++ b/test/factories/puppet_related.rb
@@ -7,51 +7,16 @@ FactoryBot.define do
 
   factory :environment_class
 
-  FactoryBot.define do
-    factory :lookup_key, class: 'LookupKey' do
-      sequence(:key) { |n| "param#{n}" }
-    end
-
-    factory :puppetclass_lookup_key, parent: :lookup_key, class: 'PuppetclassLookupKey' do
+  factory :puppetclass_lookup_key, parent: :lookup_key, class: 'PuppetclassLookupKey' do
+    trait :as_smart_class_param do
       transient do
-        overrides { {} }
+        puppetclass { nil }
       end
       after(:create) do |lkey, evaluator|
-        evaluator.overrides.each do |match, value|
-          FactoryBot.create :lookup_value, :lookup_key_id => lkey.id, :value => value, :match => match, :omit => false
-        end
-        lkey.reload
-      end
-
-      trait :with_override do
-        override { true }
-        default_value { "default value" }
-        path { "comment" }
-        overrides { { "comment=override" => "overridden value" } }
-      end
-
-      trait :as_smart_class_param do
-        transient do
-          puppetclass { nil }
-        end
-        after(:create) do |lkey, evaluator|
-          evaluator.puppetclass.environments.each do |env|
-            FactoryBot.create :environment_class, :puppetclass_id => evaluator.puppetclass.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
-          end
+        evaluator.puppetclass.environments.each do |env|
+          FactoryBot.create :environment_class, :puppetclass_id => evaluator.puppetclass.id, :environment_id => env.id, :puppetclass_lookup_key_id => lkey.id
         end
       end
-
-      trait :with_omit do
-        omit { true }
-      end
-    end
-  end
-
-  factory :lookup_value do
-    sequence(:value) { |n| "value#{n}" }
-
-    trait :with_omit do
-      omit { true }
     end
   end
 

--- a/test/models/lookup_key_test.rb
+++ b/test/models/lookup_key_test.rb
@@ -326,8 +326,8 @@ class LookupKeyTest < ActiveSupport::TestCase
     value4 = LookupValue.create(:lookup_key => key, :match => "arch=testarcg", :value => "aaa")
     value5 = LookupValue.create(:lookup_key => key, :match => "arch=testaaaa", :value => "bcd")
 
+    refute_equal([value3, value1, value5, value4, value2], key.lookup_values.reload)
     assert_equal([value3, value1, value5, value4, value2], key.sorted_values)
-    refute_equal([value3, value1, value5, value4, value2], key.lookup_values)
   end
 
   test 'should not update with invalid parameter types' do


### PR DESCRIPTION
Path to remove LookupKey / LookupValue fixtures and Puppet Extraction.
LookupKeysController should be tested in isolation and should not depend on Puppet Smart Parameter nor on its controller or its fixtures.

Add lookup keys base factories and uses them in isolated LookupKeyControllerTest