### PR TITLE
Fixes #31274 - stream reports to save memory

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -304,7 +304,8 @@ module Api
     end
 
     def log_response_body
-      logger.debug { "Body: #{response.body}" }
+      # This can be dangerous for streaming data
+      # logger.debug { "Body: #{response.body}" }
     end
 
     private

--- a/app/models/report_composer.rb
+++ b/app/models/report_composer.rb
@@ -236,9 +236,9 @@ class ReportComposer
     scheduler.perform_later(to_params, user_id: User.current.id)
   end
 
-  def render(mode: Foreman::Renderer::REAL_MODE, **params)
+  def render(output:, mode: Foreman::Renderer::REAL_MODE, **params)
     params[:params] = { :format => format }.merge(params.fetch(:params, {}))
-    result = @template.render(mode: mode, template_input_values: template_input_values, **params)
+    result = @template.render(variables: {output: output}, mode: mode, template_input_values: template_input_values, **params)
     result = ActiveSupport::Gzip.compress(result) if gzip?
     result
   end

--- a/test/models/report_composer_test.rb
+++ b/test/models/report_composer_test.rb
@@ -1,10 +1,15 @@
 require 'test_helper'
 
 class ReportComposerTest < ActiveSupport::TestCase
+  let(:template) { "some content" }
+
   def setup
-    @report_template = FactoryBot.create(:report_template, :with_input)
+    @report_template = FactoryBot.create(:report_template, :with_input, :template => template)
     @template_input = @report_template.template_inputs.first
-    @composer_params = {:template_id => @report_template.id, :input_values => { @template_input.id.to_s => { 'value' => 'hello' } }}
+    @composer_params = {
+      :template_id => @report_template.id,
+      :input_values => { @template_input.id.to_s => { 'value' => 'hello' } },
+    }
     @composer = ReportComposer.new(@composer_params)
   end
 
@@ -64,10 +69,42 @@ class ReportComposerTest < ActiveSupport::TestCase
   end
 
   describe '#render' do
-    it 'render template' do
-      @report_template.update_attribute :template, "<%= 1 + 1 %> <%= input('#{@template_input.name}') %>"
+    it 'renders a simple template' do
+      body = "<%= 1 + 1 %> <%= input('#{@template_input.name}') %>"
+      @report_template.update_attribute :template, body
       composer = ReportComposer.new(@composer_params) # to reload the inner template instance
       assert_equal composer.render, '2 hello'
+    end
+
+    describe 'formats' do
+      let(:template) do
+        "<%= report_headers('one', 'two'); report_row(one: 1, two: 2); report_row(one: 1, two: 2); report_render -%>"
+      end
+
+      it 'JSON' do
+        expected = "[{\"one\":1,\"two\":2},{\"one\":1,\"two\":2}]"
+        assert_equal expected, @composer.render(params: {format: ReportTemplateFormat.find(:json)})
+      end
+
+      it 'YAML' do
+        expected = "---\n- one: 1\n  two: 2\n- one: 1\n  two: 2\n"
+        assert_equal expected, @composer.render(params: {format: ReportTemplateFormat.find(:yaml)})
+      end
+
+      it 'CSV' do
+        expected = "one,two\n1,2\n1,2\n"
+        assert_equal expected, @composer.render(params: {format: ReportTemplateFormat.find(:csv)})
+      end
+
+      it 'HTML' do
+        expected = %r{<table><thead><tr><th>one</th><th>two</th></tr></thead><tbody><tr><td>1</td><td>2</td></tr><tr><td>1</td><td>2</td></tr></tbody></table>}
+        assert_match expected, @composer.render(params: {format: ReportTemplateFormat.find(:html)})
+      end
+
+      it 'TXT' do
+        expected = "one,two\n1,2\n1,2\n"
+        assert_equal expected, @composer.render(params: {format: ReportTemplateFormat.find(:txt)})
+      end
     end
   end
 end


### PR DESCRIPTION
The way we generate reports is memory unfriendly. All rows are stored in an array as hashes and then dumped into string which is returned to the client. In background job case, string is stored in the db or emailed.

Refactoring: Rewrite report_headers, report_row and report_render helpers so they immediately stream data into an IO object. Do not use any intermediate data structure, all formats we currently support (JSON, YAML. CSV, plaintext) do support this. When called via API, data can be streamed directly over TCP. In case of background processing, data can be streamed via SQL LOAD postgresql directly into blob/text.

This could be implemented without any user-facing changes - the three helpers will remain the same, but they will immediately stream content instead of storing anything in memory. The last call (report_render) will output optional footer and close the stream.

This is the first cut which implements streaming when using API/CLI:

```
bundle exec bin/hammer report-template generate --id 128
X,Y,Z
1,2,3
```

Only CSV and HTML implemented for now. I am currently investigating issue when development server gets stuck for some requests, maybe there is a different API than Live::Buffer available I need to dig it. All I need is an IO object I can pass into a template, this does not need to be "live" necessary just a regular IO stream.

New test was added to check all supported formats before the patch was made to ensure it works okay. Minimum user-level breaking was done, most templates if not all should work without any changes.

TODO:
* [ ] implement V2 API for all formats
* [ ] implement for the background job (stream into postgres)
* [ ] test on development
* [ ] test on production
