### PR TITLE
Refs #30842 - Update Stories files for Storybook v6 upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@babel/core": "^7.7.0",
     "@theforeman/builder": "^6.0.0",
     "@theforeman/eslint-plugin-foreman": "^6.0.0",
-    "@theforeman/stories": "^6.0.0",
+    "@theforeman/stories": "^7.0.0",
     "@theforeman/test": "^8.0.0",
     "@theforeman/vendor-dev": "^6.0.0",
     "argv-parse": "^1.0.1",

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.stories.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/AutoComplete.stories.js
@@ -8,7 +8,7 @@ import Story from '../../../../../stories/components/Story';
 import AutoComplete from './index';
 
 export default {
-  title: 'Components|AutoComplete',
+  title: 'Components/AutoComplete',
 };
 
 export const autoCompleteWithMockedData = () => {

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.stories.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.stories.js
@@ -8,7 +8,7 @@ import storeDecorator from '../../../../../stories/storeDecorator';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Page chunks|Bookmarks',
+  title: 'Page chunks/Bookmarks',
   decorators: [storeDecorator],
 };
 

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
@@ -17,7 +17,7 @@ class BreadcrumbBar extends React.Component {
     } = this.props;
     const isUrlFormatValid = resourceSwitcherItems.length
       ? resourceSwitcherItems[0].url ===
-        resource.switcherItemUrl.replace(':id', resourceSwitcherItems[0].id)
+        resource.switcherItemUrl?.replace(':id', resourceSwitcherItems[0].id)
       : true;
     if (
       !currentPage ||

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.stories.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { boolean, number, withKnobs, action } from '@theforeman/stories';
+import { boolean, number } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import BreadcrumbBar from './BreadcrumbBar';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|BreadcrumbBar',
-  decorators: [withKnobs],
+  title: 'Components/BreadcrumbBar',
 };
 
 export const withOpenSwitcher = () => (

--- a/webpack/assets/javascripts/react_app/components/CPUCoresInput/CPUCoresInput.stories.js
+++ b/webpack/assets/javascripts/react_app/components/CPUCoresInput/CPUCoresInput.stories.js
@@ -1,9 +1,11 @@
 import React from 'react';
-import { number, action, text } from '@theforeman/stories';
+import { number, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
 import CPUCoresInput from './CPUCoresInput';
 
 export default {
-  title: 'Components|Form/CPUCoresInput',
+  title: 'Components/Form/CPUCoresInput',
   component: CPUCoresInput,
   parameters: {
     centered: { disable: true },

--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
@@ -4,7 +4,7 @@ import mockStoryData from './ChartBox.fixtures';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|Charts/ChartBox',
+  title: 'Components/Charts/ChartBox',
   component: ChartBox,
 };
 

--- a/webpack/assets/javascripts/react_app/components/ConfigReports/DiffModal/DiffModal.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ConfigReports/DiffModal/DiffModal.stories.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { boolean, withKnobs, select, action } from '@theforeman/stories';
+import { boolean, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 
 import DiffModal from './DiffModal';
 import Story from '../../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|DiffModal',
-  decorators: [withKnobs],
+  title: 'Components/DiffModal',
 };
 
 export const diffModal = () => (

--- a/webpack/assets/javascripts/react_app/components/DiffView/DiffView.stories.js
+++ b/webpack/assets/javascripts/react_app/components/DiffView/DiffView.stories.js
@@ -1,12 +1,11 @@
 import React from 'react';
-import { text, withKnobs } from '@theforeman/stories';
+import { text } from '@storybook/addon-knobs';
 
 import DiffContainer from './DiffContainer';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|DiffView',
-  decorators: [withKnobs],
+  title: 'Components/DiffView',
 };
 
 export const diffView = () => (

--- a/webpack/assets/javascripts/react_app/components/FactCharts/FactChart.stories.js
+++ b/webpack/assets/javascripts/react_app/components/FactCharts/FactChart.stories.js
@@ -15,7 +15,7 @@ const mockStore = configureMockStore([thunk]);
 const dataProp = { id: 1, title: 'test title' };
 
 export default {
-  title: 'Page chunks|FactChartModal',
+  title: 'Page chunks/FactChartModal',
 };
 
 export const modalClosed = () => (

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.stories.js
@@ -6,7 +6,7 @@ import { useForemanModal } from './ForemanModalHooks';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|ForemanModal/Props & Children',
+  title: 'Components/ForemanModal/Props & Children',
   decorators: [storeDecorator],
 };
 

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalUsage.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalUsage.stories.js
@@ -13,7 +13,7 @@ import { useForemanModal } from './ForemanModalHooks';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|ForemanModal/ForemanModal Usage',
+  title: 'Components/ForemanModal/ForemanModal Usage',
   decorators: [storeDecorator],
 };
 

--- a/webpack/assets/javascripts/react_app/components/Loading/Loading.stories.js
+++ b/webpack/assets/javascripts/react_app/components/Loading/Loading.stories.js
@@ -3,7 +3,7 @@ import Story from '../../../../../stories/components/Story';
 import Loading from './Loading';
 
 export default {
-  title: 'Components|Loading',
+  title: 'Components/Loading',
 };
 
 export const defaultStory = () => (

--- a/webpack/assets/javascripts/react_app/components/MemoryAllocationInput/MemoryAllocationInput.stories.js
+++ b/webpack/assets/javascripts/react_app/components/MemoryAllocationInput/MemoryAllocationInput.stories.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { number, action, text } from '@theforeman/stories';
+import { number, text } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import MemoryAllocationInput from './MemoryAllocationInput';
 
 export default {
-  title: 'Components|Form/MemoryAllocationInput',
+  title: 'Components/Form/MemoryAllocationInput',
   component: MemoryAllocationInput,
   parameters: {
     centered: { disable: true },

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.stories.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.stories.js
@@ -7,7 +7,7 @@ import { getForemanContext } from '../../Root/Context/ForemanContext';
 const ForemanContext = getForemanContext();
 
 export default {
-  title: 'Components|Pagination',
+  title: 'Components/Pagination',
   decorators: [
     StoryFn => (
       <ForemanContext.Provider value={ContextFeatures}>

--- a/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.stories.mdx
+++ b/webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.stories.mdx
@@ -1,40 +1,39 @@
-import { Meta, Story, Preview, Props, action } from '@theforeman/stories';
-
+import { Meta, Story, Canvas, ArgsTable } from '@theforeman/stories';
 import PermissionDenied from '.';
 
-<Meta title="Components|PermissionDenied" component={PermissionDenied} />
+<Meta title="Components/PermissionDenied" component={PermissionDenied} />
 
 # PermissionDenied
 
-Use `PermissionDenied` to explain the user about the permissions needed to perform an operation.
+Use `PermissionDenied` to explain to the user about the permissions needed to perform an operation.
 
-<Preview withToolbar>
+<Canvas withToolbar>
   <Story name="With default text">
     <PermissionDenied />
   </Story>
-</Preview>
+</Canvas>
 
 ## Props
 
-<Props of={PermissionDenied} />
+<ArgsTable of={PermissionDenied} />
 
-The `missingPermissions` prop accept an array of strings, represent the missing permissions.
+The `missingPermissions` prop accepts an array of strings, representing the missing permissions.
 
-<Preview>
+<Canvas>
   <Story name="With missing-permissions">
     <PermissionDenied
       missingPermissions={['view_organizations', 'import_manifest']}
     />
   </Story>
-</Preview>
+</Canvas>
 
-The texts can be overrdided by using the `texts` prop.
+The text can be overridden by using the `texts` prop.
 
-<Preview>
-  <Story name="With custom test">
+<Canvas>
+  <Story name="With custom text">
     <PermissionDenied
       texts={{
-        notAuthorizedMsg: "Hey! You can't do that.",
+        notAuthorizedMsg: "Hey, you can't do that!",
         pleaseRequestMsg:
           'Please ask an admin to get you the following permissions:',
         permissionDeniedMsg: 'Access denied',
@@ -42,15 +41,15 @@ The texts can be overrdided by using the `texts` prop.
       missingPermissions={['view_organizations', 'import_manifest']}
     />
   </Story>
-</Preview>
+</Canvas>
 
-The back button will take the user to `/` by default, use the `backHref` prop to change the back button url.
+The back button will take the user to `/` by default. Use the `backHref` prop to change the back button url.
 
-<Preview>
+<Canvas>
   <Story name="With custom back-button href">
     <PermissionDenied
       backHref="/some-path"
       missingPermissions={['view_organizations', 'import_manifest']}
     />
   </Story>
-</Preview>
+</Canvas>

--- a/webpack/assets/javascripts/react_app/components/ToastsList/ToastsList.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/ToastsList.stories.js
@@ -18,7 +18,7 @@ import ToastsList from './index';
 import Story from '../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|Toast Notifications',
+  title: 'Components/Toast Notifications',
 };
 
 export const toaster = () => {

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.stories.js
@@ -6,7 +6,7 @@ import Text from '../../../../../../stories/components/Text';
 import { buttons } from './ActionButtons.fixtures';
 
 export default {
-  title: 'Components|Common|ActionButtons',
+  title: 'Components/Common/ActionButtons',
 };
 
 export const ButtonsStory = () => (

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DatePicker.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DatePicker.stories.js
@@ -3,7 +3,7 @@ import { Grid, Row, Col } from 'patternfly-react';
 import DatePicker from './DatePicker';
 
 export default {
-  title: 'Components|DatePicker',
+  title: 'Components/DatePicker',
   component: DatePicker,
   parameters: {
     centered: { disable: true },

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.stories.js
@@ -3,7 +3,7 @@ import { Grid, Row, Col } from 'patternfly-react';
 import DateTimePicker from './DateTimePicker';
 
 export default {
-  title: 'Components|DateTimePicker',
+  title: 'Components/DateTimePicker',
   component: DateTimePicker,
   parameters: {
     centered: { disable: true },

--- a/webpack/assets/javascripts/react_app/components/common/DocumentationLink/DocumentationLink.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/DocumentationLink/DocumentationLink.stories.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { action } from '@theforeman/stories';
+import { action } from '@storybook/addon-actions';
 
 import Story from '../../../../../../stories/components/Story';
 import DocumentationLink from './index';
 
 export default {
-  title: 'Components|DocumentationLink',
+  title: 'Components/DocumentationLink',
 };
 
 export const defaultStory = () => (

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.stories.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import store from '../../../redux';
-import { text, select, boolean, withKnobs, action } from '@theforeman/stories';
+import { text, select, boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
 import { Button } from '@patternfly/react-core';
 import DefaultEmptyState, { EmptyStatePattern } from './index';
 import Story from '../../../../../../stories/components/Story';
 
 export default {
-  title: 'Components|Empty State Pattern',
-  decorators: [withKnobs],
+  title: 'Components/Empty State Pattern',
 };
 
 export const defaultStory = () => (

--- a/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/SkeletonLoader.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/SkeletonLoader.stories.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { boolean, text, withKnobs } from '@theforeman/stories';
+import { boolean, text } from '@storybook/addon-knobs';
 import Story from '../../../../../../stories/components/Story';
 import SkeletonLoader from '.';
 
 export default {
-  title: 'Components|Common|Empty Line',
-  decorators: [withKnobs],
+  title: 'Components/Common/Empty Line',
 };
 
 export const defaultStory = () => (

--- a/webpack/assets/javascripts/react_app/components/common/TypeAheadSelect/TypeAheadSelect.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/TypeAheadSelect/TypeAheadSelect.stories.js
@@ -4,7 +4,7 @@ import Story from '../../../../../..//stories/components/Story';
 import storeDecorator from '../../../../../..//stories/storeDecorator';
 
 export default {
-  title: 'Components|TypeAheadSelect',
+  title: 'Components/TypeAheadSelect',
   decorators: [storeDecorator],
   component: TypeAheadSelect,
 };

--- a/webpack/assets/javascripts/react_app/components/common/charts/BarChart/BarChart.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/BarChart/BarChart.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import BarChart from './';
 
 export default {
-  title: 'Components|Charts/BarChart',
+  title: 'Components/Charts/BarChart',
   component: BarChart,
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.stories.js
@@ -2,7 +2,7 @@ import React from 'react';
 import DonutChart from './';
 
 export default {
-  title: 'Components|Charts/DonutChart',
+  title: 'Components/Charts/DonutChart',
   component: DonutChart,
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/charts/LineChart/LineChart.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/LineChart/LineChart.stories.js
@@ -3,7 +3,7 @@ import React from 'react';
 import LineChart from './index';
 
 export default {
-  title: 'Components|Charts/LineChart',
+  title: 'Components/Charts/LineChart',
   component: LineChart,
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/dates/dates.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/dates.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { date, boolean, select, withKnobs } from '@theforeman/stories';
+import { date, boolean, select } from '@storybook/addon-knobs';
 
 import IsoDate from './IsoDate';
 import LongDateTime from './LongDateTime';
@@ -11,8 +11,7 @@ import Story from '../../../../../../stories/components/Story';
 import Text from '../../../../../../stories/components/Text';
 
 export default {
-  title: 'Components|Common',
-  decorators: [withKnobs],
+  title: 'Components/Common',
 };
 
 export const dates = () => {
@@ -23,7 +22,7 @@ export const dates = () => {
     date('Date and time in your time zone', defaultValue)
   );
   const showSeconds = boolean('Show seconds');
-  const showRelativeTimeTooltip = boolean('Show relative time');
+  const showRelativeTimeTooltip = boolean('Show relative time tooltip');
 
   const timezoneOptions = [
     'America/Phoenix',

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.stories.js
@@ -70,7 +70,7 @@ FormComponent.propTypes = {
 };
 
 export default {
-  title: 'Components|Foreman Form',
+  title: 'Components/Foreman Form',
 };
 
 export const basicForemanForm = () => (

--- a/webpack/assets/javascripts/react_app/components/common/forms/Form.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Form.stories.js
@@ -49,7 +49,7 @@ CustomSelect.propTypes = {
 registerInputComponent('ownInput', CustomSelect);
 
 export default {
-  title: 'Components|Form',
+  title: 'Components/Form',
   decorators: [storeDecorator],
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableSelect/Orderable.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableSelect/Orderable.stories.js
@@ -59,7 +59,7 @@ OrderAppSandbox.propTypes = {
 };
 
 export default {
-  title: 'Components|Common|Orderable',
+  title: 'Components/Common/Orderable',
 };
 
 export const orderableStory = () => (

--- a/webpack/assets/javascripts/react_app/components/common/table/TableSelection.stories.mdx
+++ b/webpack/assets/javascripts/react_app/components/common/table/TableSelection.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@theforeman/stories';
 import { Icon } from 'patternfly-react';
 
 <Meta
-  title="Page chunks|Table"
+  title="Page chunks/Table"
   parameters={{
     storyWeight: 90,
   }}
@@ -10,11 +10,11 @@ import { Icon } from 'patternfly-react';
 
 # Table With Select boxes
 
-All needed functions and components are located at: `/react_app/components/common/table/index.js`  
+All needed functions and components are located at: `/react_app/components/common/table/index.js`
 To add select boxes to your foreman table please follow this steps:
 
 ## Connect The reducer
-Create a unique reducer for your table by calling the `selectionReducer(tableID)` from the table folder to your component.  
+Create a unique reducer for your table by calling the `selectionReducer(tableID)` from the table folder to your component.
 **tableID** - a string that will represents the table in the store and will be used in the actions
 
 <Icon type="pf" name="info" />
@@ -35,12 +35,12 @@ getSelectionController({
 });
 ```
 
-You will need to provide the function the following argumets:  
+You will need to provide the function the following argumets:
 **tableID**: a string that will represents the table in the store
-**allRowsSelected**: a boolean that describes if all the rows available are selected.  
-This boolean is provided by the selection reducer and should be in the components store  
-**rows**: an array of row object that are available in the current page of the table. Each object should have an id.  
-**selectedRows**: an array of the selected ids (if all rows are selected this can be empty) This array is provided by the selection reducer and should be in the components store.  
+**allRowsSelected**: a boolean that describes if all the rows available are selected.
+This boolean is provided by the selection reducer and should be in the components store
+**rows**: an array of row object that are available in the current page of the table. Each object should have an id.
+**selectedRows**: an array of the selected ids (if all rows are selected this can be empty) This array is provided by the selection reducer and should be in the components store.
 **dispatch**: dispatch function from the Redux store.
 Can be created using the useDispatch() hook.
 This is used for the selction actions.
@@ -61,14 +61,14 @@ In the table schema array add the following item:
     ),
 ```
 
-The `property` is not used in the formatter so it should be empty.  
+The `property` is not used in the formatter so it should be empty.
 The `label` will be user for the tooltip information (title property) and aria-label.
 
 ### Data provided by the reducer
 
-**allRowsSelected**: a boolean that describes if all the rows available are selected  
-**selectedRows**: an array of the selected ids  
-**showSelectAll**: a boolean that indicates should the select all option be available?  
+**allRowsSelected**: a boolean that describes if all the rows available are selected
+**selectedRows**: an array of the selected ids
+**showSelectAll**: a boolean that indicates should the select all option be available?
 This is true after a user is selection the whole page. Use this to show a select all button or message box.
 
 ### Additional Actions

--- a/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.stories.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.stories.js
@@ -15,7 +15,7 @@ import {
 } from './PowerStatus.fixtures';
 
 export default {
-  title: 'Components|Power Status',
+  title: 'Components/Power Status',
 };
 
 export const loading = () => (

--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/__tests__/StorageContainer.stories.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/__tests__/StorageContainer.stories.js
@@ -18,7 +18,7 @@ const initializeMocks = () => {
 };
 
 export default {
-  title: 'Page chunks|Host VMWare Storage',
+  title: 'Page chunks/Host VMWare Storage',
 };
 
 export const defaultStateForNewHost = () => {

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/components/ExportButton/ExportButton.stories.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/components/ExportButton/ExportButton.stories.js
@@ -3,7 +3,7 @@ import Story from '../../../../../../../../stories/components/Story';
 import ExportButton from './ExportButton';
 
 export default {
-  title: 'Components|ExportButton',
+  title: 'Components/ExportButton',
 };
 
 export const defaultStory = () => (

--- a/webpack/stories/components/StoryWithCustomState/index.js
+++ b/webpack/stories/components/StoryWithCustomState/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import { action } from '@theforeman/stories';
+import { action } from '@storybook/addon-actions'; // eslint-disable-line import/no-extraneous-dependencies
 import Story from '../Story';
 
 // A super-simple mock of a redux store with a custom state.

--- a/webpack/stories/docs/adding-dependencies.stories.mdx
+++ b/webpack/stories/docs/adding-dependencies.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Adding dependencies"
+  title="Introduction/Adding dependencies"
   parameters={{
-    storyWeight: 40,
+    storyWeight: 30,
   }}
 />
 

--- a/webpack/stories/docs/adding-new-components.stories.mdx
+++ b/webpack/stories/docs/adding-new-components.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Adding new components"
+  title="Introduction/Adding new components"
   parameters={{
     storyWeight: 20,
   }}

--- a/webpack/stories/docs/api-middleware-usage.stories.mdx
+++ b/webpack/stories/docs/api-middleware-usage.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|API Middleware Usage"
+  title="Introduction/API Middleware Usage"
   parameters={{
     storyWeight: 100,
   }}
@@ -132,6 +132,7 @@ export const selectError = state => selectAPIError(state, MY_SPECIAL_KEY);
 ```
 
 ```js
+
 /** MyComponentActions.js*/
 
 export const getData = url => ({

--- a/webpack/stories/docs/api-middleware.stories.mdx
+++ b/webpack/stories/docs/api-middleware.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|API Middleware"
+  title="Introduction/API Middleware"
   parameters={{
     storyWeight: 90,
   }}

--- a/webpack/stories/docs/client-routing.stories.mdx
+++ b/webpack/stories/docs/client-routing.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Client Routing"
+  title="Introduction/Client Routing"
   parameters={{
     storyWeight: 150,
   }}

--- a/webpack/stories/docs/connected-react-router.stories.mdx
+++ b/webpack/stories/docs/connected-react-router.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Connected React Router"
+  title="Introduction/Connected React Router"
   parameters={{
     storyWeight: 140,
   }}
@@ -29,7 +29,7 @@ You can use react router selectors for retriving data
 
 selectRouterLocation - the current location.
 electRouterPath - the current path
-selectRouterSearch - the current search 
+selectRouterSearch - the current search
 selectRouterHash  - the current hash
 selectRouter - the entire router object which includes every entry above
 

--- a/webpack/stories/docs/creating-a-form.stories.mdx
+++ b/webpack/stories/docs/creating-a-form.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Creating a Form"
+  title="Introduction/Creating a Form"
   parameters={{
     storyWeight: 120,
   }}
@@ -43,7 +43,7 @@ const FlavorForm = ({
     onCancel={onCancel}
   >
     <TextField name="flavor" type="text" required="true" label={'Name'} />
-  </ForemanForm>
+  <\/ForemanForm>
 );
 ```
 

--- a/webpack/stories/docs/foreman-context.stories.mdx
+++ b/webpack/stories/docs/foreman-context.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Foreman Context"
+  title="Introduction/Foreman Context"
   parameters={{
     storyWeight: 130,
   }}
@@ -17,7 +17,7 @@ without any redux integration nor API request.
 
 `Foreman Context` comes with every react component by default, like redux's store.
 
-### How to read a value 
+### How to read a value
 
 #### With Hooks
 Like selectors, you can consume context values by custom hooks:
@@ -36,7 +36,7 @@ const foremanVersion = useForemanVersion();
 ### How to add a value to the context
 
 Keys and values are set in the `app_metadata` method of `/application_helper.rb`.
-The `app_metadata` object is passed down and becomes ForemanContext. 
+The `app_metadata` object is passed down and becomes ForemanContext.
 
 If you add a new value to `app_metadata`, it will also be useful to add a new custom hook in `webpack/assets/javascripts/react_app/ReactApp/Context/ForemanContext.js`
 so that the value can be easily consumed on the front end.

--- a/webpack/stories/docs/getting-started.stories.mdx
+++ b/webpack/stories/docs/getting-started.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Getting Started"
+  title="Introduction/Getting Started"
   parameters={{
     storyWeight: 10,
   }}
@@ -16,17 +16,17 @@ Following steps are required to setup a webpack development environment:
 1. **Settings**
    There are 2 relevant settings in `config/settings.yml`. At least `webpack_dev_server` should be set to true:
 
-   ```yaml
-   # Use the webpack development server?
-   # Should be set to true if you want to conveniently develop webpack-processed code.
-   # Make sure to run `rake webpack:compile` if disabled.
-   :webpack_dev_server: true
+ ```yaml
+ # Use the webpack development server?
+ # Should be set to true if you want to conveniently develop webpack-processed code.
+ # Make sure to run `rake webpack:compile` if disabled.
+ :webpack_dev_server: true
 
-   # If you run Foreman in development behind some proxy or use HTTPS you need
-   # to enable HTTPS for webpack dev server too, otherwise you'd get mixed content
-   # errors in your browser
-   :webpack_dev_server_https: true
-   ```
+ # If you run Foreman in development behind some proxy or use HTTPS you need
+ # to enable HTTPS for webpack dev server too, otherwise you'd get mixed content
+ # errors in your browser
+ :webpack_dev_server_https: true
+ ```
 
 2. **Dependencies**
    Make sure you have all npm dependencies up to date:

--- a/webpack/stories/docs/hoc.stories.mdx
+++ b/webpack/stories/docs/hoc.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|HOCs"
+  title="Introduction/HOCs"
   parameters={{
-    storyWeight: 30,
+    storyWeight: 40,
   }}
 />
 

--- a/webpack/stories/docs/internationalization.stories.mdx
+++ b/webpack/stories/docs/internationalization.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Internationalization"
+  title="Introduction/Internationalization"
   parameters={{
     storyWeight: 50,
   }}

--- a/webpack/stories/docs/interval-middleware.stories.mdx
+++ b/webpack/stories/docs/interval-middleware.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Interval Middleware"
+  title="Introduction/Interval Middleware"
   parameters={{
     storyWeight: 110,
   }}

--- a/webpack/stories/docs/legacy-js.stories.mdx
+++ b/webpack/stories/docs/legacy-js.stories.mdx
@@ -2,7 +2,7 @@ import { Meta } from '@theforeman/stories';
 import ForemanFrontendDiagram from './images/foreman-frontend-infra.png';
 
 <Meta
-  title="Introduction|Legacy JS"
+  title="Introduction/Legacy JS"
   parameters={{
     storyWeight: 80,
   }}

--- a/webpack/stories/docs/plugins.stories.mdx
+++ b/webpack/stories/docs/plugins.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Plugins"
+  title="Introduction/Plugins"
   parameters={{
     storyWeight: 60,
   }}
@@ -112,6 +112,6 @@ You can make sure Webpack knows about your plugin by executing script `plugin_we
     }
 }
 ```
-# How to extend core functionaly 
+# How to extend core functionaly
 
 You can use [Slot&Fill](?selectedKind=Introduction&selectedStory=Slot%26Fill) to extend react components (See Slot&Fill section)

--- a/webpack/stories/docs/slot-and-fill.stories.mdx
+++ b/webpack/stories/docs/slot-and-fill.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|Slot And Fill"
+  title="Introduction/Slot And Fill"
   parameters={{
     storyWeight: 70,
   }}
@@ -36,7 +36,9 @@ a fill that contains a child component, which rendered by a dedicated slot
 _core_
 
 ```js
-<Slot id="slot-id">a default child // can be empty</Slot>
+<Slot id="slot-id">
+  a default child // can be empty
+</Slot>
 ```
 
 _plugin A_
@@ -44,7 +46,7 @@ _plugin A_
 ```js
 <Fill slotId="slot-id" id="some-id" weight={100}>
   <div> some text </div>
-</Fill>
+<\/Fill>
 ```
 
 _plugin B_
@@ -52,7 +54,7 @@ _plugin B_
 ```js
 <Fill slotId="slot-id" id="some-id" weight={200}>
   <div> some text </div>
-</Fill>
+<\/Fill>
 ```
 
 Plugin B has a fill with a higher weight, therefore it will be rendered in a dedicated slot.
@@ -72,7 +74,7 @@ _plugin A_
 ```js
 <Fill slotId="slot-id" id="some-id" weight={100}>
   <div> some text </div>
-</Fill>
+<\/Fill>
 ```
 
 _plugin B_
@@ -80,7 +82,7 @@ _plugin B_
 ```js
 <Fill slotId="slot-id" id="some-id" weight={200}>
   <div> some text </div>
-</Fill>
+<\/Fill>
 ```
 
 Plugin B's fill will be render first
@@ -97,7 +99,7 @@ const TextWrapper = ({ text }) => <div>{text}</div>;
 
 <Slot id="slot-id">
   <TextWrapper text="some default text" />
-</Slot>;
+<\/Slot>;
 ```
 
 _plugin A_
@@ -150,7 +152,7 @@ addGlobalFill(
 );
 ```
 
-Register `fills` global file in `plugn.rb` file:
+Register `fills` global file in `plugin.rb` file:
 
 ```ruby
 Foreman::Plugin.register :<plugin> do

--- a/webpack/stories/docs/withReactRoutes.stories.mdx
+++ b/webpack/stories/docs/withReactRoutes.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction|withReactRoutes"
+  title="Introduction/withReactRoutes"
   parameters={{
     storyWeight: 80,
   }}


### PR DESCRIPTION
This PR contains the changes to Stories files needed after the upgrade to Storybook v6.

* Use new [component names](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#previewprops-renamed): `Preview` -> `Canvas`; `Props` -> `ArgsTable`
* Change the [heirarchy separator](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#removed-hierarchy-separators) from `|` to `/`
* Import Storybook addon packages directly, not from `@theforeman/stories` (reason why and discussion on https://github.com/theforeman/foreman-js/pull/214)
* adjust some story ordering / cleanup

### To test:

* `cd ../foreman` and checkout this PR
* `npm run stories`
* Verify that stories are rendering
* Verify no console errors
* Change a stories file that has
```js
import {action} from '@storybook/addon-actions';
```
to
```js
import { action } from '@theforeman/stories';
```
You should see the helpful deprecation error.
