### PR TITLE
Fixes #31684 - use sshkey and user in kickstart

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -48,6 +48,8 @@ rootpw --iscrypted <%= root_pass %>
 
 reboot
 
+<%= snippet('remote_execution_ssh_keys_kickstart') %>
+
 <% if @dynamic -%>
 # Partition table dynamic generation
 %pre --log=/tmp/install.pre.dynamic.log
@@ -68,7 +70,6 @@ cp -vf /tmp/*pre*log /tmp/sysimage/root/
 %post
 <%= snippet 'redhat_register' %>
 rm -f /etc/ostree/remotes.d/*.conf
-<%= snippet('remote_execution_ssh_keys') %>
 <%= snippet 'efibootmgr_netboot' %>
 touch /tmp/foreman_built
 %end

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -226,6 +226,8 @@ key --skip
 text
 reboot
 
+<%= snippet('remote_execution_ssh_keys_kickstart') %>
+
 %packages
 <%= snippet_if_exists(template_name + " custom packages") %>
 yum
@@ -293,8 +295,6 @@ else
   yum -t -y update
 fi
 <% end -%>
-
-<%= snippet('remote_execution_ssh_keys') %>
 
 <%= snippet "blacklist_kernel_modules" %>
 

--- a/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
@@ -73,8 +73,13 @@ text
 reboot
 <%= @host.diskLayout %>
 
+<%= snippet('remote_execution_ssh_keys_kickstart') %>
+
 %post --log=/root/ks.post.log --erroronfail
+# Everything after "nodectl init" will not be persisted.
+# https://bugzilla.redhat.com/show_bug.cgi?id=1842484
 nodectl init
+
 <%= snippet 'redhat_register' %>
 <%= snippet 'kickstart_networking_setup' %>
 <%= snippet 'efibootmgr_netboot' %>

--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -4,7 +4,7 @@ name: remote_execution_ssh_keys
 model: ProvisioningTemplate
 snippet: true
 %>
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys_kickstart.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys_kickstart.erb
@@ -1,0 +1,55 @@
+<%#
+kind: snippet
+name: remote_execution_ssh_keys_kickstart
+model: ProvisioningTemplate
+snippet: true
+-%>
+<%#
+# SSH keys setup snippet for Remote Execution plugin via Kickstart format
+#
+# Parameters:
+#
+# remote_execution_ssh_keys: public keys to be put in ~/.ssh/authorized_keys
+#
+# remote_execution_ssh_user: user for which remote_execution_ssh_keys will be
+#                            authorized
+#
+# remote_execution_create_user: create user if it not already existing
+#
+# remote_execution_effective_user_method: method to switch from ssh user to
+#                                         effective user
+#
+# This template sets up SSH keys in any host so that as long as your public
+# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
+# works in combination with Remote Execution plugin by querying smart proxies
+# to build an array.
+#
+# To use this snippet without the plugin provide the SSH keys as host parameter
+# remote_execution_ssh_keys. It expects the same format like the authorized_keys
+# file.
+#
+# This snippet must be included outside of a %post section.
+#
+-%>
+<% if host_param_true?('host_registration_remote_execution') && !host_param('remote_execution_ssh_keys').blank? -%>
+<% ssh_user = host_param('remote_execution_ssh_user') || 'root' %>
+
+<% if ssh_user != 'root' && host_param_true?('remote_execution_create_user') -%>
+user --name=<%= ssh_user %>
+<% end -%>
+
+<% host_param('remote_execution_ssh_keys').split(',').each do |key| -%>
+sshkey --username=<%= ssh_user %> "<%= key %>"
+<% end -%>
+
+<% if ssh_user != 'root' && host_param('remote_execution_effective_user_method') == 'sudo' -%>
+%post
+echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL
+Defaults:<%= ssh_user %> !requiretty" > /etc/sudoers.d/<%= ssh_user %>
+%end
+<% end -%>
+
+<% else -%>
+# The remote_execution_ssh_user does not exist and remote_execution_create_user is not
+# set to true. No SSH key will be installed.
+<% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
@@ -43,7 +43,7 @@ runcmd:
 - |
 - |
   
-  # SSH keys setup snippet for Remote Execution plugin
+  # SSH keys setup snippet for Remote Execution plugin via Shell script
   #
   # Parameters:
   #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD (mfsBSD) finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD (mfsBSD) finish.snap.txt
@@ -52,7 +52,7 @@ export FACTER_is_installer=true
 
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
@@ -41,7 +41,7 @@ else
 fi
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
@@ -5,7 +5,7 @@
 
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
@@ -29,6 +29,10 @@ reboot
 cp -vf /tmp/*pre*log /tmp/sysimage/root/
 %end
 
+# The remote_execution_ssh_user does not exist and remote_execution_create_user is not
+# set to true. No SSH key will be installed.
+
+
 %post
 
 
@@ -39,32 +43,6 @@ cp -vf /tmp/*pre*log /tmp/sysimage/root/
 
 
 rm -f /etc/ostree/remotes.d/*.conf
-
-# SSH keys setup snippet for Remote Execution plugin
-#
-# Parameters:
-#
-# remote_execution_ssh_keys: public keys to be put in ~/.ssh/authorized_keys
-#
-# remote_execution_ssh_user: user for which remote_execution_ssh_keys will be
-#                            authorized
-#
-# remote_execution_create_user: create user if it not already existing
-#
-# remote_execution_effective_user_method: method to switch from ssh user to
-#                                         effective user
-#
-# This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
-# works in combination with Remote Execution plugin by querying smart proxies
-# to build an array.
-#
-# To use this snippet without the plugin provide the SSH keys as host parameter
-# remote_execution_ssh_keys. It expects the same format like the authorized_keys
-# file.
-
-
-
 
 
 touch /tmp/foreman_built

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
@@ -84,7 +84,7 @@ cp /etc/resolv.conf /mnt/etc
 /bin/hostname snapshothost
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
@@ -87,7 +87,7 @@ cp /etc/resolv.conf /mnt/etc
 /bin/hostname snapshothost
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -52,6 +52,10 @@ echo "Changed to TTY3 for post installation..."
 
 %end
 
+# The remote_execution_ssh_user does not exist and remote_execution_create_user is not
+# set to true. No SSH key will be installed.
+
+
 
 %post --log=/root/install.post.log
 logger "Starting anaconda snapshothost postinstall"
@@ -90,33 +94,6 @@ if [ -f /usr/bin/dnf ]; then
 else
   yum -t -y update
 fi
-
-
-# SSH keys setup snippet for Remote Execution plugin
-#
-# Parameters:
-#
-# remote_execution_ssh_keys: public keys to be put in ~/.ssh/authorized_keys
-#
-# remote_execution_ssh_user: user for which remote_execution_ssh_keys will be
-#                            authorized
-#
-# remote_execution_create_user: create user if it not already existing
-#
-# remote_execution_effective_user_method: method to switch from ssh user to
-#                                         effective user
-#
-# This template sets up SSH keys in any host so that as long as your public
-# SSH key is in remote_execution_ssh_keys, you can SSH into a host. This
-# works in combination with Remote Execution plugin by querying smart proxies
-# to build an array.
-#
-# To use this snippet without the plugin provide the SSH keys as host parameter
-# remote_execution_ssh_keys. It expects the same format like the authorized_keys
-# file.
-
-
-
 
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/remote_execution_ssh_keys.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/remote_execution_ssh_keys.snap.txt
@@ -1,5 +1,5 @@
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
@@ -18,7 +18,7 @@ EOF
 
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
@@ -50,7 +50,7 @@ else
 fi
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
@@ -21,7 +21,7 @@ EOF
 
 
 
-# SSH keys setup snippet for Remote Execution plugin
+# SSH keys setup snippet for Remote Execution plugin via Shell script
 #
 # Parameters:
 #

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
@@ -20,7 +20,7 @@ package_upgrade: true
 runcmd:
 - |
   
-  # SSH keys setup snippet for Remote Execution plugin
+  # SSH keys setup snippet for Remote Execution plugin via Shell script
   #
   # Parameters:
   #


### PR DESCRIPTION
During investigation of problem with RHV provisioning, I have found out that all commands issued in %post scriplet after "nodectl init" are never persisted due to LVM layering. Therefore installing SSH keys via %post shell script will not work as well.

There is a workaround for that, keys can be installed via user/sshkey kickstart statements. However sudo (sudoers) still needs to be done via %post which will be ignored for RHV. This will be limitation, only root can be used to perform SSH jobs on RHV hosts. We should document that if this patch gets in.

More details at: https://bugzilla.redhat.com/show_bug.cgi?id=1842484. There is an ongoing discussion, it looks like all our %post commands do not actually work (there is probably no `subscription-manager` on oVirt node at all). I cannot test, I assume RHV/oVirt requires bare metal which I currently don't have. We might end up removing all these snippets from the template as updates and networking is managed by RHV-M/oVirt Manager.

Snapshot tests currently do not have ssh key, I can add that but not in this PR, I already have a big refactoring: https://github.com/theforeman/foreman/pull/8149

@adamruzicka @aruzicka