### PR TITLE
Fixes #31645 - Missing host UUID in global registration template

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -57,7 +57,8 @@ echo "#"
 if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
-        curl --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>?uuid=$UUID" \
+        curl --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \
+             --data "uuid=$UUID" \
              <%= headers.join(' ') %> \
 <%= "          --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
 <%= "          --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>


### PR DESCRIPTION
After the refactoring of https://github.com/theforeman/smart-proxy/pull/778, missing UUID for RHEL & CentOS systems (only) caused issues during registration through the smart proxy.

Other systems (aka non-subman registrations) are not affected.
Registration directly to the Foreman works fine as well.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
