### PR TITLE
Fixes #31364 - Properly import facts when unattended == false

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -82,7 +82,7 @@ module Orchestration
   # after validation callbacks status, as rails by default does
   # not care about their return status.
   def valid?(context = nil)
-    setup_clone if SETTINGS[:unattended]
+    setup_clone
     super
     orchestration_errors?
   end
@@ -120,10 +120,10 @@ module Orchestration
   end
 
   def without_orchestration(&block)
-    skip_orchestration! if SETTINGS[:unattended]
+    skip_orchestration!
     yield
   ensure
-    enable_orchestration! if SETTINGS[:unattended]
+    enable_orchestration!
   end
 
   private


### PR DESCRIPTION
The fact importer calls `host.without_orchestration` which is defined in
orchestration concern, however the concern is only included when
unattended == true. Users who have the setting set to false will not be
able to import facts as the fact importer will fail to find this method.

Additionally, cleaning up checks for the unattended setting where they
are not needed.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
