### PR TITLE
Added arm64 support to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+  - amd64
+  - arm64
 node_js:
   - '10'
   - '12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: node_js
-arch:
-  - amd64
-  - arm64
 node_js:
   - '10'
   - '12'


### PR DESCRIPTION
Added 'arch: arm64' to .travis.yml file.

Signed-off-by: odidev odidev@puresoftware.com