### PR TITLE
Fixes #31243 - subscription API for active job

### DIFF
--- a/app/jobs/create_rss_notifications.rb
+++ b/app/jobs/create_rss_notifications.rb
@@ -1,4 +1,7 @@
 class CreateRssNotifications < ApplicationJob
+  include ::Foreman::ObservableJob
+  set_hook :create_rss_notifications_performed
+
   def perform(options = {})
     # Defaults to theforeman.org blog RSS
     UINotifications::RssNotificationsChecker.new(options).deliver!

--- a/app/jobs/stored_values_cleanup_job.rb
+++ b/app/jobs/stored_values_cleanup_job.rb
@@ -1,4 +1,7 @@
 class StoredValuesCleanupJob < ApplicationJob
+  include ::Foreman::ObservableJob
+  set_hook :stored_values_cleanup_performed
+
   def perform(options = {})
     StoredValue.expired(options[:ago] || 0).destroy_all
   ensure

--- a/app/jobs/template_render_job.rb
+++ b/app/jobs/template_render_job.rb
@@ -1,5 +1,7 @@
 class TemplateRenderJob < ApplicationJob
   queue_as :default
+  include ::Foreman::ObservableJob
+  set_hook :template_render_performed
 
   def perform(composer_params, opts = {})
     user = User.unscoped.find(opts[:user_id])

--- a/app/models/concerns/foreman/observable_job.rb
+++ b/app/models/concerns/foreman/observable_job.rb
@@ -1,0 +1,27 @@
+module Foreman
+  module ObservableJob
+    extend ActiveSupport::Concern
+    include Foreman::Observable
+
+    included do
+      class_attribute :event_subscription_hooks
+      self.event_subscription_hooks ||= []
+    end
+
+    class_methods do
+      def set_hook(hook_name, namespace: Foreman::Observable::DEFAULT_NAMESPACE, payload: nil, &blk)
+        event_name = Foreman::Observable.event_name_for(hook_name, namespace: namespace)
+        self.event_subscription_hooks |= [event_name]
+
+        after_perform do |job|
+          trigger_hook hook_name, namespace: namespace, payload: payload, block_argument: job.serialize, &blk
+        end
+        nil
+      end
+    end
+
+    def event_payload_for(payload, block_argument, blk)
+      super || block_argument
+    end
+  end
+end

--- a/app/models/concerns/foreman/observable_model.rb
+++ b/app/models/concerns/foreman/observable_model.rb
@@ -31,7 +31,7 @@ module Foreman
       end
     end
 
-    def event_payload_for(payload, blk)
+    def event_payload_for(payload, block_argument, blk)
       super || { object: self }
     end
   end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -2130,7 +2130,39 @@ where `my_event.foreman` is the name of the event you want to subscribe to. You 
   subscribe /.foreman$/, MyPlugin::MySubscriber
 ....
 
-You can find all observable events by calling `Foreman::EventSubscribers.all_observable_events` in the Rails console. Keep in mind that this list only contains events that were set by the `set_hook` method.
+Example events emitted by creating, updating or deleting of selected records (subclasses of `ApplicationRecord` which are defined via `set_hook` method):
+
+* `subnet_created.event.foreman`
+* `subnet_updated.event.foreman`
+* `subnet_destroyed.event.foreman`
+
+Payload for records is the record model object itself under key `object` and `context` with additional logging context. Keep in mind that the model classes are not subject of stable API, they will change in the future. It's recommended not to publish full object but to strip down exposed information to bare minimum (e.g. host name and ID). 
+
+Example events emitted by performing background jobs (subclasses of `ApplicationJob`):
+
+* `template_render_job_performed.event.foreman`
+* `create_rss_notifications_performed.event.foreman`
+
+Payload for background jobs is the serialized active job hash (see `ActiveJob#serialize` method) named `job` and `context` with additional logging context. Arguments are available via "arguments" key and hash keys are converted to strings. An example for `SomeJob.new(1, 2, "third option", {"a_string" => 1, :a_symbol => 1}).perform_now`:
+
+```
+{
+  "context"=>{"user_login"=>"secret_admin", "user_admin"=>true},
+  "job_class"=>nil,
+  "job_id"=>"fbbf03d3-43a3-4466-9582-16825dd56334",
+  "provider_job_id"=>nil,
+  "queue_name"=>"default",
+  "priority"=>nil,
+  "arguments"=>[1, 2, "third option", {"a_string"=>1, "a_symbol"=>1, "_aj_symbol_keys"=>["a_symbol"]}],
+  "executions"=>1,
+  "exception_executions"=>{},
+  "locale"=>"en",
+  "timezone"=>"UTC",
+  "enqueued_at"=>"2021-01-12T10:07:22Z"
+}
+```
+
+You can find all observable events by calling `Foreman::EventSubscribers.all_observable_events` in the Rails console. 
 
 [[translating]]
 == Translating

--- a/lib/foreman/event_subscribers.rb
+++ b/lib/foreman/event_subscribers.rb
@@ -2,7 +2,14 @@ module Foreman
   module EventSubscribers
     def self.all_observable_events
       # in development descendants will only return classes if they have been loaded
-      @all_observable_events ||= ActiveRecord::Base.descendants.select { |klass| klass <= ::Foreman::ObservableModel }.map(&:event_subscription_hooks).flatten.uniq
+      @all_observable_events ||= begin
+        if Rails.env.development?
+          Rails.logger.debug "Performing eager load to find out all observable classes"
+          Rails.application.eager_load!
+        end
+        ApplicationRecord.descendants.select { |klass| klass <= ::Foreman::ObservableModel }.map(&:event_subscription_hooks) +
+        ApplicationJob.descendants.select { |klass| klass <= ::Foreman::ObservableJob }.map(&:event_subscription_hooks)
+      end.flatten.uniq
     end
   end
 end

--- a/test/models/concerns/foreman/observable_job_test.rb
+++ b/test/models/concerns/foreman/observable_job_test.rb
@@ -1,0 +1,74 @@
+require 'test_helper'
+
+class ObservableJobTest < ActiveSupport::TestCase
+  describe '#set_hook' do
+    let(:job) { job_class.new({ "a_string" => 1, :a_symbol => 1 }) }
+    let(:job_class) do
+      Class.new(ApplicationJob) do
+        include ::Foreman::ObservableJob
+
+        def perform(options = {})
+        end
+
+        set_hook :job_performed
+        set_hook :job_performed_with_payload, payload: { custom_payload: true }
+        set_hook :job_performed_with_block do |serialized_job|
+          { a_string: serialized_job["arguments"].first["a_string"], block: true }
+        end
+      end
+    end
+    let(:callback) { -> {} }
+    let(:event_context) { ::Logging.mdc.context.symbolize_keys.with_indifferent_access }
+
+    test 'event subscription hooks are defined in the the job class' do
+      expected_event_subscription_hooks = [
+        'job_performed.event.foreman',
+        'job_performed_with_payload.event.foreman',
+        'job_performed_with_block.event.foreman',
+      ]
+
+      assert_same_elements expected_event_subscription_hooks, job_class.event_subscription_hooks
+    end
+
+    test 'notify with event context' do
+      ActiveSupport::Notifications.subscribed(callback, 'job_performed.event.foreman') do
+        callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+          payload[:context] == event_context
+        end
+
+        job.perform_now
+      end
+    end
+
+    test 'notify with default payload' do
+      ActiveSupport::Notifications.subscribed(callback, 'job_performed.event.foreman') do
+        callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+          # arguments in serialized active job are always strings
+          [payload["arguments"].first["a_string"], payload["arguments"].first["a_symbol"]] == [1, 1]
+        end
+
+        job.perform_now
+      end
+    end
+
+    test 'notify with custom payload' do
+      ActiveSupport::Notifications.subscribed(callback, 'job_performed_with_payload.event.foreman') do
+        callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+          payload[:custom_payload] == true
+        end
+
+        job.perform_now
+      end
+    end
+
+    test 'notify with block payload' do
+      ActiveSupport::Notifications.subscribed(callback, 'job_performed_with_block.event.foreman') do
+        callback.expects(:call).with do |name, _started, _finished, _unique_id, payload|
+          payload["a_string"] == 1 && payload[:block] == true
+        end
+
+        job.perform_now
+      end
+    end
+  end
+end

--- a/test/models/concerns/foreman/observable_model_test.rb
+++ b/test/models/concerns/foreman/observable_model_test.rb
@@ -2,8 +2,8 @@ require 'test_helper'
 
 class ObservableModelTest < ActiveSupport::TestCase
   describe '#set_hook' do
-    let(:model) { klass.create(name: 'My Model') }
-    let(:klass) do
+    let(:model) { model_class.create(name: 'My Model') }
+    let(:model_class) do
       Class.new(ApplicationRecord) do
         include ::Foreman::ObservableModel
 
@@ -20,7 +20,7 @@ class ObservableModelTest < ActiveSupport::TestCase
       end
     end
     let(:callback) { -> {} }
-    let(:event_context) { { context: ::Logging.mdc.context.symbolize_keys } }
+    let(:event_context) { ::Logging.mdc.context.symbolize_keys.with_indifferent_access }
 
     test 'event subscription hooks are defined in the the Model class' do
       expected_event_subscription_hooks = [
@@ -30,13 +30,23 @@ class ObservableModelTest < ActiveSupport::TestCase
         'model_info_updated.event.foreman',
       ]
 
-      assert_same_elements expected_event_subscription_hooks, klass.event_subscription_hooks
+      assert_same_elements expected_event_subscription_hooks, model_class.event_subscription_hooks
+    end
+
+    test 'notify with event context' do
+      ActiveSupport::Notifications.subscribed(callback, 'model_updated.event.foreman') do
+        callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+          payload[:context] == event_context
+        end
+
+        model.update(name: 'New Name')
+      end
     end
 
     test 'notify with default payload' do
       ActiveSupport::Notifications.subscribed(callback, 'model_updated.event.foreman') do
         callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-          payload == { object: model }.merge(event_context)
+          payload[:object] == model
         end
 
         model.update(name: 'New Name')
@@ -46,7 +56,7 @@ class ObservableModelTest < ActiveSupport::TestCase
     test 'notify with custom payload' do
       ActiveSupport::Notifications.subscribed(callback, 'model_updated_with_payload.event.foreman') do
         callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-          payload == { custom_payload: true }.merge(event_context)
+          payload[:custom_payload] == true
         end
 
         model.update(name: 'New Name')
@@ -56,7 +66,7 @@ class ObservableModelTest < ActiveSupport::TestCase
     test 'notify with block payload' do
       ActiveSupport::Notifications.subscribed(callback, 'model_updated_with_block.event.foreman') do
         callback.expects(:call).with do |name, _started, _finished, _unique_id, payload|
-          payload == { id: model.id, block: true }.merge(event_context)
+          payload[:id] == model.id && payload[:block] == true
         end
 
         model.update(name: 'New Name')
@@ -73,7 +83,7 @@ class ObservableModelTest < ActiveSupport::TestCase
     end
 
     describe '.set_crud_hooks' do
-      let(:klass) do
+      let(:model_class) do
         Class.new(ApplicationRecord) do
           include ::Foreman::ObservableModel
 
@@ -85,7 +95,6 @@ class ObservableModelTest < ActiveSupport::TestCase
         end
       end
 
-      let(:event_context) { { context: ::Logging.mdc.context.symbolize_keys } }
       let(:callback) { -> {} }
 
       test 'hooks are defined' do
@@ -95,16 +104,16 @@ class ObservableModelTest < ActiveSupport::TestCase
           'model_destroyed.event.foreman',
         ]
 
-        assert_same_elements expected, klass.event_subscription_hooks
+        assert_same_elements expected, model_class.event_subscription_hooks
       end
 
       describe 'model_created hook' do
-        let(:model) { klass.new(name: 'My Model') }
+        let(:model) { model_class.new(name: 'My Model') }
 
         test 'event is sent when model is created' do
           ActiveSupport::Notifications.subscribed(callback, 'model_created.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { object: model }.merge(event_context)
+              payload[:object] == model
             end
 
             model.save!
@@ -113,12 +122,12 @@ class ObservableModelTest < ActiveSupport::TestCase
       end
 
       describe 'model_updated hook' do
-        let(:model) { klass.create(name: 'My Model') }
+        let(:model) { model_class.create(name: 'My Model') }
 
         test 'event is sent when model is updated' do
           ActiveSupport::Notifications.subscribed(callback, 'model_updated.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { object: model }.merge(event_context)
+              payload[:object] == model
             end
 
             model.update!(name: 'New Name')
@@ -127,12 +136,12 @@ class ObservableModelTest < ActiveSupport::TestCase
       end
 
       describe 'model_destroyed hook' do
-        let(:model) { klass.create(name: 'My Model') }
+        let(:model) { model_class.create(name: 'My Model') }
 
         test 'event is sent when model is destroyed' do
           ActiveSupport::Notifications.subscribed(callback, 'model_destroyed.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { object: model }.merge(event_context)
+              payload[:object] == model
             end
 
             model.destroy!

--- a/test/models/hosts/managed_test.rb
+++ b/test/models/hosts/managed_test.rb
@@ -125,7 +125,7 @@ module Host
 
     describe 'hooks' do
       let(:host) { FactoryBot.create(:host, :managed) }
-      let(:event_context) { ::Logging.mdc.context.symbolize_keys }
+      let(:event_context) { ::Logging.mdc.context.symbolize_keys.with_indifferent_access }
       let(:callback) { -> {} }
 
       test 'hooks are defined' do
@@ -149,7 +149,7 @@ module Host
 
           ActiveSupport::Notifications.subscribed(callback, 'build_entered.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { id: host.id, hostname: host.hostname }.merge(context: event_context)
+              payload[:hostname] == host.hostname
             end
 
             host.setBuild
@@ -163,7 +163,7 @@ module Host
         test '"build_exited.event.foreman" event is sent when build set to false' do
           ActiveSupport::Notifications.subscribed(callback, 'build_exited.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { id: host.id, hostname: host.hostname }.merge(context: event_context)
+              payload[:hostname] == host.hostname
             end
 
             host.built
@@ -177,7 +177,7 @@ module Host
         test '"status_changed.event.foreman" event is sent when global status was changed' do
           ActiveSupport::Notifications.subscribed(callback, 'status_changed.event.foreman') do
             callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-              payload == { id: host.id, hostname: host.hostname, global_status: { from: 0, to: 1} }.merge(context: event_context)
+              payload[:global_status] == { "from" => 0, "to" => 1 }
             end
 
             host.update(global_status: 1)

--- a/test/unit/foreman/observable_test.rb
+++ b/test/unit/foreman/observable_test.rb
@@ -4,12 +4,12 @@ class ObservableTest < ActiveSupport::TestCase
   describe '#trigger_hook' do
     let(:object) { Class.new.include(::Foreman::Observable).new }
     let(:callback) { -> {} }
-    let(:event_context) { { context: ::Logging.mdc.context.symbolize_keys } }
+    let(:event_context) { ::Logging.mdc.context.symbolize_keys.with_indifferent_access }
 
     it 'triggers hook with payload' do
       ActiveSupport::Notifications.subscribed(callback, 'triggered.event.foreman') do
         callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-          payload ==  { foo: :bar }.merge(event_context)
+          payload[:foo] == :bar
         end
 
         object.trigger_hook(:triggered, payload: { foo: :bar })
@@ -19,7 +19,7 @@ class ObservableTest < ActiveSupport::TestCase
     it 'triggers hook with block' do
       ActiveSupport::Notifications.subscribed(callback, 'triggered.event.foreman') do
         callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-          payload ==  { id: object.object_id, block: true }.merge(event_context)
+          payload[:id] == object.object_id && payload[:block] == true
         end
 
         object.trigger_hook(:triggered) { |obj| { id: obj.object_id, block: true } }
@@ -29,7 +29,7 @@ class ObservableTest < ActiveSupport::TestCase
     it 'triggers hook without payload and block' do
       ActiveSupport::Notifications.subscribed(callback, 'triggered.event.foreman') do
         callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
-          payload == event_context
+          payload[:context] == event_context
         end
 
         object.trigger_hook(:triggered)


### PR DESCRIPTION
To integrate Katello/Dynflow (task #30297) let's first implement something easier - ActiveJob offers callbacks or events before/after job is performed. This can be hooked and Foreman Subscription API event can be emited. This is currently used in RSS notifications, template rendering and stored value cleanup tasks but we expect this list to grow in the future.