### PR TITLE
Fixes #31663 - Global Registration - Usability issues with templates & operating systems

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -32,7 +32,7 @@ module Api
         render plain: @provisioning_template.render(variables: @global_registration_vars).html_safe
       end
 
-      api :POST, "/register", N_("Find or create a host and render the Host registration template")
+      api :POST, "/register", N_("Find or create a host and render the 'Host initial configuration' template")
       param :host, Hash, required: true, action_aware: true do
         param :name, String, required: true
         param :location_id, :number, required: true
@@ -76,7 +76,7 @@ module Api
             host_setup_insights
             host_setup_remote_execution
             host_setup_extension
-            @template = @host.registration_template
+            @template = @host.initial_configuration_template
             raise ActiveRecord::Rollback if @template.nil?
           end
         rescue ::Foreman::Exception => e
@@ -85,7 +85,7 @@ module Api
         end
 
         unless @template
-          not_found N_("Unable to find registration template for host %{host} running %{os}, associate the registration template for this OS first") % { host: @host.name, os: @host.operatingsystem }
+          not_found N_("Unable to find 'Host initial configuration' template for host %{host} running %{os}, associate the 'Host initial configuration' template for this OS first") % { host: @host.name, os: @host.operatingsystem }
           return
         end
 

--- a/app/controllers/foreman_register/hosts_controller.rb
+++ b/app/controllers/foreman_register/hosts_controller.rb
@@ -56,7 +56,7 @@ module ForemanRegister
     end
 
     def find_template
-      @template = @host.registration_template
+      @template = @host.initial_configuration_template
     rescue ::Foreman::Exception
       render_error(message: N_('Host is not associated with an operating system'))
     end

--- a/app/models/concerns/foreman_register/host_extensions.rb
+++ b/app/models/concerns/foreman_register/host_extensions.rb
@@ -17,8 +17,8 @@ module ForemanRegister
       ForemanRegister::RegistrationUrl.new(host: self).url
     end
 
-    def registration_template
-      provisioning_template(kind: 'registration')
+    def initial_configuration_template
+      provisioning_template(kind: 'host_init_config')
     end
   end
 end

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -32,6 +32,8 @@ class ProvisioningTemplate < Template
   has_many :os_default_templates
   before_save :check_for_snippet_assoications
 
+  validate :no_os_for_registration
+
   # these can't be shared in parent class, scoped search can't handle STI properly
   # tested with scoped_search 3.2.0
   include Taxonomix
@@ -236,6 +238,11 @@ class ProvisioningTemplate < Template
 
   def self.acceptable_template_input_types
     [:fact, :variable, :puppet_parameter]
+  end
+
+  def no_os_for_registration
+    return unless template_kind&.name == 'registration'
+    errors.add(:operatingsystems, N_("can't assign operating system to Registration template")) if operatingsystems.any?
   end
 
   private

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -89,6 +89,7 @@ class Setting::Provisioning < Setting
       ),
       set('maximum_structured_facts', N_("Maximum amount of keys in structured subtree, statistics stored in foreman::dropped_subtree_facts"), 100, N_('Maximum structured facts')),
       set('default_global_registration_item', N_("Global Registration template"), 'Global Registration', N_("Default Global registration template")),
+      set('default_host_init_config_template', N_("Default 'Host intial configuration' template, automatically assigned when new operating system is created"), 'Linux host_init_config default', N_("Default 'Host intial configuration' template")),
     ] + default_global_templates + default_local_boot_templates
   end
 

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -22,6 +22,7 @@ class TemplateKind < ApplicationRecord
       "ZTP" => N_("ZTP PXE template"),
       "POAP" => N_("POAP PXE template"),
       "cloud-init" => N_("Cloud-init template"),
+      "host_init_config" => N_("Host initial configuration template"),
       "registration" => N_("Registration template"),
     }
   end
@@ -39,6 +40,7 @@ class TemplateKind < ApplicationRecord
       "ZTP" => N_("Provisioning Junos devices (Junos 12.2+)."),
       "POAP" => N_("Provisioning for switches running NX-OS."),
       "cloud-init" => N_("Template for cloud-init unattended endpoint."),
+      "host_init_config" => N_("Contains the instructions in form of a bash script for the initial host configuration, after the host is registered in Foreman"),
     }
   end
 

--- a/app/views/hosts/_init_config_tab.html.erb
+++ b/app/views/hosts/_init_config_tab.html.erb
@@ -7,13 +7,13 @@
   border: 1px solid #ccc;
 }
 </style>
-<% if @host.operatingsystem && @host.registration_template %>
+<% if @host.operatingsystem && @host.initial_configuration_template %>
 <div style="max-width: 600px">
   <%= _('For initial configuration of the host run this command:') %>
   <%= react_component('ClipboardCopy', { text: "curl #{@host.registration_url} | bash",
                                          textareaProps: { readOnly: true, rows: '1', className: 'host-init-conf-textarea'}})
   %>
-  <%= _('Host template') %>: <%= link_to(@host.registration_template, edit_provisioning_template_path(@host.registration_template))%>
+  <%= _('Host template') %>: <%= link_to(@host.initial_configuration_template, edit_provisioning_template_path(@hosthost.initial_configuration_template))%>
 </div>
 <% else %>
   <p><%= _('This host can not be configured as no registration template was set.') %></p>

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -1,6 +1,6 @@
 <%#
-kind: registration
-name: Linux registration default
+kind: host_init_config
+name: Linux host_init_config default
 model: ProvisioningTemplate
 oses:
 - CentOS

--- a/db/migrate/20210115124508_template_kind_registration.rb
+++ b/db/migrate/20210115124508_template_kind_registration.rb
@@ -1,0 +1,49 @@
+class TemplateKindRegistration < ActiveRecord::Migration[6.0]
+  def up
+    host_init_config_kind = TemplateKind.unscoped.find_or_create_by(name: 'host_init_config')
+    registration_kind = TemplateKind.unscoped.find_by(name: 'registration')
+
+    # Migrate Host registration templates to host_init_config kind
+    ProvisioningTemplate.unscoped
+                        .where(template_kind: registration_kind)
+                        .where.not(name: [Setting[:default_global_registration_item], 'Global Registration'])
+                        .update_all(template_kind_id: host_init_config_kind.id)
+
+    # Rename 'Linux registration default' to 'Linux host_init_config default'
+    ProvisioningTemplate.unscoped
+                        .where(name: 'Linux registration default')
+                        .update_all(name: Setting[:default_host_init_config_template])
+
+    # Assign default host_init_config template to all operating systems
+    # and change registration association to the host_init_config
+    template = ProvisioningTemplate.unscoped.find_by_name(Setting[:default_host_init_config_template])
+    Operatingsystem.all.each do |os|
+      template.operatingsystems << os unless template.operatingsystems.include?(os)
+
+      os_default_registration = OsDefaultTemplate.find_by(template_kind: registration_kind, operatingsystem: os)
+      if os_default_registration
+        os_default_registration.update(template_kind_id: host_init_config_kind.id)
+      else
+        OsDefaultTemplate.create template_kind: host_init_config_kind,
+                                 provisioning_template: template,
+                                 operatingsystem: os
+      end
+    end
+  end
+
+  def down
+    host_init_config_kind = TemplateKind.unscoped.find_by(name: 'host_init_config')
+    registration_kind = TemplateKind.unscoped.find_by(name: 'registration')
+
+    # Rename 'Linux host_init_config default' back to 'Linux registration default'
+    ProvisioningTemplate.unscoped.find_by_name(Setting[:default_host_init_config_template])
+                        .update(name: 'Linux registration default')
+
+    # Migrate host_init_config templates back to Host registration templates kind
+    ProvisioningTemplate.unscoped.where(template_kind_id: host_init_config_kind.id)
+                        .update_all(template_kind_id: registration_kind.id)
+
+    OsDefaultTemplate.where(template_kind_id: host_init_config_kind.id)
+                     .update_all(template_kind_id: registration_kind.id)
+  end
+end

--- a/test/controllers/api/v2/os_default_templates_controller_test.rb
+++ b/test/controllers/api/v2/os_default_templates_controller_test.rb
@@ -6,7 +6,7 @@ class Api::V2::OsDefaultTemplatesControllerTest < ActionController::TestCase
     assert_response :success
     assert_not_nil assigns(:os_default_templates)
     results = ActiveSupport::JSON.decode(@response.body)
-    assert_equal 6, results['results'].length
+    assert_equal 7, results['results'].length
   end
 
   test 'should show os_default_template' do

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -125,46 +125,7 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
   end
 
   describe 'host registration' do
-    let(:organization) { FactoryBot.create(:organization) }
-    let(:tax_location) { FactoryBot.create(:location) }
-    let(:template_kind) { template_kinds(:registration) }
-    let(:registration_template) do
-      FactoryBot.create(
-        :provisioning_template,
-        template_kind: template_kind,
-        template: 'template content <%= @host.name %>',
-        locations: [tax_location],
-        organizations: [organization]
-      )
-    end
-    let(:os) do
-      FactoryBot.create(
-        :operatingsystem,
-        :with_associations,
-        family: 'Redhat',
-        provisioning_templates: [
-          registration_template,
-        ]
-      )
-    end
-
-    let(:host_params) do
-      { host: { name: 'centos-test.example.com',
-                managed: false, build: false,
-                organization_id: organization.id,
-                location_id: tax_location.id,
-                operatingsystem_id: os.id },
-      }
-    end
-
-    setup do
-      FactoryBot.create(
-        :os_default_template,
-        template_kind: template_kind,
-        provisioning_template: registration_template,
-        operatingsystem: os
-      )
-    end
+    let(:host_params) { { host: { name: 'centos-test.example.com', operatingsystem_id: operatingsystems(:redhat).id } } }
 
     test 'should find and create host' do
       post :host, params: host_params, session: set_session_user
@@ -179,13 +140,13 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
 
       post :host, params: params, session: set_session_user
       assert_response :success
-      assert Host.find_by(name: params[:host][:name]).hostgroup_id == params[:host][:hostgroup_id]
+      assert_equal Host.find_by(name: params[:host][:name]).hostgroup_id, params[:host][:hostgroup_id]
     end
 
     test 'should render template' do
       post :host, params: host_params, session: set_session_user
       assert_response :success
-      assert_equal @response.body, "template content #{host_params[:host][:name]}"
+      assert_equal @response.body, "echo \"Linux host initial configuration\""
     end
 
     test 'should set build on host' do
@@ -202,7 +163,15 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
     end
 
     test 'should render error when template is invalid' do
-      registration_template.update(template: "<% asda =!?== '2 % %>")
+      template = FactoryBot.create(
+        :provisioning_template,
+        template_kind: template_kinds(:host_init_config),
+        template: "<% asda =!?== '2 % %>"
+      )
+
+      Setting[:default_host_init_config_template] = template.name
+      host_params = { host: { name: 'centos-test.example.com', operatingsystem_id: FactoryBot.create(:operatingsystem).id } }
+
       post :host, params: host_params, session: set_session_user
       assert_response :internal_server_error
     end

--- a/test/controllers/operatingsystems_controller_test.rb
+++ b/test/controllers/operatingsystems_controller_test.rb
@@ -130,7 +130,8 @@ class OperatingsystemsControllerTest < ActionController::TestCase
       operatingsystem = Operatingsystem.first
       put :update, params: { :id => operatingsystem.id, :operatingsystem =>
           {:os_default_templates_attributes => [{:provisioning_template_id => @provisioning_template.id, :template_kind_id => @template_kind.id}]} }, session: set_session_user
-      refute_empty operatingsystem.os_default_templates
+
+      assert operatingsystem.os_default_templates.size, 2
       assert_redirected_to operatingsystems_url
     end
 
@@ -139,7 +140,8 @@ class OperatingsystemsControllerTest < ActionController::TestCase
       put :update, params: { :id => operatingsystem.id,
                              :operatingsystem => {:os_default_templates_attributes => [{ :provisioning_template_id => nil, :template_kind_id => @template_kind.id }]} }, session: set_session_user
 
-      assert_empty operatingsystem.os_default_templates
+      assert operatingsystem.os_default_templates.size, 1
+      assert operatingsystem.os_default_templates.first.template_kind, templates(:host_init_config)
     end
 
     test 'empty provisioning_template should be destroyed' do

--- a/test/fixtures/os_default_templates.yml
+++ b/test/fixtures/os_default_templates.yml
@@ -48,3 +48,8 @@ ten:
   provisioning_template: pxeautoyast
   template_kind: PXELinux
   operatingsystem: opensuse
+
+eleven:
+  provisioning_template: host_init_config
+  template_kind: host_init_config
+  operatingsystem: redhat

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -428,3 +428,8 @@ attribute94:
   category: Setting::Provisioning
   default: 'Global Registration'
   description: "Default Global registration template"
+attribute95:
+  name: default_host_init_config_template
+  category: Setting::Provisioning
+  default: 'Linux host initial configuration'
+  description: "Default host initial configuration template"

--- a/test/fixtures/template_kinds.yml
+++ b/test/fixtures/template_kinds.yml
@@ -27,6 +27,10 @@ pxegrub2:
   name: PXEGrub2
   description: description for pxegrub2 template
 
+host_init_config:
+  name: host_init_config
+  description: description for host_init_config template
+
 registration:
   name: registration
   description: description for registration template

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -177,6 +177,13 @@ global_registration:
   name: Global Registration
   template: 'echo "Default Global registration template"'
   template_kind: registration
-  operatingsystems: redhat
+  locked: true
+  type: ProvisioningTemplate
+
+host_init_config:
+  name: Linux host initial configuration
+  template: 'echo "Linux host initial configuration"'
+  template_kind: host_init_config
+  operatingsystems: centos5_3, redhat
   locked: true
   type: ProvisioningTemplate

--- a/test/models/concerns/hostext/operating_system_test.rb
+++ b/test/models/concerns/hostext/operating_system_test.rb
@@ -32,7 +32,7 @@ module Hostext
           :template_kind => TemplateKind.friendly.find('finish'))
         host  = FactoryBot.create(:host, :operatingsystem => os_dt.operatingsystem)
 
-        assert_equal [os_dt.provisioning_template], host.available_template_kinds('build')
+        assert_equal [os_dt.provisioning_template, templates(:host_init_config)], host.available_template_kinds('build')
       end
 
       test "available_template_kinds finds templates for an image host" do

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -434,4 +434,9 @@ class OperatingsystemTest < ActiveSupport::TestCase
     results = Operatingsystem.search_for(%{params.#{parameter.name} = "#{parameter.searchable_value}"})
     refute results.include?(os)
   end
+
+  test "should assign 'host initial configuration' template after create" do
+    os = FactoryBot.create(:operatingsystem)
+    assert_equal Setting[:default_host_init_config_template], os.provisioning_templates[0]&.name
+  end
 end

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -365,4 +365,13 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should not allow to assign OS to the registration kind" do
+    template_kind = template_kinds(:registration)
+    os = operatingsystems(:redhat)
+    template = FactoryBot.build(:provisioning_template, template: "a", template_kind: template_kind, operatingsystems: [os])
+
+    refute template.valid?
+    assert_includes template.errors.keys, :operatingsystems
+  end
 end


### PR DESCRIPTION
When first users (QAs) started testing & using Global Registration feature, they were repeatedly facing some issues with usability:

1. Forgetting to assign Host registration template (HRT) to operating system
2. Assigning Global Registration Template (GRT) to OS (instead of HRT)
3. Mixing GRT & HRT in general

**Changes:**
* New template kind `Host initial configuration`
* When new OS is created, `host_init_config` template is automatically assigned
* Registration template cannot be assigned to the OS
* New setting `default_host_init_config_template`
* Migration for changing template kind & assigning `host_init_config` to all OSs
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
