### PR TITLE
Fixes #31738 - deprecate environment in templates API

### DIFF
--- a/app/controllers/api/v2/template_combinations_controller.rb
+++ b/app/controllers/api/v2/template_combinations_controller.rb
@@ -5,16 +5,17 @@ module Api
 
       before_action :find_optional_nested_object
       before_action :find_resource, :only => [:show, :update, :destroy]
+      before_action :deprecation_warning
 
       def_param_group :template_combination_identifiers do
         param :provisioning_template_id, String, :desc => N_("ID of config template")
         param :hostgroup_id, String, :desc => N_("ID of host group")
-        param :environment_id, String, :desc => N_("ID of environment")
+        param :environment_id, String, :desc => N_("ID of environment - DEPRECATED will have no effect")
       end
 
       api :GET, "/provisioning_templates/:provisioning_template_id/template_combinations", N_("List template combination")
       api :GET, "/hostgroups/:hostgroup_id/template_combinations", N_("List template combination")
-      api :GET, "/environments/:environment_id/template_combinations", N_("List template combination")
+      api :GET, "/environments/:environment_id/template_combinations", N_("DEPRECATED: List template combination")
       param_group :template_combination_identifiers
       def index
         @template_combinations = nested_obj.template_combinations
@@ -30,7 +31,7 @@ module Api
 
       api :POST, "/provisioning_templates/:provisioning_template_id/template_combinations", N_("Add a template combination")
       api :POST, "/hostgroups/:hostgroup_id/template_combinations", N_("Add a template combination")
-      api :POST, "/environments/:environment_id/template_combinations", N_("Add a template combination")
+      api :POST, "/environments/:environment_id/template_combinations", N_("DEPRECATED: Add a template combination")
       param_group :template_combination_identifiers
       param_group :template_combination, :as => :create
 
@@ -42,7 +43,7 @@ module Api
       api :GET, "/template_combinations/:id", N_("Show template combination")
       api :GET, "/provisioning_templates/:provisioning_template_id/template_combinations/:id", N_("Show template combination")
       api :GET, "/hostgroups/:hostgroup_id/template_combinations/:id", N_("Show template combination")
-      api :GET, "/environments/:environment_id/template_combinations/:id", N_("Show template combination")
+      api :GET, "/environments/:environment_id/template_combinations/:id", N_("DEPRECATED: Show template combination")
       param_group :template_combination_identifiers
       param :id, :identifier, :required => true
       def show
@@ -50,7 +51,7 @@ module Api
 
       api :PUT, "/provisioning_templates/:provisioning_template_id/template_combinations/:id", N_("Update template combination")
       api :PUT, "/hostgroups/:hostgroup_id/template_combinations/:id", N_("Update template combination")
-      api :PUT, "/environments/:environment_id/template_combinations/:id", N_("Update template combination")
+      api :PUT, "/environments/:environment_id/template_combinations/:id", N_("DEPRECATED: Update template combination")
       param :id, :identifier, :required => true
       param_group :template_combination_identifiers
       param_group :template_combination
@@ -70,6 +71,16 @@ module Api
 
       def allowed_nested_id
         %w(environment_id hostgroup_id provisioning_template_id)
+      end
+
+      def deprecation_warning
+        if request.path =~ /^\/environments\//
+          if params[:action] == :index
+            Foreman::Deprecation.api_deprecation_warning('This endpoint will be extracted to ForemanPuppetEnc plugin')
+          else
+            Foreman::Deprecation.api_deprecation_warning('Please use /template_combinations endpoint directly')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Environments are being extracted to the ForemanPuppetEnc plugin.
API endpoints using environments are going to be extracted there, we are deprecating them to remove them in the future.
