### PR TITLE
prefer exacter matches of the vlanid when auto-selecting a related network

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -894,17 +894,30 @@ function selectRelatedNetwork(subnetElement) {
   }
 
   var selected = null;
+  // prefer a match of the vlanid bounded by non digits
+  // this prevent vlanId=1 from matching "vlan100"
+  var vlanidregex = new RegExp("(^|\\D)" + vlanId + "($|\\D)")
 
   network_select.find('option').each(function(index, option) {
     if (
       selected === null &&
-      $(option)
-        .text()
-        .indexOf(vlanId) !== -1
+      vlanidregex.test($(option).text())
     ) {
       selected = option.value;
     }
   });
+  if (selected === null) {
+    network_select.find('option').each(function(index, option) {
+      if (
+        selected === null &&
+        $(option)
+          .text()
+          .indexOf(vlanId) !== -1
+      ) {
+        selected = option.value;
+      }
+    });
+  }
 
   if (selected !== null) {
     network_select.val(selected).trigger('change');


### PR DESCRIPTION
Given that vlanid's are numbers there's a big difference between vlan 23 and vlan 123
With just the substring match foreman would easily confuse the 2.

Quick drive-by patch, will look if I have the time to go trough redmine and all later, unless somebody else does that for me.

This also still falls back to the substring match which I'm not sure is needed.