### PR TITLE
Fixes #30921 - enable authorized link_to from engines

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -96,9 +96,10 @@ module ApplicationHelper
   # +options+ : Hash containing options for authorized_for and link_to
   # +html_options+ : Hash containing html options for the link or span
   def link_to_if_authorized(name, options = {}, html_options = {})
+    engine = options.delete(:engine) || main_app
     enable_link = authorized_for(options)
     if enable_link
-      link_to name, options, html_options
+      link_to name, engine.url_for(options.merge(:only_path => true)), html_options
     else
       link_to_function name, nil, html_options.merge!(:class => "#{html_options[:class]} disabled", :disabled => true)
     end


### PR DESCRIPTION
Engines with isolated namespace can't use hash to get rout of another namespace.
Enable link_to_if_authorized use the url_for directly on the required engine
to support usage from plugins using isolated namespaces.

Needed by: https://github.com/theforeman/foreman_puppet_enc/pull/26