### PR TITLE
Fixes #30834 - Add support for vnic profile

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -141,6 +141,7 @@
           "vms",
           "vmware",
           "vnc",
+          "vnic",
           "webpack",
           "wss",
           "xml",

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -8,7 +8,7 @@ module Api
 
       before_action :find_resource, :only => [:show, :update, :destroy, :available_images, :associate,
                                               :available_virtual_machines, :available_clusters, :available_flavors, :available_folders,
-                                              :available_networks, :available_resource_pools, :available_security_groups, :available_storage_domains,
+                                              :available_networks, :available_vnic_profiles, :available_resource_pools, :available_security_groups, :available_storage_domains,
                                               :available_zones, :available_storage_pods, :storage_domain, :storage_pod, :refresh_cache, :power_vm, :show_vm, :destroy_vm]
 
       api :GET, "/compute_resources/", N_("List all compute resources")
@@ -143,6 +143,13 @@ module Api
         @available_networks = @compute_resource.available_networks(params[:cluster_id].presence)
         @total = @available_networks&.size
         render :available_networks, :layout => 'api/v2/layouts/index_layout'
+      end
+
+      api :GET, "/compute_resources/:id/available_vnic_profiles", N_("List available vnic profiles for a compute resource, for oVirt only.")
+      param :id, :identifier, :required => true
+      def available_vnic_profiles
+        @available_vnic_profiles = @compute_resource.vnic_profiles
+        render :available_vnic_profiles, :layout => 'api/v2/layouts/index_layout'
       end
 
       api :GET, "/compute_resources/:id/available_clusters/:cluster_id/available_resource_pools", N_("List resource pools for a compute resource cluster")
@@ -280,7 +287,7 @@ module Api
 
       def action_permission
         case params[:action]
-          when 'available_images', 'available_virtual_machines', 'available_clusters', 'available_flavors', 'available_folders', 'available_networks', 'available_resource_pools', 'available_security_groups', 'available_storage_domains', 'storage_domain', 'available_zones', 'associate', 'available_storage_pods', 'storage_pod', 'refresh_cache', 'show_vm', 'power_vm', 'destroy_vm'
+          when 'available_images', 'available_virtual_machines', 'available_clusters', 'available_flavors', 'available_folders', 'available_networks', 'available_vnic_profiles', 'available_resource_pools', 'available_security_groups', 'available_storage_domains', 'storage_domain', 'available_zones', 'associate', 'available_storage_pods', 'storage_pod', 'refresh_cache', 'show_vm', 'power_vm', 'destroy_vm'
             :view
           else
             super

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -273,6 +273,10 @@ class ComputeResource < ApplicationRecord
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
   end
 
+  def available_vnic_profiles(cluster_id = nil)
+    raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
+  end
+
   def available_clusters
     raise ::Foreman::Exception.new(N_("Not implemented for %s"), provider_friendly_name)
   end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -81,7 +81,7 @@ Foreman::AccessControl.map do |permission_set|
     ajax_actions = [:test_connection]
     map.permission :view_compute_resources, {:compute_resources => [:index, :show, :auto_complete_search, :ping, :available_images, :refresh_cache, :welcome],
                                                 :"api/v2/compute_resources" => [:index, :show, :available_images, :available_clusters, :available_folders,
-                                                                                :available_flavors, :available_networks, :available_resource_pools, :available_virtual_machines, :show_vm,
+                                                                                :available_flavors, :available_networks, :available_vnic_profiles, :available_resource_pools, :available_virtual_machines, :show_vm,
                                                                                 :available_security_groups, :available_storage_domains, :available_zones,
                                                                                 :available_storage_pods, :storage_pod, :storage_domain, :refresh_cache],
     }

--- a/app/views/api/v2/compute_resources/available_vnic_profiles.rabl
+++ b/app/views/api/v2/compute_resources/available_vnic_profiles.rabl
@@ -1,0 +1,7 @@
+collection @available_vnic_profiles
+
+attribute :name, :id
+
+node :network do |vnic_profile|
+  vnic_profile.network&.id
+end

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -2,8 +2,16 @@
 
 <% selected_cluster ||= params.fetch(:host, {}).fetch(:compute_attributes, {}).fetch(:cluster, nil) %>
 <% selected_cluster ||= compute_resource.clusters.first.try(:id) %>
-<%= select_f f, :network, compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }), :id, :name,
+<% networks = compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }) %>
+<%= select_f f, :vnic_profile, compute_resource.vnic_profiles,
+             :id, :name, {}, :label => _('Vnic Profile'), :label_size => "col-md-3", :disabled => !new_vm,
+             :class => "ovirt_network",
+             :onchange => 'tfm.computeResource.ovirt.vnicSelected(this)',
+             :data => {:profiles => compute_resource.vnic_profiles.to_json, :networks => networks } %>
+<%= select_f f, :network, networks, :id, :name,
              { }, :disabled => !new_vm, :class => "ovirt_network",
-             :label         => _('Network'), :label_size => "col-md-3" %>
+             :label         => _('Network'), :label_size => "col-md-3"%>
+
 <%= select_f f, :interface, compute_resource.nictypes,
-               :id, :name, {}, :label => _('Interface type'), :label_size => "col-md-3", :disabled => !new_vm, :class => "ovirt_network" %>
+             :id, :name, {}, :label => _('Interface type'), :label_size => "col-md-3", :disabled => !new_vm,
+             :class => "ovirt_network" %>

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -272,6 +272,7 @@ Foreman::Application.routes.draw do
           get :available_folders, :on => :member
           get :available_flavors, :on => :member
           get :available_networks, :on => :member
+          get :available_vnic_profiles, :on => :member
           get :available_security_groups, :on => :member
           get :available_storage_domains, :on => :member
           get 'storage_domains/(:storage_domain_id)', :to => 'compute_resources#storage_domain', :on => :member

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -172,7 +172,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
       assert_equal uuid, host.uuid
       assert_nil host.domain
       assert_equal '00:1a:4a:23:1b:8f', host.mac
-      assert_equal host.primary_interface.compute_attributes, { "name" => "nic1", "network" => "00000000-0000-0000-0000-000000000009", "interface" => "virtio" }
+      assert_equal host.primary_interface.compute_attributes, { "name" => "nic1", "network" => "00000000-0000-0000-0000-000000000009", "interface" => "virtio", "vnic_profile" => "871f3a06-ef53-4ab1-922f-5aa2bea2e94e" }
       assert_equal compute_resource, host.compute_resource
     end
   end

--- a/webpack/assets/javascripts/compute_resource/ovirt.js
+++ b/webpack/assets/javascripts/compute_resource/ovirt.js
@@ -196,3 +196,30 @@ export function datacenterSelected(item) {
   // eslint-disable-next-line no-undef
   testConnection($('#test_connection_button'));
 }
+
+export function vnicSelected(item) {
+  const selectedVnicProfile = $(item).val();
+  if (selectedVnicProfile) {
+    const vnicOptions = JSON.parse(
+      $('select[id$=_vnic_profile]')[1].getAttribute('data-profiles')
+    );
+    const networkOptions = JSON.parse(
+      $('select[id$=_vnic_profile]')[1].getAttribute('data-networks')
+    );
+
+    const vnicNetwork = vnicOptions.filter(
+      vnicOption => vnicOption.id === selectedVnicProfile
+    )[0].network;
+    const networkObj = networkOptions.filter(
+      network => network.id === vnicNetwork.id
+    )[0];
+    const networkSelect = $('select[id$=_network]');
+    networkSelect.empty();
+    networkSelect.append(
+      $('<option />')
+        .val(networkObj.id)
+        .text(networkObj.name)
+    );
+    networkSelect.val(networkObj.id).trigger('change');
+  }
+}


### PR DESCRIPTION
VNIC profile was introduced in oVirt 3.3, and is now the only way to create an interface from (we can't directly do if from the network)
what we use to do, is to add a network, and in fog-ovirt find the matching vnic profile (a vnic profile was created automatically for each network in ovirt) , and created the interface from this vnic profile.
the issue was that we couldn't create an interface from a vnic-profile created .

The PR depends on fog/fog-ovirt#98