### PR TITLE
Fixes #30820 - drop digest and use hash index instead

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -2,15 +2,15 @@ class Message < ApplicationRecord
   has_many :reports, :through => :logs
   has_many :logs
   validates_lengths_from_database
-  validates :value, :digest, :presence => true
+  validates :value, :presence => true
 
   def to_s
     value
   end
 
-  def self.find_or_create(val)
-    digest = Digest::SHA1.hexdigest(val)
-    Message.find_by(:digest => digest) || Message.create(:value => val, :digest => digest)
+  # DEPRECATED: use Rails method (no warning because this is called many times)
+  def self.find_or_create(value)
+    find_or_create_by(value: value)
   end
 
   def skip_strip_attrs

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,15 +1,19 @@
 class Source < ApplicationRecord
-  validates_lengths_from_database
   has_many :reports, :through => :logs
   has_many :logs
-  validates :value, :digest, :presence => true
+  validates_lengths_from_database
+  validates :value, :presence => true
 
   def to_s
     value
   end
 
-  def self.find_or_create(val)
-    digest = Digest::SHA1.hexdigest(val)
-    Source.find_by(:digest => digest) || Source.create(:value => val, :digest => digest)
+  # DEPRECATED: use Rails method (no warning because this is called many times)
+  def self.find_or_create(value)
+    find_or_create_by(value: value)
+  end
+
+  def skip_strip_attrs
+    ['value']
   end
 end

--- a/db/migrate/20200911083030_use_hash_index_for_reports.rb
+++ b/db/migrate/20200911083030_use_hash_index_for_reports.rb
@@ -1,0 +1,11 @@
+class UseHashIndexForReports < ActiveRecord::Migration[6.0]
+  def change
+    remove_index(:messages, :digest)
+    remove_index(:sources, :digest)
+    remove_column(:messages, :digest, :string, :limit => 40)
+    remove_column(:sources, :digest, :string, :limit => 40)
+
+    add_index(:messages, :value, using: 'hash')
+    add_index(:sources, :value, using: 'hash')
+  end
+end

--- a/test/benchmark/puppet_report_benchmark.rb
+++ b/test/benchmark/puppet_report_benchmark.rb
@@ -1,0 +1,45 @@
+require 'net/http'
+require 'uri'
+require 'json'
+require 'securerandom'
+require 'benchmark/ips'
+
+UNIQUE_RECORDS = 1_000
+LOGS_PER_REPORT = 100
+
+random_strings = Array.new(UNIQUE_RECORDS)
+(0..UNIQUE_RECORDS).each do |i|
+  random_strings[i] = SecureRandom.hex
+end
+
+def make_report(random_strings, hostname, logs)
+  base = {"config_report" => {
+    "host" => hostname.to_s, "reported_at" => Time.now.utc.to_s,
+    "status" => { "applied" => 0, "restarted" => 0, "failed" => 1, "failed_restarts" => 0, "skipped" => 0, "pending" => 0 },
+    "metrics" => { "time" => { "config_retrieval" => 6.98906397819519, "total" => 13.8197405338287 }, "resources" => { "applied" => 0, "failed" => 1, "failed_restarts" => 0, "out_of_sync" => 0, "restarted" => 0, "scheduled" => 67, "skipped" => 0, "total" => 68 }, "changes" => { "total" => 0 } },
+    "logs" => []
+  }}
+  (1..logs).each do |i|
+    base["config_report"]["logs"].append(
+      {
+        "log" => {"sources" => {"source" => "Source #{i} #{random_strings[rand(UNIQUE_RECORDS)]}" },
+        "messages" => { "message" => "Message #{i} #{random_strings[rand(UNIQUE_RECORDS)]}" },
+        "level" => "err" },
+      })
+  end
+  base
+end
+
+uri = URI.parse("http://localhost:3000/api/v2/config_reports")
+headers = {'Content-Type': 'application/json'}
+http = Net::HTTP.new(uri.host, uri.port)
+
+Benchmark.ips do |x|
+  x.config(:time => 10, :warmup => 0)
+  x.report("import report via HTTP") do
+    request = Net::HTTP::Post.new(uri.request_uri, headers)
+    request.basic_auth("admin", "changeme")
+    request.body = make_report(random_strings, "host-reports", LOGS_PER_REPORT).to_json
+    http.request(request)
+  end
+end

--- a/test/factories/reports_related.rb
+++ b/test/factories/reports_related.rb
@@ -45,11 +45,9 @@ FactoryBot.define do
 
   factory :message do
     sequence(:value) { |n| "message#{n}" }
-    sequence(:digest) { |n| Digest::SHA1.hexdigest("message#{n}") }
   end
 
   factory :source do
     sequence(:value) { |n| "source#{n}" }
-    sequence(:digest) { |n| Digest::SHA1.hexdigest("source#{n}") }
   end
 end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,8 +1,0 @@
-require 'test_helper'
-
-class MessageTest < ActiveSupport::TestCase
-  # Replace this with your real tests.
-  test "the truth" do
-    assert true
-  end
-end


### PR DESCRIPTION
Foreman reports storage is designed so that reports are broken into individual lines and store them as 1:N references. The biggest offender are messages and sources tables which contain those lines together with SHA1 hash. This was designed around Puppet because it returns "source" for each log line (on terminal it is printed as "[source] log_content"). So what we essentially do is break reports into lines, break lines into two pieces, calculate SHA1 sum from both parts and store that into the database. Extremely inefficient.

The reason for all of that is that users can search for a source or for a (whole) report line using scoped search. This is only useful for Puppet users (source), I am unable to find a use case for searching for whole line. Full text search would make sense, or doing SQL LIKE query as well, but non of that Foreman supports.

The way this is implemented is to overcome SQL server limit of index because "messages"."value" and "sources"."value" fields are TEXT type. Most SQL servers, including PostgreSQL, can create B-Tree index only up to some limit (8k in this case). This is extremely slow, it's wasting of resources, there is no resolution of SHA1 conflicts.

This patch gets rid of our own SHA1 "digest" column and let SQL server do the index directly on the text column. To break the index limit, Postgres has a hash index option which is not only faster and way more storage-efficient but it's ideal for comparison only, which is exactly what we need (we do not sort logs or sources tables - it makes no sense - we only do equal operation to find duplicities).

The patch

* drops digest completely from the code base and let SQL server to do hashing via index
* drops digest field and index from both tables (2 indices, 2 fields)
* creates a hash index on value column (migration can be slow - testing needed)

The result needs to be tested on real data, but the patch essentially removes one field, removes SHA1 slow calculation in Ruby and replaces two b-tree indices with two hash indices which takes approximately 20-30% of the original space and are faster.

The only issue could be sqlite3 which we still require for packaging, from my rough testing I am able to create index on text column just fine. Initially I thought that creating hash index in RoR migration would require SQL, but it looks like RoR creates the index with the correct type just fine with "using" attribute.

For the record, hash index is supported in postgres from version 8.2 and from version 10 it is transaction safe. Meaning that a crash on pre-10 version would require index rebuild which is a trivial operation. CentOS installations already use Postgres v12 and Debian (Buster) has v11 and Ubuntu has v10. We are all good here.

Also, complete refactoring of reports is planned where searching in reports will be only possible via tablescan anyway:

https://community.theforeman.org/t/rfc-optimized-reports-storage/15573

Finally, the same change must be done in OpenSCAP where digest is being used.