### PR TITLE
Refs #29992 - pass stopInterval as callback also on API success

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { getApiResponse } from './APIHelpers';
 import { actionTypeGenerator } from './APIActionTypeGenerator';
 import { noop } from '../../common/helpers';
@@ -25,6 +26,9 @@ export const apiRequest = async (
 ) => {
   const { REQUEST, SUCCESS, FAILURE } = actionTypeGenerator(key, actionTypes);
   const modifiedPayload = { ...payload, url };
+  const stopIntervalCallback = selectDoesIntervalExist(getState(), key)
+    ? () => dispatch(stopInterval(key))
+    : () => console.warn(`There's no interval API request for the key: ${key}`);
 
   dispatch({
     type: REQUEST,
@@ -51,7 +55,7 @@ export const apiRequest = async (
         })
       );
 
-    handleSuccess(response);
+    handleSuccess(response, stopIntervalCallback);
   } catch (error) {
     dispatch({
       type: FAILURE,
@@ -65,9 +69,6 @@ export const apiRequest = async (
         addToast({ type: 'error', message: errorToast(error), key: FAILURE })
       );
 
-    const stopIntervalCallback = selectDoesIntervalExist(getState(), key)
-      ? () => dispatch(stopInterval(key))
-      : noop;
     handleError(error, stopIntervalCallback);
   }
 };

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APIRequest.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APIRequest.test.js
@@ -27,9 +27,7 @@ describe('API get', () => {
     modifiedAction.payload.handleSuccess = jest.fn();
     apiRequest(modifiedAction, store);
     await IntegrationTestHelper.flushAllPromises();
-    expect(modifiedAction.payload.handleSuccess).toHaveBeenLastCalledWith(
-      apiSuccessResponse
-    );
+    expect(modifiedAction.payload.handleSuccess.mock.calls).toMatchSnapshot();
     expect(store.dispatch.mock.calls).toMatchSnapshot();
   });
 

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -121,6 +121,21 @@ exports[`API get should dispatch request and success actions on resolve 1`] = `
 Array [
   Array [
     Object {
+      "data": Object {
+        "results": Array [
+          1,
+        ],
+      },
+    },
+    [Function],
+  ],
+]
+`;
+
+exports[`API get should dispatch request and success actions on resolve 2`] = `
+Array [
+  Array [
+    Object {
       "key": "SOME_KEY",
       "payload": Object {
         "id": 2,

--- a/webpack/stories/docs/api-middleware.stories.mdx
+++ b/webpack/stories/docs/api-middleware.stories.mdx
@@ -132,6 +132,9 @@ dispatch(
 
 The success handling function will receive the response object from the API request.
 
+In case you are also using the interval middleware with the same `KEY`,
+the `stopInterval` for your key will be passed as the second param in your `handleSuccess`/ `handleError` callbacks.
+
 ## Toast handling
 
 Instead of managing and dispatching the toast action by yourself, you can use the API middleware shortcuts,

--- a/webpack/stories/docs/interval-middleware.stories.mdx
+++ b/webpack/stories/docs/interval-middleware.stories.mdx
@@ -43,7 +43,10 @@ const sendMail = () => ({
 
 There are several ways to stop the interval:
 
-We will need to use the `stopInterval` Action from IntervalMiddlware.
+In case you are using the API middleware actions,
+the `stopInterval` for your `key` will be passed as the second param in your `handleSuccess`/ `handleError` callbacks.
+
+Another option is to use the `stopInterval` Action from IntervalMiddlware directly.
 `stopInterval` is defined in `webpack/assets/javascripts/react_app/redux/middlewares/IntervalMiddleware`
 or `foremanReact/redux/middlewares/IntervalMiddleware` for plugins
 


### PR DESCRIPTION
There are many scenarios where we would like to stop the API interval after receiving some information from the server,
in order to do it easily, the `stopInterval` for the specific key would be passed as a second param in the `handleSuccess` callback.

```js
dispatch(
  get({
    key: MY_SPECIAL_KEY,
    url,
    handleSuccess: (response, stopInterval) => {
       if (response.taskFinished) stopInterval()
    }
  })
);
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
