### PR TITLE
Fixes #31250 - add useAPI hook for API requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@theforeman/builder": "^6.0.0",
     "@theforeman/eslint-plugin-foreman": "^6.0.0",
     "@theforeman/stories": "^6.0.0",
-    "@theforeman/test": "^6.0.0",
+    "@theforeman/test": "^8.0.0",
     "@theforeman/vendor-dev": "^6.0.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.fixtures.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.fixtures.js
@@ -1,0 +1,19 @@
+export const resultsFromLOTR = {
+  data: {
+    results: [
+      { name: 'Frodo Baggins', height: 1.06 },
+      { name: 'Gandalf The White', height: 1.67 },
+    ],
+  },
+};
+
+export const resultFromGOT = {
+  data: {
+    results: [
+      { name: 'Tyrion Lannister', height: 1.3 },
+      { name: 'The Mountain', height: 2.06 },
+    ],
+  },
+};
+
+export const API_TEST_KEY = 'TEST';

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
@@ -1,0 +1,44 @@
+import { useEffect, useRef } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import uuid from 'uuid/v1';
+import {
+  selectAPIResponse,
+  selectAPIStatus,
+} from '../../../redux/API/APISelectors';
+import { APIActions } from '../../../redux/API';
+
+/**
+ * A custom hook that creates an API request
+ * @param  {string} method the API method (i.e 'post', 'get' etc)
+ * @param  {string} url the url for the API request
+ * @param  {object} options adding optional props to the API call, for more details go to the `apiRequest` function in `redux/API`
+ * @return {object} returns an object that contains the response, status, key and 'setUrl' for setting the url dynamically
+ */
+
+export const useAPI = (method, url, options) => {
+  const dispatch = useDispatch();
+  const keyRef = useRef(options?.key);
+
+  useEffect(() => {
+    if (!keyRef.current) keyRef.current = uuid();
+  }, []);
+
+  useEffect(() => {
+    if (url && method) {
+      dispatch(
+        APIActions[method]({
+          url,
+          ...options,
+          key: keyRef.current,
+        })
+      );
+    }
+  }, [dispatch, url, method, options]);
+
+  const response = useSelector(state =>
+    selectAPIResponse(state, keyRef.current)
+  );
+  const status = useSelector(state => selectAPIStatus(state, keyRef.current));
+
+  return { response, status, key: keyRef.current };
+};

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.test.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.test.js
@@ -1,0 +1,36 @@
+import { act } from '@testing-library/react-hooks';
+import { useAPI } from './APIHooks';
+import APIHelper from '../../../redux/API/API';
+import { renderHookWithRedux } from '../testHelper';
+import {
+  API_TEST_KEY,
+  resultFromGOT,
+  resultsFromLOTR,
+} from './APIHooks.fixtures';
+jest.mock('axios');
+jest.mock('../../../redux/API/API');
+jest.unmock('seamless-immutable');
+
+it('should use default url', async () => {
+  APIHelper.get.mockResolvedValue(resultFromGOT);
+  const { result, waitForNextUpdate } = renderHookWithRedux(() =>
+    useAPI('get', '/lotr')
+  );
+  await waitForNextUpdate();
+
+  expect(result.current.response.results).toEqual(resultFromGOT.data.results);
+  expect(result.current.key).toBeDefined();
+});
+
+it('shuold use the given key', async () => {
+  const options = { key: API_TEST_KEY };
+
+  APIHelper.get.mockResolvedValue(resultsFromLOTR);
+  const { result, waitForNextUpdate } = renderHookWithRedux(() =>
+    useAPI('get', '/got', options)
+  );
+  expect(result.current.response).toEqual({});
+
+  await waitForNextUpdate();
+  expect(result.current.key).toEqual(API_TEST_KEY);
+});

--- a/webpack/assets/javascripts/react_app/common/hooks/testHelper.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/testHelper.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import { createStore, applyMiddleware } from 'redux';
+import { Provider } from 'react-redux';
+import { middlewares } from '../../redux/middlewares';
+import reducers from '../../redux/reducers';
+
+export const renderHookWithRedux = (callback, options) => {
+  const store = createStore(reducers, applyMiddleware(...middlewares));
+  const wrapper = ({ children }) => (
+    <Provider store={store}>{children}</Provider>
+  );
+  return renderHook(callback, { wrapper, ...options });
+};

--- a/webpack/stories/docs/api-middleware-usage.stories.mdx
+++ b/webpack/stories/docs/api-middleware-usage.stories.mdx
@@ -6,6 +6,38 @@ import { Meta } from '@theforeman/stories';
     storyWeight: 100,
   }}
 />
+# How to use API in a Component using useAPI hook
+
+The API middleware is abstracted by the `useAPI` custom hook.
+
+```js
+import { useAPI } from '../common/hooks/API';
+import KEY_FOR_API from './consts';
+import { successCallback, errorCallback } from './helper';
+
+const MyComponent = () => {
+  const options = {
+    handleSuccess: successCallback,
+    handleError: errorCallback,
+    successToast: response => 'This text will be shown as a toast after a success call',
+    errorToast: response => 'This text will be shown as a toast when error occurs',
+  };
+  const {
+    response: { results },
+    status, // The current status of the API call
+    key, // Generated key for storing in redux's store
+  } = useAPI('get', '/api/audits', options);
+  return (
+    <ul>
+      {audits.map(item => (
+        <li key={item.id}>
+          {item.title} {item.action}
+        </li>
+      ))}
+    </ul>
+  );
+};
+```
 
 # Example: how to use the API middleware
 
@@ -111,7 +143,7 @@ export const getData = url => ({
       page: 2,
       per_page: 10,
     },
-  }
+  },
 });
 ```
 


### PR DESCRIPTION
This adds a custom hook which simplifies the usage of API requests within a react component.

- [x] Add useAPI hook
- [x] Test it with `react-hooks-testing-library`
- [x] Create test helper for hooks with redux
- [x] Add usage  (added in the host details experimental page)
- [x] Add documentation

 #### usage
```js
import { useAPI } from '../common/hooks/API';
import KEY_FOR_API from './consts';

const MyComponent = () => {
   // useAPI also accepts `setUrl` and `options` for advanced usage)
  const {
    response: { results }
  } = useAPI(KEY_FOR_API, 'get', '/api/audits');
  return (
    <ul>
      {results.map(item => (
        <li key={item.id}>
          {item.title} {item.action}
        </li>
      ))}
    </ul>
  );
};