### PR TITLE
[WIP] Fixes #30476 - Support scope of permissions for JWT authorization tokens

### DIFF
--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -40,7 +40,11 @@ module Foreman::Controller::Authentication
   end
 
   def authorized
-    User.current.allowed_to?(path_to_authenticate)
+    if @available_sso.respond_to?(:allowed_to?) && @available_sso&.scope&.any?
+      @available_sso.allowed_to?(path_to_authenticate) && User.current.allowed_to?(path_to_authenticate)
+    else
+      User.current.allowed_to?(path_to_authenticate)
+    end
   end
 
   def path_to_authenticate

--- a/app/models/concerns/jwt_auth.rb
+++ b/app/models/concerns/jwt_auth.rb
@@ -8,9 +8,12 @@ module JwtAuth
       jwt_secret || create_jwt_secret!
     end
 
-    def jwt_token!(expiration: nil)
+    # Arguments:
+    # => :scope       Array of permissions, eg: [:view_hosts, :create_hosts]
+    # => :expiration  Integer, eg: 4.hours.to_i
+    def jwt_token!(scope: [], expiration: nil)
       jwt_secret = jwt_secret!
-      JwtToken.encode(self, jwt_secret.token, expiration).to_s
+      JwtToken.encode(self, jwt_secret.token, scope: scope, expiration: expiration).to_s
     end
   end
 end

--- a/app/services/jwt_token.rb
+++ b/app/services/jwt_token.rb
@@ -3,20 +3,21 @@ require 'base64'
 
 class JwtToken < Struct.new(:token)
   class << self
-    def encode(user, secret, expiration = nil)
-      payload = prepare_payload(user, secret, expiration)
+    def encode(user, secret, scope: [], expiration: nil)
+      payload = prepare_payload(user, secret, scope, expiration)
       new JWT.encode(payload, secret)
     end
 
     private
 
-    def prepare_payload(user, secret, expiration)
+    def prepare_payload(user, secret, scope, expiration)
       jti_raw = [secret, iat].join(':')
       jti = Digest::SHA256.hexdigest(jti_raw)
       payload = {
         user_id: user.id,
         iat: iat,
         jti: jti,
+        scope: scope,
       }
 
       payload[:exp] = (Time.now.to_i + expiration) if expiration

--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -1,6 +1,6 @@
 module SSO
   class Jwt < Base
-    attr_reader :current_user
+    attr_reader :current_user, :scope
 
     def available?
       controller.api_request? && bearer_token_set? && no_issuer?
@@ -10,7 +10,10 @@ module SSO
       payload = jwt_token.decode || {}
       user_id = payload['user_id']
       user = User.unscoped.except_hidden.find_by(id: user_id) if user_id
+
       @current_user = user
+      @scope = payload['scope'] || []
+
       user&.login
     rescue JWT::ExpiredSignature
       Rails.logger.error "JWT SSO: Expired JWT token."
@@ -22,6 +25,18 @@ module SSO
 
     def authenticated?
       self.user = User.current.presence || authenticate!
+    end
+
+    def allowed_to?(action)
+      return false if @current_user.disabled?
+      return true if @current_user.admin?
+
+      required_permissions = Foreman::AccessControl.permissions_for_controller_action(action).map(&:name)
+      required_permissions.each do |permission|
+        return false unless @scope.include? permission.to_s
+      end
+
+      true
     end
 
     private

--- a/test/unit/jwt_token_test.rb
+++ b/test/unit/jwt_token_test.rb
@@ -3,8 +3,8 @@ require 'ostruct'
 
 class JwtTokenTest < ActiveSupport::TestCase
   # Token created from encoding with 'test_jwt_secret' a following payload:
-  # { 'user_id' => 123, 'iat' => 1514804400, 'jti' => '3e8286940eb162ec735f8a5aac5926037fdc7f05e521a74231a65f2557a8af94' }
-  let(:token) { 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxMjMsImlhdCI6MTUxNDgwNDQwMCwianRpIjoiM2U4Mjg2OTQwZWIxNjJlYzczNWY4YTVhYWM1OTI2MDM3ZmRjN2YwNWU1MjFhNzQyMzFhNjVmMjU1N2E4YWY5NCJ9.TSM2xMnMuMEWwAVoIidyLIwJElJQZVQvcfaxyVA7cDI' }
+  # { 'user_id' => 123, 'iat' => 1514804400, 'jti' => '3e8286940eb162ec735f8a5aac5926037fdc7f05e521a74231a65f2557a8af94', scope: [] }
+  let(:token) { 'eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoxMjMsImlhdCI6MTUxNDgwNDQwMCwianRpIjoiM2U4Mjg2OTQwZWIxNjJlYzczNWY4YTVhYWM1OTI2MDM3ZmRjN2YwNWU1MjFhNzQyMzFhNjVmMjU1N2E4YWY5NCIsInNjb3BlIjpbXX0.Amx4aE9kXZdywMONV2PxUCtW9J7cb4J9c2xvrnYVq-Y' }
 
   test 'encoding' do
     JwtToken.stubs(:iat).returns(1_514_804_400)
@@ -19,7 +19,7 @@ class JwtTokenTest < ActiveSupport::TestCase
     jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
     JwtSecret.stubs(:find_by).returns(jwt_secret)
     user = OpenStruct.new(id: 123)
-    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, 3600).token)
+    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, expiration: 3600).token)
 
     assert_nothing_raised { jwt_token.decode }
   end
@@ -31,7 +31,8 @@ class JwtTokenTest < ActiveSupport::TestCase
 
     expected = {'user_id' => 123,
                 'iat' => 1_514_804_400,
-                'jti' => '3e8286940eb162ec735f8a5aac5926037fdc7f05e521a74231a65f2557a8af94'}
+                'jti' => '3e8286940eb162ec735f8a5aac5926037fdc7f05e521a74231a65f2557a8af94',
+                'scope' => []}
 
     assert_equal expected, jwt_token.decode
   end
@@ -74,7 +75,7 @@ class JwtTokenTest < ActiveSupport::TestCase
     jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
     JwtSecret.stubs(:find_by).returns(jwt_secret)
     user = OpenStruct.new(id: 123)
-    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, -1).token)
+    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, expiration: -1).token)
 
     assert_raise(JWT::ExpiredSignature) { jwt_token.decode }
   end


### PR DESCRIPTION
How to test:
```
bundle exec rails console
 # Use Non admin user, for admin user scope check is skipped.
User.find(x).jwt_token!(scope: [:view_hosts])

# Works as expected:
curl -X GET foreman.devv/api/hosts -H "Authorization: Bearer <token>"

# Fails on missing permissions
curl -X GET foreman.devv/api/users -H "Authorization: Bearer <token>" 
```

Notes:
* UI is not part of the task, for Global Registration template it will be done in [#30473](https://projects.theforeman.org/issues/30473) and for the users after https://github.com/theforeman/foreman/pull/7806 will be merged.
* PR is part of **Simple & automatic host registration WF**, [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588) & [Redmine](https://projects.theforeman.org/issues/30440)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
