### PR TITLE
Fixes #30437 - add react context to pagination broken story

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Pagination/Context.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/Context.fixtures.js
@@ -1,0 +1,7 @@
+const contextFixtures = {
+  metadata: {
+    UISettings: { perPage: 5, perPageOptions: [5, 10, 15, 25, 50] },
+  },
+};
+
+export default contextFixtures;

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.fixtures.js
@@ -54,13 +54,13 @@ class MockPagination extends React.Component {
   render() {
     return (
       <div>
+        <ul>{this.state.items.map(renderItem)}</ul>
         <Pagination
           viewType="list"
           itemCount={mocks.length}
           pagination={this.state.pagination}
           onChange={changes => this.onPaginationChange(changes)}
         />
-        <ul>{this.state.items.map(renderItem)}</ul>
       </div>
     );
   }

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.stories.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.stories.js
@@ -1,9 +1,20 @@
 import React from 'react';
 import Story from '../../../../../stories/components/Story';
 import MockPagination from './PaginationWrapper.fixtures';
+import ContextFeatures from './Context.fixtures';
+import { getForemanContext } from '../../Root/Context/ForemanContext';
+
+const ForemanContext = getForemanContext();
 
 export default {
   title: 'Components|Pagination',
+  decorators: [
+    StoryFn => (
+      <ForemanContext.Provider value={ContextFeatures}>
+        <StoryFn />
+      </ForemanContext.Provider>
+    ),
+  ],
 };
 
 export const showPaginatedItems = () => (


### PR DESCRIPTION
Pagination uses the new react context features,
however, in the story file, there is no data in the context (no context object at all) which leads to rendering failure

