### PR TITLE
Fixes #31742 - enable eager_load in dev environment

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -6,8 +6,8 @@ Foreman::Application.configure do
   # since you don't have to restart the web server when you make code changes.
   config.cache_classes = false
 
-  # Do not eager load code on boot.
-  config.eager_load = false
+  # Eager load is set for all environments
+  config.eager_load = true
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,10 +3,7 @@ Foreman::Application.configure do |app|
   # Code is not reloaded between requests.
   config.cache_classes = true
 
-  # Eager load code on boot. This eager loads most of Rails and
-  # your application in memory, allowing both threaded web servers
-  # and those relying on copy on write to perform better.
-  # Rake tasks automatically ignore this option for performance.
+  # Eager load is set for all environments
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -12,9 +12,7 @@ Foreman::Application.configure do
   # and recreated between test runs. Don't rely on the data there!
   config.cache_classes = true
 
-  # Do not eager load code on boot. This avoids loading your whole application
-  # just for the purpose of running a single test. If you are using a tool that
-  # preloads Rails for running tests, you may have to set it to true.
+  # Eager load currently cannot be set due to: https://projects.theforeman.org/issues/31977
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.


### PR DESCRIPTION
We have some features which lists all classes (e.g. descendants of a class) during boot. This creates situations when Foreman does not behave the same as in production and it can lead to confusion for users who don’t know about this problem. For example, when working on Subscription API (Foreman events and webhooks), you actually need to turn on eager_load to be able to do anything reasonable.

Discussion: https://community.theforeman.org/t/rfc-turn-eager-load-on-for-development/22125