### PR TITLE
Fixes #30050 - Filter templates by OS family

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -36,9 +36,10 @@ class ProvisioningTemplate < Template
   # tested with scoped_search 3.2.0
   include Taxonomix
   include TemplateTax
-  scoped_search :on => :name,    :complete_value => true, :default_order => true
-  scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
-  scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}
+  scoped_search :on => :name,      :complete_value => true, :default_order => true
+  scoped_search :on => :os_family, :complete_value => true
+  scoped_search :on => :locked,    :complete_value => {:true => true, :false => false}
+  scoped_search :on => :snippet,   :complete_value => {:true => true, :false => false}
   scoped_search :on => :template
   scoped_search :on => :vendor, :only_explicit => true, :complete_value => true
   scoped_search :on => :default, :only_explicit => true, :complete_value => {:true => true, :false => false}, :rename => 'default_template'


### PR DESCRIPTION
This should add the os_family filter for templates.
Although, while testing I could not add the OS family for templates through UI, am I missing anything? I tested this by setting `os_family` attribute using rails query in console.
