### PR TITLE
Fixes #30339 - isolate LookupKey tests

### DIFF
--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -28,6 +28,9 @@ class LookupKey < ApplicationRecord
   validates_associated :lookup_values
 
   before_validation :sanitize_path
+  before_validation :cast_default_value, :if => :override?
+  validate :validate_default_value, :disable_avoid_duplicates, :disable_merge_overrides, :disable_merge_default, :if => :override?
+  after_validation :reset_override_params, :if => ->(key) { key.override_changed? && !key.override? }
   attr_name :key
 
   def self.inherited(child)
@@ -140,6 +143,13 @@ class LookupKey < ApplicationRecord
   end
 
   private
+
+  def reset_override_params
+    self.merge_overrides = false
+    self.avoid_duplicates = false
+    self.merge_default = false
+    true
+  end
 
   def sanitize_path
     self.path = path.tr("\s", "").downcase if path.present?

--- a/app/models/lookup_keys/puppetclass_lookup_key.rb
+++ b/app/models/lookup_keys/puppetclass_lookup_key.rb
@@ -3,10 +3,7 @@ class PuppetclassLookupKey < LookupKey
   has_many :environments, -> { distinct }, :through => :environment_classes
   has_many :param_classes, :through => :environment_classes, :source => :puppetclass
 
-  before_validation :cast_default_value, :if => :override?
   before_validation :check_override_selected, :if => -> { persisted? && @validation_context != :importer }
-  validate :validate_default_value, :disable_merge_overrides, :disable_avoid_duplicates, :disable_merge_default, :if => :override?
-  after_validation :reset_override_params, :if => ->(key) { key.override_changed? && !key.override? }
 
   scoped_search :relation => :param_classes, :on => :name, :rename => :puppetclass, :aliases => [:puppetclass_name], :complete_value => true
   scoped_search :relation => :environments, :on => :name, :rename => :environment, :complete_value => true, :only_explicit => true
@@ -44,14 +41,6 @@ class PuppetclassLookupKey < LookupKey
   end
 
   def puppet?
-    true
-  end
-
-  def reset_override_params
-    self.merge_overrides = false
-    self.avoid_duplicates = false
-    self.merge_default = false
-
     true
   end
 

--- a/test/factories/lookups.rb
+++ b/test/factories/lookups.rb
@@ -29,6 +29,11 @@ FactoryBot.define do
       default_value { '[{"hostname": "test.example.com"}]' }
     end
 
+    trait :hash do
+      key_type { 'hash' }
+      default_value { '{"hostname": "test.example.com"}' }
+    end
+
     trait :with_omit do
       omit { true }
     end
@@ -47,6 +52,8 @@ FactoryBot.define do
                                   '--- \nfoo: overridden\n'
                                 when 'array'
                                   '[{"overridden": "value"}]'
+                                when 'hash'
+                                  '{"overridden": "value"}'
                                 else
                                   'overridden value'
                                 end,

--- a/test/models/lookup_keys/puppetclass_lookup_key_test.rb
+++ b/test/models/lookup_keys/puppetclass_lookup_key_test.rb
@@ -9,6 +9,14 @@ class PuppetclassLookupKeyTest < ActiveSupport::TestCase
     refute lookup_key.valid?
   end
 
+  test "default_value is only validated if omit is false" do
+    lookup_key = FactoryBot.create(:puppetclass_lookup_key, :key_type => 'boolean',
+                                    :override => true, :default_value => 'whatever', :omit => true)
+    assert lookup_key.valid?
+    lookup_key.omit = false
+    refute lookup_key.valid?
+  end
+
   test "should update description when override is false" do
     lookup_key = FactoryBot.create(:puppetclass_lookup_key, :key_type => 'string',
                                     :default_value => "test123", :description => 'description')

--- a/test/unit/host_info_providers/puppet_info_test.rb
+++ b/test/unit/host_info_providers/puppet_info_test.rb
@@ -1,0 +1,67 @@
+require 'test_helper'
+
+module HostInfoProviders
+  class PuppetInfoTest < ActiveSupport::TestCase
+    let(:host_params) do
+      {
+        location:      taxonomies(:location1),
+        organization:  taxonomies(:organization1),
+        puppetclasses: [puppetclasses(:one)],
+        environment:   environments(:production),
+      }
+    end
+    let(:host1) { FactoryBot.create(:host, host_params) }
+    let(:host2) { FactoryBot.create(:host, host_params) }
+    let(:host3) { FactoryBot.create(:host, host_params) }
+
+    test 'fetching correct value to a given key' do
+      key = ""
+      value = ""
+      puppetclass = puppetclasses(:one)
+
+      as_admin do
+        key = PuppetclassLookupKey.create!(:key => "dns", :path => "domain\npuppetversion", :override => true)
+        value = LookupValue.create!(:value => "[1.2.3.4,2.3.4.5]", :match => "domain =  mydomain.net", :lookup_key => key)
+        EnvironmentClass.create!(:puppetclass => puppetclass, :environment => environments(:production),
+                                 :puppetclass_lookup_key => key)
+      end
+
+      key.reload
+      assert key.lookup_values.count > 0
+      host1.domain = domains(:mydomain)
+
+      assert_equal value.value, HostInfoProviders::PuppetInfo.new(host1).puppetclass_parameters['base']['dns']
+    end
+
+    test 'multiple paths' do
+      host1.hostgroup = hostgroups(:common)
+      host1.environment = environments(:testing)
+
+      host2.hostgroup = hostgroups(:unusual)
+      host2.environment = environments(:testing)
+
+      host3.environment = environments(:testing)
+
+      default = "default"
+      puppetclass = Puppetclass.first
+      key = PuppetclassLookupKey.create!(:key => "dns", :path => "environment,hostgroup\nhostgroup\nfqdn", :default_value => default, :override => true)
+      value1 = LookupValue.create!(:value => "v1", :match => "environment=testing,hostgroup=Common", :lookup_key => key)
+      value2 = LookupValue.create!(:value => "v2", :match => "hostgroup=Unusual", :lookup_key => key)
+
+      LookupValue.create!(:value => "v22", :match => "fqdn=#{host2.fqdn}", :lookup_key => key)
+      EnvironmentClass.create!(:puppetclass => puppetclass, :environment => environments(:testing),
+                               :puppetclass_lookup_key => key)
+      HostClass.create!(:host => host1, :puppetclass => puppetclass)
+      HostClass.create!(:host => host2, :puppetclass => puppetclass)
+      HostClass.create!(:host => host3, :puppetclass => puppetclass)
+
+      key.reload
+
+      assert_equal value1.value, HostInfoProviders::PuppetInfo.new(host1).puppetclass_parameters['apache']['dns']
+      assert_equal value2.value, HostInfoProviders::PuppetInfo.new(host2).puppetclass_parameters['apache']['dns']
+      assert_equal default, HostInfoProviders::PuppetInfo.new(host3).puppetclass_parameters['apache']['dns']
+      assert key.overridden?(host2)
+      refute key.overridden?(host1)
+    end
+  end
+end


### PR DESCRIPTION
Gets rid of the PuppetclassLookupKey dependency for testing a LookupKey.
Removes some tests as they are irrelevant to LookupKey itself.