### PR TITLE
Fixes #31262 - Warn about incorrect logging layout

### DIFF
--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -26,6 +26,10 @@ namespace :errors do
       puts "You can search the logs in #{type} for request_id #{request_id}"
       exit(1)
     end
+    if Foreman::Logging.config[:layout] != 'multiline_request_pattern'
+      $STDERR.puts "Warning: Logging layout is not multiline_request_pattern."
+      $STDERR.puts "This output of this command can be incomplete."
+    end
     file_path = File.join(Foreman::Logging.log_directory, logfile)
     unless File.exist?(file_path)
       puts "Can't find log file #{file_path}"


### PR DESCRIPTION
a7874f5722625e3a64c557a4d2d445c8b67d1548 introduced a rake task to get error reports, but this requires the multiline_request_pattern logging layout. This warns users in case the layout is incorrect.

@tbrisker: I think this is a good candidate to cherry pick to 2.2.1.