### PR TITLE
Fixes #30905 - do not use ancestry 3.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ end
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '>= 4.9.0', '< 5'
 gem 'will_paginate', '>= 3.1.7', '< 4'
-gem 'ancestry', '>= 3.0.7', '< 4'
+gem 'ancestry', '>= 3.0.7', '< 4', '!= 3.2.0'
 gem 'scoped_search', '>= 4.1.8', '< 5'
 gem 'ldap_fluff', '>= 0.4.7', '< 1.0'
 gem 'apipie-rails', '>= 0.5.17', '< 0.6.0'


### PR DESCRIPTION
Do not install ancestry 3.2.0 as it has bad require.
Details in https://github.com/stefankroes/ancestry/issues/510
