### PR TITLE
Fixes #31538 - use `distinct` scope for class params association

### DIFF
--- a/app/models/puppetclass.rb
+++ b/app/models/puppetclass.rb
@@ -21,7 +21,7 @@ class Puppetclass < ApplicationRecord
   has_many :config_group_classes
   has_many :config_groups, :through => :config_group_classes, :dependent => :destroy
 
-  has_many :class_params, :through => :environment_classes, :source => :puppetclass_lookup_key
+  has_many :class_params, -> { distinct }, :through => :environment_classes, :source => :puppetclass_lookup_key
   accepts_nested_attributes_for :class_params, :reject_if => ->(a) { a[:key].blank? }, :allow_destroy => true
 
   validates :name, :uniqueness => true, :presence => true, :no_whitespace => true


### PR DESCRIPTION
Otherwise, classes with multiple environments load the paramters
multiple times. This is a regression caused by cleanup in cd4b1820.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
