### PR TITLE
Fixes: #31585 iPXE ping gateway and name server

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -8,6 +8,11 @@ oses:
 - OpenSUSE
 %>
 
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
 <% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>

--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -21,6 +21,12 @@ oses:
     ks = foreman_url('provision')
   end
 -%>
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
 kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= ks %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 imgstat

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -22,6 +22,11 @@ oses:
   <%- netcfg_args = 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true' -%>
 <% end -%>
 
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
 <% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>

--- a/app/views/unattended/provisioning_templates/iPXE/windows_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/windows_default_ipxe.erb
@@ -5,6 +5,12 @@ model: ProvisioningTemplate
 oses:
 - Windows
 %>#!ipxe
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
 set boot-url tftp://${next-server}/
 kernel ${boot-url}<%= @host.operatingsystem.bootfile(medium_provider,:kernel) %>
 


### PR DESCRIPTION
Attempt to ping critical network resources. In theory when everything is working this should be transparent to the users. If not, this will clearly identify what went wrong.