### PR TITLE
Fixes #10577 - Handle login csrf token expiry nicely

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
   include Foreman::Controller::Authorize
   include Foreman::Controller::RequireSsl
 
-  protect_from_forgery # See ActionController::RequestForgeryProtection for details
+  protect_from_forgery with: :exception # See ActionController::RequestForgeryProtection for details
   rescue_from Exception, :with => :generic_exception if Rails.env.production?
   rescue_from ScopedSearch::QueryNotSupported, :with => :invalid_search_query
   rescue_from ActiveRecord::RecordNotFound, :with => :not_found
@@ -392,13 +392,6 @@ class ApplicationController < ActionController::Base
 
     @organization ||= Organization.current
     @location     ||= Location.current
-  end
-
-  # Called from ActionController::RequestForgeryProtection, overrides
-  # nullify session which is the default behavior for unverified requests in Rails 3.
-  # On Rails 4 we can get rid of this and use the strategy ':exception'.
-  def handle_unverified_request
-    raise ::Foreman::Exception.new(N_("Invalid authenticity token"))
   end
 
   def parameter_filter_context

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -473,15 +473,15 @@ module ApplicationHelper
 
   def notifications
     content_tag :div, id: 'toast-notifications-container',
-                      'data-notifications': toast_notifiations_data.to_json.html_safe do
+                      'data-notifications': toast_notifications_data.to_json.html_safe do
       mount_react_component('ToastNotifications', '#toast-notifications-container')
     end
   end
 
-  def toast_notifiations_data
-    selected_toast_notifiations = flash.select { |key, _| key != 'inline' }
+  def toast_notifications_data
+    selected_toast_notifications = flash.select { |key, _| key != 'inline' }
 
-    selected_toast_notifiations.map do |type, notification|
+    selected_toast_notifications.map do |type, notification|
       notification.is_a?(Hash) ? notification : { :type => type, :message => notification }
     end
   end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -3,7 +3,7 @@ module LayoutHelper
     mount_react_component('ReactApp', "#react-app-root", {
       layout: layout_data,
       metadata: app_metadata,
-      toasts: toast_notifiations_data,
+      toasts: toast_notifications_data,
     }.to_json)
   end
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -479,7 +479,7 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     test "throws exception when CSRF token is invalid or not present" do
-      assert_raises Foreman::Exception do
+      assert_raises ActionController::InvalidAuthenticityToken do
         post :logout, session: set_session_user
       end
     end


### PR DESCRIPTION
To test- 
1. set session expiry in the settings to 1 minute 
2. open two tabs. wait for both tabs to expire and log you out.
3. log in with the first login page that was rendered (the second one will change the session and cause the first to expire). Alternatively, try logging in from both of them at the same time to see there isn't a redirect loop due to already being logged in.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
