### PR TITLE
Fixes #31132: Downcase MAC addresses

### DIFF
--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -173,6 +173,10 @@ module Nic
       result
     end
 
+    def mac=(value)
+      super value&.downcase
+    end
+
     def hostname
       if domain.present? && name.present?
         "#{shortname}.#{domain.name}"

--- a/db/migrate/20210407104300_downcase_mac_addresses.rb
+++ b/db/migrate/20210407104300_downcase_mac_addresses.rb
@@ -1,0 +1,8 @@
+class DowncaseMacAddresses < ActiveRecord::Migration[6.0]
+  def up
+    execute 'UPDATE nics SET mac=LOWER(mac)'
+  end
+
+  def down
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -1214,7 +1214,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     mac = RFauxFactory.gen_alpha
     put :update, params: { :id => @host.id, :host => {:mac => mac} }
     assert_response :unprocessable_entity, "Can update host with invalid mac #{mac}"
-    assert_match "'#{mac}' is not a valid MAC address", @response.body
+    assert_match "'#{mac.downcase}' is not a valid MAC address", @response.body
   end
 
   test "should update build parameter with false value" do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2748,7 +2748,7 @@ class HostTest < ActiveSupport::TestCase
     host.mac = 'AA:AA:AA:AA:AA:AA'
     clone = host.setup_clone
     refute_equal host.object_id, clone.object_id
-    assert_equal 'AA:AA:AA:AA:AA:AA', host.mac
+    assert_equal 'aa:aa:aa:aa:aa:aa', host.mac
     refute_equal host.mac, clone.mac
     assert_equal original_mac, clone.mac
     assert_equal original_mac, clone.provision_interface.mac

--- a/test/models/orchestration_test.rb
+++ b/test/models/orchestration_test.rb
@@ -126,7 +126,7 @@ class OrchestrationTest < ActiveSupport::TestCase
     @nic.ip = '192.168.0.1'
     clone = @nic.send(:setup_object_clone, @nic) { |c| c.mac, c.ip = 'AA:AA:AA:AA:AA:AA', 'override this' }
     refute_equal @nic.object_id, clone.object_id
-    assert_equal 'AA:AA:AA:AA:AA:AA', clone.mac
+    assert_equal 'aa:aa:aa:aa:aa:aa', clone.mac
     assert_equal '192.168.0.2', clone.ip
   end
 


### PR DESCRIPTION
In order to prevent from the side effects of changing MAC address from upcased to downcase (as explained in Redmine issue), this patch always return a downcased MAC address.