### PR TITLE
Refs #31533 - pin rake to < 13.0.2 to avoid test failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ else
   raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"
 end
 
+gem 'rake', '< 13.0.2'
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '>= 4.9.0', '< 5'
 gem 'will_paginate', '>= 3.1.7', '< 4'


### PR DESCRIPTION
Tests currently fail to run with Rake 13.0.2 with
    
    uninitialized constant ApplicationRecord::ApipieDSL (NameError)
    
Pin Rake until we know how to properly fix that.
