### PR TITLE
Fixes #31228 - Improve UUID check performance

### DIFF
--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -2,14 +2,14 @@ require 'securerandom'
 module Foreman
   # generate a UUID
   def self.uuid
-    SecureRandom.uuid.to_s
+    SecureRandom.uuid
   end
 
   UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
-                           "([0-9a-f]{2})([0-9a-f]{2})-([0-9a-f]{12})$")
+                           "([0-9a-f]{4})-([0-9a-f]{12})$")
   # does this look like a UUID?
   def self.is_uuid?(str)
-    !!(str =~ UUID_REGEXP)
+    str.is_a?(String) && str.length == 36 && str.match?(UUID_REGEXP)
   end
 
   def self.in_rake?(*rake_tasks)


### PR DESCRIPTION
Doing a full match for regexp including saving match data is slow when
all we care about is whether it is a UUID or not. Instead first rule out
quick checks (not a string, wrong length) and only then check with
`.match?` instead of `=~` which just returns a boolean without saving
the match data.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
