### PR TITLE
Fixes #30860 - introduce SettingPresenter

### DIFF
--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -54,19 +54,20 @@ module SettingsHelper
   end
 
   def setting_to_hash(setting)
+    presenter = SettingPresenter.from_setting(setting)
     {
       :id => setting.id,
-      :name => setting.name,
-      :category => setting.category,
-      :description => setting.description,
-      :settings_type => setting.settings_type,
-      :default => setting.default,
-      :readonly => setting.readonly?,
-      :full_name => setting.full_name,
-      :config_file => setting.class.config_file,
-      :select_values => setting.select_collection,
-      :value => setting.safe_value,
-      :encrypted => setting.encrypted?,
+      :name => presenter.name,
+      :category => presenter.category,
+      :description => presenter.description,
+      :settings_type => presenter.settings_type,
+      :default => presenter.default,
+      :readonly => presenter.readonly?,
+      :full_name => presenter.full_name,
+      :config_file => presenter.config_file,
+      :select_values => presenter.select_values,
+      :value => presenter.safe_value,
+      :encrypted => presenter.encrypted?,
     }
   end
 end

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -1,0 +1,79 @@
+class SettingPresenter
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+
+  include HiddenValue
+
+  attribute :id, :integer
+  attribute :category, :string, :default => 'Setting::General'
+  attribute :name, :string
+  attribute :default
+  attribute :value
+  attribute :description, :string
+  attribute :full_name, :string
+  attribute :encrypted, :boolean, :default => false
+  attribute :settings_type, :string
+  attribute :select_values
+  attribute :config_file
+  attr_accessor :options
+
+  def self.from_setting(setting)
+    SettingPresenter.new({:id => setting.id,
+                          :name => setting.name,
+                          :category => setting.category,
+                          :description => setting.description,
+                          :settings_type => setting.settings_type,
+                          :default => setting.default,
+                          :full_name => setting.full_name,
+                          :config_file => setting.class.config_file,
+                          :select_values => setting.select_collection,
+                          :value => setting.value,
+                          :encrypted => setting.encrypted? })
+  end
+
+  def self.model_name
+    Setting.model_name
+  end
+
+  def model_name
+    self.class.model_name
+  end
+
+  def to_model
+    self
+  end
+
+  def id
+    name
+  end
+
+  def persisted?
+    true
+  end
+
+  def encrypted?
+    !!encrypted
+  end
+
+  def hidden_value?
+    encrypted?
+  end
+
+  def readonly?
+    SETTINGS.key?(name.to_sym)
+  end
+
+  def settings_type
+    attribute(:settings_type) || Setting.setting_type_from_value(default)
+  end
+
+  # ----- UI helpers ------
+
+  def category_label
+    category.constantize.humanized_category || _(category_name)
+  end
+
+  def category_name
+    category.gsub(/Setting::/, '')
+  end
+end

--- a/app/views/api/v2/settings/index.json.rabl
+++ b/app/views/api/v2/settings/index.json.rabl
@@ -1,3 +1,3 @@
-collection @settings
+collection @settings.map { |s| SettingPresenter.from_setting(s) }
 
 extends "api/v2/settings/main"

--- a/app/views/api/v2/settings/main.json.rabl
+++ b/app/views/api/v2/settings/main.json.rabl
@@ -1,4 +1,4 @@
-object @setting
+object @setting && SettingPresenter.from_setting(@setting)
 
 extends "api/v2/settings/base"
 
@@ -9,7 +9,7 @@ node :value do |s|
 end
 
 node :category_name do |s|
-  _(s.class.humanized_category || s.category.gsub(/Setting::/, ''))
+  s.category_label
 end
 
 node :readonly do |s|
@@ -17,7 +17,7 @@ node :readonly do |s|
 end
 
 node :config_file do |s|
-  s.class.config_file
+  s.config_file
 end
 
 node :encrypted do |s|
@@ -25,5 +25,5 @@ node :encrypted do |s|
 end
 
 node :select_values do |s|
-  s.select_collection
+  s.select_values
 end

--- a/app/views/api/v2/settings/show.json.rabl
+++ b/app/views/api/v2/settings/show.json.rabl
@@ -1,3 +1,3 @@
-object @setting
+object SettingPresenter.from_setting(@setting)
 
 extends "api/v2/settings/main"

--- a/app/views/api/v2/settings/update.json.rabl
+++ b/app/views/api/v2/settings/update.json.rabl
@@ -1,3 +1,3 @@
-object @setting
+object SettingPresenter.from_setting(@setting)
 
 extends "api/v2/settings/show"

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -78,11 +78,6 @@ class SettingTest < ActiveSupport::TestCase
     end
   end
 
-  def test_should_hide_value_if_encrypted
-    setting = Setting.create(name: 'encrypted', value: 'clear', encrypted: true)
-    assert_equal '*****', setting.safe_value
-  end
-
   def test_should_provide_default_if_no_value_defined
     assert Setting.create(:name => "foo", :default => 5, :description => "test foo")
     assert_equal 5, Setting["foo"]

--- a/test/presenters/setting_presenter_test.rb
+++ b/test/presenters/setting_presenter_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class SettingPresenterTest < ActiveSupport::TestCase
+  def test_should_hide_value_if_encrypted
+    setting = Setting.create(name: 'encrypted', value: 'clear', encrypted: true)
+    presenter = SettingPresenter.from_setting(setting)
+    assert_equal '*****', presenter.safe_value
+  end
+end


### PR DESCRIPTION
First break-up PR of #7702

Introduces SettingPresenter, that should keep all the information about setting.
This aims to keep such information only in the code and remove them from the DB.

This only prepares the ground for future drop of this information from DB,
adds HiddenValue to the presenter to show the use case of Presenter.

We should slowly move most of the logic to the SettingPresenter from Setting.
Setting model should be kept only as an interface to the key/value storage.
DB will only hold key/value of changed settings.