### PR TITLE
Fixes #30644 - Refactor host details nav-tabs width

### DIFF
--- a/app/assets/stylesheets/charts.scss
+++ b/app/assets/stylesheets/charts.scss
@@ -24,7 +24,6 @@
 .legend {
   margin-left: 485px;
   margin-top: 10px;
-  height: 450px;
   width: 110px;
   text-align: center;
   overflow-y: auto;

--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -127,7 +127,9 @@ a {
 }
 
 .tab-content {
-  min-height: 420px;
+  height: 400px;
+  margin-bottom: 20px;
+  overflow-y: auto;
 }
 
 .badge.close {

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -10,7 +10,7 @@
 <%= host_title_actions(@host) %>
 <% content_for(:search_bar) {reports_show} %>
 <div id="host-show" class="row" data-history-url='<%= host_path(@host)%>'>
-  <div class="col-md-4">
+  <div class="col-md-12">
     <table id="details_table" class="<%= table_css_classes %>">
       <thead>
         <tr>
@@ -77,7 +77,7 @@
     </div>
   </div>
 
-  <div class="col-md-8">
+  <div class="col-md-6">
     <div class="stats-well">
       <h4 class="ca"><%= _("Runtime") %></h4>
       <h6 class="ca"><%= n_("last %s day", "last %s days", @range) % @range %></h6>
@@ -85,6 +85,8 @@
         <%= spinner(_('Loading runtime information ...')) %>
       </div>
     </div>
+  </div>
+  <div class="col-md-6">
     <div class="stats-well">
       <h4 class="ca"><%= _("Resources") %></h4>
       <h6 class="ca"><%= n_("last %s day", "last %s days", @range) % @range %></h6>


### PR DESCRIPTION
Now that the host details charts are less relevant,
what do you think about making the nav-tabs section larger,
and move the charts below it:

![host_full_screen](https://user-images.githubusercontent.com/26363699/90140959-23d77b00-dd83-11ea-9a01-39baac74e99d.png)

Currently the real-estate there is very small, and with this change we will be able to extend it with more data / features.

also, the new Host Details page will have nav-tabs with full page width,
maybe it's time to refactor foreman & plugins tabs and write them in React
so when the new Host Details page will arrive, it could be switched smoothly.

Discussion here: https://community.theforeman.org/t/refactor-host-details-nav-tabs-width/20052
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
