### PR TITLE
Fixes #30844 - do not error on exposed port for BIOS

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -246,8 +246,8 @@ class Operatingsystem < ApplicationRecord
     return default_boot_filename if host.nil? || host.pxe_loader.nil?
     return host.foreman_url('iPXE') if host.pxe_loader == 'iPXE Embedded'
     architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
-    if host.subnet&.httpboot?
-      if host.pxe_loader =~ /UEFI HTTPS/
+    if host.subnet&.httpboot? && host.pxe_loader =~ /UEFI HTTP/
+      if host.pxe_loader =~ /HTTPS/
         port = host.subnet.httpboot.httpboot_https_port!
       else
         port = host.subnet.httpboot.httpboot_http_port!

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -376,8 +376,39 @@ class OperatingsystemTest < ActiveSupport::TestCase
       assert_match(%r{https://somewhere.*net:1235/httpboot/grub2/grubx64.efi}, host.operatingsystem.boot_filename(host))
     end
 
-    test 'should raise an error without subnet or httpboot feature' do
+    test 'should not raise an error without httpboot feature for PXE' do
+      host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'PXELinux BIOS')
+      host.subnet.expects(:httpboot?).returns(false)
+      assert_equal "pxelinux.0", host.operatingsystem.boot_filename(host)
+    end
+
+    test 'should not raise an error with httpboot without port for PXE' do
+      host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'PXELinux BIOS')
+      host.subnet.expects(:httpboot?).returns(true)
+      SmartProxy.any_instance.stubs(:httpboot_http_port).returns(nil)
+      SmartProxy.any_instance.stubs(:httpboot_https_port).returns(nil)
+      assert_equal "pxelinux.0", host.operatingsystem.boot_filename(host)
+    end
+
+    test 'should raise an error without subnet' do
       host = FactoryBot.build(:host, :managed, pxe_loader: 'Grub2 UEFI HTTP')
+      assert_raises Foreman::Exception do
+        host.operatingsystem.boot_filename(host)
+      end
+    end
+
+    test 'should raise an error without httpboot feature' do
+      host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'Grub2 UEFI HTTP')
+      host.subnet.expects(:httpboot?).returns(false)
+      assert_raises Foreman::Exception do
+        host.operatingsystem.boot_filename(host)
+      end
+    end
+
+    test 'should raise an error without httpboot port' do
+      host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'Grub2 UEFI HTTP')
+      host.subnet.expects(:httpboot?).returns(true)
+      SmartProxy.any_instance.stubs(:httpboot_http_port).returns(nil)
       assert_raises Foreman::Exception do
         host.operatingsystem.boot_filename(host)
       end


### PR DESCRIPTION
When there was httpboot feature turned on but no exposed HTTP/HTTPS port (e.g. after upgrade), an error is thrown which is technically correct (Foreman now needs the exposed port) however it was thrown even when creating non-UEFI HTTP host (e.g. PXELinux BIOS). This patch fixes that.

More info: https://projects.theforeman.org/projects/foreman/wiki/ERF42-9666