### PR TITLE
fixes #31543 - Fixing bad error message at puppetrun endpoint

### DIFF
--- a/app/controllers/api/v2/puppet_hosts_controller.rb
+++ b/app/controllers/api/v2/puppet_hosts_controller.rb
@@ -19,7 +19,7 @@ module Api
       end
 
       def fail_and_inform_about_plugin
-        render json: { message: _('To access Puppetrun feature you need to install Foreman Remote Execution Plugin') }, status: :not_implemented
+        render json: { message: _('The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands') }, status: :not_implemented
       end
     end
   end


### PR DESCRIPTION
Fixing bad error message for puppetrun endpoint since deprecation


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
