### PR TITLE
Fixes #31383 - Add report template for CVEs

### DIFF
--- a/app/views/unattended/report_templates/host_-_vulnerabilities.erb
+++ b/app/views/unattended/report_templates/host_-_vulnerabilities.erb
@@ -1,0 +1,36 @@
+<%#
+name: Host - Vulnerabilities
+snippet: false
+model: ReportTemplate
+template_inputs:
+- name: Without Errata Only
+  required: true
+  input_type: user
+  description: Show only CVEs without errata for host
+  advanced: false
+  value_type: plain
+  options: "yes\r\nno"
+  default: "yes"
+- name: Hosts filter
+  required: false
+  input_type: user
+  value_type: search
+  description: Limit the report only on hosts found by this search query. Keep
+    empty for report on all available hosts.
+  resource_type: Host
+require:
+- plugin: foreman_openscap
+  version: 4.3.0
+-%>
+<%- report_headers 'Host Name', 'Ref Id', 'Ref URL' -%>
+<%- load_hosts(includes: [:cves], search: input('Hosts filter')).each_record do |host| -%>
+<%- scope = input('Without Errata Only') == 'yes' ? host.cves_without_errata : host.cves -%>
+<%-   scope.each do |cve| -%>
+<%-     report_row(
+          'Host Name': host.name,
+          'Ref Id': cve.ref_id,
+          'Ref URL': cve.ref_url
+        ) -%>
+<%-   end -%>
+<%- end -%>
+<%= report_render -%>


### PR DESCRIPTION
A new report template that shows vulnerabilities
detected during an OVAL scan.

Needs https://github.com/theforeman/foreman_openscap/pull/458

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
