### PR TITLE
POC rails form helpers use React

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,18 +1,12 @@
 module FormHelper
   def text_f(f, attr, options = {})
-    field(f, attr, options) do
-      addClass options, "form-control"
-      options[:focus_on_load] = true if options[:focus_on_load].nil? && attr.to_s == 'name'
-      f.text_field attr, options
-    end
+    options[:rows] = line_count(f, attr) if options[:rows] == :auto
+    react_form_input('text', f, attr, options)
   end
 
   def textarea_f(f, attr, options = {})
-    field(f, attr, options) do
-      options[:rows] = line_count(f, attr) if options[:rows] == :auto
-      addClass options, "form-control"
-      f.text_area(attr, options)
-    end
+    options[:rows] = line_count(f, attr) if options[:rows] == :auto
+    react_form_input('textarea', f, attr, options)
   end
 
   def password_f(f, attr, options = {})
@@ -427,7 +421,6 @@ module FormHelper
     options[:error] ||= get_attr_error(f, attr)
     options[:error] = options[:error]&.to_sentence
     options[:required] = is_required?(f, attr) unless options.key?(:required)
-
     Tags::ReactInput.new(f.object_name, attr, self, options.merge(type: type, object: f.object)).render
   end
 

--- a/app/helpers/tags/react_input.rb
+++ b/app/helpers/tags/react_input.rb
@@ -26,6 +26,10 @@ module Tags
       react_opts = {}
       react_opts['inputSizeClass'] = options.delete('size') if options.key?('size')
       react_opts['labelSizeClass'] = options.delete('label_size') if options.key?('label_size')
+      react_opts['helpBlock'] = options.delete('help_block') if options.key?('help_block') && options['help_block'].html_safe?
+      react_opts['helpInline'] = options.delete('help_inline') if options.key?('help_inline') && options['help_inline'].html_safe?
+      react_opts['labelHelp'] = options.delete('label_help') if options.key?('label_help')
+      react_opts['wrapperClass'] = options.delete('wrapper_class') if options.key?('wrapper_class')
       react_opts.merge! deep_camelize_keys(options)
       react_opts['inputProps']['name'] = options['name'] if options['name'] && react_opts['inputProps']
       react_opts

--- a/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
@@ -9,7 +9,6 @@ import {
   FieldLevelHelp,
 } from 'patternfly-react';
 import InputFactory from './InputFactory';
-import { noop } from '../../../common/helpers';
 
 const InlineMessage = ({ error, helpInline }) => {
   if (!error && !helpInline) {
@@ -19,7 +18,7 @@ const InlineMessage = ({ error, helpInline }) => {
     <HelpBlock
       className={classNames('help-inline', { 'error-message': !!error })}
     >
-      {error || helpInline}
+      {error || <div dangerouslySetInnerHTML={{ __html: helpInline }} />}
     </HelpBlock>
   );
 };
@@ -44,6 +43,8 @@ const FormField = ({
   label,
   labelHelp,
   helpInline,
+  helpBlock,
+  wrapperClass,
   labelSizeClass,
   inputSizeClass,
   onChange,
@@ -67,6 +68,7 @@ const FormField = ({
       controlId={id}
       disabled={disabled}
       validationState={error ? 'error' : null}
+      className={wrapperClass}
     >
       <ControlLabel className={labelSizeClass}>
         {label}
@@ -81,6 +83,7 @@ const FormField = ({
       </ControlLabel>
       <Col className={inputSizeClass}>
         {children || <InputFactory type={type} {...controlProps} />}
+        <InlineMessage helpInline={helpBlock} />
       </Col>
       <InlineMessage error={error} helpInline={helpInline} />
     </FormGroup>
@@ -110,6 +113,8 @@ FormField.propTypes = {
   onChange: PropTypes.func,
   children: PropTypes.element,
   inputProps: PropTypes.object,
+  helpBlock: PropTypes.string,
+  wrapperClass: PropTypes.string,
 };
 
 FormField.defaultProps = {
@@ -126,9 +131,11 @@ FormField.defaultProps = {
   helpInline: null,
   inputSizeClass: 'col-md-4',
   labelSizeClass: 'col-md-2',
-  onChange: noop,
+  onChange: null,
   children: null,
   inputProps: null,
+  helpBlock: '',
+  wrapperClass: '',
 };
 
 export default FormField;

--- a/webpack/assets/javascripts/react_app/components/common/forms/InputFactory.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/InputFactory.js
@@ -1,8 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FormControl } from 'patternfly-react';
 
-import { noop } from '../../../common/helpers';
 import AutoComplete from '../../AutoComplete';
 import DateTimePicker from '../DateTimePicker/DateTimePicker';
 import DatePicker from '../DateTimePicker/DatePicker';
@@ -25,13 +24,19 @@ export const registerInputComponent = (name, Component) => {
 
 export const getComponentClass = name => inputComponents[name] || 'input';
 
-const InputFactory = ({ type, ...controlProps }) => (
-  <FormControl
-    componentClass={getComponentClass(type)}
-    type={type}
-    {...controlProps}
-  />
-);
+const InputFactory = ({ type, onChange, value, ...controlProps }) => {
+  const [stateValue, setstateValue] = useState(value || '');
+  const defaultOnChange = e => setstateValue(e.target.value);
+  return (
+    <FormControl
+      componentClass={getComponentClass(type)}
+      type={type}
+      value={stateValue}
+      onChange={onChange || defaultOnChange}
+      {...controlProps}
+    />
+  );
+};
 
 InputFactory.propTypes = {
   type: PropTypes.string,
@@ -55,7 +60,7 @@ InputFactory.defaultProps = {
   className: '',
   required: false,
   disabled: false,
-  onChange: noop,
+  onChange: null,
 };
 
 export default InputFactory;


### PR DESCRIPTION
We want rails form helpers to start using React so when the React forms will change the rails ones will change too.
Starting with text as it's the simplest one and it works well.
The issue here is rails test which test forms, for example:
https://github.com/theforeman/foreman/blob/93dd5ad7657023873c87c7aabeba4e9ed23f713e/test/integration/domain_test.rb#L3-L9
The issue is that it doesn't load the React component so it can't find the form field.
I tried running it with `class DomainIntegrationTest < IntegrationTestWithJavascript` but then it doesn't fill the value, is there a way to solve this for all tests?