### PR TITLE
2.3 - Host registration PR

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -75,6 +75,7 @@ module Api
             prepare_host
             host_setup_insights
             host_setup_remote_execution
+            host_setup_extension
             @template = @host.registration_template
             raise ActiveRecord::Rollback if @template.nil?
           end
@@ -114,6 +115,10 @@ module Api
         @host.owner = User.current
 
         @host.save!
+      end
+
+      # Extension point for plugins
+      def host_setup_extension
       end
     end
   end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -34,7 +34,7 @@ class RegistrationController < ApplicationController
   end
 
   def registration_args
-    ignored = ['utf8', 'authenticity_token', 'commit', 'action', 'locale', 'controller', 'jwt_expiration']
+    ignored = ['utf8', 'authenticity_token', 'commit', 'action', 'locale', 'controller', 'jwt_expiration', 'smart_proxy']
     args = params.except(*ignored)
     args[:setup_insights] = setup_insights_param if params['setup_insights'].to_s.present?
     args[:setup_remote_execution] = setup_remote_execution_param if params['setup_remote_execution'].to_s.present?

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -316,6 +316,7 @@ sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/ker
 
 <%= snippet 'efibootmgr_netboot' %>
 
+<%= snippet 'insights' -%>
 touch /tmp/foreman_built
 <%= section_end -%>
 

--- a/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
@@ -78,6 +78,7 @@ nodectl init
 <%= snippet 'redhat_register' %>
 <%= snippet 'kickstart_networking_setup' %>
 <%= snippet 'efibootmgr_netboot' %>
+<%= snippet 'insights' -%>
 /usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -16,6 +16,7 @@ model: ProvisioningTemplate
 <%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
 <%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
 <%= "\n# Setup Remote Execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
+<%= "\n# Remote execution interface: [#{@remote_execution_interface}]" if @remote_execution_interface.present? -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -45,6 +46,7 @@ register_host() {
        <%= "--data \"host[operatingsystem_id]=#{@operatingsystem.id}\"" if @operatingsystem -%>
        <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
        <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
+       <%= "--data \"remote_execution_interface=#{@remote_execution_interface}\"" if @remote_execution_interface.present? -%>
 
 }
 
@@ -63,6 +65,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
             <%= "--data \"host[hostgroup_id]=#{@hostgroup.id}\"" if @hostgroup -%>
             <%= "--data \"setup_insights=#{@setup_insights}\"" unless @setup_insights.nil? -%>
             <%= "--data \"setup_remote_execution=#{@setup_remote_execution}\"" unless @setup_remote_execution.nil? -%>
+            <%= "--data \"remote_execution_interface=#{@remote_execution_interface}\"" if @remote_execution_interface.present? -%>
 
     }
 

--- a/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
+++ b/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
@@ -21,7 +21,7 @@ set -e
 <% end -%>
 
 <%= snippet 'remote_execution_ssh_keys' %>
-<%= snippet 'insights' %>
+<%= snippet 'insights' -%>
 
 
 # Call home to exit build mode

--- a/app/views/unattended/provisioning_templates/snippet/insights.erb
+++ b/app/views/unattended/provisioning_templates/snippet/insights.erb
@@ -4,8 +4,6 @@ name: insights
 model: ProvisioningTemplate
 snippet: true
 %>
-# Install Insights client
-
 <% if @host.operatingsystem.name == 'RedHat' && host_param_true?('host_registration_insights') -%>
 echo '#'
 echo '# Installing Insights client'
@@ -14,4 +12,5 @@ echo '#'
 yum install -y insights-client
 insights-client --test-connection
 insights-client --register
+
 <% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -171,6 +171,7 @@ EOF
 
 
 
+
 touch /tmp/foreman_built
 %end
 


### PR DESCRIPTION
Last two missing PR for the new Host Registration feature.

    Fixes #31082 - Add Insights snippet to the Kickstart templates (#8092)
    
    (cherry picked from commit 3cc32c9edc16c5b99d83ee94ad2469282aa29c74)

    Fixes #31236 - Host setup action in RegistrationController extendable from plugins (#8121)
    
    Feature allowing plugins to "hook" into the host's setup process
    in Api::V2::RegistrationController#host method and add
    plugin-related actions for host setup.
    
    (cherry picked from commit bfc4530307bed8b304d7cc17e0a69cb1a8d7a1e3)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
