### PR TITLE
Fixes #31031 - no rocket hash keys in routes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -97,8 +97,6 @@ Style/FrozenStringLiteralComment:
 # Support both, Ruby 1.9 hashmap and hash-rocket syntax
 Style/HashSyntax:
   EnforcedStyle: no_mixed_keys
-  Exclude:
-    - config/routes.rb
 
 Style/IfUnlessModifier:
   Enabled: false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,15 +1,15 @@
 Foreman::Application.routes.draw do
   apipie_dsl
-  resources :mail_notifications, :only => [] do
+  resources :mail_notifications, only: [] do
     collection do
       get 'auto_complete_search'
     end
   end
 
   # ENC requests goes here
-  get "node/:name" => 'hosts#externalNodes', :constraints => { :name => /[^\.][\w\.-]+/ }
+  get "node/:name" => 'hosts#externalNodes', :constraints => { name: /[^\.][\w\.-]+/ }
 
-  resources :config_reports, :only => [:index, :show, :destroy] do
+  resources :config_reports, only: [:index, :show, :destroy] do
     collection do
       get 'auto_complete_search'
     end
@@ -46,10 +46,10 @@ Foreman::Application.routes.draw do
   ]
 
   welcoming_controllers.each do |welcoming_controller|
-    get "#{welcoming_controller}/help", :action => :welcome, :controller => welcoming_controller
+    get "#{welcoming_controller}/help", action: :welcome, controller: welcoming_controller
   end
 
-  constraints(:id => /[^\/]+/) do
+  constraints(id: /[^\/]+/) do
     resources :hosts do
       member do
         get 'clone'
@@ -127,60 +127,60 @@ Foreman::Application.routes.draw do
         post 'update_multiple_location'
         post 'rebuild_config'
         post 'submit_rebuild_config'
-        get 'random_name', :only => :new
+        get 'random_name', only: :new
         get 'preview_host_collection'
       end
 
-      constraints(:host_id => /[^\/]+/) do
-        resources :config_reports, :only => [:index, :show]
-        resources :facts, :only => :index, :controller => :fact_values
-        resources :puppetclasses, :only => :index
+      constraints(host_id: /[^\/]+/) do
+        resources :config_reports, only: [:index, :show]
+        resources :facts, only: :index, controller: :fact_values
+        resources :puppetclasses, only: :index
 
-        get 'parent_facts/*parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts', :parent_fact => /[\/\w.:_-]+/
+        get 'parent_facts/*parent_fact/facts', to: 'fact_values#index', as: 'parent_fact_facts', parent_fact: /[\/\w.:_-]+/
       end
     end
 
-    resources :bookmarks, :except => [:show, :new, :create] do
+    resources :bookmarks, except: [:show, :new, :create] do
       collection do
         get 'auto_complete_search'
       end
     end
 
     [:lookup_keys, :puppetclass_lookup_keys].each do |key|
-      resources key, :except => [:show, :new, :create] do
-        resources :lookup_values, :only => [:index, :create, :update, :destroy]
+      resources key, except: [:show, :new, :create] do
+        resources :lookup_values, only: [:index, :create, :update, :destroy]
         collection do
           get 'auto_complete_search'
         end
       end
     end
 
-    get 'parent_facts/:parent_fact/facts', :to => 'fact_values#index', :as => 'parent_fact_facts'
-    resources :facts, :only => [:index, :show] do
-      constraints(:id => /[^\/]+/) do
-        resources :values, :only => :index, :controller => :fact_values, :as => "host_fact_values"
+    get 'parent_facts/:parent_fact/facts', to: 'fact_values#index', as: 'parent_fact_facts'
+    resources :facts, only: [:index, :show] do
+      constraints(id: /[^\/]+/) do
+        resources :values, only: :index, controller: :fact_values, as: "host_fact_values"
       end
     end
 
-    get 'unattended/template/:id/*hostgroup', :to => "unattended#hostgroup_template", hostgroup: /.+/, :format => 'text'
+    get 'unattended/template/:id/*hostgroup', to: "unattended#hostgroup_template", hostgroup: /.+/, format: 'text'
   end
 
-  resources :settings, :only => [:index, :update] do
+  resources :settings, only: [:index, :update] do
     collection do
       get 'auto_complete_search'
     end
   end
-  resources :common_parameters, :except => [:show] do
+  resources :common_parameters, except: [:show] do
     collection do
       get 'auto_complete_search'
     end
   end
-  resources :parameters, :only => [:index] do
+  resources :parameters, only: [:index] do
     collection do
       get 'auto_complete_search'
     end
   end
-  resources :environments, :except => [:show] do
+  resources :environments, except: [:show] do
     collection do
       get 'import_environments'
       post 'obsolete_and_new'
@@ -192,13 +192,13 @@ Foreman::Application.routes.draw do
     collection do
       get 'auto_complete_search'
     end
-    resources :compute_attributes, :only => [:create, :edit, :update]
-    resources :compute_resources, :only => [] do
-      resources :compute_attributes, :only => :new
+    resources :compute_attributes, only: [:create, :edit, :update]
+    resources :compute_resources, only: [] do
+      resources :compute_attributes, only: :new
     end
   end
 
-  resources :hostgroups, :except => [:show] do
+  resources :hostgroups, except: [:show] do
     member do
       get 'nest'
       get 'clone'
@@ -216,11 +216,11 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :config_groups, :except => [:show] do
-    get 'auto_complete_search', :on => :collection
+  resources :config_groups, except: [:show] do
+    get 'auto_complete_search', on: :collection
   end
 
-  resources :puppetclasses, :except => [:new, :create, :show] do
+  resources :puppetclasses, except: [:new, :create, :show] do
     collection do
       get 'import_environments'
       post 'obsolete_and_new'
@@ -230,9 +230,9 @@ Foreman::Application.routes.draw do
       post 'parameters'
       post 'override'
     end
-    constraints(:id => /[^\/]+/) do
+    constraints(id: /[^\/]+/) do
       resources :hosts
-      resources :lookup_keys, :except => [:show, :new, :create]
+      resources :lookup_keys, except: [:show, :new, :create]
     end
   end
 
@@ -251,14 +251,14 @@ Foreman::Application.routes.draw do
       get 'modules_card'
       post 'expire_logs'
     end
-    constraints(:id => /[^\/]+/) do
-      resources :puppetca, :only => [:index, :update, :destroy] do
+    constraints(id: /[^\/]+/) do
+      resources :puppetca, only: [:index, :update, :destroy] do
         member do
           get 'counts'
           get 'expiry'
         end
       end
-      resources :autosign, :only => [:index, :new, :create, :destroy] do
+      resources :autosign, only: [:index, :new, :create, :destroy] do
         member do
           get 'counts'
         end
@@ -269,32 +269,32 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :http_proxies, :controller => 'http_proxies' do
+  resources :http_proxies, controller: 'http_proxies' do
     collection do
       get 'auto_complete_search'
       put 'test_connection'
     end
   end
 
-  resources :fact_values, :only => [:index] do
+  resources :fact_values, only: [:index] do
     collection do
       get 'auto_complete_search'
     end
   end
 
-  resources :audits, :only => [:index], constraints: ->(req) { req.format == :json }
+  resources :audits, only: [:index], constraints: ->(req) { req.format == :json }
   match '/audits/auto_complete_search' => 'audits#auto_complete_search', :via => [:get]
   match '/audits' => 'react#index', :via => [:get]
 
-  resources :usergroups, :except => [:show] do
+  resources :usergroups, except: [:show] do
     collection do
       get 'auto_complete_search'
     end
   end
 
-  get 'menu', :to => 'user_menus#menu'
+  get 'menu', to: 'user_menus#menu'
 
-  resources :users, :except => [:show] do
+  resources :users, except: [:show] do
     collection do
       get 'login'
       post 'login'
@@ -308,9 +308,9 @@ Foreman::Application.routes.draw do
     member do
       post 'impersonate'
     end
-    resources :ssh_keys, :only => [:new, :create, :destroy]
+    resources :ssh_keys, only: [:new, :create, :destroy]
   end
-  resources :roles, :except => [:show] do
+  resources :roles, except: [:show] do
     member do
       get 'clone'
       patch 'disable_filters_overriding'
@@ -320,7 +320,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :filters, :except => [:show] do
+  resources :filters, except: [:show] do
     member do
       patch 'disable_overriding'
     end
@@ -329,27 +329,27 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :permissions, :only => [:index]
+  resources :permissions, only: [:index]
 
-  resources :auth_source_ldaps, :except => [:show, :index] do
+  resources :auth_source_ldaps, except: [:show, :index] do
     collection do
       put 'test_connection'
     end
   end
 
-  resources :auth_sources, :only => [:show, :index]
-  resources :auth_source_externals, :only => [:update, :edit]
+  resources :auth_sources, only: [:show, :index]
+  resources :auth_source_externals, only: [:update, :edit]
 
-  put 'users/(:id)/test_mail', :to => 'users#test_mail', :as => 'test_mail_user'
+  put 'users/(:id)/test_mail', to: 'users#test_mail', as: 'test_mail_user'
 
-  resources :external_usergroups, :except => [:index, :new, :create, :show, :edit, :update, :destroy] do
+  resources :external_usergroups, except: [:index, :new, :create, :show, :edit, :update, :destroy] do
     member do
       put 'refresh'
     end
   end
 
   scope 'templates' do
-    resources :report_templates, :except => [:show] do
+    resources :report_templates, except: [:show] do
       member do
         get 'clone_template'
         get 'lock'
@@ -369,14 +369,14 @@ Foreman::Application.routes.draw do
   end
 
   if SETTINGS[:unattended]
-    resources :provisioning_templates, :only => [] do
+    resources :provisioning_templates, only: [] do
       collection do
         get 'build_pxe_default'
       end
     end
 
     scope 'templates' do
-      resources :ptables, :except => [:show] do
+      resources :ptables, except: [:show] do
         member do
           get 'clone_template'
           get 'lock'
@@ -391,7 +391,7 @@ Foreman::Application.routes.draw do
         end
       end
 
-      resources :provisioning_templates, :except => [:show] do
+      resources :provisioning_templates, except: [:show] do
         member do
           get 'clone_template'
           get 'lock'
@@ -407,14 +407,14 @@ Foreman::Application.routes.draw do
       end
     end
 
-    constraints(:id => /[^\/]+/) do
-      resources :domains, :except => [:show] do
+    constraints(id: /[^\/]+/) do
+      resources :domains, except: [:show] do
         collection do
           get 'auto_complete_search'
         end
       end
 
-      resources :operatingsystems, :except => [:show] do
+      resources :operatingsystems, except: [:show] do
         member do
           get 'bootfiles'
         end
@@ -423,26 +423,26 @@ Foreman::Application.routes.draw do
         end
       end
     end
-    resources :media, :except => [:show] do
+    resources :media, except: [:show] do
       collection do
         get 'auto_complete_search'
       end
     end
 
-    resources :models, :except => [:show, :index] do
+    resources :models, except: [:show, :index] do
       collection do
         get 'auto_complete_search'
       end
     end
     match 'models' => 'react#index', :via => :get
 
-    resources :architectures, :except => [:show] do
+    resources :architectures, except: [:show] do
       collection do
         get 'auto_complete_search'
       end
     end
 
-    constraints(:id => /[^\/]+/) do
+    constraints(id: /[^\/]+/) do
       resources :compute_resources do
         member do
           post 'template_selected'
@@ -453,8 +453,8 @@ Foreman::Application.routes.draw do
           put 'associate'
           put 'refresh_cache'
         end
-        constraints(:id => /[^\/]+/) do
-          resources :vms, :controller => "compute_resources_vms" do
+        constraints(id: /[^\/]+/) do
+          resources :vms, controller: "compute_resources_vms" do
             member do
               put 'power'
               put 'pause'
@@ -469,18 +469,18 @@ Foreman::Application.routes.draw do
           get 'provider_selected'
           put 'test_connection'
         end
-        resources :images, :except => [:show]
-        resources :key_pairs, :except => [:new, :edit, :update]
+        resources :images, except: [:show]
+        resources :key_pairs, except: [:new, :edit, :update]
       end
 
-      resources :realms, :except => [:show] do
+      resources :realms, except: [:show] do
         collection do
           get 'auto_complete_search'
         end
       end
     end
 
-    resources :subnets, :except => [:show] do
+    resources :subnets, except: [:show] do
       collection do
         get 'auto_complete_search'
         get 'import'
@@ -491,36 +491,36 @@ Foreman::Application.routes.draw do
 
   end
 
-  resources :widgets, :controller => 'dashboard', :only => [:show, :create, :destroy] do
+  resources :widgets, controller: 'dashboard', only: [:show, :create, :destroy] do
     collection do
-      post 'save_positions', :to => 'dashboard#save_positions'
-      put 'reset_default', :to => 'dashboard#reset_default'
+      post 'save_positions', to: 'dashboard#save_positions'
+      put 'reset_default', to: 'dashboard#reset_default'
     end
   end
 
-  root :to => 'dashboard#index'
-  get 'dashboard', :to => 'dashboard#index', :as => "dashboard"
-  get 'dashboard/auto_complete_search', :to => 'hosts#auto_complete_search', :as => "auto_complete_search_dashboard"
-  get 'status', :to => 'home#status', :as => "status"
+  root to: 'dashboard#index'
+  get 'dashboard', to: 'dashboard#index', as: "dashboard"
+  get 'dashboard/auto_complete_search', to: 'hosts#auto_complete_search', as: "auto_complete_search_dashboard"
+  get 'status', to: 'home#status', as: "status"
 
   # get only for alterator unattended scripts
-  get 'unattended/provision/:metadata', :controller => 'unattended', :action => 'host_template', :format => 'text',
-    :constraints => { :metadata => /(autoinstall\.scm|vm-profile\.scm|pkg-groups\.tar)/ }
+  get 'unattended/provision/:metadata', controller: 'unattended', action: 'host_template', format: 'text',
+    constraints: { metadata: /(autoinstall\.scm|vm-profile\.scm|pkg-groups\.tar)/ }
   # built call can be done both via GET (for backward compatibility) and POST
-  get 'unattended/built/(:id(:format))', :controller => 'unattended', :action => 'built', :format => 'text'
-  post 'unattended/built/(:id(:format))', :controller => 'unattended', :action => 'built', :format => 'text'
+  get 'unattended/built/(:id(:format))', controller: 'unattended', action: 'built', format: 'text'
+  post 'unattended/built/(:id(:format))', controller: 'unattended', action: 'built', format: 'text'
   # failed call only via POST
-  post 'unattended/failed/(:id(:format))', :controller => 'unattended', :action => 'failed', :format => 'text'
+  post 'unattended/failed/(:id(:format))', controller: 'unattended', action: 'failed', format: 'text'
   # get for all unattended scripts
-  get 'unattended/(:kind/(:id(:format)))', :controller => 'unattended', :action => 'host_template', :format => 'text'
+  get 'unattended/(:kind/(:id(:format)))', controller: 'unattended', action: 'host_template', format: 'text'
 
   get 'userdata/meta-data', controller: 'userdata', action: 'metadata', format: 'text'
   get 'userdata/user-data', controller: 'userdata', action: 'userdata', format: 'text'
 
-  resources :tasks, :only => [:show]
+  resources :tasks, only: [:show]
 
-  resources :locations, :except => [:show] do
-    resources :hosts, :only => :index
+  resources :locations, except: [:show] do
+    resources :hosts, only: :index
     member do
       get 'select'
       get "clone" => 'locations#clone_taxonomy'
@@ -540,7 +540,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :organizations, :except => [:show] do
+  resources :organizations, except: [:show] do
     member do
       get 'select'
       get "clone" => 'organizations#clone_taxonomy'
@@ -560,16 +560,16 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :about, :only => :index do
+  resources :about, only: :index do
   end
 
-  resources :interfaces, :only => :new do
+  resources :interfaces, only: :new do
     collection do
       get :random_name
     end
   end
 
-  resources :notification_recipients, :only => [:index, :update, :destroy] do
+  resources :notification_recipients, only: [:index, :update, :destroy] do
     collection do
       put 'group/:group' => 'notification_recipients#update_group_as_read'
       delete 'group/:group' => 'notification_recipients#destroy_group'
@@ -592,8 +592,8 @@ Foreman::Application.routes.draw do
   end
 
   match 'host_wizard' => 'react#index', :via => :get
-  constraints(:id => /[^\/]+/) do
+  constraints(id: /[^\/]+/) do
     match 'experimental/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
   end
-  get 'links/:type(/:section)' => 'links#show', as: 'external_link', constraints: { section: %r{.*} }
+  get 'links/:type(/:section)' => 'links#show', :as => 'external_link', :constraints => { section: %r{.*} }
 end


### PR DESCRIPTION
Follows #8064, to not mix keys, but for routes, I'd argue it's good to stay as consistent as possible, so changing for all the routes to ruby_19 style.