### PR TITLE
Fixes #31431 - Update to Puma ~> 5.1

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,4 +1,3 @@
 group :service do
-  gem 'puma', '< 5.0'
-  gem 'puma-plugin-systemd'
+  gem 'puma', '~> 5.1'
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -6,7 +6,7 @@ group :test do
   gem 'minitest-spec-rails', '~> 6.0'
   gem 'ci_reporter_minitest', :require => false
   gem 'capybara', '~> 3.0', '< 3.32.1', :require => false
-  gem 'puma', '< 5.0', :require => false
+  gem 'puma', '~> 5.1', :require => false
   gem 'show_me_the_cookies', '~> 5.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -13,19 +13,16 @@ threads ENV.fetch('FOREMAN_PUMA_THREADS_MIN', 0).to_i, ENV.fetch('FOREMAN_PUMA_T
 #
 workers ENV.fetch('FOREMAN_PUMA_WORKERS', 2).to_i
 
-# Provides systemd notify support through the
-# puma-systemd-plugin
-begin
-  plugin :systemd
-rescue Puma::UnknownPlugin
-  puts "Failed to load systemd plugin"
-end
-
 # In clustered mode, Puma can "preload" your application. This loads all the
 # application code prior to forking. Preloading reduces total memory usage of
 # your application via an operating system feature called copy-on-write
 #
 preload_app!
+
+# When systemd socket activation is detected, only use those sockets. This
+# makes FOREMAN_BIND redundant. The code is still there for non-systemd
+# deployments.
+bind_to_activated_sockets 'only'
 
 # Check if FOREMAN_BIND was set to an IP address based on the previous
 # definition of FOREMAN_BIND. If it is an IP address, define the host

--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -10,7 +10,7 @@ User=foreman
 TimeoutSec=300
 WorkingDirectory=/usr/share/foreman
 ExecStart=/usr/share/foreman/bin/rails server --environment $FOREMAN_ENV
-Environment=FOREMAN_ENV=production FOREMAN_BIND=tcp://0.0.0.0:3000
+Environment=FOREMAN_ENV=production
 Environment=MALLOC_ARENA_MAX=2
 
 SyslogIdentifier=foreman


### PR DESCRIPTION
Puma 5.1 introduced a feature to synthesize binds for systemd activated sockets. This removes the need to duplicate the FOREMAN_BIND in two places (foreman.socket and foreman.service).

puma-plugin-systemd is no longer needed since Puma 5.1 gained native support for systemd.