### PR TITLE
Fixes #30445 - Host registration template & Insights with Rex setup

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -25,13 +25,19 @@ if [ -f /etc/os-release ] ; then
 fi
 
 create_host_curl() {
-  curl --request POST <%= foreman_server_url %>/api/hosts \
+  curl --fail --request POST <%= foreman_server_url %>/api/hosts \
        <%= headers.join(' ') %> \
        -d '{ "host": { "name": "'$(hostname --fqdn)'", "build": "false", "managed": "false"
        <%= ", \"organization_id\": \"#{@organization.id}\"" if @organization -%>
        <%= ", \"location_id\": \"#{@location.id}\"" if @location -%>
        <%= ", \"hostgroup_id\": \"#{@hostgroup.id}\"" if @hostgroup -%>
        }}'
+}
+
+exit_on_error() {
+    echo ""
+    echo "Host registration failed"
+    exit 1
 }
 
 echo "#"
@@ -45,12 +51,15 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     curl --insecure --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
     yum localinstall $CONSUMER_RPM -y
     yum install subscription-manager -y
-    subscription-manager register --org=<%= @organization.label %> --activationkey="sample-key"
-
+    subscription-manager register --org=<%= @organization.label %> --activationkey="sample-key" || exit_on_error
     rm -f $CONSUMER_RPM
+
+    TOKEN=$(curl -s -X GET "<%= foreman_server_url %>/api/hosts/$(hostname --fqdn)" <%= headers.join(' ') %> | grep -Po '(?<=\"registration_token\":")([^\"]+)')
 else
-    create_host_curl
+    TOKEN=$(create_host_curl | grep -Po '(?<=\"registration_token\":")([^\"]+)') || exit_on_error
 fi
 <% else -%>
-create_host_curl
+TOKEN=$(create_host_curl | grep -Po '(?<=\"registration_token\":")([^\"]+)') || exit_on_error
 <% end -%>
+
+curl -X GET "<%= foreman_server_url %>/foreman_register/hosts/register?token=$TOKEN" | bash

--- a/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
+++ b/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
@@ -20,6 +20,23 @@ set -e
 <%= snippet 'puppet_setup' %>
 <% end -%>
 
+<%= snippet 'remote_execution_ssh_keys' %>
+
+<% if host_param_true?('host_registration_insights') -%>
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ x$ID = xrhel ]; then
+  echo '#'
+  echo '# Installing Insights client'
+  echo '#'
+
+  yum install -y insights-client
+  insights-client --register
+fi
+<% end -%>
+
 # Call home to exit build mode
 
 curl -o /dev/null --noproxy \* '<%= foreman_url('built') %>'

--- a/db/seeds.d/180-common_parameters.rb
+++ b/db/seeds.d/180-common_parameters.rb
@@ -1,0 +1,7 @@
+CommonParameter.without_auditing do
+  params = [
+    { name: "host_registration_insights", key_type: "boolean", value: false },
+  ]
+
+  params.each { |param| CommonParameter.find_or_create_by(param) }
+end


### PR DESCRIPTION
**Features:**
* Get & render _Host registration template_ in _Global registration template_
* New global parameters
```
host_registration_ssh_keys - default: true
host_registration_insights - default: false
```

**Limitations**
Before registration:
* _Host Registration template_ must have assigned OS
* OS must have assigned _Host Registration template_
* Hosts without OS (registered via `create_host_curl`) cannot render _Host registration template_

PR is part of **Simple & automatic host registration WF**, see:
* [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588)
* [Redmine (this PR)](https://projects.theforeman.org/issues/30445)
* [Redmine (Parent task)](https://projects.theforeman.org/issues/30440)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
