### PR TITLE
Fixes #30847 - rebuild taxonomy_search

### DIFF
--- a/db/migrate/20200908120905_rebuild_taxonomy_search.rb
+++ b/db/migrate/20200908120905_rebuild_taxonomy_search.rb
@@ -1,0 +1,7 @@
+class RebuildTaxonomySearch < ActiveRecord::Migration[6.0]
+  def up
+    Filter.where.not(taxonomy_search: nil).find_in_batches do |filters|
+      filters.each(&:save)
+    end
+  end
+end


### PR DESCRIPTION
As of 72209166fa58d3c5bc2b3629d98696edf7bd7250 there is more effective way to build a taxonomy_scope.
For all filters to benefit from that, we need to save the existing ones.

Completes #7553