### PR TITLE
Fixes #31021 - Global Registration & Insights setup parameter

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -71,7 +71,7 @@ module Api
           ActiveRecord::Base.transaction do
             find_host
             prepare_host
-            setup_insights
+            host_setup_insights
             @template = @host.registration_template
             raise ActiveRecord::Rollback if @template.nil?
           end
@@ -111,14 +111,6 @@ module Api
         @host.owner = User.current
 
         @host.save!
-      end
-
-      def setup_insights
-        return unless params['setup_insights'].present?
-
-        insights_param = HostParameter.find_or_initialize_by(host: @host, name: 'host_registration_insights', key_type: 'boolean')
-        insights_param.value = ActiveRecord::Type::Boolean.new.deserialize(params['setup_insights'])
-        insights_param.save!
       end
     end
   end

--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -19,6 +19,7 @@ module Api
       param :location_id, :number, desc: N_("ID of the Location to register the host in.")
       param :hostgroup_id, :number, desc: N_("ID of the Host group to register the host in.")
       param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in.")
+      param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
       def global
         find_global_registration
 
@@ -31,42 +32,46 @@ module Api
       end
 
       api :POST, "/register", N_("Find or create a host and render the Host registration template")
-      param :name, String, required: true
-      param :location_id, :number, required: true
-      param :organization_id, :number, required: true
-      param :ip, String, desc: N_("IPv4 address, not required if using a subnet with DHCP proxy")
-      param :ip6, String, desc: N_("IPv6 address, not required if using a subnet with DHCP proxy")
-      param :mac, String, desc: N_("required for managed host that is bare metal, not required if it's a virtual machine")
-      param :domain_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
-      param :operatingsystem_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
-      param :subnet_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
-      param :model_id, :number
-      param :hostgroup_id, :number
-      param :host_parameters_attributes, Array, desc: N_("Host's parameters (array or indexed hash)") do
-        param :name, String, desc: N_("Name of the parameter"), required: true
-        param :value, String, desc: N_("Parameter value"), required: true
-        param :parameter_type, Parameter::KEY_TYPES, desc: N_("Type of value")
-        param :hidden_value, :bool
-      end
-      param :build, :bool
-      param :enabled, :bool, desc: N_("Include this host within Foreman reporting")
-      param :managed, :bool, desc: N_("True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not")
-      param :comment, String, desc: N_("Additional information about this host")
-      param :interfaces_attributes, Array, desc: N_("Host's network interfaces.") do
-        param_group :interface_attributes, ::Api::V2::InterfacesController
-      end
-      Facets.registered_facets.values.each do |facet_config|
-        next unless facet_config.host_configuration.api_param_group && facet_config.host_configuration.api_controller
-        param "#{facet_config.name}_attributes".to_sym, Hash, desc: facet_config.api_param_group_description || (N_("Parameters for host's %s facet") % facet_config.name) do
-          facet_config.host_configuration.load_api_controller
-          param_group facet_config.host_configuration.api_param_group, facet_config.host_configuration.api_controller
+      param :host, Hash, required: true, action_aware: true do
+        param :name, String, required: true
+        param :location_id, :number, required: true
+        param :organization_id, :number, required: true
+        param :ip, String, desc: N_("IPv4 address, not required if using a subnet with DHCP proxy")
+        param :ip6, String, desc: N_("IPv6 address, not required if using a subnet with DHCP proxy")
+        param :mac, String, desc: N_("required for managed host that is bare metal, not required if it's a virtual machine")
+        param :domain_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
+        param :operatingsystem_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
+        param :subnet_id, :number, desc: N_("required if host is managed and value is not inherited from host group")
+        param :model_id, :number
+        param :hostgroup_id, :number
+        param :host_parameters_attributes, Array, desc: N_("Host's parameters (array or indexed hash)") do
+          param :name, String, desc: N_("Name of the parameter"), required: true
+          param :value, String, desc: N_("Parameter value"), required: true
+          param :parameter_type, Parameter::KEY_TYPES, desc: N_("Type of value")
+          param :hidden_value, :bool
+        end
+        param :build, :bool
+        param :enabled, :bool, desc: N_("Include this host within Foreman reporting")
+        param :managed, :bool, desc: N_("True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not")
+        param :comment, String, desc: N_("Additional information about this host")
+        param :interfaces_attributes, Array, desc: N_("Host's network interfaces.") do
+          param_group :interface_attributes, ::Api::V2::InterfacesController
+        end
+        Facets.registered_facets.values.each do |facet_config|
+          next unless facet_config.host_configuration.api_param_group && facet_config.host_configuration.api_controller
+          param "#{facet_config.name}_attributes".to_sym, Hash, desc: facet_config.api_param_group_description || (N_("Parameters for host's %s facet") % facet_config.name) do
+            facet_config.host_configuration.load_api_controller
+            param_group facet_config.host_configuration.api_param_group, facet_config.host_configuration.api_controller
+          end
         end
       end
+      param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
       def host
         begin
           ActiveRecord::Base.transaction do
             find_host
             prepare_host
+            setup_insights
             @template = @host.registration_template
             raise ActiveRecord::Rollback if @template.nil?
           end
@@ -106,6 +111,14 @@ module Api
         @host.owner = User.current
 
         @host.save!
+      end
+
+      def setup_insights
+        return unless params['setup_insights'].present?
+
+        insights_param = HostParameter.find_or_initialize_by(host: @host, name: 'host_registration_insights', key_type: 'boolean')
+        insights_param.value = ActiveRecord::Type::Boolean.new.deserialize(params['setup_insights'])
+        insights_param.save!
       end
     end
   end

--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -30,7 +30,8 @@ module Foreman::Controller::Registration
                    operatingsystem: operatingsystem,
                    url_host: registration_url.host,
                    registration_url: registration_url,
-                    })
+                   setup_insights: ActiveRecord::Type::Boolean.new.deserialize(params['setup_insights']),
+                  })
   end
 
   def safe_render(template)

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -15,6 +15,7 @@ class RegistrationController < ApplicationController
     @host_groups = Hostgroup.authorized(:view_hostgroups).select(:id, :name)
     @operating_systems = Operatingsystem.authorized(:view_operatingsystems).select(:id, :title)
     @smart_proxies = Feature.find_by(name: 'Registration')&.smart_proxies || []
+    @insights_param = CommonParameter.find_by(name: 'host_registration_insights')
   end
 
   def headers

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -37,6 +37,12 @@
     </div>
   </div>
   <div class='form-group'>
+    <label class='col-md-2 control-label' for='setup_insights'><%= _('Setup Insights') %></label>
+    <div class='col-md-4'>
+      <%= check_box_tag 'setup_insights', true %>
+    </div>
+  </div>
+  <div class='form-group'>
     <label class='col-md-2 control-label'><%= _('Token lifetime (hours)') %></label>
     <div class='col-md-4'>
       <%= number_field_tag 'jwt_expiration', params[:jwt_expiration] || 4, class: 'form-control', min: 1, required: true %>

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -37,7 +37,7 @@
     </div>
   </div>
   <div class='form-group'>
-    <% insights_help = _('If selected, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it.')%>
+    <% insights_help = _('If selected, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it.') %>
     <%= add_help_to_label '', '' , insights_help do %>
       <label class='col-md-2 control-label' for='setup_insights'>
         <%= _('Setup Insights') %>

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -39,7 +39,8 @@
   <div class='form-group'>
     <label class='col-md-2 control-label' for='setup_insights'><%= _('Setup Insights') %></label>
     <div class='col-md-4'>
-      <%= check_box_tag 'setup_insights', true %>
+      <% insights_opts = options_for_select([[_('Yes'), 'true'], [_('No'), 'false']], (params[:setup_insights] || @insights_param.value.to_s))%>
+      <%= select_tag 'setup_insights', insights_opts, class: 'form-control' %>
     </div>
   </div>
   <div class='form-group'>

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -37,11 +37,16 @@
     </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label' for='setup_insights'><%= _('Setup Insights') %></label>
-    <div class='col-md-4'>
-      <% insights_opts = options_for_select([[_('Yes'), 'true'], [_('No'), 'false']], (params[:setup_insights] || @insights_param.value.to_s))%>
-      <%= select_tag 'setup_insights', insights_opts, class: 'form-control' %>
-    </div>
+    <% insights_help = _('If selected, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it.')%>
+    <%= add_help_to_label '', '' , insights_help do %>
+      <label class='col-md-2 control-label' for='setup_insights'>
+        <%= _('Setup Insights') %>
+      </label>
+      <div class='col-md-4'>
+        <% insights_opts = options_for_select([[_('Yes'), 'true'], [_('No'), 'false']], params[:setup_insights]) %>
+        <%= select_tag 'setup_insights', insights_opts, class: 'form-control', include_blank: '' %>
+      </div>
+    <% end %>
   </div>
   <div class='form-group'>
     <label class='col-md-2 control-label'><%= _('Token lifetime (hours)') %></label>

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -14,7 +14,7 @@ model: ProvisioningTemplate
 <%= "\n# Location: [#{@location.name}]" if @location -%>
 <%= "\n# Hostgroup: [#{@hostgroup.name}]" if @hostgroup -%>
 <%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
-<%= "\n# Setup Insights: [#{@setup_insights}]" -%>
+<%= "\n# Setup Insights: [#{@setup_insights}]" if !@setup_insights.nil? -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -42,7 +42,7 @@ register_host() {
        <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
        <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
        <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
-       <%= "--data \"setup_insights=#{@setup_insights}\"" -%>
+       <%= "--data \"setup_insights=#{@setup_insights}\"" if !@setup_insights.nil? -%>
 
 }
 
@@ -59,7 +59,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
             <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
             <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
             <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
-            <%= "--data \"setup_insights=#{@setup_insights}\"" -%>
+            <%= "--data \"setup_insights=#{@setup_insights}\"" if !@setup_insights.nil? -%>
 
     }
 

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -14,6 +14,7 @@ model: ProvisioningTemplate
 <%= "\n# Location: [#{@location.name}]" if @location -%>
 <%= "\n# Hostgroup: [#{@hostgroup.name}]" if @hostgroup -%>
 <%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
+<%= "\n# Setup Insights: [#{@setup_insights}]" -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -41,6 +42,7 @@ register_host() {
        <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
        <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
        <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
+       <%= "--data \"setup_insights=#{@setup_insights}\"" -%>
 
 }
 
@@ -57,6 +59,8 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
             <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
             <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
             <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
+            <%= "--data \"setup_insights=#{@setup_insights}\"" -%>
+
     }
 
     CONSUMER_RPM=$(mktemp --suffix .rpm)

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -14,7 +14,7 @@ model: ProvisioningTemplate
 <%= "\n# Location: [#{@location.name}]" if @location -%>
 <%= "\n# Hostgroup: [#{@hostgroup.name}]" if @hostgroup -%>
 <%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
-<%= "\n# Setup Insights: [#{@setup_insights}]" if !@setup_insights.nil? -%>
+<%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -42,7 +42,7 @@ register_host() {
        <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
        <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
        <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
-       <%= "--data \"setup_insights=#{@setup_insights}\"" if !@setup_insights.nil? -%>
+       <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
 
 }
 
@@ -59,7 +59,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
             <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
             <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
             <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
-            <%= "--data \"setup_insights=#{@setup_insights}\"" if !@setup_insights.nil? -%>
+            <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
 
     }
 

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -213,17 +213,13 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
     end
 
     context 'setup_insights' do
-      after do
-        HostParameter.find_by(name: 'host_registration_insights')&.destroy
-      end
-
       test 'with setup_insights = true' do
         params = { setup_insights: 'true' }.merge(host_params)
         post :host, params: params, session: set_session_user
         assert_response :success
 
         host = Host.find_by(name: params[:host][:name]).reload
-        assert HostParameter.find_by(host: host, name: 'host_registration_insights')&.value
+        assert HostParameter.find_by(host: host, name: 'host_registration_insights').value
       end
 
       test 'with setup_insights = false' do
@@ -233,7 +229,7 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
         assert_response :success
 
         host = Host.find_by(name: params[:host][:name]).reload
-        refute HostParameter.find_by(host: host, name: 'host_registration_insights')&.value
+        refute HostParameter.find_by(host: host, name: 'host_registration_insights').value
       end
     end
   end

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -211,5 +211,30 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
       post :host, params: host_params, session: set_session_user, as: :html
       assert_response :unsupported_media_type
     end
+
+    context 'setup_insights' do
+      after do
+        HostParameter.find_by(name: 'host_registration_insights')&.destroy
+      end
+
+      test 'with setup_insights = true' do
+        params = { setup_insights: 'true' }.merge(host_params)
+        post :host, params: params, session: set_session_user
+        assert_response :success
+
+        host = Host.find_by(name: params[:host][:name]).reload
+        assert HostParameter.find_by(host: host, name: 'host_registration_insights')&.value
+      end
+
+      test 'with setup_insights = false' do
+        params = { setup_insights: 'false' }.merge(host_params)
+
+        post :host, params: params, session: set_session_user
+        assert_response :success
+
+        host = Host.find_by(name: params[:host][:name]).reload
+        refute HostParameter.find_by(host: host, name: 'host_registration_insights')&.value
+      end
+    end
   end
 end

--- a/test/controllers/registration_controller_test.rb
+++ b/test/controllers/registration_controller_test.rb
@@ -7,11 +7,60 @@ class RegistrationControllerTest < ActionController::TestCase
     assert_template :new
   end
 
-  test 'create' do
-    params = { organization: taxonomies(:organization1).id, location: taxonomies(:location1).id }
-    post :create, params: params, session: set_session_user
+  describe 'create' do
+    test 'create' do
+      params = { organization: taxonomies(:organization1).id, location: taxonomies(:location1).id }
+      post :create, params: params, session: set_session_user
 
-    assert_response :success
-    assert_template :create
+      assert_response :success
+      assert_template :create
+    end
+
+    context 'setup_insights_param' do
+      let(:params) { { organization: taxonomies(:organization1).id, location: taxonomies(:location1).id } }
+
+      before do
+        CommonParameter.where(name: 'host_registration_insights').destroy_all
+      end
+
+      test 'without param' do
+        post :create, params: params, session: set_session_user
+        refute assigns(:command).include?('setup_insights')
+      end
+
+      test 'when host_registration_insights = nil && setup_insights = true' do
+        post :create, params: params.merge(setup_insights: true), session: set_session_user
+        assert assigns(:command).include?('setup_insights')
+      end
+
+      test 'when host_registration_insights = nil && setup_insights = false' do
+        post :create, params: params.merge(setup_insights: false), session: set_session_user
+        assert assigns(:command).include?('setup_insights')
+      end
+
+      test 'when host_registration_insights = true && setup_insights = true' do
+        CommonParameter.create(name: 'host_registration_insights', key_type: 'boolean', value: true)
+        post :create, params: params.merge(setup_insights: true), session: set_session_user
+        refute assigns(:command).include?('setup_insights')
+      end
+
+      test 'when host_registration_insights = false && setup_insights = false' do
+        CommonParameter.create(name: 'host_registration_insights', key_type: 'boolean', value: false)
+        post :create, params: params.merge(setup_insights: false), session: set_session_user
+        refute assigns(:command).include?('setup_insights')
+      end
+
+      test 'when host_registration_insights = true && setup_insights = false' do
+        CommonParameter.create(name: 'host_registration_insights', key_type: 'boolean', value: true)
+        post :create, params: params.merge(setup_insights: false), session: set_session_user
+        assert assigns(:command).include?('setup_insights')
+      end
+
+      test 'when host_registration_insights = false && setup_insights = true' do
+        CommonParameter.create(name: 'host_registration_insights', key_type: 'boolean', value: false)
+        post :create, params: params.merge(setup_insights: true), session: set_session_user
+        assert assigns(:command).include?('setup_insights')
+      end
+    end
   end
 end


### PR DESCRIPTION
New parameter `:setup_insights`, allowing user to enable / disable installation of insights-client on the host.
If `:setup_insight`s is set, `host_registration_insights` parameter for the host will be created (or updated, if it exists already).

**How to test**
```
curl --user admin:changeme -X GET "https://foreman.example.com/register?setup_insights=true|false"
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
