### PR TITLE
Fixes #31666 - Deprecate current taxonomies from store

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
@@ -1,6 +1,7 @@
 import { createSelector } from 'reselect';
 import { get, snakeCase } from 'lodash';
 import { noop } from '../../common/helpers';
+import { deprecate } from '../../common/DeprecationService';
 
 export const selectLayout = state => state.layout;
 
@@ -8,10 +9,14 @@ export const selectMenuItems = state => selectLayout(state).items;
 export const selectActiveMenu = state => selectLayout(state).activeMenu;
 export const selectIsLoading = state => selectLayout(state).isLoading;
 export const selectIsCollapsed = state => selectLayout(state).isCollapsed;
-export const selectCurrentLocation = state =>
-  get(selectLayout(state), 'currentLocation.title');
-export const selectCurrentOrganization = state =>
-  get(selectLayout(state), 'currentOrganization.title');
+export const selectCurrentLocation = state => {
+  deprecate('selectCurrentLocation', 'useForemanLocation hook', 2.5);
+  return get(selectLayout(state), 'currentLocation.title');
+};
+export const selectCurrentOrganization = state => {
+  deprecate('selectCurrentOrganization', 'useForemanOrganization hook', 2.5);
+  return get(selectLayout(state), 'currentOrganization.title');
+};
 
 export const patternflyMenuItemsSelector = createSelector(
   selectMenuItems,


### PR DESCRIPTION
The Foreman context should be used as the single source of truth for the
current taxonomies, marks the selector as deprecated.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
