### PR TITLE
Refs #30925 - run rubocop in parallel mode

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,4 +13,4 @@ jobs:
           ruby-version: 2.5
           bundler-cache: true
       - name: Run rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop -P


### PR DESCRIPTION
Only after I merged the PR, I realized that we run Rubocop in normal mode. Not sure how many cores are available in GitHub Actions, let's see. The last run took exactly 2 minutes.