### PR TITLE
Fixes #21558 - Make compliance status clickable

### DIFF
--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -35,8 +35,9 @@ module HostDescriptionHelper
       {
         :field => [
           _("Status"),
-          content_tag(:span, ''.html_safe, :class => host_global_status_icon_class(global_status.status)) +
+          link_to(content_tag(:span, ''.html_safe, :class => host_global_status_icon_class(global_status.status)) +
             content_tag(:span, _(global_status.to_label), :class => host_global_status_class(global_status.status)),
+                  arf_reports_path(:search => "host = #{host.id}")),
         ],
         :priority => 10,
       },


### PR DESCRIPTION
Made the compliance status on the hosts/show page clickable and leads to the last report for the host.