### PR TITLE
Fixes #31495: Set a title on the logout page

### DIFF
--- a/app/views/users/logout.html.erb
+++ b/app/views/users/logout.html.erb
@@ -1,2 +1,3 @@
+<% title _('Logout') %>
 <h2><%= _('Are you sure you want to log out?') %></h2>
 <%= button_to _('Yes'), logout_users_url, :class => 'btn btn-primary' %>


### PR DESCRIPTION
This prevents a javascript error by the Breadcrumb component and
adds some notion of what page the user is on.

@ekohl Fixes a bug I kept seeing running smoker