### PR TITLE
Fixes #13459 - libvirt name coding

### DIFF
--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -11,15 +11,14 @@
                  } %>
 
 <div id='nat' class='<%= 'hide' if f.object.type != 'network' %>'>
-  <%= selectable_f f, :network, nat.map(&:name),
+  <%= selectable_f f, :network, nat.map { |n| n.name.force_encoding('UTF-8') },
                    { :include_blank => nat.any? ? false : _("No networks") },
                    { :class => "libvirt_nat", :label => _("Network"), :disabled => (f.object.type != 'network' || !new_vm), :label_size => "col-md-3" } %>
 </div>
 
 <div id='bridge' class='<%= 'hide' if f.object.type && (f.object.type != 'bridge') %>'>
   <% if bridges.any? %>
-    <%= selectable_f f, :bridge, bridges.map(&:name),
-                     { :include_blank => bridges.any? ? false : _("No bridges") },
+    <%= selectable_f f, :bridge, bridges.map { |bridge| bridge.name.force_encoding('UTF-8') },
                      { :class => "libvirt_bridge", :label => _("Network"), :disabled => !new_vm, :label_size => "col-md-3" } %>
   <% else %>
     <%= text_f f, :bridge,

--- a/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_volume.html.erb
@@ -1,5 +1,5 @@
 
-<%= selectable_f f, :pool_name, compute_resource.storage_pools.map(&:name), { }, :label => _("Storage pool"), :label_size => "col-md-2" %>
+<%= selectable_f f, :pool_name, compute_resource.storage_pools.map{|pool| pool.name.force_encoding('UTF-8') }, { }, :label => _("Storage pool"), :label_size => "col-md-2" %>
 <%= text_f f, :capacity, :label => _("Size (GB)"), :onchange => 'tfm.computeResource.capacityEdit(this)', :label_size => "col-md-2" %>
 <%= allocation_text_f f %>
 <%= select_f f, :format_type, %w[RAW QCOW2],:downcase, :to_s, { }, :label => _("Type"), :label_size => "col-md-2" %>


### PR DESCRIPTION
If libvirt has some special characters in volume/network names it breaks rendering.

Libvirt returns ASCII-8BIT encoded string with UTF8 encoded characters in it.
It's probably a bug in ruby-libvirt, but this fixes thigs on our side.

ASCII-8BIT string then forces the renderer to switch the buffer encoding to ASCII-8BIT.
Once there is another string that needs UTF-8 (owner name eg.) it fails to concat that string to buffer.