### PR TITLE
Experiment to see if SQL schema type breaks anything

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -164,7 +164,7 @@ module Foreman
     # Use SQL instead of Active Record's schema dumper when creating the database.
     # This is necessary if your schema can't be completely dumped by the schema dumper,
     # like if you have constraints or database-specific column types
-    # config.active_record.schema_format = :sql
+    config.active_record.schema_format = :sql
 
     # enables JSONP support in the Rack middleware
     config.middleware.use Rack::JSONP if SETTINGS[:support_jsonp]

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Foreman::Application.configure do
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,
   # like if you have constraints or database-specific column types
-  # config.active_record.schema_format = :sql
+  config.active_record.schema_format = :sql
 
   # Should ANSI color codes be used when logging information
   config.colorize_logging = Foreman::Logging.config[:colorize]


### PR DESCRIPTION
The postgresql-evr postgres extension works, but it causes trouble for users who need to set up remote databases in places where the postgres extension cannot be installed (like some cloud-managed databases).  In order to make the evr exentions work with Katello, the schema type likely needs to be changed to SQL to support dumping of the new postgres type.

This PR is an experiment to see if changing the schema type breaks anything in the test pipeline.