### PR TITLE
Fixes #31717 - lazy-load fast_gettext for faster boot

### DIFF
--- a/app/graphql/types/locale_enum.rb
+++ b/app/graphql/types/locale_enum.rb
@@ -1,7 +1,7 @@
 module Types
   class LocaleEnum < Types::BaseEnum
-    FastGettext.human_available_locales.each do |description, locale|
-      value locale, description: description
+    FastGettext.default_available_locales.each do |locale|
+      value locale, description: locale
     end
   end
 end

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -1,14 +1,21 @@
 class Setting::General < Setting
   include UrlValidator
 
+  # Lazy-load this to avoid loading this during Rails startup
+  def self.locales
+    Hash['' => _("Browser locale")].merge(Hash[FastGettext.human_available_locales.map { |lang| [lang[1], lang[0]] }])
+  end
+
+  # Lazy-load this to avoid loading this during Rails startup
+  def self.timezones
+    Hash['' => _("Browser timezone")].merge(Hash[ActiveSupport::TimeZone.all.map { |tz| [tz.name, "(GMT #{tz.formatted_offset}) #{tz.name}"] }])
+  end
+
   def self.default_settings
     protocol = SETTINGS[:require_ssl] ? 'https' : 'http'
     domain = SETTINGS[:domain]
     administrator = "root@#{domain}"
     foreman_url = "#{protocol}://#{SETTINGS[:fqdn]}"
-
-    locales = Hash['' => _("Browser locale")].merge(Hash[FastGettext.human_available_locales.map { |lang| [lang[1], lang[0]] }])
-    timezones = Hash['' => _("Browser timezone")].merge(Hash[ActiveSupport::TimeZone.all.map { |tz| [tz.name, "(GMT #{tz.formatted_offset}) #{tz.name}"] }])
 
     [
       set('administrator', N_("The default administrator email address"), administrator, N_('Administrator email address')),

--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -15,8 +15,6 @@ FastGettext.default_text_domain = locale_domain
 FastGettext.default_locale = "en"
 FastGettext.locale = "en"
 
-Foreman::Gettext::Support.register_human_localenames
-
 # work in all domains context by default (for plugins)
 include FastGettext::TranslationMultidomain
 

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -53,3 +53,10 @@ end
 
 # === Puma control rack application ===
 activate_control_app "unix://#{run_dir}/sockets/pumactl.sock"
+
+# Loading and initializing of all gettext languages takes about 100ms per language
+# in development environment and little less on production. Let's eager load languages
+# for production before forking to save memory on CoW operating systems.
+before_fork do
+  FastGettext.human_available_locales
+end

--- a/extras/dynflow-sidekiq.rb
+++ b/extras/dynflow-sidekiq.rb
@@ -10,6 +10,11 @@ require app_file
   world.before_termination do
     SdNotify.stopping
   end
+
+  # Loading and initializing of all gettext languages takes about 100ms per language
+  # in development environment and little less on production. Let's eager load languages
+  # but only for production.
+  FastGettext.human_available_locales
 end
 
 rails_env_file = File.expand_path('./config/environment.rb', rails_root)


### PR DESCRIPTION
It's because we switch over all 20 languages to actually pull language name in the native language into a list of available languages. We use that in three places: settings page, user page and GraphQL.

This can be easily made lazy-loaded, so those 2 seconds are not wasted during startup. Only few languages are usually used, definitely not all of them.

Ewoud had a good point that this will prefent from sharing the translation cache (about 20MB) so we actually preload translations, but only in production. This way we can enjoy startups of Foreman in a dev environment by 2 seconds (which is actually 17% for me) while preloading everything in production (where the operation is a bit faster).

See for more info: https://github.com/theforeman/foreman/pull/8273