### PR TITLE
Fixes #31461 - Allow reinitialization of init values in ForemanForm

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/BookmarkForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/BookmarkForm.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`BookmarkForm should render bookmarks form with initial values 1`] = `
 <ForemanForm
+  enableReinitialize={false}
   initialValues={
     Object {
       "name": "my bookmark",

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.js
@@ -29,6 +29,7 @@ const ForemanForm = props => (
     initialValues={props.initialValues}
     validationSchema={props.validationSchema}
     isInitialValid={isInitialValid}
+    enableReinitialize={props.enableReinitialize}
   >
     {formProps => {
       const disabled = formProps.isSubmitting || !formProps.isValid;
@@ -70,10 +71,12 @@ ForemanForm.propTypes = {
   initialValues: PropTypes.object.isRequired,
   validationSchema: PropTypes.object,
   children: PropTypes.oneOfType([PropTypes.object, PropTypes.array]).isRequired,
+  enableReinitialize: PropTypes.bool,
 };
 
 ForemanForm.defaultProps = {
   validationSchema: undefined,
+  enableReinitialize: false,
 };
 
 export default ForemanForm;

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/__snapshots__/ForemanForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/__snapshots__/ForemanForm.test.js.snap
@@ -23,6 +23,7 @@ exports[`Foreman form helper functions should recognize valid initial values 1`]
 
 exports[`ForemanForm render foreman form with fields 1`] = `
 <ForemanForm
+  enableReinitialize={false}
   initialValues={
     Object {
       "name": "Charles",


### PR DESCRIPTION
This is useful if you want to pass blank initial values to ForemanForm, but after an API request reinitialize them to be more informative.

One of the possible usages for this can be found here: https://github.com/theforeman/foreman_webhooks/pull/17