### PR TITLE
Fixes #31147 - extend StatusCalculator to use 64 bits

### DIFF
--- a/app/models/config_report.rb
+++ b/app/models/config_report.rb
@@ -1,6 +1,6 @@
 class ConfigReport < Report
-  METRIC = %w[applied restarted failed failed_restarts skipped pending]
-  BIT_NUM = 6
+  METRIC = %w[applied restarted failed failed_restarts skipped pending].freeze
+  BIT_NUM = 10
   MAX = (1 << BIT_NUM) - 1 # maximum value per metric
 
   scoped_search :on => :status, :offset => 0, :word_size => 4 * BIT_NUM, :complete_value => {:true => true, :false => false}, :rename => :eventful
@@ -82,7 +82,10 @@ class ConfigReport < Report
   end
 
   delegate :error?, :changes?, :pending?, :status, :status_of, :to => :calculator
+  # delegate all metric methods
   delegate(*METRIC, :to => :calculator)
+  # delegate all metric_s (as string) methods
+  delegate(*(METRIC.map { |x| "#{x}_s".to_sym }), :to => :calculator)
 
   def calculator
     ConfigReportStatusCalculator.new(:bit_field => self[self.class.report_status_column])

--- a/app/services/config_report_status_calculator.rb
+++ b/app/services/config_report_status_calculator.rb
@@ -1,21 +1,28 @@
 class ConfigReportStatusCalculator
-  # converts a counters hash into a bit field
-  # expects a metrics_to_hash kind of counters
-  # see the report_processor for the implementation
+  # Converts a counters hash into a 64 bit integer (bit field). Required
+  # arguments: counters (hash of counters) or bit_field (raw number for
+  # reverse calculation), metrics (array of expected counter names in
+  # the least significant bit order) and optional size (word size which
+  # is calculated automatically to fit into 64 bit integer result).
   def initialize(options = {})
     @counters   = options[:counters]  || {}
     @raw_status = options[:bit_field] || 0
+    @metrics    = options[:metrics] || ConfigReport::METRIC
+    @size       = options[:size] || (64 / @metrics.size)
+    @max_value  = (1 << @size) - 1
   end
+
+  attr_reader :raw_status, :counters, :metrics, :size, :max_value
 
   # calculates the raw_status based on counters
   def calculate
     @raw_status = 0
     counters.each do |type, value|
       value = value.to_i # JSON does everything as strings
-      value = ConfigReport::MAX if value > ConfigReport::MAX # we store up to 2^BIT_NUM -1 values as we want to use only BIT_NUM bits.
-      @raw_status |= value << (ConfigReport::BIT_NUM * ConfigReport::METRIC.index(type))
+      value = @max_value if value > @max_value
+      @raw_status |= value << (@size * metrics.index(type.to_s))
     end
-    raw_status
+    @raw_status &= 0xFFFFFFFFFFFFFFFF
   end
 
   # returns metrics (counters) based on raw_status (aka bit field)
@@ -24,16 +31,25 @@ class ConfigReportStatusCalculator
     @status ||= begin
       calculate if raw_status == 0
       counters = Hash.new(0)
-      ConfigReport::METRIC.each do |m|
-        counters[m] = (raw_status || 0) >> (ConfigReport::BIT_NUM * ConfigReport::METRIC.index(m)) & ConfigReport::MAX
+      metrics.each do |m|
+        counters[m] = (raw_status || 0) >> (@size * metrics.index(m)) & @max_value
       end
       counters
     end
   end
 
   def status_of(counter)
-    raise(Foreman::Exception.new(N_("invalid type %s"), counter)) unless ConfigReport::METRIC.include?(counter)
+    raise(Foreman::Exception.new(N_("invalid type %s"), counter)) unless metrics.include?(counter)
     status[counter]
+  end
+
+  def status_as_text_of(counter)
+    result = status_of(counter)
+    if result >= @max_value
+      "#{result}+"
+    else
+      result.to_s
+    end
   end
 
   # returns true if total error metrics are > 0
@@ -51,15 +67,13 @@ class ConfigReportStatusCalculator
     status_of('pending') > 0
   end
 
-  # generate dynamically methods for all metrics
-  # e.g. applied failed ...
   ConfigReport::METRIC.each do |method|
     define_method method do
       status_of(method)
     end
+
+    define_method "#{method}_s".to_sym do
+      status_as_text_of(method)
+    end
   end
-
-  private
-
-  attr_reader :raw_status, :counters
 end

--- a/app/views/config_reports/_list.html.erb
+++ b/app/views/config_reports/_list.html.erb
@@ -27,12 +27,12 @@
         <% end %>
         <td><%= reported_at_column(report) %></td>
         <td class="fact-origin"><%= report_origin_icon(report.origin) %></td>
-        <td><%= report_event_column(report.applied, "label-info") %></td>
-        <td><%= report_event_column(report.restarted, "label-info") %></td>
-        <td><%= report_event_column(report.failed, "label-danger") %></td>
-        <td><%= report_event_column(report.failed_restarts, "label-warning") %></td>
-        <td><%= report_event_column(report.skipped, "label-info") %></td>
-        <td><%= report_event_column(report.pending, "label-info") %></td>
+        <td><%= report_event_column(report.applied_s, "label-info") %></td>
+        <td><%= report_event_column(report.restarted_s, "label-info") %></td>
+        <td><%= report_event_column(report.failed_s, "label-danger") %></td>
+        <td><%= report_event_column(report.failed_restarts_s, "label-warning") %></td>
+        <td><%= report_event_column(report.skipped_s, "label-info") %></td>
+        <td><%= report_event_column(report.pending_s, "label-info") %></td>
         <td>
           <%= action_buttons(display_delete_if_authorized hash_for_config_report_path(:id => report).merge(:auth_object => report, :authorizer => authorizer),
                              :data => {:confirm => _("Delete report for %s?") % report.host.try(:name)}) %>

--- a/db/migrate/20201030102020_enlarge_report_status.rb
+++ b/db/migrate/20201030102020_enlarge_report_status.rb
@@ -1,0 +1,29 @@
+class EnlargeReportStatus < ActiveRecord::Migration[6.0]
+  def up
+    remove_index :reports, :status
+
+    User.without_auditing do
+      Report.unscoped.in_batches(of: 2000, load: false) do |relation|
+        relation.pluck(:id, :status).each do |report_id, current_status|
+          old_calc = ConfigReportStatusCalculator.new(bit_field: current_status, size: 6)
+          new_calc = ConfigReportStatusCalculator.new(counters: old_calc.status, size: 10)
+          Report.unscoped.where(id: report_id).update_all(status: new_calc.calculate)
+        end
+      end
+    end
+  end
+
+  def down
+    add_index :reports, :status
+
+    User.without_auditing do
+      Report.unscoped.in_batches(of: 2000, load: false) do |relation|
+        relation.pluck(:id, :status).each do |report_id, current_status|
+          old_calc = ConfigReportStatusCalculator.new(bit_field: current_status, size: 10)
+          new_calc = ConfigReportStatusCalculator.new(counters: old_calc.status, size: 6)
+          Report.unscoped.where(id: report_id).update_all(status: new_calc.calculate)
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -16,7 +16,6 @@ desc <<~END_DESC
       rake reports:expire report_type=MyReport days=3 # expires all reports of type MyReport (class name style) from the last 3 days.
 
 END_DESC
-
 namespace :reports do
   def report_type
     return ConfigReport if ENV['report_type'].blank?
@@ -42,6 +41,7 @@ namespace :reports do
     end
   end
 end
+
 # TRANSLATORS: do not translate
 desc <<~END_DESC
   Send an email notifications such as summarising hosts Puppet reports (and lack of it), audits summaries, built hosts summary etc.

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -138,4 +138,95 @@ namespace :seed do
       parts.join('.')
     end
   end
+
+  # TRANSLATORS: do not translate
+  desc <<~END_DESC
+    Generate dummy reports and display performance numbers. Half of lines are unique,
+    half are same. Reports will be expired via cron or can be expired manually or
+    by deleting all hosts named hostXX.example.com.
+
+    Available conditions:
+      * origin           => Puppet or Ansible
+      * hosts            => number of newly created hosts
+      * reports          => number of reports per host
+      * lines            => number of lines per report
+
+      Example:
+        rake reports:generate hosts=20 reports=100 lines=200
+  END_DESC
+  task :reports => :environment do
+    def randn
+      rand(100_000)
+    end
+
+    def make_report(origin, host = 1, logs = 100)
+      is_ansible = origin =~ /Ansible/i
+      is_puppet = origin =~ /Puppet/i
+      metrics = if is_puppet
+                  { "time" => { "config_retrieval" => 6.98906397819519, "total" => 13.8197405338287 },
+                    "resources" => { "applied" => 0, "failed" => 1, "failed_restarts" => 0, "out_of_sync" => 0, "restarted" => 0, "scheduled" => 67, "skipped" => 0, "total" => 68 }, "changes" => { "total" => 0 } }
+                elsif is_ansible
+                  { "metrics" => {"time" => { "total": 37 } }}
+                else
+                  {}
+                end
+      base = {
+        "host" => "host#{host}.example.com", "reported_at" => Time.now.utc.to_s,
+        "status" => {
+          "applied" => host,
+          "restarted" => host * 2,
+          "failed" => host * 3,
+          "failed_restarts" => 0,
+          "skipped" => 1,
+          "pending" => 9999999,
+        },
+        "metrics" => metrics,
+        "logs" => []
+      }
+      (1..logs).each do |i|
+        src = if is_ansible
+                "common : Copy default motd %s" % (i.even? ? randn : 0)
+              elsif is_puppet
+                "//Node/Puppet[%s]" % (i.even? ? randn : 0)
+              else
+                "A unique message %s" % (i.even? ? randn : 0)
+              end
+        msg = if is_ansible
+                "{\"_ansible_parsed\": true, \"group\": \"root\", \"uid\": 0, \"checksum\": \"%s\", \"changed\": false, \"owner\": \"root\", \"state\": \"file\", \"gid\": 0, \"mode\": \"0644\", \"diff\": {\"after\": {\"path\": \"/etc/motd\"}, \"before\": {\"path\": \"/etc/motd\"}}, \"invocation\": {\"module_args\": {\"directory_mode\": null, \"force\": false, \"remote_src\": null, \"path\": \"/etc/motd\", \"owner\": \"root\", \"follow\": false, \"group\": \"root\", \"unsafe_writes\": null, \"state\": \"file\", \"content\": null, \"serole\": null, \"diff_peek\": null, \"setype\": null, \"dest\": \"/etc/motd\", \"selevel\": null, \"original_basename\": \"motd.txt\", \"regexp\": null, \"validate\": null, \"src\": \"motd.txt\", \"seuser\": null, \"recurse\": false, \"delimiter\": null, \"mode\": null, \"attributes\": null, \"backup\": null}}, \"path\": \"/etc/motd\", \"size\": 1090, \"_ansible_no_log\": false}" % (i.even? ? Digest::SHA1.hexdigest(randn.to_s) : "0a381ff6a86081af6dc957a77c7e2017a3244c4c")
+              elsif is_puppet
+                "A Puppet message"
+              else
+                "A message"
+              end
+        base["logs"].append({
+                              "log" => { "sources" => { "source" => src },
+                              "messages" => { "message" => msg },
+                              "level" => (i.even? ? "notice" : "err") },
+                            })
+      end
+      base["reporter"] = "ansible" if is_ansible
+      base
+    end
+
+    User.as_anonymous_admin do
+      Rails.logger.level = Logger::ERROR
+      Foreman::Logging.logger('permissions').level = Logger::ERROR
+      Foreman::Logging.logger('audit').level = Logger::ERROR
+      origin = ENV['origin'] || 'Puppet'
+      hosts = ENV['hosts'] || 10
+      reports = ENV['reports'] || 50
+      lines = ENV['lines'] || 100
+      total_time = 0
+      (1..reports).each do |i|
+        host_id = i % hosts
+        report = make_report(origin, host_id + 1, lines)
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond)
+        ConfigReport.import(report)
+        total_time += Process.clock_gettime(Process::CLOCK_MONOTONIC, :nanosecond) - start_time
+      end
+      puts "Total records in the db: #{Host::Base.unscoped.all.count} hosts, #{Report.unscoped.all.count} reports"
+      puts "Time spent: #{total_time.to_f / (10**9)} seconds"
+      puts "Import rate: #{reports.to_f / (total_time / (10**9))} r/s"
+    end
+  end
 end

--- a/test/models/host_status/configuration_status_test.rb
+++ b/test/models/host_status/configuration_status_test.rb
@@ -139,17 +139,17 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
   end
 
   test '.is_not' do
-    assert_equal '((host_status.status >> 6 & 63) = 0)', HostStatus::ConfigurationStatus.is_not('restarted')
+    assert_equal '((host_status.status >> 10 & 1023) = 0)', HostStatus::ConfigurationStatus.is_not('restarted')
   end
 
   test '.is' do
-    assert_equal '((host_status.status >> 6 & 63) != 0)', HostStatus::ConfigurationStatus.is('restarted')
+    assert_equal '((host_status.status >> 10 & 1023) != 0)', HostStatus::ConfigurationStatus.is('restarted')
   end
 
   test '.bit_mask' do
-    assert_equal '0 & 63', HostStatus::ConfigurationStatus.bit_mask('applied')
-    assert_equal '6 & 63', HostStatus::ConfigurationStatus.bit_mask('restarted')
-    assert_equal '12 & 63', HostStatus::ConfigurationStatus.bit_mask('failed')
+    assert_equal '0 & 1023', HostStatus::ConfigurationStatus.bit_mask('applied')
+    assert_equal '10 & 1023', HostStatus::ConfigurationStatus.bit_mask('restarted')
+    assert_equal '20 & 1023', HostStatus::ConfigurationStatus.bit_mask('failed')
   end
 
   test 'host search by status works' do

--- a/test/unit/config_report_status_calculator_test.rb
+++ b/test/unit/config_report_status_calculator_test.rb
@@ -11,13 +11,80 @@ class ConfigReportStatusCalculatorTest < ActiveSupport::TestCase
     assert_equal 0, r.status['failed']
   end
 
-  test 'it should save metrics as bits in status integer' do
-    r = ConfigReportStatusCalculator.new(:counters => {'applied' => 92, 'restarted' => 300, 'failed' => 4, 'failed_restarts' => 12, 'skipped' => 3, 'pending' => 4})
-    assert_equal ConfigReport::MAX, r.status['applied']
-    assert_equal ConfigReport::MAX, r.status['restarted']
-    assert_equal 4, r.status['failed']
-    assert_equal 12, r.status['failed_restarts']
-    assert_equal 3, r.status['skipped']
-    assert_equal 4, r.status['pending']
+  test 'it should save metrics as bits in status integers' do
+    r = ConfigReportStatusCalculator.new(:size => 6, :counters => {
+                                           'applied': 1,
+      'restarted': 2,
+      'failed': 3,
+      'failed_restarts': 4,
+      'skipped': 5,
+      'pending': 6,
+                                         })
+    assert_equal 1, r.status_of('applied')
+    assert_equal 2, r.status_of('restarted')
+    assert_equal 3, r.status_of('failed')
+    assert_equal 4, r.status_of('failed_restarts')
+    assert_equal 5, r.status_of('skipped')
+    assert_equal 6, r.status_of('pending')
+  end
+
+  test 'it should save metrics as bits in status strings' do
+    r = ConfigReportStatusCalculator.new(:size => 6, :counters => {
+                                           'applied': 0,
+      'restarted': 1,
+      'failed': 63,
+      'failed_restarts': 64,
+      'skipped': 100,
+      'pending': 200,
+                                         })
+    assert_equal "0", r.status_as_text_of('applied')
+    assert_equal "1", r.status_as_text_of('restarted')
+    assert_equal "63+", r.status_as_text_of('failed')
+    assert_equal "63+", r.status_as_text_of('failed_restarts')
+    assert_equal "63+", r.status_as_text_of('skipped')
+    assert_equal "63+", r.status_as_text_of('pending')
+  end
+
+  test 'it should make use of some bits for (the legacy) word size 6' do
+    maximum_value = 63
+    r = ConfigReportStatusCalculator.new(:size => 6, :counters => {
+                                           'applied': maximum_value,
+      'restarted': maximum_value,
+      'failed': maximum_value,
+      'failed_restarts': maximum_value,
+      'skipped': maximum_value,
+      'pending': maximum_value,
+                                         })
+    assert_equal 0xFFFFFFFFF, r.calculate, "Expected in hex: %x, Actual in hex: %x" % [0xFFFFFFFFF, r.calculate]
+  end
+
+  test 'it should make use of all bits available' do
+    maximum_value = 255
+    r = ConfigReportStatusCalculator.new(:metrics => %w[1 2 3 4 5 6 7 8], :counters => {
+                                           '1': maximum_value,
+      '2': maximum_value,
+      '3': maximum_value,
+      '4': maximum_value,
+      '5': maximum_value,
+      '6': maximum_value,
+      '7': maximum_value,
+      '8': maximum_value,
+                                         })
+    assert_equal 0xFFFFFFFFFFFFFFFF, r.calculate, "Expected in hex: %x, Actual in hex: %x" % [0xFFFFFFFFFFFFFFFF, r.calculate]
+  end
+
+  test 'it should make use of 60 bits for Puppet' do
+    maximum_value = 1023
+    r = ConfigReportStatusCalculator.new(:metrics => %w[applied restarted failed failed_restarts skipped pending],
+      :counters => {
+        'applied': maximum_value,
+        'restarted': maximum_value,
+        'failed': maximum_value,
+        'failed_restarts': maximum_value,
+        'skipped': maximum_value,
+        'pending': maximum_value,
+      })
+    # the most significant short is unused (10bit * 6 metrics = 60bits)
+    assert_equal 0x0FFFFFFFFFFFFFFF, r.calculate, "Expected in hex: %x, Actual in hex: %x" % [0x0FFFFFFFFFFFFFFF, r.calculate]
   end
 end


### PR DESCRIPTION
ConfigReportStatusCalculator class is too tightly coupled with ConfigReport (using MAX and other constants). This needs to be decoupled there is no reason to have it like that, this will also enable using this class in the modernized report engine.

Also we currently do not indicate that the maximum number has been reached (e.g. 63 currently for puppet). There should be a helper method that returns numbers as strings returning "63+" in case the ceiling is reached. This should be used in templates to render those number correctly so users can actually recognize this hidden fact.

Next up, status is a "BIG INT" in our database schema which is 64 bits however currently the class does not make use of all bits for some reason: 36 bits are used for some strange reason in Puppet case. This will allow larger numbers. Migration must be done to convert current reports into the wider format.

Finally, there is an existing index named index_reports_on_status on the status column, but this is useless - this will never be used since scoped_search use bitwise shift and and operators: https://github.com/wvanbergen/scoped_search/blob/6fe6b86c223d7ba8eb14207bae8f4c28f676d9d0/lib/scoped_search/query_builder.rb#L343

In order to use an index, it would have to be a dynamic index on (status >> 8) but this can't be done since it is unknown how many bits are used in each plugin. The index should be simply dropped as unused.

There is a new Rake task that allows creation of the two most widely used ConfigReports: Puppet and Ansible. This allows to easily load database with some (dummy) reports, this can be also used in the future to compare performance of the newly-designed report system.

![obrazek](https://user-images.githubusercontent.com/49752/97711478-6d4f8080-1abd-11eb-9f94-4707ea7bfcc3.png)
