### PR TITLE
Fixes #27604 - added Fedora|Redhat CoreOS and IM

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -275,7 +275,7 @@ function filter_by_level(item) {
 }
 function show_release(element) {
   var os_family = $(element).val();
-  if ($.inArray(os_family, ['Debian', 'Solaris', 'Coreos']) != -1) {
+  if ($.inArray(os_family, ['Debian', 'Solaris', 'Coreos', 'Fcos', 'Rhcos']) != -1) {
     $('#release_name').show();
   } else {
     $('#release_name').hide();

--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -13,8 +13,10 @@ module OperatingsystemsHelper
     return "" if record.blank? || record.name.blank?
     size = opts[:size] ||= '16x16'
     name = case record.name.downcase
-           when /fedora/
+           when /fedora|fcos|coreos/i
              "fedora"
+           when /redhat|rhcos/i
+             "redhat"
            when /ubuntu/
              "ubuntu"
            when /solaris|sunos/
@@ -45,7 +47,7 @@ module OperatingsystemsHelper
              "stub/firebrick-h"
            when /oraclelinux/
              "stub/firebrick-o"
-           when /coreos|containerlinux|container linux/
+           when /flatcar|containerlinux|container linux/
              "coreos"
            when /flatcar/
              "stub/darkblue-f"

--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -1,5 +1,17 @@
 class Coreos < Operatingsystem
-  PXEFILES = {:kernel => 'coreos_production_pxe.vmlinuz', :initrd => 'coreos_production_pxe_image.cpio.gz'}
+  #
+  # Original CoreOS example PXE URLs:
+  # https://stable-temporary-archive.release.core-os.net/amd64-usr/2512.3.0/coreos_production_pxe.vmlinuz
+  # https://stable-temporary-archive.release.core-os.net/amd64-usr/2512.3.0/coreos_production_pxe_image.cpio.gz
+  #
+  # Flatcar example PXE URLs:
+  # https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_image.vmlinuz
+  # https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz
+  #
+  PXEFILES = {
+    kernel: 'coreos_production_pxe.vmlinuz',
+    initrd: 'coreos_production_pxe_image.cpio.gz',
+  }
 
   def pxe_type
     'coreos'
@@ -38,6 +50,21 @@ class Coreos < Operatingsystem
   # Does this OS family use release_name in its naming scheme
   def use_release_name?
     true
+  end
+
+  # Helper text shown next to major version (do not use i18n)
+  def major_version_help
+    '2512.3'
+  end
+
+  # Helper text shown next to minor version (do not use i18n)
+  def minor_version_help
+    '0'
+  end
+
+  # Helper text shown next to release name (do not use i18n)
+  def release_name_help
+    'stable, beta, alpha, edge'
   end
 
   private

--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -39,6 +39,11 @@ class Debian < Operatingsystem
     true
   end
 
+  # Helper text shown next to release name (do not use i18n)
+  def release_name_help
+    'bullseye, focal, buster, bionic, stretch, xenial...'
+  end
+
   def display_family
     "Debian"
   end

--- a/app/models/operatingsystems/fcos.rb
+++ b/app/models/operatingsystems/fcos.rb
@@ -1,0 +1,47 @@
+class Fcos < Operatingsystem
+  #
+  # Example PXE URLs:
+  # https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-kernel-x86_64
+  # https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/32.20200907.3.0/x86_64/fedora-coreos-32.20200907.3.0-live-initramfs.x86_64.img
+  #
+  PXEFILES = {
+    kernel: 'fedora-coreos-$major.$minor-live-kernel-$arch',
+    initrd: 'fedora-coreos-$major.$minor-live-initramfs.$arch.img',
+  }
+
+  def pxe_type
+    'fcos'
+  end
+
+  def bootfile(medium_provider, type)
+    medium_provider.interpolate_vars(super).to_s
+  end
+
+  def pxedir(medium_provider = nil)
+    medium_provider.interpolate_vars('prod/streams/$release/builds/$major.$minor/$arch').to_s
+  end
+
+  def display_family
+    'Fedora CoreOS'
+  end
+
+  # Does this OS family use release_name in its naming scheme
+  def use_release_name?
+    true
+  end
+
+  # Helper text shown next to major version (do not use i18n)
+  def major_version_help
+    '32'
+  end
+
+  # Helper text shown next to minor version (do not use i18n)
+  def minor_version_help
+    '20200907.3.0'
+  end
+
+  # Helper text shown next to release name (do not use i18n)
+  def release_name_help
+    'stable, testing, next'
+  end
+end

--- a/app/models/operatingsystems/nxos.rb
+++ b/app/models/operatingsystems/nxos.rb
@@ -35,6 +35,11 @@ class NXOS < Operatingsystem
     true
   end
 
+  # Helper text shown next to release name
+  def release_name_help
+    _('auxiliary field')
+  end
+
   # release_name can have upper case letters and we want to keep it that way
   def downcase_release_name
     release_name

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -67,4 +67,9 @@ class Redhat < Operatingsystem
     options << "modprobe.blacklist=#{params['blacklist'].delete(' ')}" if params['blacklist']
     options
   end
+
+  # Helper text shown next to minor version (do not use i18n)
+  def minor_version_help
+    '0, 6.1810'
+  end
 end

--- a/app/models/operatingsystems/rhcos.rb
+++ b/app/models/operatingsystems/rhcos.rb
@@ -1,0 +1,50 @@
+class Rhcos < Operatingsystem
+  #
+  # Example PXE URLs:
+  # http://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.5/4.5.6/rhcos-installer-kernel-x86_64
+  # http://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.5/4.5.6/rhcos-installer-initramfs.x86_64.img
+  #
+  # Version 4.6+ changed:
+  # http://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.6/4.6.1/rhcos-live-initramfs.x86_64.img
+  # http://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/4.6/4.6.1/rhcos-live-kernel-x86_64
+  PXEFILES = {
+    kernel: 'rhcos-live-kernel-$arch',
+    initrd: 'rhcos-live-initramfs.$arch.img',
+  }
+
+  def pxe_type
+    'rhcos'
+  end
+
+  def bootfile(medium_provider, type)
+    medium_provider.interpolate_vars(super).to_s
+  end
+
+  def pxedir(medium_provider = nil)
+    medium_provider.interpolate_vars('pub/openshift-v$major/$arch/dependencies/rhcos/$major.$minor/$major.$minor.$release').to_s
+  end
+
+  def display_family
+    'Red Hat CoreOS'
+  end
+
+  # Does this OS family use release_name in its naming scheme
+  def use_release_name?
+    true
+  end
+
+  # Helper text shown next to major version (do not use i18n)
+  def major_version_help
+    '4 (*X*.Y.Z)'
+  end
+
+  # Helper text shown next to minor version (do not use i18n)
+  def minor_version_help
+    '5 (X.*Y*.Z)'
+  end
+
+  # Helper text shown next to release name (do not use i18n)
+  def release_name_help
+    '6 (X.Y.*Z*)'
+  end
+end

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -76,6 +76,11 @@ class Solaris < Operatingsystem
     true
   end
 
+  # Helper text shown next to release name
+  def release_name_help
+    _('auxiliary field')
+  end
+
   def jumpstart_params(host, vendor)
     medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
     # root server and install server are always the same under Foreman

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -74,6 +74,10 @@ module MediumProviders
       architecture.try(:name)
     end
 
+    def interpolate_vars(pattern)
+      pattern
+    end
+
     private
 
     def parse_media(media)

--- a/app/views/operatingsystems/_form.html.erb
+++ b/app/views/operatingsystems/_form.html.erb
@@ -17,12 +17,12 @@
     <div class="tab-pane active" id="primary">
 
       <%= text_f f, :name, :help_inline => _("OS name from facter; e.g. RedHat") %>
-      <%= text_f f, :major, :help_inline => _("OS major version from facter; e.g. 7"), :class => "col-md-2" %>
-      <%= text_f f, :minor, :help_inline => _("OS minor version from facter; e.g. 0 or 6.1810 (CentOS scheme)"), :class => "col-md-2" %>
+      <%= text_f f, :major, :help_inline => _("OS major version from facter; e.g. %s") % @operatingsystem.major_version_help, :class => "col-md-2" %>
+      <%= text_f f, :minor, :help_inline => _("OS minor version from facter; e.g. %s") % @operatingsystem.minor_version_help, :class => "col-md-2" %>
       <%= text_f f, :description, :help_inline => _("OS friendly name; e.g. RHEL 6.5") %>
       <%= select_f f, :family, Operatingsystem.families_as_collection, :value, :name, { :include_blank => _("Choose a family") }, { :label => _("Family"), :onchange => 'show_release(this);' } %>
       <div id="release_name" <%= display?(!@operatingsystem.use_release_name?) %>>
-        <%= text_f f, :release_name, :help_inline => _("e.g. karmic, lucid, hw0910 etc") %>
+        <%= text_f f, :release_name, :help_inline => @operatingsystem.release_name_help %>
       </div>
       <%= select_f f, :password_hash, PasswordCrypt::ALGORITHMS.keys, :to_s, :to_s, {}, { :label => _("Root Password Hash"), :help_inline => _("Hash function to use. Change takes effect for new or updated hosts.")} %>
       <%= multiple_checkboxes f, :architectures, @operatingsystem, Architecture, :label => _("Architectures") %>

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -5,18 +5,76 @@ os_suse = Operatingsystem.unscoped.where(:type => "Suse") || Operatingsystem.uns
 # Installation media: default mirrors
 Medium.without_auditing do
   [
-    { :name => "CentOS 7 mirror",      :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major/os/$arch" },
-    { :name => "CentOS 8 mirror",      :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major/BaseOS/$arch/kickstart" },
-    { :name => "CentOS Stream",        :os_family => "Redhat",  :path => "http://mirror.centos.org/centos/$major-stream/BaseOS/$arch/os" },
-    { :name => "Debian mirror",        :os_family => "Debian",  :path => "http://ftp.debian.org/debian" },
-    { :name => "Fedora mirror",        :os_family => "Redhat",  :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Server/$arch/os/" },
-    { :name => "Fedora Atomic mirror", :os_family => "Redhat",  :path => "http://dl.fedoraproject.org/pub/alt/atomic/stable/Cloud_Atomic/$arch/os/" },
-    { :name => "FreeBSD mirror",       :os_family => "Freebsd", :path => "http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$version-RELEASE/" },
-    { :name => "OpenSUSE mirror",      :os_family => "Suse",    :path => "http://download.opensuse.org/distribution/leap/$version/repo/oss", :operatingsystems => os_suse },
-    { :name => "Ubuntu mirror",        :os_family => "Debian",  :path => "http://archive.ubuntu.com/ubuntu" },
-    { :name => "CoreOS mirror",        :os_family => "Coreos",  :path => "http://$release.release.core-os.net" },
-    { :name => "Flatcar mirror",       :os_family => "Coreos",  :path => "http://$release.release.flatcar-linux.net" },
-    { :name => "RancherOS mirror", :os_family => "Rancheros", :path => "https://github.com/rancher/os/releases/download/v$version" },
+    {
+      :name => "CentOS 7 mirror",
+      :os_family => "Redhat",
+      :path => "http://mirror.centos.org/centos/$major/os/$arch",
+    },
+    {
+      :name => "CentOS 8 mirror",
+      :os_family => "Redhat",
+      :path => "http://mirror.centos.org/centos/$major/BaseOS/$arch/kickstart",
+    },
+    {
+      :name => "CentOS Stream",
+      :os_family => "Redhat",
+      :path => "http://mirror.centos.org/centos/$major-stream/BaseOS/$arch/os",
+    },
+    {
+      :name => "Debian mirror",
+      :os_family => "Debian",
+      :path => "http://ftp.debian.org/debian",
+    },
+    {
+      :name => "Fedora mirror",
+      :os_family => "Redhat",
+      :path => "http://dl.fedoraproject.org/pub/fedora/linux/releases/$major/Server/$arch/os/",
+    },
+    {
+      :name => "Fedora Atomic mirror",
+      :os_family => "Redhat",
+      :path => "http://dl.fedoraproject.org/pub/alt/atomic/stable/Cloud_Atomic/$arch/os/",
+    },
+    {
+      :name => "FreeBSD mirror",
+      :os_family => "Freebsd",
+      :path => "http://ftp.freebsd.org/pub/FreeBSD/releases/$arch/$version-RELEASE/",
+    },
+    {
+      :name => "OpenSUSE mirror",
+      :os_family => "Suse",
+      :path => "http://download.opensuse.org/distribution/leap/$version/repo/oss", :operatingsystems => os_suse
+    },
+    {
+      :name => "Ubuntu mirror",
+      :os_family => "Debian",
+      :path => "http://archive.ubuntu.com/ubuntu",
+    },
+    {
+      :name => "RancherOS mirror",
+      :os_family => "Rancheros",
+      :path => "https://github.com/rancher/os/releases/download/v$version",
+    },
+    {
+      :name => "CoreOS mirror",
+      :os_family => "Coreos",
+      :path => "http://$release-temporary-archive.release.core-os.net",
+    },
+    {
+      :name => "Flatcar mirror",
+      :os_family => "Coreos",
+      :path => "http://$release.release.flatcar-linux.net",
+    },
+    {
+      :name => "Fedora CoreOS mirror",
+      :os_family => "Fcos",
+      :path => "https://builds.coreos.fedoraproject.org",
+    },
+    {
+      :name => "Red Hat CoreOS mirror",
+      :os_family => "Rhcos",
+      :path => "http://mirror.openshift.com",
+    },
   ].each do |input|
     next if Medium.unscoped.where(['name = ? OR path = ?', input[:name], input[:path]]).any?
     next if SeedHelper.audit_modified? Medium, input[:name]

--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -36,7 +36,7 @@ module Foreman
             @template_url = params['url']
           end
 
-          %w(coreos aif memdisk ZTP).each do |name|
+          %w(coreos fcos rhcos aif memdisk ZTP).each do |name|
             define_method("#{name}_attributes") do
               @mediapath = mediumpath(@medium_provider) if medium
             end

--- a/test/controllers/api/v2/operatingsystems_controller_test.rb
+++ b/test/controllers/api/v2/operatingsystems_controller_test.rb
@@ -94,22 +94,6 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_response :unprocessable_entity
   end
 
-  test "should not create os with invalid major version" do
-    os_params = minimum_required_os_params.merge(:major => '')
-    assert_difference('Operatingsystem.count', 0) do
-      post :create, params: { :operatingsystem => os_params }
-    end
-    assert_response :unprocessable_entity
-  end
-
-  test "should not create os with invalid minor version" do
-    os_params = minimum_required_os_params.merge(:minor => '-5')
-    assert_difference('Operatingsystem.count', 0) do
-      post :create, params: { :operatingsystem => os_params }
-    end
-    assert_response :unprocessable_entity
-  end
-
   test "should not create os with invalid password_hash" do
     os_params = minimum_required_os_params.merge(:password_hash => 'INVALID_HASH')
     assert_difference('Operatingsystem.count', 0) do
@@ -160,12 +144,6 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     assert_equal response['minor'], new_minor
   end
 
-  test "should not update os with invalid minor version" do
-    os = operatingsystems(:redhat)
-    put :update, params: { :id => os.id, :operatingsystem => { :minor => '-30' } }
-    assert_response :unprocessable_entity
-  end
-
   test "should update os major version" do
     os = operatingsystems(:redhat)
     new_major = '7'
@@ -174,12 +152,6 @@ class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
     response = JSON.parse(@response.body)
     assert response.key?('major')
     assert_equal response['major'], new_major
-  end
-
-  test "should not update os with invalid major version" do
-    os = operatingsystems(:redhat)
-    put :update, params: { :id => os.id, :operatingsystem => { :major => '-1' } }
-    assert_response :unprocessable_entity
   end
 
   test "should update os family" do

--- a/test/factories/medium.rb
+++ b/test/factories/medium.rb
@@ -28,6 +28,18 @@ FactoryBot.define do
       os_family { 'Coreos' }
     end
 
+    trait :fcos do
+      sequence(:name) { |n| "Fedora CoreOS Mirror #{n}" }
+      sequence(:path) { 'http://builds.coreos.fedoraproject.org' }
+      os_family { 'Fcos' }
+    end
+
+    trait :rhcos do
+      sequence(:name) { |n| "Red Hat CoreOS Mirror #{n}" }
+      sequence(:path) { 'http://mirror.openshift.com' }
+      os_family { 'Rhcos' }
+    end
+
     trait :ubuntu do
       sequence(:name) { |n| "Ubuntu Mirror #{n}" }
       sequence(:path) { 'http://archive.ubuntu.com/ubuntu' }

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -81,6 +81,24 @@ FactoryBot.define do
       title { 'Flatcar 2345.3.0' }
     end
 
+    factory :fcos, class: Fcos do
+      sequence(:name) { 'FedoraCoreOS' }
+      major { '32' }
+      minor { '20200907.3.0' }
+      type { 'Fcos' }
+      release_name { 'stable' }
+      title { 'FedoraCoreOS 32.20200907.3.0' }
+    end
+
+    factory :rhcos, class: Rhcos do
+      sequence(:name) { 'RedHatCoreOS' }
+      major { '4' }
+      minor { '5' }
+      release_name { '6' }
+      type { 'Rhcos' }
+      title { 'RedHatCoreOS 4.5.6' }
+    end
+
     factory :ubuntu14_10, class: Debian do
       sequence(:name) { 'Ubuntu' }
       major { '14' }

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -11,17 +11,15 @@ class OperatingsystemTest < ActiveSupport::TestCase
   end
 
   should validate_presence_of(:name)
-  should validate_numericality_of(:major).is_greater_than_or_equal_to(0)
-  should validate_numericality_of(:minor).is_greater_than_or_equal_to(0)
 
   should allow_value(*valid_name_list).for(:name)
   should_not allow_value(*invalid_name_list).for(:name)
 
-  should allow_value('1' * 5).for(:major)
-  should_not allow_values('1' * 6, '', -33).for(:major)
+  should allow_value('11111').for(:major)
+  should allow_value(11111).for(:major)
 
-  should allow_value('1' * 16).for(:minor)
-  should_not allow_values('1' * 17, -50).for(:minor)
+  should allow_value('11111').for(:minor)
+  should allow_value(11111).for(:minor)
 
   should allow_values('Base64', 'SHA256', 'SHA512').for(:password_hash)
   should_not allow_value('INVALID_HASH').for(:password_hash)
@@ -161,8 +159,8 @@ class OperatingsystemTest < ActiveSupport::TestCase
 
     test "families_as_collection contains correct names and values" do
       families = Operatingsystem.families_as_collection
-      assert_equal ["AIX", "Altlinux", "Arch Linux", "CoreOS", "Debian", "FreeBSD", "Gentoo", "Junos", "NX-OS", 'RancherOS', "Red Hat", "SUSE", "Solaris", "VRP", "Windows", "XenServer"], families.map(&:name).sort
-      assert_equal ["AIX", "Altlinux", "Archlinux", "Coreos", "Debian", "Freebsd", "Gentoo", "Junos", "NXOS", 'Rancheros', "Redhat", "Solaris", "Suse", "VRP", "Windows", "Xenserver"], families.map(&:value).sort
+      assert_equal ["AIX", "Altlinux", "Arch Linux", "CoreOS", "Debian", "Fedora CoreOS", "FreeBSD", "Gentoo", "Junos", "NX-OS", 'RancherOS', "Red Hat", "Red Hat CoreOS", "SUSE", "Solaris", "VRP", "Windows", "XenServer"], families.map(&:name).sort
+      assert_equal ["AIX", "Altlinux", "Archlinux", "Coreos", "Debian", "Fcos", "Freebsd", "Gentoo", "Junos", "NXOS", 'Rancheros', "Redhat", "Rhcos", "Solaris", "Suse", "VRP", "Windows", "Xenserver"], families.map(&:value).sort
     end
   end
 


### PR DESCRIPTION
This patch adds two new OSes:

* Fedora CoreOS
* RedHat CoreOS

Fedora CoreOS uses quite lengthy version `32.20200907.3.0` which
unfortunately cannot be stored into major or minor version field which
is by default validated to be numeric. Thing is, after validation both
major and minor are converted to strings and stored in database as
strings. Operating system versions are never compared as numbers (they
are fetched back as strings), therefore those numric validations were
removed - there is no reason to enforce them to be numbers.

We are not doing a good job explaining to our users what exactly should
be entered into major, minor and release_name fields. As part of the
patch, three new `*_help` methods are added to the operating system
where a user-facing help string can be displayed for major, minor and
release_name fields with closer explanation.

Warning: This is not end-to-end FedoraCoreOS provisioning, but it's probably the first in the series to enable the workflow.

![obrazek](https://user-images.githubusercontent.com/49752/94920091-e4412b80-04b5-11eb-945a-4143c76e7bfc.png)

![obrazek](https://user-images.githubusercontent.com/49752/94920116-edca9380-04b5-11eb-988d-cac60d17b77a.png)
