### PR TITLE
Fixes #31345: Fix permissions undefined for nil due to race condition

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -325,7 +325,7 @@ class Role < ApplicationRecord
   end
 
   def find_current_filter(current_filters, filter_record)
-    current_filters.detect { |fil| fil.id == filter_record.id }
+    current_filters.reload.detect { |fil| fil.id == filter_record.id }
   end
 
   def permission_records(permissions)


### PR DESCRIPTION
There is a race condition that can occur, most often in the installer,
when operations that load plugins are ran in parallel. This can lead
to a Role filter being created just after fetching the set of filters
but just before fetching the filter itself. When the code that
attempts to grab the filter from the set already in memory runs,
the filter is not found in the in-memory set and returns nil. Leading
to the user facing error.

This parallelization typically is only seen for new installations
given that is when multiple plugins are creating or updating roles.
This parallelization is predominantly present in the Passenger use
case as it tends to require multiple operations that load plugins
to occur at the same time. When plugins are loaded they ensure
that they are registered and that their role declarations are present
within Foreman. Thus, a situation that can cause this is Apache starting
up booting Passenger which causes plugins to load, and a rake task
such as apipie:cache:plugin which also loads plugins executing in parallel.
This effect is tended not to be seen with Puma setups because the
systemd service built around Puma does not signal completion until
the entire Foreman application has been loaded.


### How to reproduce:

1. Install Katello or Luna with Passenger and cockpit plugin (helps with reproducer) `--enable-foreman-plugins-remote-execution-cockpit --foreman-passenger`

2. Copy the following reproducer script to the system that will run two rake tasks and restart Apache in parallel:

`vim /root/reproducer.rb`
```
#!/usr/bin/env ruby

`foreman-rake role:clear_role_filters`

commands_list = [
  "/usr/sbin/foreman-rake apipie:cache:index",
  "service httpd restart",
  "/usr/sbin/foreman-rake -- config -k 'remote_execution_cockpit_url' -v '/webcon/=%{host}'"
]

p_threads = commands_list.map do |command|
  Process.detach(Process.spawn(command))
end
p_threads.each(&:join)
```

3. Add a rake task that clears out all role filters

`vim /usr/share/foreman/lib/tasks/clear_role_filters.rake`
```
namespace :role do
  task :clear_role_filters => :environment do
    Role.all.each do |role|
      filters = role.filters
      filters.each { |filter| filter.destroy }
    end
    Role.all.each do |role|
        filters = role.filters
        puts filters
    end
  end
end
```

4. Run the reproducer. Due to variances in system specs, the reproducer may need to be run multiple times to see the error.

```
./reproducer.rb
```

Example reproducer error output:
```
rake aborted!
NoMethodError: undefined method `permissions' for nil:NilClass
/usr/share/foreman/app/models/role.rb:162:in `block (2 levels) in add_permissions'
/usr/share/foreman/app/models/role.rb:161:in `each'
/usr/share/foreman/app/models/role.rb:161:in `block in add_permissions'
/usr/share/foreman/app/models/role.rb:157:in `each'
/usr/share/foreman/app/models/role.rb:157:in `add_permissions'
/usr/share/foreman/app/models/role.rb:208:in `add_permissions!'
/usr/share/foreman/app/services/foreman/plugin/role_lock.rb:56:in `block in update_plugin_role_permissions'
```

Finally, apply the patch, and run the reproducer over and over. The error should not be seen anymore.

### Note

There were likely a few ways and places to fix this, and clean up that might could be performed in this section of code. I opted to aim for the least invasive change that solves the problem for backporting.