### PR TITLE
Fixes #31397 - Global Registration - Host Group not assigned

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -54,7 +54,7 @@ class RegistrationController < ApplicationController
   def host_args
     organization = Organization.authorized(:view_organizations).find(params['organization_id']) if params['organization_id'].present?
     location = Location.authorized(:view_locations).find(params['location_id']) if params['location_id'].present?
-    host_group = Hostgroup.authorized(:view_hostgroups).find(params['host_group_id']) if params["host_group_id"].present?
+    host_group = Hostgroup.authorized(:view_hostgroups).find(params['hostgroup_id']) if params["hostgroup_id"].present?
     operatingsystem = Operatingsystem.authorized(:view_operatingsystems).find(params['operatingsystem_id']) if params["operatingsystem_id"].present?
 
     [organization, location, host_group, operatingsystem]

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -19,11 +19,11 @@
     </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label' for='host_group_id'>
+    <label class='col-md-2 control-label' for='hostgroup_id'>
       <%= _('Host Group') %>
     </label>
     <div class='col-md-4'>
-      <%= select_tag 'host_group_id', options_from_collection_for_select(@host_groups, :id, :name, params[:host_group_id]), class: 'form-control', include_blank: '' %>
+      <%= select_tag 'hostgroup_id', options_from_collection_for_select(@host_groups, :id, :name, params[:hostgroup_id]), class: 'form-control', include_blank: '' %>
     </div>
   </div>
   <div class='form-group'>
@@ -73,7 +73,7 @@
     </div>
   </div>
   <div class='form-group'>
-    <label class='col-md-2 control-label' for='jwt_expiration'>
+    <label class='col-md-2 control-label'>
       <%= _('Token lifetime (hours)') %>
       <% help = _('Expiration of the authorization token.') %>
       <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">


### PR DESCRIPTION
Issue caused by incorrect parameter: `host_group_id` instead of `hostgroup_id`.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
