### PR TITLE
Fixes #31097 - link to a tab in host details page

### DIFF
--- a/app/assets/javascripts/hosts.js
+++ b/app/assets/javascripts/hosts.js
@@ -1,4 +1,6 @@
 $(document).on('ContentLoad', function() {
+  tfm.tools.setTab();
+
   var dialog = $('#review_before_build');
   $('#build-review').click(function() {
     dialog.find('.modal-body #build_status').html('');
@@ -57,3 +59,5 @@ $(document).on('ContentLoad', function() {
     }
   });
 });
+
+$(window).on('hashchange', tfm.tools.setTab);

--- a/app/assets/javascripts/proxy_status.js
+++ b/app/assets/javascripts/proxy_status.js
@@ -12,10 +12,10 @@ $(document).on('ContentLoad', function() {
   });
   showProxies();
   loadTFTP();
-  setTab();
+  tfm.tools.setTab();
 });
 
-$(window).on('hashchange', setTab); //so buttons that link to an anchor can open that tab
+$(window).on('hashchange', tfm.tools.setTab); //so buttons that link to an anchor can open that tab
 
 function setItemStatus(item, response) {
   if (response.success && response.message && response.message.warning) {
@@ -119,17 +119,4 @@ function populateData(response, item) {
   item.find('.proxy-show-status').each(function() {
     setItemStatus($(this), response);
   });
-}
-
-// Make sure the correct tab is displayed when loading the page with an anchor,
-// even if the anchor is to a sub-tab.
-function setTab() {
-  var anchor = document.location.hash.split('?')[0];
-  if (anchor.length) {
-    var parent_tab = $(anchor).parents('.tab-pane');
-    if (parent_tab.exists()) {
-      $('.nav-tabs a[href="#' + parent_tab[0].id + '"]').tab('show');
-    }
-    $('.nav-tabs a[href="' + anchor + '"]').tab('show');
-  }
 }

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -28,7 +28,7 @@
       </tbody>
     </table>
 
-    <ul id="myTab" class="nav nav-tabs">
+    <ul id="host-show-tabs" class="nav nav-tabs">
       <li class="active"><a href="#properties" data-toggle="tab"><%= _('Properties') %></a></li>
       <li><a href="#metrics" data-toggle="tab"><%= _('Metrics') %></a></li>
       <% if SETTINGS[:unattended] && @host.managed? %>
@@ -43,7 +43,7 @@
       <li><a href="#nics" data-toggle="tab"><%= _('NICs') %></a></li>
       <%= render_tab_header_for(:main_tabs, :subject => @host) %>
     </ul>
-    <div id="myTabContent" class="tab-content">
+    <div id="host-show-tabs-content" class="tab-content">
       <div class="tab-pane active in" id="properties" data-ajax-url='<%= overview_host_path(@host)%>'>
         <%= spinner(_('Loading host information ...')) %>
       </div>

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -25,16 +25,38 @@ class HostJSTest < IntegrationTestWithJavascript
     Fog.unmock!
   end
 
-  test "show page" do
-    visit hosts_path
-    click_link @host.fqdn
-    assert_breadcrumb_text(@host.fqdn)
-    assert page.has_link?("Properties", :href => "#properties")
-    assert page.has_link?("Metrics", :href => "#metrics")
-    assert page.has_link?("Templates", :href => "#template")
-    assert page.has_link?("Edit", :href => "/hosts/#{@host.fqdn}/edit")
-    assert page.has_link?("Build", :href => "/hosts/#{@host.fqdn}#review_before_build")
-    assert page.has_link?("Delete", :href => "/hosts/#{@host.fqdn}")
+  describe "show page" do
+    test "has proper title and links" do
+      visit hosts_path
+      click_link @host.fqdn
+      assert_breadcrumb_text(@host.fqdn)
+      assert page.has_link?("Properties", :href => "#properties")
+      assert page.has_link?("Metrics", :href => "#metrics")
+      assert page.has_link?("Templates", :href => "#template")
+      assert page.has_link?("Edit", :href => "/hosts/#{@host.fqdn}/edit")
+      assert page.has_link?("Build", :href => "/hosts/#{@host.fqdn}#review_before_build")
+      assert page.has_link?("Delete", :href => "/hosts/#{@host.fqdn}")
+    end
+
+    test "link to specific tab in show page" do
+      host = FactoryBot.create(:host)
+
+      visit "#{host_path(host)}#metrics"
+      wait_for_ajax
+
+      page.assert_selector('#host-show-tabs li.active', count: 1, text: "Metrics")
+      page.assert_selector('#host-show-tabs-content div.active', count: 1, text: /No puppet activity/)
+    end
+
+    test "default active tab is properties" do
+      host = FactoryBot.create(:host)
+
+      visit host_path(host) # not passing the active-tab param here
+      wait_for_ajax
+
+      page.assert_selector('#host-show-tabs li.active', count: 1, text: "Properties")
+      page.assert_selector('#host-show-tabs-content div.active', count: 1, text: /Properties/)
+    end
   end
 
   describe 'multiple hosts selection' do

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -134,3 +134,15 @@ export function updateTable(element) {
 
 // generates an absolute, needed in case of running Foreman from a subpath
 export { foremanUrl } from './react_app/common/helpers';
+
+export const setTab = () => {
+  const urlHash = document.location.hash.split('?')[0];
+  if (urlHash.length) {
+    const tabContent = $(urlHash);
+    const parentTab = tabContent.closest('.tab-pane');
+    if (parentTab.exists()) {
+      $(`.nav-tabs a[href="#${parentTab[0].id}"]`).tab('show');
+    }
+    $(`.nav-tabs a[href="${urlHash}"]`).tab('show');
+  }
+};


### PR DESCRIPTION
### started as:

This should enable clicking on a link with an href like:
"https:/localhost:3000/{host-uuid}#templates"
to open the templates tab in the host details page.

The feature is needed for a plugin I am working on,
to link into the specific tab without the user needs to find it.

### update:
implement it on the server side instead

now go to "https:/localhost:3000/{host-uuid}?active-tab=templates"
to open the templates tab in the host details page.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
