### PR TITLE
Fixes #30699 - Log invalid JWT at warning instead of error

### DIFF
--- a/app/services/sso/jwt.rb
+++ b/app/services/sso/jwt.rb
@@ -19,10 +19,10 @@ module SSO
       @current_user = user
       user&.login
     rescue JWT::ExpiredSignature
-      Rails.logger.error "JWT SSO: Expired JWT token."
+      Rails.logger.warn "JWT SSO: Expired JWT token."
       nil
     rescue JWT::DecodeError
-      Rails.logger.error "JWT SSO: Failed to decode JWT."
+      Rails.logger.warn "JWT SSO: Failed to decode JWT."
       nil
     end
 


### PR DESCRIPTION
Logging error for broken or expired JWT should not use error level, it's expected error, so it should probably use warning.
- https://projects.theforeman.org/issues/30699
