### PR TITLE
Fixes #31365 - Breadcrumbs story is empty

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.stories.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.stories.js
@@ -27,16 +27,14 @@ export const withOpenSwitcher = () => (
           id: 3,
         },
       ]}
-      data={{
-        resource: {
-          resourceUrl: 'some_url',
-        },
-        isSwitchable: true,
-        breadcrumbItems: [
-          { caption: 'Index Page', url: '#' },
-          { caption: 'Resource Page' },
-        ],
+      resource={{
+        resourceUrl: 'some_url',
       }}
+      isSwitchable={true}
+      breadcrumbItems={[
+        { caption: 'Index Page', url: '#' },
+        { caption: 'Resource Page' },
+      ]}
     />
   </Story>
 );


### PR DESCRIPTION
just like https://github.com/theforeman/foreman/pull/8132
After
https://github.com/theforeman/foreman/commit/e59d625e53986e4de4cdd96898b1af7a711802fa
there is no need to wrap the props in data.
Because the props were wrapped with data the breadcrumbs didn't load.
I hope it's the last one with this issue :0