### PR TITLE
Fixes #31546 - cant use customBreadcrumbs in pagelayout

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -35,9 +35,8 @@ const PageLayout = ({
             <h1 className="col-md-8">{header}</h1>
           </div>
         )}
-        {customBreadcrumbs
-          ? { customBreadcrumbs }
-          : breadcrumbOptions && <BreadcrumbBar {...breadcrumbOptions} />}
+        {customBreadcrumbs ||
+          (breadcrumbOptions && <BreadcrumbBar {...breadcrumbOptions} />)}
       </div>
       {beforeToolbarComponent}
       <Row>

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.test.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.test.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 import PageLayout from './PageLayout';
 import { pageLayoutMock } from './PageLayout.fixtures';
@@ -10,7 +11,7 @@ const pageLayoutFixtures = {
   'render pageLayout without search': { ...pageLayoutMock, searchable: false },
   'render pageLayout with custom breadcrumbs': {
     ...pageLayoutMock,
-    customBreadcrumbs: 'customBreadcrumbs',
+    customBreadcrumbs: <p>customBreadcrumbs</p>,
   },
   'render pageLayout without breadcrumbs': {
     ...pageLayoutMock,
@@ -22,11 +23,11 @@ const pageLayoutFixtures = {
   },
   'render pageLayout w/toolBar': {
     ...pageLayoutMock,
-    toolbarButtons: 'toolbarButton',
+    toolbarButtons: <button>toolbarButton</button>,
   },
   'render pageLayout w/beforeToolbarComponent': {
     ...pageLayoutMock,
-    beforeToolbarComponent: 'beforeToolbarComponent',
+    beforeToolbarComponent: <p>beforeToolbarComponent</p>,
   },
 };
 

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -42,7 +42,9 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
         }
       />
     </div>
-    beforeToolbarComponent
+    <p>
+      beforeToolbarComponent
+    </p>
     <Row
       bsClass="row"
       componentClass="div"
@@ -374,7 +376,9 @@ exports[`render pageLayout w/toolBar 1`] = `
         <div
           className="btn-toolbar pull-right"
         >
-          toolbarButton
+          <button>
+            toolbarButton
+          </button>
         </div>
       </Col>
     </Row>
@@ -399,7 +403,9 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
     <div
       id="breadcrumb"
     >
-      <Component />
+      <p>
+        customBreadcrumbs
+      </p>
     </div>
     <Row
       bsClass="row"


### PR DESCRIPTION
When trying to pass a component to customBreadctumbs while using pageLayout there is an error as it's trying to render an object `{customBreadctumbs: your_component_here}` instead the component itself
```
Uncaught Invariant Violation: Objects are not valid as a React child (found: object with keys {customBreadcrumbs}). If you meant to render a collection of children, use an array instead.
in div (created by PageLayout)
in div (created by PageLayout)
in div (created by PageLayout)
in PageLayout (created by AuditsPage)
```

