### PR TITLE
Fixes #30852 - eager loading of report.logs

### DIFF
--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -4,7 +4,7 @@ module Api
       include Api::Version2
       include Foreman::Controller::SmartProxyAuth
 
-      before_action :find_resource, :only => %w{show destroy}
+      before_action :find_resource, :only => %w{destroy}
       before_action :setup_search_options, :only => [:index, :last]
       before_action :compatibility, :only => :create
 
@@ -23,6 +23,7 @@ module Api
       param :id, :identifier, :required => true
 
       def show
+        @config_report = resource_scope.includes(:logs => [:message, :source]).find(params[:id])
       end
 
       def_param_group :config_report do


### PR DESCRIPTION
This is a followup of the discussion at
https://github.com/theforeman/foreman/pull/7987 which is an API breaking
change. But I am also interested in improving performance of simple
report fetch action. It will probably not have any impact on report
upload, but it's quite easy change with big impact.

Base performance (report show, 100 log lines):
`828ms (Views: 707.4ms | ActiveRecord: 36.6ms | Allocations: 594311)`

With eager loading (no other changes, RABL rendering):
`241ms (Views: 80.3ms | ActiveRecord: 10.2ms | Allocations: 100811)`

Rendering into plain JSON with eager loading:
`191ms (Views: 5.3ms | ActiveRecord: 10.5ms | Allocations: 70498)`

Therefore I propose to do just eager loading change which has a huge
benefit, plain JSON rendering could possibly break OpenSCAP and it's not
that far from RABL. For the record, here is the code which I tested
with. I tried to do "pluck with SQL "IN" but postgres (like any other
server) reorders records randomly in that case.

```diff
diff --git a/app/models/report.rb b/app/models/report.rb
index c93fe6f12..4e6a3ef06 100644
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,6 +62,28 @@ class Report < ApplicationRecord
     self[:metrics] = m.to_h.to_yaml unless m.nil?
   end
 
+  def as_json
+    logs_json = []
+    logs.each do |log|
+      json = {}
+      json["level"] = log.level
+      json["source"] = {"source": log.source.value}
+      json["message"] = {"message": log.message.value}
+      logs_json << json
+    end
+    {
+      id: id,
+      host_id: host_id,
+      host_name: host_name,
+      created_at: created_at,
+      reported_at: reported_at,
+      updated_at: updated_at,
+      status: status,
+      metrics: metrics,
+      logs: logs_json,
+    }
+  end
+
   def to_label
     "#{host.name} / #{reported_at}"
   end
```