### PR TITLE
Fixes #30442 - Global registration template params & host registration

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -132,9 +132,12 @@ module Api
       end
 
       api :GET, '/register', N_('Render Global Registration template')
+      param :organization_id, :number, desc: N_("ID of the Organization to register the host in.")
+      param :location_id, :number, desc: N_("ID of the Location to register the host in.")
+      param :hostgroup_id, :number, desc: N_("ID of the Host group to register the host in.")
       def global_registration
         if @provisioning_template
-          render plain: @provisioning_template.render.html_safe
+          render plain: @provisioning_template.render(variables: @global_registration_vars).html_safe
         else
           render plain: _('Global Registration Template with name %s defined via default_global_registration_item Setting not found, please configure the existing template name first') % Setting[:default_global_registration_item], status: :not_found
         end

--- a/app/controllers/concerns/foreman/controller/provisioning_templates.rb
+++ b/app/controllers/concerns/foreman/controller/provisioning_templates.rb
@@ -12,7 +12,8 @@ module Foreman::Controller::ProvisioningTemplates
 
   def find_global_registration
     template_name = Setting[:default_global_registration_item]
-    @provisioning_template = ProvisioningTemplate.find_by(name: template_name)
+    @provisioning_template = ProvisioningTemplate.unscoped.find_by(name: template_name)
+    @global_registration_vars = global_registration_vars if @provisioning_template
   end
 
   private
@@ -41,5 +42,23 @@ module Foreman::Controller::ProvisioningTemplates
 
   def type_name_singular
     @type_name_singular ||= resource_class.to_s.underscore
+  end
+
+  def global_registration_vars
+    permitted = Foreman::Plugin.all
+                               .map(&:allowed_registration_vars)
+                               .flatten.compact.uniq
+
+    organization = Organization.authorized(:view_organizations).find(params['organization_id']) if params['organization_id'].present?
+    location = Location.authorized(:view_locations).find(params['location_id']) if params['location_id'].present?
+    host_group = Hostgroup.authorized(:view_hostgroups).find(params['hostgroup_id']) if params["hostgroup_id"].present?
+
+    {
+      user: User.current,
+      auth_token: User.current.jwt_token!(expiration: 4.hours.to_i),
+      organization: organization,
+      location: location,
+      hostgroup: host_group,
+    }.merge(params.permit(permitted).to_h.symbolize_keys)
   end
 end

--- a/app/models/concerns/jwt_auth.rb
+++ b/app/models/concerns/jwt_auth.rb
@@ -8,9 +8,9 @@ module JwtAuth
       jwt_secret || create_jwt_secret!
     end
 
-    def jwt_token!
+    def jwt_token!(expiration: nil)
       jwt_secret = jwt_secret!
-      JwtToken.encode(self, jwt_secret.token).to_s
+      JwtToken.encode(self, jwt_secret.token, expiration).to_s
     end
   end
 end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -130,7 +130,8 @@ module Foreman #:nodoc:
     def_field :name, :description, :url, :author, :author_url, :version, :path
     attr_reader :id, :logging, :provision_methods, :compute_resources, :to_prepare_callbacks,
       :facets, :rbac_registry, :dashboard_widgets, :info_providers, :smart_proxy_references,
-      :renderer_variable_loaders, :host_ui_description, :ping_extension, :status_extension
+      :renderer_variable_loaders, :host_ui_description, :ping_extension, :status_extension,
+      :allowed_registration_vars
 
     # Lists plugin's roles:
     # Foreman::Plugin.find('my_plugin').registered_roles
@@ -155,6 +156,7 @@ module Foreman #:nodoc:
       @renderer_variable_loaders = []
       @ping_extension = nil
       @status_extension = nil
+      @allowed_registration_vars = []
     end
 
     def engine
@@ -565,6 +567,10 @@ module Foreman #:nodoc:
 
     def describe_host(&block)
       @host_ui_description = UI.describe_host(&block)
+    end
+
+    def extend_allowed_registration_vars(var)
+      @allowed_registration_vars << var
     end
 
     delegate :subscribe, to: ActiveSupport::Notifications

--- a/app/services/jwt_token.rb
+++ b/app/services/jwt_token.rb
@@ -3,17 +3,24 @@ require 'base64'
 
 class JwtToken < Struct.new(:token)
   class << self
-    def encode(user, secret)
-      payload = prepare_payload(user, secret)
+    def encode(user, secret, expiration = nil)
+      payload = prepare_payload(user, secret, expiration)
       new JWT.encode(payload, secret)
     end
 
     private
 
-    def prepare_payload(user, secret)
+    def prepare_payload(user, secret, expiration)
       jti_raw = [secret, iat].join(':')
       jti = Digest::SHA256.hexdigest(jti_raw)
-      { user_id: user.id, iat: iat, jti: jti }
+      payload = {
+        user_id: user.id,
+        iat: iat,
+        jti: jti,
+      }
+
+      payload[:exp] = (Time.now.to_i + expiration) if expiration
+      payload
     end
 
     def iat

--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -12,6 +12,9 @@ module SSO
       user = User.unscoped.except_hidden.find_by(id: user_id) if user_id
       @current_user = user
       user&.login
+    rescue JWT::ExpiredSignature
+      Rails.logger.error "JWT SSO: Expired JWT token."
+      nil
     rescue JWT::DecodeError
       Rails.logger.error "JWT SSO: Failed to decode JWT."
       nil

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -3,8 +3,54 @@ kind: registration
 name: Global Registration
 model: ProvisioningTemplate
 -%>
+#!/bin/sh
+<%
+    headers = ["-H 'Content-Type: application/json'", "-H 'Accept: application/json'", "-H 'Authorization: Bearer #{@auth_token}'"]
+-%>
+
+# Rendered with following template parameters:
+<%= "# User: [#{@user.login}]" -%>
+<%= ", Organization: [#{@organization.name}]" if @organization -%>
+<%= ", Location: [#{@location.name}]" if @location -%>
+<%= ", Hostgroup: [#{@hostgroup.name}]" if @hostgroup -%>
+
 
 if ! [ $(id -u) = 0 ]; then
     echo "Please run as root"
     exit 1
 fi
+
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+create_host_curl() {
+  curl --request POST <%= foreman_server_url %>/api/hosts \
+       <%= headers.join(' ') %> \
+       -d '{ "host": { "name": "'$(hostname --fqdn)'", "build": "false", "managed": "false"
+       <%= ", \"organization_id\": \"#{@organization.id}\"" if @organization -%>
+       <%= ", \"location_id\": \"#{@location.id}\"" if @location -%>
+       <%= ", \"hostgroup_id\": \"#{@hostgroup.id}\"" if @hostgroup -%>
+       }}'
+}
+
+echo "#"
+echo "# Running registration"
+echo "#"
+
+<% if plugin_present?('katello') -%>
+if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
+    CONSUMER_RPM=$(mktemp --suffix .rpm)
+
+    curl --insecure --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
+    yum localinstall $CONSUMER_RPM -y
+    yum install subscription-manager -y
+    subscription-manager register --org=<%= @organization.label %> --activationkey="sample-key"
+
+    rm -f $CONSUMER_RPM
+else
+    create_host_curl
+fi
+<% else -%>
+create_host_curl
+<% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -583,6 +583,7 @@ Foreman::Application.routes.draw do
       end
     end
   end
+
   get :register, to: 'api/v2/provisioning_templates#global_registration'
 
   if Rails.env.development? && defined?(::GraphiQL::Rails::Engine)

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -200,5 +200,50 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
       get :global_registration
       assert_response :internal_server_error
     end
+
+    test "should pass permitted params to template" do
+      params = {
+        organization_id: taxonomies(:organization1).id,
+        location_id: taxonomies(:location1).id,
+        hostgroup_id: hostgroups(:common).id,
+      }
+
+      get :global_registration, params: params, session: set_session_user
+      assert_response :success
+
+      vars = assigns(:global_registration_vars)
+      assert_equal taxonomies(:organization1), vars[:organization]
+      assert_equal taxonomies(:location1), vars[:location]
+      assert_equal hostgroups(:common), vars[:hostgroup]
+      assert_equal users(:admin), vars[:user]
+    end
+
+    test "should not pass unpermitted params to template" do
+      params = {
+        not_allowed: 'something_not_allowed',
+      }
+
+      get :global_registration, params: params, session: set_session_user
+      assert_response :success
+      assert_nil assigns(:global_registration_vars)[:not_allowed]
+    end
+
+    test "should allow to extend permitted params" do
+      Foreman::Plugin.any_instance.stubs(:allowed_registration_vars).returns([:activation_key])
+      get :global_registration, params: { activation_key: 'one-two-three-key' }, session: set_session_user
+      assert_response :success
+      assert_equal 'one-two-three-key', assigns(:global_registration_vars)[:activation_key]
+    end
+
+    test 'should fail when resources are not found' do
+      get :global_registration, params: { organization_id: 0 }, session: set_session_user
+      assert_response :not_found
+
+      get :global_registration, params: { location_id: 0 }, session: set_session_user
+      assert_response :not_found
+
+      get :global_registration, params: { hostgroup_id: 0 }, session: set_session_user
+      assert_response :unprocessable_entity
+    end
   end
 end


### PR DESCRIPTION
**New features:**
* Allow to pass permitted parameters as variables to the template
  (Default permitted params: `:organization_id, :location_id & :hostgroup_id`)
* `:extend_global_registration_vars` method for extending the list of permitted parameters for the GR template 
* Added expiration time option for JWT tokens

**Template changes:**
* Added host registration (tested on RHEL, Centos, Fedora, Ubuntu & Debian)
* JWT token for curl requests is automatically generated with 4 hours expiration time


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
