### PR TITLE
Fixes #31720 - Add documentation for JavaScript state management

### DIFF
--- a/webpack/stories/docs/state-management.stories.mdx
+++ b/webpack/stories/docs/state-management.stories.mdx
@@ -35,18 +35,25 @@ This is the best place for any data that is _used only locally by the component_
 * current form values for form elements
 * Other UI element states
 
+Local state is also good for data that affects the component's direct children and can be easily passed down as props.
+
 ## Redux store
 
 The Redux store is used to store data that needs to be shared across many components, especially ones that don't share a common ancestry. Another case is when one component can trigger an action that could impact the state of another component that isn't directly in its ancestry.
 
-For the moment this includes API responses through the API middleware.
+Currently API responses are also stored in Redux by the API middleware.
+
+Don't default to using Redux when deciding where to put new data.  Keep other options in mind as well, and see if local state or context would make more sense.
+
+On the other hand, state management is not the only use for Redux.  It can also be useful for logging what happened and in what order, or triggering actions such as API calls.
 
 ## ForemanContext
 
-Data that doesn't often change but can impact many components across the application is stored in a special React Context object called ForemanContext.  For more info on how to use it, see foreman-context.stories.mdx // TODO link this
+Data that doesn't often change but can impact many components across the application is stored in a special React Context object called ForemanContext.  For more info on how to use it, see [Foreman Context](https://foreman-storybook.surge.sh/?path=/story/introduction-foreman-context--page).
 
 This data includes
 * Current taxonomy (organization, location)
+* Current user
 * Pagination settings
 * Foreman version
 
@@ -54,8 +61,8 @@ This data includes
 
 Because Foreman and plugins use both modern and legacy JS frameworks, Foreman has a unique way of storing some data on the global `window` object.  (See `webpack/assets/javascripts/bundle.js`.) This `tfm` object includes
 
-* A `componentRegistry` that makes React components accessible for mounting on Rails ERB pages // TODO add link
-* A method for legacy JS frameworks to access Foreman's Redux store // TODO add link
+* A [`componentRegistry`](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js) that makes React components accessible for mounting on Rails ERB pages.  For more info, see [Mounting components into ERB](https://foreman-storybook.surge.sh/?path=/story/introduction-plugins--page#1-mounting-components-into-erb).
+* A method for [legacy JS](https://foreman-storybook.surge.sh/?path=/story/introduction-legacy-js--page) frameworks to access Foreman's Redux store
 * Several other utilities and helpers written in jQuery and vanilla JavaScript
 
 Other than the `tfm` object, it is not advisable to store anything on the global `window` object.
@@ -68,6 +75,8 @@ React Router also uses React Context under the hood.
 
 ## localStorage and sessionStorage
 
-The browser's `sessionStorage` is currently used to store some user preferences; see `LayoutSessionStorage.js`, `HostSessionStorage.js`, and `NotificationDrawerSessionStorage.js`
+The browser's `sessionStorage` is currently used to store some user preferences; see `LayoutSessionStorage.js`, `HostSessionStorage.js`, and `NotificationDrawerSessionStorage.js`.
+
+`sessionStorage` should only be used for volatile, temporary state-- i.e. things that won't impact the user if they get lost.
 
 Currently the browser `localStorage` is not used by Foreman.  It is recommended to use the Redux store instead.

--- a/webpack/stories/docs/state-management.stories.mdx
+++ b/webpack/stories/docs/state-management.stories.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@theforeman/stories';
 
 <Meta
-  title="Introduction/Where to Put Stuff"
+  title="Introduction/Where to Put Data"
   parameters={{
     storyWeight: 132,
   }}
@@ -64,6 +64,8 @@ Because Foreman and plugins use both modern and legacy JS frameworks, Foreman ha
 * A [`componentRegistry`](https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/componentRegistry.js) that makes React components accessible for mounting on Rails ERB pages.  For more info, see [Mounting components into ERB](https://foreman-storybook.surge.sh/?path=/story/introduction-plugins--page#1-mounting-components-into-erb).
 * A method for [legacy JS](https://foreman-storybook.surge.sh/?path=/story/introduction-legacy-js--page) frameworks to access Foreman's Redux store
 * Several other utilities and helpers written in jQuery and vanilla JavaScript
+
+Should be used only if legacy code needs access to such data or methods. Avoid using it if possible.
 
 Other than the `tfm` object, it is not advisable to store anything on the global `window` object.
 

--- a/webpack/stories/docs/state-management.stories.mdx
+++ b/webpack/stories/docs/state-management.stories.mdx
@@ -1,0 +1,73 @@
+import { Meta } from '@theforeman/stories';
+
+<Meta
+  title="Introduction/Where to Put Stuff"
+  parameters={{
+    storyWeight: 132,
+  }}
+/>
+
+# State Management in Foreman & Plugins
+
+Where do I put data so that it's accessible by the React components that need it?
+
+Currently Foreman has a few places for storing data:
+
+* Component state
+* Redux store
+* ForemanContext
+* Global `window` object
+* Other React Context
+* localStorage and sessionStorage
+* Routing
+
+The following sections will outline
+
+*  The architecture around how we use each method
+*  Current opinions on best practices.
+
+## Local component state
+
+This includes anything that uses `useState` or `useReducer` hooks.  Or, in class components, `this.state`.  See the React docs for more info.
+
+This is the best place for any data that is _used only locally by the component_: for example
+* input value for a controlled UI component
+* current form values for form elements
+* Other UI element states
+
+## Redux store
+
+The Redux store is used to store data that needs to be shared across many components.
+
+For the moment this includes API responses through the API middleware.
+
+## ForemanContext
+
+Data that doesn't often change is stored in a special React Context object called ForemanContext.  For more info on how to use it, see foreman-context.stories.mdx // TODO link this
+
+This data includes
+* Current taxonomy (organization, location)
+* Pagination settings
+* Foreman version
+
+## Global `window` object
+
+Because Foreman and plugins use both modern and legacy JS frameworks, Foreman has a unique way of storing some data on the global `window` object.  (See `webpack/assets/javascripts/bundle.js`.) This `tfm` object includes
+
+* A `componentRegistry` that makes React components accessible for mounting on Rails ERB pages // TODO add link
+* A method for legacy JS frameworks to access Foreman's Redux store // TODO add link
+* Several other utilities and helpers written in jQuery and vanilla JavaScript
+
+Other than the `tfm` object, it is not advisable to store anything on the global `window` object.
+
+## Other React Context
+
+Consider the `ForemanModal` component, which is a composite React component which needs to pass data down to its subcomponents.  However, this data is not used or needed by anything other than ForemanModal internals.  For these specific use cases, it makes sense to use a React Context instance that is not connected to `ForemanContext`.
+
+React Router also uses React Context under the hood.
+
+## localStorage and sessionStorage
+
+The browser's `sessionStorage` is currently used to store some user preferences; see `LayoutSessionStorage.js`, `HostSessionStorage.js`, and `NotificationDrawerSessionStorage.js`
+
+Currently the browser `localStorage` is not used by Foreman.  It is recommended to use the Redux store instead.

--- a/webpack/stories/docs/state-management.stories.mdx
+++ b/webpack/stories/docs/state-management.stories.mdx
@@ -37,13 +37,13 @@ This is the best place for any data that is _used only locally by the component_
 
 ## Redux store
 
-The Redux store is used to store data that needs to be shared across many components.
+The Redux store is used to store data that needs to be shared across many components, especially ones that don't share a common ancestry. Another case is when one component can trigger an action that could impact the state of another component that isn't directly in its ancestry.
 
 For the moment this includes API responses through the API middleware.
 
 ## ForemanContext
 
-Data that doesn't often change is stored in a special React Context object called ForemanContext.  For more info on how to use it, see foreman-context.stories.mdx // TODO link this
+Data that doesn't often change but can impact many components across the application is stored in a special React Context object called ForemanContext.  For more info on how to use it, see foreman-context.stories.mdx // TODO link this
 
 This data includes
 * Current taxonomy (organization, location)
@@ -60,7 +60,7 @@ Because Foreman and plugins use both modern and legacy JS frameworks, Foreman ha
 
 Other than the `tfm` object, it is not advisable to store anything on the global `window` object.
 
-## Other React Context
+## Other React Contexts
 
 Consider the `ForemanModal` component, which is a composite React component which needs to pass data down to its subcomponents.  However, this data is not used or needed by anything other than ForemanModal internals.  For these specific use cases, it makes sense to use a React Context instance that is not connected to `ForemanContext`.
 


### PR DESCRIPTION
In the UI interest group meeting we discussed coming to a consensus on how we use the Redux store and other methods of state management in Foreman's React code. This is to add a document to the Storybook outlining Foreman's best practices, etc.
﻿
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
