### PR TITLE
Fixes #31573 - drop IPAPPEND2 and use BOOTIF with 01 prefix (2.3 CP)

### DIFF
--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -24,13 +24,6 @@ LABEL installer
   MENU LABEL <%= template_name %>
   KERNEL <%= @kernel %>
   APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-<%
-  # workaround for EL 8.3: https://projects.theforeman.org/issues/31452
-  unless rhel_compatible && os_major == 8 && os_minor == 3
--%>
   IPAPPEND 2
-<%
-  end
--%>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -22,11 +22,9 @@ snippet: true
     options.push("network", "ksdevice=bootif", "ks.device=bootif")
   end
 
-  if mac && rhel_compatible && os_major == 8 && os_minor == 3
-    # workaround for EL 8.3: https://projects.theforeman.org/issues/31452
-    options.push("BOOTIF=#{mac.gsub(':', '-')}")
-  elsif mac
-    options.push("BOOTIF=00-#{mac.gsub(':', '-')}")
+  if mac
+    # hardware type is always 01 (ethernet) unless specified otherwise
+    options.push("BOOTIF=#{host_param("hardware_type", "01")}-#{mac.gsub(':', '-')}")
   end
 
   # tell Anaconda what to pass off to kickstart server

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart default PXEGrub.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart default PXEGrub.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../ ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=00-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+  kernel (nd)/../ ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
   initrd (nd)/../
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart default PXEGrub2.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart default PXEGrub2.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linuxefi  ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=00-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+  linuxefi  ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
   initrdefi 
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart default PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart default PXELinux.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
   MENU LABEL Kickstart default PXELinux
   KERNEL 
-  APPEND initrd= ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=00-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+  APPEND initrd= ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
   IPAPPEND 2
 
 


### PR DESCRIPTION
In order to be able to provision EL 8.4 and later, this fix is needed for the final solution to the problem. This was delayed due to longer discussion with Anaconda/NM team on how to approach this.

(cherry picked from commit 789225c2a67684eb1699ada81770c8d0c120046d)

https://github.com/theforeman/foreman/pull/8230