### PR TITLE
Fixes #30268 - Lock foreman-vendor to < 4.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^4.3.0",
+    "@theforeman/vendor": "<4.9.0",
+    "@theforeman/vendor-core": "<4.9.0",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -31,11 +32,11 @@
     "@babel/plugin-transform-modules-systemjs": "7.9.0",
     "@babel/plugin-transform-modules-commonjs": "7.9.0",
     "@babel/plugin-transform-modules-amd": "7.9.0",
-    "@theforeman/builder": "^4.3.0",
-    "@theforeman/eslint-plugin-foreman": "^4.3.0",
-    "@theforeman/stories": "^4.3.0",
-    "@theforeman/test": "^4.3.0",
-    "@theforeman/vendor-dev": "^4.3.0",
+    "@theforeman/builder": "<4.9.0",
+    "@theforeman/eslint-plugin-foreman": "<4.9.0",
+    "@theforeman/stories": "<4.9.0",
+    "@theforeman/test": "<4.9.0",
+    "@theforeman/vendor-dev": "<4.9.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",


### PR DESCRIPTION
While cherry-picking for Katello 3.16 we saw some react failures due to foreman-vendor 4.10.0 being pulled in. I checked the 2.1 repos and found that foreman-vendor version 4.3 is there, so clearly there's some discrepancy. I tested foreman and katello locally with 4.8.0 and the tests pass but fail with 4.9.0+, so I think this is really the version we want in 2.1 and Katello 3.16 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
