### PR TITLE
Fixes #30563 - link to generated page instead of directory

### DIFF
--- a/app/views/apipie_dsl/apipie_dsls/help.html.erb
+++ b/app/views/apipie_dsl/apipie_dsls/help.html.erb
@@ -143,10 +143,10 @@ service <&#37;= input("service") &#37;> <&#37;= input("action") &#37;>
 <%= apipie_dsl_example(apipie_erb_wrap('@host.name') + "\n" +
                            apipie_erb_wrap('if @host.name == "host1.example.com"', mode: :silent, open_trim: true, close_trim: true) + "\n" +
                            apipie_erb_wrap('  result = "positive"', mode: :silent, open_trim: true, close_trim: true) + "\n" +
-                           apipie_erb_wrap('else"', mode: :silent, open_trim: true, close_trim: true) + "\n" +
+                           apipie_erb_wrap('else', mode: :silent, open_trim: true, close_trim: true) + "\n" +
                            apipie_erb_wrap('  result = "negative"', mode: :silent, open_trim: true, close_trim: true) + "\n" +
-                           apipie_erb_wrap('end"', mode: :silent, open_trim: true, close_trim: true) + "\n" +
-                           apipie_erb_wrap('result"'),
+                           apipie_erb_wrap('end', mode: :silent, open_trim: true, close_trim: true) + "\n" +
+                           apipie_erb_wrap('result'),
                        "host1.example.com\npositive") %>
 
 <p><%= _('Note that the else branch is optional. Also multiple conditions can be specified using elsif, but that is usually better written using a case/when construct. See the example below') %></p>

--- a/app/views/apipie_dsl/apipie_dsls/help.html.erb
+++ b/app/views/apipie_dsl/apipie_dsls/help.html.erb
@@ -114,7 +114,7 @@ service <&#37;= input("service") &#37;> <&#37;= input("action") &#37;>
 
 <p><%= _('The Ruby code inside of the ERB tags typically contain expressions. They consist of program flow control terminals, variables, macros. Variables and macros evaluates to objects. Each object has set of allowed methods that can be called on it. These methods can return objects.') %></p>
 <p><%= (_('An example of a control flow terminal is an if condition or for each cycle. Macros are functions called by their name without specifying any object, e.g. %{load_hosts} or %{input}. See all available macros %{all_macros}. Example of object class is an %{integer}, String, %{host}, %{subnet}, %{user}. Calling a method on an object is denoted by <code>.</code>. For example <code>@host.fqdn</code> expression is an instance variable that holds and evaluates to an object of a Host, on which the fqdn method is called. To find the list of all available methods on objects, see the documentation for each template type.') % {
-    all_macros: link_to(_('here'), @doc[:doc_url] + section_ext('all')),
+    all_macros: link_to(_('here'), @doc[:doc_url] + section_ext('all') + '.html'),
     load_hosts: link_to('load_hosts', @doc[:doc_url] + section_ext('all') + '/Foreman::Renderer::Scope::Macros::Loaders/load_hosts.html'),
     input: link_to('input', @doc[:doc_url] + section_ext('all') + '/Foreman::Renderer::Scope::Macros::Inputs/input.html'),
     integer: link_to('Integer', @doc[:doc_url] + section_ext('basic_ruby_methods') + '/Foreman::Renderer::DocTemplates::BasicRubyMethods::Integer.html'),


### PR DESCRIPTION
Two changes on DSL documentation help page:

1. Link in "Basic building blocks - macros, variables, methods" referred to `/dsldoc/all`, which is directory. Change it to refer to `/dsldoc/all.html`, which is generated documentation page.

I don't like how this link is language-unaware, i.e. when opened on French help page, it will refer user to English one. But all links in this paragraph behave this way.

2. Example in "Conditional statements" had quotation mark `"` attached to end of some lines, making it use incorrect syntax. Remove that character, so example can be copy-pasted.

Let me know if I should squash both commits, I don't think these changes require separate issue each.

CC @ares 