### PR TITLE
Fixes #30992 - HRT API endpoint should document ipv6 parameter

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -34,7 +34,8 @@ module Api
       param :name, String, required: true
       param :location_id, :number, required: true
       param :organization_id, :number, required: true
-      param :ip, String, desc: N_("not required if using a subnet with DHCP proxy")
+      param :ip, String, desc: N_("IPv4 address, not required if using a subnet with DHCP proxy")
+      param :ip6, String, desc: N_("IPv6 address, not required if using a subnet with DHCP proxy")
       param :mac, String, desc: N_("required for managed host that is bare metal, not required if it's a virtual machine")
       param :domain_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
       param :operatingsystem_id, :number, desc: N_("required if host is managed and value is not inherited from host group")


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
