### PR TITLE
fixes #31593 replaces puppetlabs references with puppet-offical

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -11,9 +11,9 @@ oses:
 <%#
 This template accepts the following parameters:
 - force-puppet: boolean (default=false)
-- enable-puppetlabs-repo: boolean (default=false)
-- enable-puppetlabs-puppet5-repo: boolean (default=false)
-- enable-puppetlabs-puppet6-repo: boolean (default=false)
+- enable-puppet-official-repo: boolean (default=false)
+- enable-puppet-official-puppet5-repo: boolean (default=false)
+- enable-puppet-official-puppet6-repo: boolean (default=false)
 -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -55,10 +55,10 @@ runcmd:
 <% end -%>
 - |
 <%=
-  if puppet_enabled && (host_param_true?('enable-puppetlabs-repo') ||
-    host_param_true?('enable-puppetlabs-puppet6-repo') ||
-    host_param_true?('enable-puppetlabs-puppet5-repo'))
-    indent(2) { snippet 'puppetlabs_repo' }
+  if puppet_enabled && (host_param_true?('enable-puppet-official-repo') ||
+    host_param_true?('enable-puppet-official-puppet6-repo') ||
+    host_param_true?('enable-puppet-official-puppet5-repo'))
+    indent(2) { snippet 'puppet_official_repo' }
   elsif puppet_enabled
     indent(2) { snippet('puppet_setup', :variables => { :full_puppet_run => true }) }
   else

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -65,8 +65,8 @@ fi
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<% if host_param_true?('enable-puppet-official-repo') || host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
+<%= snippet 'puppet_official_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -50,8 +50,8 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<% if host_param_true?('enable-puppet-official-repo') || host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
+<%= snippet 'puppet_official_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -10,7 +10,7 @@ oses:
   os_minor = @host.operatingsystem.minor.to_i
   # safemode renderer does not support unary negation
   pm_set = @host.puppetmaster.empty? ? false : true
-  aio_enabled = host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+  aio_enabled = host_param_true?('enable-puppet-officials-puppet5-repo') || host_param_true?('enable-puppet5')
   puppet_enabled = pm_set || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   sles_minor_string = (os_minor == 0) ? '' : "_SP#{os_minor}"
@@ -252,12 +252,12 @@ rm /etc/resolv.conf
   <% end -%>
 <% end -%>
 <% if puppet_enabled -%>
-<% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
 <%
   puppet_repo_url_base = 'http://yum.puppet.com'
-  if host_param_true?('enable-puppetlabs-puppet6-repo')
+  if host_param_true?('enable-puppet-official-puppet6-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet6/sles/#{os_major}/#{@host.architecture}/"
-  elsif host_param_true?('enable-puppetlabs-puppet5-repo')
+  elsif host_param_true?('enable-puppet-official-puppet5-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet5/sles/#{os_major}/#{@host.architecture}/"
   end
 %>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -17,9 +17,9 @@ This template accepts the following parameters:
 - http-proxy-port: string (default="")
 - force-puppet: boolean (default=false)
 - enable-epel: boolean (default=true)
-- enable-puppetlabs-repo: boolean (default=false)
-- enable-puppetlabs-puppet5-repo: boolean (default=false)
-- enable-puppetlabs-puppet6-repo: boolean (default=false)
+- enable-puppet-official-repo: boolean (default=false)
+- enable-puppet-official-puppet5-repo: boolean (default=false)
+- enable-puppet-official-puppet6-repo: boolean (default=false)
 - salt_master: string (default=undef)
 - ntp-server: string (default=undef)
 - bootloader-append: string (default="nofb quiet splash=quiet")
@@ -292,8 +292,8 @@ fi
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')|| host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<% if host_param_true?('enable-puppet-official-repo') || host_param_true?('enable-puppet-official-puppet6-repo')|| host_param_true?('enable-puppet-official-puppet5-repo') -%>
+<%= snippet 'puppet_official_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
+++ b/app/views/unattended/provisioning_templates/registration/linux_registration_default.erb
@@ -16,7 +16,7 @@ set -e
 # Host: <%= @host.name %>
 
 <% if @host.puppetmaster.present? -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet 'puppet_official_repo' %>
 <%= snippet 'puppet_setup' %>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -8,7 +8,7 @@ snippet: true
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+  aio_enabled = host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppet-official-puppet5-repo') || host_param_true?('enable-puppet5')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_official_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_official_repo.erb
@@ -1,6 +1,6 @@
 <%#
 kind: snippet
-name: puppetlabs_repo
+name: puppet_official_repo
 model: ProvisioningTemplate
 snippet: true
 -%>
@@ -23,7 +23,7 @@ if os_family == 'Redhat'
   end
 elsif os_family == 'Suse'
   repo_host = 'yum.puppet.com'
-  repo_os = 'sles' # PuppetLabs repos only exist for SLES, not OpenSUSE
+  repo_os = 'sles' # Puppet official repos only exist for SLES, not OpenSUSE
 elsif os_family == 'Debian'
   repo_host = 'apt.puppet.com'
   repo_os = @host.operatingsystem.release_name
@@ -32,13 +32,13 @@ elsif os_family == 'Windows'
   repo_os = 'windows'
 end
 
-if host_param_true?('enable-puppetlabs-repo')
+if host_param_true?('enable-puppet-official-repo')
   repo_name = 'puppet-release'
   repo_subdir = ''
-elsif host_param_true?('enable-puppetlabs-puppet6-repo')
+elsif host_param_true?('enable-puppet-official-puppet6-repo')
   repo_name = 'puppet6-release'
   repo_subdir = 'puppet6/'
-elsif host_param_true?('enable-puppetlabs-puppet5-repo')
+elsif host_param_true?('enable-puppet-official-puppet5-repo')
   repo_name = 'puppet5-release'
   repo_subdir = 'puppet5/'
 end

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -10,7 +10,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+aio_enabled = host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppet-official-puppet5-repo') || host_param_true?('enable-puppet5')
 
 if os_family == 'Freebsd'
   freebsd_package = host_param_true?('enable-puppet6') ? 'puppet6' : 'puppet5'
@@ -42,7 +42,7 @@ else
   yum -t -y install <%= linux_package %>
 fi
 <% elsif os_family == 'Suse' -%>
-<% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppet-officials-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
 rpmkeys --import http://yum.puppet.com/RPM-GPG-KEY-puppetlabs
 rpmkeys --import http://yum.puppet.com/RPM-GPG-KEY-puppet
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -27,8 +27,8 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet "blacklist_kernel_modules" %>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<% if host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
+<%= snippet 'puppet_officials_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -56,8 +56,8 @@ fi
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<% if host_param_true?('enable-puppet-official-repo') || host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
+<%= snippet 'puppet_official_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -37,8 +37,8 @@ echo 'Acquire::http::Proxy "<%= proxy_uri %>";' >> /etc/apt/apt.conf
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<% if host_param_true?('enable-puppet-official-repo') || host_param_true?('enable-puppet-official-puppet6-repo') || host_param_true?('enable-puppet-official-puppet5-repo') -%>
+<%= snippet 'puppet_official_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -68,7 +68,7 @@ runcmd:
 <% end -%>
 <% if puppet_enabled -%>
 - |
-<%= indent(2) { snippet('puppetlabs_repo') } %>
+<%= indent(2) { snippet('puppet_official_repo') } %>
 - |
 <%= indent(2) { snippet('puppet_setup') } %>
 <% end -%>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

simple change to change references to puppetlabs to puppet-official and rename the puppetlabs_repo snippet to puppet_official_repo

This is a basic foundational change to prepare future changes (issues to be raised) to do some optimisation of the provisioning templates, mostly targeted around the EL based distributions. 

A migration may be needed to version upgrades to manage the fact that host params / global params will be renamed. 