### PR TITLE
fixes #31675 - Fix provisioning template to build correct bond configuration for centos

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -155,7 +155,7 @@ skipx
   if iface.bond? && rhel_compatible && os_major >= 6
     bond_slaves = iface.attached_devices_identifiers.join(',')
     network_options.push("--bondslaves=#{bond_slaves}")
-    network_options.push("--bondopts=mode=#{iface.mode};#{iface.bond_options.tr(' ', ';')}")
+    network_options.push("--bondopts=mode=#{iface.mode},#{iface.bond_options.tr(' ', ',')}")
   end
 
   # VLAN (only on physical is recognized)

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
@@ -11,6 +11,9 @@ kind: snippet
                   :subnet6 => @subnet6,
                   :dhcp => @dhcp }) -%>
 TYPE=Bond
+<%-   if @interface.mac.to_s.present? -%>
+MACADDR="<%= @interface.mac -%>"
+<%-   end -%>
 BONDING_OPTS="<%= @interface.bond_options -%> mode=<%= @interface.mode -%>"
 BONDING_MASTER=yes
 <%-   if ( @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.major.to_i <= 7 ) -%>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_get_identifier_names.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_get_identifier_names.erb
@@ -8,11 +8,14 @@ kind: snippet
 <%- if @identifier -%>
 <%=   "real=\"#{@identifier}\"" %>
 <%- else -%>
-<%=   "real=`grep -l #{@interface.inheriting_mac} /sys/class/net/*/{bonding_slave/perm_hwaddr,address} 2>/dev/null | awk -F '/' '// {print $5}' | head -1`" -%>
+<%-   if !@interface.inheriting_mac -%>
+<%=     "\nreal=`echo #{@interface.identifier}`" -%>
+<%-   else -%>
+<%=     "real=`grep -l #{@interface.inheriting_mac} /sys/class/net/*/{bonding_slave/perm_hwaddr,address} 2>/dev/null | awk -F '/' '// {print $5}' | head -1`" -%>
+<%-   end -%>
 <%-   if @interface.virtual? -%>
 <%=     "\nreal=`echo #{@interface.identifier} | sed s/#{@interface.attached_to}/$real/`" -%>
 <%-   end -%>
 <%- end -%>
 <%# ifcfg files are ignored by NM if their name contains colons so we convert colons to underscore %>
 sanitized_real=`echo $real | sed s/:/_/`
-


### PR DESCRIPTION
Fix creating of bond configuration.
Don't create `_slave_X` files use nic name (e.g. ethX) instead.
Put mac address into it if any mac address for nic is configured.
Disable use of network manager.
Skip managed_interfaces block for bonded interfaces.