### PR TITLE
Fixes #31368 - Simplify mount_search_bar method

### DIFF
--- a/app/helpers/search_bar_helper.rb
+++ b/app/helpers/search_bar_helper.rb
@@ -1,31 +1,20 @@
 module SearchBarHelper
-  def mount_search_bar(
-    id,
-    controller: auto_complete_controller_name,
-    url: send("auto_complete_search_#{auto_complete_controller_name}_path"),
-    search_query: params[:search],
-    use_bookmarks: true,
-    use_key_shortcuts: true,
-    autocomplete_id: "searchBar"
-  )
-    bookmarks = {}
-    if use_bookmarks
-      bookmarks = {
-        url: main_app.api_bookmarks_path,
-        canCreate: authorizer.can?(:create_bookmarks),
-        documentationUrl: documentation_url("4.1.5Searching"),
-      }
-    end
-    react_component("SearchBar", {
-                      data: {
-                        controller: controller,
+  def mount_search_bar
+    bookmarks = {
+      url: main_app.api_bookmarks_path,
+      canCreate: authorizer.can?(:create_bookmarks),
+      documentationUrl: documentation_url("4.1.5Searching"),
+    }
+    url = send("auto_complete_search_#{auto_complete_controller_name}_path")
+    react_component("SearchBar", data: {
+                      controller: auto_complete_controller_name,
                       autocomplete: {
-                        id: autocomplete_id,
-                        searchQuery: search_query,
+                        id: 'searchBar',
+                        searchQuery: params[:search],
                         url: url,
-                        useKeyShortcuts: use_key_shortcuts,
+                        useKeyShortcuts: true,
                       },
                       bookmarks: bookmarks,
-                      }})
+                    })
   end
 end

--- a/app/views/common/_searchbar.html.erb
+++ b/app/views/common/_searchbar.html.erb
@@ -1,1 +1,0 @@
-<%= mount_search_bar("search-bar") %>

--- a/app/views/layouts/_application_content.html.erb
+++ b/app/views/layouts/_application_content.html.erb
@@ -11,7 +11,7 @@
     <%= yield(:before_search_bar) %>
     <div class="row">
       <div class="title_filter <%= searchable? ? " col-md-6 " : "col-md-4 " %>">
-        <%= render "common/searchbar" if searchable? %>
+        <%= mount_search_bar if searchable? %>
           <%= yield(:search_bar) %>&nbsp;
       </div>
       <div id="title_action" class= <%= searchable? ? "col-md-6" : "col-md-8" %>>


### PR DESCRIPTION
This method made a lot of preperations for customization, but in
practice it is never used except for the default case in the main
layout. Any more elaborate customization should be done in react and
not in erb.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
