### PR TITLE
Fixes #31282 - JWT scope

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -22,7 +22,7 @@ module Foreman::Controller::Registration
 
     context = {
       user: User.current,
-      auth_token: User.current.jwt_token!(expiration: 4.hours.to_i),
+      auth_token: User.current.jwt_token!(expiration: 4.hours.to_i, scope: 'registration'),
       organization: (organization || User.current.default_organization || User.current.my_organizations.first),
       location: (location || User.current.default_location || User.current.my_locations.first),
       hostgroup: host_group,

--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -22,7 +22,7 @@ module Foreman::Controller::Registration
 
     context = {
       user: User.current,
-      auth_token: User.current.jwt_token!(expiration: 4.hours.to_i, scope: 'registration'),
+      auth_token: api_authorization_token,
       organization: (organization || User.current.default_organization || User.current.my_organizations.first),
       location: (location || User.current.default_location || User.current.my_locations.first),
       hostgroup: host_group,
@@ -129,5 +129,13 @@ module Foreman::Controller::Registration
     rex_param = HostParameter.find_or_initialize_by(host: @host, name: 'host_registration_remote_execution', key_type: 'boolean')
     rex_param.value = ActiveRecord::Type::Boolean.new.deserialize(params['setup_remote_execution'])
     rex_param.save!
+  end
+
+  def api_authorization_token
+    scope = [{
+      controller: :registration,
+      actions: [:global, :host],
+    }]
+    User.current.jwt_token!(expiration: 4.hours.to_i, scope: scope)
   end
 end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -22,7 +22,7 @@ class RegistrationController < ApplicationController
 
   def headers
     hours = (params[:jwt_expiration].presence || 4).to_i.hours.to_i
-    jwt = User.current.jwt_token!(expiration: hours)
+    jwt = User.current.jwt_token!(expiration: hours, scope: 'registration')
 
     "-H 'Authorization: Bearer #{jwt}'"
   end

--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -22,7 +22,11 @@ class RegistrationController < ApplicationController
 
   def headers
     hours = (params[:jwt_expiration].presence || 4).to_i.hours.to_i
-    jwt = User.current.jwt_token!(expiration: hours, scope: 'registration')
+    scope = [{
+      controller: :registration,
+      actions: [:global, :host],
+    }]
+    jwt = User.current.jwt_token!(expiration: hours, scope: scope)
 
     "-H 'Authorization: Bearer #{jwt}'"
   end

--- a/app/models/concerns/jwt_auth.rb
+++ b/app/models/concerns/jwt_auth.rb
@@ -9,8 +9,8 @@ module JwtAuth
     end
 
     # expiration:  integer, eg: 4.hours.to_i
-    # scope:       string or array with controller name(s)
-    def jwt_token!(expiration: nil, scope: nil)
+    # scope:       example: [{ controller: :registration, actions: [:global, :host] }]
+    def jwt_token!(expiration: nil, scope: [])
       jwt_secret = jwt_secret!
       JwtToken.encode(self, jwt_secret.token, expiration: expiration, scope: scope).to_s
     end

--- a/app/models/concerns/jwt_auth.rb
+++ b/app/models/concerns/jwt_auth.rb
@@ -8,9 +8,11 @@ module JwtAuth
       jwt_secret || create_jwt_secret!
     end
 
-    def jwt_token!(expiration: nil)
+    # expiration:  integer, eg: 4.hours.to_i
+    # scope:       string or array with controller name(s)
+    def jwt_token!(expiration: nil, scope: nil)
       jwt_secret = jwt_secret!
-      JwtToken.encode(self, jwt_secret.token, expiration).to_s
+      JwtToken.encode(self, jwt_secret.token, expiration: expiration, scope: scope).to_s
     end
   end
 end

--- a/app/services/jwt_token.rb
+++ b/app/services/jwt_token.rb
@@ -3,16 +3,17 @@ require 'base64'
 
 class JwtToken < Struct.new(:token)
   class << self
-    def encode(user, secret, expiration = nil)
-      payload = prepare_payload(user, secret, expiration)
+    def encode(user, secret, expiration: nil, scope: nil)
+      payload = prepare_payload(user, secret, expiration: expiration, scope: scope)
       new JWT.encode(payload, secret)
     end
 
     private
 
-    def prepare_payload(user, secret, expiration)
+    def prepare_payload(user, secret, expiration: nil, scope: nil)
       jti_raw = [secret, iat].join(':')
       jti = Digest::SHA256.hexdigest(jti_raw)
+      scope = scope.join(' ') if scope.is_a? Array
       payload = {
         user_id: user.id,
         iat: iat,
@@ -20,6 +21,7 @@ class JwtToken < Struct.new(:token)
       }
 
       payload[:exp] = (Time.now.to_i + expiration) if expiration
+      payload[:scope] = scope if scope
       payload
     end
 

--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -51,7 +51,8 @@ module SSO
 
     def valid_scope?(scope)
       return true if scope.empty?
-      scope.split(' ').include? controller.controller_permission
+      required_scope = "#{controller.controller_permission}##{controller.action_name}"
+      scope.split(' ').include? required_scope
     end
   end
 end

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -112,11 +112,6 @@
       <div class='col-md-8'>
         <pre class='ellipsis white-space-normal' id='registration_command'><%= @command %></pre>
         <a class='btn btn-default' onclick="tfm.hosts.copyRegistrationCommand();" ><%= _('Copy to clipboard') %></a>
-        <div>&nbsp;</div>
-        <div class="alert alert-info" role="alert">
-          <span class="pficon pficon-info"></span>
-          <%= _("Note: the command contains an authentication token which grants access to your Foreman account until it expires.") %>
-        </div>
       </div>
     </div>
   <% end %>

--- a/test/unit/jwt_token_test.rb
+++ b/test/unit/jwt_token_test.rb
@@ -19,9 +19,26 @@ class JwtTokenTest < ActiveSupport::TestCase
     jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
     JwtSecret.stubs(:find_by).returns(jwt_secret)
     user = OpenStruct.new(id: 123)
-    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, 3600).token)
+    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, expiration: 3600).token)
 
     assert_nothing_raised { jwt_token.decode }
+  end
+
+  test 'encode with scope (string)' do
+    jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
+    JwtSecret.stubs(:find_by).returns(jwt_secret)
+    jwt_token = JwtToken.new(JwtToken.encode(OpenStruct.new(id: 123), jwt_secret.token, scope: 'onescope').token)
+
+    assert_equal 'onescope', jwt_token.decode['scope']
+  end
+
+  test 'encode with scope (array)' do
+    jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
+    JwtSecret.stubs(:find_by).returns(jwt_secret)
+    scope = ['one', 'two', 'three']
+    jwt_token = JwtToken.new(JwtToken.encode(OpenStruct.new(id: 123), jwt_secret.token, scope: scope).token)
+
+    assert_equal 'one two three', jwt_token.decode['scope']
   end
 
   test 'decoding' do
@@ -74,7 +91,7 @@ class JwtTokenTest < ActiveSupport::TestCase
     jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
     JwtSecret.stubs(:find_by).returns(jwt_secret)
     user = OpenStruct.new(id: 123)
-    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, -1).token)
+    jwt_token = JwtToken.new(JwtToken.encode(user, jwt_secret.token, expiration: -1).token)
 
     assert_raise(JWT::ExpiredSignature) { jwt_token.decode }
   end

--- a/test/unit/jwt_token_test.rb
+++ b/test/unit/jwt_token_test.rb
@@ -24,21 +24,13 @@ class JwtTokenTest < ActiveSupport::TestCase
     assert_nothing_raised { jwt_token.decode }
   end
 
-  test 'encode with scope (string)' do
+  test 'encode with scope' do
     jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
     JwtSecret.stubs(:find_by).returns(jwt_secret)
-    jwt_token = JwtToken.new(JwtToken.encode(OpenStruct.new(id: 123), jwt_secret.token, scope: 'onescope').token)
-
-    assert_equal 'onescope', jwt_token.decode['scope']
-  end
-
-  test 'encode with scope (array)' do
-    jwt_secret = FactoryBot.build(:jwt_secret, token: 'test_jwt_secret')
-    JwtSecret.stubs(:find_by).returns(jwt_secret)
-    scope = ['one', 'two', 'three']
+    scope = [{ controller: 'hosts', actions: ['create', 'update']}]
     jwt_token = JwtToken.new(JwtToken.encode(OpenStruct.new(id: 123), jwt_secret.token, scope: scope).token)
 
-    assert_equal 'one two three', jwt_token.decode['scope']
+    assert_equal 'hosts#create hosts#update', jwt_token.decode['scope']
   end
 
   test 'decoding' do

--- a/test/unit/sso/jwt_test.rb
+++ b/test/unit/sso/jwt_test.rb
@@ -72,49 +72,14 @@ class JwtTest < ActiveSupport::TestCase
   end
 
   context 'scope' do
-    test 'with one valid scope (string)' do
-      token = users(:one).jwt_token!(scope: 'hosts')
+    test 'with scope' do
+      token = users(:one).jwt_token!(scope: [{ controller: :hosts, actions: [:create]}])
       sso = SSO::Jwt.new(get_controller(true, token))
 
       assert_equal users(:one).login, sso.authenticated?
     end
 
-    test 'with multiple scopes (array)' do
-      token = users(:one).jwt_token!(scope: ['one', 'two', 'hosts'])
-      sso = SSO::Jwt.new(get_controller(true, token))
-
-      assert_equal users(:one).login, sso.authenticated?
-    end
-
-    test 'with one invalid scope (string)' do
-      token = users(:one).jwt_token!(scope: 'users')
-      sso = SSO::Jwt.new(get_controller(true, token))
-
-      assert_nil sso.authenticated?
-    end
-
-    test 'with multiple invalid scopes (array)' do
-      token = users(:one).jwt_token!(scope: ['one', 'two', 'three'])
-      sso = SSO::Jwt.new(get_controller(true, token))
-
-      assert_nil sso.authenticated?
-    end
-
-    test 'with nil scope' do
-      token = users(:one).jwt_token!(scope: nil)
-      sso = SSO::Jwt.new(get_controller(true, token))
-
-      assert_equal users(:one).login, sso.authenticated?
-    end
-
-    test 'with empty string scope' do
-      token = users(:one).jwt_token!(scope: '')
-      sso = SSO::Jwt.new(get_controller(true, token))
-
-      assert_equal users(:one).login, sso.authenticated?
-    end
-
-    test 'with empty array scope' do
+    test 'without scope' do
       token = users(:one).jwt_token!(scope: [])
       sso = SSO::Jwt.new(get_controller(true, token))
 
@@ -128,6 +93,7 @@ class JwtTest < ActiveSupport::TestCase
     controller = Struct.new(:request).new(Struct.new(:authorization, :headers).new("Bearer #{jwt_token}", headers))
     controller.stubs(:api_request?).returns(api_request)
     controller.stubs(:controller_permission).returns('hosts')
+    controller.stubs(:action_name).returns('create')
     controller.stubs(:session).returns(ActionController::TestSession.new)
     controller
   end

--- a/test/unit/sso/jwt_test.rb
+++ b/test/unit/sso/jwt_test.rb
@@ -71,11 +71,63 @@ class JwtTest < ActiveSupport::TestCase
     end
   end
 
+  context 'scope' do
+    test 'with one valid scope (string)' do
+      token = users(:one).jwt_token!(scope: 'hosts')
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_equal users(:one).login, sso.authenticated?
+    end
+
+    test 'with multiple scopes (array)' do
+      token = users(:one).jwt_token!(scope: ['one', 'two', 'hosts'])
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_equal users(:one).login, sso.authenticated?
+    end
+
+    test 'with one invalid scope (string)' do
+      token = users(:one).jwt_token!(scope: 'users')
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_nil sso.authenticated?
+    end
+
+    test 'with multiple invalid scopes (array)' do
+      token = users(:one).jwt_token!(scope: ['one', 'two', 'three'])
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_nil sso.authenticated?
+    end
+
+    test 'with nil scope' do
+      token = users(:one).jwt_token!(scope: nil)
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_equal users(:one).login, sso.authenticated?
+    end
+
+    test 'with empty string scope' do
+      token = users(:one).jwt_token!(scope: '')
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_equal users(:one).login, sso.authenticated?
+    end
+
+    test 'with empty array scope' do
+      token = users(:one).jwt_token!(scope: [])
+      sso = SSO::Jwt.new(get_controller(true, token))
+
+      assert_equal users(:one).login, sso.authenticated?
+    end
+  end
+
   protected
 
   def get_controller(api_request, jwt_token = 'invalid', headers = {})
     controller = Struct.new(:request).new(Struct.new(:authorization, :headers).new("Bearer #{jwt_token}", headers))
     controller.stubs(:api_request?).returns(api_request)
+    controller.stubs(:controller_permission).returns('hosts')
     controller.stubs(:session).returns(ActionController::TestSession.new)
     controller
   end


### PR DESCRIPTION
Added scope for JWT, allowing user to limit token access to the specific controllers.
JWTs generated for Global Registration have now scope set by default to the registration controllers only.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
