### PR TITLE
Fixes #31625 - Correctly display environments for class params

### DIFF
--- a/app/views/lookup_keys/_fields.html.erb
+++ b/app/views/lookup_keys/_fields.html.erb
@@ -4,7 +4,7 @@
     <%= text_f f, :key, :disabled => true, :size => "col-md-8" %>
     <%= f.hidden_field :key %>
     <%= textarea_f f, :description, :rows => :auto, :size => "col-md-8", :class => "no-stretch" %>
-    <%= text_f(f, :environment_classes, :value => f.object.environment_classes.map(&:environment).to_sentence, :label => _('Puppet Environments'), :size => "col-md-8", :disabled => true) %>
+    <%= text_f(f, :environment_classes, :value => f.object.environment_classes.map(&:environment).compact.to_sentence, :label => _('Puppet Environments'), :size => "col-md-8", :disabled => true) %>
     <%= show_puppet_class f %>
   </fieldset>
   <fieldset>


### PR DESCRIPTION
In case there is a taxonomy scope active and a certain param is present
in an environment that isn't in the current scope, the field showing
environments will display empty strings for this envirionment.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
