### PR TITLE
Fixes #31669 - Register RegistrationFacet in application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -298,6 +298,10 @@ module Foreman
         template_compatibility_properties :cores, :virtual, :sockets, :ram, :uptime_seconds
       end
 
+      Facets.register(ForemanRegister::RegistrationFacet, :registration_facet) do
+        set_dependent_action :destroy
+      end
+
       Plugin.all.each do |plugin|
         plugin.to_prepare_callbacks.each(&:call)
       end

--- a/config/initializers/foreman_register.rb
+++ b/config/initializers/foreman_register.rb
@@ -5,7 +5,3 @@ Pagelets::Manager.with_key 'hosts/show' do |mgr|
     priority: 100,
     onlyif: proc { |host, ctx| host.managed? }
 end
-
-Facets.register(ForemanRegister::RegistrationFacet, :registration_facet) do
-  set_dependent_action :destroy
-end


### PR DESCRIPTION
Before:

```
pry(main)> ::Host.last.registration_facet                                                                                                                                                                                                 
NoMethodError: undefined method `registration_facet' for #<Host::Managed:0x0000000018bb1760>      
```

After:

```
pry(main)> ::Host.last.registration_facet                                                                                                                                                                                                 
=> #<ForemanRegister::RegistrationFacet:0x0000000014f8d108 id: 1, host_id: 1, jwt_secret: [FILTERED], created_at: Tue, 15 Dec 2020 19:06:41 UTC +00:00, updated_at: Tue, 15 Dec 2020 19:06:41 UTC +00:00>    
```