### PR TITLE
Fixes #31715 - print slow initializers to debug log

### DIFF
--- a/config/initializers/0_print_time_spent.rb
+++ b/config/initializers/0_print_time_spent.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# This class is taken from https://github.com/nevir/Bumbler which
+# depends on bundler. But for RPM environment, Foreman does not
+# use bundler (but bundler_ext stub). The gem won't load in that
+# environment.
+module ForemanInitializers
+  @slow_threshold = 100.0
+  @slow_items = {}
+
+  class << self
+    attr_writer :slow_threshold
+    attr_reader :slow_items
+
+    def benchmark(key)
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      result = yield
+      time = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start) * 1000 # ms
+      @slow_items[key] = time if time > @slow_threshold
+      result
+    end
+
+    def print_slow_items
+      if slow_items.any?
+        Rails.logger.debug "Slow initializers:"
+        slow_items.sort_by { |k, v| v }.each do |name, time|
+          Rails.logger.debug format('  %s  %s', ('%.2f' % time).rjust(8), name)
+        end
+      end
+      self
+    end
+  end
+end
+
+Rails::Engine.prepend(Module.new do
+  def load(file, *)
+    initializer = file.sub(Rails.root.to_s, ".")
+    ForemanInitializers.benchmark(initializer) { super }
+  end
+end)
+
+Rails::Initializable::Initializer.prepend(Module.new do
+  def run(*)
+    name = (@name.is_a?(Symbol) ? @name.inspect : @name)
+    ForemanInitializers.benchmark(name) { super }
+  end
+end)

--- a/config/initializers/z_print_slow_initializers.rb
+++ b/config/initializers/z_print_slow_initializers.rb
@@ -1,0 +1,1 @@
+ForemanInitializers.print_slow_items


### PR DESCRIPTION
In order to find which initializers are the slowest, we should add time measuring. It should work also with plugins, thus dynamically. All initializers that are slower than a sane threashold (100ms) are print into the debug logger, like this:

```
2021-01-25T13:01:34 [D|app|] Slow initializers:
2021-01-25T13:01:34 [D|app|]     130.85  ./config/initializers/apipie.rb
2021-01-25T13:01:34 [D|app|]     791.64  ./config/initializers/foreman.rb
2021-01-25T13:01:34 [D|app|]    2165.86  ./config/initializers/1_fast_gettext.rb
```

There is an excellent library https://github.com/nevir/Bumbler which does exactly that plus it can also track Bundler require timings, but it requires Bundler to be present. Foreman only uses Bundler for development and debian deployments, but on EL bundler_ext stub is used instead of that. Therefore the gem cannot be used, let's just implement timing of initializers ourselves.