### PR TITLE
Fix ipv6 factory to stop failing

### DIFF
--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -89,7 +89,7 @@ FactoryBot.define do
     end
 
     trait :with_ipv6 do
-      sequence(:ip6) { |n| Array.new(4) { '%x' % rand(16**4) }.join(':') + '::' + n }
+      sequence(:ip6) { |n| Array.new(4) { '%x' % rand(16**4) }.join(':') + '::' + n.to_s }
     end
   end
 


### PR DESCRIPTION
Without the fix, the `:with_ipv6` trait for nic does not work