### PR TITLE
Fixes #30441 - Global Registration Template API endpoint

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -133,7 +133,11 @@ module Api
 
       api :GET, '/provisioning_templates/global_registration', N_('Render Global Registration template')
       def global_registration
-        render plain: @provisioning_template.render.html_safe
+        if @provisioning_template
+          render plain: @provisioning_template.render.html_safe
+        else
+          render plain: _('Global Registration Template not found'), status: :not_found
+        end
       end
 
       private
@@ -159,16 +163,6 @@ module Api
             'view'
           else
             super
-        end
-      end
-
-      def find_global_registration
-        template_name = Setting['default_global_registration_item']
-        @provisioning_template = ProvisioningTemplate.find_by(name: template_name)
-
-        unless @provisioning_template
-          error = _('Template %s not found') % template_name
-          render plain: error, status: :not_found
         end
       end
     end

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -131,7 +131,7 @@ module Api
         send_data @provisioning_template.to_erb, :type => 'text/plain', :disposition => 'attachment', :filename => @provisioning_template.filename
       end
 
-      api :GET, '/provisioning_templates/global_registration', N_('Render Global Registration template')
+      api :GET, '/register', N_('Render Global Registration template')
       def global_registration
         if @provisioning_template
           render plain: @provisioning_template.render.html_safe

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -136,7 +136,7 @@ module Api
         if @provisioning_template
           render plain: @provisioning_template.render.html_safe
         else
-          render plain: _('Global Registration Template not found'), status: :not_found
+          render plain: _('Global Registration Template with name %s defined via default_global_registration_item Setting not found, please configure the existing template name first') % Setting[:default_global_registration_item], status: :not_found
         end
       end
 

--- a/app/controllers/concerns/foreman/controller/provisioning_templates.rb
+++ b/app/controllers/concerns/foreman/controller/provisioning_templates.rb
@@ -10,6 +10,11 @@ module Foreman::Controller::ProvisioningTemplates
     @operatingsystems = @template.operatingsystems if @template.respond_to?(:operatingsystems)
   end
 
+  def find_global_registration
+    template_name = Setting[:default_global_registration_item]
+    @provisioning_template = ProvisioningTemplate.find_by(name: template_name)
+  end
+
   private
 
   def default_template_url(template, hostgroup)

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -77,6 +77,7 @@ class Setting::Provisioning < Setting
         N_('Exclude pattern for facts stored in foreman')
       ),
       set('maximum_structured_facts', N_("Maximum amount of keys in structured subtree, statistics stored in foreman::dropped_subtree_facts"), 100, N_('Maximum structured facts')),
+      set('default_global_registration_item', N_("Global Registration template"), 'Global Registration', N_("Default Global registration template")),
     ] + default_global_templates + default_local_boot_templates
   end
 

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -132,7 +132,7 @@ Foreman::AccessControl.map do |permission_set|
                                         :"api/v2/template_combinations" => [:destroy],
                                       }
     map.permission :deploy_provisioning_templates,  {:provisioning_templates => [:build_pxe_default],
-                                        :"api/v2/provisioning_templates" => [:build_pxe_default, :global_registration],
+                                        :"api/v2/provisioning_templates" => [:build_pxe_default],
                                       }
 
     map.permission :lock_provisioning_templates,    {:provisioning_templates => [:lock, :unlock],
@@ -308,6 +308,7 @@ Foreman::AccessControl.map do |permission_set|
                                      :"api/v2/hosts" => [:create],
                                      :"api/v2/interfaces" => [:create],
                                      :"api/v2/tasks" => [:index],
+                                     :"api/v2/provisioning_templates" => [:global_registration],
                                   }
     map.permission :edit_hosts,    {:hosts => [:edit, :update, :multiple_actions, :reset_multiple, :submit_multiple_enable,
                                                :select_multiple_hostgroup, :select_multiple_environment, :submit_multiple_disable,

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -132,7 +132,7 @@ Foreman::AccessControl.map do |permission_set|
                                         :"api/v2/template_combinations" => [:destroy],
                                       }
     map.permission :deploy_provisioning_templates,  {:provisioning_templates => [:build_pxe_default],
-                                        :"api/v2/provisioning_templates" => [:build_pxe_default],
+                                        :"api/v2/provisioning_templates" => [:build_pxe_default, :global_registration],
                                       }
 
     map.permission :lock_provisioning_templates,    {:provisioning_templates => [:lock, :unlock],

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -1,0 +1,10 @@
+<%#
+kind: registration
+name: Global Registration
+model: ProvisioningTemplate
+-%>
+
+if (( $EUID != 0 )); then
+    echo "Please run as root"
+    exit 1
+fi

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -4,7 +4,7 @@ name: Global Registration
 model: ProvisioningTemplate
 -%>
 
-if (( $EUID != 0 )); then
+if ! [ $(id -u) = 0 ]; then
     echo "Please run as root"
     exit 1
 fi

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -586,6 +586,7 @@ Foreman::Application.routes.draw do
       end
     end
   end
+  get :register, to: 'api/v2/provisioning_templates#global_registration'
 
   if Rails.env.development? && defined?(::GraphiQL::Rails::Engine)
     mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/api/graphql'

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -50,7 +50,6 @@ Foreman::Application.routes.draw do
           post 'build_pxe_default'
           get 'revision'
           post :import
-          get :global_registration
         end
         resources :template_combinations, :only => [:index, :create, :update, :show]
         resources :operatingsystems, :except => [:new, :edit]

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -50,6 +50,7 @@ Foreman::Application.routes.draw do
           post 'build_pxe_default'
           get 'revision'
           post :import
+          get :global_registration
         end
         resources :template_combinations, :only => [:index, :create, :update, :show]
         resources :operatingsystems, :except => [:new, :edit]

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -193,7 +193,6 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
       Setting::Provisioning.any_instance.stubs(:value).returns('not-existing-template')
       get :global_registration
       assert_response :not_found
-      assert_equal @response.body, "Global Registration Template not found"
     end
 
     test "should render error when template is invalid" do

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -193,7 +193,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
       Setting::Provisioning.any_instance.stubs(:value).returns('not-existing-template')
       get :global_registration
       assert_response :not_found
-      assert_equal @response.body, "Template not-existing-template not found"
+      assert_equal @response.body, "Global Registration Template not found"
     end
 
     test "should render error when template is invalid" do

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -181,4 +181,25 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
     template_combination = TemplateCombination.find(template_combinations[0]['id'])
     assert_equal response['id'], template_combination.provisioning_template_id
   end
+
+  describe 'global registration template' do
+    test "should get template" do
+      get :global_registration
+      assert_response :success
+      assert_equal @response.body, templates(:global_registration).template
+    end
+
+    test "should render not_found" do
+      Setting::Provisioning.any_instance.stubs(:value).returns('not-existing-template')
+      get :global_registration
+      assert_response :not_found
+      assert_equal @response.body, "Template not-existing-template not found"
+    end
+
+    test "should render error when template is invalid" do
+      Foreman::Renderer::Source::Database.any_instance.stubs(:content).returns("<% asda =!?== '2 % %>")
+      get :global_registration
+      assert_response :internal_server_error
+    end
+  end
 end

--- a/test/controllers/foreman_register/hosts_controller_test.rb
+++ b/test/controllers/foreman_register/hosts_controller_test.rb
@@ -7,7 +7,7 @@ module ForemanRegister
     let(:organization) { FactoryBot.create(:organization) }
     let(:tax_location) { FactoryBot.create(:location) }
     let(:template_content) { 'template content <%= @host.name %>' }
-    let(:template_kind) { FactoryBot.create(:template_kind, name: 'registration') }
+    let(:template_kind) { template_kinds(:registration) }
     let(:registration_template) do
       FactoryBot.create(
         :provisioning_template,

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -423,3 +423,8 @@ attribute93:
   category: Setting::Puppet
   default: true
   description: "Foreman will update a host's hostgroup from its facts"
+attribute94:
+  name: default_global_registration_item
+  category: Setting::Provisioning
+  default: 'Global Registration'
+  description: "Default Global registration template"

--- a/test/fixtures/template_kinds.yml
+++ b/test/fixtures/template_kinds.yml
@@ -26,3 +26,7 @@ pxegrub:
 pxegrub2:
   name: PXEGrub2
   description: description for pxegrub2 template
+
+registration:
+  name: registration
+  description: description for registration template

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -172,3 +172,11 @@ autopart:
   operatingsystems: centos5_3
   locked: true
   type: Ptable
+
+global_registration:
+  name: Global Registration
+  template: 'echo "Default Global registration template"'
+  template_kind: registration
+  operatingsystems: redhat
+  locked: true
+  type: ProvisioningTemplate


### PR DESCRIPTION
PR is part of **Simple & automatic host registration WF**, see:
* [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588)
* [Redmine (Parent task)](https://projects.theforeman.org/issues/30440)
* [Redmine (PR)](https://projects.theforeman.org/issues/30441)

**Features:**
* Global registration template
* New API endpoint `/provisioning_templates/global_registration`
* New Settings::Provisioning _Default Global registration template_ 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
