### PR TITLE
Refs #30715 - cache node_modules for GH actions

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -22,6 +22,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: restore node_modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-modules-${{ matrix.node-version }}-${{ hashFiles('package-json.lock') }}
+          restore-keys: ${{ runner.os }}-modules-${{ matrix.node-version }}-
       - name: Install npm dependencies
         run: npm install
       - name: Run linter


### PR DESCRIPTION
Cache the node_modules in GH jobs to:

- speedup testing _significantly_ (`2:40min` -> `24sec` to restore + `45sec` npm i)
- decrease the load to npmjs.com

@laviro :)