### PR TITLE
Fixes #30559 - allow "ids" in safemode for ActiveRecord

### DIFF
--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -8,15 +8,15 @@ end
 # Permit safemode template rendering to have basic read-only access over
 # model relations
 class ActiveRecord::AssociationRelation::Jail < Safemode::Jail
-  allow :[], :each, :first, :to_a, :map, :find_in_batches, :size, :group_by
+  allow :[], :each, :first, :to_a, :map, :find_in_batches, :size, :group_by, :ids
 end
 
 class ActiveRecord::Relation::Jail < Safemode::Jail
-  allow :[], :each, :first, :to_a, :map, :find_in_batches, :size, :group_by
+  allow :[], :each, :first, :to_a, :map, :find_in_batches, :size, :group_by, :ids
 end
 
 class ActiveRecord::Associations::CollectionProxy::Jail < Safemode::Jail
-  allow :[], :each, :first, :to_a, :map, :find_in_batches, :size, :group_by
+  allow :[], :each, :first, :to_a, :map, :find_in_batches, :size, :group_by, :ids
 end
 
 class ActiveRecord::Batches::BatchEnumerator::Jail < Safemode::Jail


### PR DESCRIPTION
Complementary PR for https://github.com/theforeman/foreman_remote_execution/pull/453

This PR allows `.ids` method for safemode in reporting 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
