### PR TITLE
Fixes #31017 - Do not use updates,security repos for Debian installations

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/preseed_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/preseed_default.erb
@@ -125,6 +125,13 @@ d-i apt-setup/local<%= repos %>/key string http://keyserver.ubuntu.com/pks/looku
 <% end -%>
 <% end -%>
 
+<% if host_param('kt_activation_keys') && @host.operatingsystem.name == 'Debian' -%>
+# If we are using Katello for content management, then do not add updates and
+# security repos during the initial installation. Prevents us from defaulting to:
+# d-i apt-setup/services-select multiselect updates,security
+d-i apt-setup/services-select multiselect
+
+<% end -%>
 # Install minimal task set (see tasksel --task-packages minimal)
 tasksel tasksel/first multiselect minimal, ssh-server, openssh-server
 


### PR DESCRIPTION
https://projects.theforeman.org/issues/31017

Adding the line prevents it from defaulting to:
d-i apt-setup/services-select multiselect updates,security
