### PR TITLE
Fixes #29024 - help distinguish multiple Foremans from each other

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -58,7 +58,9 @@ module LayoutHelper
       stop_impersonation_url: main_app.stop_impersonation_users_path,
       user: fetch_user, brand: 'foreman',
       taxonomies: taxonomies_booleans, root: main_app.root_path,
-      locations: fetch_locations, orgs: fetch_organizations }
+      locations: fetch_locations, orgs: fetch_organizations,
+      instance_title: Setting[:instance_title]
+    }
   end
 
   def title(page_title, page_header = nil)

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -16,7 +16,7 @@ class Setting < ApplicationRecord
   FROZEN_ATTRS = %w{name category}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page outofsync_interval}
   BLANK_ATTRS = %w{ host_owner trusted_hosts login_delegation_logout_url root_pass default_location default_organization websockets_ssl_key websockets_ssl_cert oauth_consumer_key oauth_consumer_secret login_text oidc_audience oidc_issuer oidc_algorithm
-                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list default_locale default_timezone ssl_certificate ssl_ca_file ssl_priv_key default_pxe_item_global default_pxe_item_local oidc_jwks_url }
+                    smtp_address smtp_domain smtp_user_name smtp_password smtp_openssl_verify_mode smtp_authentication sendmail_arguments sendmail_location http_proxy http_proxy_except_list default_locale default_timezone ssl_certificate ssl_ca_file ssl_priv_key default_pxe_item_global default_pxe_item_local oidc_jwks_url instance_title }
   ARRAY_HOSTNAMES = %w{trusted_hosts}
   URI_ATTRS = %w{foreman_url unattended_url}
   URI_BLANK_ATTRS = %w{login_delegation_logout_url}

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -28,6 +28,7 @@ class Setting::General < Setting
       set('instance_id', N_("Foreman instance ID, uniquely identifies this Foreman instance."), 'uuid', N_('Foreman UUID'), Foreman.uuid),
       set('default_locale', N_("Language to use for new users"), nil, N_('Default language'), nil, { :collection => proc { locales } }),
       set('default_timezone', N_("Timezone to use for new users"), nil, N_('Default timezone'), nil, { :collection => proc { timezones } }),
+      set('instance_title', N_("The instance title is shown on the top navigation bar (requires reload of page)."), nil, N_('Instance title')),
     ]
   end
 

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -250,6 +250,7 @@ export const layoutMock = {
     taxonomies: { locations: true, organizations: true },
     user,
     stop_impersonation_url: '/users/stop_impersonation',
+    instance_title: 'Production',
   },
 };
 

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.js
@@ -68,6 +68,7 @@ const Layout = ({
           user={data.user}
           changeActiveMenu={changeActiveMenu}
           stopImpersonationUrl={data.stop_impersonation_url}
+          instanceTitle={data.instance_title}
         />
       </VerticalNav.Masthead>
     </VerticalNav>

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -203,6 +203,7 @@ export const layoutPropTypes = {
   data: PropTypes.shape({
     brand: PropTypes.string,
     stop_impersonation_url: PropTypes.string.isRequired,
+    instance_title: PropTypes.string,
     menu: PropTypes.arrayOf(
       PropTypes.shape({
         type: PropTypes.string.isRequired,

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -110,6 +110,7 @@ exports[`Layout rendering renders layout 1`] = `
       <UserDropdowns
         changeActiveMenu={[Function]}
         className=""
+        instanceTitle="Production"
         notificationUrl="/notification_recipients"
         stopImpersonationUrl="/users/stop_impersonation"
         user={

--- a/webpack/assets/javascripts/react_app/components/Layout/components/InstanceTitleViewer.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/InstanceTitleViewer.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Icon, OverlayTrigger, Tooltip } from 'patternfly-react';
+import PropTypes from 'prop-types';
+import NavItem from './NavItem';
+
+const InstanceTitleViewer = ({ title }) => {
+  if (!title) {
+    return null;
+  }
+
+  const tooltip = <Tooltip id="tooltip">{title}</Tooltip>;
+
+  return (
+    <NavItem className="nav-item-iconic">
+      <OverlayTrigger
+        placement="bottom"
+        id="notifications-toggle-icon"
+        overlay={tooltip}
+      >
+        <Icon type="fa" name="server small" />
+      </OverlayTrigger>
+    </NavItem>
+  );
+};
+
+InstanceTitleViewer.propTypes = {
+  /** Title to display */
+  title: PropTypes.string,
+};
+InstanceTitleViewer.defaultProps = {
+  title: '',
+};
+export default InstanceTitleViewer;

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -14,6 +14,7 @@ import { userPropType } from '../LayoutHelper';
 import NotificationContainer from '../../notifications';
 import NavItem from './NavItem';
 import ImpersonateIcon from './ImpersonateIcon';
+import InstanceTitleViewer from './InstanceTitleViewer';
 import { translate as __ } from '../../../common/I18n';
 
 const UserDropdowns = ({
@@ -21,6 +22,7 @@ const UserDropdowns = ({
   changeActiveMenu,
   notificationUrl,
   stopImpersonationUrl,
+  instanceTitle,
   ...props
 }) => {
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
@@ -56,6 +58,7 @@ const UserDropdowns = ({
 
   return (
     <VerticalNav.IconBar {...props}>
+      <InstanceTitleViewer title={instanceTitle} />
       <NavItem
         className="drawer-pf-trigger dropdown notification-dropdown"
         id="notifications_container"
@@ -95,6 +98,7 @@ UserDropdowns.propTypes = {
   /** changeActiveMenu Func */
   changeActiveMenu: PropTypes.func,
   stopImpersonationUrl: PropTypes.string,
+  instanceTitle: PropTypes.string,
 };
 UserDropdowns.defaultProps = {
   className: '',
@@ -102,5 +106,6 @@ UserDropdowns.defaultProps = {
   notificationUrl: '',
   changeActiveMenu: null,
   stopImpersonationUrl: '',
+  instanceTitle: '',
 };
 export default UserDropdowns;

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/UserDropdowns.test.js.snap
@@ -7,6 +7,9 @@ exports[`UserDropdown render 1`] = `
   isOpen={true}
   notification_url="/"
 >
+  <InstanceTitleViewer
+    title=""
+  />
   <NavItem
     activeHref=""
     activeKey=""
@@ -71,6 +74,9 @@ exports[`UserDropdown render with impersonated by icon 1`] = `
   isOpen={true}
   notification_url="/"
 >
+  <InstanceTitleViewer
+    title=""
+  />
   <NavItem
     activeHref=""
     activeKey=""


### PR DESCRIPTION
A lot of times, customers asks us, how they can distinguish between multiple foreman instances.
Currently, we use the Setting[:login_text] so that the user knows when logging in, which instance he/she is using. I guess, for this feature a new setting should be introduced. 

![image](https://user-images.githubusercontent.com/25485845/86180112-ca492300-bb2b-11ea-8cc5-347ef7c1b90a.png)
