### PR TITLE
Fixes #31420 - Global Registration Template - Exit script when sub-man fails

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -72,7 +72,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     yum localinstall $CONSUMER_RPM -y
     rm -f $CONSUMER_RPM
 
-    subscription-manager register --org='<%= @organization.label %>' --activationkey='<%= @activation_key %>'
+    subscription-manager register --org='<%= @organization.label %>' --activationkey='<%= @activation_key %>' || exit 1
     register_katello_host | bash
 else
     register_host | bash


### PR DESCRIPTION
When `subscription-manager register` fails we should not continue and exit the script.
It doesn't make sense to render host registration template and create `@host` in the Foreman when  `subscription-manager register` failed.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
