### PR TITLE
Fixes #31191 - use correct status when report scheduling fails

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -162,7 +162,8 @@ module Api
           process_resource_error
         end
       rescue => e
-        render_error 'standard_error', :status => :internal_error, :locals => { :exception => e }
+        render_error :custom_error, :status => :unprocessable_entity,
+                     :locals => { :message => _("Scheduling Report template failed for: %s." % e.message) }
       end
 
       api :GET, "/report_templates/:id/report_data/:job_id", N_("Downloads a generated report")


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
