### PR TITLE
Add some safe Performance Cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,14 +41,36 @@ Layout/ParameterAlignment:
 Metrics:
   Enabled: false
 
-Performance/Casecmp:
+Performance/Caller:
+  Enabled: true
+
+Performance/CaseWhenSplat:
+  Enabled: true
+
+# Hard to review, can introduce regressions
+Performance/ChainArrayAllocation:
   Enabled: false
 
-Performance/RedundantMatch:
+Performance/DoubleStartEndWith:
   Enabled: true
 
-Performance/RedundantMerge:
+Performance/InefficientHashSearch:
   Enabled: true
+
+Performance/ReverseEach:
+  Enabled: true
+
+Performance/StartWith:
+  Enabled: true
+
+Performance/EndWith:
+  Enabled: true
+
+Performance/UriDefaultParser:
+  Enabled: true
+
+Performance/Casecmp:
+  Enabled: false
 
 Performance/RegexpMatch:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,32 +41,7 @@ Layout/ParameterAlignment:
 Metrics:
   Enabled: false
 
-Performance/Caller:
-  Enabled: true
-
 Performance/CaseWhenSplat:
-  Enabled: true
-
-# Hard to review, can introduce regressions
-Performance/ChainArrayAllocation:
-  Enabled: false
-
-Performance/DoubleStartEndWith:
-  Enabled: true
-
-Performance/InefficientHashSearch:
-  Enabled: true
-
-Performance/ReverseEach:
-  Enabled: true
-
-Performance/StartWith:
-  Enabled: true
-
-Performance/EndWith:
-  Enabled: true
-
-Performance/UriDefaultParser:
   Enabled: true
 
 Performance/Casecmp:

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -331,13 +331,14 @@ module Api
       @nested_obj = parent_resource_scope.first
     end
 
+    ALLOWED_NESTED_ID_NAMES = ['organization_id', 'location_id']
     def not_found_if_nested_id_exists
       allowed_nested_id.each do |obj_id|
         # this method does not reliably work when you have multiple parameters and some of them can be nil
         # find_nested_object in such case returns nil (since org and loc can be nil for any context),
         # but it detects other paramter which can have value set
         # therefore we always skip these
-        next if ['organization_id', 'location_id'].include?(obj_id)
+        next if ALLOWED_NESTED_ID_NAMES.include?(obj_id)
         if params[obj_id].present?
           not_found _("%{resource_name} not found by id '%{id}'") % { :resource_name => obj_id.humanize, :id => params[obj_id] }
           return

--- a/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
+++ b/app/controllers/concerns/api/import_puppetclasses_common_controller.rb
@@ -18,6 +18,7 @@ module Api::ImportPuppetclassesCommonController
   param :dryrun, :bool, :required => false
   param :except, String, :required => false, :desc => N_("Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes")
 
+  ALLOWED_KINDS = ["new", "obsolete", "updated", "ignored"]
   def import_puppetclasses
     return unless changed_environments
     # @changed is returned from the method above changed_environments
@@ -26,7 +27,7 @@ module Api::ImportPuppetclassesCommonController
     if params[:except].present?
       kinds = params[:except].split(',')
       kinds.each do |kind|
-        @changed[kind] = {} if ["new", "obsolete", "updated", "ignored"].include?(kind)
+        @changed[kind] = {} if ALLOWED_KINDS.include?(kind)
       end
     end
 

--- a/app/controllers/concerns/foreman/controller/auto_complete_search.rb
+++ b/app/controllers/concerns/foreman/controller/auto_complete_search.rb
@@ -6,12 +6,13 @@ module Foreman::Controller::AutoCompleteSearch
     before_action :store_redirect_to_url, :except => [:index, :show, :create, :update]
   end
 
+  CATEGORIES = ['and', 'or', 'not', 'has']
   def auto_complete_search
     begin
       model = (controller_name == "hosts") ? Host::Managed : model_of_controller
       @items = model.complete_for(params[:search], {:controller => controller_name})
       @items = @items.map do |item|
-        category = ['and', 'or', 'not', 'has'].include?(item.to_s.sub(/^.*\s+/, '')) ? _('Operators') : ''
+        category = CATEGORIES.include?(item.to_s.sub(/^.*\s+/, '')) ? _('Operators') : ''
         part = item.to_s.sub(/^.*\b(and|or)\b/i) { |match| match.sub(/^.*\s+/, '') }
         completed = item.to_s.chomp(part)
         {:completed => CGI.escapeHTML(completed), :part => CGI.escapeHTML(part), :label => item, :category => category}

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -67,9 +67,10 @@ module AuditExtensions
         end
       end
 
+      TAXABLE_NAMES = [:location, :organization]
       def fully_taxable
         known_auditable_types.select do |model|
-          [:location, :organization].map do |taxable|
+          TAXABLE_NAMES.map do |taxable|
             has_any_association_to?(taxable, model)
           end.all?
         end

--- a/app/models/concerns/facets/model_extensions_base.rb
+++ b/app/models/concerns/facets/model_extensions_base.rb
@@ -95,13 +95,14 @@ module Facets
     # define instance methods in a module, so they will be set
     # even for models that do not include this module directly
     # like in case Hostgroup -> HostgroupExtensions -> ModelExtensionsBase
+    FACET_ATTRIBUTES = %w(created_at updated_at)
     module InstanceMethods
       def attributes
         hash = super
 
         # include all facet attributes by default
         facets_with_definitions.each do |facet, facet_definition|
-          hash["#{facet_definition.name}_attributes"] = facet.attributes.reject { |key| %w(created_at updated_at).include? key }
+          hash["#{facet_definition.name}_attributes"] = facet.attributes.reject { |key| FACET_ATTRIBUTES.include? key }
         end
         hash
       end

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -38,6 +38,8 @@ module NestedAncestryCommon
 
   module ClassMethods
     attr_reader :nested_attribute_fields
+
+    NESTED_PROXY_CLASSES = ["puppet_proxy", "puppet_ca_proxy"]
     def nested_attribute_for(*fields)
       @nested_attribute_fields = fields
       @nested_attribute_fields.each do |field|
@@ -59,7 +61,7 @@ module NestedAncestryCommon
           define_method md[1] do
             if ancestry.present?
               klass = md[1].classify
-              klass = "SmartProxy" if ["puppet_proxy", "puppet_ca_proxy"].include?(md[1])
+              klass = "SmartProxy" if NESTED_PROXY_CLASSES.include?(md[1])
               klass = 'Subnet::Ipv4' if md[1] == 'subnet'
               klass = 'Subnet::Ipv6' if md[1] == 'subnet6'
               klass.classify.constantize.find_by_id(send("inherited_#{field}"))

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -128,6 +128,7 @@ module Orchestration::Compute
     failure _("Failed to remove certificates for %{name}: %{e}") % { :name => name, :e => e }, e
   end
 
+  SET_DETAILS_IP_FIELDS = [:ip, :ip6]
   def setComputeDetails
     if vm
       attrs = compute_resource.provided_attributes
@@ -135,7 +136,7 @@ module Orchestration::Compute
       attrs.each do |foreman_attr, fog_attr|
         if foreman_attr == :mac
           return false unless match_macs_to_nics(fog_attr)
-        elsif [:ip, :ip6].include?(foreman_attr)
+        elsif SET_DETAILS_IP_FIELDS.include?(foreman_attr)
           value = vm.send(fog_attr) || find_address(foreman_attr)
           send("#{foreman_attr}=", value)
           return false if send(foreman_attr).present? && !validate_foreman_attr(value, ::Nic::Base, foreman_attr)

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -202,7 +202,9 @@ class Filter < ApplicationRecord
 
   # if we have 0 types, empty validation will set error, we can't have more than one type
   def same_resource_type_permissions
-    types = permissions.map(&:resource_type).uniq
+    # Performance/ChainArrayAllocation
+    types = permissions.map(&:resource_type)
+    types.uniq!
     if types.size > 1
       errors.add(
         :permissions,

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -260,7 +260,7 @@ class Hostgroup < ApplicationRecord
 
   def children_hosts_count
     counter = HostCounter.new(:hostgroup)
-    subtree_ids.map { |child_id| counter.fetch(child_id, 0) }.sum
+    subtree_ids.sum { |child_id| counter.fetch(child_id, 0) }
   end
 
   # rebuilds orchestration configuration for hostgroup's hosts

--- a/app/registries/foreman/plugin/report_origin_registry.rb
+++ b/app/registries/foreman/plugin/report_origin_registry.rb
@@ -23,7 +23,7 @@ module Foreman
       end
 
       def all_origins
-        @report_origins.map { |_, origins| origins }.inject(:+)
+        @report_origins.map { |_, origins| origins }.sum
       end
 
       def origins_with_interval_setting

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -107,7 +107,10 @@ class Authorizer
   def build_scoped_search_condition(filters)
     raise ArgumentError if filters.blank?
 
-    filters.select { |f| f.search_condition.present? }.map { |f| "(#{f.search_condition})" }.join(' OR ')
+    # Performance/ChainArrayAllocation
+    condition = filters.select { |f| f.search_condition.present? }
+    condition.map! { |f| "(#{f.search_condition})" }
+    condition.join(' OR ')
   end
 
   private

--- a/app/services/fact_cleaner.rb
+++ b/app/services/fact_cleaner.rb
@@ -53,7 +53,9 @@ class FactCleaner
     logger.debug "Cleaning facts matching excluded pattern: #{excluded_facts_regex}"
 
     FactName.unscoped.reorder(nil).select(:id, :name).find_in_batches(:batch_size => @batch_size) do |names_batch|
-      fact_name_ids = names_batch.select { |fact_name| fact_name.name.match(excluded_facts_regex) }.map(&:id)
+      # Performance/ChainArrayAllocation
+      fact_name_ids = names_batch.select { |fact_name| fact_name.name.match(excluded_facts_regex) }
+      fact_name_ids.map!(&:id)
       @deleted_count += delete_facts_names_values(fact_name_ids)
     end
   end

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -66,7 +66,12 @@ class PuppetClassImporter
   # Returns   : Array of Strings containing all record errors
   def obsolete_and_new(changes = { })
     return if changes.empty?
-    changes.values.map(&:keys).flatten.uniq.each do |env_name|
+    # Performance/ChainArrayAllocation
+    values = changes.values
+    values.map!(&:keys)
+    values.flatten!
+    values.uniq!
+    values.each do |env_name|
       if changes['new'] && changes['new'][env_name].try(:>, '') # we got new classes
         add_classes_to_foreman(env_name, JSON.parse(changes['new'][env_name]))
       end

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -73,7 +73,9 @@ class PuppetFactParser < FactParser
   end
 
   def ipmi_interface
-    ipmi = facts.select { |name, _| name =~ /\Aipmi_(.*)\Z/ }.map { |name, value| [name.sub(/\Aipmi_/, ''), value] }
+    # Performance/ChainArrayAllocation
+    ipmi = facts.select { |name, _| name =~ /\Aipmi_(.*)\Z/ }
+    ipmi.map! { |name, value| [name.sub(/\Aipmi_/, ''), value] }
     Hash[ipmi].with_indifferent_access
   end
 

--- a/app/services/structured_fact_importer.rb
+++ b/app/services/structured_fact_importer.rb
@@ -80,9 +80,11 @@ class StructuredFactImporter < FactImporter
   def ensure_fact_names
     super
 
+    # Performance/ChainArrayAllocation
     composite_fact_names = facts.map do |key, value|
       key if value.nil?
-    end.compact
+    end
+    composite_fact_names.compact!
 
     affected_records = fact_name_class.where(:name => composite_fact_names, :compose => false).update_all(:compose => true)
 

--- a/app/services/tax_host.rb
+++ b/app/services/tax_host.rb
@@ -121,7 +121,10 @@ class TaxHost
         }
       end
     end
-    @mismatches = mismatches.uniq.compact
+    # Performance/ChainArrayAllocation
+    @mismatches = mismatches
+    @mismatches.uniq!
+    @mismatches.compact!
   end
 
   def check_for_orphans
@@ -148,7 +151,11 @@ class TaxHost
     # end
     define_method "#{key}s".to_sym do
       # can't use pluck(key), :domain_id is delegated method, not SQL column, performance diff wasn't big
-      hosts.map(&key).uniq.compact
+      # Performance/ChainArrayAllocation
+      keys = hosts.map(&key)
+      keys.uniq!
+      keys.compact!
+      keys
     end
   end
 

--- a/app/services/tax_host.rb
+++ b/app/services/tax_host.rb
@@ -91,10 +91,11 @@ class TaxHost
     @missing_ids = missing_ids
   end
 
+  TAXONOMIES = %w[Location Organization]
   def import_missing_ids
     missing_ids.each do |row|
       # no object for table locations_organizations, so use method *_ids = [array id's] to create relationship
-      if %w[Location Organization].include?(row[:taxable_type])
+      if TAXONOMIES.include?(row[:taxable_type])
         if (tax = Taxonomy.find_by_id(row[:taxonomy_id]))
           tax.send("#{opposite_taxonomy_type}_ids=".to_sym, [row[:taxable_id]] + tax.send("#{opposite_taxonomy_type}_ids"))
         end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -66,7 +66,9 @@ class ActiveRecord::Base
     def initialize(base, source, target)
       @source, @target = source, target
       @base = base.map { |record| [record.send(@source), record.send(@target)] }
-      @nodes = @base.flatten.uniq
+      # Performance/ChainArrayAllocation
+      @nodes = @base.flatten
+      @nodes.uniq!
       @graph = Hash.new { |h, k| h[k] = [] }
       @base.each { |s, t| @graph[s] << t }
     end

--- a/lib/foreman/telemetry_sinks/statsd_sink.rb
+++ b/lib/foreman/telemetry_sinks/statsd_sink.rb
@@ -52,7 +52,12 @@ module Foreman::TelemetrySinks
     def name_tag_mapping(name, tags)
       insts = @instances[name]
       return name if insts.blank?
-      (name.to_s + '.' + insts.map { |x| tags[x] }.compact.join('.')).tr('-:/ ', '____')
+      # Performance/ChainArrayAllocation
+      inmap = insts.map { |x| tags[x] }
+      inmap.compact!
+      result = name.to_s + '.' + inmap.join('.')
+      result.tr!('-:/ ', '____')
+      result
     end
 
     def tags_in_statsd(tags)


### PR DESCRIPTION
I've reviewed https://docs.rubocop.org/rubocop-performance/cops_performance.html and enabled reasonable Cops. This is for discussion. There were no offences in the core codebase at all.

Then I upgraded Rubocop locally to 0.9x series and manually fixed some
offenses where it makes sense (there is some potentical benefit - e.g. a
controller or code path which can be executed more common):

* Performance/ChainArrayAllocation
* Performance/CollectionLiteralInLoop
* Performance/Sum

None of these Cops above were actually enabled for enforcion.