### PR TITLE
Fixes #31578 - External IPAM now fails with 'mac address cannot be nil'

### DIFF
--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -63,7 +63,6 @@ module ProxyAPI
     #     {"error": "Unable to connect to External IPAM server"}
     def next_ip(subnet, mac, group = "")
       raise "subnet cannot be nil" if subnet.nil?
-      raise "mac address cannot be nil" if mac.nil?
       response = parse get("/subnet/#{subnet}/next_ip?mac=#{mac}&group=#{URI.escape(group.to_s)}")
       raise(response['error']) if response['error'].present?
       response['data']


### PR DESCRIPTION
We should not raise an exception here if mac address is nil, to account for hosts that use Compute Resources. 

In the case where the mac address is nil, the `smart_proxy_ipam` plugin will generate a unique id, and use that for the IP cache key. 