### PR TITLE
Fixes #30601 - replace mount_react_component in toasts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -474,7 +474,7 @@ module ApplicationHelper
   def notifications
     content_tag :div, id: 'toast-notifications-container',
                       'data-notifications': toast_notifications_data.to_json.html_safe do
-      mount_react_component('ToastNotifications', '#toast-notifications-container')
+      react_component('ToastNotifications')
     end
   end
 


### PR DESCRIPTION
Didn't want to make this a toast refactor PR so I kept the div for the J-Query to add toasts
replaces mount_react_component with react_component in ToastNotifications