### PR TITLE
Fixes #30993 - Host Registration endpoind - Remove :owner from Host params

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/registration.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/registration.rb
@@ -22,7 +22,6 @@ module Foreman::Controller::Parameters::Registration
           :managed,
           :comment,
           :uuid,
-          :owner,
           interfaces: [nic_interface_params_filter],
           interfaces_attributes: [nic_interface_params_filter],
           host_parameters_attributes: [parameter_params_filter(HostParameter)]


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
