### PR TITLE
Fixes #31483 - Provisioning templates - Error message for blank template & fix resetting fields

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -44,6 +44,7 @@ class TemplatesController < ApplicationController
     if @template.save
       process_success :object => @template
     else
+      load_vars_from_template
       process_error :object => @template
     end
   end
@@ -57,6 +58,7 @@ class TemplatesController < ApplicationController
       process_success :object => @template
     else
       load_history
+      load_vars_from_template
       process_error :object => @template
     end
   end

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -38,24 +38,28 @@
         <% warning_text = (_("The template is associated to at least one host in build mode. To apply the change, disable and enable build mode on hosts to update the live templates or choose to %s their configuration from 'Select Action' menu") % link_to(_('recreate'), building_hosts_path(@template))).html_safe %>
         <%= alert(:class => 'alert-warning', :header => 'Warning', :text => warning_text) %>
       <% end -%>
-
-      <div class='form-group'>
+      <div class='form-group <%= 'has-error' if @template.errors[:template] %>'>
         <div class="col-md-12">
-              <%= react_component('Editor', { data: {
-                template: @template.template,
-                locked: @template.locked,
-                id: @template.id,
-                type: 'templates',
-                name: template_name_attribute(@template.class),
-                templateClass: @template.class.to_s,
-                title: @template.name,
-                showImport: !@template.locked,
-                showPreview: true,
-                showHostSelector: @template.support_single_host_render?,
-                isSafemodeEnabled: Setting[:safemode_render],
-                renderPath: url_for(template_hash_for_member(@template, 'preview')),
-                safemodeRenderPath: url_for(template_hash_for_member(@template, 'preview').merge({ params: { force_safemode: true }})),
-              }}) %>
+          <% if @template.errors[:template] %>
+            <span class="help-block help-inline">
+              <span class="error-message"><%= @template.errors[:template].join('<br>').html_safe %></span>
+            </span>
+          <% end %>
+          <%= react_component('Editor', { data: {
+            template: @template.template,
+            locked: @template.locked,
+            id: @template.id,
+            type: 'templates',
+            name: template_name_attribute(@template.class),
+            templateClass: @template.class.to_s,
+            title: @template.name,
+            showImport: !@template.locked,
+            showPreview: true,
+            showHostSelector: @template.support_single_host_render?,
+            isSafemodeEnabled: Setting[:safemode_render],
+            renderPath: url_for(template_hash_for_member(@template, 'preview')),
+            safemodeRenderPath: url_for(template_hash_for_member(@template, 'preview').merge({ params: { force_safemode: true }})),
+          }}) %>
         </div>
       </div>
 


### PR DESCRIPTION
* Empty template is now displaying error message (plus tab header has red color)
* Type field & OS Association is not reset anymore when there is a validation error


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
