### PR TITLE
Fixes #31048 - Fix 'add widget' dropdown header style

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -11,7 +11,7 @@ module DashboardHelper
         link_to_function(_('Save positions'), "tfm.dashboard.savePosition('#{save_positions_widgets_path}')"),
         link_to(_('Reset to default'), reset_default_widgets_path, :method => :put),
         content_tag(:li, '', :class => 'divider'),
-        content_tag(:li, _("Add widgets"), :class => 'nav-header'),
+        content_tag(:h6, _("Add widgets"), :class => 'dropdown-header'),
         content_tag(:li, '', :class => 'widget-add') do
           widgets_to_add
         end


### PR DESCRIPTION
The `Add widgets` option looks like a regular option that can be clicked, but it should be a header
before:
![no-header-section](https://user-images.githubusercontent.com/11807069/95749215-ed937a80-0ca3-11eb-9d4b-8b5ef78cb99d.png)
after:
![with-header-section](https://user-images.githubusercontent.com/11807069/95749235-f2582e80-0ca3-11eb-9798-5d540dc2bbc9.png)
