### PR TITLE
Fixes #30328 - Adds patternfly 4 Loading react component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Loading/Loading.js
+++ b/webpack/assets/javascripts/react_app/components/Loading/Loading.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Bullseye,
+  Title,
+  EmptyState,
+  EmptyStateIcon,
+  Spinner,
+} from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+
+// Centered patternfly 4 loading icon
+const Loading = ({ textSize, iconSize, showText }) => {
+  const LoadingSpinner = () => (
+    <Spinner size={iconSize} aria-label="loading icon" />
+  );
+  return (
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon variant="container" component={LoadingSpinner} />
+        {showText && (
+          <Title size={textSize} headingLevel="h4">
+            {__('Loading')}
+          </Title>
+        )}
+      </EmptyState>
+    </Bullseye>
+  );
+};
+
+Loading.propTypes = {
+  textSize: PropTypes.string,
+  iconSize: PropTypes.string,
+  showText: PropTypes.bool,
+};
+
+Loading.defaultProps = {
+  textSize: 'lg',
+  iconSize: 'xl',
+  showText: true,
+};
+
+export default Loading;

--- a/webpack/assets/javascripts/react_app/components/Loading/Loading.stories.js
+++ b/webpack/assets/javascripts/react_app/components/Loading/Loading.stories.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import Story from '../../../../../stories/components/Story';
+import Loading from './Loading';
+
+export default {
+  title: 'Components|Loading',
+};
+
+export const defaultStory = () => (
+  <Story>
+    <Loading />
+  </Story>
+);
+
+export const smallText = () => (
+  <Story>
+    <Loading textSize="sm" />
+  </Story>
+);
+
+export const noText = () => (
+  <Story>
+    <Loading showText={false} />
+  </Story>
+);
+
+export const smallerIconAndText = () => (
+  <Story>
+    <Loading textSize="sm" iconSize="md" />
+  </Story>
+);
+
+defaultStory.story = {
+  name: 'Default',
+};

--- a/webpack/assets/javascripts/react_app/components/Loading/__tests__/Loading.test.js
+++ b/webpack/assets/javascripts/react_app/components/Loading/__tests__/Loading.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Loading from '../Loading';
+
+const loadingText = 'Loading';
+const iconLabel = /loading icon/i;
+
+test('Loading icon and text show by default', () => {
+  const { getByText, getByLabelText } = render(<Loading />);
+
+  expect(getByText(loadingText)).toBeInTheDocument();
+  expect(getByLabelText(iconLabel)).toBeInTheDocument();
+});
+
+test('Text and icon size can be specified and component renders', () => {
+  const { getByText, getByLabelText } = render(
+    <Loading textSize="sm" iconSize="sm" />
+  );
+
+  expect(getByText(loadingText)).toBeInTheDocument();
+  expect(getByLabelText(iconLabel)).toBeInTheDocument();
+});
+
+test('Loading text will not show when showText is false', () => {
+  const { queryByText, getByLabelText } = render(<Loading showText={false} />);
+
+  expect(queryByText(loadingText)).not.toBeInTheDocument();
+  expect(getByLabelText(iconLabel)).toBeInTheDocument();
+});

--- a/webpack/assets/javascripts/react_app/components/Loading/index.js
+++ b/webpack/assets/javascripts/react_app/components/Loading/index.js
@@ -1,0 +1,3 @@
+import Loading from './Loading';
+
+export default Loading;


### PR DESCRIPTION
This is a patternfly 4 component to show a centered loading spinner, with or without text. We currently have this in Katello and this would make it available in Foreman.

To see examples, check the storybook `npm run stories`.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
