### PR TITLE
Fixes #30247 - do not delete VMs by default

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -67,7 +67,7 @@ class Setting::Provisioning < Setting
       set(
         'destroy_vm_on_host_delete',
         N_("Destroy associated VM on host delete. When enabled, VMs linked to Hosts will be deleted on Compute Resource. When disabled, VMs are unlinked when the host is deleted, meaning they remain on Compute Resource and can be re-associated or imported back to Foreman again. This does not automatically power off the VM"),
-        true,
+        false,
         N_("Destroy associated VM on host delete")
       ),
       set(

--- a/db/migrate/20200630092207_change_default_vm_deletion_setting.rb
+++ b/db/migrate/20200630092207_change_default_vm_deletion_setting.rb
@@ -1,0 +1,15 @@
+class ChangeDefaultVmDeletionSetting < ActiveRecord::Migration[6.0]
+  def up
+    Setting.without_auditing do
+      setting = Setting.where(:name => 'destroy_vm_on_host_delete').first
+      setting&.update_attribute(:default, false)
+    end
+  end
+
+  def down
+    Setting.without_auditing do
+      setting = Setting.where(:name => 'destroy_vm_on_host_delete').first
+      setting&.update_attribute(:default, true)
+    end
+  end
+end


### PR DESCRIPTION
We've seen multiple users deleting their VMs when they deleted host in
Foreman. That still seems to be very unexpected especially in case of
unmanaged hosts. It's safer to keep the VM and delete it only if users
explicitly want to.

This changes the default behavior and we'll need to cover that in
release notes. However it probably causes less pain than having VMs
running and consuming resources, when people forget to destroy them.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
