### PR TITLE
Fixes #31718 - Remove use of {locations,organizations}_enabled

### DIFF
--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -23,8 +23,8 @@ module Menu
 
       Manager.map :admin_menu do |menu|
         menu.sub_menu :administer_menu,  :caption => N_('Administer'), :icon => 'fa fa-cog' do
-          menu.item :locations,          :caption => N_('Locations') if SETTINGS[:locations_enabled]
-          menu.item :organizations,      :caption => N_('Organizations') if SETTINGS[:organizations_enabled]
+          menu.item :locations,          :caption => N_('Locations')
+          menu.item :organizations,      :caption => N_('Organizations')
           menu.item :auth_sources,       :caption => N_('Authentication Sources')
           menu.item :users,              :caption => N_('Users')
           menu.item :usergroups,         :caption => N_('User Groups')


### PR DESCRIPTION
Since Foreman 1.21 locations and organizations are always enabled and this setting should no longer be used.

7389ec4006dbb2b21695fd5b774148cc61f02377 already removed these exact conditionals, but they were reintroduced in 6020f357300b196eef7abcaae4a0d9f4945d0039.