### PR TITLE
Fixes #29914 - show taxonomy switcher when no view permission

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -11,10 +11,6 @@ module LayoutHelper
     UserMenu.new.menus.flatten
   end
 
-  def taxonomies_booleans
-    { locations: show_location_tab?, organizations: show_organization_tab? }
-  end
-
   def available_organizations
     Organization.my_organizations.map do |organization|
       {id: organization.id, title: organization.title, href: main_app.select_organization_path(organization)}
@@ -36,15 +32,11 @@ module LayoutHelper
   end
 
   def fetch_organizations
-    if show_organization_tab?
-      { current_org: current_organization, available_organizations: available_organizations }
-    end
+    { current_org: current_organization, available_organizations: available_organizations }
   end
 
   def fetch_locations
-    if show_location_tab?
-      { current_location: current_location, available_locations: available_locations }
-    end
+    { current_location: current_location, available_locations: available_locations }
   end
 
   def fetch_user
@@ -57,7 +49,7 @@ module LayoutHelper
       notification_url: main_app.notification_recipients_path,
       stop_impersonation_url: main_app.stop_impersonation_users_path,
       user: fetch_user, brand: 'foreman',
-      taxonomies: taxonomies_booleans, root: main_app.root_path,
+      root: main_app.root_path,
       locations: fetch_locations, orgs: fetch_organizations,
       instance_title: Setting[:instance_title]
     }

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.js
@@ -48,18 +48,11 @@ const Layout = ({
           href={data.root}
         />
         <TaxonomySwitcher
-          taxonomiesBool={data.taxonomies}
           currentLocation={currentLocation}
-          locations={
-            data.taxonomies.locations ? data.locations.available_locations : []
-          }
+          locations={data.locations.available_locations || []}
           onLocationClick={changeLocation}
           currentOrganization={currentOrganization}
-          organizations={
-            data.taxonomies.organizations
-              ? data.orgs.available_organizations
-              : []
-          }
+          organizations={data.orgs.available_organizations || []}
           onOrgClick={changeOrganization}
           isLoading={isLoading}
         />

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -59,13 +59,9 @@ export const combineMenuItems = data => {
     items.push(translatedItem);
   });
 
-  if (data.taxonomies.organizations) {
-    items.push(createOrgItem(data.orgs.available_organizations));
-  }
+  items.push(createOrgItem(data.orgs.available_organizations));
+  items.push(createLocationItem(data.locations.available_locations));
 
-  if (data.taxonomies.locations) {
-    items.push(createLocationItem(data.locations.available_locations));
-  }
   return items;
 };
 

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -100,12 +100,6 @@ exports[`Layout rendering renders layout 1`] = `
             },
           ]
         }
-        taxonomiesBool={
-          Object {
-            "locations": true,
-            "organizations": true,
-          }
-        }
       />
       <UserDropdowns
         changeActiveMenu={[Function]}

--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher.js
@@ -13,38 +13,33 @@ const TaxonomySwitcher = ({
   currentLocation,
   organizations,
   locations,
-  taxonomiesBool,
   isLoading,
   onLocationClick,
   onOrgClick,
 }) => (
   <Nav navbar pullLeft className="navbar-iconic">
-    {taxonomiesBool.organizations && (
-      <TaxonomyDropdown
-        taxonomyType="Organization"
-        id="organization-dropdown"
-        currentTaxonomy={currentOrganization}
-        taxonomies={organizations}
-        changeTaxonomy={onOrgClick}
-        anyTaxonomyText={ANY_ORGANIZATION_TEXT}
-        manageTaxonomyText="Manage Organizations"
-        anyTaxonomyURL="/organizations/clear"
-        manageTaxonomyURL="/organizations"
-      />
-    )}
-    {taxonomiesBool.locations && (
-      <TaxonomyDropdown
-        taxonomyType="Location"
-        id="location-dropdown"
-        currentTaxonomy={currentLocation}
-        taxonomies={locations}
-        changeTaxonomy={onLocationClick}
-        anyTaxonomyText={ANY_LOCATION_TEXT}
-        manageTaxonomyText="Manage Locations"
-        anyTaxonomyURL="/locations/clear"
-        manageTaxonomyURL="/locations"
-      />
-    )}
+    <TaxonomyDropdown
+      taxonomyType="Organization"
+      id="organization-dropdown"
+      currentTaxonomy={currentOrganization}
+      taxonomies={organizations}
+      changeTaxonomy={onOrgClick}
+      anyTaxonomyText="Any Organization"
+      manageTaxonomyText="Manage Organizations"
+      anyTaxonomyURL="/organizations/clear"
+      manageTaxonomyURL="/organizations"
+    />
+    <TaxonomyDropdown
+      taxonomyType="Location"
+      id="location-dropdown"
+      currentTaxonomy={currentLocation}
+      taxonomies={locations}
+      changeTaxonomy={onLocationClick}
+      anyTaxonomyText="Any Location"
+      manageTaxonomyText="Manage Locations"
+      anyTaxonomyURL="/locations/clear"
+      manageTaxonomyURL="/locations"
+    />
     {isLoading && (
       <NavItem id="vertical-spinner">
         <Spinner size="md" inverse loading />
@@ -60,10 +55,6 @@ TaxonomySwitcher.propTypes = {
   currentLocation: PropTypes.string,
   organizations: PropTypes.arrayOf(organizationPropType).isRequired,
   locations: PropTypes.arrayOf(locationPropType).isRequired,
-  taxonomiesBool: PropTypes.shape({
-    locations: PropTypes.bool.isRequired,
-    organizations: PropTypes.bool.isRequired,
-  }).isRequired,
 };
 TaxonomySwitcher.defaultProps = {
   isLoading: false,

--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher.test.js
@@ -4,7 +4,6 @@ import { layoutMock } from '../Layout.fixtures';
 
 const props = {
   organizations: layoutMock.data.orgs.available_organizations,
-  taxonomiesBool: layoutMock.data.taxonomies,
   locations: layoutMock.data.locations.available_locations,
   currentLocation: 'location',
   currentOrganization: 'organization',

--- a/webpack/assets/javascripts/react_app/components/Layout/index.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/index.js
@@ -41,20 +41,18 @@ const ConnectedLayout = ({ children, data }) => {
         items: combineMenuItems(data),
         activeMenu: getActiveMenuItem(data.menu).title,
         isCollapsed: getIsNavbarCollapsed(),
-        organization:
-          data.taxonomies.organizations && data.orgs.current_org
-            ? createInitialTaxonomy(
-                data.orgs.current_org,
-                data.orgs.available_organizations
-              )
-            : ANY_ORGANIZATION_TAXONOMY,
-        location:
-          data.taxonomies.locations && data.locations.current_location
-            ? createInitialTaxonomy(
-                data.locations.current_location,
-                data.locations.available_locations
-              )
-            : ANY_LOCATION_TAXONOMY,
+        organization: data.orgs.current_org
+          ? createInitialTaxonomy(
+              data.orgs.current_org,
+              data.orgs.available_organizations
+            )
+          : ANY_ORGANIZATION_TAXONOMY,
+        location: data.locations.current_location
+          ? createInitialTaxonomy(
+              data.locations.current_location,
+              data.locations.available_locations
+            )
+          : ANY_LOCATION_TAXONOMY,
       })
     );
   }, [data, dispatch]);


### PR DESCRIPTION
The taxonomy switcher in the top bar is only shown if the user has the permission `view_location/organization`. a user with more than one taxonomy should be able to change it even without the view permission.
