### PR TITLE
Fixes #31454 - extract eject cdrom into snippet

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -60,7 +60,8 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
-<%= snippet 'preseed_networking_setup' %>
-<%= snippet 'efibootmgr_netboot' %>
-<%= snippet 'built' %>
+<%= snippet 'preseed_networking_setup' -%>
+<%= snippet 'efibootmgr_netboot' -%>
+<%= snippet 'eject_cdrom' -%>
+<%= snippet 'built' -%>
 <%= snippet 'schedule_reboot' -%>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -198,11 +198,8 @@ cp /etc/resolv.conf /mnt/etc
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
-<% if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build? %>
-eject -v
-<% end -%>
-
-<%= snippet 'built' %>
+<%= snippet 'eject_cdrom' -%>
+<%= snippet 'built' -%>
 
 rm /etc/resolv.conf
 ]]>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -219,11 +219,8 @@ cp /etc/resolv.conf /mnt/etc
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 
-<% if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build? %>
-eject -v
-<% end -%>
-
-<%= snippet 'built' %>
+<%= snippet 'eject_cdrom' -%>
+<%= snippet 'built' -%>
 
 rm /etc/resolv.conf
 ]]>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -334,9 +334,7 @@ The last post section halts Anaconda to prevent endless loop in case HTTP reques
 %post --erroronfail
 <% end -%>
 
-<% if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build? %>
-eject -v
-<% end -%>
+<%= snippet 'eject_cdrom' -%>
 
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"

--- a/app/views/unattended/provisioning_templates/snippet/eject_cdrom.erb
+++ b/app/views/unattended/provisioning_templates/snippet/eject_cdrom.erb
@@ -1,0 +1,12 @@
+<%#
+kind: snippet
+name: eject_cdrom
+model: ProvisioningTemplate
+snippet: true
+-%>
+<%# 
+  This template will eject DVD/CD ROM for bootdisk provisioning method
+-%>
+<% if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build? -%>
+eject -v
+<% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
@@ -78,8 +78,6 @@ iface $real inet dhcp
 EOF
 
 
-
-
 if [ -x /usr/bin/curl ]; then
   /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
 elif [ -x /usr/bin/wget ]; then
@@ -87,5 +85,4 @@ elif [ -x /usr/bin/wget ]; then
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
 fi
-
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
@@ -141,7 +141,6 @@ export FACTER_is_installer=true
 
 
 
-
 if [ -x /usr/bin/curl ]; then
   /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
 elif [ -x /usr/bin/wget ]; then
@@ -149,7 +148,6 @@ elif [ -x /usr/bin/wget ]; then
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
 fi
-
 
 rm /etc/resolv.conf
 ]]>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
@@ -143,7 +143,6 @@ export FACTER_is_installer=true
 
 
 
-
 if [ -x /usr/bin/curl ]; then
   /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
 elif [ -x /usr/bin/wget ]; then
@@ -151,7 +150,6 @@ elif [ -x /usr/bin/wget ]; then
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
 fi
-
 
 rm /etc/resolv.conf
 ]]>


### PR DESCRIPTION
This patch extract eject CDROM command into a snippet, also clears a bit too many newlines.

Finally, it adds the same eject into preseed template, it was missing there and it was reported bootdisk does not work in this case:

https://community.theforeman.org/t/failed-to-detach-iso-image-from-cdrom-drive-from-vmware/21506