### PR TITLE
Fixes #31041 - Insights snippet - Add connection test

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/insights.erb
+++ b/app/views/unattended/provisioning_templates/snippet/insights.erb
@@ -12,5 +12,6 @@ echo '# Installing Insights client'
 echo '#'
 
 yum install -y insights-client
+insights-client --test-connection
 insights-client --register
 <% end -%>


### PR DESCRIPTION
If there is an issue with Foreman's Insights API (let's say 404),
`insights-client --register` command will fail with really-really long ugly HTML error.

Running `insights-client --test-connection` we can catch the error with
nice output like this:

```
Running Connection Tests...
=== Begin Upload URL Connection Test ===
Connection failed
=== End Upload URL Connection Test: FAILURE ===

=== Begin API URL Connection Test ===
Connection failed
=== End API URL Connection Test: FAILURE ===

Connectivity tests completed with some errors
See /var/log/insights-client/insights-client.log for more details.
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
