### PR TITLE
Fixes #31218 - disable parameter wrapping for reports

### DIFF
--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -4,6 +4,9 @@ module Api
       include Api::Version2
       include Foreman::Controller::SmartProxyAuth
 
+      # wrapping is extremely slow for large JSON reports, make sure it's not used for this endpoint
+      wrap_parameters :format => []
+
       before_action :find_resource, :only => %w{destroy}
       before_action :setup_search_options, :only => [:index, :last]
       before_action :compatibility, :only => :create


### PR DESCRIPTION
Parameter wrapping is a feature of Rails that adds missing root JSON element in case it's missing. The thing is it uses Hash.merge method which is slow, it does not work similarly to HashWithIndefferentAccess. Our fact/reports clients do send full JSON documents (including the root elements) so we should be able to disable this behavior for those endpoints without any problems, this patch will prevent anyone else from sending without root elements.

This patch can possibly break 3rd party integrations, howevers it's the purpose - to avoid slow JSON processing. We will do upgrade notes on how to fix this.

This patch only makes the change for reports, facts use host controller and there is no way to disable per action currently.