### PR TITLE
Fixes #26968 - Switch to minitest-ci

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -2,9 +2,9 @@ group :test do
   gem 'mocha', '~> 1.11'
   gem 'single_test', '~> 0.6'
   gem 'minitest', '~> 5.1', '< 5.11'
+  gem 'minitest-ci', '~> 3.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 6.0'
-  gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 3.33', :require => false
   gem 'puma', '~> 5.1', :require => false
   gem 'show_me_the_cookies', '~> 5.0', :require => false

--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -1,5 +1,4 @@
 begin
-  require "ci/reporter/rake/minitest"
   require 'robottelo/reporter/rake/minitest'
 
   namespace :jenkins do
@@ -11,10 +10,10 @@ begin
 
     namespace :setup do
       task :pre_ci do
-        ENV["CI_REPORTS"] = 'jenkins/reports/unit/'
-        gem 'ci_reporter'
+        require 'minitest/ci'
+        Minitest::Ci.report_dir = 'jenkins/reports/unit/'
       end
-      minitest_plugins = [:pre_ci, 'ci:setup:minitest']
+      minitest_plugins = [:pre_ci]
       minitest_plugins << 'robottelo:setup:minitest' if ENV['GENERATE_ROBOTTELO_REPORT'] == 'true'
       task :minitest => minitest_plugins
     end

--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -10,6 +10,7 @@ begin
 
     namespace :setup do
       task :pre_ci do
+        ENV['USE_MEAN_TIME_REPORTER'] = '0'
         require 'minitest/ci'
         Minitest::Ci.report_dir = 'jenkins/reports/unit/'
       end


### PR DESCRIPTION
ci_reporter_minitest is unmaintained and since minitest 5.1 it no longer shows the class names. minitest-ci does.

Submitting as a draft to see what the result on Jenkins is. I chose [minitest-ci](https://github.com/circleci/minitest-ci) over [minitest-reporters](https://github.com/kern/minitest-reporters) since it appears to be lighter, especially when it comes to Rails. However, perhaps developers prefer the other.