### PR TITLE
Fixes #30768 - remove API status selector default

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
@@ -5,7 +5,7 @@ export const selectAPI = state => state.API;
 export const selectAPIByKey = (state, key) => selectAPI(state)[key] || {};
 
 export const selectAPIStatus = (state, key) =>
-  selectAPIByKey(state, key).status || STATUS.PENDING;
+  selectAPIByKey(state, key).status;
 
 export const selectAPIPayload = (state, key) =>
   selectAPIByKey(state, key).payload || {};


### PR DESCRIPTION
The issue is when an API call wasn't created yet, the status was returning 'PENDING' always, while it should really return 'undefined'.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
