### PR TITLE
Fixes #30444 - Host registration template

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -39,7 +39,6 @@ module Host
     validates :name, :presence => true, :uniqueness => true, :format => {:with => Net::Validations::HOST_REGEXP, :message => _(Net::Validations::HOST_REGEXP_ERR_MSG)}
     validate :host_has_required_interfaces
     validate :uniq_interfaces_identifiers
-    validate :build_managed_only
 
     include PxeLoaderSuggestion
 
@@ -657,12 +656,6 @@ module Host
 
       errors.add(:interfaces, _('some interfaces are invalid')) unless success
       success
-    end
-
-    def build_managed_only
-      if !managed? && build?
-        errors.add(:build, _('cannot be enabled for an unmanaged host'))
-      end
     end
 
     def password_base64_encrypted?

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -33,6 +33,8 @@ end
 # display the token, if it hasn't expired
 node(:token, :if => ->(h) { h.token && !h.token_expired? }) { |host| host.token.value }
 
+node(:registration_token) { |h| h.registration_token }
+
 node :hostgroup_name do |host|
   host.hostgroup.name if host.hostgroup.present?
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -226,6 +226,12 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal puppet_proxy.name, response['puppet_proxy_name']
   end
 
+  test "should show registration token" do
+    get :show, params: {:id => @host.id}, session: set_session_user
+    assert_response :success
+    assert_not_empty ActiveSupport::JSON.decode(@response.body)['registration_token']
+  end
+
   test "should create host" do
     disable_orchestration
     assert_difference('Host.count') do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1005,12 +1005,11 @@ class HostTest < ActiveSupport::TestCase
     assert h.valid?
   end
 
-  test "should not allow build mode for unmanaged hosts" do
+  test "should allow build mode for unmanaged hosts" do
     h = FactoryBot.build_stubbed(:host)
     assert h.valid?
     h.build = true
-    refute h.valid?
-    assert h.errors[:build].include?("cannot be enabled for an unmanaged host")
+    assert h.valid?
   end
 
   test "should allow to save root pw" do


### PR DESCRIPTION
**Features:**
* Enable build mode for unmanaged hosts.
* Catch errors when rendering Host register template.
* Add register token to host detail in api (so it can be used later in Global registration template)

**Notes:**
* PR is part of **Simple & automatic host registration WF**, [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588) & [Redmine](https://projects.theforeman.org/issues/30440)
* Adding Host registration template to Global registration template will be done in [#30445](https://projects.theforeman.org/issues/30445)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
