### PR TITLE
Fixes #31473 - Invalid value returning is OS hepler

### DIFF
--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -56,8 +56,7 @@ module OperatingsystemsHelper
            when /Windows/i
              "stub/steelblue-w"
            else
-             return "icons#{size}/black-\%23.png" if record.family.blank?
-             record.family.downcase
+             record.family.blank? && "stub/black-o" || record.family.downcase
            end
     return image_path("icons#{size}/#{name}.png") if opts[:path]
 


### PR DESCRIPTION
- [x] ! code detecting icon path for unknown OS record name, defaulting to
  black-x
