### PR TITLE
Fixes #30838 - do not return report after create

### DIFF
--- a/app/views/api/v2/config_reports/create.json.rabl
+++ b/app/views/api/v2/config_reports/create.json.rabl
@@ -1,3 +1,3 @@
 object @config_report
 
-extends "api/v2/config_reports/show"
+extends "api/v2/config_reports/main"


### PR DESCRIPTION
Uploaded reports render themselves on upload via RABL and it looks like this is very slow. Generally, it's not needed to read the inserted data, so we should be able to completely remove this and return nothing. Alternatively, we could optimize this.

Let's discuss how to solve this. Since report API is under heavy load, I
lean towards returning nothing, therefore deprecating the output
completely. The question is how to do this, deprecation warning message
is quite useless, so probably only Release Notes for 2.3?

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->