### PR TITLE
Fixes #31503 - Add insecure checkbox to the registration form

### DIFF
--- a/app/controllers/registration_controller.rb
+++ b/app/controllers/registration_controller.rb
@@ -7,8 +7,9 @@ class RegistrationController < ApplicationController
 
   def create
     form_options
+    insecure = params[:insecure] ? '--insecure' : ''
     args_query = "?#{registration_args.to_query}"
-    @command = "curl -X GET \"#{endpoint}#{args_query if args_query != '?'}\" #{headers} | bash"
+    @command = "curl #{insecure} -X GET \"#{endpoint}#{args_query if args_query != '?'}\" #{headers} | bash"
   end
 
   private
@@ -34,7 +35,7 @@ class RegistrationController < ApplicationController
   end
 
   def registration_args
-    ignored = ['utf8', 'authenticity_token', 'commit', 'action', 'locale', 'controller', 'jwt_expiration', 'smart_proxy']
+    ignored = ['utf8', 'authenticity_token', 'commit', 'action', 'locale', 'controller', 'jwt_expiration', 'smart_proxy', 'insecure']
     args = params.except(*ignored)
     args[:setup_insights] = setup_insights_param if params['setup_insights'].to_s.present?
     args[:setup_remote_execution] = setup_remote_execution_param if params['setup_remote_execution'].to_s.present?

--- a/app/views/registration/_form.erb
+++ b/app/views/registration/_form.erb
@@ -84,6 +84,18 @@
       <%= number_field_tag 'jwt_expiration', params[:jwt_expiration] || 4, class: 'form-control', min: 1, required: true %>
     </div>
   </div>
+  <div class='form-group'>
+    <label class='col-md-2 control-label'>
+      <%= _('Insecure') %>
+      <% help = _('If the target machine does not trust the Foreman SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process.') %>
+      <a rel="popover" data-content="<%= help %>" data-trigger="focus" data-container="body" data-html="true" tabindex="-1">
+        <span class="pficon pficon-info "></span>
+      </a>
+    </label>
+    <div class='col-md-4'>
+      <%= check_box_tag 'insecure', '', params[:insecure] %>
+    </div>
+  </div>
 
   <% pagelets_for(:global_registration).each do |pagelet| %>
     <%= render_pagelet(pagelet) %>


### PR DESCRIPTION
We no longer need the insecure parameter in our endpoints, since we deploy the certificates as part of the registration. 
However we should add a checkbox that would add `--insecure` to the first `curl` command that we generate.
There's no point in hiding this from user, since they end up adding that manually.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
