### PR TITLE
Fixes transient mailer test failure

### DIFF
--- a/test/mailers/audit_mailer_test.rb
+++ b/test/mailers/audit_mailer_test.rb
@@ -56,7 +56,7 @@ class AuditMailerTest < ActionMailer::TestCase
   test "Audit template change should not crash" do
     template = FactoryBot.create(:provisioning_template, :template => 'aaaa', :snippet => true)
     template.update!(:template => 'bbbbbb')
-    audit = Audit.where(auditable_type: "ProvisioningTemplate", auditable_id: template.id).last
+    audit = template.reload.audits.last
     @options[:query] = "id = #{audit.id}"
     assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, 'Template content changed')
   end


### PR DESCRIPTION
try running tests with this change.
The audit search query probably happens bit before the audit is saved for some reason.
Then the test is failing on `audit.id` NoMethodError id for NilClass.