### PR TITLE
Fixes #31032 - argumets indentation to the method name

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,9 +26,6 @@ Layout/DotPosition:
 Layout/EmptyLineAfterGuardClause:
   Enabled: false
 
-Layout/FirstArgumentIndentation:
-  EnforcedStyle: consistent
-
 Layout/HashAlignment:
   Enabled: false
 

--- a/app/controllers/api/v2/compute_attributes_controller.rb
+++ b/app/controllers/api/v2/compute_attributes_controller.rb
@@ -47,8 +47,8 @@ module Api
 
       def create
         @compute_attribute = ComputeAttribute.new(compute_attribute_params.merge(
-          :compute_profile_id => params[:compute_profile_id],
-          :compute_resource_id => params[:compute_resource_id]))
+                                                    :compute_profile_id => params[:compute_profile_id],
+                                                    :compute_resource_id => params[:compute_resource_id]))
         process_response @compute_attribute.save
       end
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -226,22 +226,22 @@ module Foreman
 
     # Check that the loggers setting exist to configure the app and sql loggers
     Foreman::Logging.add_loggers((SETTINGS[:loggers] || {}).reverse_merge(
-      :app => {:enabled => true},
-      :audit => {:enabled => true},
-      :ldap => {:enabled => false},
-      :permissions => {:enabled => false},
-      :proxy => {:enabled => false},
-      :sql => {:enabled => false},
-      :templates => {:enabled => true},
-      :notifications => {:enabled => true},
-      :background => {:enabled => true},
-      :dynflow => {:enabled => true},
-      :telemetry => {:enabled => false},
-      :blob => {:enabled => false},
-      :taxonomy => {:enabled => true},
-      :api_deprecations => {:enabled => true},
-      :sidekiq => {:enabled => true, :level => :warn}
-    ))
+                                   :app => {:enabled => true},
+                                   :audit => {:enabled => true},
+                                   :ldap => {:enabled => false},
+                                   :permissions => {:enabled => false},
+                                   :proxy => {:enabled => false},
+                                   :sql => {:enabled => false},
+                                   :templates => {:enabled => true},
+                                   :notifications => {:enabled => true},
+                                   :background => {:enabled => true},
+                                   :dynflow => {:enabled => true},
+                                   :telemetry => {:enabled => false},
+                                   :blob => {:enabled => false},
+                                   :taxonomy => {:enabled => true},
+                                   :api_deprecations => {:enabled => true},
+                                   :sidekiq => {:enabled => true, :level => :warn}
+                                 ))
 
     config.logger = Foreman::Logging.logger('app')
     # Explicitly set the log_level from our config, overriding the Rails env default

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -335,11 +335,11 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
 
   test "#interfaces ignores legacy facts when facter >= v3.0" do
     parser = get_parser(structured_networking_facts.merge(
-      interfaces: 'eth5',
-      ipadress_eth3: '192.168.6.1',
-      macaddress_eth3: '00:50:56:B7:69:F6',
-      netmask_eth3: '255.255.254.0'
-    ))
+                          interfaces: 'eth5',
+                          ipadress_eth3: '192.168.6.1',
+                          macaddress_eth3: '00:50:56:B7:69:F6',
+                          netmask_eth3: '255.255.254.0'
+                        ))
 
     assert_not_nil parser.interfaces['eth1:1']
     assert parser.interfaces.values.any? { |x| x[:ipaddress] == '192.168.0.1' }


### PR DESCRIPTION
Enable default of Cop `Layout/FirstArgumentIndentation`.
We have just few places to fix and it make sense to me.
Please downvote if you dont agree, upvote if you do.