### PR TITLE
Fixes #31557 - avoid multiple logins to maintain single active session

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   skip_before_action :authorize, :only => [:extlogin, :impersonate, :stop_impersonation]
   before_action      :require_admin, :only => :impersonate
   after_action       :update_activity_time, :only => :login
-  before_action      :verify_active_session, :only => :login
+  before_action      :verify_active_session, :only => [:login, :extlogin]
 
   def index
     @users = User.authorized(:view_users).except_hidden.search_for(params[:search], :order => params[:order]).includes(:auth_source, :cached_usergroups).paginate(:page => params[:page], :per_page => params[:per_page])


### PR DESCRIPTION
While an internal user is logged in, an external user login using the same browser results in an internal error. This PR makes sure that only one active session is maintained at a time.