### PR TITLE
Fixes #30538 - Update set of available events

### DIFF
--- a/app/models/concerns/foreman/observable_model.rb
+++ b/app/models/concerns/foreman/observable_model.rb
@@ -32,7 +32,7 @@ module Foreman
     end
 
     def event_payload_for(payload, blk)
-      super || { id: id }
+      super || { object: self }
     end
   end
 end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -10,6 +10,7 @@ class Domain < ApplicationRecord
   include Parameterizable::ByIdName
   include BelongsToProxies
   include ParameterAttributes
+  include Foreman::ObservableModel
 
   validates_lengths_from_database
   has_many :hostgroups
@@ -47,6 +48,8 @@ class Domain < ApplicationRecord
       order("domains.name")
     end
   }
+
+  set_crud_hooks :domain
 
   apipie :class, desc: "A class representing #{model_name.human} object" do
     sections only: %w[all additional]

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -46,9 +46,7 @@ class Host::Managed < Host::Base
     output
   end
 
-  set_crud_hooks :host do |h|
-    { id: h.id, hostname: h.hostname }
-  end
+  set_crud_hooks :host
 
   set_hook :build_entered, if: -> { saved_change_to_build? && build? } do |h|
     { id: h.id, hostname: h.hostname }
@@ -56,6 +54,10 @@ class Host::Managed < Host::Base
 
   set_hook :build_exited, if: -> { saved_change_to_build? && !build? } do |h|
     { id: h.id, hostname: h.hostname }
+  end
+
+  set_hook :status_changed, if: -> { saved_change_to_global_status? } do |h|
+    { id: h.id, hostname: h.hostname, global_status: { from: h.previous_changes[:global_status][0], to: h.previous_changes[:global_status][1] } }
   end
 
   # Define custom hook that can be called in model by magic methods (before, after, around)

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -48,9 +48,7 @@ class Hostgroup < ApplicationRecord
   nested_attribute_for :compute_profile_id, :environment_id, :domain_id, :puppet_proxy_id, :puppet_ca_proxy_id, :compute_resource_id,
     :operatingsystem_id, :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id, :realm_id, :pxe_loader
 
-  set_crud_hooks :hostgroup do |hostgroup|
-    { id: hostgroup.id, name: hostgroup.name }
-  end
+  set_crud_hooks :hostgroup
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -6,11 +6,7 @@ class Model < ApplicationRecord
   include Parameterizable::ByIdName
   include ::Foreman::ObservableModel
 
-  set_hook :model_created, on: :create
-  set_hook :model_updated, on: :update
-  set_hook :model_destroyed, on: :destroy do |model|
-    { id: model.id, name: model.name }
-  end
+  set_crud_hooks :model
 
   before_destroy EnsureNotUsedBy.new(:hosts)
   has_many_hosts

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -17,6 +17,7 @@ class Subnet < ApplicationRecord
   include BelongsToProxies
   include ScopedSearchExtensions
   include ParameterSearch
+  include Foreman::ObservableModel
 
   attr_exportable :name, :network, :mask, :gateway, :dns_primary, :dns_secondary, :from, :to, :boot_mode,
     :ipam, :vlanid, :mtu, :nic_delay, :network_type, :description
@@ -119,6 +120,8 @@ class Subnet < ApplicationRecord
   scoped_search :relation => :domains, :on => :name, :rename => :domain, :complete_value => true
 
   delegate :supports_ipam_mode?, :supported_ipam_modes, :show_mask?, to: 'self.class'
+
+  set_crud_hooks :subnet
 
   apipie :class, "A class representing #{model_name.human} object" do
     sections only: %w[all additional]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,7 @@ class User < ApplicationRecord
   include Exportable
   include TopbarCacheExpiry
   include JwtAuth
+  include Foreman::ObservableModel
 
   ANONYMOUS_ADMIN = 'foreman_admin'
   ANONYMOUS_API_ADMIN = 'foreman_api_admin'
@@ -143,6 +144,8 @@ class User < ApplicationRecord
   def as_json(options = {})
     super.tap { |h| h.key?('user') ? h['user']['name'] = name : h['name'] = name }
   end
+
+  set_crud_hooks :user
 
   apipie :class, desc: "A class representing #{model_name.human} object" do
     sections only: %w[all additional]

--- a/test/models/concerns/foreman/observable_model_test.rb
+++ b/test/models/concerns/foreman/observable_model_test.rb
@@ -36,7 +36,7 @@ class ObservableModelTest < ActiveSupport::TestCase
     test 'notify with default payload' do
       ActiveSupport::Notifications.subscribed(callback, 'model_updated.event.foreman') do
         callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-          payload == { id: model.id }.merge(event_context)
+          payload == { object: model }.merge(event_context)
         end
 
         model.update(name: 'New Name')
@@ -104,7 +104,7 @@ class ObservableModelTest < ActiveSupport::TestCase
         test 'event is sent when model is created' do
           ActiveSupport::Notifications.subscribed(callback, 'model_created.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { id: model.id }.merge(event_context)
+              payload == { object: model }.merge(event_context)
             end
 
             model.save!
@@ -118,7 +118,7 @@ class ObservableModelTest < ActiveSupport::TestCase
         test 'event is sent when model is updated' do
           ActiveSupport::Notifications.subscribed(callback, 'model_updated.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { id: model.id }.merge(event_context)
+              payload == { object: model }.merge(event_context)
             end
 
             model.update!(name: 'New Name')
@@ -132,7 +132,7 @@ class ObservableModelTest < ActiveSupport::TestCase
         test 'event is sent when model is destroyed' do
           ActiveSupport::Notifications.subscribed(callback, 'model_destroyed.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { id: model.id }.merge(event_context)
+              payload == { object: model }.merge(event_context)
             end
 
             model.destroy!

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -14,6 +14,16 @@ class DomainTest < ActiveSupport::TestCase
   should validate_uniqueness_of(:fullname).allow_blank
   should belong_to(:dns)
 
+  test 'hooks are defined' do
+    expected = [
+      'domain_created.event.foreman',
+      'domain_updated.event.foreman',
+      'domain_destroyed.event.foreman',
+    ]
+
+    assert_same_elements expected, Domain.event_subscription_hooks
+  end
+
   test "when cast to string should return the name" do
     s = @domain.to_s
     assert_equal @domain.name, s

--- a/test/models/subnet_test.rb
+++ b/test/models/subnet_test.rb
@@ -14,6 +14,16 @@ class SubnetTest < ActiveSupport::TestCase
   should belong_to(:dns)
   should belong_to(:dhcp)
 
+  test 'hooks are defined' do
+    expected = [
+      'subnet_created.event.foreman',
+      'subnet_updated.event.foreman',
+      'subnet_destroyed.event.foreman',
+    ]
+
+    assert_same_elements expected, Subnet.event_subscription_hooks
+  end
+
   test 'should sort by vlanid as number' do
     # ensure we have subnets that would be incorrectly sorted in text sort
     FactoryBot.create(:subnet_ipv4, vlanid: 3)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -71,6 +71,16 @@ class UserTest < ActiveSupport::TestCase
   # Associations
   should have_many(:ssh_keys).dependent(:destroy)
 
+  test 'hooks are defined' do
+    expected = [
+      'user_created.event.foreman',
+      'user_updated.event.foreman',
+      'user_destroyed.event.foreman',
+    ]
+
+    assert_same_elements expected, User.event_subscription_hooks
+  end
+
   test 'should update with multiple valid descriptions' do
     user = users(:one)
     valid_name_list.each do |description|


### PR DESCRIPTION
Adds CUD events for some models.

The change that requires attention is that default payload for events. Before only object id was returned, but now the whole object is being returned. This might solve reference errors in case of need to access e.g. `object.relation` for destroyed object. I've saved custom payload for other events, but CUD. 