### PR TITLE
Fixes #30600 - use react_component in asciidoc

### DIFF
--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -494,8 +494,7 @@ in core:
 [source, ERB]
 ....
  <%= webpacked_plugins_js_for :foreman_plugin, :foreman_other_plugin %>
- <span id=my_id></span>
- <%= mount_react_component('MyComponent', '#my_id, { :id => '5', :name => 'whatever' }.to_json) %>
+ <%= react_component('MyComponent', :id => '5', :name => 'whatever') %>
 ....
 
 [[adding-3rd-party-js-libraries]]


### PR DESCRIPTION
replace the mount_react_component with react_component
in the developer_docs


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
