### PR TITLE
Fixes #30466 - trigger toasts from API middleware

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/integration.test.js.snap
@@ -46,6 +46,7 @@ Array [
     Object {
       "payload": Object {
         "actionTypes": undefined,
+        "errorToast": [Function],
         "handleError": [Function],
         "handleSuccess": [Function],
         "headers": undefined,
@@ -56,6 +57,7 @@ Array [
           "public": false,
           "query": "name ~ my",
         },
+        "successToast": [Function],
         "url": "/api/v2/hosts",
       },
       "type": "API_POST",
@@ -79,6 +81,19 @@ Array [
   Array [
     Object {
       "payload": Object {
+        "key": "BOOKMARKS_FORM_SUBMITTED_SUCCESS",
+        "message": Object {
+          "key": "BOOKMARKS_FORM_SUBMITTED_SUCCESS",
+          "message": "Bookmark was successfully created.",
+          "type": "success",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
         "data": Object {
           "controller": "hosts",
           "name": "Joe.D",
@@ -88,19 +103,6 @@ Array [
         "item": "Bookmarks",
       },
       "type": "BOOKMARKS_FORM_SUBMITTED",
-    },
-  ],
-  Array [
-    Object {
-      "payload": Object {
-        "key": "1547e1c0-309a-11e9-98f5-5f761412a4c2",
-        "message": Object {
-          "key": "1547e1c0-309a-11e9-98f5-5f761412a4c2",
-          "message": "Bookmark was successfully created.",
-          "type": "success",
-        },
-      },
-      "type": "TOASTS_ADD",
     },
   ],
 ]

--- a/webpack/assets/javascripts/react_app/redux/API/APIActions.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIActions.js
@@ -10,8 +10,10 @@ const { GET, POST, PUT, DELETE, PATCH } = API_OPERATIONS;
  * @param { String } payload.url the url for the API request.
  * @param { String } payload.headers the API get request headers.
  * @param { Object } payload.params the API get request params.
- * @param { Object } payload.handleError an error handling callback.
- * @param { Object } payload.handleSuccess a success handling callback.
+ * @param { Function } payload.handleError an error handling callback.
+ * @param { Function } payload.handleSuccess a success handling callback.
+ * @param { Function } payload.errorToast an error toast will be triggered with this message after API error.
+ * @param { Function } payload.successToast a succes toast will be triggered with this message after API success.
  * @param { Object } payload.payload the API payload which will be passed also to the reducer.
  * @param { Object } payload.actionTypes action types which will replace the default action types.
  */

--- a/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
@@ -3,6 +3,7 @@ import { actionTypeGenerator } from './APIActionTypeGenerator';
 import { noop } from '../../common/helpers';
 import { stopInterval } from '../middlewares/IntervalMiddleware';
 import { selectDoesIntervalExist } from '../middlewares/IntervalMiddleware/IntervalSelectors';
+import { addToast } from '../actions/toasts';
 
 export const apiRequest = async (
   {
@@ -15,6 +16,8 @@ export const apiRequest = async (
       actionTypes = {},
       handleError = noop,
       handleSuccess = noop,
+      successToast,
+      errorToast,
       payload = {},
     },
   },
@@ -22,19 +25,32 @@ export const apiRequest = async (
 ) => {
   const { REQUEST, SUCCESS, FAILURE } = actionTypeGenerator(key, actionTypes);
   const modifiedPayload = { ...payload, url };
+
   dispatch({
     type: REQUEST,
     key,
     payload: modifiedPayload,
   });
+
   try {
     const response = await getApiResponse({ type, url, headers, params });
+
     dispatch({
       type: SUCCESS,
       key,
       payload: modifiedPayload,
       response: response.data,
     });
+
+    successToast &&
+      dispatch(
+        addToast({
+          type: 'success',
+          message: successToast(response),
+          key: SUCCESS,
+        })
+      );
+
     handleSuccess(response);
   } catch (error) {
     dispatch({
@@ -43,6 +59,12 @@ export const apiRequest = async (
       payload: modifiedPayload,
       response: error,
     });
+
+    errorToast &&
+      dispatch(
+        addToast({ type: 'error', message: errorToast(error), key: FAILURE })
+      );
+
     const stopIntervalCallback = selectDoesIntervalExist(getState(), key)
       ? () => dispatch(stopInterval(key))
       : noop;

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APIRequest.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APIRequest.test.js
@@ -64,4 +64,45 @@ describe('API get', () => {
     expect(modifiedAction.payload.handleError.mock.calls).toMatchSnapshot();
     expect(store.dispatch.mock.calls).toMatchSnapshot();
   });
+
+  it('should dispatch a success toast notification on API resolve', async () => {
+    const apiSuccessResponse = { data };
+    API.get.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          resolve(apiSuccessResponse);
+        })
+    );
+    const modifiedAction = { ...action };
+    modifiedAction.payload.successToast = jest.fn(
+      () => 'Your API request was successful!'
+    );
+    apiRequest(modifiedAction, store);
+    await IntegrationTestHelper.flushAllPromises();
+    expect(modifiedAction.payload.successToast).toHaveBeenLastCalledWith(
+      apiSuccessResponse
+    );
+    expect(store.dispatch.mock.calls).toMatchSnapshot();
+  });
+
+  it('should dispatch an error toast notification on API failure', async () => {
+    const apiError = new Error('bad request');
+    API.get.mockImplementation(
+      () =>
+        new Promise((resolve, reject) => {
+          reject(apiError);
+        })
+    );
+    const modifiedAction = { ...action };
+    modifiedAction.payload.errorToast = jest.fn(
+      error =>
+        `Oh no! Something went wrong, server returned the error: ${error.message}`
+    );
+    apiRequest(modifiedAction, store);
+    await IntegrationTestHelper.flushAllPromises();
+    expect(modifiedAction.payload.errorToast).toHaveBeenLastCalledWith(
+      apiError
+    );
+    expect(store.dispatch.mock.calls).toMatchSnapshot();
+  });
 });

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -1,5 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`API get should dispatch a success toast notification on API resolve 1`] = `
+Array [
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "type": "SOME_KEY_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "response": Object {
+        "results": Array [
+          1,
+        ],
+      },
+      "type": "SOME_KEY_SUCCESS",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "key": "SOME_KEY_SUCCESS",
+        "message": Object {
+          "key": "SOME_KEY_SUCCESS",
+          "message": "Your API request was successful!",
+          "type": "success",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
+exports[`API get should dispatch an error toast notification on API failure 1`] = `
+Array [
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "type": "SOME_KEY_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "response": [Error: bad request],
+      "type": "SOME_KEY_FAILURE",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "key": "SOME_KEY_FAILURE",
+        "message": Object {
+          "key": "SOME_KEY_FAILURE",
+          "message": "Oh no! Something went wrong, server returned the error: bad request",
+          "type": "error",
+        },
+      },
+      "type": "TOASTS_ADD",
+    },
+  ],
+]
+`;
+
 exports[`API get should dispatch request and failure actions on reject 1`] = `
 Array [
   Array [

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -1,6 +1,4 @@
 import { APIActions } from '../../API';
-
-import { addToast } from '../toasts';
 import { sprintf, translate as __ } from '../../../../react_app/common/I18n';
 
 export class SubmissionError {
@@ -67,14 +65,16 @@ export const submitForm = ({
         type: uniqueAPIKey,
         payload: { item, data },
       });
-      dispatch(
-        addToast({
-          type: 'success',
-          // eslint-disable-next-line no-undef
-          message: message || sprintf('%s was successfully created.', __(item)),
-        })
-      );
     };
+
+    const successToast = response =>
+      message || sprintf('%s was successfully created.', __(item));
+
+    const errorToast = error =>
+      sprintf(
+        'Oh no! Something went wrong while submiting the form, the server returned the following error: %s',
+        error
+      );
 
     dispatch(
       APIActions[method]({
@@ -85,6 +85,8 @@ export const submitForm = ({
         actionTypes,
         handleError,
         handleSuccess,
+        successToast,
+        errorToast,
       })
     );
   };

--- a/webpack/assets/javascripts/react_app/redux/actions/toasts/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/toasts/index.js
@@ -3,7 +3,7 @@ import uuidV1 from 'uuid/v1';
 import { TOASTS_ADD, TOASTS_DELETE, TOASTS_CLEAR } from '../../consts';
 
 export const addToast = toast => {
-  const key = uuidV1();
+  const key = toast.key || uuidV1();
 
   return {
     type: TOASTS_ADD,

--- a/webpack/stories/docs/api-middleware.stories.mdx
+++ b/webpack/stories/docs/api-middleware.stories.mdx
@@ -26,7 +26,7 @@ import { get, post, put, patch } from '../../redux/API';
 ```js
 import { get } from '../../redux/API';
 
-const someAction = (url) =>
+const someAction = url =>
   get({
     key: MY_SPECIAL_KEY, // this will be used later to identify your API call, so keep it unique.
     url,
@@ -131,3 +131,19 @@ dispatch(
 ```
 
 The success handling function will receive the response object from the API request.
+
+## Toast handling
+
+Instead of managing and dispatching the toast action by yourself, you can use the API middleware shortcuts,
+by passing `toastSuccess` or `toastError` as keys in the API action, e.g:
+
+```js
+dispatch(
+  get({
+    key: MY_SPECIAL_KEY,
+    url,
+    toastError: error => `Oh no! Something went wrong while submiting the form, the server returned the following error: ${error}`
+    toastSuccess: response => `Yay! task: ${response.taskID} was successfully created.`
+  })
+);
+```


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
## Toast handling

Instead of managing and dispatching the toast action by yourself, you can use the API middleware shortcuts,
by passing `toastSuccess` or `toastError` as keys in the API action, e.g:

```js
dispatch(
  get({
    key: MY_SPECIAL_KEY,
    url,
    toastError: error => `Oh no! Something went wrong while submiting the form, the server returned the following error: ${error}`,
    toastSuccess: response => `Yay! task: ${response.taskID} was successfully created.`
  })
);
```

![c7c586875109ec38f103e3fc9985c0b2](https://user-images.githubusercontent.com/26363699/88090852-da867800-cb96-11ea-9b6b-0df4947e25cb.png)
