### PR TITLE
Fixes #31626 - convert list into comma separated string

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -76,7 +76,8 @@ snippet: true
 
   # bond
   if iface.bond? && rhel_compatible && os_major >= 6
-    options.push("bond=#{iface.identifier}:#{iface.attached_devices_identifiers}:mode=#{iface.mode},#{iface.bond_options.tr(' ', ',')}")
+    bond_slaves = iface.attached_devices_identifiers.join(',')
+    options.push("bond=#{iface.identifier}:#{bond_slaves}:mode=#{iface.mode},#{iface.bond_options.tr(' ', ',')}")
   end
 
   # VLAN (only on physical is recognized)


### PR DESCRIPTION
As dracut bond kernel option expect comma separated list of bond slaves
we need to convert list into string.