### PR TITLE
Fixes #30430 - fix split_matcher

### DIFF
--- a/app/services/classification/values_hash_query.rb
+++ b/app/services/classification/values_hash_query.rb
@@ -69,11 +69,11 @@ module Classification
         matcher_key = ''
         matcher_value = ''
 
-        lookup_value.match.split(LookupKey::KEY_DELM).each do |match_key|
-          element = match_key.split(LookupKey::EQ_DELM).first
-          matcher_key += element + ','
-          if LookupKey::MATCHERS_INHERITANCE.include?(element)
-            matcher_value = match_key.split(LookupKey::EQ_DELM).last
+        lookup_value.match.split(LookupKey::KEY_DELM).each do |match_keyval|
+          key, value = match_keyval.split(LookupKey::EQ_DELM)
+          matcher_key += key + ','
+          if LookupKey::MATCHERS_INHERITANCE.include?(key)
+            matcher_value += value + ','
           end
         end
 

--- a/test/unit/classification/values_hash_query_test.rb
+++ b/test/unit/classification/values_hash_query_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+module Classification
+  class ValuesHashQueryTest < ActiveSupport::TestCase
+    let(:lookup_key) { FactoryBot.create(:lookup_key, path: "compute_resource,hostgroup\nhostgroup\nfqdn") }
+
+    describe '#sort_lookup_values' do
+      it 'sort values according to a value length for members of MATCHERS_INHERITANCE' do
+        lookup_values = [stub(lookup_key: lookup_key, match: 'hostgroup=Common,organization=Org', value: 'a'),
+                         stub(lookup_key: lookup_key, match: 'hostgroup=Common/ChildGroup,organization=Org', value: 'b')]
+        lookup_values_cache = stub(select: lookup_values)
+        Classification::ValuesHashQuery.stubs(:lookup_values).returns(lookup_values_cache)
+        values = Classification::ValuesHashQuery.values_hash(mock('host'), [lookup_key])
+        assert_equal 'b', values[lookup_key]
+      end
+    end
+  end
+end


### PR DESCRIPTION
`sort_lookup_values` takes in count a `value` of the matcher as well, but we only return the last value from the split_matcher.
This can be an issue for more complex matchers, that have the same fallback, but differs in the value length.
See example in the test file.