### PR TITLE
Fixes #30999 - Add :activation_key to the Global registration template

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -57,7 +57,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     yum localinstall $CONSUMER_RPM -y
     rm -f $CONSUMER_RPM
 
-    subscription-manager register --org=<%= @organization.label %> --activationkey="sample-key"
+    subscription-manager register --org=<%= @organization.label %> --activationkey="<%= @activation_key %>"
     register_katello_host | bash
 else
     register_host | bash


### PR DESCRIPTION
`@activation_key` is for Katello plugin, see https://github.com/Katello/katello/pull/8903
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
