### PR TITLE
Fixes #31464 - Use wiki_url helper in welcome

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 Before submitting a pull request, please verify that:
 * The commit message is in the format "Fixes #12345 - Change description here".
 * There are tests added to make sure the bug does not return/feature does not break in the future.
-* Any strings are extracted for [translation](http://projects.theforeman.org/projects/foreman/wiki/Translating).
+* Any strings are extracted for [translation](https://projects.theforeman.org/projects/foreman/wiki/Translating).
 
-For more information regarding contributions, plese read the [Foreman Handbook](http://theforeman.org/handbook.html) and [Foreman contributions](http://theforeman.org/contribute.html).
+For more information regarding contributions, plese read the [Foreman Handbook](https://theforeman.org/handbook.html) and [Foreman contributions](https://theforeman.org/contribute.html).

--- a/app/views/config_reports/welcome.html.erb
+++ b/app/views/config_reports/welcome.html.erb
@@ -8,7 +8,7 @@
   <%= _('If you wish to configure Puppet to forward it reports to Foreman, please follow') %>
   <%= link_to _("setting up reporting"), documentation_url("3.5.4PuppetReports"), :rel => "external" %>
   <%= _("and") %>
-  <%= link_to _("e-mail reporting"), "http://theforeman.org/projects/foreman/wiki/Mail_Notifications", :rel => "external" %>.
+  <%= link_to _("e-mail reporting"), documentation_url('Mail_Notifications', type: 'wiki'), :rel => "external" %>.
   </p>
   <div class="blank-slate-pf-main-action">
     <%= link_to _('Documentation'), documentation_url("3.5.4PuppetReports"), :rel => 'external', :class => 'btn btn-primary btn-lg' %>

--- a/app/views/unattended/provisioning_templates/PXELinux/pxelinux_chain_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/pxelinux_chain_ipxe.erb
@@ -9,7 +9,7 @@ associated and file ipxe.lkrn was copied in the TFTP directory (e.g. from
 /usr/share/ipxe/ipxe.lkrn or iPXE project web site).
 
 For more info visit:
-http://projects.theforeman.org/projects/foreman/wiki/Fetch_boot_files_via_http_instead_of_TFTP
+https://projects.theforeman.org/projects/foreman/wiki/Fetch_boot_files_via_http_instead_of_TFTP
 %>
 DEFAULT linux
 LABEL linux

--- a/app/views/unattended/provisioning_templates/PXELinux/pxelinux_chain_ipxe_undi.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/pxelinux_chain_ipxe_undi.erb
@@ -11,7 +11,7 @@ the iPXE project web site). Changes need to be made in the DHCP
 configuration to prevent an endless loop to happen.
 
 For more info visit:
-http://projects.theforeman.org/projects/foreman/wiki/Fetch_boot_files_via_http_instead_of_TFTP
+https://projects.theforeman.org/projects/foreman/wiki/Fetch_boot_files_via_http_instead_of_TFTP
 %>
 DEFAULT linux
 LABEL linux

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -132,7 +132,7 @@ for versioning
 3.  Push a gem of each release to rubygems.org
 4.  Add it to https://projects.theforeman.org/projects/foreman/wiki/List_of_Plugins[List_of_Plugins]
 5.  Add some tests and enable testing in
-http://projects.theforeman.org/projects/foreman/wiki/Jenkins#Foreman-plugin-testing[Jenkins]
+https://projects.theforeman.org/projects/foreman/wiki/Jenkins#Foreman-plugin-testing[Jenkins]
 6.  Create an RPM and Debian package for the plugin - submitted to the
 foreman-packaging repo, we're also happy to do this and publish to our
 official plugin repos
@@ -141,7 +141,7 @@ organization] - in case you move on, this lets us help with maintenance
 or delegate permissions to somebody else and keep the project alive. It
 also makes it easier for people to find. See also https://projects.theforeman.org/projects/foreman/wiki/GitHub[GitHub].
 8.  Have an issue tracker on
-http://projects.theforeman.org/projects[projects.theforeman.org] - a
+https://projects.theforeman.org/projects[projects.theforeman.org] - a
 common location for users for any Foreman-related issue
 9.  Ensure other maintainers can push to rubygems.org - again in case
 you should move on

--- a/developer_docs/pr_review.asciidoc
+++ b/developer_docs/pr_review.asciidoc
@@ -48,7 +48,7 @@ Feel free to edit this page and more items to the list.
 [[Additionally]]
 == Additional info
 
-String extractions have http://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers[several hard to remember rules].
+String extractions have https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers[several hard to remember rules].
 
 Scoped_search definitions for virtual fields can stop free text search if the field definition added doesn't actually exist - i.e. it's a fake field that uses :ext_method to return results. In this case it should use :only_explicit => true too so it isn't searched in free text searches (see also #5777 for another instance of this).
 

--- a/lib/tasks/locale.rake
+++ b/lib/tasks/locale.rake
@@ -38,7 +38,7 @@ namespace :locale do
     if errors.count > 0
       errors.each { |e| puts "MALFORMED: #{e}" }
       puts "Malformed strings found: #{errors.count}"
-      puts "Please read http://projects.theforeman.org/projects/foreman/wiki/Translating"
+      puts "Please read https://projects.theforeman.org/projects/foreman/wiki/Translating"
     end
   end
 


### PR DESCRIPTION
97b997fda5dbeebcd60ad2d5f29d6bc2ac59033b introduced the wiki_url helper, but it wasn't used here.

It also changes http:// to https:// URLs where relevant.