### PR TITLE
Fixes #31241 - show dateTimePicker default value

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
+++ b/webpack/assets/javascripts/react_app/components/Template/TemplateInput.js
@@ -48,7 +48,6 @@ const TemplateInput = ({
           inputProps={{
             name: `${template}[input_values][${id}][value]`,
           }}
-          hideValue={!value.length}
           value={value || undefined}
         />
       );

--- a/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Template/__test__/__snapshots__/ReportTemplateInput.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`Report Template AutoComplete rendering renders report template with date input 1`] = `
 <DateTime
-  hideValue={false}
   id={4}
   info="Format is yyyy-mm-dd HH-mm-ss"
   inputProps={

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DatePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DatePicker.js
@@ -13,14 +13,19 @@ import { formatDate } from '../../../common/helpers';
 import './date-time-picker.scss';
 
 class DatePicker extends React.Component {
+  get hasDefaultValue() {
+    const { value } = this.props;
+    return !!Date.parse(value);
+  }
+
   get initialDate() {
     const { value } = this.props;
-    return Date.parse(value) ? new Date(value) : new Date();
+    return this.hasDefaultValue ? new Date(value) : new Date();
   }
 
   state = {
     value: this.initialDate,
-    hiddenValue: this.props.hiddenValue,
+    hiddenValue: !this.hasDefaultValue,
   };
 
   setSelected = date => {
@@ -99,17 +104,15 @@ DatePicker.propTypes = {
   weekStartsOn: PropTypes.number,
   id: PropTypes.string,
   placement: OverlayTrigger.propTypes.placement,
-  hiddenValue: PropTypes.bool,
   required: PropTypes.bool,
 };
 DatePicker.defaultProps = {
-  value: new Date(),
+  value: null,
   name: null,
   locale: 'en-US',
   weekStartsOn: 1,
   id: 'date-picker-popover',
   placement: 'top',
-  hiddenValue: true,
   required: false,
 };
 export default DatePicker;

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DatePicker.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DatePicker.test.js
@@ -2,17 +2,23 @@ import React from 'react';
 import { shallow, mount } from '@theforeman/test';
 import DatePicker from './DatePicker';
 
-test('DatePicker is working properly', () => {
-  const component = shallow(<DatePicker value="2/21/2019 , 2:22:31 PM" />);
+describe('DatePicker', () => {
+  test('renders properly', () => {
+    const component = shallow(<DatePicker/>);
+    expect(component.render()).toMatchSnapshot();
+  });
 
-  expect(component.render()).toMatchSnapshot();
-});
+  test('prefils the value from prop', () => {
+    const component = shallow(<DatePicker value="2/21/2019 , 2:22:31 PM"/>);
+    expect(component.render()).toMatchSnapshot();
+  });
 
-test('Edit form of DatePicker', () => {
-  const component = mount(<DatePicker value="2/21/2019  " />);
-  expect(component.render()).toMatchSnapshot();
-  component
-    .find('input')
-    .simulate('change', { target: { value: '2/22/2019  ' } });
-  expect(component.state().value).toEqual(new Date('2/22/2019  '));
+  test('edit works', () => {
+    const component = mount(<DatePicker value="2/21/2019  " />);
+    component
+      .find('input')
+      .simulate('change', { target: { value: '2/22/2019' } });
+    expect(component.state().value).toEqual(new Date('2/22/2019'));
+    expect(component.render()).toMatchSnapshot();
+  });
 });

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -15,16 +15,21 @@ import { formatDateTime } from '../../../common/helpers';
 import './date-time-picker.scss';
 
 class DateTimePicker extends React.Component {
+  get hasDefaultValue() {
+    const { value } = this.props;
+    return !!Date.parse(value);
+  }
+
   get initialDate() {
     const { value } = this.props;
-    return Date.parse(value) ? new Date(value) : new Date();
+    return this.hasDefaultValue ? new Date(value) : new Date();
   }
 
   state = {
     value: this.initialDate,
     typeOfDateInput: MONTH,
     isTimeTableOpen: false,
-    hiddenValue: this.props.hiddenValue,
+    hiddenValue: !this.hasDefaultValue,
   };
 
   setSelected = date => {
@@ -122,18 +127,16 @@ DateTimePicker.propTypes = {
   weekStartsOn: PropTypes.number,
   inputProps: PropTypes.object,
   id: PropTypes.string,
-  hiddenValue: PropTypes.bool,
   placement: OverlayTrigger.propTypes.placement,
   name: PropTypes.string,
   required: PropTypes.bool,
 };
 DateTimePicker.defaultProps = {
-  value: new Date(),
+  value: null,
   locale: 'en-US',
   weekStartsOn: 1,
   inputProps: {},
   id: 'datetime-picker-popover',
-  hiddenValue: true,
   placement: 'top',
   name: undefined,
   required: false,

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.test.js
@@ -2,17 +2,23 @@ import React from 'react';
 import { shallow, mount } from '@theforeman/test';
 import DateTimePicker from './DateTimePicker';
 
-test('DateTimePicker is working properly', () => {
-  const component = shallow(<DateTimePicker value="2/21/2019 , 2:22:31 PM" />);
+describe('DateTimePicker', () => {
+  test('renders properly', () => {
+    const component = shallow(<DateTimePicker/>);
+    expect(component.render()).toMatchSnapshot();
+  });
 
-  expect(component.render()).toMatchSnapshot();
-});
+  test('prefils the value from prop', () => {
+    const component = shallow(<DateTimePicker value="2/21/2019 , 2:22:31 PM"/>);
+    expect(component.render()).toMatchSnapshot();
+  });
 
-test('Edit form of DateTimePicker', () => {
-  const component = mount(<DateTimePicker value="2/21/2019 ,2:22:31 PM" />);
-  expect(component.render()).toMatchSnapshot();
-  component
-    .find('input')
-    .simulate('change', { target: { value: '2/22/2019 , 2:22:31 PM' } });
-  expect(component.state().value).toEqual(new Date('2/22/2019 , 2:22:31 PM'));
+  test('edit works', () => {
+    const component = mount(<DateTimePicker value="2/21/2019 ,2:22:31 PM" />);
+    component
+      .find('input')
+      .simulate('change', { target: { value: '2/22/2019 , 2:22:31 PM' } });
+    expect(component.state().value).toEqual(new Date('2/22/2019 , 2:22:31 PM'));
+    expect(component.render()).toMatchSnapshot();
+  });
 });

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/__snapshots__/DatePicker.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/__snapshots__/DatePicker.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DatePicker is working properly 1`] = `
+exports[`DatePicker edit works 1`] = `
 <div>
   <span
     class="input-group date-time-picker-pf input-group"
@@ -9,7 +9,7 @@ exports[`DatePicker is working properly 1`] = `
       aria-label="date-time-picker-input"
       class="date-input form-control"
       type="text"
-      value=""
+      value="2019-02-22"
     />
     <span
       class="date-picker-pf input-group-addon"
@@ -31,7 +31,38 @@ exports[`DatePicker is working properly 1`] = `
 </div>
 `;
 
-exports[`Edit form of DatePicker 1`] = `
+exports[`DatePicker prefils the value from prop 1`] = `
+<div>
+  <span
+    class="input-group date-time-picker-pf input-group"
+  >
+    <input
+      aria-label="date-time-picker-input"
+      class="date-input form-control"
+      type="text"
+      value="2019-02-21"
+    />
+    <span
+      class="date-picker-pf input-group-addon"
+    >
+      <span
+        aria-hidden="true"
+        class="fa fa-calendar"
+      />
+    </span>
+    <span
+      class="clear-button input-group-addon"
+    >
+      <span
+        aria-hidden="true"
+        class="fa fa-close"
+      />
+    </span>
+  </span>
+</div>
+`;
+
+exports[`DatePicker renders properly 1`] = `
 <div>
   <span
     class="input-group date-time-picker-pf input-group"

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateTimePicker is working properly 1`] = `
+exports[`DateTimePicker edit works 1`] = `
 <div>
   <span
     class="input-group date-time-picker-pf input-group"
@@ -9,7 +9,7 @@ exports[`DateTimePicker is working properly 1`] = `
       aria-label="date-picker-input"
       class="date-time-input form-control"
       type="text"
-      value=""
+      value="2019-02-22 14:22:00"
     />
     <span
       class="date-time-picker-pf input-group-addon"
@@ -31,7 +31,38 @@ exports[`DateTimePicker is working properly 1`] = `
 </div>
 `;
 
-exports[`Edit form of DateTimePicker 1`] = `
+exports[`DateTimePicker prefils the value from prop 1`] = `
+<div>
+  <span
+    class="input-group date-time-picker-pf input-group"
+  >
+    <input
+      aria-label="date-picker-input"
+      class="date-time-input form-control"
+      type="text"
+      value="2019-02-21 14:22:00"
+    />
+    <span
+      class="date-time-picker-pf input-group-addon"
+    >
+      <span
+        aria-hidden="true"
+        class="fa fa-calendar"
+      />
+    </span>
+    <span
+      class="clear-button input-group-addon"
+    >
+      <span
+        aria-hidden="true"
+        class="fa fa-close"
+      />
+    </span>
+  </span>
+</div>
+`;
+
+exports[`DateTimePicker renders properly 1`] = `
 <div>
   <span
     class="input-group date-time-picker-pf input-group"

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.js
@@ -12,7 +12,6 @@ const DateTime = ({
   id,
   info,
   isRequired,
-  hideValue,
   locale,
   inputProps,
   value,
@@ -36,7 +35,6 @@ const DateTime = ({
       }
     >
       <DateTimePicker
-        hiddenValue={hideValue && !isRequired}
         value={value}
         id={`template-date-input-${id}`}
         inputProps={{
@@ -58,7 +56,6 @@ DateTime.propTypes = {
   inputProps: PropTypes.object,
   value: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
   initialError: PropTypes.string,
-  hideValue: PropTypes.bool,
 };
 
 DateTime.defaultProps = {
@@ -67,7 +64,6 @@ DateTime.defaultProps = {
   locale: null,
   value: new Date(),
   initialError: undefined,
-  hideValue: false,
   inputProps: {},
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/DateTime.test.js
@@ -7,7 +7,7 @@ const fixtures = {
   'renders with Require and Info': DateTimeWithRequireAndInfo,
 };
 
-describe('Report Template AutoComplete', () => {
+describe('DateTime', () => {
   describe('rendering', () => {
     testComponentSnapshotsWithFixtures(DateTime, fixtures);
   });

--- a/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/DateTime/__snapshots__/DateTime.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Report Template AutoComplete rendering renders Report Date input 1`] = `
+exports[`DateTime rendering renders Report Date input 1`] = `
 <CommonForm
   className=""
   inputClassName="col-md-4"
@@ -10,7 +10,6 @@ exports[`Report Template AutoComplete rendering renders Report Date input 1`] = 
   touched={true}
 >
   <DateTimePicker
-    hiddenValue={false}
     id="template-date-input-4"
     inputProps={
       Object {
@@ -27,7 +26,7 @@ exports[`Report Template AutoComplete rendering renders Report Date input 1`] = 
 </CommonForm>
 `;
 
-exports[`Report Template AutoComplete rendering renders with Require and Info 1`] = `
+exports[`DateTime rendering renders with Require and Info 1`] = `
 <CommonForm
   className=""
   inputClassName="col-md-4"
@@ -48,7 +47,6 @@ exports[`Report Template AutoComplete rendering renders with Require and Info 1`
   touched={true}
 >
   <DateTimePicker
-    hiddenValue={false}
     id="template-date-input-4"
     inputProps={
       Object {


### PR DESCRIPTION
By default we hid the default value from user to prevent showing the default date.
But if prop value is passed, we need to show that value.

Easy test:
- have report template with some required fields and dateTime field.
- Try to generate that template, without filling the required field, but filling the date field.
- It will rerender the template and you should see the value prefilled in the template.