### PR TITLE
Refs #30987 - fix ArrowIcon import failing

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import Skeleton from 'react-loading-skeleton';
-import ArrowIcon from '@patternfly/react-icons/dist/js/icons/arrow-icon';
+import { ArrowIcon } from '@patternfly/react-icons';
 import ElipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import {
   Card,


### PR DESCRIPTION
The following import fails during build
```js
import ArrowIcon from '@patternfly/react-icons/dist/js/icons/arrow-icon';
```

The file `arrow-icon.js` exists even in an old version like 3.15.16 (verified)
though I guess webpack fails in the tree shaking process (like patternfly suggests [here](https://github.com/patternfly/patternfly-react/tree/master/packages/react-icons)) due to its old version. 
therefore I changed the import mechanism 