### PR TITLE
Fixes #30931 - Add a default empty query string to pushUrl helper

### DIFF
--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -31,7 +31,7 @@ export const reloadPage = () => {
  * @param {String} url - the base url i.e `/hosts`
  * @param {Object} searchQuery - the query params, i.e {'per_page': 4, 'page': 2}
  */
-export const pushUrl = (url, queryParams) => {
+export const pushUrl = (url, queryParams = {}) => {
   const urlWithQueries = new URI(url).search(queryParams).toString();
   return store.dispatch(push(urlWithQueries));
 };


### PR DESCRIPTION
pushUrl has two args - the first is a url, the second is an object that represents query strings.
if this function called only with a url (pushUrl('/hosts')) - nothing occurs

