### PR TITLE
Fixes #31111 - set welcome flag only if welcome template exists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,12 +29,11 @@ class ApplicationController < ActionController::Base
   attr_reader :original_search_parameter
 
   def welcome
-    if (model_of_controller.first.nil? rescue false)
+    return if model_of_controller&.any?
+    if template_exists?(:welcome, _prefixes, variants: request.variant)
       @welcome = true
-      render :welcome rescue nil
+      render :welcome
     end
-  rescue
-    not_found
   end
 
   def api_request?
@@ -159,7 +158,7 @@ class ApplicationController < ActionController::Base
   end
 
   def model_of_controller
-    @model_of_controller ||= controller_path.singularize.camelize.gsub('/', '::').constantize
+    @model_of_controller ||= controller_path.singularize.camelize.gsub('/', '::').safe_constantize
   end
 
   def controller_permission

--- a/test/integration/middleware_test.rb
+++ b/test/integration/middleware_test.rb
@@ -29,7 +29,7 @@ class MiddlewareIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     test 'it is added Content-Security-Policy on welcome pages' do
-      Domain.stubs(:first).returns(nil)
+      Domain.stubs(:any?).returns(false)
       visit '/domains'
       assert page.has_content? 'Learn more about this in the documentation.'
       assert page.response_headers['Content-Security-Policy'].include?(@webpack_url)


### PR DESCRIPTION
Set `@welcome`, only if the 'welcome' template exists for given resource.
It messes up some other parts of layout, if the flag is wrongly set.

To support this, it also improves the rescue and moves it to `safe_constantize` failsafe in `model_of_controller` method.