### PR TITLE
Fixes #31746 - add custom error alert to settings page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingForm/SettingForm.js
+++ b/webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingForm/SettingForm.js
@@ -28,6 +28,8 @@ const SettingForm = ({
       item: 'Settings',
       message: __('Setting was successfully updated.'),
       method: 'put',
+      customErrorAlert: ({ response: { data }, message }) =>
+        data.error ? data.error.full_messages : message,
     });
     setModalClosed();
   };

--- a/webpack/assets/javascripts/react_app/redux/actions/common/__snapshots__/forms.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/__snapshots__/forms.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`form actions should submitForm 1`] = `
+Array [
+  Array [
+    Object {
+      "payload": Object {
+        "actionTypes": undefined,
+        "errorToast": [Function],
+        "handleError": [Function],
+        "handleSuccess": [Function],
+        "headers": Object {},
+        "key": "RESOURCE_FORM_SUBMITTED",
+        "params": Object {
+          "a": 1,
+        },
+        "successToast": [Function],
+        "url": "/api/resource",
+      },
+      "type": "API_POST",
+    },
+  ],
+]
+`;

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.fixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.fixtures.js
@@ -1,7 +1,11 @@
 export const requestData = {
-  values: { a: 1 },
-  url: '/api/resource',
+  headers: {},
   item: 'Resource',
+  url: '/api/resource',
+  values: { a: 1 },
+  customErrorAlert: () => {
+    return 'Value should not be blank';
+  },
 };
 
 export const requestDataMsg = Object.assign({}, requestData, {

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -52,6 +52,7 @@ export const submitForm = ({
   message,
   method = 'post',
   headers,
+  customErrorAlert,
   apiActionTypes: actionTypes,
   errorToast,
   successToast,
@@ -89,7 +90,7 @@ export const submitForm = ({
         handleError,
         handleSuccess,
         successToast: successToast || defaultSuccessToast,
-        errorToast: errorToast || defaultErrorToast,
+        errorToast: customErrorAlert || errorToast,
       })
     );
   };

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
@@ -1,8 +1,16 @@
 /* eslint-disable promise/prefer-await-to-then */
 import { submitForm } from './forms';
 import { mockReset } from '../../../mockRequests';
+import { requestData } from './forms.fixtures';
+import { testActionSnapshotWithFixtures } from '../../../common/testHelpers';
+
+const fixtures = {
+  'should submitForm': () => submitForm(requestData),
+};
 
 describe('form actions', () => {
+  testActionSnapshotWithFixtures(fixtures);
+
   beforeEach(() => {
     document.head.innerHTML = `<meta name="csrf-param" content="authenticity_token" />
      <meta name="csrf-token" content="token123" />`;


### PR DESCRIPTION
This PR makes sure a correct error message is displayed while there is a validation error for any settings field. This PR fixes the toast notification bar error to display appropriate error.

@laviro can you please take a look? 