### PR TITLE
Fixes #31480 - External IPAM Error Handling Fix

### DIFF
--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -124,7 +124,7 @@ module ProxyAPI
     #     {"error": "Unable to connect to External IPAM server"}
     def get_groups
       response = parse get("/groups")
-      raise(response['error']) if response['error'].present?
+      raise(response['error']) if response.is_a?(Hash) && response['error'].present?
       response
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to obtain groups from External IPAM."))
@@ -174,7 +174,7 @@ module ProxyAPI
     def get_subnets_by_group(group)
       raise "group must be provided" if group.blank?
       response = parse get("/groups/#{URI.escape(group)}/subnets")
-      raise(response['error']) if response['error'].present?
+      raise(response['error']) if response.is_a?(Hash) && response['error'].present?
       response
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to obtain subnets in group %{group} from External IPAM."), group: group)


### PR DESCRIPTION
This is a minor update to the error handling in External IPAM that was missed in the last PR.

This does not affect the Foreman integration with the `smart_proxy_ipam` plugin in any way, but does affect the integration with the `foreman_ipam` plugin.
