### PR TITLE
Fixes #30528 - Run rake console as dynflow client

### DIFF
--- a/lib/tasks/console.rake
+++ b/lib/tasks/console.rake
@@ -1,4 +1,4 @@
-task :console => :environment do
+task :console => [:environment, 'dynflow:client'] do
   flags = (ARGV.drop_while { |s| s != "--" }) || []
   flags.shift
   require 'rails/command'

--- a/lib/tasks/console.rake
+++ b/lib/tasks/console.rake
@@ -1,4 +1,4 @@
-task :console => [:environment, 'dynflow:client'] do
+task :console => 'dynflow:client' do
   flags = (ARGV.drop_while { |s| s != "--" }) || []
   flags.shift
   require 'rails/command'

--- a/lib/tasks/dynflow.rake
+++ b/lib/tasks/dynflow.rake
@@ -30,7 +30,7 @@ namespace :dynflow do
   desc <<~END_DESC
     Sets up the environment to act as a Dynflow client. By acting as a client, it still send tasks to be processed, but it cannot execute tasks.
   END_DESC
-  task :client do
+  task :client => :environment do
     dynflow = ::Rails.application.dynflow
     dynflow.config.remote = true
     dynflow.initialize!


### PR DESCRIPTION
Dynflow identifies separate runtime units (think processes) as worlds. Dynflow
distinguishes two kinds of worlds, executors worlds which can actually perform
things and client worlds, which can only ask the executor worlds to execute
something on their behalf.

Due to the recent move to sidekiq and puma, Dynflow gets initialized slightly
differently and all rake tasks now don't register themselves as Dynflow worlds.
This is mostly fine, since the world registration isn't exactly free operation
and most of the rake tasks don't interact with Dynflow in any way. However,
tasks which need to interact with Dynflow started failing. To fix this, we
introduced the dynflow:client rake task in 4e53859, on which other tasks can
depend and which registers the current process as a Dynflow client.

This patch allows running rails console as a Dynflow client so users can
interact with Dynflow from the console.