### PR TITLE
Fixes #30670 - start dynflow client in report tasks

### DIFF
--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -108,15 +108,15 @@ namespace :reports do
     end
   end
 
-  task :daily => :environment do
+  task :daily => [:environment, 'dynflow:client'] do
     process_notifications :daily
   end
 
-  task :weekly => :environment do
+  task :weekly => [:environment, :'dynflow:client'] do
     process_notifications :weekly
   end
 
-  task :monthly => :environment do
+  task :monthly => [:environment, :'dynflow:client'] do
     process_notifications :monthly
   end
 end


### PR DESCRIPTION
As reported, a single foreman-rake reports:daily in fact triggers the
rake task twice. This is caused by plugins that need to extend this (and
similar tasks) with their own logic and add other rake tasks
dependencies. For that they need to `load` our core tasks, causing the
duplication. `load` should be avoided entirely.

In this specific case though, the need was to add dynflow:client
dependecy to reports, since Katello plugin may schedule some dynflow
job as part of that. Therefore it needs client connection to dynflow.
This task does not start the executor.

Instead of asking all plugins to add such dependency if their custom
mail notification requires dynflow client, the Foreman core should offer
this by default.

The real fix needs to land in Katello, it should no longer load the core
task definition, however in order for that to be possible, this PR needs
to be merged first.

What was tried:
* modify the Katello in a way requiring the task does not cause
  duplicity
* clearing the task after it's loaded - this helps but may have other
  consequences and does not solve the issue for other plugins


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
