### PR TITLE
Fixes #31425 - Templates rendering host status

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -832,9 +832,7 @@ class HostsController < ApplicationController
 
   def find_templates
     find_resource
-    @templates = TemplateKind.order(:name).map do |kind|
-      @host.provisioning_template(:kind => kind.name)
-    end.compact
+    @templates = @host.find_templates
     raise Foreman::Exception.new(N_("No templates found")) if @templates.empty?
   end
 

--- a/app/controllers/templates_rendering_statuses_controller.rb
+++ b/app/controllers/templates_rendering_statuses_controller.rb
@@ -1,0 +1,19 @@
+class TemplatesRenderingStatusesController < ApplicationController
+  include AuthorizeHelper
+
+  before_action :find_resource, only: [:show]
+
+  def show
+    @combinations_count = @templates_rendering_status.combinations
+                                                     .group('templates_rendering_status_combinations.status')
+                                                     .count
+  end
+
+  def model_of_controller
+    ::HostStatus::TemplatesRenderingStatus
+  end
+
+  def resource_class_for(resource)
+    ::HostStatus::TemplatesRenderingStatus
+  end
+end

--- a/app/helpers/templates_rendering_statuses_helper.rb
+++ b/app/helpers/templates_rendering_statuses_helper.rb
@@ -1,0 +1,16 @@
+module TemplatesRenderingStatusesHelper
+  def to_label(status)
+    case status
+      when HostStatus::TemplatesRenderingStatus::OK
+        HostStatus::TemplatesRenderingStatus::OK_LABEL
+      when HostStatus::TemplatesRenderingStatus::SAFEMODE_ERRORS
+        HostStatus::TemplatesRenderingStatus::SAFEMODE_ERRORS_LABEL
+      when HostStatus::TemplatesRenderingStatus::UNSAFEMODE_ERRORS
+        HostStatus::TemplatesRenderingStatus::UNSAFEMODE_ERRORS_LABEL
+      when HostStatus::TemplatesRenderingStatus::MISSING_TEMPLATE_ERROR
+        HostStatus::TemplatesRenderingStatus::MISSING_TEMPLATE_ERROR_LABEL
+      else
+        HostStatus::TemplatesRenderingStatus::PENDING_LABEL
+    end
+  end
+end

--- a/app/jobs/refresh_templates_rendering_statuses_job.rb
+++ b/app/jobs/refresh_templates_rendering_statuses_job.rb
@@ -1,0 +1,34 @@
+class RefreshTemplatesRenderingStatusesJob < ApplicationJob
+  around_perform do |job, block|
+    block.call
+
+    self.class.queue
+  rescue StandardError => e
+    Foreman::Logging.logger('background').error("#{self.class} error: #{e} \n#{e.backtrace.join("\n")}")
+
+    self.class.queue
+  end
+
+  def self.queue
+    set(wait: wait_time).perform_later
+  end
+
+  def self.wait_time
+    Setting[:templates_rendering_status_refresh_interval].minutes
+  end
+
+  queue_as :refresh_templates_rendering_statuses
+
+  def perform
+    User.as_anonymous_admin do
+      Host::Managed.where(managed: true).where(id: HostStatus::TemplatesRenderingStatus.pending.select(:host_id)).map do |host|
+        Foreman::Logging.logger('background').info("#{host} - Refreshing templates rendering status")
+        host.refresh_statuses([HostStatus::TemplatesRenderingStatus])
+        Foreman::Logging.logger('background').info("#{host} - Successfully refreshed templates rendering status")
+      rescue StandardError => e
+        Foreman::Logging.logger('background').error("#{host} - Error while refreshing templates rendering status: #{e}\n#{e.backtrace.join("\n")}")
+        nil
+      end
+    end
+  end
+end

--- a/app/models/concerns/hostext/operating_system.rb
+++ b/app/models/concerns/hostext/operating_system.rb
@@ -21,6 +21,12 @@ module Hostext
       end
     end
 
+    def find_templates
+      TemplateKind.order(:name).map do |kind|
+        provisioning_template(kind: kind.name)
+      end.compact
+    end
+
     def available_template_kinds(provisioning = nil)
       kinds = template_kinds(provisioning)
       kinds.map do |kind|

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -71,6 +71,7 @@ class Host::Managed < Host::Base
   after_commit :build_hooks
   before_save :clear_data_on_build
   before_save :clear_puppetinfo, :if => :environment_id_changed?
+  after_save :refresh_templates_rendering_status, if: -> { (saved_changes.keys - ['global_status', 'updated_at']).any? }
 
   include PxeLoaderValidator
 
@@ -945,6 +946,10 @@ autopart"', desc: 'to render the content of host partition table'
   end
 
   private
+
+  def refresh_templates_rendering_status
+    get_status(HostStatus::TemplatesRenderingStatus).update(status: HostStatus::TemplatesRenderingStatus::PENDING)
+  end
 
   def update_os_from_facts
     operatingsystem.architectures << architecture if operatingsystem && architecture && !operatingsystem.architectures.include?(architecture)

--- a/app/models/host_status/templates_rendering_status.rb
+++ b/app/models/host_status/templates_rendering_status.rb
@@ -1,0 +1,82 @@
+module HostStatus
+  class TemplatesRenderingStatus < Status
+    PENDING = 0
+    OK = 1
+    SAFEMODE_ERRORS = 2
+    UNSAFEMODE_ERRORS = 3
+    MISSING_TEMPLATE_ERROR = 4
+
+    OK_LABEL = N_('OK')
+    SAFEMODE_ERRORS_LABEL = N_('Safe mode Error')
+    UNSAFEMODE_ERRORS_LABEL = N_('Unsafe mode Error')
+    MISSING_TEMPLATE_ERROR_LABEL = N_('Provisioning Template is missing')
+    PENDING_LABEL = N_('Pending')
+
+    def self.status_name
+      N_('Templates Rendering Status')
+    end
+
+    has_many :combinations, class_name: 'HostStatus::TemplatesRenderingStatusCombination',
+                            inverse_of: :host_status,
+                            dependent: :destroy,
+                            primary_key: :host_id,
+                            foreign_key: :host_id
+    has_many :templates, through: :combinations
+
+    scope :pending, -> { where(status: PENDING) }
+
+    def to_status(_options = {})
+      actual_templates = host.find_templates
+
+      combinations.where.not(template: actual_templates).delete_all
+      statuses = actual_templates.map { |template| combinations.find_or_initialize_by(template: template) }
+                      .each(&:refresh_status)
+                      .each(&:save)
+                      .map(&:status)
+
+      return MISSING_TEMPLATE_ERROR unless statuses.any?
+      return UNSAFEMODE_ERRORS if statuses.include?(UNSAFEMODE_ERRORS)
+      return SAFEMODE_ERRORS if statuses.include?(SAFEMODE_ERRORS)
+
+      OK
+    end
+
+    def to_global(_options = {})
+      case status
+      when UNSAFEMODE_ERRORS, MISSING_TEMPLATE_ERROR
+        HostStatus::Global::ERROR
+      when SAFEMODE_ERRORS
+        HostStatus::Global::WARN
+      else
+        HostStatus::Global::OK
+      end
+    end
+
+    def to_label(_options = {})
+      label = case status
+              when OK
+                OK_LABEL
+              when SAFEMODE_ERRORS
+                SAFEMODE_ERRORS_LABEL
+              when UNSAFEMODE_ERRORS
+                UNSAFEMODE_ERRORS_LABEL
+              when MISSING_TEMPLATE_ERROR
+                MISSING_TEMPLATE_ERROR_LABEL
+              else
+                PENDING_LABEL
+              end
+
+      url = url_helpers.templates_rendering_status_path(self)
+
+      "<a href='#{url}'>#{label}</a>".html_safe
+    end
+
+    def relevant?(_options = {})
+      host.managed?
+    end
+
+    delegate :url_helpers, to: 'Rails.application.routes'
+  end
+end
+
+HostStatus.status_registry.add(HostStatus::TemplatesRenderingStatus)

--- a/app/models/host_status/templates_rendering_status_combination.rb
+++ b/app/models/host_status/templates_rendering_status_combination.rb
@@ -1,0 +1,46 @@
+module HostStatus
+  class TemplatesRenderingStatusCombination < ::ApplicationRecord
+    belongs_to_host
+    belongs_to :template, class_name: 'ProvisioningTemplate'
+    belongs_to :host_status, inverse_of: :combinations,
+                             class_name: 'HostStatus::TemplatesRenderingStatus',
+                             primary_key: :host_id,
+                             foreign_key: :host_id
+
+    validates :host, uniqueness: { scope: :template }
+    validates :host, presence: true
+    validates :template, presence: true
+    validates :status, presence: true
+
+    scope :not_pending, -> { where.not(status: HostStatus::TemplatesRenderingStatus::PENDING) }
+
+    def refresh_status
+      assign_attributes(status: to_status)
+    end
+
+    def to_status
+      return HostStatus::TemplatesRenderingStatus::UNSAFEMODE_ERRORS if !Setting::Provisioning[:safemode_render] && !render_unsafemode
+      return HostStatus::TemplatesRenderingStatus::SAFEMODE_ERRORS unless render_safemode
+
+      HostStatus::TemplatesRenderingStatus::OK
+    end
+
+    private
+
+    def render_safemode
+      template.render(renderer: Foreman::Renderer::SafeModeRenderer, host: host)
+      true
+    rescue StandardError => e
+      Foreman::Logging.exception("#{self.class} Safemode Error", e)
+      false
+    end
+
+    def render_unsafemode
+      template.render(renderer: Foreman::Renderer::UnsafeModeRenderer, host: host)
+      true
+    rescue StandardError => e
+      Foreman::Logging.exception("#{self.class} Unsafemode Error", e)
+      false
+    end
+  end
+end

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -75,6 +75,7 @@ class Setting::Provisioning < Setting
       set('default_pxe_item_global', N_("Default PXE menu item in global template - 'local', 'discovery' or custom, use blank for template default"), nil, N_("Default PXE global template entry")),
       set('default_pxe_item_local', N_("Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"), nil, N_("Default PXE local template entry")),
       set('intermediate_ipxe_script', N_('Intermediate iPXE script for unattended installations'), 'iPXE intermediate script', N_('iPXE intermediate script'), nil, { :collection => proc { Hash[ProvisioningTemplate.unscoped.of_kind(:iPXE).map { |tmpl| [tmpl.name, tmpl.name] }] } }),
+      set('templates_rendering_status_refresh_interval', N_('The refreshing interval for templates rendering status (in minutes)'), 5, N_('Templates rendering status refresh interval')),
       set(
         'destroy_vm_on_host_delete',
         N_("Destroy associated VM on host delete. When enabled, VMs linked to Hosts will be deleted on Compute Resource. When disabled, VMs are unlinked when the host is deleted, meaning they remain on Compute Resource and can be re-associated or imported back to Foreman again. This does not automatically power off the VM"),

--- a/app/views/templates_rendering_statuses/show.html.erb
+++ b/app/views/templates_rendering_statuses/show.html.erb
@@ -1,0 +1,48 @@
+<% title _("Templates Rendering Status for: %s") % @templates_rendering_status.host.name %>
+
+<div class="container-fluid container-cards-pf">
+  <div class="row row-cards-pf">
+    <div class="col-xs-12 col-sm-6">
+      <div class="card-pf card-pf-accented card-pf-aggregate-status">
+        <div class="card-pf-body">
+          <table class="table">
+            <tr>
+              <td><%= icon_text('ok', '', kind: 'pficon') %></td>
+              <td><%= to_label(HostStatus::TemplatesRenderingStatus::OK) %></td>
+              <td><%= @combinations_count.fetch(HostStatus::TemplatesRenderingStatus::OK, 0) %></td>
+            </tr>
+            <tr>
+              <td><%= icon_text('error-circle-o', '', kind: 'pficon') %></td>
+              <td><%= to_label(HostStatus::TemplatesRenderingStatus::SAFEMODE_ERRORS) %></td>
+              <td><%= @combinations_count.fetch(HostStatus::TemplatesRenderingStatus::SAFEMODE_ERRORS, 0) %></td>
+            </tr>
+            <tr>
+              <td><%= icon_text('error-circle-o', '', kind: 'pficon') %></td>
+              <td><%= to_label(HostStatus::TemplatesRenderingStatus::UNSAFEMODE_ERRORS) %></td>
+              <td><%= @combinations_count.fetch(HostStatus::TemplatesRenderingStatus::UNSAFEMODE_ERRORS, 0) %></td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-xs-12">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th><%= _("Template") %></th>
+            <th><%= _("Status") %></th>
+          </tr>
+        </thead>
+        <tbody>
+        <% @templates_rendering_status.combinations.not_pending.each do |combination| %>
+          <tr>
+            <td><%= link_to_if_authorized(combination.template.name, hash_for_edit_provisioning_template_path(id: combination.template)) %></td>
+            <td><%= to_label(combination.status) %></td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>

--- a/config/initializers/refresh_templates_rendering_statuses.rb
+++ b/config/initializers/refresh_templates_rendering_statuses.rb
@@ -1,0 +1,3 @@
+::Foreman::Application.dynflow.config.on_init do |world|
+  RefreshTemplatesRenderingStatusesJob.spawn_if_missing(world)
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -602,4 +602,6 @@ Foreman::Application.routes.draw do
     match 'experimental/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
   end
   get 'links/:type(/:section)' => 'links#show', :as => 'external_link', :constraints => { section: %r{.*} }
+
+  resources :templates_rendering_statuses, only: :show
 end

--- a/db/migrate/20201019184012_create_templates_rendering_status_combinations.rb
+++ b/db/migrate/20201019184012_create_templates_rendering_status_combinations.rb
@@ -1,0 +1,13 @@
+class CreateTemplatesRenderingStatusCombinations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :templates_rendering_status_combinations do |t|
+      t.references :host, null: false, foreign_key: true
+      t.references :template, null: false, foreign_key: true
+      t.integer :status, null: false, default: HostStatus::TemplatesRenderingStatus::PENDING
+
+      t.timestamps
+    end
+
+    add_index :templates_rendering_status_combinations, [:host_id, :template_id], unique: true, name: :index_templates_rendering_status_combinations_host_and_templat
+  end
+end

--- a/lib/tasks/templates_rendering_statuses.rake
+++ b/lib/tasks/templates_rendering_statuses.rake
@@ -1,0 +1,24 @@
+# TRANSLATORS: do not translate
+desc <<~END_DESC
+  Refresh templates rendering statuses for all managed hosts
+
+    Example:
+      rake templates_rendering_statuses:refresh
+
+END_DESC
+
+namespace :templates_rendering_statuses do
+  task refresh: :environment do
+    Host::Managed.where(managed: true).in_batches(of: 100) do |batch|
+      batch.map do |host|
+        puts "#{host} - Refreshing templates rendering status"
+        host.refresh_statuses([HostStatus::TemplatesRenderingStatus])
+        puts Rainbow("#{host} - Successfully refreshed templates rendering status").green
+      rescue StandardError => e
+        puts Rainbow("#{host} - Error while refreshing templates rendering status: #{e}").red
+        puts Rainbow(e.backtrace.join("\n"))
+        nil
+      end
+    end
+  end
+end

--- a/test/factories/host_status/templates_rendering_status_combination.rb
+++ b/test/factories/host_status/templates_rendering_status_combination.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :templates_rendering_status_combination, class: "HostStatus::TemplatesRenderingStatusCombination" do
+    association :host, factory: [:host, :managed]
+    association :template, factory: :provisioning_template
+    host_status { host.get_status('HostStatus::TemplatesRenderingStatus') }
+    status { HostStatus::TemplatesRenderingStatus::OK }
+  end
+end

--- a/test/models/host_status/templates_rendering_status_combination_test.rb
+++ b/test/models/host_status/templates_rendering_status_combination_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class TemplatesRenderingStatusCombinationTest < ActiveSupport::TestCase
+  describe '#to_status' do
+    setup do
+      Setting[:safemode_render] = false
+    end
+
+    subject do
+      FactoryBot.build_stubbed(
+        :templates_rendering_status_combination,
+        template: FactoryBot.build_stubbed(:provisioning_template, template: template)
+      ).to_status
+    end
+
+    describe 'unsafemode error' do
+      let(:expected) { HostStatus::TemplatesRenderingStatus::UNSAFEMODE_ERRORS }
+      let(:template) { '<% invalid_macro %>' }
+
+      it { assert_equal expected, subject }
+
+      context 'with snippet' do
+        let(:template) { "<%= snippet('#{snippet.name}') %>" }
+        let(:snippet) { FactoryBot.create(:provisioning_template, :snippet, template: '<% invalid_macro %>') }
+
+        it { assert_equal expected, subject }
+      end
+    end
+
+    describe 'safemode error' do
+      let(:expected) { HostStatus::TemplatesRenderingStatus::SAFEMODE_ERRORS }
+      let(:template) { '<% @host.owner_name %>' }
+
+      it { assert_equal expected, subject }
+
+      context 'with snippet' do
+        let(:template) { "<%= snippet('#{snippet.name}') %>" }
+        let(:snippet) { FactoryBot.create(:provisioning_template, :snippet, template: '<% @host.owner_name %>') }
+
+        it { assert_equal expected, subject }
+      end
+    end
+
+    describe 'ok' do
+      let(:expected) { HostStatus::TemplatesRenderingStatus::OK }
+      let(:template) { '<% @host.name %>' }
+
+      it { assert_equal expected, subject }
+
+      context 'with snippet' do
+        let(:template) { "<%= snippet('#{snippet.name}') %>" }
+        let(:snippet) { FactoryBot.create(:provisioning_template, :snippet, template: '<% @host.name %>') }
+
+        it { assert_equal expected, subject }
+      end
+    end
+  end
+end

--- a/test/models/host_status/templates_rendering_status_test.rb
+++ b/test/models/host_status/templates_rendering_status_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class TemplatesRenderingStatusTest < ActiveSupport::TestCase
+  describe '#refresh!' do
+    let(:combination) { FactoryBot.create(:templates_rendering_status_combination) }
+    let(:status) { combination.host_status }
+    let(:host) { status.host }
+
+    test 'remove old combinations' do
+      host.expects(:find_templates).returns([])
+
+      assert_difference('HostStatus::TemplatesRenderingStatusCombination.count', -1) do
+        status.refresh!
+      end
+    end
+
+    test 'create new combinations' do
+      host.expects(:find_templates).returns(
+        [
+          combination.template,
+          FactoryBot.create(:provisioning_template),
+        ]
+      )
+
+      assert_difference('HostStatus::TemplatesRenderingStatusCombination.count', 1) do
+        status.refresh!
+      end
+    end
+
+    test 'update exisiting combinations' do
+      host.expects(:find_templates).returns([combination.template])
+      HostStatus::TemplatesRenderingStatusCombination.any_instance.expects(:refresh_status).once
+
+      assert_difference('HostStatus::TemplatesRenderingStatusCombination.count', 0) do
+        status.refresh!
+      end
+    end
+  end
+end


### PR DESCRIPTION
It introduces a new "Templates Rendering" host status, possible statuses are: `PENDING`, `OK`, `SAFEMODE_ERRORS`, `UNSAFEMODE_ERRORS` and `MISSING_TEMPLATE_ERROR`. Whenever the host or template is saved, the status is set to `PENDING`. There is a background job that runs every 5 minutes (by default) and refreshes all `PENDING` statuses.

The status label is a link to details page:

![image](https://user-images.githubusercontent.com/37402924/100767443-101b5780-33fa-11eb-909e-2ec038870edb.png)

and on details page you can see  the statuses of all checked templates:

![image](https://user-images.githubusercontent.com/37402924/100769372-3f32c880-33fc-11eb-8d0f-3661b32920e8.png)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
