### PR TITLE
Fixes #30926 - move parse_facts to HostFactImporter

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -137,30 +137,6 @@ module Host
       HostFactImporter.new(self).import_facts(facts, source_proxy)
     end
 
-    def parse_facts(facts, type, source_proxy)
-      time = facts[:_timestamp]
-      time = time.to_time if time.is_a?(String)
-      self.last_compile = time if time
-
-      # taxonomy must be set before populate_fields_from_facts call
-      set_taxonomies(facts)
-
-      unless build?
-        parser = FactParser.parser_for(type).new(facts)
-
-        telemetry_duration_histogram(:importer_facts_import_duration, 1000, type: type) do
-          populate_fields_from_facts(parser, type, source_proxy)
-        end
-      end
-
-      # we are saving here with no validations, as we want this process to be as fast
-      # as possible, assuming we already have all the right settings in Foreman.
-      # If we don't (e.g. we never install the server via Foreman, we populate the fields from facts
-      # TODO: if it was installed by Foreman and there is a mismatch,
-      # we should probably send out an alert.
-      save(:validate => false)
-    end
-
     def attributes_to_import_from_facts
       [:model]
     end
@@ -253,28 +229,6 @@ module Host
         comparison_object.is_a?(Host::Base) &&
         id.present? &&
         comparison_object.id == id
-    end
-
-    def set_taxonomies(facts)
-      ['location', 'organization'].each do |taxonomy|
-        taxonomy_class = taxonomy.classify.constantize
-        taxonomy_fact = Setting["#{taxonomy}_fact"]
-
-        if taxonomy_fact.present? && facts.key?(taxonomy_fact)
-          taxonomy_from_fact = taxonomy_class.find_by_title(facts[taxonomy_fact].to_s)
-        else
-          default_taxonomy = taxonomy_class.find_by_title(Setting["default_#{taxonomy}"])
-        end
-
-        if send(taxonomy).present?
-          # Change taxonomy to fact taxonomy if set, otherwise leave it as is
-          send("#{taxonomy}=", taxonomy_from_fact) unless taxonomy_from_fact.nil?
-        else
-          # No taxonomy was set, set to fact taxonomy or default taxonomy
-          send "#{taxonomy}=", (taxonomy_from_fact || default_taxonomy)
-        end
-        taxonomy_class.current = send(taxonomy)
-      end
     end
 
     def overwrite?

--- a/app/services/host_fact_importer.rb
+++ b/app/services/host_fact_importer.rb
@@ -35,12 +35,54 @@ class HostFactImporter
   end
 
   def parse_facts(facts, type, source_proxy)
+    time = facts[:_timestamp]
+    time = time.to_time if time.is_a?(String)
+    host.last_compile = time if time
+
+    # taxonomy must be set before populate_fields_from_facts call
+    set_host_taxonomies(facts)
+
     skipping_orchestration do
-      host.parse_facts facts, type, source_proxy
+      unless host.build?
+        parser = FactParser.parser_for(type).new(facts)
+
+        telemetry_duration_histogram(:importer_facts_import_duration, 1000, type: type) do
+          host.populate_fields_from_facts(parser, type, source_proxy)
+        end
+      end
+
+      # we are saving here with no validations, as we want this process to be as fast
+      # as possible, assuming we already have all the right settings in Foreman.
+      # If we don't (e.g. we never install the server via Foreman, we populate the fields from facts
+      # TODO: if it was installed by Foreman and there is a mismatch,
+      # we should probably send out an alert.
+      host.save(:validate => false)
     end
   end
 
   private
+
+  def set_host_taxonomies(facts)
+    ['location', 'organization'].each do |taxonomy|
+      taxonomy_class = taxonomy.classify.constantize
+      taxonomy_fact = Setting["#{taxonomy}_fact"]
+
+      if taxonomy_fact.present? && facts.key?(taxonomy_fact)
+        taxonomy_from_fact = taxonomy_class.find_by_title(facts[taxonomy_fact].to_s)
+      else
+        default_taxonomy = taxonomy_class.find_by_title(Setting["default_#{taxonomy}"])
+      end
+
+      if host.send(taxonomy).present?
+        # Change taxonomy to fact taxonomy if set, otherwise leave it as is
+        host.send("#{taxonomy}=", taxonomy_from_fact) unless taxonomy_from_fact.nil?
+      else
+        # No taxonomy was set, set to fact taxonomy or default taxonomy
+        host.send("#{taxonomy}=", (taxonomy_from_fact || default_taxonomy))
+      end
+      taxonomy_class.current = host.send(taxonomy)
+    end
+  end
 
   def skipping_orchestration
     if host.is_a?(Host::Managed)

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -117,7 +117,7 @@ class FacetTest < ActiveSupport::TestCase
       @host.stubs(:save)
       facts_json = read_json_fixture('facts/brslc022.facts.json')
 
-      @host.parse_facts(facts_json['facts'], nil, nil)
+      HostFactImporter.new(@host).parse_facts(facts_json['facts'], nil, nil)
     end
   end
 


### PR DESCRIPTION
Move `parse_facts` method to `HostFactImporter` to isolate fact population from Host class.
Followup for bb84e41d391ba1b18dc9e2db8f0cbabf92a3b1e8
