### PR TITLE
Fixes #31750 - :foreman_server_ca_cert macro & not existing file

### DIFF
--- a/lib/foreman/renderer/errors.rb
+++ b/lib/foreman/renderer/errors.rb
@@ -46,6 +46,10 @@ module Foreman
       class HostgroupNotFoundError < RenderingError
         MESSAGE = N_('Hostgroup not found or not accessible').freeze
       end
+
+      class UndefinedSetting < RenderingError
+        MESSAGE = N_("Undefined setting '%{setting}'").freeze
+      end
     end
   end
 end

--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -342,10 +342,11 @@ module Foreman
                      curl --cacert $SSL_CA_CERT https://smart-proxy.example.com:8443"
           end
           def foreman_server_ca_cert
-            if File.exist?(Setting[:ssl_ca_file])
+            raise UndefinedSetting.new(setting: 'SSL CA file') if Setting[:ssl_ca_file].blank?
+            begin
               File.read(Setting[:ssl_ca_file])
-            else
-              msg = N_("SSL CA file not found, check the 'SSL CA file' in Settings > Authentication")
+            rescue => e
+              msg = N_("%s, check the 'SSL CA file' in Settings > Authentication") % e.message
               raise Foreman::Exception.new(msg)
             end
           end

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -215,9 +215,22 @@ module RenderersSharedTests
     test "foreman_server_ca_cert - not existing file" do
       Setting[:ssl_ca_file] = 'not-existing-file'
       source = OpenStruct.new(content: '<%= foreman_server_ca_cert %>')
-      assert_raise Foreman::Exception do
+      error = assert_raise Foreman::Exception do
         renderer.render(source, @scope)
       end
+
+      assert_includes error.message, '[Foreman::Exception]: No such file or directory'
+    end
+
+    test "foreman_server_ca_cert - blank setting" do
+      Setting[:ssl_ca_file] = ''
+      source = OpenStruct.new(content: '<%= foreman_server_ca_cert %>')
+      error = assert_raise Foreman::Renderer::Errors::UndefinedSetting do
+        renderer.render(source, @scope)
+      end
+
+      # assert_includes error.message, "No CA file set, check the 'SSL CA file' in Settings > Authentication"
+      assert_includes error.message, "Undefined setting 'SSL CA file'"
     end
 
     context 'renderer for template with user input used' do


### PR DESCRIPTION
```
curl -X GET "https://foreman.example.com/register" --user admin:changeme
```

Before:
```
echo "ERROR: standard_error";
echo "no implicit conversion of nil into String";
exit 1
```

Now:
```
echo "ERROR: standard_error";
echo "ERF42-9049 [Foreman::Exception]: SSL CA file not found, check the 'SSL CA file' in Settings > Authentication";
exit 1
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
