### PR TITLE
Fixes #18304 - Support VMware network edit for nic

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -355,7 +355,12 @@ module Api
             interface_attributes(nic_attr, allow_nil_type: host.nil?)
           end
         end
-        params = host.apply_inherited_attributes(params) if host
+
+        if host
+          params = host.apply_inherited_attributes(params)
+          params = host.apply_interfaces_compute_attributes(params)
+        end
+
         params
       end
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -113,6 +113,7 @@ class HostsController < ApplicationController
     Taxonomy.no_taxonomy_scope do
       attributes = @host.apply_inherited_attributes(host_params)
       attributes.delete(:compute_resource_id)
+      attributes = @host.apply_interfaces_compute_attributes(attributes)
       if @host.update(attributes)
         process_success :success_redirect => host_path(@host)
       else

--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -76,10 +76,9 @@ module ComputeResourcesVmsHelper
   def vsphere_networks(compute_resource, cluster_id = nil)
     networks = compute_resource.networks(cluster_id: cluster_id)
     networks.map do |net|
-      net_id = net.id
       net_name = net.name
       net_name += " (#{net.virtualswitch})" if net.virtualswitch
-      [net_id, net_name]
+      [net.name, net_name]
     end
   end
 

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -465,8 +465,8 @@ module Foreman::Model
       dc_networks = networks
       args["interfaces_attributes"]&.each do |key, interface|
         # Consolidate network to network id
-        net = dc_networks.detect { |n| n.id == interface['network'] }
-        net ||= dc_networks.detect { |n| n.name == interface['network'] }
+        net = dc_networks.detect { |n| n.name == interface['network'] }
+        net ||= dc_networks.detect { |n| n.id == interface['network'] }
         raise "Unknown Network ID: #{interface['network']}" if net.nil?
         interface["network"] = net.id
         interface["virtualswitch"] = net.virtualswitch
@@ -658,7 +658,7 @@ module Foreman::Model
         interface_attrs = {}
         interface_attrs[:compute_attributes] = {}
         interface_attrs[:mac] = interface.mac
-        interface_attrs[:compute_attributes][:network] = network.id
+        interface_attrs[:compute_attributes][:network] = network.name
         interface_attrs[:compute_attributes][:type] = interface.type.to_s.split('::').last
         hsh[index.to_s] = interface_attrs
       end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -39,6 +39,7 @@ module Orchestration::Compute
 
   def queue_compute
     return log_orchestration_errors unless compute? && errors.empty?
+
     # Create a new VM if it doesn't already exist or update an existing vm
     vm_exists? ? queue_compute_update : queue_compute_create
   end
@@ -67,8 +68,12 @@ module Orchestration::Compute
   end
 
   def queue_compute_update
-    return unless compute_update_required?
-    logger.debug("Detected a change is required for compute resource")
+    unless compute_update_required?
+      logger.info "No compute update required, skipping compute machine update."
+      return
+    end
+
+    logger.info("Detected a change, update of compute machine is required.")
     queue.create(:name   => _("Compute resource update for %s") % old, :priority => 7,
                  :action => [self, :setComputeUpdate])
   end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -626,6 +626,25 @@ autopart"', desc: 'to render the content of host partition table'
     attributes
   end
 
+  def apply_interfaces_compute_attributes(attributes)
+    return attributes unless compute_resource
+    return attributes unless attributes[:interfaces_attributes]
+
+    attributes = hash_clone(attributes).with_indifferent_access
+
+    interfaces_attributes = {}
+    attributes[:interfaces_attributes].each do |key, attrs|
+      interfaces_attributes[key] = {
+        compute_attributes: attrs[:compute_attributes],
+        mac: attrs[:mac],
+      }
+    end
+
+    attributes[:compute_attributes] = {} unless attributes[:compute_attributes].present?
+    attributes[:compute_attributes][:interfaces_attributes] = interfaces_attributes
+    attributes
+  end
+
   def hash_clone(value)
     if value.is_a? Hash
       # Prefer dup to constructing a new object to perserve permitted state

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,9 +1,9 @@
+<% cluster = local_assigns[:selected_cluster] || f.object.try(:cluster) %>
 <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
   :class => "col-md-3 vmware_type",
   :label => _('NIC type'), :label_size => "col-md-3", :disabled => !new_vm
 %>
-<% cluster_id = params.fetch(:host, {}).fetch(:compute_attributes, {}).fetch(:cluster, nil).presence %>
-<%= select_f f, :network, vsphere_networks(compute_resource), :first, :last, { },
+<%= select_f f, :network, vsphere_networks(compute_resource, cluster), :first, :last, { },
   :class => "col-md-3 vmware_network",
-  :label => _('Network'), :label_size => "col-md-3", :disabled => !new_vm
+  :label => _('Network'), :label_size => "col-md-3"
 %>

--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -7,7 +7,7 @@
               :label => _("MAC Address"),
               :label_help => _("Media access control address for this interface. Format must be six groups of two hexadecimal digits <br/> separated by colons (:), e.g. 00:11:22:33:44:55. Most virtualization compute resources (e.g. VMware, oVirt, libvirt) <br/> will provide new random MAC address.").html_safe,
               :label_help_options => { :rel => 'popover-modal' },
-              :disabled => f.object.host.try(:compute_provides?, :mac),
+              :readonly => f.object.host.try(:compute_provides?, :mac),
               :class => :interface_mac, :'data-url' => random_name_interfaces_path, :size => "col-md-8", :label_size => "col-md-3" %>
 <%= text_f f, :identifier,
               :label => _("Device Identifier"),

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -453,7 +453,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
       assert_equal attrs_out, @cr.parse_networks(attrs_in)
     end
 
-    test "matches the network id, before name lookup" do
+    test "matches the network name, before id lookup" do
       attrs = HashWithIndifferentAccess.new(
         "interfaces_attributes" => {
           "0" => {
@@ -464,7 +464,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
           },
         }
       )
-      assert_equal attrs, @cr.parse_networks(attrs)
+      assert_equal 'network-11', @cr.parse_networks(attrs)['interfaces_attributes']['0']['network']
     end
 
     test "ignores existing network IDs" do
@@ -603,7 +603,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
           "0" => { :vol => 1, :size_gb => 4 },
           "1" => { :vol => 2, :size_gb => 4 },
         },
-        :interfaces_attributes => {"0" => {:compute_attributes => {:network => "dvportgroup-123456", :type => "VirtualVmxnet3"}, :mac => "00:50:56:84:f1:b1"}},
+        :interfaces_attributes => {"0" => {:compute_attributes => {:network => "Testnetwork", :type => "VirtualVmxnet3"}, :mac => "00:50:56:84:f1:b1"}},
         :scsi_controllers => [
           {
             :type => "VirtualLsiLogicController",

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -603,7 +603,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
           "0" => { :vol => 1, :size_gb => 4 },
           "1" => { :vol => 2, :size_gb => 4 },
         },
-        :interfaces_attributes => {"0" => {:compute_attributes => {:network => "Testnetwork", :type => "VirtualVmxnet3"}, :mac => "00:50:56:84:f1:b1"}},
+        :interfaces_attributes => {"0" => {:compute_attributes => {:network => "dvportgroup-123456", :type => "VirtualVmxnet3"}, :mac => "00:50:56:84:f1:b1"}},
         :scsi_controllers => [
           {
             :type => "VirtualLsiLogicController",

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3082,7 +3082,7 @@ class HostTest < ActiveSupport::TestCase
       attributes = {
         interfaces_attributes: {
           '0' => {
-            compute_attributes: { network: 'someportgroup-12345' },
+            compute_attributes: { network: 'super-fancey-network' },
             mac: '00:00:00:00:00:00',
           },
         },
@@ -3092,7 +3092,7 @@ class HostTest < ActiveSupport::TestCase
         'interfaces_attributes' => {
           "0" => {
             'compute_attributes' => {
-              'network' => 'someportgroup-12345',
+              'network' => 'super-fancey-network',
             },
             'mac' => '00:00:00:00:00:00',
           },

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3071,6 +3071,41 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#apply_compute_attributes' do
+    test 'should merge interfaces_attributes into the compute_attributes' do
+      network = mock('network')
+      network.stubs(id: 'someportgroup-12345')
+      network.stubs(name: 'super-fancey-network')
+
+      host = FactoryBot.build_stubbed(:host, :managed, :compute_resource => compute_resources(:one))
+
+      attributes = {
+        interfaces_attributes: {
+          '0' => {
+            compute_attributes: { network: 'someportgroup-12345' },
+            mac: '00:00:00:00:00:00',
+          },
+        },
+      }
+
+      expected_attrs = {
+        'interfaces_attributes' => {
+          "0" => {
+            'compute_attributes' => {
+              'network' => 'someportgroup-12345',
+            },
+            'mac' => '00:00:00:00:00:00',
+          },
+        },
+      }
+
+      compute_resources(:one).stubs(:networks).returns([network])
+      result = host.apply_interfaces_compute_attributes(attributes)
+
+      assert_equal expected_attrs, result[:compute_attributes]
+    end
+  end
+
   describe 'rendering interface' do
     let(:host) { FactoryBot.build_stubbed(:host, :managed) }
 

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -278,7 +278,7 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
       host.vm.stubs(:interfaces).returns([])
       host.vm.expects(:select_nic).once.returns(OpenStruct.new(:mac => 'aa:bb:cc:dd:ee:ff'))
       host.compute_resource.stubs(:provided_attributes).returns({:mac => :mac})
-      host.stubs(:vm_exists?).returns(false)
+      host.stubs(:vm_exists?).returns(true)
       assert_valid host
       assert host.send(:setComputeDetails)
       assert host.send(:setComputeIPAM)

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -41,7 +41,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
 
       test 'imports the VM with all parameters' do
         expected_compute_attributes = {
-          'network' => 'dvportgroup-123456',
+          'network' => 'network1',
           'type' => 'VirtualE1000',
         }
 

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -41,7 +41,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
 
       test 'imports the VM with all parameters' do
         expected_compute_attributes = {
-          'network' => 'network1',
+          'network' => 'dvportgroup-123456',
           'type' => 'VirtualE1000',
         }
 


### PR DESCRIPTION
Switches to the usage of network name now.
That requires:
- [ ] test of behaviour with two servers with the same ntwrk name
- [ ] migrate network `compute_attributes`