### PR TITLE
Global registration - add :url parameter to the list of allowed params for GRT endpoint

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -135,6 +135,7 @@ module Api
       param :organization_id, :number, desc: N_("ID of the Organization to register the host in.")
       param :location_id, :number, desc: N_("ID of the Location to register the host in.")
       param :hostgroup_id, :number, desc: N_("ID of the Host group to register the host in.")
+      param :url, String, desc: N_("URL to the Foreman or Smart proxy used in the template.")
       def global_registration
         if @provisioning_template
           render plain: @provisioning_template.render(variables: @global_registration_vars).html_safe

--- a/app/controllers/concerns/foreman/controller/provisioning_templates.rb
+++ b/app/controllers/concerns/foreman/controller/provisioning_templates.rb
@@ -59,6 +59,7 @@ module Foreman::Controller::ProvisioningTemplates
       organization: organization,
       location: location,
       hostgroup: host_group,
+      url: params['url'],
     }.merge(params.permit(permitted).to_h.symbolize_keys)
   end
 end

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -6,6 +6,7 @@ model: ProvisioningTemplate
 #!/bin/sh
 <%
     headers = ["-H 'Content-Type: application/json'", "-H 'Accept: application/json'", "-H 'Authorization: Bearer #{@auth_token}'"]
+    foreman_url = @url || foreman_server_url
 -%>
 
 # Rendered with following template parameters:
@@ -25,7 +26,7 @@ if [ -f /etc/os-release ] ; then
 fi
 
 create_host_curl() {
-  curl --request POST <%= foreman_server_url %>/api/hosts \
+  curl --request POST <%= foreman_url %>/api/hosts \
        <%= headers.join(' ') %> \
        -d '{ "host": { "name": "'$(hostname --fqdn)'", "build": "false", "managed": "false"
        <%= ", \"organization_id\": \"#{@organization.id}\"" if @organization -%>
@@ -42,9 +43,8 @@ echo "#"
 if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     CONSUMER_RPM=$(mktemp --suffix .rpm)
 
-    curl --insecure --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
+    curl --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
     yum localinstall $CONSUMER_RPM -y
-    yum install subscription-manager -y
     subscription-manager register --org=<%= @organization.label %> --activationkey="sample-key"
 
     rm -f $CONSUMER_RPM

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -206,6 +206,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
         organization_id: taxonomies(:organization1).id,
         location_id: taxonomies(:location1).id,
         hostgroup_id: hostgroups(:common).id,
+        url: 'http://foreman.example.com',
       }
 
       get :global_registration, params: params, session: set_session_user
@@ -215,6 +216,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
       assert_equal taxonomies(:organization1), vars[:organization]
       assert_equal taxonomies(:location1), vars[:location]
       assert_equal hostgroups(:common), vars[:hostgroup]
+      assert_equal 'http://foreman.example.com', vars[:url]
       assert_equal users(:admin), vars[:user]
     end
 


### PR DESCRIPTION
Related to: https://github.com/theforeman/smart-proxy/pull/763

How to test:
```
curl -X GET "/register?url=https://my-new-foreman-url.com" --user admin:changeme
```