### PR TITLE
Fixes #31730 - cleaner event name and documentation

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -165,7 +165,7 @@ module Foreman #:nodoc:
     attr_reader :id, :logging, :provision_methods, :compute_resources, :to_prepare_callbacks,
       :facets, :rbac_registry, :dashboard_widgets, :info_providers, :smart_proxy_references,
       :renderer_variable_loaders, :host_ui_description, :ping_extension, :status_extension,
-      :allowed_registration_vars
+      :allowed_registration_vars, :observable_events
 
     # Lists plugin's roles:
     # Foreman::Plugin.find('my_plugin').registered_roles
@@ -191,6 +191,7 @@ module Foreman #:nodoc:
       @ping_extension = nil
       @status_extension = nil
       @allowed_registration_vars = []
+      @observable_events = []
     end
 
     def engine
@@ -606,6 +607,10 @@ module Foreman #:nodoc:
 
     def extend_allowed_registration_vars(var)
       @allowed_registration_vars << var
+    end
+
+    def extend_observable_events(events)
+      (@observable_events << events).flatten!.uniq!
     end
 
     delegate :subscribe, to: ActiveSupport::Notifications

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -2162,6 +2162,12 @@ Payload for background jobs is the serialized active job hash (see `ActiveJob#se
 }
 ```
 
+Example events emitted by Remote Execution plugin:
+
+* actions.remote_execution.run_host_job_succeeded
+
+Foreman Webhooks plugin ships with an example "Remote Execution Host Job" template.
+
 You can find all observable events by calling `Foreman::EventSubscribers.all_observable_events` in the Rails console. 
 
 [[translating]]

--- a/lib/foreman/event_subscribers.rb
+++ b/lib/foreman/event_subscribers.rb
@@ -8,7 +8,8 @@ module Foreman
           Rails.application.eager_load!
         end
         ApplicationRecord.descendants.select { |klass| klass <= ::Foreman::ObservableModel }.map(&:event_subscription_hooks) +
-        ApplicationJob.descendants.select { |klass| klass <= ::Foreman::ObservableJob }.map(&:event_subscription_hooks)
+        ApplicationJob.descendants.select { |klass| klass <= ::Foreman::ObservableJob }.map(&:event_subscription_hooks) +
+        Foreman::Plugin.all.map(&:observable_events)
       end.flatten.uniq
     end
   end

--- a/lib/foreman/observable.rb
+++ b/lib/foreman/observable.rb
@@ -13,7 +13,7 @@ module Foreman
     private
 
     def event_name_for(hook_name, namespace: DEFAULT_NAMESPACE)
-      [hook_name, namespace].compact.join('.')
+      [hook_name.to_s.tr('/', '.'), namespace].compact.join('.')
     end
     module_function :event_name_for
 


### PR DESCRIPTION
Events created from Ruby namespace often contain slash characters which looks weird: actions/remote_execution/run_hosts_job_stopped.event.foreman.event.foreman

Let's convert them to dots.

Do not merge yet, we are still discussing format of the event in foreman-tasks PR: https://github.com/theforeman/foreman-tasks/pull/605