### PR TITLE
Adjust Puppet Master and Puppet CA wording and tooltip on Host records

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -15,14 +15,14 @@ module HostCommon
   included do
     belongs_to_proxy :puppet_proxy,
       :feature => N_('Puppet'),
-      :label => N_('Puppet Master'),
-      :description => N_('Use this puppet server as an initial Puppet Server or to execute puppet runs'),
+      :label => N_('Puppet Proxy'),
+      :description => N_('Use the Puppetserver configured on this Smart Proxy'),
       :api_description => N_('Puppet proxy ID')
 
     belongs_to_proxy :puppet_ca_proxy,
       :feature => 'Puppet CA',
-      :label => N_('Puppet CA'),
-      :description => N_('Use this puppet server as a CA server'),
+      :label => N_('Puppet CA Proxy'),
+      :description => N_('Use the Puppetserver CA configured on this Smart Proxy'),
       :api_description => N_('Puppet CA proxy ID')
 
     belongs_to :architecture


### PR DESCRIPTION
Adjust the wording on hosts so that it reflects the value represents the Smart Proxy whose puppet_url will be used, not the FQDN of the Puppet CA or Puppetserver themselves.

Fixes #30351

See - https://community.theforeman.org/t/foreman-provision-template-host-doesnt-have-correct-puppetserver-or-puppetca/19440 for further discussion

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)

* Suggest prerequisites for testing and testing scenarios following example above.
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
