### PR TITLE
[WIP] Fixes #31081 - Global Registration - interface for REX

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -21,6 +21,7 @@ module Api
       param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in.")
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host.")
+      param :remote_execution_interface, String, desc: N_("Identifier of the Host interface for Remote execution")
       def global
         find_global_registration
 
@@ -68,6 +69,7 @@ module Api
       end
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host.")
+      param :remote_execution_interface, String, desc: N_("Identifier of the Host interface for Remote execution")
       def host
         begin
           ActiveRecord::Base.transaction do
@@ -75,6 +77,8 @@ module Api
             prepare_host
             host_setup_insights
             host_setup_remote_execution
+            remote_execution_interface
+
             @template = @host.registration_template
             raise ActiveRecord::Rollback if @template.nil?
           end

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -73,6 +73,18 @@
     </div>
   </div>
   <div class='form-group'>
+    <label class='col-md-2 control-label'>
+      <%= _('Remote Execution Interface') %>
+      <% help = _('Identifier of the Host interface for Remote execution') %>
+      <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+        <span class="pficon pficon-info "></span>
+      </a>
+    </label>
+    <div class='col-md-4'>
+      <%= text_field_tag 'remote_execution_interface', params[:remote_execution_interface], class: 'form-control' %>
+    </div>
+  </div>
+  <div class='form-group'>
     <label class='col-md-2 control-label' for='jwt_expiration'>
       <%= _('Token lifetime (hours)') %>
       <% help = _('Expiration of the authorization token.') %>

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -16,6 +16,7 @@ model: ProvisioningTemplate
 <%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
 <%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
 <%= "\n# Setup Remote Execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
+<%= "\n# Remote execution interface: [#{@remote_execution_interface}]" if @remote_execution_interface.present? -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -45,6 +46,7 @@ register_host() {
        <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
        <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
        <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
+       <%= "--data \"remote_execution_interface=#{@remote_execution_interface}\"" if @remote_execution_interface.present? -%>
 
 }
 
@@ -63,6 +65,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
             <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
             <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
             <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
+            <%= "--data \"remote_execution_interface=#{@remote_execution_interface}\"" if @remote_execution_interface.present? -%>
 
     }
 


### PR DESCRIPTION
With new parameter 'remote_execution_interface', users
can specify host's primary interface for remote execution.

**How to test**
* Host with multiple interfaces
* Run:
```
curl --user admin:changeme -X GET "https://foreman.example.com/register?remote_execution_interface=INTERFACE"
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
