### PR TITLE
Fixes #30817 - Remove AIO dirs in puppet.conf

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -3,7 +3,7 @@ kind: snippet
 name: puppet.conf
 model: ProvisioningTemplate
 snippet: true
-%>
+-%>
 <%
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
@@ -11,12 +11,7 @@ snippet: true
   aio_enabled = host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
-  if aio_enabled && aio_available
-    var_dir = '/opt/puppetlabs/puppet/cache'
-    log_dir = '/var/log/puppetlabs/puppet'
-    run_dir = '/var/run/puppetlabs'
-    ssl_dir = '/etc/puppetlabs/puppet/ssl'
-  elsif os_family == 'Windows'
+  if os_family == 'Windows'
     var_dir = 'C:\ProgramData\PuppetLabs\puppet\cache'
     log_dir = 'C:\ProgramData\PuppetLabs\puppet\var\log'
     run_dir = 'C:\ProgramData\PuppetLabs\puppet\var\run'
@@ -31,17 +26,16 @@ snippet: true
     run_dir = '/var/run/puppet'
     ssl_dir = '\$vardir/ssl'
   end
-%>
+-%>
 [main]
 <%- unless host_param('dns_alt_names').to_s.empty? -%>
 dns_alt_names = <%= host_param('dns_alt_names') %>
 <%- end -%>
+<% unless aio_enabled && aio_available -%>
 vardir = <%= var_dir %>
 logdir = <%= log_dir %>
 rundir = <%= run_dir %>
 ssldir = <%= ssl_dir %>
-<% if host_param_true?('fips_enabled') -%>
-digest_algorithm = sha256
 <% end -%>
 
 [agent]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator default finish.snap.txt
@@ -20,8 +20,6 @@ apt-get -y install puppet >/dev/null 2>/dev/null
 
 
 cat > /etc/puppet/puppet.conf << EOF
-
-
 [main]
 vardir = /var/lib/puppet
 logdir = /var/log/puppet

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.snap.txt
@@ -1,5 +1,3 @@
-
-
 [main]
 vardir = /var/lib/puppet
 logdir = /var/log/puppet

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.snap.txt
@@ -3,8 +3,6 @@
 
 
 cat > /etc/puppet/puppet.conf << EOF
-
-
 [main]
 vardir = /var/lib/puppet
 logdir = /var/log/puppet


### PR DESCRIPTION
In Puppet's AIO package the default puppet.conf doesn't contain any of these directories so it's not needed to set them.

I confirmed this on CentOS 7 with Puppet 5 and 6 as well as on Debian 10 with Puppet 6. Since Puppet 4 is EOL, there's no need to test that. It's to be expected that Puppet 7 will also not need these directories.

I've left in puppet.conf on Windows and non-AIO. On Debian non-AIO some directories are still set and I can't verify other platforms.

The digest_algorithm on FIPS is not needed since Puppet 5.4.0. Anything older is EOL so it can be safely dropped.

I debated leaving out the FIPS change since it's not strictly the same thing.