### PR TITLE
Fixes #30412 - fix shifted react-container

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -11,17 +11,6 @@ body {
   display: table-cell;
 }
 
-.react-container {
-  margin-right: auto;
-  margin-left: 200px;
-  padding-left: 20px;
-  padding-right: 20px;
-
-  &.collapsed-nav {
-    margin-left: 75px;
-  }
-}
-
 .base li {
   list-style: none;
   margin-left: 20px;

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutSessionStorage.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutSessionStorage.js
@@ -1,4 +1,4 @@
 import { getValue } from '../../common/SessionStorage';
 
 export const getIsNavbarCollapsed = () =>
-  !!getValue(`["navCollapsed","pinnedPath"]`);
+  !!getValue(`["navCollapsed","pinnedPath"]`)?.navCollapsed;

--- a/webpack/assets/javascripts/react_app/components/Layout/layout.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/layout.scss
@@ -1,3 +1,4 @@
+@import '~@theforeman/vendor/scss/variables';
 @import '../../common/colors.scss';
 
 .secondary-nav-item-pf > .nav-pf-secondary-nav {
@@ -29,47 +30,76 @@
   }
 }
 
-#react-app-root > .nav-pf-vertical {
-  background-color: $nav-pf-vertical-secondary-active-bg-color;
+#react-app-root {
+  .react-container {
+    margin-right: auto;
+    margin-left: 200px;
+    padding-left: 20px;
+    padding-right: 20px;
 
-  .list-group {
-    .list-group-item {
-      a {
-        span {
-          color: $nav-pf-vertical-icon-color;
+    &.collapsed-nav {
+      margin-left: 75px;
+    }
+  }
+
+  .nav-pf-vertical {
+    background-color: $nav-pf-vertical-secondary-active-bg-color;
+
+    .list-group {
+      .list-group-item {
+        a {
+          span {
+            color: $nav-pf-vertical-icon-color;
+          }
+
+          &:hover {
+            background-color: $nav-pf-vertical-active-bg-color;
+
+            span {
+              color: $nav-pf-vertical-active-icon-color;
+            }
+          }
+
+          &::after {
+            color: $nav-pf-vertical-icon-color;
+          }
         }
 
         &:hover {
-          background-color: $nav-pf-vertical-active-bg-color;
+          a {
+            background-color: $nav-pf-vertical-active-bg-color;
 
-          span {
-            color: $nav-pf-vertical-active-icon-color;
+            span {
+              color: $nav-pf-vertical-active-icon-color;
+            }
           }
         }
 
-        &::after {
-          color: $nav-pf-vertical-icon-color;
-        }
-      }
+        &.active {
+          a {
+            background-color: $nav-pf-vertical-active-bg-color;
 
-      &:hover {
-        a {
-          background-color: $nav-pf-vertical-active-bg-color;
-
-          span {
-            color: $nav-pf-vertical-active-icon-color;
+            span {
+              color: $nav-pf-vertical-active-icon-color;
+            }
           }
         }
       }
+    }
+  }
+}
 
-      &.active {
-        a {
-          background-color: $nav-pf-vertical-active-bg-color;
+/*
+  patternfly-sass hides the vertical-nav on smaller screens, see: https://github.com/patternfly/patternfly-sass/blob/5e7cce3445d5b1af1e16500695b9f33edc6a4f6c/assets/javascripts/patternfly-functions.js#L260
+  the react-container needs to be shifted when it happens.
+*/
+@media only screen and (max-width: $pf-global--breakpoint--md) {
+  #react-app-root {
+    .react-container {
+      margin-left: 0;
 
-          span {
-            color: $nav-pf-vertical-active-icon-color;
-          }
-        }
+      &.collapsed-nav {
+        margin-left: 0;
       }
     }
   }


### PR DESCRIPTION
This is something that I think css `@media` query would do the work for.
patternfly hides the vertical-nav [when the page gets smaller](https://github.com/patternfly/patternfly-sass/blob/5e7cce3445d5b1af1e16500695b9f33edc6a4f6c/assets/javascripts/patternfly-functions.js#L260)

I think our JS implementation is overkill to what the layout needs to do - to shift to the left when the vertical nav is hidden.
I don't think we need to use the `session` for it, and I didn't notice anyone using the `ON_COLLAPSE`/`ON_EXPAND` actions.

current react pages are shifted:
![shifted_audits](https://user-images.githubusercontent.com/26363699/87525300-f919da00-c691-11ea-87d3-b7ec740e0745.png)

this is how it looks with this PR:
![Audits](https://user-images.githubusercontent.com/26363699/87525126-bfe16a00-c691-11ea-8a77-0501e66e7eb0.gif)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
