### PR TITLE
Fixes #30595,#30656 - support rendering multiple distribution widgets

### DIFF
--- a/app/views/dashboard/_distribution_widget.html.erb
+++ b/app/views/dashboard/_distribution_widget.html.erb
@@ -6,12 +6,9 @@
     <%= N_('Run Distribution Chart') %>
   <% end %>
 </h4>
-<div id="run_distribution"></div>
-<%= mount_react_component('ComponentWrapper', '#run_distribution', {
-    component: 'BarChart', 
-    componentProps: {
+<%= react_component('BarChart', {
       data: get_run_distribution_data(@data.hosts, :origin => origin),
       xAxisLabel: _("Minutes Ago"),
       yAxisLabel: _("Number Of Clients"),
       config: 'small'
-    }}.to_json) %>
+    }) %>


### PR DESCRIPTION
migrate the distribution_widget to use react_component.

Fixes https://projects.theforeman.org/issues/30595 and https://projects.theforeman.org/issues/30656

Before:
<img width="1283" alt="Screen Shot 2020-08-18 at 11 55 47" src="https://user-images.githubusercontent.com/1262502/90494449-30c1e900-e14c-11ea-92c0-0f52c4741892.png">

After:
<img width="1286" alt="Screen Shot 2020-08-18 at 11 56 09" src="https://user-images.githubusercontent.com/1262502/90494482-37506080-e14c-11ea-8155-fc9231937a5b.png">


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
