### PR TITLE
Fixes #30862 - introduce SettingRegistry

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,6 +6,7 @@ module Api
     include Foreman::Controller::ApiCsrfProtection
     include Foreman::Controller::BruteforceProtection
 
+    before_action :load_settings
     before_action :set_default_response_format, :authorize, :set_taxonomy
     before_action :assign_lone_taxonomies, :only => :create
     before_action :add_info_headers, :set_gettext_locale

--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -17,7 +17,6 @@ module Api
         property :encrypted, [true, false], desc: N_('Is this setting encrypted?')
         property :config_file, String, desc: N_('If this setting needs to be changed in file, it will have the file path.')
         property :select_values, Array, desc: N_('If this setting has list of possible values, this includes the list of the values.')
-        property :created_at, Time, desc: N_('DEPRECATED: this will be always application install time and dropped in the future release.')
         property :updated_at, Time, desc: N_('Last updated. NOTE: this will be reset to application install time, when setting is reset to default value.')
       end
 
@@ -30,6 +29,7 @@ module Api
 
       def index
         @settings = resource_scope_for_index.live_descendants
+        @settings = @settings.map { |s| Foreman.settings.find(s.name) }
       end
 
       api :GET, "/settings/:id/", N_("Show a setting")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,6 +17,7 @@ class ApplicationController < ActionController::Base
   helper 'layout'
   helper_method :resource_path
 
+  before_action :load_settings
   before_action :require_login, :check_user_enabled
   before_action :set_gettext_locale_db, :set_gettext_locale
   before_action :session_expiry, :update_activity_time, :unless => proc { |c| c.remote_user_provided? || c.api_request? }

--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -19,6 +19,10 @@ module ApplicationShared
     user.present?
   end
 
+  def load_settings
+    Foreman.settings.load_values
+  end
+
   def set_taxonomy
     TopbarSweeper.expire_cache
     user = User.current

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -22,7 +22,10 @@ module SettingsHelper
 
   def setting_to_hash(setting)
     presenter = Foreman.settings.find(setting.name)
-    logger.warn("Setting #{setting.name} doesn't exist anymore, clean up your database") and return nil if presenter.nil?
+    if presenter.nil?
+      logger.warn("Setting #{setting.name} doesn't exist anymore, clean up your database")
+      return nil
+    end
     {
       :id => setting.id,
       :name => presenter.name,

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -10,6 +10,7 @@ module SettingsHelper
   def grouped_settings(settings)
     settings.each_with_object({}) do |setting, memo|
       hash = setting_to_hash(setting)
+      next unless hash
       if memo[setting.category]
         memo[setting.category] << hash
       else
@@ -20,7 +21,8 @@ module SettingsHelper
   end
 
   def setting_to_hash(setting)
-    presenter = SettingPresenter.from_setting(setting)
+    presenter = Foreman.settings.find(setting.name)
+    logger.warn("Setting #{setting.name} doesn't exist anymore, clean up your database") and return nil if presenter.nil?
     {
       :id => setting.id,
       :name => presenter.name,

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -239,7 +239,7 @@ class Setting < ApplicationRecord
       # update query for every setting
       to_update.delete(:default) if to_update[:default].to_yaml.strip == s[:default]
       s.attributes = to_update
-      s.save if s.changed? # to bypass name uniqueness validator to query db
+      s.save(validate: false)
       s.update_column :category, opts[:category] if s.category != opts[:category]
       s.update_column :full_name, opts[:full_name] if column_check([:full_name]).present? && s.full_name != opts[:full_name]
       raw_value = s.read_attribute(:value)
@@ -344,6 +344,7 @@ class Setting < ApplicationRecord
   end
 
   def refresh_registry_value
+    return unless Foreman.settings.ready?
     Foreman.settings.find(name)&.tap do |definition|
       definition.updated_at = updated_at
       definition.value = value

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -54,9 +54,9 @@ class Setting < ApplicationRecord
   validates :value, :email => true, :if => proc { |s| EMAIL_ATTRS.include? s.name }
   before_validation :set_setting_type_from_value
   before_save :clear_value_when_default
-  before_save :clear_cache
   validate :validate_frozen_attributes
   after_find :readonly_when_overridden
+  after_save :refresh_registry_value
   default_scope -> { order(:name) }
 
   # Filer out settings from disabled plugins
@@ -89,22 +89,12 @@ class Setting < ApplicationRecord
     nil
   end
 
-  def self.cache_key(name)
-    "settings/#{name}"
-  end
-
   def self.[](name)
-    name = name.to_s
-    cache.fetch(cache_key(name)) do
-      find_by(:name => name)&.value
-    end
+    Foreman.settings[name]
   end
 
   def self.[]=(name, value)
-    name   = name.to_s
-    record = where(:name => name).first!
-    record.value = value
-    record.save!
+    Foreman.settings[name] = value
   end
 
   def self.setting_type_from_value(value_for_type)
@@ -270,10 +260,6 @@ class Setting < ApplicationRecord
     s.readonly! if old_readonly
   end
 
-  def self.cache
-    Rails.cache
-  end
-
   # Methods for loading default settings
 
   def self.default_settings
@@ -353,18 +339,14 @@ class Setting < ApplicationRecord
     end
   end
 
-  def clear_cache
-    # Rails cache returns false if the delete failed and nil if the key is missing
-    if Setting.cache.delete(cache_key) == false
-      Rails.logger.warn "Failed to remove #{name} from cache"
-    end
-  end
-
-  def cache_key
-    Setting.cache_key(name)
-  end
-
   def readonly_when_overridden
     readonly! if !new_record? && has_readonly_value?
+  end
+
+  def refresh_registry_value
+    Foreman.settings.find(name)&.tap do |definition|
+      definition.updated_at = updated_at
+      definition.value = value
+    end
   end
 end

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -13,27 +13,8 @@ class SettingPresenter
   attribute :full_name, :string
   attribute :encrypted, :boolean, :default => false
   attribute :settings_type, :string
-  attribute :select_values
-  attribute :config_file
-  attribute :updated_at, :datetime
-  attribute :created_at, :datetime
-  attr_accessor :options
-
-  def self.from_setting(setting)
-    SettingPresenter.new({id: setting.id,
-                          name: setting.name,
-                          category: setting.category,
-                          description: setting.description,
-                          settings_type: setting.settings_type,
-                          default: setting.default,
-                          full_name: setting.full_name,
-                          updated_at: setting.updated_at,
-                          created_at: setting.created_at,
-                          config_file: setting.class.config_file,
-                          select_values: setting.select_collection,
-                          value: setting.value,
-                          encrypted: setting.encrypted? })
-  end
+  attribute :config_file, :string
+  attribute :updated_at
 
   def self.model_name
     Setting.model_name
@@ -79,5 +60,9 @@ class SettingPresenter
 
   def category_name
     category.gsub(/Setting::/, '')
+  end
+
+  def select_values
+    Setting.select_collection_registry.collection_for name
   end
 end

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -3,7 +3,10 @@ class SettingRegistry
 
   def initialize
     @settings = {}
-    load
+  end
+
+  def ready?
+    @settings.any?
   end
 
   def logger
@@ -11,6 +14,7 @@ class SettingRegistry
   end
 
   def find(name)
+    logger.warn("Setting is not initialized yet, requested value for #{name} will be always nil") unless ready?
     @settings[name.to_s]
   end
 
@@ -22,7 +26,10 @@ class SettingRegistry
   #
   def [](name)
     definition = find(name)
-    logger.warn("Setting #{name} has no definition, please define it before using") and return unless definition
+    unless definition
+      logger.warn("Setting #{name} has no definition, please define it before using") if ready?
+      return
+    end
     definition.value
   end
 

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -62,17 +62,19 @@ class SettingRegistry
 
   def load_values
     loaded_names = []
-    Setting.unscoped.all.each do |set|
-      set_definition = find(set.name)
-      logger.debug("Setting #{set.name} has no definition, clean up your database") and next unless set_definition
-      loaded_names << set.name
-      set_definition.updated_at = set.updated_at
-      set_definition.value = set.value
+    Setting.unscoped.all.each do |s|
+      unless (definition = find(s.name))
+        logger.debug("Setting #{s.name} has no definition, clean up your database")
+        next
+      end
+      loaded_names << s.name
+      definition.updated_at = s.updated_at
+      definition.value = s.value
     end
     # load nil to set value to default
-    @settings.except(*loaded_names).each do |name, set_definition|
-      set_definition.updated_at = nil
-      set_definition.value = set_definition.default
+    @settings.except(*loaded_names).each do |name, definition|
+      definition.updated_at = nil
+      definition.value = definition.default
     end
   end
 

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -1,0 +1,100 @@
+class SettingRegistry
+  include Singleton
+
+  def initialize
+    @settings = {}
+    load
+  end
+
+  def logger
+    Foreman::Logging.logger('app')
+  end
+
+  def find(name)
+    @settings[name.to_s]
+  end
+
+  # Returns a setting effective value
+  # Call as `Foreman.settings[<name>]`
+  #
+  #   Foreman.settings['default_locale'] => nil.
+  #   Foreman.settings[:default_locale] => nil.
+  #
+  def [](name)
+    definition = find(name)
+    logger.warn("Setting #{name} has no definition, please define it before using") and return unless definition
+    definition.value
+  end
+
+  def []=(name, value)
+    definition = find(name)
+    raise ::Foreman::Exception.new(N_("Setting definition for '%s' not found, can not set"), name) unless definition
+    db_record = _find_or_new_db_record(name)
+    db_record.value = value
+    db_record.save!
+    definition.value = db_record.value
+  end
+
+  def load
+    # add() all setting definitions
+    Setting.descendants.each do |cat_cls|
+      if cat_cls.default_settings.empty?
+        # Setting category uses really old way of doing things
+        _load_category_from_db(cat_cls)
+      else
+        cat_cls.default_settings.each { |s| _add(s[:name], s.except(:name).merge(category: cat_cls.name)) }
+      end
+    end
+
+    # load all db values
+    load_values
+
+    # if create_missing create missing values in DB
+    # not needed now as old load mechanism takes care of that
+  end
+
+  def load_values
+    loaded_names = []
+    Setting.unscoped.all.each do |set|
+      set_definition = find(set.name)
+      logger.debug("Setting #{set.name} has no definition, clean up your database") and next unless set_definition
+      loaded_names << set.name
+      set_definition.updated_at = set.updated_at
+      set_definition.value = set.value
+    end
+    # load nil to set value to default
+    @settings.except(*loaded_names).each do |name, set_definition|
+      set_definition.updated_at = nil
+      set_definition.value = set_definition.default
+    end
+  end
+
+  def _add(name, category:, default:, description:, full_name: nil, value: nil, encrypted: false)
+    @settings[name.to_s] = SettingPresenter.new({ name: name,
+                                                  category: category,
+                                                  description: description,
+                                                  default: default,
+                                                  full_name: full_name,
+                                                  encrypted: encrypted })
+  end
+
+  def _find_or_new_db_record(name)
+    definition = find(name)
+    Setting.find_by(name: name) ||
+      Setting.new(name: name,
+                  category: definition.category,
+                  default: definition.default,
+                  description: definition.description,
+                  full_name: definition.full_name,
+                  encrypted: definition.encrypted?)
+  end
+
+  # ==== Load old defaults
+
+  def _load_category_from_db(category_klass)
+    category_klass.all.each do |set|
+      # set.value can be user value, we have no way of telling the initial value
+      _add(set.name, category: category_klass.name, description: set.description, default: set.default, full_name: set.full_name, encrypted: set.encrypted)
+    end
+  end
+end

--- a/app/services/setting_select_collection.rb
+++ b/app/services/setting_select_collection.rb
@@ -11,8 +11,9 @@ class SettingSelectCollection
     @collection_mapping.has_key? setting.name
   end
 
-  def collection_for(setting)
-    opts = @collection_mapping[setting.name]
+  def collection_for(setting_or_name)
+    setting_or_name = setting_or_name.name if setting_or_name.is_a?(Setting)
+    opts = @collection_mapping[setting_or_name]
     return unless opts
     SettingValueSelection.new(opts[:collection].call, opts).collection
   end

--- a/app/views/api/v2/settings/index.json.rabl
+++ b/app/views/api/v2/settings/index.json.rabl
@@ -1,3 +1,3 @@
-collection @settings.map { |s| SettingPresenter.from_setting(s) }
+collection @settings
 
 extends "api/v2/settings/main"

--- a/app/views/api/v2/settings/main.json.rabl
+++ b/app/views/api/v2/settings/main.json.rabl
@@ -1,4 +1,4 @@
-object @setting && SettingPresenter.from_setting(@setting)
+object @setting
 
 extends "api/v2/settings/base"
 

--- a/app/views/api/v2/settings/show.json.rabl
+++ b/app/views/api/v2/settings/show.json.rabl
@@ -1,3 +1,3 @@
-object SettingPresenter.from_setting(@setting)
+object Foreman.settings.find(@setting.name)
 
 extends "api/v2/settings/main"

--- a/app/views/api/v2/settings/update.json.rabl
+++ b/app/views/api/v2/settings/update.json.rabl
@@ -1,3 +1,3 @@
-object SettingPresenter.from_setting(@setting)
+object Foreman.settings.find(@setting.name)
 
 extends "api/v2/settings/show"

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -27,6 +27,7 @@ if (Setting.table_exists? rescue(false))
   end
 
   Setting.descendants.each(&:load_defaults)
+  Foreman.settings.load
 end
 
 # load topbar

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -40,6 +40,9 @@ Foreman::Plugin.initialize_default_registries
 Foreman::Plugin.medium_providers_registry.register MediumProviders::Default
 
 Rails.application.config.to_prepare do
+  # Force reload settings after all plugins have loaded and on code reload
+  Foreman.settings.load if (Setting.table_exists? rescue(false))
+
   Foreman.input_types_registry.register(InputType::UserInput)
   Foreman.input_types_registry.register(InputType::FactInput)
   Foreman.input_types_registry.register(InputType::VariableInput)

--- a/db/migrate/20190801143210_convert_dns_conflict_timeout_setting.rb
+++ b/db/migrate/20190801143210_convert_dns_conflict_timeout_setting.rb
@@ -17,11 +17,6 @@ class FakeSetting < ApplicationRecord
 end
 
 class ConvertDnsConflictTimeoutSetting < ActiveRecord::Migration[5.2]
-  def clean_cache
-    Rails.cache.delete(Setting.cache_key("dns_conflict_timeout"))
-    Rails.cache.delete(Setting.cache_key("dns_timeout"))
-  end
-
   def up
     Setting.without_auditing do
       old_setting = FakeSetting.find_by_name("dns_conflict_timeout")
@@ -33,14 +28,12 @@ class ConvertDnsConflictTimeoutSetting < ActiveRecord::Migration[5.2]
         new_setting.save!
       end
       old_setting.destroy!
-      clean_cache
     end
   end
 
   def down
     Setting.without_auditing do
       FakeSetting.where("name = 'dns_timeout' or name = 'dns_conflict_timeout'").destroy_all
-      clean_cache
     end
   end
 end

--- a/db/migrate/20200112121946_fix_dns_timeout_setting.rb
+++ b/db/migrate/20200112121946_fix_dns_timeout_setting.rb
@@ -1,7 +1,5 @@
 class FixDnsTimeoutSetting < ActiveRecord::Migration[5.2]
   def up
-    Rails.cache.delete(Setting.cache_key("dns_timeout"))
     Setting.find_by_name('dns_timeout')&.update_column(:value, nil) if Setting[:dns_timeout] == [nil]
-    Rails.cache.delete(Setting.cache_key("dns_timeout"))
   end
 end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -115,7 +115,7 @@ class ActiveRecord::Base
   def self.per_page
     # Foreman.in_rake? prevents the failure of db:migrate for postgresql
     # don't query settings table if in rake
-    return 20 if Foreman.in_rake?
+    return 20 unless Foreman.settings.ready?
     Setting[:entries_per_page] rescue 20
   end
 

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -34,4 +34,8 @@ module Foreman
   def self.input_types_registry
     @input_types_registry ||= Foreman::InputTypesRegistry.new
   end
+
+  def self.settings
+    SettingRegistry.instance
+  end
 end

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -9,6 +9,7 @@ class ActiveSupport::TestCase
   setup :begin_gc_deferment
   setup :reset_rails_cache
   setup :skip_if_plugin_asked_to
+  setup :load_settings
   setup :set_admin
 
   teardown :reconsider_gc_deferment
@@ -39,6 +40,10 @@ class ActiveSupport::TestCase
     if skips.any? { |name| @NAME.end_with?(name) }
       skip "Test was disabled by plugin"
     end
+  end
+
+  def load_settings
+    Foreman.settings.load
   end
 
   def set_admin

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -20,7 +20,6 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
     get :show, params: { :id => settings(:attributes1).to_param }
     assert_response :success
     show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_include show_response.keys, 'created_at'
     assert_include show_response.keys, 'updated_at'
   end
 

--- a/test/models/host_status/configuration_status_test.rb
+++ b/test/models/host_status/configuration_status_test.rb
@@ -101,6 +101,8 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
       def stub_outofsync_setting(value)
         Setting.create(name: :testorigin_out_of_sync_disabled,
                        description: 'description', default: false)
+        Foreman.settings._add('testorigin_out_of_sync_disabled', category: 'Setting::General', description: 'description', default: false)
+        Foreman.settings.load
         Setting[:testorigin_out_of_sync_disabled] = value
       end
     end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -1,0 +1,51 @@
+require 'test_helper'
+
+class SettingRegistryTest < ActiveSupport::TestCase
+  let(:registry) { SettingRegistry.instance }
+  let(:default) { 5 }
+  let(:setting_value) { nil }
+  let(:setting) { Setting.create(registry.find('foo').attributes.merge(value: setting_value)) }
+
+  setup do
+    registry._add('foo', category: 'Setting::General', default: default, description: 'test foo')
+    setting
+    registry.load
+  end
+
+  context 'with nil default' do
+    let(:default) { nil }
+
+    it 'allows nil default value' do
+      assert_nil registry['foo']
+    end
+  end
+
+  it 'provides default if no value defined' do
+    assert_equal 5, registry['foo']
+    assert_equal 5, registry[:foo]
+  end
+
+  it 'saves the value on assignment' do
+    registry[:foo] = 3
+    assert Setting.find_by(name: 'foo').persisted?
+    assert_equal 3, registry['foo']
+  end
+
+  it 'returns updated value only after it is saved' do
+    setting.value = 3
+    assert_equal 5, registry['foo']
+
+    setting.save
+    registry.load
+    assert_equal 3, setting.value
+    assert_equal 3, registry['foo']
+  end
+
+  context 'with value' do
+    let(:setting_value) { 10 }
+
+    it 'retrieves the value' do
+      assert_equal setting_value, registry['foo']
+    end
+  end
+end


### PR DESCRIPTION
SettingRegistry keeps all the setting information as set of SettingPresenters.
This registry should be the public API for accessing setting values.

The public interface should be called as `Foreman.settings[<name>] => value`

This allows new DSL that will be introduced in: #8437
And can be followed by serving these on index pages: #8438