### PR TITLE
Fixes #31452 - BOOTIF workaround for EL 8.3

### DIFF
--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -9,6 +9,9 @@ oses:
 -%>
 # This file was deployed via '<%= template_name %>' template
 <%
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
+  os_major = @host.operatingsystem.major.to_i
+  os_minor = @host.operatingsystem.minor.to_i
   timeout = host_param('loader_timeout').to_i * 10
   timeout = 100 if timeout.nil? || timeout <= 0
 -%>
@@ -21,6 +24,13 @@ LABEL installer
   MENU LABEL <%= template_name %>
   KERNEL <%= @kernel %>
   APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+<%
+  # workaround for EL 8.3: https://projects.theforeman.org/issues/31452
+  unless rhel_compatible && os_major == 8 && os_minor == 3
+-%>
   IPAPPEND 2
+<%
+  end
+-%>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -22,9 +22,11 @@ snippet: true
     options.push("network", "ksdevice=bootif", "ks.device=bootif")
   end
 
-  if mac
-    bootif = '00-' + mac.gsub(':', '-')
-    options.push("BOOTIF=#{bootif}")
+  if mac && rhel_compatible && os_major == 8 && os_minor == 3
+    # workaround for EL 8.3: https://projects.theforeman.org/issues/31452
+    options.push("BOOTIF=#{mac.gsub(':', '-')}")
+  elsif mac
+    options.push("BOOTIF=00-#{mac.gsub(':', '-')}")
   end
 
   # tell Anaconda what to pass off to kickstart server


### PR DESCRIPTION
Dracut in PXE images for RHEL 8.3 no longer accepts hardware type prefix in the BOOTIF kernel command line parameter. Foreman PXE/Grub2 templates adds BOOTIF with the prefix (e.g. BOOTIF=00-AA-BB-CC-DD-EE-FF) which leads to failure because NIC is not properly initialized. For PXELinux IPAPPEND 2 statement must be also removed because it automatically generates and appends BOOTIF statement with the prefix.

We need to implement a workaround in PXELinux, iPXE and Grub templates for this specifically for EL 8.3 or EL 8.3+ if this turns out to be expected behavior.

If we had https://github.com/theforeman/foreman/pull/8149 merged before this PR, I'd implement a special test for PXE template and EL 8.3 which ensures the expected behavior.