### PR TITLE
Refs #30840 - spelling findings after using eslint spellcheck plugin

### DIFF
--- a/app/controllers/api/graphql_controller.rb
+++ b/app/controllers/api/graphql_controller.rb
@@ -102,7 +102,7 @@ module Api
       render_error
     end
 
-    def render_error(error = 'An error occured.', options = {})
+    def render_error(error = 'An error occurred.', options = {})
       options[:status] ||= :internal_server_error
       render options.merge(json: {error: error})
     end

--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -216,7 +216,7 @@ class UnattendedController < ApplicationController
     %w[iPXE gPXE].include?(params[:kind])
   end
 
-  def render_ipxe_message(message: _('An error occured.'), status: :not_found)
+  def render_ipxe_message(message: _('An error occurred.'), status: :not_found)
     render(plain: Foreman::Ipxe::MessageRenderer.new(message: message).to_s, status: status, content_type: 'text/plain')
   end
 

--- a/app/models/concerns/orchestration/common.rb
+++ b/app/models/concerns/orchestration/common.rb
@@ -2,7 +2,7 @@ module Orchestration::Common
   def handle_validation_errors
     yield
   rescue Net::Validations::Error => e
-    logger.debug "Error occured during validations of #{self.class.name}: #{e.message}"
+    logger.debug "Error occurred during validations of #{self.class.name}: #{e.message}"
     nil
   end
 

--- a/app/validators/subnets_consistency_validator.rb
+++ b/app/validators/subnets_consistency_validator.rb
@@ -7,12 +7,12 @@ class SubnetsConsistencyValidator < ActiveModel::Validator
 
   def validate_mtu(record)
     return unless record.subnet.mtu != record.subnet6.mtu
-    add_error(record, _('MTU is not consistent accross subnets'))
+    add_error(record, _('MTU is not consistent across subnets'))
   end
 
   def validate_vlanid(record)
     return unless record.subnet.vlanid != record.subnet6.vlanid
-    add_error(record, _('VLAN ID is not consistent accross subnets'))
+    add_error(record, _('VLAN ID is not consistent across subnets'))
   end
 
   def add_error(record, message)

--- a/lib/tasks/rss.rake
+++ b/lib/tasks/rss.rake
@@ -21,7 +21,7 @@ namespace :rss do
          FOREMAN_RSS_FORCE_REPOST, no new notifications will be created for these three posts. If you do,
          the task will create notifications once again for "Newsletter December", November and October.
      - FOREMAN_RSS_AUDIENCE
-       + The audience that will recieve the notification. By default, 'global'
+       + The audience that will receive the notification. By default, 'global'
        + Possible values:
          - 'global' - All users will receive the notification
          - 'admin' - Only administrator users will receive the notification

--- a/lib/tasks/templates_renderer.rake
+++ b/lib/tasks/templates_renderer.rake
@@ -20,7 +20,7 @@ namespace :templates do
       service = Foreman::RenderTemplatesFromFolder.new(source_directory: source_directory)
       service.render_all
       if service.errors.any?
-        puts Rainbow('Errors occured while rendering the templates.').red
+        puts Rainbow('Errors occurred while rendering the templates.').red
         puts ''
         service.errors.each do |template, message|
           puts " ==== #{template.name} ===="

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -394,7 +394,7 @@ class UsersControllerTest < ActionController::TestCase
     assert_match /An email address is required/, flash[:error]
   end
 
-  test "test email was deliver an email successfuly" do
+  test "test email was deliver an email successfully" do
     user = User.create :login => "foo", :mail => "foo@bar.com", :auth_source => auth_sources(:one)
     put :test_mail, params: { :id => user.id, :user => {:login => user.login}, :user_email => user.mail }, session: set_session_user
     mail = ActionMailer::Base.deliveries.detect { |delivery| delivery.subject =~ /Foreman test email/ }

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/__snapshots__/integration.test.js.snap
@@ -31,7 +31,7 @@ Object {
             "label": "results1 ",
           },
           Object {
-            "category": "Dolphine",
+            "category": "Dolphin",
             "label": "results2 ",
           },
         ],
@@ -171,7 +171,7 @@ Object {
             "label": "results1 ",
           },
           Object {
-            "category": "Dolphine",
+            "category": "Dolphin",
             "label": "results2 ",
           },
         ],
@@ -240,7 +240,7 @@ Object {
               "label": "results1 ",
             },
             Object {
-              "category": "Dolphine",
+              "category": "Dolphin",
               "label": "results2 ",
             },
           ],
@@ -263,7 +263,7 @@ Object {
             "label": "results1 ",
           },
           Object {
-            "category": "Dolphine",
+            "category": "Dolphin",
             "label": "results2 ",
           },
         ],

--- a/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/AutoComplete/__tests__/integration.test.js
@@ -63,7 +63,7 @@ describe('Autocomplete integration test', () => {
     // Set a new mocked API response
     const secondAPICall = [
       { label: 'results1', category: '' },
-      { label: 'results2', category: 'Dolphine' },
+      { label: 'results2', category: 'Dolphin' },
     ];
     API.get.mockImplementation(async () => ({ data: secondAPICall }));
     // Choose an option.

--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.stories.js
@@ -37,7 +37,7 @@ export const WithError = () => (
       chart={{ data: [] }}
       title="Title"
       noDataMsg="No data here"
-      errorText="Ooops"
+      errorText="Oops"
       status="ERROR"
     />
   </Story>

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.stories.js
@@ -174,7 +174,7 @@ export const withPropsPassedDownViaSpreadSyntax = () =>
         <Button bsStyle="primary" onClick={setModalOpen}>
           Show Modal
         </Button>
-        <ForemanModal id="propsPassed" title="I'm a modal!" myProp="Hii">
+        <ForemanModal id="propsPassed" title="I'm a modal!" myProp="Hi">
           <ForemanModal.Header />
           The inner {`<Modal>`} component will have any props you pass to
           {`<ForemanModal>`}. (Look in the React dev tools for

--- a/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/ActionButtons/ActionButtons.stories.js
@@ -12,7 +12,7 @@ export default {
 export const ButtonsStory = () => (
   <Story>
     <Text>
-      <u>Input</u>: an array of button props each contaning: a title string and
+      <u>Input</u>: an array of button props each containing: a title string and
       an action object. <br />
       action can be <strong> href</strong> with <strong>data-method</strong> or
       <strong> onClick</strong>

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyState.stories.js
@@ -98,7 +98,7 @@ withCustomizedDocumentation.story = {
 
 export const foremanEmptyState = () => {
   const customizeDocLabel = boolean('customize doc label', false);
-  const customizeDocButtonLabel = boolean('costumize button label', false);
+  const customizeDocButtonLabel = boolean('customize button label', false);
   const docObject = { url: '#' };
   if (customizeDocLabel) {
     docObject.label = text('documentation label', 'Read documents ->');

--- a/webpack/assets/javascripts/react_app/components/common/dates/dates.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/dates/dates.stories.js
@@ -47,8 +47,8 @@ export const dates = () => {
     <Story>
       <Text>
         <h1>Dates</h1>
-        There are 4 date/time formats that should be used accross the Foreman
-        and plugins. Each of the formats is represented by one React component.
+        There are 4 date/time formats that should be used across the Foreman and
+        plugins. Each of the formats is represented by one React component.
         <br />
         <br />
         Examples display {dateToShow.toString()}.<h3>IsoDate</h3>
@@ -58,7 +58,7 @@ export const dates = () => {
         </pre>
         <h3>LongDateTime</h3>
         Renders full date with time. Relative time tooltip and seconds can be
-        displyed optionally :
+        displayed optionally :
         <pre>
           <LongDateTime
             date={dateToShow}
@@ -67,15 +67,15 @@ export const dates = () => {
             showRelativeTimeTooltip={showRelativeTimeTooltip}
           />
         </pre>
-        There&apos;s an erb helper alernative for rendering the same format with
-        relative time tooltip true as a default:
+        There&apos;s an erb helper alternative for rendering the same format
+        with relative time tooltip true as a default:
         <Code lang="ruby">
           date_time_absolute(time, :short, seconds = false,
           show_relative_time_tooltip = true)
         </Code>
         <h3>ShortDateTime</h3>
         Renders shortened date with time. Relative time tooltip and seconds can
-        be displyed optionally :
+        be displayed optionally :
         <pre>
           <ShortDateTime
             date={dateToShow}
@@ -84,18 +84,18 @@ export const dates = () => {
             showRelativeTimeTooltip={showRelativeTimeTooltip}
           />
         </pre>
-        There&apos;s an erb helper alernative for rendering the same format with
-        relative time tooltip true as a default:
+        There&apos;s an erb helper alternative for rendering the same format
+        with relative time tooltip true as a default:
         <Code lang="ruby">
           date_time_absolute(time, :long, seconds = false,
           show_relative_time_tooltip = true)
         </Code>
         <h3>RelativeDateTime</h3>
-        Renders relative date with long date in a tooltop:
+        Renders relative date with long date in a tooltip:
         <pre>
           <RelativeDateTime date={dateToShow} defaultValue="N/A" />
         </pre>
-        There&apos;s an erb helper alernative for rendering a relative time:
+        There&apos;s an erb helper alternative for rendering a relative time:
         <Code lang="ruby">date_time_relative(time)</Code>
       </Text>
     </Story>

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.stories.js
@@ -35,7 +35,7 @@ const fixtures = {
 
 const radios = [
   { label: 'Hammer', value: 'hammer' },
-  { label: 'Nail Gun', value: 'naigun' },
+  { label: 'Nail Gun', value: 'nailgun' },
   { label: 'Wrecking Ball', value: 'wreckingball' },
 ];
 

--- a/webpack/assets/javascripts/react_app/components/common/table/reducers/__snapshots__/createTableReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/table/reducers/__snapshots__/createTableReducer.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Table createTableReducer should handle FAILURE 1`] = `
 Object {
-  "error": [Error: ooops!],
+  "error": [Error: Oops!],
   "pagination": Object {
     "page": 1,
     "perPage": 20,

--- a/webpack/assets/javascripts/react_app/components/common/table/reducers/createTableReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/reducers/createTableReducer.test.js
@@ -38,7 +38,7 @@ const fixtures = {
         url: 'some_url',
         tableID: 'some_ID',
       },
-      response: new Error('ooops!'),
+      response: new Error('Oops!'),
     },
   },
 };

--- a/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.stories.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/powerStatus/PowerStatus.stories.js
@@ -60,7 +60,7 @@ export const connectedMD = () => (
         given url,
       </p>
       <p>
-        the state will update by it and the PowerStatus component will recieve
+        the state will update by it and the PowerStatus component will receive
         the following props from the selectors:
       </p>
       <Code lang="javascript">{'{ state, title }'}</Code>

--- a/webpack/stories/docs/api-middleware.stories.mdx
+++ b/webpack/stories/docs/api-middleware.stories.mdx
@@ -145,7 +145,7 @@ dispatch(
   get({
     key: MY_SPECIAL_KEY,
     url,
-    toastError: error => `Oh no! Something went wrong while submiting the form, the server returned the following error: ${error}`
+    toastError: error => `Oh no! Something went wrong while submitting the form, the server returned the following error: ${error}`
     toastSuccess: response => `Yay! task: ${response.taskID} was successfully created.`
   })
 );


### PR DESCRIPTION
After using the eslint spellcheck plugin in #7989 ,
I looked for other places in the code (also ruby) where we might misspelled words like `occurred` or `across`.

Also, in that PR we decided to drop spellcheck for `*.stories.js` and `*.test.js` since they might contain jokes (e.g: "One does not simply walk into Mordor." ),
so I added small fixes into this PR too.

cc @tbrisker @ekohl 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
