### PR TITLE
Fixes #31295 - Table pagination in react has extra space

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -228,7 +228,7 @@ select {
 }
 
 table.table {
-  margin-bottom: 6px;
+  margin-bottom: 0;
 }
 
 table {

--- a/webpack/assets/javascripts/react_app/components/Pagination/pagination.scss
+++ b/webpack/assets/javascripts/react_app/components/Pagination/pagination.scss
@@ -1,6 +1,4 @@
 #pagination {
-  margin-top: -6px;
-
   .form-group {
     align-items: center;
   }

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
@@ -8,8 +8,6 @@ import PageLayout from '../../common/PageLayout/PageLayout';
 import ModelsPageContent from './components/ModelsPageContent';
 import { MODELS_SEARCH_PROPS } from '../constants';
 
-import './ModelsPage.scss';
-
 const ModelsPage = ({
   fetchAndPush,
   search,

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.scss
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.scss
@@ -1,3 +1,0 @@
-#models-table {
-  margin-bottom: -1px;
-}


### PR DESCRIPTION
default margin was 20px. It doesn't really makes sense to change it to 6px and then have -6px margin for pagination.
Will add prs for tasks and remote execution to remove the 6px override.
Before the change:
![Screenshot from 2020-11-11 11-10-41](https://user-images.githubusercontent.com/30431079/98794619-ed58dd00-2411-11eb-8b1f-3698870aa564.png)
After this change table in rails (for example hosts) and in react (for example models) look the same (without the space)