### PR TITLE
Refs #30803: Enable unix socket binding

### DIFF
--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -27,6 +27,22 @@ end
 #
 preload_app!
 
+# Check if FOREMAN_BIND was set to an IP address based on the previous
+# definition of FOREMAN_BIND. If it is an IP address, define the host
+# and port through Puma's DSL. Otherwise rescue and assume the new
+# style of a fully specified bind in the formats of:
+#
+#  * unix:///run/foreman.sock
+#  * tcp://127.0.0.1:3000
+#
+begin
+  IPAddr.new(ENV['FOREMAN_BIND'])
+
+  port ENV.fetch('FOREMAN_PORT', '3000'), ENV['FOREMAN_BIND']
+rescue IPAddr::Error
+  bind ENV.fetch('FOREMAN_BIND', 'tcp://127.0.0.1:3000')
+end
+
 on_worker_boot do
   dynflow = ::Rails.application.dynflow
   dynflow.initialize! unless dynflow.config.lazy_initialization

--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -9,8 +9,8 @@ Type=notify
 User=foreman
 TimeoutSec=300
 WorkingDirectory=/usr/share/foreman
-ExecStart=/usr/share/foreman/bin/rails server --environment $FOREMAN_ENV --port $FOREMAN_PORT --binding $FOREMAN_BIND
-Environment=FOREMAN_ENV=production FOREMAN_PORT=3000 FOREMAN_BIND=0.0.0.0
+ExecStart=/usr/share/foreman/bin/rails server --environment $FOREMAN_ENV
+Environment=FOREMAN_ENV=production FOREMAN_BIND=tcp://0.0.0.0:3000
 Environment=MALLOC_ARENA_MAX=2
 
 SyslogIdentifier=foreman


### PR DESCRIPTION
Switches to configure bind and port inside Puma's configuration
to allow Unix socket binding or tcp.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
