### PR TITLE
Add .nvmrc to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ npm-debug.log
 .yo-rc.json
 .vendor/
 .solargraph.yml
+.nvmrc


### PR DESCRIPTION
As there are different node/npm versions in the wild it is common to use
virtual envs for development. To make it easy to use this with different
develompment enviroments it is a good idea to place a `.nvmrc` file in
your dev root. So a simple `nvm install` or `nvm use` do nvm magic with
the given version.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
