### PR TITLE
Fixes #30447 - add :insecure parameter to the Global registration endpoint

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -135,6 +135,7 @@ module Api
       param :organization_id, :number, desc: N_("ID of the Organization to register the host in.")
       param :location_id, :number, desc: N_("ID of the Location to register the host in.")
       param :hostgroup_id, :number, desc: N_("ID of the Host group to register the host in.")
+      param :insecure, :bool, desc: N_("Flag for allowing insecure connections when using SSL.")
       def global_registration
         if @provisioning_template
           render plain: @provisioning_template.render(variables: @global_registration_vars).html_safe

--- a/app/controllers/concerns/foreman/controller/provisioning_templates.rb
+++ b/app/controllers/concerns/foreman/controller/provisioning_templates.rb
@@ -59,6 +59,7 @@ module Foreman::Controller::ProvisioningTemplates
       organization: organization,
       location: location,
       hostgroup: host_group,
+      insecure: ActiveRecord::Type::Boolean.new.deserialize(params['insecure']),
     }.merge(params.permit(permitted).to_h.symbolize_keys)
   end
 end

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -26,7 +26,7 @@ fi
 
 create_host_curl() {
   curl --request POST <%= foreman_server_url %>/api/hosts \
-       <%= headers.join(' ') %> \
+       <%= '--insecure' if @insecure %> <%= headers.join(' ') %> \
        -d '{ "host": { "name": "'$(hostname --fqdn)'", "build": "false", "managed": "false"
        <%= ", \"organization_id\": \"#{@organization.id}\"" if @organization -%>
        <%= ", \"location_id\": \"#{@location.id}\"" if @location -%>
@@ -42,9 +42,8 @@ echo "#"
 if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     CONSUMER_RPM=$(mktemp --suffix .rpm)
 
-    curl --insecure --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
+    curl --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
     yum localinstall $CONSUMER_RPM -y
-    yum install subscription-manager -y
     subscription-manager register --org=<%= @organization.label %> --activationkey="sample-key"
 
     rm -f $CONSUMER_RPM

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -206,6 +206,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
         organization_id: taxonomies(:organization1).id,
         location_id: taxonomies(:location1).id,
         hostgroup_id: hostgroups(:common).id,
+        insecure: 'true',
       }
 
       get :global_registration, params: params, session: set_session_user
@@ -215,6 +216,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
       assert_equal taxonomies(:organization1), vars[:organization]
       assert_equal taxonomies(:location1), vars[:location]
       assert_equal hostgroups(:common), vars[:hostgroup]
+      assert vars[:insecure]
       assert_equal users(:admin), vars[:user]
     end
 


### PR DESCRIPTION
How to test:
```
curl -X GET "foreman.example.com/register?insecure=true" --user admin:changeme
```

Notes:
* PR is part of **Simple & automatic host registration WF**, [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588) & [Redmine](https://projects.theforeman.org/issues/30440)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
