### PR TITLE
Fixes #30889 - random unitialized constants failures

### DIFF
--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,4 +1,4 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 3.3.1', '< 4.0'
+  gem 'fog-vsphere', '>= 3.5.0', '< 4.0'
   gem 'rbvmomi', '~> 2.0'
 end


### PR DESCRIPTION
This new fog-vsphere release mainly contains a fix for sporadic unitialized constant failures.
Most likely caused by wrong autoloading in the gem namespaces.
The new release should fix it and we should get that release in as soon as possible.

- [x] packaging: https://github.com/theforeman/foreman-packaging/pull/6104