### PR TITLE
Fixes #30930 Allow methods to traverse hostgroup hierarchy

### DIFF
--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -127,7 +127,8 @@ class Hostgroup < ApplicationRecord
     allow :id, :name, :diskLayout, :puppetmaster, :operatingsystem, :architecture,
       :environment, :ptable, :url_for_boot, :params, :puppet_proxy,
       :puppet_ca_server, :os, :arch, :domain, :subnet, :hosts,
-      :subnet6, :realm, :root_pass, :description, :pxe_loader, :title
+      :subnet6, :realm, :root_pass, :description, :pxe_loader, :title,
+      :children, :parent
   end
 
   # TODO: add a method that returns the valid os for a hostgroup


### PR DESCRIPTION
This makes hierarchy traversal methods for hostgroup available in safemode jail.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
