### PR TITLE
Fixes #30966 - make host substatus clickable

### DIFF
--- a/app/assets/stylesheets/status-colors.scss
+++ b/app/assets/stylesheets/status-colors.scss
@@ -10,3 +10,28 @@
 .status-question {
   color: $brand-warning;
 }
+
+.status-ok-link {
+  color: $brand-success;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.status-error-link {
+  color: $brand-danger;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.status-warn-link,
+.status-question-link {
+  color: $brand-warning;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}

--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -53,8 +53,8 @@ module HostDescriptionHelper
       { :field => [
         _(status.name),
         content_tag(:span, ' '.html_safe, :class => host_global_status_icon_class(status.to_global)) +
-          content_tag(:span, _(status.to_label), :class => host_global_status_class(status.to_global)) +
-          content_tag(:span, link_to(_('clear'), forget_status_host_path(host, status: status), :class => 'pull-right', :method => 'post')),
+            link_to_if(status.status_link, content_tag(:span, _(status.to_label), :class => host_global_status_link_class(status)), status.status_link) +
+            content_tag(:span, link_to(_('clear'), forget_status_host_path(host, status: status), :class => 'pull-right', :method => 'post')),
       ], :priority => priority += 1 }
     end.compact
   end

--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -135,6 +135,23 @@ module HostsHelper
     end
   end
 
+  def host_global_status_link_class(status)
+    if status.status_link
+      case status.to_global
+      when HostStatus::Global::OK
+        'status-ok-link'
+      when HostStatus::Global::WARN
+        'status-warn-link'
+      when HostStatus::Global::ERROR
+        'status-error-link'
+      else
+        'status-question-link'
+      end
+    else
+      host_global_status_class(status.to_global)
+    end
+  end
+
   def days_ago(time)
     ((Time.zone.now - time) / 1.day).ceil.to_i
   end

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -63,6 +63,9 @@ module HostStatus
       false
     end
 
+    def status_link
+    end
+
     private
 
     def update_timestamp


### PR DESCRIPTION
Made host substatus on the hosts/show page clickable.