### PR TITLE
Fixes #31367 - Drop unused get_search_props method

### DIFF
--- a/app/helpers/search_bar_helper.rb
+++ b/app/helpers/search_bar_helper.rb
@@ -28,26 +28,4 @@ module SearchBarHelper
                       bookmarks: bookmarks,
                       }})
   end
-
-  def get_search_props(
-    controller: auto_complete_controller_name,
-    url: send("auto_complete_search_#{auto_complete_controller_name}_path"),
-    search_query: params[:search],
-    autocomplete_id: "searchBar"
-  )
-    bookmarks = {
-      url: main_app.api_bookmarks_path,
-      canCreate: authorizer.can?(:create_bookmarks),
-      documentationUrl: documentation_url("4.1.5Searching"),
-    }
-    {
-      controller: controller,
-      autocomplete: {
-        searchQuery: search_query,
-        url: url,
-        id: autocomplete_id,
-      },
-      bookmarks: bookmarks,
-    }
-  end
 end


### PR DESCRIPTION
This method was needed as an interim helper to get the search props for
the react page while it was still loaded via erb and not as part of the
react controller. It is not in use anymore.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
