### PR TITLE
Refs #28384 - Use correct Foreman version in error log task

### DIFF
--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -38,7 +38,7 @@ namespace :errors do
     end
     puts result
     puts "\n"
-    puts "Foreman version: #{Foreman::VERSION.new.full}"
+    puts "Foreman version: #{Foreman::Version.new.full}"
     unless (plugins = Foreman::Plugin.all).empty?
       puts "Plugins: "
       plugins.each do |plugin|


### PR DESCRIPTION
Looks like this was missed when updating the original PR for comments.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
