### PR TITLE
Fixes #31291 - No breadcrumbs for React pages

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -36,7 +36,7 @@ const PageLayout = ({
           )}
           {customBreadcrumbs
             ? { customBreadcrumbs }
-            : breadcrumbOptions && <BreadcrumbBar data={breadcrumbOptions} />}
+            : breadcrumbOptions && <BreadcrumbBar {...breadcrumbOptions} />}
         </div>
         {beforeToolbarComponent}
         <Row>

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -14,27 +14,27 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
       id="breadcrumb"
     >
       <Connect(BreadcrumbBar)
-        data={
-          Object {
-            "breadcrumbItems": Array [
-              Object {
-                "caption": "root",
-                "url": "/some-url",
-              },
-              Object {
-                "caption": "child with onClick",
-                "onClick": [MockFunction],
-              },
-              Object {
-                "caption": "active child",
-              },
-            ],
-            "isSwitchable": false,
-            "resource": Object {
-              "nameField": "name",
-              "resourceUrl": "some/url",
-              "switcherItemUrl": "some/url/:id",
+        breadcrumbItems={
+          Array [
+            Object {
+              "caption": "root",
+              "url": "/some-url",
             },
+            Object {
+              "caption": "child with onClick",
+              "onClick": [MockFunction],
+            },
+            Object {
+              "caption": "active child",
+            },
+          ]
+        }
+        isSwitchable={false}
+        resource={
+          Object {
+            "nameField": "name",
+            "resourceUrl": "some/url",
+            "switcherItemUrl": "some/url/:id",
           }
         }
       />
@@ -105,27 +105,27 @@ exports[`render pageLayout w/search 1`] = `
       id="breadcrumb"
     >
       <Connect(BreadcrumbBar)
-        data={
-          Object {
-            "breadcrumbItems": Array [
-              Object {
-                "caption": "root",
-                "url": "/some-url",
-              },
-              Object {
-                "caption": "child with onClick",
-                "onClick": [MockFunction],
-              },
-              Object {
-                "caption": "active child",
-              },
-            ],
-            "isSwitchable": false,
-            "resource": Object {
-              "nameField": "name",
-              "resourceUrl": "some/url",
-              "switcherItemUrl": "some/url/:id",
+        breadcrumbItems={
+          Array [
+            Object {
+              "caption": "root",
+              "url": "/some-url",
             },
+            Object {
+              "caption": "child with onClick",
+              "onClick": [MockFunction],
+            },
+            Object {
+              "caption": "active child",
+            },
+          ]
+        }
+        isSwitchable={false}
+        resource={
+          Object {
+            "nameField": "name",
+            "resourceUrl": "some/url",
+            "switcherItemUrl": "some/url/:id",
           }
         }
       />
@@ -203,27 +203,27 @@ exports[`render pageLayout w/toastNotifications 1`] = `
       id="breadcrumb"
     >
       <Connect(BreadcrumbBar)
-        data={
-          Object {
-            "breadcrumbItems": Array [
-              Object {
-                "caption": "root",
-                "url": "/some-url",
-              },
-              Object {
-                "caption": "child with onClick",
-                "onClick": [MockFunction],
-              },
-              Object {
-                "caption": "active child",
-              },
-            ],
-            "isSwitchable": false,
-            "resource": Object {
-              "nameField": "name",
-              "resourceUrl": "some/url",
-              "switcherItemUrl": "some/url/:id",
+        breadcrumbItems={
+          Array [
+            Object {
+              "caption": "root",
+              "url": "/some-url",
             },
+            Object {
+              "caption": "child with onClick",
+              "onClick": [MockFunction],
+            },
+            Object {
+              "caption": "active child",
+            },
+          ]
+        }
+        isSwitchable={false}
+        resource={
+          Object {
+            "nameField": "name",
+            "resourceUrl": "some/url",
+            "switcherItemUrl": "some/url/:id",
           }
         }
       />
@@ -293,27 +293,27 @@ exports[`render pageLayout w/toolBar 1`] = `
       id="breadcrumb"
     >
       <Connect(BreadcrumbBar)
-        data={
-          Object {
-            "breadcrumbItems": Array [
-              Object {
-                "caption": "root",
-                "url": "/some-url",
-              },
-              Object {
-                "caption": "child with onClick",
-                "onClick": [MockFunction],
-              },
-              Object {
-                "caption": "active child",
-              },
-            ],
-            "isSwitchable": false,
-            "resource": Object {
-              "nameField": "name",
-              "resourceUrl": "some/url",
-              "switcherItemUrl": "some/url/:id",
+        breadcrumbItems={
+          Array [
+            Object {
+              "caption": "root",
+              "url": "/some-url",
             },
+            Object {
+              "caption": "child with onClick",
+              "onClick": [MockFunction],
+            },
+            Object {
+              "caption": "active child",
+            },
+          ]
+        }
+        isSwitchable={false}
+        resource={
+          Object {
+            "nameField": "name",
+            "resourceUrl": "some/url",
+            "switcherItemUrl": "some/url/:id",
           }
         }
       />
@@ -525,27 +525,27 @@ exports[`render pageLayout without search 1`] = `
       id="breadcrumb"
     >
       <Connect(BreadcrumbBar)
-        data={
-          Object {
-            "breadcrumbItems": Array [
-              Object {
-                "caption": "root",
-                "url": "/some-url",
-              },
-              Object {
-                "caption": "child with onClick",
-                "onClick": [MockFunction],
-              },
-              Object {
-                "caption": "active child",
-              },
-            ],
-            "isSwitchable": false,
-            "resource": Object {
-              "nameField": "name",
-              "resourceUrl": "some/url",
-              "switcherItemUrl": "some/url/:id",
+        breadcrumbItems={
+          Array [
+            Object {
+              "caption": "root",
+              "url": "/some-url",
             },
+            Object {
+              "caption": "child with onClick",
+              "onClick": [MockFunction],
+            },
+            Object {
+              "caption": "active child",
+            },
+          ]
+        }
+        isSwitchable={false}
+        resource={
+          Object {
+            "nameField": "name",
+            "resourceUrl": "some/url",
+            "switcherItemUrl": "some/url/:id",
           }
         }
       />


### PR DESCRIPTION
After 
https://github.com/theforeman/foreman/commit/e59d625e53986e4de4cdd96898b1af7a711802fa
there is no need to wrap the props in `data`.
Because the props were wrapped with `data` the breadcrumbs didn't load.

Currently only plugins use breadcrumbs in page layout, to test locally on foreman replace :
https://github.com/theforeman/foreman/blob/a600617c1ce75582fdb61a7dca5d549fc6a01cca/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js#L38
with:
```js  
breadcrumbOptions={{
    breadcrumbItems: [
        {
        caption: __('Hardware Models'),
        },
    ],
}}
```