### PR TITLE
Fixes #30684 - add password edit button to the http proxy form

### DIFF
--- a/app/views/http_proxies/_form.html.erb
+++ b/app/views/http_proxies/_form.html.erb
@@ -20,7 +20,7 @@
       <%= text_f   f, :name %>
       <%= text_f   f, :url, :help_inline => _("URL of the proxy including schema (https://proxy.example.com:8080)") %>
       <%= text_f   f, :username, :help_inline => _("Username to use if authentication is required.") %>
-      <%= password_f   f, :password, :help_inline => _("Password to use if authentication is required.") %>
+      <%= password_f   f, :password, :help_inline => _("Password to use if authentication is required."), :unset => true %>
 
       <%= text_f   f, :test_url, :value => "https://aws.amazon.com", :name => "test_url", :label => _("Test URL"),
                    :help_inline => spinner_button_f(f, 'Test Connection', "tfm.httpProxies.testConnection(this, '#{test_connection_http_proxies_path}')",


### PR DESCRIPTION
It should allow users to send the form without editing the password


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
