### PR TITLE
explicitly use rsync.theforeman.org for debug upload

### DIFF
--- a/config/foreman-debug.conf
+++ b/config/foreman-debug.conf
@@ -34,7 +34,7 @@
 #UPLOAD_DISABLED=0
 
 # URL of the upload location (string)
-#UPLOAD_URL='rsync://theforeman.org/debug-incoming'
+#UPLOAD_URL='rsync://rsync.theforeman.org/debug-incoming'
 
 # The full upload command in strict quotes (string)
 #UPLOAD_CMD='rsync "${TARBALL}" "${UPLOAD_URL}"'

--- a/script/foreman-debug
+++ b/script/foreman-debug
@@ -143,7 +143,7 @@ VERBOSE=0
 DEBUG=0
 UPLOAD=0
 UPLOAD_DISABLED=0
-UPLOAD_URL='rsync://theforeman.org/debug-incoming'
+UPLOAD_URL='rsync://rsync.theforeman.org/debug-incoming'
 UPLOAD_CMD='rsync "${TARBALL}" "${UPLOAD_URL}"'
 UPLOAD_USAGE_MSG="\
 You may want to upload the tarball (with -u) to our public server via rsync.


### PR DESCRIPTION
theforeman.org might point at a different system than the one running
rsync


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
