### PR TITLE
Fixes #30952 - Rename react-component to foreman-react-component

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -13,7 +13,7 @@ module ReactjsHelper
   def react_component(name, props = {})
     props = props.to_json if props.is_a?(Hash)
 
-    content_tag('react-component', '', :name => name, :data => { props: props })
+    content_tag('foreman-react-component', '', :name => name, :data => { props: props })
   end
 
   def webpacked_plugins_js_for(*plugin_names)

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -53,7 +53,7 @@ class ReactComponentElement extends HTMLElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(
-        `Unable to mount react-component: ${this.componentName}`,
+        `Unable to mount foreman-react-component: ${this.componentName}`,
         error
       );
     }
@@ -65,13 +65,16 @@ class ReactComponentElement extends HTMLElement {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(
-        `Unable to unmount react-component: ${this.componentName}`,
+        `Unable to unmount foreman-react-component: ${this.componentName}`,
         error
       );
     }
   }
 }
 
-if (!window.customElements.get('react-component')) {
-  window.customElements.define('react-component', ReactComponentElement);
+if (!window.customElements.get('foreman-react-component')) {
+  window.customElements.define(
+    'foreman-react-component',
+    ReactComponentElement
+  );
 }

--- a/webpack/stories/docs/adding-new-components.stories.mdx
+++ b/webpack/stories/docs/adding-new-components.stories.mdx
@@ -120,13 +120,13 @@ react_component(component_name, props)
 will render the following HTML:
 
 ```html
-<react-component
+<foreman-react-component
   name="PowerStatus"
   data-props="<%= {
     id: host.id,
     url: power_host_path(host.id)
   }.to_json %>"
-></react-component>
+></foreman-react-component>
 ```
 
 (Note that the React component is rendered as a [web component](https://developer.mozilla.org/en-US/docs/Web/Web_Components).)

--- a/webpack/stories/docs/plugins.stories.mdx
+++ b/webpack/stories/docs/plugins.stories.mdx
@@ -31,13 +31,13 @@ react_component(component_name, props)
 will render the following HTML:
 
 ```html
-<react-component
+<foreman-react-component
   name="PowerStatus"
   data-props="<%= {
     id: host.id,
     url: power_host_path(host.id)
   }.to_json %>"
-></react-component>
+></foreman-react-component>
 ```
 
 (Note that the React component is rendered as a [web component](https://developer.mozilla.org/en-US/docs/Web/Web_Components).)


### PR DESCRIPTION
I'll file a redmine (or not) based on the outcome of this discussion, but figured I could illustrate the scope of this change with this PR (it's not complete) since I had to test my theory anyway.

Recently in Katello I've been seeing this error on our Angular pages:

```
bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:32303 Error: Cannot find react component ToastNotifications
    at getReactComponent (ngReact.js:53)
    at Object.link (ngReact.js:202)
    at bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:18123
    at invokeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:28002)
    at nodeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:27321)
    at compositeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:26568)
    at compositeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:26571)
    at compositeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:26571)
    at compositeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:26571)
    at compositeLinkFn (bastion-93eff2becb35d171d82e6d88d3a6ab8cbc324ab4de03f83baa7797d09691cdd8.js:26571) "<react-component name="ToastNotifications" data-props="{}">"
```

It turns out that https://github.com/theforeman/foreman/pull/7943 introduced this because [ngReact](https://github.com/ngReact/ngReact), which Katello uses on its Angular pages, also defines an element named `react-component`. In Katello's Angular pages, the ngReact implementation ends up being used rather than Foreman's! This seemed like a quick and easy way to fix it, though I'm not sure if any other plugins are using `react-component` directly, or if there's a better way.

Any ideas @MariaAga ?
