### PR TITLE
Fixes #31143 - use single quotes in registration templates

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -40,14 +40,13 @@ register_host() {
        --data "host[name]=$(hostname --fqdn)" \
        --data "host[build]=false" \
        --data "host[managed]=false" \
-       <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
-       <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
-       <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
-       <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
-       <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
-       <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
-       <%= "--data \"remote_execution_interface=#{@remote_execution_interface}\"" if @remote_execution_interface.present? -%>
-
+<%= "       --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
+<%= "       --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
+<%= "       --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
+<%= "       --data 'host[operatingsystem_id]=#{@operatingsystem.id}' \\\n" if @operatingsystem -%>
+<%= "       --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
+<%= "       --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
+<%= "       --data 'remote_execution_interface=#{@remote_execution_interface}' \\\n" if @remote_execution_interface.present? -%>
 }
 
 echo "#"
@@ -59,22 +58,21 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
         curl --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>?uuid=$UUID" \
-            <%= headers.join(' ') %> \
-            <%= "--data \"host[organization_id]=#{@organization.id}\"" if @organization -%>
-            <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
-            <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
-            <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
-            <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
-            <%= "--data \"remote_execution_interface=#{@remote_execution_interface}\"" if @remote_execution_interface.present? -%>
-
-    }
+             <%= headers.join(' ') %> \
+<%= "          --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
+<%= "          --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
+<%= "          --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
+<%= "          --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
+<%= "          --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
+<%= "          --data 'remote_execution_interface=#{@remote_execution_interface}' \\\n" if @remote_execution_interface.present? -%>
+}
 
     CONSUMER_RPM=$(mktemp --suffix .rpm)
     curl --output $CONSUMER_RPM <%= subscription_manager_configuration_url(hostname: @url_host) %>
     yum localinstall $CONSUMER_RPM -y
     rm -f $CONSUMER_RPM
 
-    subscription-manager register --org=<%= @organization.label %> --activationkey="<%= @activation_key %>"
+    subscription-manager register --org='<%= @organization.label %>' --activationkey='<%= @activation_key %>'
     register_katello_host | bash
 else
     register_host | bash


### PR DESCRIPTION
This is generally safer to avoid shell injection through macros. Also
URLs can contain & in between parameters, which also causes shell side
effects. This replaces all " with ' where it makes sense.