### PR TITLE
Feature #31363 - allow for dual stack IPv4 and v6 network settings during PXE boot

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -32,7 +32,6 @@ snippet: true
   options.push("kssendmac", "ks.sendmac", "inst.ks.sendmac")
 
   # networking credentials
-  raise("Dual-stack provisioning not supported") if subnet4 && subnet6
   if subnet4 && subnet4.dhcp_boot_mode?
     options.push("ip=dhcp") if rhel_compatible && major >= 7
   elsif subnet4 && !subnet4.dhcp_boot_mode?
@@ -50,7 +49,7 @@ snippet: true
         options.push("ip=#{iface.ip}::#{subnet4.gateway}:#{subnet4.mask}:#{hostname}:#{iface.identifier}:none")
       end
     end
-  elsif subnet6.dhcp_boot_mode? && rhel_compatible && major >= 7
+  elsif subnet6 && subnet6.dhcp_boot_mode? && rhel_compatible && major >= 7
     if host_param_true?("use-slaac")
       options.push("ip=auto6")
     else
@@ -102,7 +101,7 @@ snippet: true
   end
 
   nic_delay = subnet4 ? subnet4.nic_delay : nil
-  nic_delay ||= subnet6 ? subnet6.nic_delay : nil
+  nic_delay ||= !subnet4 && subnet6 ? subnet6.nic_delay : nil
   if nic_delay && rhel_compatible && major >= 7
     ["dhcp", "iflink", "ifup", "route", "ipv6dad", "ipv6auto", "carrier"].each do |type|
       options.push("rd.net.timeout.#{type}=#{nic_delay}")


### PR DESCRIPTION
The template snippet **kickstart_kernel_options** has been modified to allow for PXE provisioning in a dual stack environment. In the past, the snippet would throw an error and the PXE operation would fail if both an IPv4 and IPv6 network are attached to the host to be provisioned.
This change will prefer IPv4 over IPv6 when both are configured and still allow for v4 only and v6 only operation.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
