### PR TITLE
Fixes #31099 - filter out unstable facts: memory and load

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -14,6 +14,17 @@ class Setting::Provisioning < Setting
   Setting::BLANK_ATTRS.push(*(default_global_labels + local_boot_labels))
   validates :value, :pxe_template_name => true, :if => proc { |s| s.class.default_global_labels.include?(s.name) }
 
+  # facts which change way too often
+  IGNORED_FACTS = [
+    'load_averages::*',
+    'memory::system::capacity',
+    'memory::system::used*',
+    'memory::system::available*',
+    'memory::swap::capacity',
+    'memory::swap::used*',
+    'memory::swap::available*',
+  ].freeze
+
   IGNORED_INTERFACES = [
     'lo',
     'en*v*',
@@ -32,7 +43,7 @@ class Setting::Provisioning < Setting
     'vlinuxbr*',
     'vovsbr*',
     'br-int',
-  ]
+  ].freeze
 
   def self.default_settings
     fqdn = SETTINGS[:fqdn]
@@ -110,7 +121,7 @@ class Setting::Provisioning < Setting
     end
   end
 
-  def self.default_excluded_facts(ignored_interfaces = IGNORED_INTERFACES)
-    ignored_interfaces
+  def self.default_excluded_facts
+    IGNORED_INTERFACES + IGNORED_FACTS
   end
 end

--- a/test/fact_importer_test_helper.rb
+++ b/test/fact_importer_test_helper.rb
@@ -162,6 +162,19 @@ module FactsData
         'net::interface::docker4::ipv6_netmask::link_list' => '64',
         'net::interface::vlinuxbr4::mac_address' => 'FE:54:00:59:4E:BF',
         'net::interface::usb4::permanent_mac_address' => 'Unknown',
+        'load_averages::5m' => '0.01',
+        'load_averages::10m' => '0.02',
+        'load_averages::15m' => '0.03',
+        'memory::system::capacity' => '0%',
+        'memory::system::used' => '0 bytes',
+        'memory::system::used_bytes' => '0',
+        'memory::system::available' => '1.00 GiB',
+        'memory::system::available_bytes' => '1073737728',
+        'memory::swap::capacity' => '0%',
+        'memory::swap::used' => '0 bytes',
+        'memory::swap::used_bytes' => '0',
+        'memory::swap::available' => '1.00 GiB',
+        'memory::swap::available_bytes' => '1073737728',
       }
     end
   end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -345,7 +345,7 @@ attribute77:
 attributes78:
   name: excluded_facts
   category: Setting::Provisioning
-  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*']"
+  default: "['lo', 'en*v*', 'usb*', 'vnet*', 'macvtap*', '_vdsmdummy_', 'veth*', 'docker*', 'tap*', 'qbr*', 'qvb*', 'qvo*', 'qr-*', 'qg-*', 'vlinuxbr*', 'vovsbr*', 'load_averages::*', 'memory::system::capacity', 'memory::system::used*', 'memory::system::available*', 'memory::swap::capacity', 'memory::swap::used*', 'memory::swap::available*']"
   description: 'Ignore fact names that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*'
   settings_type: 'array'
 attribute79:


### PR DESCRIPTION
Filter out puppet facts which are unstable. For more info read: https://community.theforeman.org/t/facter-4-and-unstable-facts/20900