### PR TITLE
Fixes #30734 - Use noninteractive frontend while installing freeipa-client on debian systems. 

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/freeipa_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/freeipa_register.erb
@@ -45,7 +45,7 @@ snippet: true
   freeipa_client=freeipa-client
 <% end -%>
 
-<%= @host.operatingsystem.family == 'Redhat' ? 'yum install -y libsss_sudo' : 'apt-get install -y libsss-sudo' %> $freeipa_client
+<%= @host.operatingsystem.family == 'Redhat' ? 'yum install -y libsss_sudo' : 'DEBIAN_FRONTEND=noninteractive apt-get install -y libsss-sudo' %> $freeipa_client
 
 ##
 ## IPA Client Installation

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/freeipa_register.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/freeipa_register.snap.txt
@@ -26,7 +26,7 @@
 
   freeipa_client=freeipa-client
 
-apt-get install -y libsss-sudo $freeipa_client
+DEBIAN_FRONTEND=noninteractive apt-get install -y libsss-sudo $freeipa_client
 
 ##
 ## IPA Client Installation


### PR DESCRIPTION
I ran into an issue when installing freeipa-client, specifically when it installs the krb5 dependency. Because DEBIAN_FRONTEND is not set it opens a dialog to configure the package which causes cloud-init and finish scripts to fail because they are noninteractive. This patch fixes this by setting DEBIAN_FRONTEND to noninteractive.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
