### PR TITLE
Fixes #31686 - Highlight changed matchers

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -324,6 +324,14 @@ function fill_in_matchers() {
         .attr('selected', 'selected');
       matcher_value.val(key_value[1]);
     }
+
+    $(matcher_value).data('initialValue', matcher_value.val());
+    $(matcher_key).data('initialValue', matcher_key.find(":selected").text());
+
+  });
+
+  $('.input-group textarea[data-property="value"]').each(function(idx, element) {
+    $(element).data('initialValue', $(element).val());
   });
 }
 

--- a/app/assets/stylesheets/lookup_keys.scss
+++ b/app/assets/stylesheets/lookup_keys.scss
@@ -1,0 +1,37 @@
+.matcher-field-changed {
+  background: rgba(251, 234, 188, 0.55);
+}
+
+.matcher-value-cell {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  .input-group {
+    flex-grow: 2;
+    padding-right: 3px;
+  }
+}
+
+a.warn-field-changed {
+  position: relative;
+  opacity: 0;
+  cursor: default;
+  z-index: -1;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+  };
+}
+
+a.warn-field-changed.warn-show {
+  opacity: 1;
+  cursor: pointer;
+  z-index: 2;
+}

--- a/app/views/lookup_keys/_value.html.erb
+++ b/app/views/lookup_keys/_value.html.erb
@@ -5,13 +5,17 @@
   <td>
     <%= f.hidden_field :match, :class => 'match' %>
     <div class="matcher-group">
-    <%= select_tag '', nil, :class => 'matcher_key without_select2' %>
-    <span> = </span>
-    <%= text_field_tag '', nil, :class => 'matcher_value' %>
+      <%= select_tag '', nil, :class => 'matcher_key without_select2', :onchange => 'tfm.lookupKeys.matcherKeyChanged(this)' %>
+      <span> = </span>
+      <%= text_field_tag '', nil, :class => 'matcher_value', :onkeyup => 'tfm.lookupKeys.matcherValueChanged(this)' %>
+      <%= popover("", 'Highlighted fields with a value change'.html_safe, :icon => 'warning-triangle-o', :class => 'warn-field-changed') %>
     </div>
   </td>
   <td>
-    <%= hidden_value_field(f, :value, f.object.omit, :value => f.object.value_before_type_cast, :'data-property' => 'value', :hidden_value => hidden_value) %>
+    <div class="matcher-value-cell">
+      <%= hidden_value_field(f, :value, f.object.omit, :value => f.object.value_before_type_cast, :'data-property' => 'value', :hidden_value => hidden_value, :onkeyup => 'tfm.lookupKeys.matcherValueChanged(this)') %>
+      <%= popover("", 'Highlighted fields with a value change'.html_safe, :icon => 'warning-triangle-o', :class => 'warn-field-changed') %>
+    </div>
   </td>
   <% if is_param %>
     <td class="ca">

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -27,6 +27,7 @@ import * as dashboard from './dashboard';
 import * as spice from './spice';
 import * as autocomplete from './foreman_autocomplete';
 import * as typeAheadSelect from './foreman_type_ahead_select';
+import * as lookupKeys from './foreman_lookup_keys';
 import './bundle_novnc';
 
 // Set the public path for dynamic imports
@@ -62,4 +63,5 @@ window.tfm = Object.assign(window.tfm || {}, {
   store,
   autocomplete,
   typeAheadSelect,
+  lookupKeys,
 });

--- a/webpack/assets/javascripts/foreman_lookup_keys.js
+++ b/webpack/assets/javascripts/foreman_lookup_keys.js
@@ -1,0 +1,39 @@
+/* eslint-disable jquery/no-data */
+/* eslint-disable jquery/no-find */
+/* eslint-disable jquery/no-class */
+/* eslint-disable jquery/no-closest */
+/* eslint-disable jquery/no-val */
+/* eslint-disable jquery/no-sizzle */
+/* eslint-disable jquery/no-text */
+
+import $ from 'jquery';
+
+const matcherFieldChanged = (element, currentValue) => {
+  const { initialValue } = $(element).data();
+
+  const popover = $(element)
+    .closest('td')
+    .find('a.warn-field-changed');
+
+  if (initialValue === currentValue) {
+    $(element).removeClass('matcher-field-changed');
+    $(popover).removeClass('warn-show');
+  } else {
+    $(element).addClass('matcher-field-changed');
+    $(popover).addClass('warn-show');
+  }
+};
+
+export const matcherKeyChanged = element => {
+  const currentValue = $(element)
+    .find(':selected')
+    .text();
+
+  matcherFieldChanged(element, currentValue);
+};
+
+export const matcherValueChanged = element => {
+  const currentValue = $(element).val();
+
+  matcherFieldChanged(element, currentValue);
+};


### PR DESCRIPTION
I might need some UX guidance here on how to best highlight the changed fields and what colour to use. Background works good for input fields, but if we want to do background for checkbox we would need a custom one. I tried outlines as well, but they do not look that great. Any suggestions?

![input-highlights](https://user-images.githubusercontent.com/2664090/105159737-b688fc80-5b0f-11eb-88e3-709d2a12ddd6.png)
