### PR TITLE
Fixes #31619 - Add host sub-statuses endpoint

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -27,7 +27,7 @@ class HostsController < ApplicationController
   before_action :find_resource, :only => [:show, :clone, :edit, :update, :destroy, :review_before_build,
                                           :setBuild, :cancelBuild, :power, :overview, :bmc, :vm,
                                           :runtime, :resources, :nics, :ipmi_boot, :console,
-                                          :toggle_manage, :pxe_config, :disassociate, :build_errors, :forget_status]
+                                          :toggle_manage, :pxe_config, :disassociate, :build_errors, :forget_status, :get_statuses]
 
   before_action :taxonomy_scope, :only => [:new, :edit] + AJAX_REQUESTS
   before_action :set_host_type, :only => [:update]
@@ -629,6 +629,18 @@ class HostsController < ApplicationController
     end
   end
 
+  def get_statuses
+    statuses = []
+    HostStatus.status_registry.each do |status_class|
+      if @host.get_status(status_class).relevant?
+        statuses << { name: status_class.humanized_name,
+                      status: @host.send("#{status_class.humanized_name}_status"),
+                      label: @host.send("#{status_class.humanized_name}_status_label") }
+      end
+    end
+    render :json => statuses.to_json
+  end
+
   private
 
   def resource_base
@@ -637,7 +649,7 @@ class HostsController < ApplicationController
 
   define_action_permission [
     'clone', 'externalNodes', 'overview', 'bmc', 'vm', 'runtime', 'resources', 'templates', 'nics',
-    'pxe_config', 'active', 'errors', 'out_of_sync', 'pending', 'disabled', 'get_power_state', 'preview_host_collection', 'build_errors'
+    'pxe_config', 'active', 'errors', 'out_of_sync', 'pending', 'disabled', 'get_power_state', 'preview_host_collection', 'build_errors', 'get_statuses'
   ], :view
   define_action_permission [
     'setBuild', 'cancelBuild', 'multiple_build', 'submit_multiple_build', 'review_before_build',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Foreman::Application.routes.draw do
         post 'forget_status'
         put 'ipmi_boot'
         put 'disassociate'
+        get 'get_statuses'
       end
       collection do
         post 'multiple_actions'

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1873,6 +1873,16 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
 
+  test "get statuses" do
+    SETTINGS[:unattended] = true
+    host = FactoryBot.create(:host, :managed)
+    ::HostStatus::BuildStatus.create!(host_id: host.id)
+    expected = [{ :name => 'build', :status => 0, :label => 'Installed' }].to_json
+
+    get :get_statuses, params: { :id => host.name, :format => 'json' }, session: set_session_user
+    assert_equal expected, @response.body
+  end
+
   private
 
   def initialize_host


### PR DESCRIPTION
In order to create the new  host sub-statuses  overview  (new host details page), an endpoint for a host's sub statuses is required (the API doesn't organize the statuses as a separate sub-structure )