### PR TITLE
Fixes #31478 - Stop using deprecated API export in common/index.js

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/actions/common/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/index.js
@@ -1,4 +1,4 @@
-import API from '../../../API';
+import { API } from '../../../redux/API';
 
 export const ajaxRequestAction = async ({
   dispatch,


### PR DESCRIPTION
For some reason this file is still importing the deprecated API module.

see https://github.com/theforeman/foreman/blob/ec35c4d82e493574da0b55e0d52dd24dbc6b638f/webpack/assets/javascripts/react_app/API.js#L5

This change fixes test failures for Katello like https://ci.theforeman.org/blue/organizations/jenkins/katello-pr-test/detail/katello-pr-test/5651/pipeline/

