### PR TITLE
Fixes #30738 - Configure katello-agent with act key

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -88,7 +88,7 @@ snippet: true
       subscription_manager_atomic_url = subscription_manager_configuration_url(@host, false)
       subscription_manager_org = @host.rhsm_organization_label
       activation_key = host_param('kt_activation_keys')
-      redhat_install_agent = true
+      redhat_install_agent = host_param_true?('redhat_install_agent', true)
       redhat_install_host_tools = true
       redhat_install_host_tracer_tools = false
     else


### PR DESCRIPTION
When kt_activation_keys parameter is present for host,
katello-agent is always installed. Because goferless setup
is recommended, it would be good to have an easy way
how not to install the agent even though the param
is present.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
