### PR TITLE
Fixes #30375 - fix os_minor search to not show empty minor

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -234,7 +234,7 @@ module Hostext
         y, z = value.split(".")
         z ||= 0
         operatingsystem_ids = []
-        Operatingsystem.all.find_each do |os|
+        Operatingsystem.where.not(minor: [nil, '']).find_each do |os|
           os_y, os_z = os.minor.split('.')
           os_z ||= 0
           operator_addition1 = (operator.length == 1) ? "=" : ""

--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -144,56 +144,84 @@ module Hostext
       end
 
       context "search by operatingsystem major and minor" do
-        let (:operatingsystem) { FactoryBot.create(:operatingsystem, :major => '7', :minor => '6.1810') }
-        let (:host) { FactoryBot.create(:host, :operatingsystem => operatingsystem) }
+        let (:operatingsystem1) { FactoryBot.create(:operatingsystem, :major => '7', :minor => '6.1810') }
+        let (:host) { FactoryBot.create(:host, :operatingsystem => operatingsystem1) }
 
-        test "searching os_major returns correct host" do
+        test "searching os_major > 5 returns correct host" do
           result = Host.search_for("os_major > 5")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_major < 10 returns correct host" do
           result = Host.search_for("os_major < 10")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_major = 7 returns correct host" do
           result = Host.search_for("os_major = 7")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_major <= 7 returns correct host" do
           result = Host.search_for("os_major <= 7")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_major >= 7 returns correct host" do
           result = Host.search_for("os_major >= 7")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_major < 5 returns correct host" do
           result = Host.search_for("os_major < 5")
           assert_equal(0, result.count)
           assert_empty result
         end
 
-        test "searching os_minor returns correct host" do
+        test "searching os_minor > 6.2 returns correct host" do
           result = Host.search_for("os_minor > 6.2")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_minor <10 returns correct host" do
           result = Host.search_for("os_minor < 10")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_minor = 6.1810 returns correct host" do
           result = Host.search_for("os_minor = 6.1810")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_minor <= 6.1810 returns correct host" do
           result = Host.search_for("os_minor <= 6.1810")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching  >= 6.1810 returns correct host" do
           result = Host.search_for("os_minor >= 6.1810")
           assert_equal(1, result.count)
           assert_equal(host.id, result.first.id)
+        end
 
+        test "searching os_minor < 6 returns correct host" do
+          result = Host.search_for("os_minor < 6")
+          assert_equal(0, result.count)
+          assert_empty result
+        end
+
+        test "searching os_minor < 3 returns correct host" do
+          os1 = FactoryBot.create(:operatingsystem, :major => '6', :minor => nil)
+          FactoryBot.create(:host, :operatingsystem => os1)
           result = Host.search_for("os_minor < 6")
           assert_equal(0, result.count)
           assert_empty result


### PR DESCRIPTION
The issue: 
when we search for os_minor < 0, all hosts with empty minor versions are shown.

