### PR TITLE
Refs #30667 - Use separate logger config for sidekiq workers

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -239,7 +239,8 @@ module Foreman
       :telemetry => {:enabled => false},
       :blob => {:enabled => false},
       :taxonomy => {:enabled => true},
-      :api_deprecations => {:enabled => true}
+      :api_deprecations => {:enabled => true},
+      :sidekiq => {:enabled => true, :level => :warn}
     ))
 
     config.logger = Foreman::Logging.logger('app')

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,5 @@
 if defined?(::Sidekiq)
   Sidekiq.configure_server do |config|
-    config.logger.level = ::Foreman::Logging.logger('dynflow').level
+    config.logger.level = ::Foreman::Logging.logger('sidekiq').level
   end
 end

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -103,6 +103,9 @@
 #    :enabled: true
 #  :blob:
 #    :enabled: false
+#  :sidekiq:
+#    :enabled: true
+#    :level: warn
 
 # Foreman telemetry has three destinations: prometheus, statsd and rails log.
 :telemetry:


### PR DESCRIPTION
Sidekiq emits two log messages for each job it processes and those end up in
system journal and possibly /var/log/messages. Originally I opened a PR so
sidekiq workers would "inherit" their log levels from Dynflow loggers. This made
things configurable, but didn't really fix anything out of the box because
Dynflow's log level is set to INFO by default and that is the default level for
sidekiq as well. Since we need to change the log levels independently, new
logger dedicated to sidekiq is introduced.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
