### PR TITLE
Fixes #31751 - make enable-epel false by default

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -35,7 +35,7 @@ runcmd:
 - |
 <%= indent(2) { snippet 'ntp' } -%>
 - |
-<% if rhel_compatible && !host_param_false?('enable-epel') -%>
+<% if rhel_compatible && host_param_true?('enable-epel') -%>
 <%= indent(2) { snippet 'epel' } -%>
 <% end -%>
 - |

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -36,7 +36,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 
 <%= snippet 'ntp' %>
 
-<% if rhel_compatible && !host_param_false?('enable-epel') -%>
+<% if rhel_compatible && host_param_true?('enable-epel') -%>
 <%= snippet 'epel' -%>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -16,7 +16,7 @@ This template accepts the following parameters:
 - http-proxy: string (default="")
 - http-proxy-port: string (default="")
 - force-puppet: boolean (default=false)
-- enable-epel: boolean (default=true)
+- enable-epel: boolean (default=false)
 - enable-puppetlabs-repo: boolean (default=false)
 - enable-puppetlabs-puppet5-repo: boolean (default=false)
 - enable-puppetlabs-puppet6-repo: boolean (default=false)
@@ -271,7 +271,7 @@ logger "Starting anaconda <%= @host %> postinstall"
 
 <%= snippet 'yum_proxy' %>
 
-<% if rhel_compatible && !host_param_false?('enable-epel') -%>
+<% if rhel_compatible && host_param_true?('enable-epel') -%>
 <%= snippet 'epel' -%>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -27,7 +27,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 
 <%= snippet 'ntp' %>
 
-<% if rhel_compatible && !host_param_false?('enable-epel') -%>
+<% if rhel_compatible && host_param_true?('enable-epel') -%>
 <%= snippet 'epel' -%>
 <% end -%>
 


### PR DESCRIPTION
Users should explicitly opt-in to have EPEL enabled on their systems

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
