### PR TITLE
Fixes #30544 - deprecate mount_react_component

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -1,5 +1,6 @@
 module ReactjsHelper
   def mount_react_component(name, selector, data = [], opts = {})
+    Foreman::Deprecation.deprecation_warning('2.5', 'use #react_component instead of #mount_react_component')
     javascript_tag defer: 'defer' do
       "$(tfm.reactMounter.mount('#{name}', '#{selector}', #{data}, #{opts[:flatten_data] || false}));".html_safe
     end


### PR DESCRIPTION
Deprecate the ReactjsHelper#mount_react_component,
please use ReactjsHelper#react_component instead.

**Please wait for the next develop version before merging.**
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
