### PR TITLE
Fixes #31372 - improve facet relation hook

### DIFF
--- a/app/models/concerns/facets/base_host_extensions.rb
+++ b/app/models/concerns/facets/base_host_extensions.rb
@@ -5,10 +5,6 @@ module Facets
     extend ActiveSupport::Concern
     include Facets::ModelExtensionsBase
 
-    included do
-      refresh_facet_relations
-    end
-
     # This method will return attributes list augmented with attributes that are
     # set by the facet. Each registered facet will get opportunity to add its
     # own attributes to the list.

--- a/app/models/concerns/facets/hostgroup_extensions.rb
+++ b/app/models/concerns/facets/hostgroup_extensions.rb
@@ -7,12 +7,6 @@ module Facets
 
     included do
       configure_facet(:hostgroup, :hostgroup, :hostgroup_id)
-
-      refresh_facet_relations
-
-      Facets.after_entry_created do |entry|
-        register_facet_relation(entry) if entry.has_hostgroup_configuration?
-      end
     end
 
     def hostgroup_ancestry_cache

--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -3,16 +3,11 @@ require_dependency 'facets'
 module Facets
   module ManagedHostExtensions
     extend ActiveSupport::Concern
+    include Facets::BaseHostExtensions
 
     included do
-      include Facets::BaseHostExtensions
       configure_facet(:host, :host, :host_id) do |facet_config|
         include_in_clone facet_config.name
-      end
-      refresh_facet_relations
-
-      Facets.after_entry_created do |entry|
-        register_facet_relation(entry) if entry.has_host_configuration?
       end
     end
   end

--- a/test/unit/facet_configuration_test.rb
+++ b/test/unit/facet_configuration_test.rb
@@ -15,7 +15,7 @@ class FacetConfigurationTest < ActiveSupport::TestCase
   setup do
     # Do not mess with the Host::Managed object as
     # we just want to test the configuration here
-    Host::Managed.stubs(:register_facet_relation)
+    Host::Managed.stubs(:register_facet_relation_for_type)
   end
 
   test 'enables block configuration' do
@@ -93,7 +93,7 @@ class FacetConfigurationTest < ActiveSupport::TestCase
       end
 
       test 'no class generates an error' do
-        Host::Managed.unstub(:register_facet_relation)
+        Host::Managed.unstub(:register_facet_relation_for_type)
         assert_raises NoMethodError do
           Facets.register :test_facet do
             configure_host


### PR DESCRIPTION
This introduce more rigid relation registration.
Instead of refreshing the relations every time we register new facet.