### PR TITLE
Fixes #30554 - Update Storybook docs for plugins and mount_react_component

### DIFF
--- a/webpack/stories/docs/adding-new-components.stories.mdx
+++ b/webpack/stories/docs/adding-new-components.stories.mdx
@@ -101,11 +101,11 @@ This is useful especially for debugging because it doesn't hide console output.
 
 Linter (code style checking) can be executed with `npm run lint`. You can run it with parameter `--fix` to let it automatically fix the discovered issues. You need to pass the parameter to eslint, so run the command like this `npm run lint -- --fix`.
 
-## Making it available from erb
+## Making it available from ERB
 
-If you want your component to be available for mounting into erb templates, you have to add them to [the component registry](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js#L60-L71).
+If you want your component to be available for mounting into ERB templates, it must be added to [the component registry](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js#L60-L71).
 
-Then it will be possible to mount it with `react_component` helper:
+Then, you can mount it with the `react_component` helper:
 
 ```ruby
 react_component(component_name, props)
@@ -117,7 +117,7 @@ react_component(component_name, props)
 <%= react_component('PowerStatus', id: host.id, url: power_host_path(host.id)) %>
 ```
 
-Will render following HTML:
+will render the following HTML:
 
 ```html
 <react-component
@@ -128,6 +128,8 @@ Will render following HTML:
   }.to_json %>"
 ></react-component>
 ```
+
+(Note that the React component is rendered as a [web component](https://developer.mozilla.org/en-US/docs/Web/Web_Components).)
 
 ## Before you start writing a new component
 

--- a/webpack/stories/docs/plugins.stories.mdx
+++ b/webpack/stories/docs/plugins.stories.mdx
@@ -9,30 +9,44 @@ import { Meta } from '@theforeman/stories';
 
 # Plugins
 
-## Using components from core
+## Using components from Foreman core
 
-There are three ways how components provided by Foreman core can be re-used:
+There are three ways components provided by Foreman core can be re-used:
 
-### Mounting components into erb
+### 1. Mounting components into ERB
 
-No special setup is required and you can re-use React components that are available in `componentRegistry` even when you plugin doesn't use webpack.
-Components can be mounted into erb using `mount_react_component` helper:
+No special setup is required and you can re-use React components that are available in `componentRegistry` even when your plugin doesn't use Webpack.
+Components can be mounted into ERB using the `react_component` helper:
 
 ```ruby
-mount_react_component(component_name, html_node_selector, json_data)
+react_component(component_name, props)
 ```
 
 **Example:**
 
 ```erb
-<%= mount_react_component('PowerStatus', '#power', {:id => host.id, :url => power_host_path(host.id)}.to_json) %>
+<%= react_component('PowerStatus', id: host.id, url: power_host_path(host.id)) %>
 ```
 
-The list of available compoennts is [here](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js#L60).
+will render the following HTML:
 
-### Re-using core code in webpack
+```html
+<react-component
+  name="PowerStatus"
+  data-props="<%= {
+    id: host.id,
+    url: power_host_path(host.id)
+  }.to_json %>"
+></react-component>
+```
 
-If your plugin uses webpack, you can import and the core functionality from `foremanReact`.
+(Note that the React component is rendered as a [web component](https://developer.mozilla.org/en-US/docs/Web/Web_Components).)
+
+The list of available components is [here](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js#L60).
+
+### 2. Re-using core code in Webpack
+
+If your plugin uses Webpack, you can import and the core functionality from `foremanReact`.
 
 **Example:**
 
@@ -44,46 +58,42 @@ import { noop } from 'foremanReact/common/helpers';
 import { MessageBox } from 'foremanReact/components/common/MessageBox';
 ```
 
-Please note that using functionality from core may cause troubles in jest tests where `foremanReact` isn't available because it isn't a real npm package, see [the webpack configuration](https://github.com/theforeman/foreman/blob/develop/config/webpack.config.js#L70-L76) for details.
+### 3. Using components outside of Webpack
 
-Until this is fixed in Foreman core the workaround is using [mocks](https://github.com/Katello/katello/tree/master/webpack/__mocks__) in your plugin's tests.
-
-### Using components outside of webpack
-
-The component registry is available in `Window.tfm.componentRegistry`. That gives you access to the components even from js code that isn't processed by webpack.
+The component registry is available in `Window.tfm.componentRegistry`. That gives you access to the components even from js code that isn't processed by Webpack.
 
 ```js
 const MyComponent = Window.tfm.componentRegistry.getComponent(componentName)
   .type;
 ```
 
-Most of the components require to be wrapped with a [Higher-Order Component](https://reactjs.org/docs/higher-order-components.html) that provides some context like Redux store or Intl. `componentRegistry` publishes a wrapper factory that can create a wrapper function with HOCs according to your needs.
+Most of the components must be wrapped with a [Higher-Order Component](https://reactjs.org/docs/higher-order-components.html) that provides some context like Redux store or Intl. `componentRegistry` publishes a wrapper factory that can create a wrapper function with HOCs according to your needs.
 
 ```js
 const i18nWrapper = componentRegistry.wrapperFactory().with('i18n').wrapper;
 const MyComponentWithIntl = i18nWrapper(MyComponent);
 ```
 
-# Using webpack in plugin
+# Using Webpack in plugins
 
-There are 3 conditions that a plugin has to fulfill to share the webpack infrastructure from Foreman core:
+There are 3 conditions that a plugin has to fulfill to share the Webpack infrastructure from Foreman core:
 
-- folder `./webpack/` containing all the webpack processed code
-- `package.json` in with dependencies
-- defined main entry point in `package.json` or just have `./webpack/index.js`
+- A `./webpack/` folder containing all the Webpack-processed code
+- A `package.json` file with dependencies
+- A defined main entry point in `package.json` or just have `./webpack/index.js`
 
-The webpack config is shared with core so there's no need for custom configuration.
+The Webpack config is shared with core, so there's no need for custom configuration.
 
-Once all the above is set up then the script `npm run install` executed from root of the core's git checkout installs dependencies for plugins too.
-Also `npm run lint` behaves similarly.
+Once all the above is set up, then the script `npm run install` executed from root of the core's git checkout installs dependencies for plugins too.
+Also `npm run lint` and `npm run test` behaves similarly.
 
 ### Entry points
 
-The webpack config respects the main entry point defined in `package.json`. On top of that it loads all files matching `./webpack/*index.js`. That allows plugins to define multiple independent entry points. This can be useful in special use-cases. For example when you need to mix some parts of webpack processed code into pages that use asset pipeline only.
+The Webpack config respects the main entry point defined in `package.json`. On top of that it loads all files matching `./webpack/*index.js`. That allows plugins to define multiple independent entry points. This can be useful in special use-cases. For example when you need to mix some parts of Webpack-processed code into pages that use asset pipeline only.
 
 ### Troubleshooting
 
-You can make sure webpack knows about your plugin by executing script `plugin_webpack_directories.rb` that prints json-formatted info about all recognized plugins.
+You can make sure Webpack knows about your plugin by executing script `plugin_webpack_directories.rb` that prints json-formatted info about all recognized plugins.
 
 ```bash
 > ./script/plugin_webpack_directories.rb | json_reformat


### PR DESCRIPTION
* Update `adding-new-components.stories.mdx`: add note about web components
* Update `plugins.stories.mdx`: this had info about `mount_react_component` which is being deprecated.  Replaced it with info about `react_component`.
* Some style/grammar/capitalization updates