### PR TITLE
Fixes #31168 - Add host name to ENC output

### DIFF
--- a/app/models/host_info_providers/static_info.rb
+++ b/app/models/host_info_providers/static_info.rb
@@ -4,6 +4,8 @@ module HostInfoProviders
       # Static parameters
       param = {}
 
+      param["name"] = host.name unless host.name.nil?
+      param["fqdn"] = host.fqdn unless host.fqdn.nil?
       param["hostgroup"] = host.hostgroup.to_label unless host.hostgroup.nil?
       param["comment"] = host.comment if host.comment.present?
 


### PR DESCRIPTION
**Use case:**

Having this parameter exposed would help in exporting it as an Ansible variable in roles. 