### PR TITLE
Fixes #30319 - Taxonomy scope for AuthSources#index

### DIFF
--- a/app/controllers/auth_sources_controller.rb
+++ b/app/controllers/auth_sources_controller.rb
@@ -2,10 +2,14 @@ class AuthSourcesController < ApplicationController
   def index
     @auth_sources = AuthSource.except_hidden
     @users = User.except_hidden.includes(:auth_source)
-    @auth_source_ldaps = resource_base_search_and_page.only_ldap
+    @auth_source_ldaps = resource_base_search_and_page
   end
 
   private
+
+  def model_of_controller
+    @model_of_controller ||= AuthSourceLdap
+  end
 
   def controller_permission
     'authenticators'


### PR DESCRIPTION
`AuthSource.only_ldaps` is not using taxonomy scope, so all the auth sources are visible on the index page, but edit is already a `AuthSourceLdap`, that has taxonomy scope as `default_scope`, so I can't edit records, that I can see on the index page.