### PR TITLE
Refs #27298 - drop unstable audit mailer test

### DIFF
--- a/test/mailers/audit_mailer_test.rb
+++ b/test/mailers/audit_mailer_test.rb
@@ -52,12 +52,4 @@ class AuditMailerTest < ActionMailer::TestCase
     query_should_be = CGI.escape(@options[:query])
     assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, query_should_be)
   end
-
-  test "Audit template change should not crash" do
-    template = FactoryBot.create(:provisioning_template, :template => 'aaaa', :snippet => true)
-    template.update!(:template => 'bbbbbb')
-    audit = template.reload.audits.last
-    @options[:query] = "id = #{audit.id}"
-    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, 'Template content changed')
-  end
 end


### PR DESCRIPTION
This test has been failing randomly very often and three previous
attempts at fixing it have all failed.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
