### PR TITLE
Fixes #31285 - setting timestamps for API

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -15,6 +15,8 @@ class SettingPresenter
   attribute :settings_type, :string
   attribute :select_values
   attribute :config_file
+  attribute :updated_at, :datetime
+  attribute :created_at, :datetime
   attr_accessor :options
 
   def self.from_setting(setting)
@@ -25,6 +27,8 @@ class SettingPresenter
                           :settings_type => setting.settings_type,
                           :default => setting.default,
                           :full_name => setting.full_name,
+                          :updated_at => setting.updated_at,
+                          :created_at => setting.created_at,
                           :config_file => setting.class.config_file,
                           :select_values => setting.select_collection,
                           :value => setting.value,

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -16,6 +16,14 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
     assert !show_response.empty?
   end
 
+  test "validate show attributes" do
+    get :show, params: { :id => settings(:attributes1).to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_include show_response.keys, 'created_at'
+    assert_include show_response.keys, 'updated_at'
+  end
+
   test "should not update setting" do
     put :update, params: { :id => settings(:attributes1).to_param, :setting => { } }
     assert_response 422


### PR DESCRIPTION
Presenter doesn't include Setting timestamps, what resulted in a regressision,
the timestamps were not present for the API responses anymore.
This brings the timestamps back temporarily.

(cherry picked from commit 957a215f1b44d1bb500dd2f7e8f93666e1eb3973)