### PR TITLE
Fixes #30822 - disabling filling of mac address in UI when hostgroup is set

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -28,7 +28,7 @@ module Orchestration::Compute
 
   def compute_provides?(attr)
     return false if compute_resource.nil?
-    compute? && compute_resource.provided_attributes.key?(attr)
+    compute_resource.provided_attributes.key?(attr)
   end
 
   def vm_name

--- a/test/models/orchestration/dhcp_test.rb
+++ b/test/models/orchestration/dhcp_test.rb
@@ -209,6 +209,7 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
       as_admin do
         FactoryBot.create(:host,
           :with_dhcp_orchestration,
+          :compute_resource => nil,
           :subnet => subnet,
           :interfaces => interfaces,
           :build => true,


### PR DESCRIPTION
This PR is trying to solve one of edgecases when the "Create host" form is used. 

We found that MAC address field is ready to fill when the host is assigned to hostgroup when is creating. This hostgroup had set deploying to some compute resource (eg. oVirt) and no compute profile is set. 

In that case the problem is that [`compute_provides?`](https://github.com/theforeman/foreman/blob/develop/app/models/concerns/orchestration/compute.rb#L29) method rely on the result of [`compute?`](https://github.com/theforeman/foreman/blob/develop/app/models/concerns/orchestration/compute.rb#L14) method. However, `compute?` method rely on the present `compute_attributes` when the host creating (and `uuid` is not available). When the host is trying to inherit some attributes from profiless hostgroup, the `compute_attributes` are empty hash (and `compute_attributes.present? = false`). This false result means that result of `compute_provides?` method is false regardless of parameter with described circumstances and field of MAC address is still enabled.  

After the discussion with @ezr-ondrej we end up with the solution where the `compute_provides?` method doesn't rely on the result of `compute?` method.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
