### PR TITLE
Refs #31107 - test login page separately

### DIFF
--- a/test/integration/login_page_test.rb
+++ b/test/integration/login_page_test.rb
@@ -1,9 +1,9 @@
 require 'integration_test_helper'
 
-class MiddlewareJSTest < IntegrationTestWithJavascript
+class LoginPageTest < IntegrationTestWithJavascript
   test 'login page appears after logout' do
     logout_admin
-    visit '/environments'
+    visit '/domains'
     assert page.has_selector? 'input[name="login[password]"]'
   end
 end


### PR DESCRIPTION
Login page was tested as part of MiddlewareTest.
It deserves its own integration tests.
The middleware tests is moved to test with `/domains` as part of this.

Forgotten in #8087 