### PR TITLE
Fixes #31317 - Fix broken VNC console in a secured connection

### DIFF
--- a/app/controllers/concerns/foreman/controller/console_common.rb
+++ b/app/controllers/concerns/foreman/controller/console_common.rb
@@ -1,6 +1,5 @@
 module Foreman::Controller::ConsoleCommon
   def console
-    @encrypt = Setting[:websockets_encrypt]
     render case @console[:type]
              when 'spice'
                'hosts/console/spice'

--- a/lib/ws_proxy.rb
+++ b/lib/ws_proxy.rb
@@ -58,7 +58,7 @@ class WsProxy
       end
     end
     @proxy_port = port
-    { :port => proxy_port, :password => password, :encrypt => @encrypt }
+    { :port => proxy_port, :password => password, :encrypt => Setting[:websockets_encrypt] }
   end
 
   private


### PR DESCRIPTION
@encrypt veriable that was created in console_common.rb wasn't in the scope of the ws_proxy.rb
so, instead i sent directly Setting[:websockets_encrypt]


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
