### PR TITLE
[WIP] Fixes #30834 - Add vnic profile to ovirt interface

### DIFF
--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -224,6 +224,10 @@ module Foreman::Model
       true
     end
 
+    def vnic_profiles
+      client.list_vnic_profiles
+    end
+
     def networks(opts = {})
       if opts[:cluster_id]
         client.clusters.get(opts[:cluster_id]).networks
@@ -457,6 +461,7 @@ module Foreman::Model
     end
 
     def normalize_vm_attrs(vm_attrs)
+      normalized = slice_vm_attributes(vm_attrs, ['cores', 'interfaces_attributes', 'memory'])
       normalized = slice_vm_attributes(vm_attrs, ['cores', 'interfaces_attributes', 'memory'])
       normalized['cluster_id'] = vm_attrs['cluster']
       normalized['cluster_name'] = clusters.detect { |c| c.id == normalized['cluster_id'] }.try(:name)
@@ -704,6 +709,7 @@ module Foreman::Model
               name: interface.name,
               network: interface.network,
               interface: interface.interface,
+              vnic_profile: interface.vnic_profile,
             },
           }
           hsh[index.to_s] = interface_attrs

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -2,8 +2,16 @@
 
 <% selected_cluster ||= params.fetch(:host, {}).fetch(:compute_attributes, {}).fetch(:cluster, nil) %>
 <% selected_cluster ||= compute_resource.clusters.first.try(:id) %>
-<%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
-             { }, :disabled => !new_vm, :class => "ovirt_network",
-             :label         => _('Network'), :label_size => "col-md-3" %>
-<%= select_f f, :interface, compute_resource.nictypes,
-               :id, :name, {}, :label => _('Interface type'), :label_size => "col-md-3", :disabled => !new_vm, :class => "ovirt_network" %>
+<% networks = compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { })  %>
+<%= react_component(
+        'OvirtNetwork',
+        name: "ovirt",
+        vnic_profile: f.object.vnic_profile.present? ? f.object.vnic_profile : compute_resource.vnic_profiles[0].id,
+        vnic_profiles: compute_resource.vnic_profiles,
+        network: f.object.network.present? ? f.object.network : networks[0].id,
+        networks: networks,
+        interface_type: f.object.interface.present? ? f.object.interface : compute_resource.nictypes[0].id,
+        interface_types: compute_resource.nictypes,
+        vmExists: !new_vm,
+        scope: f.object_name
+)%>

--- a/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
@@ -10,11 +10,12 @@ const CommonForm = ({
   children,
   inputClassName,
   tooltipHelp,
+  labelClass,
 }) => (
   <div
     className={`form-group ${className} ${touched && error ? 'has-error' : ''}`}
   >
-    <label className="col-md-2 control-label">
+    <label className={`${labelClass} control-label`}>
       {label}
       {required && ' *'}
       {tooltipHelp}
@@ -37,6 +38,7 @@ CommonForm.propTypes = {
   children: PropTypes.node,
   inputClassName: PropTypes.string,
   tooltipHelp: PropTypes.node,
+  labelClass: PropTypes.string,
 };
 
 CommonForm.defaultProps = {
@@ -48,6 +50,7 @@ CommonForm.defaultProps = {
   children: null,
   inputClassName: 'col-md-4',
   tooltipHelp: null,
+  labelClass:  'col-md-2'
 };
 
 export default CommonForm;

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -53,6 +53,7 @@ class Select extends React.Component {
       disabled,
       status = STATUS.RESOLVED,
       errorMessage = __('An error occurred.'),
+      labelClass,
     } = this.props;
 
     let content;
@@ -97,7 +98,11 @@ class Select extends React.Component {
       return innerSelect;
     }
     return (
-      <CommonForm label={label} className={`common-select ${className}`}>
+      <CommonForm
+      label={label}
+      labelClass={labelClass}
+      className={`common-select ${className}`}
+      >
         {content}
       </CommonForm>
     );
@@ -116,6 +121,7 @@ Select.propTypes = {
   errorMessage: PropTypes.string,
   onChange: PropTypes.func,
   useSelect2: PropTypes.bool,
+  labelClass: PropTypes.string,
 };
 
 Select.defaultProps = {
@@ -130,6 +136,7 @@ Select.defaultProps = {
   errorMessage: __('An error occurred.'),
   onChange: noop,
   useSelect2: true,
+  labelClass: undefined,
 };
 
 export default Select;

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -15,6 +15,7 @@ import IsoDate from './common/dates/IsoDate';
 import FormField from './common/forms/FormField';
 import InputFactory from './common/forms/InputFactory';
 import StorageContainer from './hosts/storage/vmware/';
+import OvirtNetwork from './hosts/network/ovirt/';
 import PasswordStrength from './PasswordStrength';
 import BreadcrumbBar from './BreadcrumbBar';
 import FactChart from './FactCharts';
@@ -118,6 +119,7 @@ const coreComponets = [
   { name: 'NotificationContainer', type: NotificationContainer },
   { name: 'ToastNotifications', type: ToastsList },
   { name: 'StorageContainer', type: StorageContainer },
+  { name: 'OvirtNetwork', type: OvirtNetwork },
   { name: 'PasswordStrength', type: PasswordStrength },
   { name: 'BreadcrumbBar', type: BreadcrumbBar },
   { name: 'FactChart', type: FactChart },

--- a/webpack/assets/javascripts/react_app/components/hosts/network/ovirt/Network.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/network/ovirt/Network.js
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { WarningTriangleIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
+import { HelpBlock, Grid, Col, Row } from 'patternfly-react';
+import { translate as __ } from '../../../../common/I18n';
+import Select from "../../../common/forms/Select";
+
+const OvirtNetwork = ({
+  name,
+  vnic_profile,
+  vnic_profiles,
+  network,
+  networks,
+  interface_type,
+  interface_types,
+  vmExists,
+  scope,
+}) => {
+  const modifySelectFields = (array) => array.map((item)=> ({...item,label: item.name || item.table.name,value: item.id || item.table.id}));
+  const [vnicOptions, setVnicOptions] = useState(modifySelectFields(vnic_profiles));
+  const [networksOptions, setNetworkOptions] = useState(modifySelectFields(networks));
+  const [interfaceTypeOptions, setInterfaceTypeOptions] = useState(modifySelectFields(interface_types));
+
+  const [vnicValue, setVnicValue ] = useState(vnic_profile);
+  const [networkValue, setNetworkValue ] = useState(network);
+  const [interfaceTypeValue, setInterfaceType ] = useState(interface_type);
+  useEffect(() => {
+      if (vnicValue) {
+          const vnicObject = vnicOptions.filter(vnic_option => vnic_option.id == vnicValue)[0];
+          const filtered_networks = networksOptions.filter(network_option => network_option.id === vnicObject.network.id);
+          setNetworkValue(filtered_networks[0].id)
+          setNetworkOptions(filtered_networks)
+      }
+  },[vnicValue]);
+    return (
+          <div className="network-container">
+            <Select
+              name = { scope + "[vnic_profile]"}
+              label={__('Vnic Profile')}
+              value = {vnicValue}
+              labelClass="col-md-3"
+              options={vnicOptions}
+              disabled={vmExists}
+              allowClear
+              className="ovirt_network"
+              onChange={event => setVnicValue(event.target.value)}
+            />
+            <Select
+              name =  { scope + "[network]"}
+              label={__('Network')}
+              labelClass="col-md-3"
+              value = {networkValue}
+              options={networksOptions}
+              disabled={vmExists}
+              allowClear
+              className="ovirt_network"
+              onChange={event => setNetworkValue(event.target.value)}
+            />
+              <Select
+              name =  { scope + "[interface]"}
+              label={__('Interface type')}
+              labelClass="col-md-3"
+              value = {interfaceTypeValue}
+              options={interfaceTypeOptions}
+              disabled={vmExists}
+              allowClear
+              key="Network Select"
+              className="ovirt_network"
+
+            />
+          </div>
+
+);
+};
+
+OvirtNetwork.propTypes = {
+  name: PropTypes.string,
+  vnic_profile: PropTypes.string,
+  vnic_profiles: PropTypes.array,
+  network: PropTypes.string,
+  networks:  PropTypes.array,
+  interface_type: PropTypes.string,
+  interface_types:  PropTypes.array,
+  vmExists: PropTypes.boolean,
+  scope: PropTypes.string,
+};
+
+OvirtNetwork.defaultProps = {
+  name: __('ovirt'),
+  vnic_profile: undefined,
+  vnic_profiles: [],
+  network: undefined,
+  networks: [],
+  interface_type: undefined,
+  interface_types: [],
+  vmExists: undefined,
+  scope: undefined,
+
+};
+
+export default OvirtNetwork;

--- a/webpack/assets/javascripts/react_app/components/hosts/network/ovirt/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/network/ovirt/index.js
@@ -1,0 +1,3 @@
+import Network from './Network';
+
+export default Network;


### PR DESCRIPTION
VNIC profile was introduced in oVirt 3.3, and is now the only way to create an interface from (we can't directly do if from the network) 
what we use to do, is to add a network, and in fog-ovirt find the matching vnic profile (a vnic profile was created automatically for each network in ovirt) , and created the interface from this vnic profile. 
the issue was that we couldn't create an interface from a vnic-profile created . 

The PR depends on https://github.com/fog/fog-ovirt/pull/98