### PR TITLE
Fixes #31440 - adding snippet_if_exists to nochroot block

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -246,6 +246,7 @@ redhat-lsb-core
 %post --nochroot --log=/mnt/sysimage/root/install.postnochroot.log
 /usr/bin/chvt 3
 echo "Changed to TTY3 for post installation..."
+<%= snippet_if_exists(template_name + " custom postnochroot") -%>
 
 <% if host_param_false?('no-resolv-override') -%>
 cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf


### PR DESCRIPTION
Adding call of macro snippet_if_exists for better logging in nochroot block of kickstart_default template.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
