### PR TITLE
Fixes #31531 - less general OS name matchers

### DIFF
--- a/app/helpers/operatingsystems_helper.rb
+++ b/app/helpers/operatingsystems_helper.rb
@@ -12,50 +12,50 @@ module OperatingsystemsHelper
   def icon(record, opts = {})
     return "" if record.blank? || record.name.blank?
     size = opts[:size] ||= '16x16'
-    name = case record.name
-           when /fedora/i
+    name = case record.name.downcase
+           when /fedora/
              "fedora"
-           when /ubuntu/i
+           when /ubuntu/
              "ubuntu"
-           when /solaris|sunos/i
+           when /solaris|sunos/
              "stub/steelblue-s"
-           when /darwin/i
+           when /darwin/
              "stub/darkred-d"
-           when /centos/i
+           when /centos/
              "centos"
-           when /scientific/i
+           when /scientific/
              "scientific"
-           when /archlinux/i
+           when /archlinux/
              "archlinux"
-           when /alt/i
+           when /^alt/
              "alt"
-           when /gentoo/i
+           when /gentoo/
              "gentoo"
-           when /SLC/i
+           when /slc/
              "stub/blue-s"
-           when /FreeBSD/i
+           when /freebsd/
              "freebsd"
-           when /aix/i
+           when /aix/
              "stub/forestgreen-a"
-           when /Junos/i
+           when /junos/
              "stub/darkblue-j"
-           when /VRP/i
+           when /vrp/
              "stub/firebrick-h"
-           when /OracleLinux/i
+           when /oraclelinux/
              "stub/firebrick-o"
-           when /CoreOS|ContainerLinux|Container Linux/i
+           when /coreos|containerlinux|container linux/
              "coreos"
-           when /Flatcar/i
+           when /flatcar/
              "stub/darkblue-f"
-           when /RancherOS/i
+           when /rancheros/
              "rancheros"
-           when /NXOS/i
+           when /nxos/
              "stub/darkslateblue-n"
-           when /XenServer/i
+           when /xenserver/
              "stub/black-x"
-           when /Puppet/i
+           when /puppet/
              "stub/goldenrod-p"
-           when /Windows/i
+           when /windows/
              "stub/steelblue-w"
            else
              if record.family.blank?


### PR DESCRIPTION
Based on a comment in https://github.com/theforeman/foreman/pull/8199#discussion_r540929076.
Just want to see the feedback, if there is some reason for not having the `^` regexps :)