### PR TITLE
Fixes #30408 - full report data for scanning

### DIFF
--- a/app/services/report_scanner/puppet_report_scanner.rb
+++ b/app/services/report_scanner/puppet_report_scanner.rb
@@ -1,11 +1,12 @@
 module Foreman
   class PuppetReportScanner
     class << self
-      def scan(report, logs)
-        if (is_puppet = puppet_report?(logs))
-          report.origin = 'Puppet'
-        end
-        is_puppet
+      def identify_origin(report_data)
+        'Puppet' if puppet_report?(report_data['logs'] || [])
+      end
+
+      def add_reporter_data(report, report_data)
+        # no additional data apart of origin
       end
 
       def puppet_report?(logs)

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -134,19 +134,20 @@ class ReportImporterTest < ActiveSupport::TestCase
   end
 
   describe 'Report scanning' do
-    let(:report_scanner) { stub_everything('TestReportScanner') }
+    let(:report_scanner) { stub_everything('TestReportScanner', :identify_origin => 'TestOrigin') }
     let(:report) { read_json_fixture('reports/empty.json') }
 
-    describe '.scan' do
+    describe '#add_reporter_specific_data' do
       let(:importer) { TestReportImporter.new(report) }
       setup do
         importer.stubs(:report_scanners).returns([report_scanner])
         importer.send(:create_report_and_logs)
       end
 
-      it 'calls scan with the report on scanner' do
-        report_scanner.expects(:scan)
-        importer.send(:scan)
+      it 'calls add_reporter_specific_data with the report on scanner' do
+        report_scanner.expects(:add_reporter_data)
+        importer.send(:add_reporter_specific_data)
+        assert_equal importer.report.origin, 'TestOrigin'
       end
     end
   end

--- a/test/unit/report_scanner/puppet_report_scanner_test.rb
+++ b/test/unit/report_scanner/puppet_report_scanner_test.rb
@@ -3,21 +3,15 @@ require 'test_helper'
 class PuppetReportScannerTest < ActiveSupport::TestCase
   subject { Foreman::PuppetReportScanner }
 
-  describe '.scan' do
-    let(:report) { stub_everything('ConfigReport') }
-
-    it 'sets the report origin to Puppet when puppet_report? returns true' do
-      assert_nil report.origin
+  describe '.identify_origin' do
+    it 'returns Puppet if puppet_report' do
       subject.expects(:puppet_report?).returns(true)
-      report.expects(:"origin=").with('Puppet')
-      assert subject.scan(report, [])
+      assert_equal 'Puppet', subject.identify_origin({})
     end
 
-    it 'sets the report NO origin when puppet_report? returns false' do
-      assert_nil report.origin
+    it 'returns nil if not puppet_report' do
       subject.expects(:puppet_report?).returns(false)
-      report.expects(:"origin=").never
-      refute subject.scan(report, [])
+      assert_nil subject.identify_origin({})
     end
   end
 


### PR DESCRIPTION
Scanners are supposed to identify the origin of the report.
Currently we are passing just `logs` for this recognition, we could benefit greatly, if we pass all the data for the scan.

This is why I've come up with the idea: https://github.com/theforeman/foreman-ansible-modules/pull/870