### PR TITLE
Refs #31495 - Properly handle missing breadcrumb caption

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
@@ -63,7 +63,6 @@ class BreadcrumbBar extends React.Component {
     return (
       <div className="breadcrumb-bar">
         <Breadcrumb
-          title
           items={breadcrumbItems}
           isTitle={isTitle}
           titleReplacement={titleReplacement}

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/__tests__/__snapshots__/BreadcrumbBar.test.js.snap
@@ -22,7 +22,6 @@ exports[`BreadcrumbBar rendering renders breadcrumb-bar 1`] = `
         },
       ]
     }
-    title={true}
     titleReplacement={null}
   />
   <hr
@@ -53,7 +52,6 @@ exports[`BreadcrumbBar rendering renders switchable breadcrumb-bar 1`] = `
         },
       ]
     }
-    title={true}
     titleReplacement={null}
   >
     <BreadcrumbSwitcher

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -28,12 +28,14 @@ const Breadcrumb = ({
     <PfBreadcrumb {...props}>
       {items.map((item, index) => {
         const active = index === items.length - 1;
-        const {
-          caption,
-          caption: { icon, text },
-        } = item;
+        const { caption, url, onClick } = item;
+        const { icon, text } = caption || {};
+
         const overrideTitle = active && titleReplacement;
-        const itemTitle = overrideTitle || text || caption;
+        const itemTitle = overrideTitle || text || caption || '';
+
+        if (!icon && !itemTitle) return null;
+
         const inner = active ? (
           <EllipsisWithTooltip placement="bottom">
             {itemTitle}
@@ -46,8 +48,8 @@ const Breadcrumb = ({
           <BreadcrumbItem
             key={index}
             isActive={active}
-            onClick={item.onClick}
-            to={item.url}
+            onClick={onClick}
+            to={url}
             className={classNames('breadcrumb-item', {
               active,
               'breadcrumb-item-with-icon': icon && active,

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -10,7 +10,6 @@ import './Breadcrumbs.scss';
 
 const Breadcrumb = ({
   items,
-  title,
   isTitle,
   titleReplacement,
   children,
@@ -67,7 +66,6 @@ const Breadcrumb = ({
 
 Breadcrumb.propTypes = {
   children: PropTypes.node,
-  title: PropTypes.bool,
   titleReplacement: PropTypes.string,
   isTitle: PropTypes.bool,
   items: PropTypes.arrayOf(
@@ -89,7 +87,6 @@ Breadcrumb.propTypes = {
 
 Breadcrumb.defaultProps = {
   children: null,
-  title: false,
   isTitle: false,
   items: [],
   titleReplacement: null,


### PR DESCRIPTION
If `caption` is null, deconstructing it will fail. Added a guard clause
to properly handle this case. This can occur when a page has no title
set.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
