### PR TITLE
Fixes #31786 - Add cache ability to the API middleware

### DIFF
--- a/webpack/assets/javascripts/react_app/common/testHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/testHelpers.js
@@ -148,3 +148,17 @@ export const testSelectorsSnapshotWithFixtures = fixtures =>
   Object.entries(fixtures).forEach(([description, selectorRunner]) =>
     it(description, () => expect(selectorRunner()).toMatchSnapshot())
   );
+
+/**
+ * Mock Date.now() with a custom time
+ * @param  {Object} time  time in ms (i.e 1530518207007)
+ * @return {Function} returns a callback to stop mocking the global Date
+ */
+export const mockNowDate = time => {
+  const realDateNow = Date.now.bind(global.Date);
+  const dateNowStub = jest.fn(() => time);
+  global.Date.now = dateNowStub;
+  return () => {
+    global.Date.now = realDateNow;
+  };
+};

--- a/webpack/assets/javascripts/react_app/redux/API/APIFixtures.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIFixtures.js
@@ -26,6 +26,19 @@ export const action = {
   },
 };
 
+export const actionWithTimestamp = {
+  type: API_OPERATIONS.GET,
+  payload: {
+    key,
+    url,
+    headers,
+    params,
+    actionTypes,
+    payload,
+    expiresIn: 15000,
+  },
+};
+
 export const middlewareActions = {
   request: {
     type: actionTypes.REQUEST,

--- a/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
@@ -22,3 +22,6 @@ export const selectAPIErrorMessage = (state, key) => {
   const error = selectAPIError(state, key);
   return error && error.message;
 };
+
+export const selectAPITimestamp = (state, key) =>
+  selectAPIPayload(state, key)?.timestamp;

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APISelectors.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APISelectors.test.js
@@ -7,6 +7,7 @@ import {
   selectAPIErrorMessage,
   selectAPIResponse,
   selectAPIPayload,
+  selectAPITimestamp,
 } from '../APISelectors';
 import { key, payload, data, error } from '../APIFixtures';
 import { STATUS } from '../../../constants';
@@ -31,6 +32,13 @@ const failureState = {
   },
 };
 
+const withTimestamp = {
+  API: {
+    [key]: {
+      payload: { timestamp: 10000 }
+    }
+  }
+}
 const fixtures = {
   'should return the API wrapper': () => selectAPI(successState),
   'should return the API substate by key': () =>
@@ -45,6 +53,8 @@ const fixtures = {
     selectAPIError(failureState, key),
   'should return the API substate error message': () =>
     selectAPIErrorMessage(failureState, key),
+  'should return the API current timestamp': () =>
+    selectAPITimestamp(withTimestamp, key),
 };
 
 describe('API selectors', () => testSelectorsSnapshotWithFixtures(fixtures));

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -196,3 +196,36 @@ Array [
   ],
 ]
 `;
+
+exports[`API get should dispatch when timestamp is outdated 1`] = `
+Array [
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "url": "some/url",
+      },
+      "type": "SOME_KEY_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "key": "SOME_KEY",
+      "payload": Object {
+        "id": 2,
+        "timestamp": 1530518207007,
+        "url": "some/url",
+      },
+      "response": Object {
+        "results": Array [
+          1,
+        ],
+      },
+      "type": "SOME_KEY_SUCCESS",
+    },
+  ],
+]
+`;
+
+exports[`API get should not dispatch when timestamp is valid 1`] = `Array []`;

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APISelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APISelectors.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`API selectors should return the API current timestamp 1`] = `10000`;
+
 exports[`API selectors should return the API substate by key 1`] = `
 Object {
   "payload": Object {

--- a/webpack/stories/docs/api-middleware.stories.mdx
+++ b/webpack/stories/docs/api-middleware.stories.mdx
@@ -150,3 +150,17 @@ dispatch(
   })
 );
 ```
+
+## With timestamp
+
+In order to avoid redundant API calls, you can define an optional minimum delta time between API calls.
+
+```js
+dispatch(
+  get({
+    key: MY_SPECIAL_KEY,
+    url,
+    expiresIn: 10000, // an API call with the same key won't be dispatched unless at least 10 seconds been passed
+  })
+);
+```


### PR DESCRIPTION
This optional timestamp addition defines a minimum delta time between dispatching the same API call multiple times, mainly for avoiding redundant API calls.

Example:
```js
dispatch(
  get({
    key: MY_SPECIAL_KEY,
    url,
    withTimestamp: 10000, // an API call with the same key won't be dispatched unless at least 10 seconds been passed
  })
);
```