### PR TITLE
Fixes #31410 - Clone Operating system

### DIFF
--- a/app/controllers/operatingsystems_controller.rb
+++ b/app/controllers/operatingsystems_controller.rb
@@ -2,7 +2,7 @@ class OperatingsystemsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::Parameters::Operatingsystem
 
-  before_action :find_resource, :only => [:edit, :update, :destroy]
+  before_action :find_resource, :only => [:edit, :update, :destroy, :clone]
 
   def index
     @operatingsystems = resource_base_search_and_page
@@ -45,6 +45,21 @@ class OperatingsystemsController < ApplicationController
       process_success
     else
       process_error
+    end
+  end
+
+  def clone
+    @operatingsystem = @operatingsystem.deep_clone include: [:media, :ptables, :architectures, :puppetclasses, :os_parameters], except: [:title]
+  end
+
+  private
+
+  def action_permission
+    case params[:action]
+      when 'clone'
+        :create
+      else
+        super
     end
   end
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -453,7 +453,7 @@ Foreman::AccessControl.map do |permission_set|
                                              :"api/v2/operatingsystems" => [:index, :show, :bootfiles],
                                              :"api/v2/os_default_templates" => [:index, :show],
                                             }
-    map.permission :create_operatingsystems, {:operatingsystems => [:new, :create],
+    map.permission :create_operatingsystems, {:operatingsystems => [:new, :create, :clone],
                                              :"api/v2/operatingsystems" => [:create],
                                              :"api/v2/os_default_templates" => [:create],
                                             }

--- a/app/views/operatingsystems/clone.erb
+++ b/app/views/operatingsystems/clone.erb
@@ -1,0 +1,3 @@
+<% title _("Clone %s") % @operatingsystem.to_s %>
+
+<%= render :partial => 'form' %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -12,12 +12,16 @@
   </thead>
   <tbody>
     <% @operatingsystems.each do |operatingsystem| %>
+      <%
+        edit_btn = display_link_if_authorized(_("Edit"), hash_for_edit_operatingsystem_path(id: operatingsystem).merge(auth_object: operatingsystem, authorizer: authorizer))
+        clone_btn = display_link_if_authorized(_("Clone"), hash_for_clone_operatingsystem_path(id: operatingsystem).merge(auth_object: operatingsystem, authorizer: authorizer, permission: 'create_operatingsystems'))
+        delete_btn = display_delete_if_authorized(hash_for_operatingsystem_path(id: operatingsystem).merge(auth_object: operatingsystem, authorizer: authorizer), data: { confirm: _("Delete %s?") % operatingsystem.fullname }, class: 'delete')
+      %>
       <tr>
         <td class="ellipsis"><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer)) %></td>
         <td><%= link_to hosts_count[operatingsystem], hosts_path(:search => "os_id = #{operatingsystem.id}") %></td>
         <td>
-          <%= action_buttons(display_delete_if_authorized hash_for_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer),
-            :data => { :confirm => _("Delete %s?") % operatingsystem.fullname }) %>
+          <%= action_buttons(edit_btn, clone_btn, delete_btn) %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -422,6 +422,7 @@ Foreman::Application.routes.draw do
       resources :operatingsystems, except: [:show] do
         member do
           get 'bootfiles'
+          get 'clone'
         end
         collection do
           get 'auto_complete_search'

--- a/test/controllers/operatingsystems_controller_test.rb
+++ b/test/controllers/operatingsystems_controller_test.rb
@@ -42,6 +42,11 @@ class OperatingsystemsControllerTest < ActionController::TestCase
       put :update, params: { :id => Operatingsystem.first, :operatingsystem => {:name => Operatingsystem.first.name} }, session: set_session_user
       assert_template 'edit'
     end
+
+    test 'clone' do
+      get :clone, params: { :id => Operatingsystem.first.id }, session: set_session_user
+      assert_template 'clone'
+    end
   end
 
   context 'redirects' do


### PR DESCRIPTION
New option for cloning operating systems, so when new version of OS is released, users don't have to fill all the fields again.
All template's parameters are cloned except the templates.

<!---
**Note**
When cloning, all fields except templates are cloned. 
Not that it can't be done, this works:
```
@operatingsystem.deep_clone include: [:provisioning_templates, :os_default_templates]
```
but the performance is very poor, even only with the set of default templates.




Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
