### PR TITLE
Fixes #30566 - Host overview on status click

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -92,11 +92,11 @@ module HostsHelper
 
   # method that reformat the hostname column by adding the status icons
   def name_column(host)
-    style = host_global_status_icon_class_for_host(host)
-    displayable_statuses = host.host_statuses.select { |status| status.relevant? && !status.substatus? }
-    tooltip = displayable_statuses.sort_by(&:type).map { |status| "#{_(status.name)}: #{_(status.to_label)}" }.join(', ')
-
-    content = content_tag(:span, "", {:rel => "twipsy", :class => style, :"data-original-title" => tooltip})
+    content = content_tag(:span, "")
+    content += react_component('HostStatus',
+                                className: host_global_status_icon_class_for_host(host),
+                                overviewFields: overview_fields(host)
+                              )
     content += link_to("  #{host}", host_path(host))
     content
   end

--- a/webpack/assets/javascripts/react_app/components/HostStatus/HostStatus.js
+++ b/webpack/assets/javascripts/react_app/components/HostStatus/HostStatus.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger, Popover } from 'patternfly-react';
+import classNames from 'classnames';
+import './HostStatus.scss';
+
+const HostStatus = ({ className, overviewFields }) => {
+  const cx = classNames(className, 'clickable-host-status');
+  const table = (
+    <table id="properties_table">
+      <tbody>
+        {overviewFields.map(([name, value], key) => (
+          <tr key={key}>
+            <td className="property_name">{name}</td>
+            <td
+              className="property_value"
+              dangerouslySetInnerHTML={{ __html: value }}
+            />
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+
+  return (
+    <OverlayTrigger
+      rootClose
+      trigger="click"
+      placement="right"
+      overlay={
+        <Popover id="host-status-popover" title="Properties Overview">
+          {table}
+        </Popover>
+      }
+    >
+      <span className={cx} />
+    </OverlayTrigger>
+  );
+};
+
+HostStatus.propTypes = {
+  className: PropTypes.string.isRequired,
+  overviewFields: PropTypes.array.isRequired,
+};
+
+export default HostStatus;

--- a/webpack/assets/javascripts/react_app/components/HostStatus/HostStatus.scss
+++ b/webpack/assets/javascripts/react_app/components/HostStatus/HostStatus.scss
@@ -1,0 +1,15 @@
+#properties_table {
+  .property_name {
+    width: 150px;
+  }
+
+  .property_value {
+    min-width: 150px;
+  }
+}
+
+table {
+  .clickable-host-status {
+    cursor: pointer;
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -38,6 +38,7 @@ import Slot from './common/Slot';
 import TypeAheadSelect from './common/TypeAheadSelect';
 import DatePicker from './common/DateTimePicker/DatePicker';
 import RedirectCancelButton from './common/RedirectCancelButton';
+import HostStatus from './HostStatus/HostStatus';
 
 const componentRegistry = {
   registry: forceSingleton('component_registry', () => ({})),
@@ -133,6 +134,7 @@ const coreComponets = [
   { name: 'TypeAheadSelect', type: TypeAheadSelect },
   { name: 'DatePicker', type: DatePicker },
   { name: 'RedirectCancelButton', type: RedirectCancelButton },
+  { name: 'HostStatus', type: HostStatus },
 
   {
     name: 'RelativeDateTime',


### PR DESCRIPTION
This may reduce the extra step of going to the overview page
just in order to see some host's properties.

now you can click on the host's status, and see the properties that are displayed in the overview page:
![Selection_346](https://user-images.githubusercontent.com/26363699/89390341-3ad8f600-d70f-11ea-9270-3ecec88ad8c4.png)

Before, we had a tooltip which didn't show all of the information:
![Selection_347](https://user-images.githubusercontent.com/26363699/89390558-930ff800-d70f-11ea-9ecd-9d7e324c973c.png)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
