### PR TITLE
fixes #31633 - Introducing format_time macro

### DIFF
--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -47,7 +47,8 @@ module Foreman
         :parse_json,
         :to_json,
         :to_yaml,
-        :foreman_server_ca_cert
+        :foreman_server_ca_cert,
+        :format_time
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/lib/foreman/renderer/scope/macros/helpers.rb
+++ b/lib/foreman/renderer/scope/macros/helpers.rb
@@ -46,6 +46,23 @@ module Foreman
           def to_yaml(data)
             data.to_yaml
           end
+
+          apipie :method, "Generate a formatted time from a Ruby Time object or a Float object representing a UNIX timestamp" do
+            required :time, [Float, Time], desc: 'Ruby Time object or a Float object representing a UNIX timestamp'
+            optional :format, String, desc: 'Pattern to format time', default: '%Y-%-m-%-d %k:%M:%S %z'
+            optional :zone, String, desc: 'This parameter can be used for specify timezone of time, for example Europe/Prague', default: 'Default local timezone'
+            returns String
+          end
+          def format_time(time, format: '%Y-%-m-%-d %k:%M:%S %z', zone: Time.zone)
+            # if time is in float, we need to understand it as UNIX timestamp that is in UTC
+            time_to_format = if (time.is_a? Float) || (time.is_a? Integer)
+                               Time.zone.at(time).utc
+                             else
+                               time
+                             end
+
+            time_to_format.in_time_zone(zone).strftime(format)
+          end
         end
       end
     end

--- a/test/unit/foreman/renderer/scope/macros/helpers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/helpers_test.rb
@@ -30,4 +30,12 @@ class HelpersTest < ActiveSupport::TestCase
 
     it { assert_equal expected, scope.to_yaml(data) }
   end
+
+  describe '#format_time' do
+    let(:unix_timestamp) { 1356006012 } # 2012-12-20 12:20:12
+    let(:utc_time) { Time.zone.local(2012, 12, 20, 12, 20, 12).utc }
+    let(:format_pattern) { '%Y-%-m-%-d %k:%M:%S %z' }
+
+    it { assert_equal utc_time.strftime(format_pattern), scope.format_time(unix_timestamp, format: format_pattern) }
+  end
 end


### PR DESCRIPTION
There is no way how to show Unix timestamp in pretty way in reports. This macro solves the problem.

Complementary PR for https://github.com/theforeman/foreman/pull/8178 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
