### PR TITLE
Fixes #31016 - refresh registries after plugin testing

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -81,7 +81,7 @@ module HostCommon
   end
 
   def medium_provider
-    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(self)
+    @medium_provider ||= Foreman::Plugin.medium_providers_registry.find_provider(self)
   end
 
   apipie :method, 'Returns a url pointing to boot file' do

--- a/app/models/concerns/host_template_helpers.rb
+++ b/app/models/concerns/host_template_helpers.rb
@@ -35,6 +35,6 @@ module HostTemplateHelpers
   end
 
   def medium_provider
-    @medium_provider ||= Foreman::Plugin.medium_providers.find_provider(self)
+    @medium_provider ||= Foreman::Plugin.medium_providers_registry.find_provider(self)
   end
 end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -186,14 +186,14 @@ class Operatingsystem < ApplicationRecord
   # sets the prefix for the tfp files based on medium unique identifier
   def pxe_prefix(medium_provider)
     unless medium_provider.is_a? MediumProviders::Provider
-      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers.find_provider(host)'))
+      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers_registry.find_provider(host)'))
     end
     "boot/#{medium_provider.unique_id}"
   end
 
   def pxe_files(medium_provider)
     unless medium_provider.is_a? MediumProviders::Provider
-      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers.find_provider(host)'))
+      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers_registry.find_provider(host)'))
     end
     boot_files_uri(medium_provider).collect do |img|
       { pxe_prefix(medium_provider).to_sym => img.to_s}
@@ -222,7 +222,7 @@ class Operatingsystem < ApplicationRecord
 
   def bootfile(medium_provider, type)
     unless medium_provider.is_a? MediumProviders::Provider
-      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers.find_provider(host)'))
+      raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers_registry.find_provider(host)'))
     end
     pxe_prefix(medium_provider) + "-" + family.constantize::PXEFILES[type.to_sym]
   end

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -77,7 +77,7 @@ class Solaris < Operatingsystem
   end
 
   def jumpstart_params(host, vendor)
-    medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+    medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
     # root server and install server are always the same under Foreman
     server_name = host.medium.media_host
     server_ip   = host.domain.resolver.getaddress(server_name).to_s

--- a/app/models/operatingsystems/vrp.rb
+++ b/app/models/operatingsystems/vrp.rb
@@ -43,7 +43,7 @@ class VRP < Operatingsystem
   end
 
   def ztp_arguments(host)
-    medium_provider = Foreman::Plugin.medium_providers.find_provider host
+    medium_provider = Foreman::Plugin.medium_providers_registry.find_provider host
 
     {
       :vendor   => "huawei",

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -189,7 +189,7 @@ class ProvisioningTemplate < Template
 
   def self.fetch_boot_files_combo(tftp)
     @profiles.each do |combo|
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(combo[:hostgroup])
+      medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(combo[:hostgroup])
       combo[:hostgroup].operatingsystem.pxe_files(medium_provider).each do |bootfile_info|
         bootfile_info.each do |prefix, path|
           tftp.fetch_boot_file(:prefix => prefix.to_s, :path => path)
@@ -210,7 +210,7 @@ class ProvisioningTemplate < Template
       template.template_combinations.each do |combination|
         hostgroup = combination.hostgroup
         if hostgroup&.operatingsystem && hostgroup&.architecture
-          if (medium_provider = Foreman::Plugin.medium_providers.find_provider(hostgroup))
+          if (medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(hostgroup))
             combos << {
               :hostgroup => hostgroup,
               :template => template,

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -36,4 +36,5 @@ Menu::Loader.load
 # The users table may not be exist during initial migration of the database
 TopbarSweeper.expire_cache_all_users if (User.table_exists? rescue false)
 
+Foreman::Plugin.initialize_registries
 Foreman::Plugin.medium_providers.register MediumProviders::Default

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -36,5 +36,5 @@ Menu::Loader.load
 # The users table may not be exist during initial migration of the database
 TopbarSweeper.expire_cache_all_users if (User.table_exists? rescue false)
 
-Foreman::Plugin.initialize_registries
-Foreman::Plugin.medium_providers.register MediumProviders::Default
+Foreman::Plugin.initialize_default_registries
+Foreman::Plugin.medium_providers_registry.register MediumProviders::Default

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1798,7 +1798,7 @@ declaration:
 [source, ruby]
 ----
 Foreman::Plugin.register :my_plugin do
-  medium_providers.register(MyPlugin::ManagedContentMediumProvider)
+  medium_providers_registry.register(MyPlugin::ManagedContentMediumProvider)
 end
 ----
 [[compute-resources]]

--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -25,7 +25,7 @@ module Foreman
           end
 
           def load_variables_base
-            @medium_provider = Foreman::Plugin.medium_providers.find_provider(host) if host
+            @medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host) if host
             if operatingsystem&.respond_to?(:pxe_type)
               send "#{operatingsystem.pxe_type}_attributes"
               pxe_config

--- a/test/models/concerns/belongs_to_proxies_test.rb
+++ b/test/models/concerns/belongs_to_proxies_test.rb
@@ -20,7 +20,6 @@ class BelongsToProxiesTest < ActiveSupport::TestCase
   end
 
   setup :clear_plugins
-  teardown :restore_plugins
 
   test '#registered_smart_proxies has default value' do
     assert_equal({}, EmptySampleModel.registered_smart_proxies)

--- a/test/models/operatingsystems/operatingsystems_test.rb
+++ b/test/models/operatingsystems/operatingsystems_test.rb
@@ -33,7 +33,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
         :operatingsystem => operatingsystem,
         :architecture => arch,
         :medium => media(:unused))
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
 
       assert_equal(config['expected'], operatingsystem.pxedir(medium_provider))
     end
@@ -54,7 +54,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
           :media => [media(config['medium'])]),
         :architecture => arch,
         :medium => media(config['medium']))
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
 
       assert_equal(config['expected'], host.operatingsystem.kernel(medium_provider))
     end
@@ -76,7 +76,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
         :architecture => arch,
         :medium => media(config['medium']))
 
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
       assert_equal(config['expected'], host.operatingsystem.initrd(medium_provider))
     end
   end
@@ -96,7 +96,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
           :media => [media(config['medium'])]),
         :architecture => arch,
         :medium => media(config['medium']))
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
       assert_equal(config['expected'], host.operatingsystem.pxe_prefix(medium_provider))
     end
   end
@@ -129,7 +129,7 @@ class OperatingsystemsTest < ActiveSupport::TestCase
 
       host.medium.operatingsystems << host.operatingsystem
       host.arch.operatingsystems << host.operatingsystem
-      medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+      medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
 
       prefix = host.operatingsystem.pxe_prefix(medium_provider).to_sym
       pxe_files = host.operatingsystem.pxe_files(medium_provider)

--- a/test/models/operatingsystems/ztp_test.rb
+++ b/test/models/operatingsystems/ztp_test.rb
@@ -4,7 +4,7 @@ class ZTPTest < ActiveSupport::TestCase
   setup { disable_orchestration }
 
   test "Huawei ZTP parameter generation" do
-    h = FactoryBot.create(:host, :managed, :with_environment, :domain => domains(:yourdomain),
+    host = FactoryBot.create(:host, :managed, :with_environment, :domain => domains(:yourdomain),
           :interfaces => [FactoryBot.build(:nic_primary_and_provision,
             :ip => '2.3.4.10')],
           :architecture => architectures(:ASIC),
@@ -15,8 +15,8 @@ class ZTPTest < ActiveSupport::TestCase
           :puppet_proxy => smart_proxies(:puppetmaster),
           :ptable => FactoryBot.create(:ptable, :operatingsystem_ids => [operatingsystems(:vrp5).id])
     )
-    medium_provider = Foreman::Plugin.medium_providers.find_provider h
-    result = h.os.ztp_arguments h
+    medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
+    result = host.os.ztp_arguments host
     assert_equal(
       {
         :vendor => "huawei",

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -213,19 +213,19 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
       @ctd = FactoryBot.create(:provisioning_template, :name => "ctd", :template_kind => @tk, :operatingsystems => [@os1])
       @ctd.os_default_templates.create(:operatingsystem => @os1, :template_kind_id => @ctd.template_kind_id)
 
-      Foreman::Plugin.medium_providers.register(AMediumProvider)
+      Foreman::Plugin.medium_providers_registry.register(AMediumProvider)
     end
 
     teardown do
-      Foreman::Plugin.medium_providers.unregister(AMediumProvider)
+      Foreman::Plugin.medium_providers_registry.unregister(AMediumProvider)
     end
 
     test "medium providers validate hostgroups" do
-      p1 = Foreman::Plugin.medium_providers.find_provider(@hg1)
+      p1 = Foreman::Plugin.medium_providers_registry.find_provider(@hg1)
       refute_nil p1
       assert_empty p1.validate
 
-      p2 = Foreman::Plugin.medium_providers.find_provider(@hg2)
+      p2 = Foreman::Plugin.medium_providers_registry.find_provider(@hg2)
       refute_nil p2
       assert_empty p2.validate
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -105,17 +105,22 @@ class ActiveSupport::TestCase
   end
 
   def clear_plugins
-    @klass = Foreman::Plugin
-    @plugins_backup = @klass.registered_plugins
-    @registry_backup = @klass.registries
-    @klass.clear
-    @klass.initialize_registries
+    @clear_plugins = true
+    @plugins_backup = Foreman::Plugin.registered_plugins
+    @registries_backup = Foreman::Plugin.registries
+    Foreman::Plugin.send(:clear)
   end
 
   def restore_plugins
-    @klass.clear
-    @klass.initialize_registries(@registry_backup)
-    @klass.instance_variable_set('@registered_plugins', @plugins_backup)
+    Foreman::Deprecation.deprecation_warning('2.5', '`teardown :restore_plugins` is deprecated, plugin restoration is automated when `setup :clear_plugins` is used')
+  end
+
+  def after_teardown
+    super
+
+    return unless @clear_plugins
+    Foreman::Plugin.send(:clear, @plugins_backup, @registries_backup)
+    @clear_plugins = nil
   end
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -103,6 +103,20 @@ class ActiveSupport::TestCase
     Resolv::DNS.any_instance.stubs(:getaddress).raises(Resolv::ResolvError, "DNS must be stub: Resolv::DNS.any_instance.stubs(:getaddress).returns('127.0.0.15')")
     Resolv::DNS.any_instance.stubs(:getaddresses).raises(Resolv::ResolvError, "DNS must be stub: Resolv::DNS.any_instance.stubs(:getaddresses).returns(['127.0.0.15'])")
   end
+
+  def clear_plugins
+    @klass = Foreman::Plugin
+    @plugins_backup = @klass.registered_plugins
+    @registry_backup = @klass.registries
+    @klass.clear
+    @klass.initialize_registries
+  end
+
+  def restore_plugins
+    @klass.clear
+    @klass.initialize_registries(@registry_backup)
+    @klass.instance_variable_set('@registered_plugins', @plugins_backup)
+  end
 end
 
 class ActionView::TestCase
@@ -184,17 +198,6 @@ class GraphQLQueryTestCase < ActiveSupport::TestCase
 
     assert_same_elements expected_global_ids, actual_global_ids
   end
-end
-
-def clear_plugins
-  @klass = Foreman::Plugin
-  @plugins_backup = @klass.registered_plugins
-  @klass.clear
-end
-
-def restore_plugins
-  @klass.clear
-  @klass.instance_variable_set('@registered_plugins', @plugins_backup)
 end
 
 def with_auditing(klass)

--- a/test/unit/medium_providers/default_test.rb
+++ b/test/unit/medium_providers/default_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DefaultMediumProviderTest < ActiveSupport::TestCase
   test 'returns default provider for managed host' do
     host = FactoryBot.create(:host, :managed)
-    medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+    medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
     assert_instance_of MediumProviders::Default, medium_provider
   end
 

--- a/test/unit/medium_providers/plugin_test.rb
+++ b/test/unit/medium_providers/plugin_test.rb
@@ -11,17 +11,14 @@ class PluginMediumProviderTest < ActiveSupport::TestCase
     end
   end
 
+  setup :clear_plugins
   setup do
-    Foreman::Plugin.medium_providers.register(PluginMediumProvider)
-  end
-
-  teardown do
-    Foreman::Plugin.medium_providers.unregister(PluginMediumProvider)
+    Foreman::Plugin.medium_providers_registry.register(PluginMediumProvider)
   end
 
   test 'plugin can provide media without medium set' do
     host = FactoryBot.create(:host, :with_operatingsystem, medium: nil)
-    medium_provider = Foreman::Plugin.medium_providers.find_provider(host)
+    medium_provider = Foreman::Plugin.medium_providers_registry.find_provider(host)
     assert_nil host.medium
     assert_instance_of PluginMediumProvider, medium_provider
   end

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -44,10 +44,9 @@ class PluginTest < ActiveSupport::TestCase
   end
 
   setup :clear_plugins
-  teardown :restore_plugins
 
   def test_register
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       name 'Foo plugin'
       url 'http://example.net/plugins/foo'
       author 'John Smith'
@@ -57,9 +56,9 @@ class PluginTest < ActiveSupport::TestCase
       path '/some/path/on/disk'
     end
 
-    assert_equal 1, @klass.all.size
+    assert_equal 1, Foreman::Plugin.all.size
 
-    plugin = @klass.find('foo')
+    plugin = Foreman::Plugin.find('foo')
     assert plugin.is_a?(Foreman::Plugin)
     assert_equal :foo, plugin.id
     assert_equal 'Foo plugin', plugin.name
@@ -72,15 +71,15 @@ class PluginTest < ActiveSupport::TestCase
   end
 
   def test_installed
-    @klass.register(:foo) {}
-    assert_equal true, @klass.installed?(:foo)
-    assert_equal false, @klass.installed?(:bar)
+    Foreman::Plugin.register(:foo) {}
+    assert_equal true, Foreman::Plugin.installed?(:foo)
+    assert_equal false, Foreman::Plugin.installed?(:bar)
   end
 
   def test_menu
     url_hash = {:controller => 'hosts', :action => 'index'}
     assert_difference 'Menu::Manager.items(:project_menu).size' do
-      @klass.register :foo do
+      Foreman::Plugin.register :foo do
         menu :project_menu, :foo_menu_item, :url_hash => url_hash, :caption => 'Foo'
       end
     end
@@ -93,7 +92,7 @@ class PluginTest < ActiveSupport::TestCase
   def test_delete_menu_item
     Menu::Manager.map(:project_menu).item(:foo_menu_item, :caption => 'Foo')
     assert_difference 'Menu::Manager.items(:project_menu).size', -1 do
-      @klass.register :foo do
+      Foreman::Plugin.register :foo do
         delete_menu_item :project_menu, :foo_menu_item
       end
     end
@@ -180,16 +179,16 @@ class PluginTest < ActiveSupport::TestCase
   def test_requires_foreman_plugin
     test = self
     other_version = '0.5.0'
-    @klass.register :other do
+    Foreman::Plugin.register :other do
       name 'Other'
       version other_version
     end
     other_version_pre = '0.5.0.pre.master'
-    @klass.register :other_pre do
+    Foreman::Plugin.register :other_pre do
       name 'Other'
       version other_version_pre
     end
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       test.assert requires_foreman_plugin(:other, '>= 0.1.0')
       test.assert requires_foreman_plugin(:other, other_version)
       test.assert_raise Foreman::PluginRequirementError do
@@ -221,36 +220,36 @@ class PluginTest < ActiveSupport::TestCase
     Foreman::Renderer.configure { |config| config.allowed_generic_helpers -= [:my_helper] }
     refute_includes Foreman::Renderer.config.allowed_helpers, :my_helper
 
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       allowed_template_helpers :my_helper
     end
 
     # simulate application start
-    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    Foreman::Plugin.find(:foo).to_prepare_callbacks.each(&:call)
     assert_includes Foreman::Renderer.config.allowed_helpers, :my_helper
   end
 
   def test_register_allowed_template_variables
     refute_includes Foreman::Renderer.config.allowed_variables, :my_variable
 
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       allowed_template_variables :my_variable
     end
 
     # simulate application start
-    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    Foreman::Plugin.find(:foo).to_prepare_callbacks.each(&:call)
     assert_includes Foreman::Renderer.config.allowed_variables, :my_variable
   end
 
   def test_register_allowed_global_settings
     refute_includes Foreman::Renderer.config.allowed_global_settings, :my_global_setting
 
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       allowed_template_global_settings :my_global_setting
     end
 
     # simulate application start
-    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    Foreman::Plugin.find(:foo).to_prepare_callbacks.each(&:call)
     assert_includes Foreman::Renderer.config.allowed_global_settings, :my_global_setting
   end
 
@@ -258,12 +257,12 @@ class PluginTest < ActiveSupport::TestCase
     refute_includes Foreman::Renderer::Scope::Base.public_instance_methods, :my_helper
     refute_includes Foreman::Renderer::Scope::Base.public_instance_methods, :private_helper
 
-    @klass.register(:foo) do
+    Foreman::Plugin.register(:foo) do
       extend_template_helpers(MyMod)
     end
 
     # simulate application start
-    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    Foreman::Plugin.find(:foo).to_prepare_callbacks.each(&:call)
     assert_includes Foreman::Renderer::Scope::Base.public_instance_methods, :my_helper
     refute_includes Foreman::Renderer::Scope::Base.public_instance_methods, :private_helper
   end
@@ -299,25 +298,25 @@ class PluginTest < ActiveSupport::TestCase
   end
 
   def test_can_merge_tests_to_skip_arrays
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       tests_to_skip "FooTest" => ["test1", "test2"]
     end
-    @klass.register :bar do
+    Foreman::Plugin.register :bar do
       tests_to_skip "FooTest" => ["test3", "test4"]
     end
-    assert_equal ["test1", "test2", "test3", "test4"], @klass.tests_to_skip["FooTest"]
+    assert_equal ["test1", "test2", "test3", "test4"], Foreman::Plugin.tests_to_skip["FooTest"]
   end
 
   def test_configure_logging
     Foreman::Plugin::Logging.any_instance.expects(:configure).with(nil)
-    @klass.register(:foo) {}
+    Foreman::Plugin.register(:foo) {}
 
     assert Foreman::Plugin.find(:foo).logging
   end
 
   def test_logger
     Foreman::Plugin::Logging.any_instance.expects(:configure).with(nil)
-    @klass.register(:foo) {}
+    Foreman::Plugin.register(:foo) {}
     plugin = Foreman::Plugin.find(:foo)
 
     plugin.logging.expects(:add_logger).with(:test_logger, {:enabled => true})
@@ -326,11 +325,11 @@ class PluginTest < ActiveSupport::TestCase
 
   def test_register_custom_status
     status = Struct.new(:status)
-    @klass.register :foo do
+    Foreman::Plugin.register :foo do
       register_custom_status(status)
     end
     # simulate application start
-    @klass.find(:foo).to_prepare_callbacks.each(&:call)
+    Foreman::Plugin.find(:foo).to_prepare_callbacks.each(&:call)
     assert_include HostStatus.status_registry, status
     HostStatus.status_registry.delete status
   end

--- a/test/unit/rabl_test.rb
+++ b/test/unit/rabl_test.rb
@@ -26,7 +26,6 @@ class RablTest < ActiveSupport::TestCase
 
   context 'with plugin' do
     setup :clear_plugins
-    teardown :restore_plugins
 
     test 'render of extended plugin template' do
       Foreman::Plugin.register :test_extend_rabl_template do


### PR DESCRIPTION
Introduce mechanisms to refresh the plugin registries.
We pollute these during plugin mechanisms testing and it never gets cleaned up.
This makes sure we clean mocks and stubs from the registries.