### PR TITLE
Fixes #30791 - Add tab-extension ability (host details page)

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
@@ -78,7 +78,10 @@ const AuditCard = ({ hostName }) => {
                       {audit &&
                         Object.entries(audit.audited_changes).map(
                           ([key, value], i) => (
-                            <DataListItem aria-labelledby="">
+                            <DataListItem
+                              key={`audit-item${i}`}
+                              aria-labelledby=""
+                            >
                               <DataListItemRow>
                                 <DataListItemCells
                                   dataListCells={[

--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
@@ -7,3 +7,8 @@
   margin-right: -20px;
   background: white;
 }
+
+.host-details-tab-item {
+  padding: 18px;
+  background: #f0f0f0;
+}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Details.css
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Details.css
@@ -1,0 +1,7 @@
+.details-tab {
+  padding-top: 20px;
+}
+
+.details-cards {
+  padding-top: 20px;
+}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
@@ -1,0 +1,49 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Grid, GridItem } from '@patternfly/react-core';
+
+import Properties from '../../Properties';
+import ParametersCard from '../../Parameters';
+import InterfacesCard from '../../Interfaces';
+import AuditCard from '../../Audits';
+import StatusAlert from '../../Status';
+import './Details.css';
+
+const DetailsTab = ({ response }) => (
+  <div className="details-tab">
+    <Grid>
+      <GridItem offset={3} span={4}>
+        <StatusAlert status={response ? response.global_status_label : null} />
+      </GridItem>
+    </Grid>
+    <Grid className="details-cards">
+      <GridItem span={3} rowSpan={3}>
+        <Properties hostData={response} />
+      </GridItem>
+      <GridItem style={{ marginLeft: '40px' }} span={3}>
+        <ParametersCard paramters={response.all_parameters} />
+      </GridItem>
+      <GridItem style={{ marginLeft: '40px' }} span={3} rowSpan={2}>
+        <AuditCard hostName={response.name} />
+      </GridItem>
+      <GridItem
+        style={{ marginLeft: '40px', marginTop: '20px' }}
+        offset={3}
+        span={3}
+      >
+        <InterfacesCard interfaces={response.interfaces} />
+      </GridItem>
+    </Grid>
+  </div>
+);
+
+DetailsTab.propTypes = {
+  response: PropTypes.shape({
+    all_parameters: PropTypes.string,
+    global_status_label: PropTypes.string,
+    interfaces: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
+};
+
+export default DetailsTab;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { addGlobalFill } from '../../common/Fill/GlobalFill';
+import DetailsTab from './Details';
+
+export const registerCoreTabs = () => {
+  addGlobalFill('host-details-page-tabs', 'Details', <DetailsTab />, 1000);
+};

--- a/webpack/assets/javascripts/react_app/components/common/Fill/FillActions.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/FillActions.js
@@ -11,7 +11,7 @@ export const registerFillComponent = (
   add(slotId, fillId, component, weight, overrideProps);
   dispatch({
     type: REGISTER_FILL,
-    payload: { slotId, fillId },
+    payload: { slotId, fillId, weight },
   });
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/Fill/FillReducer.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/FillReducer.js
@@ -9,7 +9,7 @@ export default (state = initialState, action) => {
 
   switch (action.type) {
     case REGISTER_FILL:
-      return state.setIn([payload.slotId, payload.fillId], true);
+      return state.setIn([payload.slotId, payload.fillId], payload.weight);
 
     case REMOVE_FILLED_COMPONENT:
       return state.setIn([payload.slotId, payload.fillId], false);

--- a/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillActions.test.js.snap
@@ -12,6 +12,7 @@ Array [
           "slotId": "slot-id",
           "weight": 100,
         },
+        "weight": undefined,
       },
       "type": "SLOT_AND_FILL_REGISTER_FILL",
     },

--- a/webpack/assets/javascripts/react_app/components/common/Slot/SlotSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/SlotSelectors.js
@@ -12,10 +12,25 @@ export const selectFillsAmount = (state, id) => {
   return registerdFills ? Object.keys(registerdFills).length : 0;
 };
 
+export const selectFillsIDs = (state, id) => {
+  const registerdFills = state.extendable[id];
+  if (registerdFills) {
+    const fillIDs = Object.keys(registerdFills);
+    return fillIDs.sort((a, b) => registerdFills[b] - registerdFills[a]);
+  }
+  return null;
+};
+
 export const selectFillsComponents = (state, props) => {
-  const { id, multiple } = props;
+  const { id, multiple, fillID } = props;
 
   if (selectFillsAmount(state, id)) {
+    if (fillID) {
+      const slotComponent = getSlotComponents(id);
+      const getFill = slotComponent.filter(c => c.id === fillID);
+
+      return [getFill[0].component];
+    }
     if (multiple) return selectComponentByWeight(id);
     return [selectMaxComponent(id)];
   }

--- a/webpack/assets/javascripts/react_app/components/common/Slot/__snapshots__/Slot.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/__snapshots__/Slot.test.js.snap
@@ -197,8 +197,8 @@ exports[`Slot-Fill render multiple fills 2`] = `
 Object {
   "extendable": Object {
     "slot-1": Object {
-      "some-key-1": true,
-      "some-key-2": true,
+      "some-key-1": 100,
+      "some-key-2": 200,
     },
   },
 }
@@ -211,6 +211,7 @@ Array [
       "payload": Object {
         "fillId": "some-key-1",
         "slotId": "slot-1",
+        "weight": 100,
       },
       "type": "SLOT_AND_FILL_REGISTER_FILL",
     },
@@ -220,6 +221,7 @@ Array [
       "payload": Object {
         "fillId": "some-key-2",
         "slotId": "slot-1",
+        "weight": 200,
       },
       "type": "SLOT_AND_FILL_REGISTER_FILL",
     },

--- a/webpack/assets/javascripts/react_app/components/common/Slot/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/index.js
@@ -7,6 +7,7 @@ const mapStateToProps = (state, ownProps) => ({
   fills: selectFillsComponents(state, {
     id: ownProps.id,
     multiple: ownProps.multi,
+    fillID: ownProps.fillID,
   }),
 });
 

--- a/webpack/assets/javascripts/services/SlotsRegistry/__snapshots__/SlotsRegistry.test.js.snap
+++ b/webpack/assets/javascripts/services/SlotsRegistry/__snapshots__/SlotsRegistry.test.js.snap
@@ -4,6 +4,7 @@ exports[`Extendable Registry should render one component after a removal 1`] = `
 Array [
   Object {
     "component": [Function],
+    "id": "fill-id-1",
     "weight": 100,
   },
 ]
@@ -13,10 +14,12 @@ exports[`Extendable Registry should render two components by weights 1`] = `
 Array [
   Object {
     "component": [Function],
+    "id": "fill-id-1",
     "weight": 100,
   },
   Object {
     "component": [Function],
+    "id": "fill-id-2",
     "weight": 200,
   },
 ]

--- a/webpack/assets/javascripts/services/SlotsRegistry/index.js
+++ b/webpack/assets/javascripts/services/SlotsRegistry/index.js
@@ -5,7 +5,7 @@ export const add = (SlotId, fillId, component, weight, overrideProps) => {
     slotsRegistry[SlotId] = {};
   }
   component = component || overrideProps;
-  slotsRegistry[SlotId][fillId] = { component, weight };
+  slotsRegistry[SlotId][fillId] = { component, weight, id: fillId };
 };
 
 export const remove = (SlotId, fillId) => {
@@ -14,4 +14,7 @@ export const remove = (SlotId, fillId) => {
   delete slotItems[fillId];
 };
 
-export const getSlotComponents = id => Object.values(slotsRegistry[id]);
+export const getSlotComponents = id =>
+  slotsRegistry[id] && Object.values(slotsRegistry[id]);
+
+export const getFillsFromSlot = slotId => slotsRegistry[slotId];


### PR DESCRIPTION
This pr adds the ability to add tabs from core and plugins into the new host details page:
1. Registry for adding react component as a tab content by using slot&fill
2. Weight-based ordering - plugins can reorder tabs by changing the weight prop
3. Navigate to a tab directly - by adding `#` to the URL following the tab name  (_i.e /experimental/hosts/<host-name>#Details_)

_Reordering tabs - subscription tab (arrived from katello) has a greater weight than core's `Details` tab_
![image](https://user-images.githubusercontent.com/11807069/92418262-446ed700-f16f-11ea-9160-3d5dfe7d32ad.png)


