### PR TITLE
Fixes #31168 - rename ENC var name to hostname

### DIFF
--- a/app/models/host_info_providers/static_info.rb
+++ b/app/models/host_info_providers/static_info.rb
@@ -4,7 +4,7 @@ module HostInfoProviders
       # Static parameters
       param = {}
 
-      param["name"] = host.name unless host.name.nil?
+      param["hostname"] = host.name unless host.name.nil?
       param["fqdn"] = host.fqdn unless host.fqdn.nil?
       param["hostgroup"] = host.hostgroup.to_label unless host.hostgroup.nil?
       param["comment"] = host.comment if host.comment.present?


### PR DESCRIPTION
Renamed `name` to `hostname` as suggested in https://github.com/theforeman/foreman/pull/8103#discussion_r511947049