### PR TITLE
Fixes #30617 - Fix Change Owner bulk action

### DIFF
--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -22,7 +22,7 @@ module HostDescriptionHelper
       actions << { :action => [_('Build Hosts'), multiple_build_hosts_path], :priority => 110 } if SETTINGS[:unattended]
       actions <<  { :action => [_('Assign Organization'), select_multiple_organization_hosts_path], :priority => 800 }
       actions <<  { :action => [_('Assign Location'), select_multiple_location_hosts_path], :priority => 900 }
-      actions <<  { :action => [_('Change Owner'), select_multiple_owner_hosts_path], :priority => 1000 } if SETTINGS[:login]
+      actions <<  { :action => [_('Change Owner'), select_multiple_owner_hosts_path], :priority => 1000 }
     end
     actions << { :action => [_('Change Power State'), select_multiple_power_state_hosts_path], :priority => 1100 } if authorized_for(:controller => :hosts, :action => :power)
     actions << { :action => [_('Delete Hosts'), multiple_destroy_hosts_path], :priority => 1200 } if authorized_for(:controller => :hosts, :action => :destroy)


### PR DESCRIPTION
fabec12951d0881dbe851e3f4216b8404632423a removed `SETTINGS[:login]` but 377ff667bbe3c2df8cd0831d9fe60bb9b316d680 still used it. This is probably a rebase that missed the change.