### PR TITLE
Refs #30519 - Add graphql types related to report

### DIFF
--- a/app/graphql/types/config_report.rb
+++ b/app/graphql/types/config_report.rb
@@ -1,12 +1,10 @@
 module Types
-  class ConfigReport < BaseObject
+  class ConfigReport < Types::Report
     description 'A Config Report'
 
     global_id_field :id
-    timestamps
     field :metrics, Types::RawJson
     field :status, Types::RawJson
     field :origin, String
-    belongs_to :host, Types::Host
   end
 end

--- a/app/graphql/types/log.rb
+++ b/app/graphql/types/log.rb
@@ -1,0 +1,11 @@
+module Types
+  class Log < BaseObject
+    description 'A Log'
+
+    global_id_field :id
+    field :level, String
+    belongs_to :source, Types::Source
+    belongs_to :message, Types::Message
+    belongs_to :report, Types::Report
+  end
+end

--- a/app/graphql/types/message.rb
+++ b/app/graphql/types/message.rb
@@ -1,0 +1,10 @@
+module Types
+  class Message < BaseObject
+    description 'A Message'
+
+    global_id_field :id
+    field :value, String
+    field :digest, String
+    has_many :logs, Types::Log
+  end
+end

--- a/app/graphql/types/report.rb
+++ b/app/graphql/types/report.rb
@@ -1,0 +1,7 @@
+module Types
+  class Report < BaseObject
+    timestamps
+    belongs_to :host, Types::Host
+    has_many :logs, Types::Log
+  end
+end

--- a/app/graphql/types/source.rb
+++ b/app/graphql/types/source.rb
@@ -1,0 +1,10 @@
+module Types
+  class Source < BaseObject
+    description 'A Source'
+
+    global_id_field :id
+    field :value, String
+    field :digest, String
+    has_many :logs, Types::Log
+  end
+end

--- a/test/graphql/queries/config_report_query_test.rb
+++ b/test/graphql/queries/config_report_query_test.rb
@@ -12,24 +12,44 @@ module Queries
             metrics
             status
             origin
+            logs {
+              nodes {
+                id
+                message {
+                  value
+                }
+                source {
+                  value
+                }
+              }
+            }
           }
         }
       GRAPHQL
     end
 
     let(:host) { FactoryBot.create(:host) }
-    let(:report) { FactoryBot.create(:report, :host_id => host.id) }
+
+    let(:report) do
+      report = FactoryBot.create(:report, :host_id => host.id)
+      2.times do
+        FactoryBot.create(:log, :report => report)
+      end
+      report
+    end
+
     let(:global_id) { Foreman::GlobalId.for(report) }
     let(:variables) { { id: global_id } }
     let(:data) { result['data']['configReport'] }
 
     test 'fetch config report by global id' do
       assert_empty result['errors']
-
       assert_equal global_id, data['id']
       assert_equal report.metrics, data['metrics']
       assert_equal report.status, data['status']
       assert_equal report.origin, data['origin']
+      assert_equal report.logs.first.message.value, data['logs']['nodes'].first['message']['value']
+      assert_equal report.logs.first.source.value, data['logs']['nodes'].first['source']['value']
     end
   end
 end


### PR DESCRIPTION
Adds types for Log, Message and Source that hold
report-related information.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
