### PR TITLE
fixes #31631 - configure bond the right way

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -96,7 +96,11 @@ skipx
   subnet6 = iface.subnet6
 
   # device and hostname
-  network_options.push("--device=#{iface.mac || iface.identifier}")
+  if iface.bond? && rhel_compatible && os_major >= 6
+    network_options.push("--device=#{iface.identifier}")
+  else
+    network_options.push("--device=#{iface.mac || iface.identifier}")
+  end
   network_options.push("--hostname #{@host.name}")
 
   # single stack
@@ -143,7 +147,8 @@ skipx
 
   # bond
   if iface.bond? && rhel_compatible && os_major >= 6
-    network_options.push("--bondslaves=#{iface.attached_devices_identifiers}")
+    bond_slaves = iface.attached_devices_identifiers.join(',')
+    network_options.push("--bondslaves=#{bond_slaves}")
     network_options.push("--bondopts=mode=#{iface.mode};#{iface.bond_options.tr(' ', ';')}")
   end
 


### PR DESCRIPTION
We now generate a device with the give name from foreman. 
We also fix the bond slave list generation (related to #31626).