### PR TITLE
Fixes #31043 - Global Registration Template - Replace JSON in CURL with form-data

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -86,6 +86,13 @@ module Api
 
       private
 
+      def check_media_type
+        return super if action_name != 'host'
+        return if ["application/json", "application/x-www-form-urlencoded"].include?(request.media_type)
+
+        render_error(:unsupported_media_type, status: :unsupported_media_type)
+      end
+
       def find_host
         @host = Host.find_or_initialize_by(name: host_params('host')['name'])
       end

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -5,7 +5,7 @@ model: ProvisioningTemplate
 -%>
 #!/bin/sh
 <%
-    headers = ["-H 'Content-Type: application/json'", "-H 'Accept: application/json'", "-H 'Authorization: Bearer #{@auth_token}'"]
+    headers = ["-H 'Authorization: Bearer #{@auth_token}'"]
 -%>
 
 # Rendered with following template parameters:
@@ -34,12 +34,14 @@ EOF
 register_host() {
   curl --cacert $SSL_CA_CERT --request POST <%= foreman_server_url %>/register \
        <%= headers.join(' ') %> \
-       -d '{ "host": { "name": "'$(hostname --fqdn)'", "build": "false", "managed": "false"
-       <%= ", \"organization_id\": \"#{@organization.id}\"" if @organization -%>
-       <%= ", \"location_id\": \"#{@location.id}\"" if @location -%>
-       <%= ", \"hostgroup_id\": \"#{@hostgroup.id}\"" if @hostgroup -%>
-       <%= ", \"operatingsystem_id\": \"#{@operatingsystem.id}\"" if @operatingsystem -%>
-       }}'
+       --data "host[name]=$(hostname --fqdn)" \
+       --data "host[build]=false" \
+       --data "host[managed]=false" \
+       <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
+       <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
+       <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
+       <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
+
 }
 
 echo "#"
@@ -52,10 +54,9 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
         curl --cacert $SSL_CA_CERT --request POST "<%= foreman_server_url %>/register?uuid=$UUID" \
             <%= headers.join(' ') %> \
-            -d '{ "host": { "organization_id": "<%= @organization.id -%>"
-            <%= ", \"location_id\": \"#{@location.id}\"" if @location -%>
-            <%= ", \"hostgroup_id\": \"#{@hostgroup.id}\"" if @hostgroup -%>
-            }}'
+            <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
+            <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
+            <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
     }
 
     CONSUMER_RPM=$(mktemp --suffix .rpm)

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -153,5 +153,10 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
       post :host, params: host_params, session: set_session_user
       assert_response :internal_server_error
     end
+
+    test 'with unsupported media_type' do
+      post :host, params: host_params, session: set_session_user, as: :html
+      assert_response :unsupported_media_type
+    end
   end
 end


### PR DESCRIPTION
* Skipping `:check_media_type` so users can choose if they want to send data as `JSON` or `form-data`
* Replace `JSON` with `form-data` - It's easier to read plus no need for escaping special characters as before

**Tested on:**
OS | Version
------------ | -------------
Fedora | 31
CentOS | 7
RHEL | 7.8
Debian | 10
Ubuntu | 18.04

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
