### PR TITLE
Fix #30936 - Toast should have fallback type

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ToastsList/ToastList.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/ToastList.fixtures.js
@@ -58,3 +58,25 @@ export const multipleMessagesState = Immutable({
     },
   },
 });
+
+export const errorMessageState = Immutable({
+  toasts: {
+    messages: {
+      1: {
+        message: 'Widget positions successfully saved.',
+        type: 'random',
+      },
+    },
+  },
+});
+
+export const warnMessageState = Immutable({
+  toasts: {
+    messages: {
+      1: {
+        message: 'Widget positions successfully saved.',
+        type: 'notice',
+      },
+    },
+  },
+});

--- a/webpack/assets/javascripts/react_app/components/ToastsList/ToastList.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/ToastList.js
@@ -3,10 +3,30 @@ import {
   ToastNotificationList,
   ToastNotification,
   TimedToastNotification,
+  Alert,
 } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import { noop } from '../../common/helpers';
 import AlertBody from '../common/Alert/AlertBody';
+
+const toastType = type => {
+  if (Alert.ALERT_TYPES.includes(type)) return type;
+  const message = `Toast notification type '${type}' is invalid. Please use one of the following types: ${Alert.ALERT_TYPES}`;
+  switch (type) {
+    case 'alert':
+      // eslint-disable-next-line no-console
+      console.warn(message);
+      return 'warning';
+    case 'notice':
+      // eslint-disable-next-line no-console
+      console.warn(message);
+      return 'info';
+    default:
+      // eslint-disable-next-line no-console
+      console.error(message);
+      return 'info';
+  }
+};
 
 const ToastsList = ({ messages, deleteToast }) => {
   const toastsList = Object.entries(messages)
@@ -15,12 +35,12 @@ const ToastsList = ({ messages, deleteToast }) => {
       const ToastComponent = sticky
         ? ToastNotification
         : TimedToastNotification;
-
       return (
         <ToastComponent
           key={key}
           onDismiss={() => deleteToast(key)}
           {...toastProps}
+          type={toastType(toastProps.type)}
         >
           <AlertBody link={link} message={message} />
         </ToastComponent>

--- a/webpack/assets/javascripts/react_app/components/ToastsList/ToastsList.test.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/ToastsList.test.js
@@ -8,6 +8,8 @@ import {
   singleMessageState,
   singleMessageWithLinkState,
   multipleMessagesState,
+  errorMessageState,
+  warnMessageState,
 } from './ToastList.fixtures';
 
 import ToastList from './';
@@ -39,4 +41,30 @@ describe('ToastList', () => {
       state: statesToTest[key],
     }))
     .forEach(testToastListRenderWithState);
+
+  it('Should show error for invalid type', () => {
+    const mockError = jest.fn();
+    // eslint-disable-next-line no-console
+    console.error = mockError;
+    const store = mockStore(errorMessageState);
+    mount(<ToastList store={store} />);
+    expect(mockError).toBeCalledWith(
+      "Toast notification type 'random' is invalid. Please use one of the following types: error,warning,success,info"
+    );
+    // eslint-disable-next-line no-console
+    console.error.mockRestore();
+  });
+
+  it('Should show warn for notice type', () => {
+    const mockWarn = jest.fn();
+    // eslint-disable-next-line no-console
+    console.warn = mockWarn;
+    const store = mockStore(warnMessageState);
+    mount(<ToastList store={store} />);
+    expect(mockWarn).toBeCalledWith(
+      "Toast notification type 'notice' is invalid. Please use one of the following types: error,warning,success,info"
+    );
+    // eslint-disable-next-line no-console
+    console.warn.mockRestore();
+  });
 });


### PR DESCRIPTION
for example Foreman_remote_execution uses flash[:notice] and causes page to render blank after importing a job template as it's not supported in PF
```
helpers.js:38 Uncaught Error: Unsupported alert type=notice
    at getClassName (helpers.js:38)
    at Alert (Alert.js:27)
    at renderWithHooks (react-dom.development.js:15108)
    at mountIndeterminateComponent (react-dom.development.js:17342)
    at beginWork$1 (react-dom.development.js:18486)
    at HTMLUnknownElement.callCallback (react-dom.development.js:347)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:397)
    at invokeGuardedCallback (react-dom.development.js:454)
    at beginWork$$1 (react-dom.development.js:23217)
    at performUnitOfWork (react-dom.development.js:22208)
14:15:39.103 react-dom.development.js:19814 The above error occurred in the <Alert> component:
    in Alert (created by ToastNotification)
    in ToastNotification (created by ToastsList)
    in div (created by ToastNotificationList)
    in ToastNotificationList (created by ToastsList)
    in ToastsList (created by ConnectFunction)
    in ConnectFunction (created by I18nProviderWrapper(Connect(ToastsList)))
    in IntlProvider (created by I18nProviderWrapper(Connect(ToastsList)))
    in I18nProviderWrapper(Connect(ToastsList)) (created by StoreProvider(I18nProviderWrapper(Connect(ToastsList))))
    in Provider (created by StoreProvider(I18nProviderWrapper(Connect(ToastsList))))
    in StoreProvider(I18nProviderWrapper(Connect(ToastsList)))
```
the ToastsList component should convert unknown types to info