### PR TITLE
Fixes #30727 - Fix setting validation

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -40,7 +40,7 @@ class Setting < ApplicationRecord
   validates :value, :numericality => true, :length => {:maximum => 8}, :if => proc { |s| s.settings_type == "integer" }
   validates :value, :numericality => {:greater_than => 0}, :if => proc { |s| NONZERO_ATTRS.include?(s.name) }
   validates :value, :inclusion => {:in => [true, false]}, :if => proc { |s| s.settings_type == "boolean" }
-  validates :value, :presence => true, :if => proc { |s| s.settings_type == "array" && !BLANK_ATTRS.include?(s.name) }
+  validates :value, :presence => true, :if => proc { |s| (s.settings_type == "array" || s.settings_type == "string") && !BLANK_ATTRS.include?(s.name) }
   validates :settings_type, :inclusion => {:in => TYPES}, :allow_nil => true, :allow_blank => true
   validates :value, :url_schema => ['http', 'https'], :if => proc { |s| URI_ATTRS.include?(s.name) }
 

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -345,7 +345,7 @@ class SettingTest < ActiveSupport::TestCase
     setting = Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
     setting.value = ""
     assert !setting.save
-    assert_equal "URL must be valid and schema must be one of http and https", setting.errors[:value].first
+    assert_equal "can't be blank", setting.errors[:value].first
   end
 
   test "unattended_url must have a valid format" do
@@ -358,9 +358,9 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   test "unattended_url must have proper format" do
-    attrs = { :name => "foreman_url", :default => "http://foo.com" }
+    attrs = { :name => "unattended_url", :default => "http://foo.com" }
     assert Setting.where(:name => attrs[:name]).first || Setting.create(attrs)
-    setting = Setting.find_by_name("foreman_url")
+    setting = Setting.find_by_name("unattended_url")
     setting.value = "random_string"
     assert !setting.save
     assert_equal "URL must be valid and schema must be one of http and https", setting.errors[:value].first


### PR DESCRIPTION
This PR makes sure that Settings that belong to the `BLANK_ATTRS`, must be allowed to have empty values. Other settings with setting_type as 'string' must display an error.

related pr: https://github.com/theforeman/foreman_discovery/pull/505