### PR TITLE
Fixes #31213 - hostgroup API facets extension point

### DIFF
--- a/app/models/concerns/facets/hostgroup_extensions.rb
+++ b/app/models/concerns/facets/hostgroup_extensions.rb
@@ -8,6 +8,8 @@ module Facets
     included do
       configure_facet(:hostgroup, :hostgroup, :hostgroup_id)
 
+      refresh_facet_relations
+
       Facets.after_entry_created do |entry|
         register_facet_relation(entry) if entry.has_hostgroup_configuration?
       end

--- a/app/services/facets.rb
+++ b/app/services/facets.rb
@@ -9,6 +9,10 @@ module Facets
     facets.select { |_, facet| facet.has_configuration(facet_type) }
   end
 
+  def facets_for_type(facet_type)
+    registered_facets(facet_type).map { |_, entry| entry.configuration_for(facet_type) }
+  end
+
   def find_facet_by_class(facet_class, facet_type = :host)
     hash = registered_facets(facet_type).select { |_, facet| facet.configuration_for(facet_type).model == facet_class }
     hash.first

--- a/app/services/facets/host_base_entry.rb
+++ b/app/services/facets/host_base_entry.rb
@@ -14,6 +14,10 @@ module Facets
       @name = facet_name
     end
 
+    def facet_record_for(base_record)
+      base_record.public_send(name)
+    end
+
     # Declare a helper module that will be added to host's view.
     def add_helper(facet_helper)
       @helper = facet_helper

--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -18,3 +18,10 @@ if @parameters
     { :parameters => partial("api/v2/parameters/index", :object => hostgroup.group_parameters.authorized) }
   end
 end
+
+@object.facets_with_definitions.each do |facet, definition|
+  next unless definition.api_list_view
+  node(false, if: ->(hostgroup) { definition.facet_record_for(hostgroup) }) do |hostgroup|
+    partial(definition.api_list_view, object: hostgroup, locals: { facet: definition.facet_record_for(hostgroup) })
+  end
+end

--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -19,7 +19,7 @@ if @parameters
   end
 end
 
-@object.facets_with_definitions.each do |facet, definition|
+@object.facet_definitions.each do |definition|
   next unless definition.api_list_view
   node(false, if: ->(hostgroup) { definition.facet_record_for(hostgroup) }) do |hostgroup|
     partial(definition.api_list_view, object: hostgroup, locals: { facet: definition.facet_record_for(hostgroup) })

--- a/app/views/api/v2/hostgroups/show.json.rabl
+++ b/app/views/api/v2/hostgroups/show.json.rabl
@@ -18,6 +18,13 @@ child :config_groups do
   extends "api/v2/config_groups/main"
 end
 
+root_object.facets_with_definitions.each do |facet, definition|
+  next unless definition.api_single_view
+  node(false, if: ->(hostgroup) { definition.facet_record_for(hostgroup) }) do |hostgroup|
+    partial(definition.api_single_view, object: hostgroup, locals: { facet: definition.facet_record_for(hostgroup) })
+  end
+end
+
 node do |hostgroup|
   partial("api/v2/taxonomies/children_nodes", :object => hostgroup)
 end

--- a/app/views/api/v2/hostgroups/show.json.rabl
+++ b/app/views/api/v2/hostgroups/show.json.rabl
@@ -18,7 +18,7 @@ child :config_groups do
   extends "api/v2/config_groups/main"
 end
 
-root_object.facets_with_definitions.each do |facet, definition|
+root_object.facet_definitions.each do |definition|
   next unless definition.api_single_view
   node(false, if: ->(hostgroup) { definition.facet_record_for(hostgroup) }) do |hostgroup|
     partial(definition.api_single_view, object: hostgroup, locals: { facet: definition.facet_record_for(hostgroup) })

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -55,8 +55,9 @@ if @all_parameters
   end
 end
 
-@object.facets_with_definitions.each do |_facet, definition|
-  node do
-    partial(definition.api_list_view, :object => @object) if definition.api_list_view
+@object.facets_with_definitions.each do |facet, definition|
+  next unless definition.api_list_view
+  node(false, if: ->(host) { definition.facet_record_for(host) }) do |host|
+    partial(definition.api_list_view, object: host, locals: { facet: definition.facet_record_for(host) })
   end
 end

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -55,7 +55,7 @@ if @all_parameters
   end
 end
 
-@object.facets_with_definitions.each do |facet, definition|
+@object.facet_definitions.each do |definition|
   next unless definition.api_list_view
   node(false, if: ->(host) { definition.facet_record_for(host) }) do |host|
     partial(definition.api_list_view, object: host, locals: { facet: definition.facet_record_for(host) })

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -18,7 +18,7 @@ child :config_groups do
   extends "api/v2/config_groups/main"
 end
 
-root_object.facets_with_definitions.each do |facet, definition|
+root_object.facet_definitions.each do |definition|
   next unless definition.api_single_view
   node(false, if: ->(host) { definition.facet_record_for(host) }) do |host|
     partial(definition.api_single_view, object: host, locals: { facet: definition.facet_record_for(host) })

--- a/app/views/api/v2/hosts/show.json.rabl
+++ b/app/views/api/v2/hosts/show.json.rabl
@@ -18,9 +18,10 @@ child :config_groups do
   extends "api/v2/config_groups/main"
 end
 
-root_object.facets_with_definitions.each do |_facet, definition|
-  node do
-    partial(definition.api_single_view, :object => root_object) if definition.api_single_view
+root_object.facets_with_definitions.each do |facet, definition|
+  next unless definition.api_single_view
+  node(false, if: ->(host) { definition.facet_record_for(host) }) do |host|
+    partial(definition.api_single_view, object: host, locals: { facet: definition.facet_record_for(host) })
   end
 end
 

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -327,6 +327,40 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  describe 'facets works in API' do
+    let(:hostgroup) { FactoryBot.create(:hostgroup) }
+    let(:facet) { mock('HostgroupTestFacet') }
+
+    setup do
+      hostgroup # create prior facet stubing
+      Api::V2::BaseController.append_view_path(Rails.root.join('test', 'static_fixtures', 'views'))
+      facet_definition = mock('Facets::HostBaseEntry')
+      facet_definition.stubs(name: :test_facet, api_single_view: 'api/v2/test/two', api_list_view: 'api/v2/test/facet')
+      Hostgroup.any_instance.stubs(:facet_definitions).returns([facet_definition])
+
+      facet_definition.stubs(:facet_record_for).returns(facet)
+      facet.stubs(attributes: { 'id' => 123 })
+    end
+
+    test 'show include both views' do
+      facet.expects(:foo).returns('bar')
+      get :show, params: { id: hostgroup.to_param }
+      json_response = JSON.parse(@response.body)
+      assert_includes json_response.keys, 'two'
+      assert_includes json_response.keys, 'facet_param'
+      assert_equal json_response['facet_param'], 'bar'
+    end
+
+    test 'index include list view' do
+      facet.expects(:foo).times(Hostgroup.count).returns('bar')
+      get :index
+      json_response = JSON.parse(@response.body)['results'].detect { |hostgroup_node| hostgroup_node['id'] == hostgroup.id }
+      assert_not_includes json_response.keys, 'two'
+      assert_includes json_response.keys, 'facet_param'
+      assert_equal json_response['facet_param'], 'bar'
+    end
+  end
+
   private
 
   def last_record

--- a/test/static_fixtures/views/api/v2/test/facet.json.rabl
+++ b/test/static_fixtures/views/api/v2/test/facet.json.rabl
@@ -1,0 +1,3 @@
+node :facet_param do
+  @facet.foo
+end


### PR DESCRIPTION
Adds Facet extension points for Hostgroup API responses.
Adds forgotten refresh for existing entires on hostgroup.

**EDIT**: This is needed by [foreman_puppet_enc plugin](https://github.com/theforeman/foreman_puppet_enc) since https://github.com/theforeman/foreman_puppet_enc/commit/40cfb9bee669488aa4f04f55fdaba34945e7878a#diff-8dc4b7b4116cb63c7a7b1b3c40a25c515f61ccceff63bb4b387eda1f10607988R102-R104