### PR TITLE
Fixes #31091 - logging config absolute path

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -120,10 +120,11 @@ module Foreman
     private
 
     def load_config(environment, overrides = {})
-      fail "Logging configuration 'config/logging.yaml' not present" unless File.exist?('config/logging.yaml')
+      config_file = Rails.root.join('config', 'logging.yaml')
+      fail "Logging configuration 'config/logging.yaml' not present" unless File.exist?(config_file)
       overrides ||= {}
       overrides.deep_merge!(overrides[environment.to_sym]) if overrides.has_key?(environment.to_sym)
-      @config = YAML.load_file('config/logging.yaml')
+      @config = YAML.load_file(config_file)
       @config = @config[:default].deep_merge(@config[environment.to_sym]).deep_merge(overrides)
     end
 


### PR DESCRIPTION
Use absolute path for logging config file lookup.

Motivation:
In https://github.com/theforeman/foreman_puppet_enc/pull/45 I'm trying to run rake tasks from plugin directory.
As Rails officially supports it, I think it should be possible to do in our plugins.
It is just for developers convenience - not to need switch folders all the time to run the rake.
So it's not a big deal, but there is not much missing to enable it. This is one of the blockers for it.