### PR TITLE
Fixes #29017 - do not show 2nd tooltip on SP name

### DIFF
--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -17,7 +17,7 @@
   <tbody>
     <% for proxy in @smart_proxies %>
       <tr class="proxy-show" data-url="<%= ping_smart_proxy_path(proxy) %>">
-        <td class="nbsp ellipsis"><%= link_to_if_authorized proxy.name, {:action => :show, :id => proxy}, :title => proxy.url %></td>
+        <td class="nbsp ellipsis"><%= link_to_if_authorized proxy.name, {:action => :show, :id => proxy} %></td>
         <td class="hidden-sm hidden-xs nbsp ellipsis"><%= generate_links_for(proxy.locations).html_safe %></td>
         <td class="hidden-sm hidden-xs nbsp ellipsis"><%= generate_links_for(proxy.organizations).html_safe %></td>
         <td class="ellipsis"><%= proxy.features.map(&:name).sort.to_sentence %></td>


### PR DESCRIPTION
Previously the smart proxy name always appeared on
a tooltip when hovering, even when the name was fully
displayed.  That meant that when the name wasn't fully
displayed the ellipsis would display a 2nd tooltip too.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
