### PR TITLE
Fixes #30836 - prevent DHCP nil exception

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -175,7 +175,7 @@ module Orchestration::DHCP
       (old.hostname != hostname) ||
       provision_mac_addresses_changed? ||
       (old.subnet != subnet) ||
-      (old.operatingsystem.boot_filename(old.host) != operatingsystem.boot_filename(host)) ||
+      (old&.operatingsystem&.boot_filename(old.host) != operatingsystem&.boot_filename(host)) ||
       ((old.host.pxe_loader == "iPXE Embedded" || host.pxe_loader == "iPXE Embedded") && (old.host.build != host.build)) ||
       (!old.build? && build? && !all_dhcp_records_valid?))
     # Handle jumpstart


### PR DESCRIPTION
Discovery plugin was modified to call unused_ip during provisioning, however this leads to DHCP orchestration while operatingsystem (and hostgroup) is not set assigned. This raises a nil exception in core.