### PR TITLE
Fixes #31020 - Global Registration & REX setup parameter

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -20,6 +20,7 @@ module Api
       param :hostgroup_id, :number, desc: N_("ID of the Host group to register the host in.")
       param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in.")
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
+      param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host.")
       def global
         find_global_registration
 
@@ -66,12 +67,14 @@ module Api
         end
       end
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
+      param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host.")
       def host
         begin
           ActiveRecord::Base.transaction do
             find_host
             prepare_host
             host_setup_insights
+            host_setup_remote_execution
             @template = @host.registration_template
             raise ActiveRecord::Rollback if @template.nil?
           end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -17,7 +17,6 @@ class RegistrationController < ApplicationController
     @host_groups = Hostgroup.authorized(:view_hostgroups).select(:id, :name)
     @operating_systems = Operatingsystem.authorized(:view_operatingsystems).select(:id, :title)
     @smart_proxies = Feature.find_by(name: 'Registration')&.smart_proxies || []
-    @insights_param = CommonParameter.find_by(name: 'host_registration_insights')
   end
 
   def headers
@@ -38,17 +37,26 @@ class RegistrationController < ApplicationController
     ignored = ['utf8', 'authenticity_token', 'commit', 'action', 'locale', 'controller', 'jwt_expiration']
     args = params.except(*ignored)
     args[:setup_insights] = setup_insights_param if params['setup_insights'].to_s.present?
+    args[:setup_remote_execution] = setup_remote_execution_param if params['setup_remote_execution'].to_s.present?
 
     args.delete_if { |_, v| v.blank? }
         .permit!
   end
 
   def setup_insights_param
+    global_setup_insights(host_config_params(*host_args)).to_s
+  end
+
+  def setup_remote_execution_param
+    global_setup_remote_execution(host_config_params(*host_args)).to_s
+  end
+
+  def host_args
     organization = Organization.authorized(:view_organizations).find(params['organization_id']) if params['organization_id'].present?
     location = Location.authorized(:view_locations).find(params['location_id']) if params['location_id'].present?
     host_group = Hostgroup.authorized(:view_hostgroups).find(params['host_group_id']) if params["host_group_id"].present?
     operatingsystem = Operatingsystem.authorized(:view_operatingsystems).find(params['operatingsystem_id']) if params["operatingsystem_id"].present?
 
-    global_setup_insights(organization, location, host_group, operatingsystem).to_s
+    [organization, location, host_group, operatingsystem]
   end
 end

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -19,37 +19,67 @@
     </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label'><%= _('Host Group') %></label>
+    <label class='col-md-2 control-label' for='host_group_id'>
+      <%= _('Host Group') %>
+    </label>
     <div class='col-md-4'>
       <%= select_tag 'host_group_id', options_from_collection_for_select(@host_groups, :id, :name, params[:host_group_id]), class: 'form-control', include_blank: '' %>
     </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label'><%= _('Operating System') %></label>
+    <label class='col-md-2 control-label' for='operatingsystem_id'>
+      <%= _('Operating System') %>
+    </label>
     <div class='col-md-4'>
       <%= select_tag 'operatingsystem_id', options_from_collection_for_select(@operating_systems, :id, :title, params[:operatingsystem_id]), class: 'form-control', include_blank: '' %>
     </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label'><%= _('Proxy') %></label>
+    <label class='col-md-2 control-label' for='smart_proxy'>
+      <%= _('Proxy') %>
+      <% help = _('Only Smart Proxies with enabled Registration module are available') %>
+      <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+        <span class="pficon pficon-info"></span>
+      </a>
+    </label>
     <div class='col-md-4'>
       <%= select_tag 'smart_proxy', options_from_collection_for_select(@smart_proxies, :id, :name, params[:smart_proxy]), class: 'form-control', include_blank: '' %>
     </div>
   </div>
   <div class='form-group'>
-    <% insights_help = _('If selected, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it.') %>
-    <%= add_help_to_label '', '' , insights_help do %>
-      <label class='col-md-2 control-label' for='setup_insights'>
-        <%= _('Setup Insights') %>
-      </label>
-      <div class='col-md-4'>
-        <% insights_opts = options_for_select([[_('Yes'), 'true'], [_('No'), 'false']], params[:setup_insights]) %>
-        <%= select_tag 'setup_insights', insights_opts, class: 'form-control', include_blank: '' %>
-      </div>
-    <% end %>
+    <label class='col-md-2 control-label' for='setup_insights'>
+      <% help = _('If selected, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it.') %>
+      <%= _('Setup Insights') %>
+      <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+        <span class="pficon pficon-info "></span>
+      </a>
+    </label>
+    <div class='col-md-4'>
+      <% insights_opts = options_for_select([[_('Yes'), 'true'], [_('No'), 'false']], params[:setup_insights]) %>
+      <%= select_tag 'setup_insights', insights_opts, class: 'form-control', include_blank: '' %>
+    </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label'><%= _('Token lifetime (hours)') %></label>
+    <label class='col-md-2 control-label' for='setup_remote_execution'>
+      <%= _('Remote Execution') %>
+      <% help = _('If selected, SSH keys will be installed on the registered host.') %>
+      <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+        <span class="pficon pficon-info "></span>
+      </a>
+    </label>
+    <div class='col-md-4'>
+      <% rex_opts = options_for_select([[_('Yes'), 'true'], [_('No'), 'false']], params[:setup_remote_execution]) %>
+      <%= select_tag 'setup_remote_execution', rex_opts, class: 'form-control', include_blank: '' %>
+    </div>
+  </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label' for='jwt_expiration'>
+      <%= _('Token lifetime (hours)') %>
+      <% help = _('Expiration of the authorization token.') %>
+      <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+        <span class="pficon pficon-info "></span>
+      </a>
+    </label>
     <div class='col-md-4'>
       <%= number_field_tag 'jwt_expiration', params[:jwt_expiration] || 4, class: 'form-control', min: 1, required: true %>
     </div>

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -15,6 +15,7 @@ model: ProvisioningTemplate
 <%= "\n# Hostgroup: [#{@hostgroup.name}]" if @hostgroup -%>
 <%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
 <%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
+<%= "\n# Setup Remote Execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -43,6 +44,7 @@ register_host() {
        <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
        <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
        <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
+       <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
 
 }
 
@@ -60,6 +62,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
             <%= "--data \"host[location_id]=#{@location.id}\"" if @location -%>
             <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
             <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
+            <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
 
     }
 

--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -19,7 +19,7 @@ snippet: true
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
@@ -28,6 +28,7 @@ snippet: true
 # file.
 
 
+<% if host_param_true?('host_registration_remote_execution') -%>
 <% if !host_param('remote_execution_ssh_keys').blank? %>
 <% ssh_user = host_param('remote_execution_ssh_user') || 'root' %>
 
@@ -55,7 +56,7 @@ EOF
 
   # Restore SELinux context with restorecon, if it's available:
   command -v restorecon && restorecon -RvF <%= ssh_path %> || true
-  
+
 <% if ssh_user != 'root' && host_param('remote_execution_effective_user_method') == 'sudo' -%>
 <% if @host.operatingsystem.family == 'Redhat' || @host.operatingsystem.family == 'Debian' -%>
 echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL
@@ -69,3 +70,4 @@ else
   echo 'The remote_execution_ssh_user does not exist and remote_execution_create_user is not set to true.  remote_execution_ssh_keys snippet will not install keys'
 fi
 <% end %>
+<% end -%>

--- a/db/seeds.d/180-common_parameters.rb
+++ b/db/seeds.d/180-common_parameters.rb
@@ -1,6 +1,7 @@
 CommonParameter.without_auditing do
   params = [
     { name: "host_registration_insights", key_type: "boolean", value: false },
+    { name: "host_registration_remote_execution", key_type: "boolean", value: true },
   ]
 
   params.each { |param| CommonParameter.find_or_create_by(param) }

--- a/test/controllers/registration_controller_test.rb
+++ b/test/controllers/registration_controller_test.rb
@@ -62,5 +62,52 @@ class RegistrationControllerTest < ActionController::TestCase
         assert assigns(:command).include?('setup_insights')
       end
     end
+
+    context 'setup_remote_execution' do
+      let(:params) { { organization: taxonomies(:organization1).id, location: taxonomies(:location1).id } }
+
+      before do
+        CommonParameter.where(name: 'host_registration_remote_execution').destroy_all
+      end
+
+      test 'without param' do
+        post :create, params: params, session: set_session_user
+        refute assigns(:command).include?('setup_remote_execution')
+      end
+
+      test 'when host_registration_remote_execution = nil && setup_remote_execution = true' do
+        post :create, params: params.merge(setup_remote_execution: true), session: set_session_user
+        assert assigns(:command).include?('setup_remote_execution')
+      end
+
+      test 'when host_registration_remote_execution = nil && setup_remote_execution = false' do
+        post :create, params: params.merge(setup_remote_execution: false), session: set_session_user
+        assert assigns(:command).include?('setup_remote_execution')
+      end
+
+      test 'when host_registration_remote_execution = true && setup_remote_execution = true' do
+        CommonParameter.create(name: 'host_registration_remote_execution', key_type: 'boolean', value: true)
+        post :create, params: params.merge(setup_remote_execution: true), session: set_session_user
+        refute assigns(:command).include?('setup_remote_execution')
+      end
+
+      test 'when host_registration_remote_execution = false && setup_remote_execution = false' do
+        CommonParameter.create(name: 'host_registration_remote_execution', key_type: 'boolean', value: false)
+        post :create, params: params.merge(setup_remote_execution: false), session: set_session_user
+        refute assigns(:command).include?('setup_remote_execution')
+      end
+
+      test 'when host_registration_remote_execution = true && setup_remote_execution = false' do
+        CommonParameter.create(name: 'host_registration_remote_execution', key_type: 'boolean', value: true)
+        post :create, params: params.merge(setup_remote_execution: false), session: set_session_user
+        assert assigns(:command).include?('setup_remote_execution')
+      end
+
+      test 'when host_registration_remote_execution = false && setup_remote_execution = true' do
+        CommonParameter.create(name: 'host_registration_remote_execution', key_type: 'boolean', value: false)
+        post :create, params: params.merge(setup_remote_execution: true), session: set_session_user
+        assert assigns(:command).include?('setup_remote_execution')
+      end
+    end
   end
 end

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
@@ -58,14 +58,13 @@ runcmd:
   #                                         effective user
   #
   # This template sets up SSH keys in any host so that as long as your public
-  # SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+  # SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
   # works in combination with Remote Execution plugin by querying smart proxies
   # to build an array.
   #
   # To use this snippet without the plugin provide the SSH keys as host parameter
   # remote_execution_ssh_keys. It expects the same format like the authorized_keys
   # file.
-  
   
   
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD (mfsBSD) finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD (mfsBSD) finish.snap.txt
@@ -67,14 +67,13 @@ export FACTER_is_installer=true
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
@@ -56,14 +56,13 @@ fi
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
@@ -20,14 +20,13 @@
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
@@ -44,14 +44,13 @@ rm -f /etc/ostree/remotes.d/*.conf
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
@@ -99,14 +99,13 @@ cp /etc/resolv.conf /mnt/etc
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
@@ -102,14 +102,13 @@ cp /etc/resolv.conf /mnt/etc
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -113,14 +113,13 @@ fi
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/remote_execution_ssh_keys.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/remote_execution_ssh_keys.snap.txt
@@ -14,13 +14,12 @@
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
@@ -33,14 +33,13 @@ EOF
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
@@ -65,14 +65,13 @@ fi
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
@@ -36,14 +36,13 @@ EOF
 #                                         effective user
 #
 # This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
 # works in combination with Remote Execution plugin by querying smart proxies
 # to build an array.
 #
 # To use this snippet without the plugin provide the SSH keys as host parameter
 # remote_execution_ssh_keys. It expects the same format like the authorized_keys
 # file.
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
@@ -35,14 +35,13 @@ runcmd:
   #                                         effective user
   #
   # This template sets up SSH keys in any host so that as long as your public
-  # SSH key is in remote_execution_ssh_keys, you can SSH into a host. This 
+  # SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
   # works in combination with Remote Execution plugin by querying smart proxies
   # to build an array.
   #
   # To use this snippet without the plugin provide the SSH keys as host parameter
   # remote_execution_ssh_keys. It expects the same format like the authorized_keys
   # file.
-  
   
   
 


### PR DESCRIPTION
- New Host parameter `host_registration_remote_execution`, seeded with default value set to `true`.
- New parameter `setup_remote_execution` for Global registration endpoint, allowing users to enable/disable REX setup when registering host.

*How to test:*
```
curl --user admin:changeme -X GET "https://foreman.example.com/register?setup_remote_execution=true|false"
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
