### PR TITLE
Fixes #31567 - Fix bundler not found issue in Storybook deploy action

### DIFF
--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -15,6 +15,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.7
     - name: Run npm install
       run: npm install
     - name: Build Storybook


### PR DESCRIPTION
Add-on to https://github.com/theforeman/foreman/pull/8209

This PR implements the same fix for the Storybook deploy action.