### PR TITLE
Fixes #31554 - empty? check on integer

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -87,7 +87,7 @@ module Api
       end
 
       def metadata_per_page
-        @per_page ||= Setting[:entries_per_page] if params[:per_page].empty?
+        @per_page ||= Setting[:entries_per_page] if params[:per_page].blank?
         @per_page ||= params[:per_page] == 'all' ? metadata_total : params[:per_page].to_i
       end
 


### PR DESCRIPTION
We were sending `empty?` to integers in quite common cases since 1831e5680eb3933674323c4f38be9b7f85d3f263 (#7685).
We need to call `blank?` instead.