### PR TITLE
Fixes #31290 - plugin_documentation_url params

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -11,7 +11,7 @@ class LinksController < ApplicationController
     when 'manual'
       documentation_url(options['section'], options)
     when 'plugin_manual'
-      plugin_documentation_url(options['name'])
+      plugin_documentation_url
     when 'feed'
       Setting['rss_url']
     when 'wiki'
@@ -29,15 +29,26 @@ class LinksController < ApplicationController
 
   private
 
+  def foreman_org_path(sub_path)
+    "https://theforeman.org/#{sub_path}"
+  end
+
   def documentation_url(section = "", options = {})
-    root_url = options[:root_url] || "https://theforeman.org/manuals/#{SETTINGS[:version].short}/index.html#"
+    root_url = options[:root_url] || foreman_org_path("manuals/#{SETTINGS[:version].short}/index.html#")
     root_url + (section || '')
   end
 
-  def plugin_documentation_url(plugin_name, version: nil, options: {})
-    root_url = options[:root_url] || "https://theforeman.org/plugins"
-    path = version ? "#{plugin_name}/#{version}" : plugin_name
-    "#{root_url}/#{path}"
+  def plugin_documentation_url
+    name, version, section, root_url = plugin_documentation_params.values_at(:name, :version, :section, :root_url)
+    path = root_url || foreman_org_path("plugins")
+    path += "/#{name}"
+    path += "/#{version}" unless version.nil?
+    path + (section || '')
+  end
+
+  def plugin_documentation_params
+    params.require(:name)
+    params.permit(:version, :section, :root_url, :name, :type)
   end
 
   def forum_url(post_path = nil, options: {})

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -25,5 +25,19 @@ class LinksControllerTest < ActionController::TestCase
       assert_redirected_to /PluginSection/
       assert_redirected_to /my_plugin/
     end
+
+    test '#plugin_documentation_url returns foreman docs url for a plugin with a version and a given section' do
+      get :show, params: {
+        type: 'plugin_manual',
+        name: 'foreman_discovery',
+        version: '15.0',
+        section: '#4.Usage',
+      }
+
+      assert_redirected_to /plugins/
+      assert_redirected_to /foreman_discovery/
+      assert_redirected_to /15.0/
+      assert_redirected_to /Usage/
+    end
   end
 end


### PR DESCRIPTION
Enable to pass params to 'plugin_documentation_url' through links#show

setting a link from a plugin to `"/links/plugin_manual?name=foreman_discovery&version=15.0&section=#4.Usage"`
should redirect to: `https://theforeman.org/plugins/foreman_discovery/15.0/#4.Usage`

cc @lzap @ekohl @ShimShtein

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
