### PR TITLE
minor fix to correct puppetlabs repo files to be named puppet-release…

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -33,7 +33,7 @@ elsif os_family == 'Windows'
 end
 
 if host_param_true?('enable-puppetlabs-repo')
-  repo_name = 'puppetlabs-release'
+  repo_name = 'puppet-release'
   repo_subdir = ''
 elsif host_param_true?('enable-puppetlabs-puppet6-repo')
   repo_name = 'puppet6-release'


### PR DESCRIPTION
…, not puppetlabs-release

fixes issue **#31568**

This is a short trivial fix - an additional issue will be raised and more complete PR made to remove/rename the global parameters to update references to puppetlabs to puppet
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
