### PR TITLE
Fixes #31637 - nilify http proxy credentials

### DIFF
--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -12,6 +12,8 @@ class HttpProxy < ApplicationRecord
 
   has_many :compute_resources
 
+  before_validation :nilify_empty_credentials
+
   validates :name, :presence => true, :uniqueness => true
 
   validates :url, :presence => true
@@ -45,5 +47,12 @@ class HttpProxy < ApplicationRecord
     )
   rescue Excon::Error::Socket => e
     e.message
+  end
+
+  private
+
+  def nilify_empty_credentials
+    self.username = nil if username.empty?
+    self.password = nil if password.empty?
   end
 end

--- a/db/migrate/20210114143800_nilify_empty_proxy_credentials.rb
+++ b/db/migrate/20210114143800_nilify_empty_proxy_credentials.rb
@@ -1,0 +1,19 @@
+class NilifyEmptyProxyCredentials < ActiveRecord::Migration[6.0]
+  def up
+    if User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).present?
+      User.as_anonymous_admin do
+        HttpProxy.where(username: "").update_all(username: nil)
+        HttpProxy.where(password: "").update_all(password: nil)
+      end
+    end
+  end
+
+  def down
+    if User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).present?
+      User.as_anonymous_admin do
+        HttpProxy.where(username: nil).update_all(username: "")
+        HttpProxy.where(password: nil).update_all(password: "")
+      end
+    end
+  end
+end

--- a/test/unit/http_proxy_test.rb
+++ b/test/unit/http_proxy_test.rb
@@ -12,6 +12,17 @@ class HttpProxyTest < ActiveSupport::TestCase
     assert proxy.save
   end
 
+  # the form sends empty string for the username and password fields
+  # backend systems may have problems detecting the empty string as a no-value
+  # so we should must keep them as nil
+  test 'create with empty username' do
+    proxy = HttpProxy.new(:name => 'foobar', :url => "http://someurl:5000", :username => '', :password => '')
+
+    assert proxy.save
+    assert_nil proxy.username
+    assert_nil proxy.password
+  end
+
   test 'search by name' do
     assert_equal 1, HttpProxy.search_for("name = #{http_proxy.name}").count
   end


### PR DESCRIPTION
Recently a HTTP form password field changed and is disabled unless user
explicitly sets the password. From the HTML forms nature, if user does
not specify any value in the text field, server receives the value as an
empty string. If the field is disabled, there's no value sent and the
server keeps that attribute as nil.

After the mentioned change, if user does not set any of username and
password, we end up in a situation where username is empty string and
password is nil. This causes problems at some backend services, namely
Pulp 2.

We should either keep both as empty strings or both as nils. The later
seems more universal, since it's consistent with the API behavior in
case user does not specify the values. Therefore we make sure the value
is nilified if it's an empty string.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
