### PR TITLE
Fixes #31258 - Don't fail migration if setting is hardcoded

### DIFF
--- a/db/migrate/20200602155700_drop_puppet_run.rb
+++ b/db/migrate/20200602155700_drop_puppet_run.rb
@@ -1,6 +1,6 @@
 class DropPuppetRun < ActiveRecord::Migration[5.2]
   def up
-    Setting.where(:name => 'puppetrun').destroy_all
+    Setting.where(:name => 'puppetrun').delete_all
     Permission.where(:name => 'puppetrun_hosts').destroy_all
   end
 end


### PR DESCRIPTION
If the puppetrun setting has been hardcoded in settings.yaml, it will be
marked as readonly causing the migration attempting to delete it to
fail. Since settings have no associations and we don't need callbacks to
run we can use `delete` instead of `destroy` to trigger an sql query
deleting it.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
