### PR TITLE
Fixes #30839 - accept Arrays of nested compute attributes

### DIFF
--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -56,7 +56,7 @@ class ComputeAttribute < ApplicationRecord
   end
 
   def attribute_values(attr_name)
-    attr_key = "#{attr_name}_attributes"
-    vm_attrs[attr_key].try(:values) || []
+    attrs = vm_attrs["#{attr_name}_attributes"]
+    (attrs.is_a?(Array) ? attrs : attrs.try(:values)) || []
   end
 end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -430,9 +430,11 @@ class ComputeResource < ApplicationRecord
     opts = opts.to_hash if opts.class == ActionController::Parameters
 
     opts = opts.dup # duplicate to prevent changing the origin opts.
-    opts.delete("new_#{type}") || opts.delete("new_#{type}".to_sym) # delete template
-    # convert our options hash into a sorted array (e.g. to preserve nic / disks order)
-    opts = opts.sort { |l, r| l[0].to_s.sub('new_', '').to_i <=> r[0].to_s.sub('new_', '').to_i }.map { |e| Hash[e[1]] }
+    unless opts.is_a?(Array)
+      opts.delete("new_#{type}") || opts.delete("new_#{type}".to_sym) # delete template
+      # convert our options hash into a sorted array (e.g. to preserve nic / disks order)
+      opts = opts.sort { |l, r| l[0].to_s.sub('new_', '').to_i <=> r[0].to_s.sub('new_', '').to_i }.map { |e| Hash[e[1]] }
+    end
     opts.map do |v|
       if v[:_delete] == '1' && v[:id].blank?
         nil

--- a/test/controllers/api/v2/compute_attributes_controller_test.rb
+++ b/test/controllers/api/v2/compute_attributes_controller_test.rb
@@ -18,9 +18,9 @@ class Api::V2::ComputeAttributesControllerTest < ActionController::TestCase
   end
 
   test "should create compute attribute" do
+    valid_attrs = {:vm_attrs => {"cpus" => "2", "memory" => "2147483648"}}
+    ComputeAttribute.any_instance.stubs(:new_vm).returns(nil)
     assert_difference('ComputeAttribute.count') do
-      ComputeAttribute.any_instance.stubs(:new_vm).returns(nil)
-      valid_attrs = {:vm_attrs => {"cpus" => "2", "memory" => "2147483648"}}
       post :create, params: { :compute_attribute => valid_attrs,
                               :compute_profile_id => compute_profiles(:three).id,
                               :compute_resource_id => compute_resources(:one).id }

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -343,7 +343,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   test "should create interfaces from compute profile" do
     disable_orchestration
 
-    compute_attrs = compute_attributes(:with_interfaces)
+    compute_attrs = FactoryBot.create(:compute_attribute, :with_interfaces, compute_resource: compute_resources(:one))
     post :create, params: { :host => basic_attrs_with_profile(compute_attrs).merge(:interfaces_attributes => nics_attrs) }
     assert_response :created
 

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -95,13 +95,31 @@ FactoryBot.define do
 
   factory :compute_attribute do
     sequence(:name) { |n| "attributes#{n}" }
+    compute_profile
+
+    transient do
+      interfaces_attributes { nil }
+    end
+
     vm_attrs do
       {
         :flavor_id => 'm1.small',
         :availability_zone => 'eu-west-1a',
       }
     end
+
+    trait :with_interfaces do
+      interfaces_attributes do
+        {
+          '1' => { 'attr' => 1 },
+          '2' => { 'attr' => 2 },
+        }
+      end
+    end
     before(:create) { |attr| attr.stubs(:pretty_vm_attrs).returns('m1.small VM') }
+    before(:create) do |attr, evaluator|
+      attr.vm_attrs["#{evaluator.compute_resource.interfaces_attrs_name}_attributes"] = evaluator.interfaces_attributes if evaluator.interfaces_attributes
+    end
   end
 
   factory :compute_profile do

--- a/test/models/compute_attribute_test.rb
+++ b/test/models/compute_attribute_test.rb
@@ -4,14 +4,17 @@ class ComputeAttributeTest < ActiveSupport::TestCase
   setup do
     Fog.mock!
     User.current = users :admin
-    @set = compute_attributes(:one)
-    @compute_profile = @set.compute_profile # 1-Small
-    @compute_resource = @set.compute_resource # EC2
   end
 
   teardown do
     Fog.unmock!
   end
+
+  let(:compute_profile) { FactoryBot.create(:compute_profile) }
+  let(:compute_resource) { FactoryBot.create(:compute_resource, :libvirt) }
+  let(:basic_vm_attrs) { { 'flavor_id' => 'm1.small', 'availability_zone' => 'eu-west-1a' } }
+  let(:vm_attrs) { basic_vm_attrs }
+  let(:compute_attribute) { FactoryBot.create(:compute_attribute, compute_profile: compute_profile, compute_resource: compute_resource, vm_attrs: vm_attrs) }
 
   should validate_uniqueness_of(:compute_profile_id).
     scoped_to(:compute_resource_id)
@@ -19,34 +22,47 @@ class ComputeAttributeTest < ActiveSupport::TestCase
     scoped_to(:compute_profile_id)
 
   test "getter attributes in vm_attrs hash" do
-    assert_equal 'm1.small', @set.flavor_id
-    assert_equal 'eu-west-1a', @set.availability_zone
+    assert_equal 'm1.small', compute_attribute.flavor_id
+    assert_equal 'eu-west-1a', compute_attribute.availability_zone
   end
 
   test "raise error for nonexistant getter attribute in vm_attrs hash" do
     assert_raise Foreman::Exception do
-      @set.nonexistant_flavor_field
+      compute_attribute.nonexistant_flavor_field
     end
   end
 
   test "#provider_friendly_name" do
-    refute_nil @set.provider_friendly_name
-    assert_equal(@compute_resource.provider_friendly_name, @set.provider_friendly_name)
+    refute_nil compute_attribute.provider_friendly_name
+    assert_equal(compute_resource.provider_friendly_name, compute_attribute.provider_friendly_name)
   end
 
   describe "vm_interfaces" do
-    test "returns array of interface attributes" do
-      set = compute_attributes(:with_interfaces)
-      expected_vm_interfaces = [
-        {'attr' => 1},
-        {'attr' => 2},
-      ]
-      assert_equal expected_vm_interfaces, set.vm_interfaces
+    let(:vm_attrs) { basic_vm_attrs.merge("#{compute_resource.interfaces_attrs_name}_attributes" => nics_attributes) }
+    let(:expected_vm_interfaces) { [{'attr' => 1}, {'attr' => 2}] }
+
+    context 'without nics_attributes' do
+      let(:vm_attrs) { basic_vm_attrs }
+
+      test "returns empty array if interface attributes are missing" do
+        assert_empty compute_attribute.vm_interfaces
+      end
     end
 
-    test "returns empty array if interface attributes are missing" do
-      set = compute_attributes(:one)
-      assert_empty set.vm_interfaces
+    context 'with hash attributes' do
+      let(:nics_attributes) { { '1' => { 'attr' => 1 }, '2' => { 'attr' => 2 } } }
+
+      test 'returns array of interface attributes' do
+        assert_equal expected_vm_interfaces, compute_attribute.vm_interfaces
+      end
+    end
+
+    context 'with array attributes' do
+      let(:nics_attributes) { [{ 'attr' => 1 }, { 'attr' => 2 }] }
+
+      test 'returns array of interface attributes' do
+        assert_equal expected_vm_interfaces, compute_attribute.vm_interfaces
+      end
     end
   end
 end

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -376,11 +376,20 @@ class ComputeResourceTest < ActiveSupport::TestCase
     end
   end
 
-  test "returns nested_attribute_for ActionController::Parameters" do
-    cr = compute_resources(:mycompute)
-    hash = {:disk => "test"}
-    volume_attributes = ActionController::Parameters.new("1520857914238" => ActionController::Parameters.new(hash))
-    volumes = cr.send(:nested_attributes_for, :volumes, volume_attributes.permit("1520857914238" => {}))
-    assert_equal hash, volumes[0]
+  describe '#nested_attribute_for' do
+    test "handles ActionController::Parameters" do
+      cr = compute_resources(:mycompute)
+      hash = {:disk => "test"}
+      volume_attributes = ActionController::Parameters.new("1520857914238" => ActionController::Parameters.new(hash))
+      volumes = cr.send(:nested_attributes_for, :volumes, volume_attributes.permit("1520857914238" => {}))
+      assert_equal hash, volumes[0]
+    end
+
+    test "handles Array" do
+      cr = compute_resources(:mycompute)
+      volume_attributes = [{:disk => "test"}, {size_gb: 10}]
+      volumes = cr.send(:nested_attributes_for, :volumes, volume_attributes)
+      assert_equal volume_attributes, volumes
+    end
   end
 end


### PR DESCRIPTION
API should be able to handle interfaces_attributes: [{attrs1},{attrs2}],
Until now it only handled hashes with numbered keys.

