### PR TITLE
Refs #30080 - run GH react tests only on relevant files changes

### DIFF
--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -3,6 +3,11 @@ name: (non-blocking) React on plugins
 on:
   pull_request:
     branches: [develop]
+    paths:
+      - 'webpack/*'
+      - 'package.json'
+      - 'config/webpack.config.js'
+      - '.github/workflows/plugins_react_tests.yml'
 
 jobs:
   test:


### PR DESCRIPTION
Added those files to the list:
- 'webpack/*'
- 'package.json'
- 'config/webpack.config.js'
- '.github/workflows/plugins_react_tests.yml'

this files are the same files we check diff for in travis.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
