### PR TITLE
Fixes #30946: Use Rails default for JSON root node

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -457,8 +457,8 @@ function update_provisioning_image() {
       $.each(result, function() {
         image_options.append(
           $('<option />')
-            .val(this.image.uuid)
-            .text(this.image.name)
+            .val(this.uuid)
+            .text(this.name)
         );
       });
       if (image_options.find('option').length > 0) {
@@ -766,18 +766,18 @@ function interface_domain_selected(element) {
     success: function(result) {
       $.each(result, function() {
         select = null;
-        if (this.subnet.type === 'Subnet::Ipv4') {
+        if (this.type === 'Subnet::Ipv4') {
           select = subnet_options;
-        } else if (this.subnet.type === 'Subnet::Ipv6') {
+        } else if (this.type === 'Subnet::Ipv6') {
           select = subnet6_options;
         }
         if (select) {
           select.append(
             $('<option />')
-              .val(this.subnet.id)
-              .attr('data-suggest_new', this.subnet.unused_ip.suggest_new)
-              .attr('data-vlan_id', this.subnet.vlanid)
-              .text(this.subnet.to_label)
+              .val(this.id)
+              .attr('data-suggest_new', this.unused_ip.suggest_new)
+              .attr('data-vlan_id', this.vlanid)
+              .text(this.to_label)
           );
         }
       });

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -43,8 +43,6 @@ module Api
 
       before_action :setup_has_many_params, :only => [:create, :update]
       before_action :check_media_type
-      # ensure include_root_in_json = false for V2 only
-      around_action :disable_json_root
 
       layout 'api/v2/layouts/index_layout', :only => :index
 
@@ -171,17 +169,6 @@ module Api
         options = set_error_details(error, options)
         render options.merge(:template => "api/v2/errors/#{error}",
                              :layout   => 'api/v2/layouts/error_layout')
-      end
-
-      private
-
-      def disable_json_root
-        # disable json root element
-        ActiveRecord::Base.include_root_in_json = false
-        yield
-      ensure
-        # re-enable json root element
-        ActiveRecord::Base.include_root_in_json = true
       end
     end
   end

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -6,8 +6,3 @@
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters :format => [:json]
 end
-
-# Enable root element in JSON by default.
-ActiveSupport.on_load(:active_record) do
-  self.include_root_in_json = true
-end

--- a/test/controllers/hostgroups_controller_test.rb
+++ b/test/controllers/hostgroups_controller_test.rb
@@ -136,8 +136,8 @@ class HostgroupsControllerTest < ActionController::TestCase
     domain.subnets << subnet
     domain.save
     post :domain_selected, params: {:id => hostgroups(:common), :hostgroup => {}, :domain_id => domain.id, :format => :json}, session: set_session_user, xhr: true
-    assert_equal subnet.name, JSON.parse(response.body)[0]["subnet"]["name"]
-    assert_equal subnet.unused_ip.suggest_new?, JSON.parse(response.body)[0]["subnet"]["unused_ip"]["suggest_new"]
+    assert_equal subnet.name, JSON.parse(response.body)[0]["name"]
+    assert_equal subnet.unused_ip.suggest_new?, JSON.parse(response.body)[0]["unused_ip"]["suggest_new"]
   end
 
   test "domain_selected should return empty on no domain_id" do

--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -168,13 +168,11 @@ const logo =
   '/assets/header_logo-c9614c16f2ee399ae9cb7f36ec94b9a26bf8cf9eabaa7fe6099bf80d1f7940db.svg';
 const user = {
   current_user: {
-    user: {
-      id: 4,
-      login: 'admin',
-      firstname: 'Admin',
-      lastname: 'User',
-      name: 'Admin User',
-    },
+    id: 4,
+    login: 'admin',
+    firstname: 'Admin',
+    lastname: 'User',
+    name: 'Admin User',
   },
   user_dropdown: [
     {
@@ -214,11 +212,9 @@ const locations = {
 
 const serverUser = {
   current_user: {
-    user: {
-      firstname: 'G',
-      lastname: 'L',
-      name: 'G L',
-    },
+    firstname: 'G',
+    lastname: 'L',
+    name: 'G L',
   },
   user_dropdown: [
     {

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -116,13 +116,11 @@ exports[`Layout rendering renders layout 1`] = `
         user={
           Object {
             "current_user": Object {
-              "user": Object {
-                "firstname": "Admin",
-                "id": 4,
-                "lastname": "User",
-                "login": "admin",
-                "name": "Admin User",
-              },
+              "firstname": "Admin",
+              "id": 4,
+              "lastname": "User",
+              "login": "admin",
+              "name": "Admin User",
             },
             "user_dropdown": Array [
               Object {

--- a/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/UserDropdowns.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { VerticalNav } from 'patternfly-react';
-import { get } from 'lodash';
 import {
   Dropdown,
   DropdownToggle,
@@ -33,7 +32,7 @@ const UserDropdowns = ({
   const onDropdownSelect = () => {
     setUserDropdownOpen(userDropdownOpen);
   };
-  const userInfo = get(user, 'current_user.user');
+  const userInfo = user.current_user;
   const impersonateIcon = (
     <ImpersonateIcon stopImpersonationUrl={stopImpersonationUrl} />
   );


### PR DESCRIPTION
…equest

Back when the application had a V1 and V2 API, the V2 API needed to
adhere to the designed format. This included not having a root node
in the JSON output for the object being returned. Given the use of
Rabl was not enforced across the ecosystem of plugins, this was
disabled per request for any request that did not go through the
Rabl rendering engine. The configuration that controls this is a
class variable and is thus not thread safe.

To enable the use of a multi-threaded Puma deployment, this setting
has to be set at application boot and not per request. The previous
implementation returned the setting back to it's default value of
true so that the V1 API was unaffected. This has potential consequences
across other areas of code or plugins that relied on the `to_json`
method on a model to perform further manipulations and were coded
to expect the root.

The alternative approach is to avoid setting this setting all together
and drop it's use. The expectation here would be that all API implementations
should be using Rabl templates properly to follow the API V2 spec
and any plugins relying on attempting to render through to_json
will need to fix this or potentiall encounter a change in their
API responses to have the root node.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
