### PR TITLE
Fixes #31561 - fix propTypes in EmptyStatePattern

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
@@ -31,9 +31,9 @@ const EmptyStatePattern = props => {
       return documentation;
     }
     const {
-      label = __('For more information please see '),
-      buttonLabel = __('documentation'),
-      url,
+      label = __('For more information please see '), // eslint-disable-line react/prop-types
+      buttonLabel = __('documentation'), // eslint-disable-line react/prop-types
+      url, // eslint-disable-line react/prop-types
     } = documentation;
     return (
       <span>
@@ -72,6 +72,7 @@ EmptyStatePattern.defaultProps = {
   documentation: {
     url: '#',
   },
+  action: null,
   iconType: 'pf',
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
@@ -7,7 +7,8 @@ export const actionButtonPropTypes = {
 };
 
 export const emptyStatePatternPropTypes = {
-  icon: PropTypes.string.isRequired,
+  icon: PropTypes.string,
+  iconType: PropTypes.string,
   header: PropTypes.string.isRequired,
   documentation: PropTypes.oneOfType([
     PropTypes.shape({


### PR DESCRIPTION
`eslint-plugin-react` was updated from @7.21.5 to @7.22.0 and now it has a weird bug for this component. I'm not sure how to fix it other than ignoring eslint in the specific failed lines.
This only happens if the prop-types are imported so if we move the same object to the `EmptyStatePattern.js` eslint is happy.
Also fixed the icon, iconType, action prop-types.