### PR TITLE
Refs #31250 - fix API middleware usage  story

### DIFF
--- a/webpack/stories/docs/api-middleware-usage.stories.mdx
+++ b/webpack/stories/docs/api-middleware-usage.stories.mdx
@@ -6,6 +6,7 @@ import { Meta } from '@theforeman/stories';
     storyWeight: 100,
   }}
 />
+
 # How to use API in a Component using useAPI hook
 
 The API middleware is abstracted by the `useAPI` custom hook.


### PR DESCRIPTION
`api-middleware-usage.stories.mdx` story  fails to compile and returns
```
WARNING in ./webpack/stories/docs/api-middleware-usage.stories.mdx
Module build failed (from ./node_modules/@theforeman/stories/node_modules/@mdx-js/loader/index.js):
SyntaxError: Unexpected token (7:0)
```

an empty line is needed for parsing.