### PR TITLE
Fixes #30912 - Fix ovirt API CR creation with Quota name

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -500,7 +500,7 @@ module Foreman::Model
       if attrs[:ovirt_quota_id].nil?
         attrs[:ovirt_quota_id] = client.quotas.first.id
       else
-        get_ovirt_id(client.quotas, attrs[:ovirt_quota_id])
+        attrs[:ovirt_quota_id] = get_ovirt_id(client.quotas, attrs[:ovirt_quota_id])
       end
     end
 


### PR DESCRIPTION
This PR fixes the ability to create an ovirt CR from hammer/API with Quota name. 
steps to reproduce:
hammer  compute-resource create --name="shira-rhev" --provider="Ovirt" --user="admin@internal" --password="" --datacenter="" --url="https://blabla/ovirt-engine/api" --ovirt-quota="mshira" --locations="Default Location" --organizations="Default Organization"