### PR TITLE
Fixes #30473 - UI for Global Registration

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -1,0 +1,40 @@
+class RegistrationController < ApplicationController
+  def new
+    form_options
+  end
+
+  def create
+    form_options
+    args_query = "?#{registration_args.to_query}"
+    @command = "curl -X GET \"#{endpoint}#{args_query if args_query != '?'}\" #{headers} | bash"
+  end
+
+  private
+
+  def form_options
+    @host_groups = Hostgroup.authorized(:view_hostgroups).select(:id, :name)
+    @operating_systems = Operatingsystem.authorized(:view_operatingsystems).select(:id, :title)
+    @smart_proxies = Feature.find_by(name: 'Registration')&.smart_proxies || []
+  end
+
+  def headers
+    hours = (params[:jwt_expiration].presence || 4).to_i.hours.to_i
+    jwt = User.current.jwt_token!(expiration: hours)
+
+    "-H 'Authorization: Bearer #{jwt}'"
+  end
+
+  def endpoint
+    return global_registration_url if params['smart_proxy'].blank?
+
+    proxy = SmartProxy.authorized(:view_smart_proxies).find(params[:smart_proxy])
+    "#{proxy.url}/register"
+  end
+
+  def registration_args
+    ignored = ['utf8', 'authenticity_token', 'commit', 'action', 'locale', 'controller', 'jwt_expiration']
+    params.except(*ignored)
+          .delete_if { |_, v| v.blank? }
+          .permit!
+  end
+end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -305,6 +305,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :puppetclasses => pc_ajax_actions,
                                     :subnets => subnets_ajax_actions,
                                     :interfaces => [:new, :random_name],
+                                    :registration => [:new, :create],
                                      :"api/v2/hosts" => [:create],
                                      :"api/v2/interfaces" => [:create],
                                      :"api/v2/tasks" => [:index],

--- a/app/views/hosts/index.html.erb
+++ b/app/views/hosts/index.html.erb
@@ -1,4 +1,8 @@
-<% title_actions multiple_actions_select, csv_link, button_group(new_link(_("Create Host"))) %>
+<%
+  register_btn = display_link_if_authorized(_("Register Host"), { :controller => 'registration', :action => :new }, :class => "btn btn-default")
+%>
+
+<% title_actions multiple_actions_select, csv_link, register_btn, button_group(new_link(_("Create Host"))) %>
 <%= alert(:class => 'alert-info hide', :id => 'multiple-alert', :close => false, :header => '',
           :text => n_("Single host on this page is selected.",
                       "All %{per_page} hosts on this page are selected.", per_page(@hosts)).html_safe % {per_page: per_page(@hosts)} + ' ' +

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -1,0 +1,64 @@
+<% title _('Register Host') %>
+<%= form_tag({controller: 'registration', action: 'create' }, method: :post, class: 'form-horizontal well') do %>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'><%= _('Organization') %></label>
+    <div class='col-md-4'>
+      <p class="form-control-static">
+        <%= Organization.current&.name || _('No Organization selected') %>
+        <%= hidden_field_tag 'organization_id', Organization.current&.id %>
+      </p>
+    </div>
+  </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'><%= _('Location') %></label>
+    <div class='col-md-4'>
+      <p class="form-control-static">
+        <%= Location.current&.name || _('No Location selected') %>
+        <%= hidden_field_tag 'location_id', Location.current&.id %>
+      </p>
+    </div>
+  </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'><%= _('Host Group') %></label>
+    <div class='col-md-4'>
+      <%= select_tag 'host_group_id', options_from_collection_for_select(@host_groups, :id, :name, params[:host_group_id]), class: 'form-control', include_blank: '' %>
+    </div>
+  </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'><%= _('Operating System') %></label>
+    <div class='col-md-4'>
+      <%= select_tag 'operatingsystem_id', options_from_collection_for_select(@operating_systems, :id, :title, params[:operatingsystem_id]), class: 'form-control', include_blank: '' %>
+    </div>
+  </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'><%= _('Proxy') %></label>
+    <div class='col-md-4'>
+      <%= select_tag 'smart_proxy', options_from_collection_for_select(@smart_proxies, :id, :name, params[:smart_proxy]), class: 'form-control', include_blank: '' %>
+    </div>
+  </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'><%= _('Token lifetime (hours)') %></label>
+    <div class='col-md-4'>
+      <%= number_field_tag 'jwt_expiration', params[:jwt_expiration] || 4, class: 'form-control', min: 1, required: true %>
+    </div>
+  </div>
+
+  <% pagelets_for(:global_registration).each do |pagelet| %>
+    <%= render_pagelet(pagelet) %>
+  <% end %>
+
+  <div class='form-group '>
+    <%= submit_tag _('Generate command'), class: 'btn btn-primary' %>
+    <%= link_to _('Cancel'), hosts_path, class: 'btn btn-default' %>
+  </div>
+
+  <% if action_name == 'create' %>
+    <div class='form-group '>
+      <label class='col-md-2 control-label'><%= _('Command') %></label>
+      <div class='col-md-8'>
+        <pre class='ellipsis white-space-normal' id='registration_command'><%= @command %></pre>
+        <a class='btn btn-default' onclick="tfm.hosts.copyRegistrationCommand();" ><%= _('Copy to clipboard') %></a>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/registration/create.html.erb
+++ b/app/views/registration/create.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/app/views/registration/new.html.erb
+++ b/app/views/registration/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -129,6 +129,9 @@ Foreman::Application.routes.draw do
         post 'submit_rebuild_config'
         get 'random_name', only: :new
         get 'preview_host_collection'
+
+        get 'register', to: 'registration#new'
+        post 'register', to: 'registration#create'
       end
 
       constraints(host_id: /[^\/]+/) do
@@ -584,7 +587,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  get :register, to: 'api/v2/registration#global'
+  get :register, to: 'api/v2/registration#global', as: :global_registration
   post :register, to: 'api/v2/registration#host'
 
   if Rails.env.development? && defined?(::GraphiQL::Rails::Engine)

--- a/test/controllers/registration_controller_test.rb
+++ b/test/controllers/registration_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class RegistrationControllerTest < ActionController::TestCase
+  test 'new' do
+    get :new, session: set_session_user
+    assert_response :success
+    assert_template :new
+  end
+
+  test 'create' do
+    params = { organization: taxonomies(:organization1).id, location: taxonomies(:location1).id }
+    post :create, params: params, session: set_session_user
+
+    assert_response :success
+    assert_template :create
+  end
+end

--- a/webpack/assets/javascripts/foreman_hosts.js
+++ b/webpack/assets/javascripts/foreman_hosts.js
@@ -5,6 +5,7 @@ export default {
   table,
   registerPluginAttributes,
   getAttributesToPost,
+  copyRegistrationCommand,
   checkPXELoaderCompatibility,
   pxeCompatibility,
 };
@@ -41,6 +42,18 @@ export function getAttributesToPost(componentType) {
     attrsToPost = attrsToPost.concat(pluginEditAttributes[componentType]);
   }
   return uniq(attrsToPost);
+}
+
+export function copyRegistrationCommand() {
+  const commandText = document.getElementById('registration_command')
+    .textContent;
+  const tmpElement = document.createElement('textarea');
+
+  tmpElement.textContent = commandText;
+  document.body.appendChild(tmpElement);
+  tmpElement.select();
+  document.execCommand('copy');
+  document.body.removeChild(tmpElement);
 }
 
 class PXECompatibilityCheck {


### PR DESCRIPTION
User interface for Global Registration feature, allowing users to quickly generate command via simple form.

*Features*
* New page _Register Host_ (Go to _Hosts > All hosts_ and click on **Register Host** button)
* Form extendable from plugins by `extend_allowed_registration_vars :your_param`

![registration_UI_new](https://user-images.githubusercontent.com/59385976/95834910-ddc87480-0d3d-11eb-8a0e-85e0ac3f3031.png)

---

PR is part of **Simple & automatic host registration WF**, see:
* [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588)
* [Redmine (this PR)](https://projects.theforeman.org/issues/30473)
* [Redmine (Parent task)](https://projects.theforeman.org/issues/30440)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
