### PR TITLE
Fixes #30706 - Gracefully recover from CR connection error

### DIFF
--- a/app/controllers/compute_resources_controller.rb
+++ b/app/controllers/compute_resources_controller.rb
@@ -36,7 +36,7 @@ class ComputeResourcesController < ApplicationController
       @compute_resource.valid?
       process_error
     end
-  rescue Fog::Errors::Error => e
+  rescue Fog::Errors::Error, Excon::Error => e
     Foreman::Logging.exception("Error while creating a resource", e)
     process_error(
       error_msg: _('Error while trying to create resource: %s') % e.message
@@ -75,7 +75,7 @@ class ComputeResourcesController < ApplicationController
     else
       process_error
     end
-  rescue Fog::Errors::Error => e
+  rescue Fog::Errors::Error, Excon::Error => e
     Foreman::Logging.exception("Error while updating resource", e)
     process_error(
       error_msg: _('Error while trying to update resource: %s') % e.message


### PR DESCRIPTION
If the connection fails to the compute resource due to networking
issues we should capture it nicely rather than causing a 500 page.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
