### PR TITLE
Fixes #30387 - User can view bookmarks without permission

### DIFF
--- a/db/seeds.d/020-roles_list.rb
+++ b/db/seeds.d/020-roles_list.rb
@@ -40,7 +40,7 @@ class RolesList
 
     def default_role
       {
-        'Default role' => { permissions: [:view_bookmarks, :view_tasks],
+        'Default role' => { permissions: [:view_tasks],
                             description: 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody',
         },
       }


### PR DESCRIPTION
`view_bookmarks` is set as a permission to the default role. Should we remove it in the first place? If so, why was it set earlier as a permission to the default role?
Thoughts?