### PR TITLE
Fixes #30232 - user dropdown use pf4

### DIFF
--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -11,6 +11,7 @@
 
   #account_menu {
     font-size: 11px;
+    padding-top: 10px;
   }
 
   .active > a,

--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -12,6 +12,10 @@
   #account_menu {
     font-size: 11px;
     padding-top: 10px;
+
+    .user-icon {
+      margin-right: 10px;
+    }
   }
 
   .active > a,

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -266,4 +266,6 @@ export const hasTaxonomiesMock = {
 export const userDropdownProps = {
   user: serverUser,
   notification_url: '/',
+  changeActiveMenu: jest.fn(),
+  isOpen: true,
 };

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { VerticalNav, Icon } from 'patternfly-react';
+import { VerticalNav } from 'patternfly-react';
 import { get } from 'lodash';
 import {
   Dropdown,
@@ -8,6 +8,7 @@ import {
   DropdownItem,
   DropdownSeparator,
 } from '@patternfly/react-core';
+import { UserAltIcon } from '@patternfly/react-icons';
 
 import NotificationContainer from '../../notifications';
 import NavItem from './NavItem';
@@ -70,7 +71,7 @@ const UserDropdowns = ({
             isOpen={userDropdownOpen}
             toggle={
               <DropdownToggle onToggle={onDropdownToggle}>
-                <Icon type="fa" name="user avatar small" />
+                <UserAltIcon className="user-icon" />
                 {userInfo.name}
               </DropdownToggle>
             }

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -1,26 +1,57 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, VerticalNav, Icon, MenuItem } from 'patternfly-react';
+import { VerticalNav, Icon } from 'patternfly-react';
 import { get } from 'lodash';
+import {
+  Dropdown,
+  DropdownToggle,
+  DropdownItem,
+  DropdownSeparator,
+} from '@patternfly/react-core';
+
 import NotificationContainer from '../../notifications';
-import NavDropdown from './NavDropdown';
 import NavItem from './NavItem';
 import ImpersonateIcon from './ImpersonateIcon';
 import { translate as __ } from '../../../common/I18n';
 
 const UserDropdowns = ({
-  activeKey, // eslint-disable-line react/prop-types
-  activeHref, // eslint-disable-line react/prop-types
   user,
   changeActiveMenu,
   notificationUrl,
   stopImpersonationUrl,
   ...props
 }) => {
+  const [userDropdownOpen, setUserDropdownOpen] = useState(false);
+
+  const onDropdownToggle = newUserDropdownOpen => {
+    setUserDropdownOpen(newUserDropdownOpen);
+  };
+  const onDropdownSelect = () => {
+    setUserDropdownOpen(userDropdownOpen);
+  };
   const userInfo = get(user, 'current_user.user');
   const impersonateIcon = (
     <ImpersonateIcon stopImpersonationUrl={stopImpersonationUrl} />
   );
+
+  const userDropdownItems = user.user_dropdown[0].children.map((item, i) =>
+    item.type === 'divider' ? (
+      <DropdownSeparator key={i} />
+    ) : (
+      <DropdownItem
+        key={i}
+        className="user_menuitem"
+        href={item.url}
+        onClick={() => {
+          changeActiveMenu({ title: 'User' });
+        }}
+        {...item.html_options}
+      >
+        {__(item.name)}
+      </DropdownItem>
+    )
+  );
+
   return (
     <VerticalNav.IconBar {...props}>
       <NavItem
@@ -30,33 +61,24 @@ const UserDropdowns = ({
         <NotificationContainer data={{ url: notificationUrl }} />
       </NavItem>
       {user.impersonated_by && impersonateIcon}
-      {userInfo && (
-        <NavDropdown componentClass="li" id="account_menu">
-          <Dropdown.Toggle useAnchor className="nav-item-iconic">
-            <Icon type="fa" name="user avatar small" />
-            {userInfo.name}
-          </Dropdown.Toggle>
-          <Dropdown.Menu>
-            {user.user_dropdown[0].children.map((item, i) =>
-              item.type === 'divider' ? (
-                <MenuItem key={i} divider />
-              ) : (
-                <MenuItem
-                  key={i}
-                  className="user_menuitem"
-                  href={item.url}
-                  onClick={() => {
-                    changeActiveMenu({ title: 'User' });
-                  }}
-                  {...item.html_options}
-                >
-                  {__(item.name)}
-                </MenuItem>
-              )
-            )}
-          </Dropdown.Menu>
-        </NavDropdown>
-      )}
+      <NavItem id="account_menu" className="pf-c-page__header">
+        {userInfo && (
+          <Dropdown
+            isPlain
+            position="right"
+            onSelect={onDropdownSelect}
+            isOpen={userDropdownOpen}
+            toggle={
+              <DropdownToggle onToggle={onDropdownToggle}>
+                <Icon type="fa" name="user avatar small" />
+                {userInfo.name}
+              </DropdownToggle>
+            }
+            dropdownItems={userDropdownItems}
+            {...props}
+          />
+        )}
+      </NavItem>
     </VerticalNav.IconBar>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.test.js
@@ -1,30 +1,14 @@
-import React from 'react';
-import { shallow } from '@theforeman/test';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 
-import UserDropdowns from '../components/UserDropdowns';
+import UserDropdowns from './UserDropdowns';
 import { userDropdownProps } from '../Layout.fixtures';
 
-const createStubs = () => ({
-  changeActiveMenu: jest.fn(),
-});
-
 const fixtures = {
-  'render switcher w/loading': {
+  render: userDropdownProps,
+  'render with impersonated by icon': {
     ...userDropdownProps,
-    ...createStubs(),
+    user: { ...userDropdownProps.user, impersonated_by: true },
   },
 };
-
-describe('UserDropdown', () => {
-  describe('rendering', () =>
-    testComponentSnapshotsWithFixtures(UserDropdowns, fixtures));
-
-  describe('trigger onClicks', () => {
-    const wrapper = shallow(
-      <UserDropdowns {...userDropdownProps} {...createStubs()} />
-    );
-
-    wrapper.find('.user_menuitem').simulate('click');
-  });
-});
+describe('UserDropdown', () =>
+  testComponentSnapshotsWithFixtures(UserDropdowns, fixtures));

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
@@ -50,9 +50,12 @@ exports[`UserDropdown render 1`] = `
         <DropdownToggle
           onToggle={[Function]}
         >
-          <Icon
-            name="user avatar small"
-            type="fa"
+          <UserAltIcon
+            className="user-icon"
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
           />
           G L
         </DropdownToggle>
@@ -115,9 +118,12 @@ exports[`UserDropdown render with impersonated by icon 1`] = `
         <DropdownToggle
           onToggle={[Function]}
         >
-          <Icon
-            name="user avatar small"
-            type="fa"
+          <UserAltIcon
+            className="user-icon"
+            color="currentColor"
+            noVerticalAlign={false}
+            size="sm"
+            title={null}
           />
           G L
         </DropdownToggle>

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
@@ -1,9 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`UserDropdown rendering render switcher w/loading 1`] = `
+exports[`UserDropdown render 1`] = `
 <VerticalNav.IconBar
   className=""
   collapse={true}
+  isOpen={true}
   notification_url="/"
 >
   <NavItem
@@ -20,51 +21,108 @@ exports[`UserDropdown rendering render switcher w/loading 1`] = `
       }
     />
   </NavItem>
-  <NavDropdown
+  <NavItem
     activeHref=""
     activeKey=""
-    className=""
-    componentClass="li"
+    className="pf-c-page__header"
     id="account_menu"
   >
-    <DropdownToggle
-      bsClass="dropdown-toggle"
-      bsRole="toggle"
-      className="nav-item-iconic"
-      open={false}
-      useAnchor={true}
-    >
-      <Icon
-        name="user avatar small"
-        type="fa"
-      />
-      G L
-    </DropdownToggle>
-    <DropdownMenu
-      bsClass="dropdown-menu"
-      bsRole="menu"
-      pullRight={false}
-    >
-      <MenuItem
-        bsClass="dropdown"
-        className="user_menuitem"
-        disabled={false}
-        divider={false}
-        header={false}
-        href="/"
-        key="0"
-        onClick={[Function]}
-      >
-        My Account
-      </MenuItem>
-      <MenuItem
-        bsClass="dropdown"
-        disabled={false}
-        divider={true}
-        header={false}
-        key="1"
-      />
-    </DropdownMenu>
-  </NavDropdown>
+    <Dropdown
+      className=""
+      dropdownItems={
+        Array [
+          <DropdownItem
+            className="user_menuitem"
+            href="/"
+            onClick={[Function]}
+          >
+            My Account
+          </DropdownItem>,
+          <DropdownSeparator />,
+        ]
+      }
+      isOpen={true}
+      isPlain={true}
+      notification_url="/"
+      onSelect={[Function]}
+      position="right"
+      toggle={
+        <DropdownToggle
+          onToggle={[Function]}
+        >
+          <Icon
+            name="user avatar small"
+            type="fa"
+          />
+          G L
+        </DropdownToggle>
+      }
+    />
+  </NavItem>
+</VerticalNav.IconBar>
+`;
+
+exports[`UserDropdown render with impersonated by icon 1`] = `
+<VerticalNav.IconBar
+  className=""
+  collapse={true}
+  isOpen={true}
+  notification_url="/"
+>
+  <NavItem
+    activeHref=""
+    activeKey=""
+    className="drawer-pf-trigger dropdown notification-dropdown"
+    id="notifications_container"
+  >
+    <Connect(OnClickOutside(notificationContainer))
+      data={
+        Object {
+          "url": "",
+        }
+      }
+    />
+  </NavItem>
+  <Connect(ImpersonateIcon)
+    stopImpersonationUrl=""
+  />
+  <NavItem
+    activeHref=""
+    activeKey=""
+    className="pf-c-page__header"
+    id="account_menu"
+  >
+    <Dropdown
+      className=""
+      dropdownItems={
+        Array [
+          <DropdownItem
+            className="user_menuitem"
+            href="/"
+            onClick={[Function]}
+          >
+            My Account
+          </DropdownItem>,
+          <DropdownSeparator />,
+        ]
+      }
+      isOpen={true}
+      isPlain={true}
+      notification_url="/"
+      onSelect={[Function]}
+      position="right"
+      toggle={
+        <DropdownToggle
+          onToggle={[Function]}
+        >
+          <Icon
+            name="user avatar small"
+            type="fa"
+          />
+          G L
+        </DropdownToggle>
+      }
+    />
+  </NavItem>
 </VerticalNav.IconBar>
 `;


### PR DESCRIPTION
Starting to split and refactor this PR: https://github.com/theforeman/foreman/pull/7555
Before:
![Screenshot from 2020-06-28 19-29-27](https://user-images.githubusercontent.com/30431079/85952977-b491fd00-b975-11ea-90d8-abcdff1b3135.png)
After:
![Screenshot from 2020-06-28 19-29-09](https://user-images.githubusercontent.com/30431079/85952978-b52a9380-b975-11ea-893b-bd1dc3dc9ca4.png)

After with the PF4 icon:
![Screenshot from 2020-06-29 10-00-26](https://user-images.githubusercontent.com/30431079/85983699-a208d980-b9f0-11ea-8bb1-530bd90aca24.png)
`id="account_menu" className="pf-c-page__header"` added until the navigation will be all pf4


