### PR TITLE
Fixes #30978 - add css to global js files

### DIFF
--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -13,6 +13,7 @@
     <%= stylesheet_link_tag *webpack_asset_paths('foreman-vendor', :extension => 'css') %>
     <%= stylesheet_link_tag *webpack_asset_paths('bundle', :extension => 'css') %>
     <%= stylesheet_link_tag 'application' %>
+    <%= webpacked_plugins_with_global_css %>
     <%= yield(:stylesheets) %>
 
     <%= csrf_meta_tags %>

--- a/webpack/stories/docs/client-routing.stories.mdx
+++ b/webpack/stories/docs/client-routing.stories.mdx
@@ -95,3 +95,22 @@ Doing so by updating the plugin's `routes.rb`:
  match '/plugin_page' => '/react#index', :via => [:get]
 ```
 This will use the react template in foreman core.
+
+### Adding Styles
+CSS importing should work out of the box.
+Please use `local` scope when overriding core's styles.
+```css
+/* styles.css */
+:local(.overrideClass) {
+  margin-top: 50px;
+  color: red;
+}
+
+```
+```js
+// index.js
+import React from 'react';
+import pluginStyles from 'styles.css';
+
+return <Component className={pluginStyles.overrideClass} />
+```


### PR DESCRIPTION
Adds CSS files out of the box to  global js files from plugins (slot&fill components, routes registration)
