### PR TITLE
Fixes #30244 - prevent Filter empty search_condition

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -50,7 +50,7 @@ class Filter < ApplicationRecord
   scoped_search :relation => :permissions, :on => :name,          :rename => :permission
 
   before_validation :build_taxonomy_search, :nilify_empty_searches, :enforce_override_flag
-  before_save :enforce_inherited_taxonomies
+  before_save :enforce_inherited_taxonomies, :nilify_empty_searches
 
   validates :search, :presence => true, :unless => proc { |o| o.search.nil? }
   validates_with ScopedSearchValidator

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -104,8 +104,7 @@ class Authorizer
   def build_scoped_search_condition(filters)
     raise ArgumentError if filters.blank?
 
-    strings = filters.map { |f| "(#{f.search_condition.presence || '1=1'})" }
-    strings.join(' OR ')
+    filters.select { |f| f.search_condition.present? }.map { |f| "(#{f.search_condition})" }.join(' OR ')
   end
 
   private

--- a/db/migrate/20200709160133_set_empty_filter_taxonomy_search_nil.rb
+++ b/db/migrate/20200709160133_set_empty_filter_taxonomy_search_nil.rb
@@ -1,0 +1,5 @@
+class SetEmptyFilterTaxonomySearchNil < ActiveRecord::Migration[6.0]
+  def change
+    Filter.where(taxonomy_search: '').update_all(taxonomy_search: nil)
+  end
+end

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -241,4 +241,11 @@ class FilterTest < ActiveSupport::TestCase
     f.enforce_inherited_taxonomies
     assert_equal "(organization_id ^ (#{f.organizations.first.id}))", f.taxonomy_search
   end
+
+  test 'saving nilifies empty taxonomy search' do
+    f = FactoryBot.build(:filter, :resource_type => 'Domain')
+    f.role = FactoryBot.build(:role, :organizations => [FactoryBot.build(:organization)])
+    f.save
+    assert_nil f.taxonomy_search
+  end
 end

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -255,7 +255,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     filters = [FactoryBot.build_stubbed(:filter)]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '(1=1)', result
+    assert_equal '', result
   end
 
   test "#build_scoped_search_condition(filters) for limited and unlimited filter" do
@@ -263,7 +263,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     filters = [FactoryBot.build_stubbed(:filter, :on_name_all), FactoryBot.build_stubbed(:filter)]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '(name ~ *) OR (1=1)', result
+    assert_equal '(name ~ *)', result
   end
 
   test "#build_scoped_search_condition(filters) for empty filter" do
@@ -271,7 +271,7 @@ class AuthorizerTest < ActiveSupport::TestCase
     filters = [FactoryBot.build_stubbed(:filter, :search => '')]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '(1=1)', result
+    assert_equal '', result
   end
 
   test "#find_collection(Host, :permission => :view_hosts) with scoped_search join returns r/w resources" do


### PR DESCRIPTION
Backporting #7787 (Thanks @jturel)
when inherited taxonomy search is empty, it would save search_condition as empty string instead of `nil`, we need to nilify in such case.

(cherry picked from commit 447e3b55a13e5bb6b1c0f57997893a1691b524d1)
