### PR TITLE
Fixes #31722 - Improve url validation for HTTP proxies

### DIFF
--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -16,8 +16,7 @@ class HttpProxy < ApplicationRecord
 
   validates :name, :presence => true, :uniqueness => true
 
-  validates :url, :presence => true
-  validates :url, :format => URI.regexp(["http", "https"])
+  validates :url, :format => { :with => /\Ahttps?:\/\// }, :presence => true
 
   # with proc support, default_scope can no longer be chained
   # include all default scoping here


### PR DESCRIPTION
We should not accept http:foo.com as a valid URL.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
