### PR TITLE
Fixes #30786 - Fix yup snapshots

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/BookmarkForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/BookmarkForm.test.js.snap
@@ -67,6 +67,7 @@ exports[`BookmarkForm should render bookmarks form with initial values 1`] = `
           "transforms": Array [
             [Function],
           ],
+          "type": "string",
         },
         "query": StringSchema {
           "_blacklist": RefSet {
@@ -97,12 +98,14 @@ exports[`BookmarkForm should render bookmarks form with initial values 1`] = `
           "transforms": Array [
             [Function],
           ],
+          "type": "string",
         },
       },
       "tests": Array [],
       "transforms": Array [
         [Function],
       ],
+      "type": "object",
     }
   }
 >

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/__snapshots__/ForemanForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/__snapshots__/ForemanForm.test.js.snap
@@ -85,6 +85,7 @@ exports[`ForemanForm render foreman form with fields 1`] = `
           "transforms": Array [
             [Function],
           ],
+          "type": "string",
         },
         "surname": StringSchema {
           "_blacklist": RefSet {
@@ -113,12 +114,14 @@ exports[`ForemanForm render foreman form with fields 1`] = `
           "transforms": Array [
             [Function],
           ],
+          "type": "string",
         },
       },
       "tests": Array [],
       "transforms": Array [
         [Function],
       ],
+      "type": "object",
     }
   }
 >


### PR DESCRIPTION
Yup was updates in @theforeman/vendor-core (4.14.6) (https://github.com/theforeman/foreman-js/pull/199)
The snapshots from `Yup.string()`  and `Yup.object()` were changed.

