### PR TITLE
Refs #30331 - Adds PF4 CustomContextSelector

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/components/CustomContextSelector.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/CustomContextSelector.js
@@ -1,0 +1,241 @@
+/**
+ * Modified PF4 ContextSelector
+ *
+ * Includes static group before the filter input and can show the filter input conditionally
+ * Removed FocusTrap wrapper
+ */
+import React from 'react';
+/* eslint-disable */
+import styles from '@patternfly/react-styles/css/components/ContextSelector/context-selector';
+import selectStyles from '@patternfly/react-styles/css/components/Select/select';
+import { css } from '@patternfly/react-styles';
+import SearchIcon from '@patternfly/react-icons/dist/js/icons/search-icon';
+/* eslint-enable */
+import PropTypes from 'prop-types';
+import {
+  ContextSelectorItem,
+  Button,
+  ButtonVariant,
+  TextInput,
+  InputGroup,
+  Divider,
+  KEY_CODES,
+  Popper,
+  FocusTrap,
+} from '@patternfly/react-core';
+import { ContextSelectorToggle } from '@patternfly/react-core/dist/js/components/ContextSelector/ContextSelectorToggle';
+import { ContextSelectorMenuList } from '@patternfly/react-core/dist/js/components/ContextSelector/ContextSelectorMenuList';
+import { ContextSelectorContext } from '@patternfly/react-core/dist/js/components/ContextSelector/contextSelectorConstants';
+
+// seed for the aria-labelledby ID
+let currentId = 0;
+const newId = currentId++;
+
+class CustomContextSelector extends React.Component {
+  parentRef = React.createRef();
+
+  onEnterPressed = event => {
+    if (event.charCode === KEY_CODES.ENTER) {
+      this.props.onSearchButtonClick();
+    }
+  };
+
+  render() {
+    const toggleId = `pf-context-selector-toggle-id-${newId}`;
+    const screenReaderLabelId = `pf-context-selector-label-id-${newId}`;
+    const searchButtonId = `pf-context-selector-search-button-id-${newId}`;
+    const {
+      children,
+      className,
+      isOpen,
+      onToggle,
+      onSelect,
+      screenReaderLabel,
+      toggleText,
+      searchButtonAriaLabel,
+      searchInputValue,
+      onSearchInputChange,
+      searchInputPlaceholder,
+      onSearchButtonClick,
+      menuAppendTo,
+      showFilter,
+      staticGroup,
+      searchProps,
+      ...props
+    } = this.props;
+
+    const nonFilterableGroup = (
+      <div className={selectStyles.select}>
+        <div className={selectStyles.selectMenuGroup}>
+          <div className={selectStyles.selectMenuGroupTitle}>
+            {staticGroup.title}
+          </div>
+          <ContextSelectorMenuList
+            isOpen={isOpen}
+            style={{ overflowY: 'hidden' }}
+          >
+            {staticGroup.items.map((item, i) => (
+              <ContextSelectorItem key={i}>
+                <a
+                  href={item.href}
+                  onClick={item.onClick}
+                  style={{ textDecoration: 'inherit', color: 'inherit' }}
+                  className={item.className}
+                >
+                  {item.title}
+                </a>
+              </ContextSelectorItem>
+            ))}
+          </ContextSelectorMenuList>
+        </div>
+        <Divider component="div" />
+      </div>
+    );
+
+    const menuContainer = (
+      <div className={css(styles.contextSelectorMenu)}>
+        {isOpen && (
+          <FocusTrap focusTrapOptions={{ clickOutsideDeactivates: true }}>
+            {nonFilterableGroup}
+            {showFilter && (
+              <div className={css(styles.contextSelectorMenuSearch)}>
+                <InputGroup>
+                  <TextInput
+                    value={searchInputValue}
+                    type="search"
+                    placeholder={searchInputPlaceholder}
+                    onChange={onSearchInputChange}
+                    onKeyPress={this.onEnterPressed}
+                    aria-labelledby={searchButtonId}
+                    {...searchProps}
+                  />
+                  <Button
+                    variant={ButtonVariant.control}
+                    aria-label={searchButtonAriaLabel}
+                    id={searchButtonId}
+                    onClick={onSearchButtonClick}
+                  >
+                    <SearchIcon aria-hidden="true" />
+                  </Button>
+                </InputGroup>
+              </div>
+            )}
+            <ContextSelectorContext.Provider value={{ onSelect }}>
+              <ContextSelectorMenuList isOpen={isOpen}>
+                {children}
+              </ContextSelectorMenuList>
+            </ContextSelectorContext.Provider>
+          </FocusTrap>
+        )}
+      </div>
+    );
+    const popperContainer = (
+      <div
+        className={css(
+          styles.contextSelector,
+          isOpen && styles.modifiers.expanded,
+          className
+        )}
+        ref={this.parentRef}
+        {...props}
+      >
+        {isOpen && menuContainer}
+      </div>
+    );
+    const mainContainer = (
+      <div
+        className={css(
+          styles.contextSelector,
+          isOpen && styles.modifiers.expanded,
+          className
+        )}
+        ref={this.parentRef}
+        {...props}
+      >
+        {screenReaderLabel && (
+          <span id={screenReaderLabelId} hidden>
+            {screenReaderLabel}
+          </span>
+        )}
+        <ContextSelectorToggle
+          onToggle={onToggle}
+          isOpen={isOpen}
+          toggleText={toggleText}
+          id={toggleId}
+          parentRef={this.parentRef.current}
+          aria-labelledby={`${screenReaderLabelId} ${toggleId}`}
+        />
+        {isOpen && menuAppendTo === 'inline' && menuContainer}
+      </div>
+    );
+    const getParentElement = () => {
+      if (this.parentRef && this.parentRef.current) {
+        return this.parentRef.current.parentElement;
+      }
+      return null;
+    };
+    return menuAppendTo === 'inline' ? (
+      mainContainer
+    ) : (
+      <Popper
+        trigger={mainContainer}
+        popper={popperContainer}
+        appendTo={menuAppendTo === 'parent' ? getParentElement() : menuAppendTo}
+        isVisible={isOpen}
+      />
+    );
+  }
+}
+CustomContextSelector.propTypes = {
+  /** content rendered inside the Context Selector */
+  children: PropTypes.node,
+  /** Classes applied to root element of Context Selector */
+  className: PropTypes.string,
+  /** Flag to indicate if Context Selector is opened */
+  isOpen: PropTypes.bool,
+  /** Function callback called when user clicks toggle button */
+  onToggle: PropTypes.func,
+  /** Function callback called when user selects item */
+  onSelect: PropTypes.func,
+  /** Labels the Context Selector for Screen Readers */
+  screenReaderLabel: PropTypes.string,
+  /** Text that appears in the Context Selector Toggle */
+  toggleText: PropTypes.string,
+  /** Aria-label for the Context Selector Search Button */
+  searchButtonAriaLabel: PropTypes.string,
+  /** Value in the Search field */
+  searchInputValue: PropTypes.string,
+  /** Function callback called when user changes the Search Input */
+  onSearchInputChange: PropTypes.func,
+  /** Search Input placeholder */
+  searchInputPlaceholder: PropTypes.string,
+  /** Function callback for when Search Button is clicked */
+  onSearchButtonClick: PropTypes.func,
+  /** True to show the search filter */
+  showFilter: PropTypes.bool,
+  /** Items that are inserted before the search filter */
+  staticGroup: PropTypes.any,
+  /** Additional props passed to the search filter */
+  searchProps: PropTypes.any,
+  /** Should the dropdown be appended 'inline' or to the 'parent' */
+  menuAppendTo: PropTypes.string,
+};
+CustomContextSelector.defaultProps = {
+  children: null,
+  className: '',
+  isOpen: false,
+  onToggle: () => undefined,
+  onSelect: () => undefined,
+  screenReaderLabel: '',
+  toggleText: '',
+  searchButtonAriaLabel: 'Search menu items',
+  searchInputValue: '',
+  onSearchInputChange: () => undefined,
+  searchInputPlaceholder: 'Search',
+  onSearchButtonClick: () => undefined,
+  showFilter: true,
+  staticGroup: null,
+  searchProps: null,
+  menuAppendTo: 'inline',
+};
+export default CustomContextSelector;

--- a/webpack/assets/javascripts/react_app/components/Layout/components/CustomContextSelector.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/CustomContextSelector.test.js
@@ -1,0 +1,37 @@
+import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
+import { hasTaxonomiesMock } from '../Layout.fixtures';
+
+import CustomContextSelector from './CustomContextSelector';
+
+const fixtures = {
+  'render CustomContextSelector': {
+    toggleText: hasTaxonomiesMock.currentOrganization,
+    onSearchInputChange: () => {},
+    isOpen: true,
+    searchInputValue: '',
+    onToggle: () => {},
+    onSelect: () => {},
+    onSearchButtonClick: () => {},
+    screenReaderLabel: 'Selected Taxonomy:',
+    showFilter: hasTaxonomiesMock.data.orgs.available_organizations.length > 6,
+    staticGroup: {
+      title: 'Organization',
+      items: [
+        {
+          title: 'Any Organization',
+          href: '/organizations/clear',
+          onClick: () => {},
+        },
+        {
+          title: 'Manage Organizations',
+          href: '/organizations',
+        },
+      ],
+    },
+  },
+};
+
+describe('CustomContextSelector', () => {
+  describe('rendering', () =>
+    testComponentSnapshotsWithFixtures(CustomContextSelector, fixtures));
+});

--- a/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/CustomContextSelector.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/__snapshots__/CustomContextSelector.test.js.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CustomContextSelector rendering render CustomContextSelector 1`] = `
+<div
+  className="pf-c-context-selector pf-m-expanded"
+>
+  <span
+    hidden={true}
+    id="pf-context-selector-label-id-0"
+  >
+    Selected Taxonomy:
+  </span>
+  <ContextSelectorToggle
+    aria-labelledby="pf-context-selector-label-id-0 pf-context-selector-toggle-id-0"
+    className=""
+    id="pf-context-selector-toggle-id-0"
+    isActive={false}
+    isOpen={true}
+    onEnter={[Function]}
+    onToggle={[Function]}
+    parentRef={null}
+    toggleText="org1"
+  />
+  <div
+    className="pf-c-context-selector__menu"
+  >
+    <FocusTrap
+      active={true}
+      focusTrapOptions={
+        Object {
+          "clickOutsideDeactivates": true,
+        }
+      }
+      paused={false}
+    >
+      <div
+        className="pf-c-select"
+      >
+        <div
+          className="pf-c-select__menu-group"
+        >
+          <div
+            className="pf-c-select__menu-group-title"
+          >
+            Organization
+          </div>
+          <ContextSelectorMenuList
+            className=""
+            isOpen={true}
+            style={
+              Object {
+                "overflowY": "hidden",
+              }
+            }
+          >
+            <ContextSelectorItem
+              className=""
+              isDisabled={false}
+              key="0"
+              onClick={[Function]}
+              sendRef={[Function]}
+            >
+              <a
+                href="/organizations/clear"
+                onClick={[Function]}
+                style={
+                  Object {
+                    "color": "inherit",
+                    "textDecoration": "inherit",
+                  }
+                }
+              >
+                Any Organization
+              </a>
+            </ContextSelectorItem>
+            <ContextSelectorItem
+              className=""
+              isDisabled={false}
+              key="1"
+              onClick={[Function]}
+              sendRef={[Function]}
+            >
+              <a
+                href="/organizations"
+                style={
+                  Object {
+                    "color": "inherit",
+                    "textDecoration": "inherit",
+                  }
+                }
+              >
+                Manage Organizations
+              </a>
+            </ContextSelectorItem>
+          </ContextSelectorMenuList>
+        </div>
+        <Divider
+          component="div"
+        />
+      </div>
+      <ContextProvider
+        value={
+          Object {
+            "onSelect": [Function],
+          }
+        }
+      >
+        <ContextSelectorMenuList
+          className=""
+          isOpen={true}
+        />
+      </ContextProvider>
+    </FocusTrap>
+  </div>
+</div>
+`;


### PR DESCRIPTION
A copy of https://github.com/patternfly/patternfly-react/blob/master/packages/react-core/src/components/ContextSelector/ContextSelector.tsx
Will contribute this PR to PF4 (https://github.com/patternfly/patternfly-react/pull/4517), but to get the navigation working well we should use the custom version.
The only difference between the Foreman one to PF4 one is that this version has `staticGroup` which turns to  `nonFilterableGroup`