### PR TITLE
Fixes #30934 - Allow overriding template name for invocation_form

### DIFF
--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -58,7 +58,7 @@ module TemplatesHelper
     'hide' unless obj.value_type == 'search'
   end
 
-  def mount_report_template_input(input_value)
+  def mount_report_template_input(input_value, options = {})
     return if input_value.nil?
 
     input = input_value.template_input
@@ -67,7 +67,7 @@ module TemplatesHelper
     react_component('TemplateInput', { data: {
                       value: input_value.value.to_s,
                       required: input.required,
-                      template: 'report_template_report',
+                      template: options[:template_name] || 'report_template_report',
                       description: input.description,
                       supportedTypes: TemplateInput::VALUE_TYPE,
                       resourceType: controller,

--- a/app/views/template_inputs/_invocation_form.html.erb
+++ b/app/views/template_inputs/_invocation_form.html.erb
@@ -12,7 +12,7 @@
         :id => input.name,
         :class => input.hidden_value? ? 'masked-input' : '' %>
     <% else %>
-      <%= mount_report_template_input(input_fields.object) %>
+      <%= mount_report_template_input(input_fields.object, local_assigns.fetch(:search_input_options, {})) %>
     <% end %>
   <% end %>
 <% end %>

--- a/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
+++ b/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
@@ -45,9 +45,7 @@ const TemplateInput = ({
           isRequired={required}
           info={description || 'Format is yyyy-mm-dd HH-mm-ss'}
           initialError={initialError}
-          inputProps={{
-            name: `${template}[input_values][${id}][value]`,
-          }}
+          name={`${template}[input_values][${id}][value]`}
           hideValue={!value.length}
           value={value || undefined}
         />

--- a/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
@@ -5,14 +5,11 @@ exports[`Report Template AutoComplete rendering renders report template with dat
   hideValue={false}
   id={4}
   info="Format is yyyy-mm-dd HH-mm-ss"
-  inputProps={
-    Object {
-      "name": "report_template_report[input_values][4][value]",
-    }
-  }
+  inputProps={Object {}}
   isRequired={false}
   label="some-label"
   locale={null}
+  name="report_template_report[input_values][4][value]"
   value="2019-01-04"
 />
 `;

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -78,13 +78,13 @@ class DateTimePicker extends React.Component {
       <div>
         <InputGroup className="input-group date-time-picker-pf">
           <FormControl
+            {...inputProps}
             aria-label="date-picker-input"
             type="text"
             className="date-time-input"
             name={name}
             value={hiddenValue && !required ? '' : formatDateTime(value)}
             onChange={e => this.setSelected(e.target.value)}
-            {...inputProps}
           />
 
           <OverlayTrigger

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -78,13 +78,13 @@ class DateTimePicker extends React.Component {
       <div>
         <InputGroup className="input-group date-time-picker-pf">
           <FormControl
-            {...inputProps}
             aria-label="date-picker-input"
             type="text"
             className="date-time-input"
             name={name}
             value={hiddenValue && !required ? '' : formatDateTime(value)}
             onChange={e => this.setSelected(e.target.value)}
+            {...inputProps}
           />
 
           <OverlayTrigger

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
@@ -17,6 +17,7 @@ const DateTime = ({
   inputProps,
   value,
   initialError,
+  name,
 }) => {
   const currentLocale = locale || documentLocale();
 
@@ -43,6 +44,7 @@ const DateTime = ({
           autoComplete: 'off',
           ...inputProps,
         }}
+        name={name}
         locale={currentLocale}
       />
     </Form>
@@ -59,6 +61,7 @@ DateTime.propTypes = {
   value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
   initialError: PropTypes.string,
   hideValue: PropTypes.bool,
+  name: PropTypes.string,
 };
 
 DateTime.defaultProps = {
@@ -69,6 +72,7 @@ DateTime.defaultProps = {
   initialError: undefined,
   hideValue: false,
   inputProps: {},
+  name: undefined,
 };
 
 export default DateTime;


### PR DESCRIPTION
By default when this partial is rendered, it puts the data for the input under `params["report_template_report"]`, which is confusing when using in a different context, eg. from a plugin.

This commit introduces an option using which the path can be overridden.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
