### PR TITLE
Fixes #31364 - Properly import facts when unattended == false

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -341,6 +341,10 @@ class Host::Managed < Host::Base
     def compute_provides?(attr)
       false
     end
+
+    def without_orchestration
+      yield
+    end
   end
 
   before_validation :set_hostgroup_defaults, :set_ip_address


### PR DESCRIPTION
The fact importer calls host.without_orchestration which is defined in
orchestration concern, however the concern is only included when
unattended == true. Users who have the setting set to false will not be
able to import facts as the fact importer will fail to find this method.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
