### PR TITLE
Fixes #30763 - move architecture to abstract provider

### DIFF
--- a/app/services/medium_providers/default.rb
+++ b/app/services/medium_providers/default.rb
@@ -36,10 +36,6 @@ module MediumProviders
       entity.respond_to?(:medium) && errors.empty?
     end
 
-    def architecture
-      entity.try(:architecture)
-    end
-
     private
 
     def medium_vars_to_uri(url, arch, os, &block)

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -66,6 +66,10 @@ module MediumProviders
       raise "validate is not implemented for #{self.class.name}"
     end
 
+    def architecture
+      entity.try(:architecture)
+    end
+
     private
 
     def parse_media(media)


### PR DESCRIPTION
Some time ago I defined `architecture` helper method returning entity
(host) architecture. It works fine for Foreman core where only Default
media provider is used but Katello plugin uses abstract class Provider
which don't have this method. Therefore the call returns nil, thus for
PPC64 architecture the installation media URL is not constructed
correctly.

https://github.com/theforeman/foreman/pull/7381

Before (Katello must be installed, a host with Katello content):

```
irb(main):007:0> h = Host.find_by_name("barry-mauter.foo.bar")
=> #<Host::Managed id: 14, name: "barry-mauter.foo.bar", last_compile: nil, last_report: nil, updated_at: "2020-09-02 08:20:12", created_at: "2020-09-02 08:20:12", root_pass: [FILTERED], architecture_id: 31, operatingsystem_id: 6, environment_id: 1, ptable_id: 116, medium_id: nil, build: true, comment: "", disk: "", installed_at: nil, model_id: nil, hostgroup_id: 1, owner_id: 4, owner_type: "User", enabled: true, puppet_ca_proxy_id: nil, managed: true, use_image: nil, image_file: nil, uuid: nil, compute_resource_id: nil, puppet_proxy_id: nil, certname: nil, image_id: nil, organization_id: 1, location_id: 2, type: "Host::Managed", otp: nil, realm_id: nil, compute_profile_id: nil, provision_method: "build", grub_pass: "$5$61Hlb5aFbqjG164v$JrxUKJ/s9COZrJDqGgV57xcCkMur2u...", discovery_rule_id: nil, global_status: 0, lookup_value_matcher: [FILTERED], openscap_proxy_id: nil, pxe_loader: "PXELinux BIOS", initiated_at: nil, build_errors: nil>
irb(main):010:0> h.operatingsystem.boot_files_uri(h.medium_provider)
=> ["http://xxx.redhat.com/pulp/repos/Default_Organization/Library/content/beta/rhel8/8/ppc64le/baseos/kickstart//images/pxeboot/vmlinuz", "http://xxx.redhat.com/pulp/repos/Default_Organization/Library/content/beta/rhel8/8/ppc64le/baseos/kickstart//images/pxeboot/initrd.img"]
```

After:

The url contains `ppc/ppc64` path.