### PR TITLE
Refs #30029 - moved initialization of allowed tags

### DIFF
--- a/config/initializers/5_telemetry_metrics.rb
+++ b/config/initializers/5_telemetry_metrics.rb
@@ -100,4 +100,4 @@ allowed_labels = {
     'Widget',
   ],
 }
-telemetry.allowed_tags(allowed_labels)
+telemetry.add_allowed_tags!(allowed_labels)

--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -12,6 +12,7 @@ module Foreman
     def initialize
       @sinks = []
       @exporter = ::Foreman::TelemetrySinks::MetricExporterSink.new
+      @allowed_tags = {}
     end
 
     def setup(opts = {})
@@ -96,8 +97,7 @@ module Foreman
       @sinks.count > 1
     end
 
-    def allowed_tags(labels)
-      @allowed_tags = {}
+    def add_allowed_tags!(labels)
       labels.each do |k, v|
         @allowed_tags[k] = Regexp.compile('^(' + v.join('|') + ')$')
       end


### PR DESCRIPTION
Telemetry was broken causing nil exception until Rails booted up and
initializer added some allowed tags. This fixes it. I have suspicion
that it broke some rake task too. Quick merge appreciated, sorry about
that.