### PR TITLE
Fixes #30713 - power_status helper fixed

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -265,7 +265,7 @@ class HostsController < ApplicationController
 
   def bmc
     render :partial => 'bmc', :locals => {
-      status: power_status(@host.power.state),
+      status: helpers.power_status(@host.power.state),
       bmc_proxy: @host.bmc_proxy,
     }
   rescue Foreman::BMCFeatureException

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1256,6 +1256,15 @@ class HostsControllerTest < ActionController::TestCase
     assert @host.root_pass.empty?
   end
 
+  test "host should get bmc status" do
+    @host.stubs(:bmc_proxy).returns(nil)
+    @host.interfaces.create(:name => "bmc1", :mac => '52:54:00:b0:0c:fc', :type => 'Nic::BMC',
+                      :ip => '10.0.1.101', :username => 'user1111', :password => 'abc123456', :provider => 'IPMI')
+    @host.power.stubs(:state).returns("on")
+    get :bmc, params: { :id => @host.id }, session: set_session_user
+    assert_response :success
+  end
+
   test "host update without BMC paasword in the params does not erase existing password" do
     bmc1 = @host.interfaces.build(:name => "bmc1", :mac => '52:54:00:b0:0c:fc', :type => 'Nic::BMC',
                       :ip => '10.0.1.101', :username => 'user1111', :password => 'abc123456', :provider => 'IPMI')


### PR DESCRIPTION
I have no idea why but Rails complains about non-existing method for
this code. I googled this, I have no idea why/how this worked. Probably
something from the pre-Rails5 time.