### PR TITLE
Fixes #31123 - cover menu generation by test

### DIFF
--- a/test/unit/user_menu_test.rb
+++ b/test/unit/user_menu_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class UserMenuTest < ActiveSupport::TestCase
+  test 'should generate all menu items without error' do
+    Foreman::Logging.expects(:exception).never
+    as_admin do
+      UserMenu.new.menus
+    end
+  end
+
   test 'should generate menu items for user' do
     as_user :view_hosts do
       menu = UserMenu.new.generate


### PR DESCRIPTION
Covers the UserMenu#menus by a test, that ensures there is no exception rised.
If there would be an exception in the past, we would just silently hid the exception.