### PR TITLE
Fixes #30459 - Global Registration Template - Smart Proxy callback support

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -27,7 +27,10 @@ module Foreman::Controller::Registration
                    organization: (organization || User.current.default_organization || User.current.my_organizations.first),
                    location: (location || User.current.default_location || User.current.my_locations.first),
                    hostgroup: host_group,
-                   operatingsystem: operatingsystem })
+                   operatingsystem: operatingsystem,
+                   url_host: registration_url.host,
+                   registration_url: registration_url,
+                    })
   end
 
   def safe_render(template)
@@ -69,5 +72,18 @@ module Foreman::Controller::Registration
     render_error 'not_found', nf_opts
 
     false
+  end
+
+  def registration_url
+    uri = if params[:url].present?
+            URI.join(params[:url], '/register')
+          else
+            URI(register_url)
+          end
+
+    return uri if uri.scheme && uri.host
+
+    msg = N_('URL in :url parameter is missing a scheme, please set http:// or https://')
+    fail Foreman::Exception.new(msg)
   end
 end

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -32,7 +32,7 @@ EOF
 
 
 register_host() {
-  curl --cacert $SSL_CA_CERT --request POST <%= foreman_server_url %>/register \
+  curl --cacert $SSL_CA_CERT --request POST <%= @registration_url %> \
        <%= headers.join(' ') %> \
        --data "host[name]=$(hostname --fqdn)" \
        --data "host[build]=false" \
@@ -52,7 +52,7 @@ echo "#"
 if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
-        curl --cacert $SSL_CA_CERT --request POST "<%= foreman_server_url %>/register?uuid=$UUID" \
+        curl --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>?uuid=$UUID" \
             <%= headers.join(' ') %> \
             <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
             <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
@@ -60,7 +60,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     }
 
     CONSUMER_RPM=$(mktemp --suffix .rpm)
-    curl --output $CONSUMER_RPM <%= subscription_manager_configuration_url %>
+    curl --output $CONSUMER_RPM <%= subscription_manager_configuration_url(hostname: @url_host) %>
     yum localinstall $CONSUMER_RPM -y
     rm -f $CONSUMER_RPM
 

--- a/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
+++ b/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
@@ -25,8 +25,14 @@ set -e
 
 
 # Call home to exit build mode
-
-curl -o /dev/null --noproxy \* '<%= foreman_url('built') %>'
+<% built_https = foreman_url('built').start_with?('https') -%>
+<% if built_https -%>
+SSL_CA_CERT=$(mktemp)
+cat << EOF > $SSL_CA_CERT
+<%= foreman_server_ca_cert %>
+EOF
+<% end -%>
+curl <%= '--cacert $SSL_CA_CERT' if built_https -%> -o /dev/null --noproxy \* '<%= foreman_url('built') %>'
 
 echo "Successfully enrolled host <%= @host.name %> with Foreman."
 


### PR DESCRIPTION
Pass `:url` to the template when rendering via proxy.

**Requirements:**
* Proxy: https://github.com/theforeman/smart-proxy/pull/768
* Katello: https://github.com/Katello/katello/pull/8938

*How to test:*
```
curl proxy.example.com/register | bash
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
