### PR TITLE
Refs #28384 - handle case when request ID is missing

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -258,8 +258,18 @@ module Foreman
     end
 
     class MultilineRequestPatternLayout < MultilinePatternLayout
+      private
+
       def indent_lines(string)
-        string.gsub("\n", "\n #{::Logging.mdc['request'].split('-').first} | ")
+        if request_id
+          string.gsub("\n", "\n #{request_id.split('-').first} | ")
+        else
+          super(string)
+        end
+      end
+
+      def request_id
+        ::Logging.mdc['request']
       end
     end
   end


### PR DESCRIPTION
test.log was being written as an empty file because the logging context middleware is not used when running tests, which means no request id was set. The fact that split was being called on the nil Logging.mdc['request'] was not surfacing, so the problem was hidden.

@domitea can you take a look? This regressed in the original PR

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
