### PR TITLE
Fixes #31100 - Create PF4 Bookmarks dropdown

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksReducer.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksReducer.js
@@ -33,12 +33,15 @@ export default (state = initialState, { type, payload, response }) => {
         .setIn([payload.controller, 'results'], response.results)
         .setIn([payload.controller, 'status'], STATUS.RESOLVED);
     case BOOKMARKS_FORM_SUBMITTED:
-      return state.setIn(
-        [payload.data.controller, 'results'],
-        [...state[payload.data.controller].results, payload.data].sort(
-          sortByName
-        )
-      );
+      if (state[payload.data.controller]?.results) {
+        return state.setIn(
+          [payload.data.controller, 'results'],
+          [...state[payload.data.controller].results, payload.data].sort(
+            sortByName
+          )
+        );
+      }
+      return state;
     case BOOKMARKS_FAILURE:
       return state
         .setIn([payload.controller, 'errors'], response)

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarkItems.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarkItems.js
@@ -1,0 +1,60 @@
+import React from 'react';
+import EllipisWithTooltip from 'react-ellipsis-with-tooltip';
+import { DropdownItem, DropdownGroup, Spinner } from '@patternfly/react-core';
+import { sprintf, translate as __ } from '../../../common/I18n';
+import { STATUS } from '../../../constants';
+import DocumentationUrl from '../DocumentationLink';
+
+export const actionItems = ({ canCreate, setModalOpen, documentationUrl }) => (
+  <DropdownGroup key="group 1">
+    {canCreate && (
+      <DropdownItem key="newBookmark" id="newBookmark" onClick={setModalOpen}>
+        {__('Bookmark this search')}
+      </DropdownItem>
+    )}
+    <DocumentationUrl href={documentationUrl} />
+  </DropdownGroup>
+);
+
+const pendingItem = (
+  <DropdownItem key="spinner" className="loader-root" isDisabled>
+    <Spinner size="xs" />
+  </DropdownItem>
+);
+
+const bookmarksList = ({ bookmarks, onBookmarkClick }) =>
+  (bookmarks.length > 0 &&
+    bookmarks.map(({ name, query }) => (
+      <DropdownItem key={name} onClick={() => onBookmarkClick(query)}>
+        <EllipisWithTooltip>{name}</EllipisWithTooltip>
+      </DropdownItem>
+    ))) || (
+    <DropdownItem key="not found" isDisabled>
+      {__('None found')}
+    </DropdownItem>
+  );
+
+const errorItem = errors => (
+  <DropdownItem key="bookmarks-errors" isDisabled>
+    <EllipisWithTooltip>
+      {sprintf('Failed to load bookmarks: %s', errors)}
+    </EllipisWithTooltip>
+  </DropdownItem>
+);
+
+export const savedBookmarksItems = ({
+  bookmarks,
+  onBookmarkClick,
+  status,
+  errors,
+}) => (
+  <DropdownGroup key="saved bookmarks" label={__('Saved Bookmarks')}>
+    {[
+      status === STATUS.PENDING && [pendingItem],
+      status === STATUS.RESOLVED && [
+        bookmarksList({ bookmarks, onBookmarkClick }),
+      ],
+      status === STATUS.ERROR && [errorItem(errors)],
+    ].filter(item => item)}
+  </DropdownGroup>
+);

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.fixtures.js
@@ -1,0 +1,43 @@
+export const controller = 'hosts';
+/* eslint-disable camelcase */
+export const bookmarks = [
+  {
+    name: '1111',
+    controller,
+    query: 'abc',
+    public: true,
+    id: 52,
+    owner_id: 1,
+    owner_type: 'User',
+  },
+  {
+    name: '1122',
+    controller,
+    query: 'abc',
+    public: true,
+    id: 54,
+    owner_id: 1,
+    owner_type: 'User',
+  },
+];
+
+export const response = {
+  data: {
+    results: bookmarks,
+  },
+};
+
+export const name = 'Joe.D';
+export const search = 'name ~ my';
+export const publik = false;
+export const item = 'Bookmark';
+
+export const submitResponse = {
+  data: {
+    name,
+    query: search,
+    controller,
+    public: publik,
+  },
+  item,
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown, DropdownToggle } from '@patternfly/react-core';
+import { BookmarkIcon } from '@patternfly/react-icons';
+import BookmarkModal from '../../Bookmarks/components/SearchModal';
+import { STATUS } from '../../../constants';
+import { noop } from '../../../common/helpers';
+import { actionItems, savedBookmarksItems } from './BookmarkItems';
+
+const Bookmarks = ({
+  bookmarks,
+  status,
+  url,
+  controller,
+  getBookmarks,
+  canCreate,
+  errors,
+  documentationUrl,
+  onBookmarkClick,
+  setModalOpen,
+  setModalClosed,
+}) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+
+  const onToggle = isOpen => {
+    setIsDropdownOpen(isOpen);
+    if (bookmarks.length === 0 && status !== STATUS.PENDING) {
+      getBookmarks();
+    }
+  };
+  const dropdownItems = [
+    actionItems({ canCreate, setModalOpen, documentationUrl }),
+    savedBookmarksItems({
+      bookmarks,
+      onBookmarkClick,
+      status,
+      errors,
+    }),
+  ];
+
+  return (
+    <React.Fragment>
+      <BookmarkModal
+        controller={controller}
+        url={url}
+        setModalClosed={setModalClosed}
+        bookmarks={bookmarks}
+      />
+      <Dropdown
+        isOpen={isDropdownOpen}
+        toggle={
+          <DropdownToggle onToggle={onToggle}>
+            <BookmarkIcon />
+          </DropdownToggle>
+        }
+        id={controller}
+        dropdownItems={dropdownItems}
+        isGrouped
+      />
+    </React.Fragment>
+  );
+};
+
+Bookmarks.propTypes = {
+  controller: PropTypes.string.isRequired,
+  onBookmarkClick: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
+  canCreate: PropTypes.bool,
+  bookmarks: PropTypes.array,
+  errors: PropTypes.string,
+  status: PropTypes.string,
+  documentationUrl: PropTypes.string,
+  getBookmarks: PropTypes.func,
+  setModalOpen: PropTypes.func.isRequired,
+  setModalClosed: PropTypes.func.isRequired,
+};
+
+Bookmarks.defaultProps = {
+  canCreate: false,
+  bookmarks: [],
+  errors: '',
+  status: null,
+  documentationUrl: '',
+  getBookmarks: noop,
+};
+
+export default Bookmarks;

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.stories.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.stories.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import Bookmarks from './Bookmarks';
+import Story from '../../../../../../stories/components/Story';
+import store from '../../../redux';
+
+export default {
+  title: 'Components|PF4 Bookmarks',
+  decorators: [],
+};
+
+export const defaultStory = () => (
+  <Provider store={store}>
+    <Story>
+      <Bookmarks
+        controller="storybook"
+        onBookmarkClick={() => null}
+        url=""
+        canCreate
+        bookmarks={[
+          {
+            name: 'recent hosts',
+            query: '',
+          },
+          {
+            name: 'managed hosts',
+            query: '',
+          },
+          {
+            name: 'disabled hosts',
+            query: '',
+          },
+        ]}
+        status="RESOLVED"
+        setModalOpen={() => null}
+        setModalClosed={() => null}
+      />
+    </Story>
+  </Provider>
+);
+
+defaultStory.story = {
+  name: 'Default',
+};
+
+export const pendingStory = () => (
+  <Provider store={store}>
+    <Story>
+      <Bookmarks
+        controller="storybook"
+        onBookmarkClick={() => null}
+        url=""
+        canCreate
+        bookmarks={[]}
+        status="PENDING"
+        setModalOpen={() => null}
+        setModalClosed={() => null}
+      />
+    </Story>
+  </Provider>
+);
+
+pendingStory.story = {
+  name: 'Pending',
+};
+
+export const errorStory = () => (
+  <Provider store={store}>
+    <Story>
+      <Bookmarks
+        controller="storybook"
+        onBookmarkClick={() => null}
+        url=""
+        canCreate
+        bookmarks={[]}
+        status="ERROR"
+        errors="Some error!"
+        setModalOpen={() => null}
+        setModalClosed={() => null}
+      />
+    </Story>
+  </Provider>
+);
+
+errorStory.story = {
+  name: 'Error',
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksActions.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksActions.js
@@ -1,0 +1,14 @@
+import URI from 'urijs';
+import { get } from '../../../redux/API';
+import { BOOKMARKS } from './BookmarksConstants';
+
+export const getBookmarks = (url, controller) => {
+  const uri = new URI(url);
+  // eslint-disable-next-line camelcase
+  uri.setSearch({ search: `controller=${controller}`, per_page: 'all' });
+
+  return get({
+    url: uri.toString(),
+    key: `${BOOKMARKS}_${controller.toUpperCase()}`,
+  });
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksConstants.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksConstants.js
@@ -1,0 +1,5 @@
+export const BOOKMARKS = 'BOOKMARKS';
+export const BOOKMARKS_FORM_SUBMITTED_SUCCESS =
+  'BOOKMARKS_FORM_SUBMITTED_SUCCESS';
+
+export const BOOKMARKS_MODAL = 'bookmarksModal';

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksReducer.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksReducer.js
@@ -1,0 +1,16 @@
+import Immutable from 'seamless-immutable';
+import { BOOKMARKS_FORM_SUBMITTED_SUCCESS } from './BookmarksConstants';
+
+export const initialState = Immutable({});
+
+export default (state = initialState, { type, payload, response }) => {
+  switch (type) {
+    case BOOKMARKS_FORM_SUBMITTED_SUCCESS:
+      return state.setIn(
+        [response.controller, 'results'],
+        [...(state.results || []), response]
+      );
+    default:
+      return state;
+  }
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksSelectors.js
@@ -1,0 +1,21 @@
+import { selectAPIResponse } from '../../../redux/API/APISelectors';
+
+const sortByName = (a, b) => {
+  if (a.name < b.name) {
+    return -1;
+  }
+  if (a.name > b.name) {
+    return 1;
+  }
+  // names must be equal
+  return 0;
+};
+const selectBookmarks = state => state.bookmarksPF4 || {};
+const selectBookmarksByController = (state, controller) =>
+  selectBookmarks(state)[controller] || {};
+
+export const selectBookmarksResults = (store, key, controller) =>
+  [
+    ...(selectBookmarksByController(store, controller).results || []),
+    ...(selectAPIResponse(store, key).results || []),
+  ].sort(sortByName);

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/Bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/Bookmarks.test.js
@@ -1,0 +1,42 @@
+import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+
+import Bookmarks from '../Bookmarks';
+import { STATUS } from '../../../../constants';
+
+const commonFixture = {
+  controller: 'architectures',
+  onBookmarkClick: () => {},
+  url: '/api/v2/architectures',
+  documentationUrl: 'https://test-docs.com',
+  canCreate: true,
+  status: STATUS.PENDING,
+  errors: null,
+  bookmarks: [],
+  setModalOpen: jest.fn(),
+  setModalClosed: jest.fn(),
+};
+
+const fixtures = {
+  'should render bookmarks dropdown when loading': {
+    ...commonFixture,
+  },
+  'should render bookmarks dropdown when loaded': {
+    ...commonFixture,
+    status: STATUS.RESOLVED,
+    bookmarks: [
+      { name: 'my-bookmark', controller: 'architectures', query: 'name ~ 86' },
+    ],
+  },
+  'should render when no bookmarks loaded': {
+    ...commonFixture,
+    status: STATUS.RESOLVED,
+  },
+  'should show error': {
+    ...commonFixture,
+    status: STATUS.ERROR,
+    errors: 'Random test error',
+  },
+};
+
+describe('Bookmarks', () =>
+  testComponentSnapshotsWithFixtures(Bookmarks, fixtures));

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
@@ -1,0 +1,236 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
+<Fragment>
+  <SearchModal
+    bookmarks={
+      Array [
+        Object {
+          "controller": "architectures",
+          "name": "my-bookmark",
+          "query": "name ~ 86",
+        },
+      ]
+    }
+    controller="architectures"
+    onEnter={[Function]}
+    setModalClosed={[MockFunction]}
+    title="Create Bookmark"
+    url="/api/v2/architectures"
+  />
+  <Dropdown
+    dropdownItems={
+      Array [
+        <DropdownGroup>
+          <DropdownItem
+            id="newBookmark"
+            onClick={[MockFunction]}
+          >
+            Bookmark this search
+          </DropdownItem>
+          <DocumentationLink
+            href="https://test-docs.com"
+          >
+            Documentation
+          </DocumentationLink>
+        </DropdownGroup>,
+        <DropdownGroup
+          label="Saved Bookmarks"
+        >
+          <DropdownItem
+            onClick={[Function]}
+          >
+            <EllipisWithTooltip>
+              my-bookmark
+            </EllipisWithTooltip>
+          </DropdownItem>
+        </DropdownGroup>,
+      ]
+    }
+    id="architectures"
+    isGrouped={true}
+    isOpen={false}
+    toggle={
+      <DropdownToggle
+        onToggle={[Function]}
+      >
+        <BookmarkIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </DropdownToggle>
+    }
+  />
+</Fragment>
+`;
+
+exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
+<Fragment>
+  <SearchModal
+    bookmarks={Array []}
+    controller="architectures"
+    onEnter={[Function]}
+    setModalClosed={[MockFunction]}
+    title="Create Bookmark"
+    url="/api/v2/architectures"
+  />
+  <Dropdown
+    dropdownItems={
+      Array [
+        <DropdownGroup>
+          <DropdownItem
+            id="newBookmark"
+            onClick={[MockFunction]}
+          >
+            Bookmark this search
+          </DropdownItem>
+          <DocumentationLink
+            href="https://test-docs.com"
+          >
+            Documentation
+          </DocumentationLink>
+        </DropdownGroup>,
+        <DropdownGroup
+          label="Saved Bookmarks"
+        >
+          <DropdownItem
+            className="loader-root"
+            isDisabled={true}
+          >
+            <Spinner
+              size="xs"
+            />
+          </DropdownItem>
+        </DropdownGroup>,
+      ]
+    }
+    id="architectures"
+    isGrouped={true}
+    isOpen={false}
+    toggle={
+      <DropdownToggle
+        onToggle={[Function]}
+      >
+        <BookmarkIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </DropdownToggle>
+    }
+  />
+</Fragment>
+`;
+
+exports[`Bookmarks should render when no bookmarks loaded 1`] = `
+<Fragment>
+  <SearchModal
+    bookmarks={Array []}
+    controller="architectures"
+    onEnter={[Function]}
+    setModalClosed={[MockFunction]}
+    title="Create Bookmark"
+    url="/api/v2/architectures"
+  />
+  <Dropdown
+    dropdownItems={
+      Array [
+        <DropdownGroup>
+          <DropdownItem
+            id="newBookmark"
+            onClick={[MockFunction]}
+          >
+            Bookmark this search
+          </DropdownItem>
+          <DocumentationLink
+            href="https://test-docs.com"
+          >
+            Documentation
+          </DocumentationLink>
+        </DropdownGroup>,
+        <DropdownGroup
+          label="Saved Bookmarks"
+        >
+          <DropdownItem
+            isDisabled={true}
+          >
+            None found
+          </DropdownItem>
+        </DropdownGroup>,
+      ]
+    }
+    id="architectures"
+    isGrouped={true}
+    isOpen={false}
+    toggle={
+      <DropdownToggle
+        onToggle={[Function]}
+      >
+        <BookmarkIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </DropdownToggle>
+    }
+  />
+</Fragment>
+`;
+
+exports[`Bookmarks should show error 1`] = `
+<Fragment>
+  <SearchModal
+    bookmarks={Array []}
+    controller="architectures"
+    onEnter={[Function]}
+    setModalClosed={[MockFunction]}
+    title="Create Bookmark"
+    url="/api/v2/architectures"
+  />
+  <Dropdown
+    dropdownItems={
+      Array [
+        <DropdownGroup>
+          <DropdownItem
+            id="newBookmark"
+            onClick={[MockFunction]}
+          >
+            Bookmark this search
+          </DropdownItem>
+          <DocumentationLink
+            href="https://test-docs.com"
+          >
+            Documentation
+          </DocumentationLink>
+        </DropdownGroup>,
+        <DropdownGroup
+          label="Saved Bookmarks"
+        >
+          <DropdownItem
+            isDisabled={true}
+          >
+            <EllipisWithTooltip>
+              Failed to load bookmarks: %s
+            </EllipisWithTooltip>
+          </DropdownItem>
+        </DropdownGroup>,
+      ]
+    }
+    id="architectures"
+    isGrouped={true}
+    isOpen={false}
+    toggle={
+      <DropdownToggle
+        onToggle={[Function]}
+      >
+        <BookmarkIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+      </DropdownToggle>
+    }
+  />
+</Fragment>
+`;

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/index.js
@@ -1,0 +1,70 @@
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import { getBookmarks } from './BookmarksActions';
+import { BOOKMARKS_MODAL, BOOKMARKS } from './BookmarksConstants';
+import { useForemanModal } from '../../ForemanModal/ForemanModalHooks';
+import { selectIsModalOpen } from '../../ForemanModal/ForemanModalSelectors';
+import Bookmarks from './Bookmarks';
+
+import reducer from './BookmarksReducer';
+import {
+  selectAPIStatus,
+  selectAPIError,
+} from '../../../redux/API/APISelectors';
+import { selectBookmarksResults } from './BookmarksSelectors';
+
+const ConnectedBookmarks = ({
+  controller,
+  onBookmarkClick,
+  url,
+  canCreate,
+  documentationUrl,
+}) => {
+  const key = `${BOOKMARKS}_${controller.toUpperCase()}`;
+  const status = useSelector(store => selectAPIStatus(store, key));
+  const errors = useSelector(store => selectAPIError(store, key));
+  const bookmarks = useSelector(store =>
+    selectBookmarksResults(store, key, controller)
+  );
+  const isModalOpen = useSelector(store =>
+    selectIsModalOpen(store, BOOKMARKS_MODAL)
+  );
+  const dispatch = useDispatch();
+
+  const { setModalOpen, setModalClosed } = useForemanModal({
+    id: BOOKMARKS_MODAL,
+  });
+  return (
+    <Bookmarks
+      bookmarks={bookmarks}
+      status={status}
+      url={url}
+      controller={controller}
+      getBookmarks={() => dispatch(getBookmarks(url, controller))}
+      canCreate={canCreate}
+      errors={errors}
+      documentationUrl={documentationUrl}
+      onBookmarkClick={onBookmarkClick}
+      setModalOpen={setModalOpen}
+      setModalClosed={setModalClosed}
+      isModalOpen={isModalOpen}
+    />
+  );
+};
+
+ConnectedBookmarks.propTypes = {
+  controller: PropTypes.string.isRequired,
+  onBookmarkClick: PropTypes.func.isRequired,
+  url: PropTypes.string.isRequired,
+  canCreate: PropTypes.bool,
+  documentationUrl: PropTypes.string,
+};
+
+ConnectedBookmarks.defaultProps = {
+  canCreate: false,
+  documentationUrl: '',
+};
+
+export const reducers = { bookmarksPF4: reducer };
+export default ConnectedBookmarks;

--- a/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/DocumentationLink.stories.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/DocumentationLink.stories.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { action } from '@theforeman/stories';
+
+import Story from '../../../../../../stories/components/Story';
+import DocumentationLink from './index';
+
+export default {
+  title: 'Components|PF4 DocumentationLink',
+};
+
+export const defaultStory = () => (
+  <Story>
+    <ul>
+      <DocumentationLink handleClick={action('Link was clicked')} href="#" />
+    </ul>
+  </Story>
+);
+
+defaultStory.story = {
+  name: 'Default',
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/DocumentationLink.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/DocumentationLink.test.js
@@ -1,0 +1,11 @@
+import { shallow } from '@theforeman/test';
+import React from 'react';
+import Link from './index';
+
+describe('documentation links', () => {
+  it('should have an external link to documentation', () => {
+    const wrapper = shallow(<Link href="http://theforeman.org" />);
+
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/__snapshots__/DocumentationLink.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/__snapshots__/DocumentationLink.test.js.snap
@@ -1,20 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`documentation links should have an external link to documentation 1`] = `
-<MenuItem
-  bsClass="dropdown"
-  disabled={false}
-  divider={false}
-  header={false}
+<DropdownItem
   href="http://theforeman.org"
   key="documentationUrl"
   onClick={[Function]}
 >
-  <Icon
-    name="question-circle"
-    type="fa"
+  <QuestionCircleIcon
+    color="currentColor"
+    noVerticalAlign={false}
+    size="sm"
   />
-   $
-  Documentation
-</MenuItem>
+   Documentation
+</DropdownItem>
 `;

--- a/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/index.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { MenuItem, Icon } from 'patternfly-react';
+import { DropdownItem } from '@patternfly/react-core';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { newWindowOnClick } from '../../../common/helpers';
 import { translate as __ } from '../../../../react_app/common/I18n';
 
 const DocumentationLink = ({ href, children }) => (
-  <MenuItem key="documentationUrl" href={href} onClick={newWindowOnClick(href)}>
-    <Icon type="fa" name="question-circle" /> ${children}
-  </MenuItem>
+  <DropdownItem
+    key="documentationUrl"
+    href={href}
+    onClick={newWindowOnClick(href)}
+  >
+    <QuestionCircleIcon />
+    {` ${children}`}
+  </DropdownItem>
 );
 
 DocumentationLink.propTypes = {

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -29,7 +29,7 @@ export const prepareErrors = (errors, base) =>
 
 export const onError = (error, actions) => {
   actions.setSubmitting(false);
-  if (error.response.status === 422) {
+  if (error.response?.status === 422) {
     const base = getBaseErrors(error?.response?.data);
 
     actions.setErrors(
@@ -39,9 +39,8 @@ export const onError = (error, actions) => {
     actions.setErrors({
       _error: {
         errorMsgs: [
-          `${__('Error submitting data:')} ${error.response.status} ${__(
-            error.response.statusText
-          )}`,
+          `${__('Error submitting data:')} ${error.response?.status} ${error
+            .response?.statusText && __(error.response?.statusText)}`,
         ],
       },
     });

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -17,6 +17,7 @@ import { reducers as typeAheadSelectReducers } from '../../components/common/Typ
 import { reducers as auditsPageReducers } from '../../routes/Audits/AuditsPage';
 import { reducers as intervalReducers } from '../middlewares/IntervalMiddleware';
 import { reducers as bookmarksReducers } from '../../components/Bookmarks';
+import { reducers as bookmarksPF4Reducers } from '../../components/PF4/Bookmarks';
 import { reducers as modalReducers } from '../../components/ForemanModal';
 import { reducers as apiReducer } from '../API';
 import { reducers as modelsPageReducers } from '../../routes/Models/ModelsPage';
@@ -26,6 +27,7 @@ import { reducers as personalAccessTokensReducers } from '../../components/users
 export function combineReducersAsync(asyncReducers) {
   return combineReducers({
     ...bookmarksReducers,
+    ...bookmarksPF4Reducers,
     hosts,
     notifications,
     toasts,


### PR DESCRIPTION
This is a refactor of the "old" bookmarks component.
I removed most of the reducer in favor of the API middleware.

To test in foreman change the import here: 
(Real data, open modal, create new bookmark ...)
It will not look good with the old searchbar :)
https://github.com/theforeman/foreman/blob/9857413daba51beed05ff158e51b0e15bce9236c/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js#L5

to `import Bookmarks from '../PF4/Bookmarks';`

Available stories are: 

default with data
![Screenshot from 2020-10-19 19-17-58](https://user-images.githubusercontent.com/30431079/96477995-d45c7200-123f-11eb-801b-5552acf877ef.png)
pending
![Screenshot from 2020-10-19 19-18-18](https://user-images.githubusercontent.com/30431079/96478042-e211f780-123f-11eb-9cb4-192067405a26.png)

error
![Screenshot from 2020-10-19 19-18-25](https://user-images.githubusercontent.com/30431079/96478039-e1796100-123f-11eb-90ae-071b1dbd4c0d.png)

