### PR TITLE
Fixes #31600 - cant change taxonomies in small screens

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -8,13 +8,16 @@ import {
   changeLocation,
 } from '../../../foreman_navigation';
 import { translate as __ } from '../../common/I18n';
-import { removeLastSlashFromPath, noop } from '../../common/helpers';
+import {
+  removeLastSlashFromPath,
+  noop,
+  foremanUrl,
+} from '../../common/helpers';
 
 export const createInitialTaxonomy = (currentTaxonomy, availableTaxonomies) => {
   const taxonomyId = availableTaxonomies.find(
     taxonomy => taxonomy.title === currentTaxonomy
   ).id;
-
   return {
     title: currentTaxonomy,
     id: taxonomyId,
@@ -67,9 +70,9 @@ export const combineMenuItems = data => {
 const createOrgItem = orgs => {
   const anyOrg = {
     name: __('Any Organization'),
-    url: '/organizations/clear',
     onClick: () => {
       changeOrganization();
+      window.location.assign(foremanUrl('/organizations/clear'));
     },
   };
   const childrenArray = [anyOrg];
@@ -80,8 +83,8 @@ const createOrgItem = orgs => {
       name: isEmpty(org.title) ? org.title : __(org.title),
       onClick: () => {
         changeOrganization(__(org.title));
+        window.location.assign(org.href);
       },
-      url: org.href,
     };
     childrenArray.push(childObject);
   });
@@ -100,9 +103,9 @@ const createOrgItem = orgs => {
 const createLocationItem = locations => {
   const anyLoc = {
     name: __('Any Location'),
-    url: '/locations/clear',
     onClick: () => {
       changeLocation();
+      window.location.assign(foremanUrl('/locations/clear'));
     },
   };
   const childrenArray = [anyLoc];
@@ -113,8 +116,8 @@ const createLocationItem = locations => {
       name: isEmpty(loc.title) ? loc.title : __(loc.title),
       onClick: () => {
         changeLocation(__(loc.title));
+        window.location.assign(loc.href);
       },
-      url: loc.href,
     };
     childrenArray.push(childObject);
   });

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutHelper.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutHelper.test.js.snap
@@ -80,19 +80,16 @@ Array [
       Object {
         "name": "Any Organization",
         "onClick": [Function],
-        "url": "/organizations/clear",
       },
       Object {
         "name": "org1",
         "onClick": [Function],
         "type": undefined,
-        "url": "/organizations/1-org1/select",
       },
       Object {
         "name": "org2",
         "onClick": [Function],
         "type": undefined,
-        "url": "/organizations/2-org2/select",
       },
     ],
     "className": "visible-xs-block",
@@ -105,25 +102,21 @@ Array [
       Object {
         "name": "Any Location",
         "onClick": [Function],
-        "url": "/locations/clear",
       },
       Object {
         "name": "yaml",
         "onClick": [Function],
         "type": undefined,
-        "url": "/locations/1-yaml/select",
       },
       Object {
         "name": "london",
         "onClick": [Function],
         "type": undefined,
-        "url": "/locations/2-london/select",
       },
       Object {
         "name": "norway",
         "onClick": [Function],
         "type": undefined,
-        "url": "/locations/3-norway/select",
       },
     ],
     "className": "visible-xs-block",

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/integration.test.js.snap
@@ -104,19 +104,16 @@ Object {
             Object {
               "name": "Any Organization",
               "onClick": [Function],
-              "url": "/organizations/clear",
             },
             Object {
               "name": "org1",
               "onClick": [Function],
               "type": undefined,
-              "url": "/organizations/1-org1/select",
             },
             Object {
               "name": "org2",
               "onClick": [Function],
               "type": undefined,
-              "url": "/organizations/2-org2/select",
             },
           ],
           "className": "visible-xs-block",
@@ -129,25 +126,21 @@ Object {
             Object {
               "name": "Any Location",
               "onClick": [Function],
-              "url": "/locations/clear",
             },
             Object {
               "name": "yaml",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/1-yaml/select",
             },
             Object {
               "name": "london",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/2-london/select",
             },
             Object {
               "name": "norway",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/3-norway/select",
             },
           ],
           "className": "visible-xs-block",
@@ -268,19 +261,16 @@ Object {
             Object {
               "name": "Any Organization",
               "onClick": [Function],
-              "url": "/organizations/clear",
             },
             Object {
               "name": "org1",
               "onClick": [Function],
               "type": undefined,
-              "url": "/organizations/1-org1/select",
             },
             Object {
               "name": "org2",
               "onClick": [Function],
               "type": undefined,
-              "url": "/organizations/2-org2/select",
             },
           ],
           "className": "visible-xs-block",
@@ -293,25 +283,21 @@ Object {
             Object {
               "name": "Any Location",
               "onClick": [Function],
-              "url": "/locations/clear",
             },
             Object {
               "name": "yaml",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/1-yaml/select",
             },
             Object {
               "name": "london",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/2-london/select",
             },
             Object {
               "name": "norway",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/3-norway/select",
             },
           ],
           "className": "visible-xs-block",
@@ -432,19 +418,16 @@ Object {
             Object {
               "name": "Any Organization",
               "onClick": [Function],
-              "url": "/organizations/clear",
             },
             Object {
               "name": "org1",
               "onClick": [Function],
               "type": undefined,
-              "url": "/organizations/1-org1/select",
             },
             Object {
               "name": "org2",
               "onClick": [Function],
               "type": undefined,
-              "url": "/organizations/2-org2/select",
             },
           ],
           "className": "visible-xs-block",
@@ -457,25 +440,21 @@ Object {
             Object {
               "name": "Any Location",
               "onClick": [Function],
-              "url": "/locations/clear",
             },
             Object {
               "name": "yaml",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/1-yaml/select",
             },
             Object {
               "name": "london",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/2-london/select",
             },
             Object {
               "name": "norway",
               "onClick": [Function],
               "type": undefined,
-              "url": "/locations/3-norway/select",
             },
           ],
           "className": "visible-xs-block",
@@ -582,19 +561,16 @@ Object {
           Object {
             "name": "Any Organization",
             "onClick": [Function],
-            "url": "/organizations/clear",
           },
           Object {
             "name": "org1",
             "onClick": [Function],
             "type": undefined,
-            "url": "/organizations/1-org1/select",
           },
           Object {
             "name": "org2",
             "onClick": [Function],
             "type": undefined,
-            "url": "/organizations/2-org2/select",
           },
         ],
         "className": "visible-xs-block",
@@ -607,25 +583,21 @@ Object {
           Object {
             "name": "Any Location",
             "onClick": [Function],
-            "url": "/locations/clear",
           },
           Object {
             "name": "yaml",
             "onClick": [Function],
             "type": undefined,
-            "url": "/locations/1-yaml/select",
           },
           Object {
             "name": "london",
             "onClick": [Function],
             "type": undefined,
-            "url": "/locations/2-london/select",
           },
           Object {
             "name": "norway",
             "onClick": [Function],
             "type": undefined,
-            "url": "/locations/3-norway/select",
           },
         ],
         "className": "visible-xs-block",


### PR DESCRIPTION
When selecting a taxonomy from the dropdown in a mobile display, the server enters a redirect loop in effect preventing a mobile user from switching their active taxonomy.