### PR TITLE
Fixes #30431 - Grub2 IPv6 only subnet nil error

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -248,9 +248,9 @@ class Operatingsystem < ApplicationRecord
     architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
     if host.subnet&.httpboot?
       if host.pxe_loader =~ /UEFI HTTPS/
-        port = host.subnet.httpboot.httpboot_https_port
+        port = host.subnet.httpboot.httpboot_https_port!
       else
-        port = host.subnet.httpboot.httpboot_http_port
+        port = host.subnet.httpboot.httpboot_http_port!
       end
       hostname = URI.parse(host.subnet.httpboot.url).hostname
       self.class.all_loaders_map(architecture, "#{hostname}:#{port}")[host.pxe_loader]

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -101,11 +101,19 @@ class SmartProxy < ApplicationRecord
   end
 
   def httpboot_http_port
-    setting(:HTTPBoot, 'http_port') || raise(::Foreman::Exception.new(N_("HTTP boot requires proxy with httpboot feature and http_port exposed setting")))
+    setting(:HTTPBoot, 'http_port')
+  end
+
+  def httpboot_http_port!
+    httpboot_http_port || raise(::Foreman::Exception.new(N_("HTTP boot requires proxy with httpboot feature and http_port exposed setting")))
   end
 
   def httpboot_https_port
-    setting(:HTTPBoot, 'https_port') || raise(::Foreman::Exception.new(N_("HTTPS boot requires proxy with httpboot feature and https_port exposed setting")))
+    setting(:HTTPBoot, 'https_port')
+  end
+
+  def httpboot_https_port!
+    httpboot_https_port || raise(::Foreman::Exception.new(N_("HTTPS boot requires proxy with httpboot feature and https_port exposed setting")))
   end
 
   def statuses
@@ -180,6 +188,6 @@ class SmartProxy < ApplicationRecord
   end
 
   class Jail < ::Safemode::Jail
-    allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port
+    allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port, :httpboot_http_port!, :httpboot_https_port!
   end
 end

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -32,21 +32,31 @@ menuentry '<%= template_name %>' {
 
 <%
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1811561 and https://bugzilla.redhat.com/show_bug.cgi?id=1842893
-if @host.provision_interface.subnet.httpboot
-  proxy_http_port = @host.provision_interface.subnet.httpboot.httpboot_http_port
-  proxy_https_port = @host.provision_interface.subnet.httpboot.httpboot_https_port
+subnet = @host.provision_interface.subnet || @host.provision_interface.subnet6
+if subnet && subnet.httpboot
+  proxy_http_port = subnet.httpboot.httpboot_http_port
+  proxy_https_port = subnet.httpboot.httpboot_https_port
   # Workaround for "no DNS server configured" https://bugzilla.redhat.com/show_bug.cgi?id=1842509
-  proxy_host = dns_lookup(@host.provision_interface.subnet.httpboot.hostname)
+  proxy_host = dns_lookup(subnet.httpboot.hostname)
 -%>
+<% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
   <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
   <%= initrdcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
 }
+<% else -%>
+# Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
+<% end -%>
 
+<% if proxy_https_port -%>
 menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
   <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
   <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
 }
+<% else -%>
+# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
+<% end -%>
+
 <% end %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>


### PR DESCRIPTION
Subnet is set to nil in case of IPv6 only, thus undefined method
'#httpboot' for NilClass::Jail (NilClass) error. This solves it.

I need this in 2.1 as this is a blocker for IPv6 feature, do I do cherry
pick against Foreman core or community templates, @tbrisker? :-)