### PR TITLE
Fixes #30196 - Remove double listed marcos

### DIFF
--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -20,8 +20,6 @@ module Foreman
         :plugin_present?,
         :medium_provider,
         :medium_uri,
-        :load_hosts,
-        :load_users,
         :user_auth_source_name,
         :all_host_statuses,
         :all_host_statuses_hash,


### PR DESCRIPTION
This issue solves problem where at edit template page was listed `load_users` and `load_hosts` macro twice. These macros has been loaded from two places - from generic helpers and from loaders class.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
