### PR TITLE
Fixes #30454 - identify `isFirstRequest` in API middleware 

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APIReducer.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIReducer.js
@@ -18,11 +18,13 @@ const apiReducer = (state = initialState, { type, key, payload, response }) => {
           ...state[key],
           payload,
           status: PENDING,
+          isFirstRequest: !state[key],
         },
       });
     case SUCCESS:
       return state.merge({
         [key]: {
+          ...state[key],
           payload,
           response,
           status: RESOLVED,
@@ -31,6 +33,7 @@ const apiReducer = (state = initialState, { type, key, payload, response }) => {
     case FAILURE:
       return state.merge({
         [key]: {
+          ...state[key],
           payload,
           response,
           status: ERROR,

--- a/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
@@ -22,3 +22,6 @@ export const selectAPIErrorMessage = (state, key) => {
   const error = selectAPIError(state, key);
   return error && error.message;
 };
+
+export const selectIsFirstRequest = (state, key) =>
+  selectAPIByKey(state, key).isFirstRequest;

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APISelectors.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APISelectors.test.js
@@ -7,6 +7,7 @@ import {
   selectAPIErrorMessage,
   selectAPIResponse,
   selectAPIPayload,
+  selectIsFirstRequest,
 } from '../APISelectors';
 import { key, payload, data, error } from '../APIFixtures';
 import { STATUS } from '../../../constants';
@@ -17,6 +18,7 @@ const successState = {
       payload,
       response: data,
       status: STATUS.RESOLVED,
+      isFirstRequest: true,
     },
   },
 };
@@ -41,6 +43,8 @@ const fixtures = {
     selectAPIResponse(successState, key),
   'should return the API substate payload': () =>
     selectAPIPayload(successState, key),
+  'should return the API substate isFirstRequest': () =>
+    selectIsFirstRequest(successState, key),
   'should return the API substate error': () =>
     selectAPIError(failureState, key),
   'should return the API substate error message': () =>

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIReducer.test.js.snap
@@ -15,6 +15,7 @@ Object {
 exports[`API reducer should handle API request action 1`] = `
 Object {
   "SOME_KEY": Object {
+    "isFirstRequest": true,
     "payload": Object {
       "id": 2,
     },

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APISelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APISelectors.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`API selectors should return the API substate by key 1`] = `
 Object {
+  "isFirstRequest": true,
   "payload": Object {
     "id": 2,
   },
@@ -17,6 +18,8 @@ Object {
 exports[`API selectors should return the API substate error 1`] = `[Error: some_error]`;
 
 exports[`API selectors should return the API substate error message 1`] = `"some_error"`;
+
+exports[`API selectors should return the API substate isFirstRequest 1`] = `true`;
 
 exports[`API selectors should return the API substate payload 1`] = `
 Object {
@@ -37,6 +40,7 @@ exports[`API selectors should return the API substate status 1`] = `"RESOLVED"`;
 exports[`API selectors should return the API wrapper 1`] = `
 Object {
   "SOME_KEY": Object {
+    "isFirstRequest": true,
     "payload": Object {
       "id": 2,
     },

--- a/webpack/stories/docs/api-middleware.stories.mdx
+++ b/webpack/stories/docs/api-middleware.stories.mdx
@@ -26,7 +26,7 @@ import { get, post, put, patch } from '../../redux/API';
 ```js
 import { get } from '../../redux/API';
 
-const someAction = (url) =>
+const someAction = url =>
   get({
     key: MY_SPECIAL_KEY, // this will be used later to identify your API call, so keep it unique.
     url,
@@ -94,7 +94,7 @@ it will manage the request statuses, errors and responses.
 ### Access the API store
 
 We provided you the `selectAPIByKey` in '/APISelectors.js' which will return the key substate,
-there are also `selectAPIStatus`, `selectAPIPayload`, `selectAPIResponse`, `selectAPIError` and `selectAPIErrorMessage`.
+there are also `selectAPIStatus`, `selectAPIPayload`, `selectAPIResponse`, `selectAPIError`, `selectAPIErrorMessage`, `selectIsFirstRequest`.
 
 ## Error handling
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
