### PR TITLE
Fixes #31518 - remove unused registration_token from API

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -33,8 +33,6 @@ end
 # display the token, if it hasn't expired
 node(:token, :if => ->(h) { h.token && !h.token_expired? }) { |host| host.token.value }
 
-node(:registration_token) { |h| h.registration_token }
-
 node :hostgroup_name do |host|
   host.hostgroup.name if host.hostgroup.present?
 end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -226,12 +226,6 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal puppet_proxy.name, response['puppet_proxy_name']
   end
 
-  test "should show registration token" do
-    get :show, params: {:id => @host.id}, session: set_session_user
-    assert_response :success
-    assert_not_empty ActiveSupport::JSON.decode(@response.body)['registration_token']
-  end
-
   test "should create host" do
     disable_orchestration
     assert_difference('Host.count') do


### PR DESCRIPTION
In f981d43 we've introduced a registration_token in host API.
This token is not used in final design and is causing issues during orchestration.