### PR TITLE
Fixes #29536: Use puma-systemd-plugin to provide systemd notify support

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,3 +1,4 @@
 group :service do
   gem 'puma'
+  gem 'puma-plugin-systemd'
 end

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -13,6 +13,14 @@ threads ENV.fetch('FOREMAN_PUMA_THREADS_MIN', 0).to_i, ENV.fetch('FOREMAN_PUMA_T
 #
 workers ENV.fetch('FOREMAN_PUMA_WORKERS', 2).to_i
 
+# Provides systemd notify support through the
+# puma-systemd-plugin
+begin
+  plugin :systemd
+rescue Puma::UnknownPlugin
+  puts "Failed to load systemd plugin"
+end
+
 # In clustered mode, Puma can "preload" your application. This loads all the
 # application code prior to forking. Preloading reduces total memory usage of
 # your application via an operating system feature called copy-on-write

--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -5,7 +5,7 @@ After=network.target remote-fs.target nss-lookup.target
 Requires=foreman.socket
 
 [Service]
-Type=simple
+Type=notify
 User=foreman
 TimeoutSec=300
 WorkingDirectory=/usr/share/foreman


### PR DESCRIPTION
This points to a fork of puma-systemd-plugin maintained by theforeman
organization to ensure this works with Puma 4.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
