### PR TITLE
Fixes #31549 - Navigating twice removes highlight from nav

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -37,7 +37,7 @@ export const getActiveMenuItem = (items, path = getCurrentPath()) => {
 };
 
 export const handleMenuClick = (primary, activeMenu, changeActive) => {
-  if (primary.title !== activeMenu) changeActive(primary);
+  if (primary.title !== __(activeMenu)) changeActive(primary);
 };
 
 export const combineMenuItems = data => {


### PR DESCRIPTION
For example: open Audits page, then in the navigation click "Audits".
Expected: Monitor should still be highlighted
Actual: nothing is highlighted
*This bug happens only if the menu is translated