### PR TITLE
Refs #29970 - speedup Applicable Errata report

### DIFF
--- a/app/views/unattended/report_templates/host_-_applicable_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applicable_errata.erb
@@ -22,7 +22,7 @@ require:
 ￼ version: 3.16.0
 -%>
 <%- report_headers 'Host', 'Operating System', 'Environment', 'Erratum', 'Type', 'Published', 'Applicable since', 'Severity', 'Packages', 'CVEs', 'Reboot suggested' -%>
-<%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :applicable_errata, :lifecycle_environment]).each_record do |host| -%>
+<%- load_hosts(search: input('Hosts filter'), preload: [:operatingsystem, :lifecycle_environment]).each_record do |host| -%>
 <%-   host_applicable_errata_filtered(host, input('Errata filter')).each do |erratum| -%>
 <%-     report_row(
           'Host': host.name,


### PR DESCRIPTION
Preloads are much faster as those load records only once per batch.
The SQL query is much simplier and transformation to the Rails models is simplier.

This speedup is to 70% of original time.