### PR TITLE
Switch autoloader to zeitwerk

### DIFF
--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -1,5 +1,5 @@
 module HostDescriptionHelper
-  UI.register_host_description do
+  ::UI.register_host_description do
     multiple_actions_provider :base_multiple_actions
     overview_fields_provider :base_status_overview_fields
     overview_fields_provider :base_host_overview_fields

--- a/app/models/concerns/foreman/sti.rb
+++ b/app/models/concerns/foreman/sti.rb
@@ -2,6 +2,7 @@ module Foreman
   module STI
     def self.prepended(base)
       class << base
+        cattr_accessor :preloaded, instance_accessor: false
         prepend ClassMethods
       end
     end
@@ -26,6 +27,34 @@ module Foreman
       super
     ensure
       self.class.instance_variable_set("@finder_needs_type_condition", :true) if type_changed
+    end
+
+    def descendants
+      preload_sti unless preloaded
+      super
+    end
+
+    # Constantizes all types present in the database. There might be more on
+    # disk, but that does not matter in practice as far as the STI API is
+    # concerned.
+    #
+    # Assumes store_full_sti_class is true, the default.
+    def preload_sti
+      puts "#{self}: #{base_class.connected?} #{base_class.table_exists?}"
+      return [] unless base_class.connected? && base_class.table_exists?
+      types_in_db = base_class
+                        .unscoped
+                        .select(inheritance_column)
+                        .distinct
+                        .pluck(inheritance_column)
+                        .compact
+
+      types_in_db.each do |type|
+        logger.debug("Preloading STI type #{type}")
+        type.constantize
+      end
+
+      self.preloaded = true
     end
   end
 end

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -102,3 +102,5 @@ module NestedAncestryCommon
     lookup_values.update_all(:match => "#{obj_type}=#{title}")
   end
 end
+
+require_dependency 'nested_ancestry_common/search'

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -54,7 +54,7 @@ class Taxonomy < ApplicationRecord
       end
       child.const_set('Jail', jail_class)
     end
-    child.send(:include, NestedAncestryCommon::Search)
+    child.send(:include, ::NestedAncestryCommon::Search)
     super
   end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -80,6 +80,7 @@ require_dependency File.expand_path('../lib/foreman/middleware/catch_json_parse_
 require_dependency File.expand_path('../lib/foreman/middleware/logging_context_request', __dir__)
 require_dependency File.expand_path('../lib/foreman/middleware/logging_context_session', __dir__)
 require_dependency File.expand_path('../lib/foreman/middleware/telemetry', __dir__)
+require_dependency File.expand_path('../app/services/facets.rb', __dir__)
 
 if SETTINGS[:support_jsonp]
   if File.exist?(File.expand_path('../Gemfile.in', __dir__))
@@ -107,13 +108,14 @@ module Foreman
     config.autoload_paths += Dir[Rails.root.join('app', 'models', 'power_manager')]
     config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/services"]
+
     config.autoload_paths += Dir["#{config.root}/app/mailers"]
 
     config.autoload_paths += %W(#{config.root}/app/models/auth_sources)
     config.autoload_paths += %W(#{config.root}/app/models/compute_resources)
     config.autoload_paths += %W(#{config.root}/app/models/fact_names)
     config.autoload_paths += %W(#{config.root}/app/models/lookup_keys)
-    config.autoload_paths += %W(#{config.root}/app/models/host_status)
+    # config.autoload_paths += %W(#{config.root}/app/models/host_status)
     config.autoload_paths += %W(#{config.root}/app/models/operatingsystems)
     config.autoload_paths += %W(#{config.root}/app/models/parameters)
     config.autoload_paths += %W(#{config.root}/app/models/taxonomies)
@@ -168,6 +170,9 @@ module Foreman
 
     # enables JSONP support in the Rack middleware
     config.middleware.use Rack::JSONP if SETTINGS[:support_jsonp]
+
+    config.load_defaults "6.0"
+    config.autoloader = :zeitwerk
 
     # Enable Rack OpenID middleware
     begin
@@ -292,7 +297,7 @@ module Foreman
         child.helper helpers
       end
 
-      Facets.register(HostFacets::ReportedDataFacet, :reported_data) do
+      ::Facets.register(HostFacets::ReportedDataFacet, :reported_data) do
         set_dependent_action :destroy
         template_compatibility_properties :cores, :virtual, :sockets, :ram, :uptime_seconds
       end

--- a/config/initializers/zeitwerk.rb
+++ b/config/initializers/zeitwerk.rb
@@ -1,0 +1,17 @@
+Rails.autoloaders.each do |autoloader|
+  autoloader.inflector = Zeitwerk::Inflector.new
+  autoloader.inflector.inflect(
+    'ui' => 'UI',
+    'proxy_api' => 'ProxyAPI',
+    'sti' => 'STI',
+    'dhcp' => 'DHCP',
+    'dns' => 'DNS',
+    'tftp' => 'TFTP',
+    'external_ipam' => 'ExternalIPAM',
+    'bmc' => 'BMC',
+    'ui_notifications' => 'UINotifications',
+    'ssh_provision' => 'SSHProvision',
+    'ipam' => 'IPAM'
+  )
+end
+Rails.autoloaders.log!

--- a/db/migrate/20140902102858_convert_ipam_to_string.rb
+++ b/db/migrate/20140902102858_convert_ipam_to_string.rb
@@ -4,13 +4,13 @@ class ConvertIpamToString < ActiveRecord::Migration[4.2]
   end
 
   def up
-    add_column :subnets, :ipam_tmp, :string, :default => IPAM::MODES[:dhcp], :null => false, :limit => 255
+    add_column :subnets, :ipam_tmp, :string, :default => ::IPAM::MODES[:dhcp], :null => false, :limit => 255
     FakeSubnet.reset_column_information
     FakeSubnet.all.each do |subnet|
       if subnet.ipam
-        subnet.ipam_tmp = IPAM::MODES[:dhcp]
+        subnet.ipam_tmp = ::IPAM::MODES[:dhcp]
       else
-        subnet.ipam_tmp = IPAM::MODES[:none]
+        subnet.ipam_tmp = ::IPAM::MODES[:none]
       end
       subnet.save!
     end
@@ -22,7 +22,7 @@ class ConvertIpamToString < ActiveRecord::Migration[4.2]
     add_column :subnets, :ipam_tmp, :boolean, :default => true, :null => false
     FakeSubnet.reset_column_information
     FakeSubnet.all.each do |subnet|
-      subnet.ipam_tmp = subnet.ipam != IPAM::MODES[:none]
+      subnet.ipam_tmp = subnet.ipam != ::IPAM::MODES[:none]
       subnet.save!
     end
     remove_column :subnets, :ipam


### PR DESCRIPTION
I had to patch zeitwerk with https://gist.github.com/adamruzicka/066e3f484648c5d5d36d0955fd96ca9a to make db:{create,migrate} pass. Not ideal, but I haven't found where it comes from.

TODOs:
- [x] rake db:create
- [x] rake db:migrate
- [ ] rake db:seed
- [ ] rake test
- [ ] rails server

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
