### PR TITLE
Fixes #30821 - checking core migrations as well

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -359,7 +359,8 @@ module Foreman #:nodoc:
       return true if Foreman.in_setup_db_rake?
       return @pending_migrations unless @pending_migrations.nil?
 
-      @pending_migrations = ActiveRecord::MigrationContext.new(migrations_paths, ActiveRecord::SchemaMigration).needs_migration?
+      @pending_migrations = ActiveRecord::Base.connection.migration_context.needs_migration?
+      @pending_migrations ||= ActiveRecord::MigrationContext.new(migrations_paths, ActiveRecord::SchemaMigration).needs_migration?
 
       Rails.logger.debug("There are pending migrations for #{id}. Please run foreman-rake db:migrate.") if @pending_migrations
 


### PR DESCRIPTION
We need this to support plugins that need the DB fully migrated.
For example, permissions need the core migrations up.
Especially if the plugin has no migrations, this becomes important.