### PR TITLE
Fixes #31064 - sequence helper macro

### DIFF
--- a/lib/foreman/advisory_lock_manager.rb
+++ b/lib/foreman/advisory_lock_manager.rb
@@ -1,0 +1,52 @@
+# Simple advisory lock manager for PostgreSQL. When used on different database
+# it does not perform any locking. Rails (6) only implements advisory non-blocking
+# locking for migrations via Connection#get_advisory_lock which is not suitable
+# for application use. More information:
+#
+# https://www.postgresql.org/docs/current/explicit-locking.html
+# https://www.kostolansky.sk/posts/postgresql-advisory-locks/
+#
+module Foreman
+  class AdvisoryLockManager
+    class << self
+      # Performs transaction-level advisory lock which is automaticaly released when the
+      # built-in explicit transaction ends, or when the session ends.
+      def with_transaction_lock(lock_name)
+        if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+          lock_id = generate_lock_id(lock_name)
+          ActiveRecord::Base.transaction do
+            ActiveRecord::Base.connection.execute("SELECT pg_advisory_xact_lock(#{lock_id})")
+            yield
+          end
+        else
+          yield
+        end
+      end
+
+      # Performs session-level advisory lock which is automaticaly released when the block
+      # returns. Does not create explicit transaction.
+      def with_session_lock(lock_name)
+        if ActiveRecord::Base.connection.adapter_name == 'PostgreSQL'
+          begin
+            lock_id = generate_lock_id(lock_name)
+            ActiveRecord::Base.connection.execute("SELECT pg_advisory_lock(#{lock_id})")
+            yield
+          ensure
+            ActiveRecord::Base.connection.execute("SELECT pg_advisory_unlock(#{lock_id})")
+          end
+        else
+          yield
+        end
+      end
+
+      private
+
+      # PostgreSQL requires signed 64 bit (BIGINT), this uses built-in Ruby hash to generate it.
+      # The method can result in different results with different Ruby versions, but this is
+      # unlikely to happen (possibly during rolling restart when upgrading to new Ruby).
+      def generate_lock_id(lock_name)
+        lock_name.to_s.hash & 0x7FFFFFFFFFFFFFFF
+      end
+    end
+  end
+end

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -43,6 +43,7 @@ module Foreman
         :number_with_precision,
         :number_to_human_size,
         :gem_version_compare,
+        :sequence_hostgroup_param_next,
         :parse_yaml,
         :parse_json,
         :to_json,

--- a/lib/foreman/renderer/errors.rb
+++ b/lib/foreman/renderer/errors.rb
@@ -42,6 +42,10 @@ module Foreman
       class UnknownReportColumn < RenderingError
         MESSAGE = N_('Rendering failed, one or more unknown columns specified for ordering - "%{unknown}"').freeze
       end
+
+      class HostgroupNotFoundError < RenderingError
+        MESSAGE = N_('Hostgroup not found or not accessible').freeze
+      end
     end
   end
 end

--- a/test/unit/foreman/advisory_lock_manager_test.rb
+++ b/test/unit/foreman/advisory_lock_manager_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class AdvisoryLockManagerTest < ActiveSupport::TestCase
+  test "transaction lock" do
+    ::Foreman::AdvisoryLockManager.with_transaction_lock("test_lock") do
+      # just perform a dummy select for a fixture
+      assert Setting.unscoped.count > 0
+    end
+  end
+
+  test "transaction lock" do
+    ::Foreman::AdvisoryLockManager.with_session_lock("test_tx_lock") do
+      # just perform a dummy select for a fixture
+      assert Setting.unscoped.count > 0
+    end
+  end
+end

--- a/test/unit/foreman/renderer/scope/macros/helpers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/helpers_test.rb
@@ -1,7 +1,61 @@
 require 'test_helper'
 
 class HelpersTest < ActiveSupport::TestCase
-  let(:scope) { Class.new.include(Foreman::Renderer::Scope::Macros::Helpers).new }
+  class HelpersTestScope
+    def initialize(preview)
+      @preview = preview
+    end
+
+    def preview?
+      @preview
+    end
+  end
+
+  let(:scope) { HelpersTestScope.include(Foreman::Renderer::Scope::Macros::Helpers).new(false) }
+  let(:preview_scope) { HelpersTestScope.include(Foreman::Renderer::Scope::Macros::Helpers).new(true) }
+
+  describe '#sequence_hostgroup_param_next' do
+    let(:hg) { FactoryBot.create(:hostgroup) }
+
+    it "should default to 1" do
+      assert_equal "1", scope.sequence_hostgroup_param_next(hg.title)
+    end
+
+    it "preview should not increase" do
+      assert_equal "1", scope.sequence_hostgroup_param_next(hg.title)
+      assert_equal "2", preview_scope.sequence_hostgroup_param_next(hg.title)
+      assert_equal "2", preview_scope.sequence_hostgroup_param_next(hg.title)
+    end
+
+    it "should increase by one" do
+      assert_equal "1", scope.sequence_hostgroup_param_next(hg.title)
+      assert_equal "2", scope.sequence_hostgroup_param_next(hg.title)
+      hg.reload
+      assert_equal 2, hg.parameters["sequence_num_default"]
+    end
+
+    it "should store the counter in a hostgroup parameter" do
+      assert_equal "200", scope.sequence_hostgroup_param_next(hg.title, 200)
+      hg.reload
+      assert_equal 200, hg.parameters["sequence_num_default"]
+    end
+
+    it "should store the counter in a hostgroup parameter under a name" do
+      assert_equal "200", scope.sequence_hostgroup_param_next(hg.title, 200, "mycounter")
+      hg.reload
+      assert_equal 200, hg.parameters["sequence_num_mycounter"]
+    end
+
+    it "should store the counter with leading zeroes" do
+      assert_equal "00003", scope.sequence_hostgroup_param_next(hg.title, 3, "mycounter", 5)
+    end
+
+    it "should raise an error on non-existing hostgroup" do
+      assert_raises Foreman::Renderer::Errors::HostgroupNotFoundError do
+        scope.sequence_hostgroup_param_next('does-not-exist')
+      end
+    end
+  end
 
   describe '#parse_yaml' do
     let(:data) { "---\nkey: value\n" }


### PR DESCRIPTION
Users cannot assign sequence numbers to hostnames or other artifacts during provisioning. Initially I was thinking storing these into global settings, but hostgroups seem to be better place because then they can be easily accessed by users. Also users can create multiple sequences per hostgroup. Also it supports number casting.