### PR TITLE
Fixes #30512 - avoid query for smart proxy settings

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -83,13 +83,19 @@ class SmartProxy < ApplicationRecord
     conditions
   end
 
+  def smart_proxy_feature_by_name(feature_name)
+    feature_id = Feature.find_by(:name => feature_name).try(:id)
+    # loop through the in memory object to work on unsaved objects
+    smart_proxy_features.find { |spf| spf.feature_id == feature_id }
+  end
+
   def has_feature?(feature_name)
     feature_ids = Feature.where(:name => feature_name).pluck(:id)
     smart_proxy_features.any? { |proxy_feature| feature_ids.include?(proxy_feature.feature_id) }
   end
 
   def capabilities(feature)
-    smart_proxy_features.find_by(:feature_id => Feature.find_by(:name => feature)).try(:capabilities)
+    smart_proxy_feature_by_name(feature).try(:capabilities)
   end
 
   def has_capability?(feature, capability)
@@ -97,7 +103,7 @@ class SmartProxy < ApplicationRecord
   end
 
   def setting(feature, setting)
-    smart_proxy_features.find_by(:feature_id => Feature.find_by(:name => feature)).try(:settings).try(:[], setting)
+    smart_proxy_feature_by_name(feature).try(:settings).try(:[], setting)
   end
 
   def httpboot_http_port


### PR DESCRIPTION
While this is less efficient, the number of
smart proxy features is low.  This allows settings
to be read on an unsaved objects, improving testing
and allowing us to rely on settings in before_create


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
