### PR TITLE
Fixes #30036 - add fallback to parameterize in templates 

### DIFF
--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -103,35 +103,35 @@
         <%= link_to(_('For more info visit our documentation.'), documentation_url(controller.documentation_anchor)) if controller.respond_to?(:documentation_anchor) %>
         <h2><%= _('Examples') %></h2>
         <div class="panel-group" id="accordion-markup">
-          <%= render "help_accordion", :title => _('Comments'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Comments'), :contents => (capture { %>
             <%%# this is a comment %>
           <% }) %>
-          <%= render "help_accordion", :title => _('In-line code syntax'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('In-line code syntax'), :contents => (capture { %>
             <%% if true -%><br/>
             &nbsp;&nbsp;some content<br/>
             <%% end -%>
           <% }) %>
-          <%= render "help_accordion", :title => _('Printing data'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Printing data'), :contents => (capture { %>
             <%%= "some content from variable" %>
           <% }) %>
-          <%= render "help_accordion", :title => _('Variables'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Variables'), :contents => (capture { %>
             <%%= @host %>
           <% }) %>
-          <%= render "help_accordion", :title => _('Calling methods on objects'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Calling methods on objects'), :contents => (capture { %>
             <%%= @host.operatingsystem.major %>
           <% }) %>
-          <%= render "help_accordion", :title => _('Safe mode methods'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Safe mode methods'), :contents => (capture { %>
             <%%# @host.operatingsystem.set_title("this method is not listed for Operatingsystem") %>
           <% }) %>
-          <%= render "help_accordion", :title => _('Global macros'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Global macros'), :contents => (capture { %>
             <%%= rand(9999) + 1 %>
           <% }) %>
-          <%= render "help_accordion", :title => _('Iterating'), :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Iterating'), :contents => (capture { %>
             <%% @host.interfaces.each do |interface| -%><br/>
             &nbsp;&nbsp;NIC name: <%%= interface.name %><br/>
             <%% end -%><br/>
           <% }) %>
-          <%= render "help_accordion", :title => _('Inputs'), :wrap_in_code => false, :contents => (capture { %>
+          <%= render "help_accordion", :title => N_('Inputs'), :wrap_in_code => false, :contents => (capture { %>
               <p>
                 <%= (_('Once you define a template input in Inputs tab and save the template, it can be used in the ERB.
                 To load value specified through this input, use global macro %{example1} and pass the input

--- a/app/views/templates/_help_accordion.html.erb
+++ b/app/views/templates/_help_accordion.html.erb
@@ -2,7 +2,7 @@
   <div class="panel-heading">
     <h4 class="panel-title">
       <a data-toggle="collapse" data-parent="#accordion-markup" href="#<%= title.parameterize %>" class="collapsed">
-        <%= title %>
+        <%= _(title) %>
       </a>
     </h4>
   </div>


### PR DESCRIPTION
parameterize returns empty strings for Japanese (probably because transliterate returns "?" for Japanese).
This causes an error when loading `/templates/report_templates/_ID_/edit`
and trying to expend the help accordions
```
foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:329765 Uncaught Error: Syntax error, unrecognized expression: #
    at Function.Sizzle.error (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:329765)
    at Sizzle.tokenize (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:330422)
    at Sizzle.select (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:330843)
    at Function.Sizzle [as find] (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:329166)
    at jQuery.fn.init.find (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:331089)
    at getTargetFromTrigger (application-7aaa020a7d4aa862005381ff6c8f397e5eb488f3008ca27ec0a36bb0e2d60ca7.js:3301)
    at HTMLAnchorElement.<anonymous> (application-7aaa020a7d4aa862005381ff6c8f397e5eb488f3008ca27ec0a36bb0e2d60ca7.js:3343)
    at HTMLDocument.dispatch (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:333034)
    at HTMLDocument.elemData.handle (foreman-vendor.bundle-v4.15.1-development-e5b8494c82f561b65232.js:332846)
```