### PR TITLE
Host Registration - Install packages

### DIFF
--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -25,6 +25,9 @@ set -e
 
 <% end -%>
 
+<%= install_packages(host_param('host_packages')) -%>
+<%= snippet_if_exists('host_init_config_post') -%>
+
 <% if host_param_true?('host_registration_insights') -%>
 <%= snippet 'insights' %>
 

--- a/db/seeds.d/180-common_parameters.rb
+++ b/db/seeds.d/180-common_parameters.rb
@@ -2,6 +2,7 @@ CommonParameter.without_auditing do
   params = [
     { name: "host_registration_insights", key_type: "boolean", value: false },
     { name: "host_registration_remote_execution", key_type: "boolean", value: true },
+    { name: "host_packages", key_type: "string", value: "" },
   ]
 
   params.each { |param| CommonParameter.find_or_create_by(param) }

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -61,7 +61,8 @@ module Foreman
         :host_param_true?, :host_param_false?,
         :host_param, :host_param!,
         :host_puppet_classes,
-        :host_enc
+        :host_enc,
+        :install_packages
       ]
 
       DEFAULT_ALLOWED_VARIABLES = [

--- a/lib/foreman/renderer/errors.rb
+++ b/lib/foreman/renderer/errors.rb
@@ -50,6 +50,10 @@ module Foreman
       class UndefinedSetting < RenderingError
         MESSAGE = N_("Undefined setting '%{setting}'").freeze
       end
+
+      class UnsupportedOS < RenderingError
+        MESSAGE = N_('Unsupported or no operating system found for this host.').freeze
+      end
     end
   end
 end

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -147,4 +147,91 @@ class HostTemplateTest < ActiveSupport::TestCase
       assert_equal 'console=ttyS0,9600', @scope.ks_console
     end
   end
+
+  describe '#install_packages' do
+    test 'no packages' do
+      os = FactoryBot.create(:operatingsystem, family: 'Redhat', name: 'CentOS')
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+
+      assert_includes '', @scope.install_packages(nil)
+    end
+
+    test 'no OS' do
+      host = FactoryBot.create(:host, operatingsystem: nil)
+      @scope.instance_variable_set('@host', host)
+
+      error = assert_raises(Foreman::Renderer::Errors::UnsupportedOS) do
+        @scope.install_packages('pkg1')
+      end
+
+      assert_includes error.message, 'Unsupported or no operating system found for this host.'
+    end
+
+    test 'unsupported OS' do
+      os = FactoryBot.create(:operatingsystem, family: 'AIX')
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+
+      error = assert_raises(Foreman::Renderer::Errors::UnsupportedOS) do
+        @scope.install_packages('pkg1')
+      end
+
+      assert_includes error.message, 'Unsupported or no operating system found for this host.'
+    end
+
+    test 'RHEL 7' do
+      os = FactoryBot.create(:operatingsystem, family: 'Redhat', name: 'RedHat', major: 7)
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+      command = @scope.install_packages('pkg1')
+
+      assert_includes command, 'yum -y install pkg1'
+    end
+
+    test 'RHEL 8' do
+      os = FactoryBot.create(:operatingsystem, family: 'Redhat', name: 'RedHat', major: 8)
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+      command = @scope.install_packages('pkg1')
+
+      assert_includes command, 'dnf -y install pkg1'
+    end
+
+    test 'fedora 21' do
+      os = FactoryBot.create(:operatingsystem, family: 'Redhat', name: 'Fedora', major: 21)
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+      command = @scope.install_packages('pkg1')
+
+      assert_includes command, 'yum -y install pkg1'
+    end
+
+    test 'fedora 22' do
+      os = FactoryBot.create(:operatingsystem, family: 'Redhat', name: 'Fedora', major: 22)
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+      command = @scope.install_packages('pkg1')
+
+      assert_includes command, 'dnf -y install pkg1'
+    end
+
+    test 'debian' do
+      os = FactoryBot.create(:operatingsystem, family: 'Debian', name: 'Debian', release_name: 'Buster')
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+      command = @scope.install_packages('pkg1')
+
+      assert_includes command, 'apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y install pkg1'
+    end
+
+    test 'openSUSE' do
+      os = FactoryBot.create(:operatingsystem, family: 'Suse', name: 'OpenSUSE')
+      host = FactoryBot.create(:host, operatingsystem: os)
+      @scope.instance_variable_set('@host', host)
+      command = @scope.install_packages('pkg1')
+
+      assert_includes command, 'zypper -n install pkg1'
+    end
+  end
 end


### PR DESCRIPTION
New host macro `:manage_packages` for package installation
on supported OS families: Red Hat, Debian & Suse.

In host registration users can now install packages
on the host by setting the `host_registration_packages`.