### PR TITLE
Fixes #30643 - Properly handle AuthSource subclasses

### DIFF
--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -46,9 +46,21 @@ class AuthSource < ApplicationRecord
 
   validates :name, :presence => true, :uniqueness => true, :length => { :maximum => 60 }
 
-  scope :non_internal, -> { where("auth_sources.type NOT IN (?)", ['AuthSourceInternal', 'AuthSourceHidden']) }
-  scope :except_hidden, -> { where('auth_sources.type <> ?', 'AuthSourceHidden') }
-  scope :only_ldap, -> { where("auth_sources.type = ?", 'AuthSourceLdap') }
+  scope :non_internal, -> { where.not(type: (internal_types + hidden_types).map(&:to_s)) }
+  scope :except_hidden, -> { where.not(type: hidden_types.map(&:to_s)) }
+  scope :only_ldap, -> { where(type: ldap_types.map(&:to_s)) }
+
+  def self.internal_types
+    [AuthSourceInternal] + AuthSourceInternal.descendants
+  end
+
+  def self.hidden_types
+    [AuthSourceHidden] + AuthSourceHidden.descendants
+  end
+
+  def self.ldap_types
+    [AuthSourceLdap] + AuthSourceLdap.descendants
+  end
 
   def authenticate(login, password)
   end


### PR DESCRIPTION
AuthSource subclasses may be inherited, leading scopes to return
unexpected results - for example, AuthSource.except_hidden returned auth
sources that inherited the AuthSourceHidden class. The scopes have been
modified to also take into account the descendants of the various types.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
