### PR TITLE
Fixes #31791 - Add duplicate name validation to bookmarks

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.js
@@ -37,6 +37,7 @@ const Bookmarks = props => {
         controller={controller}
         url={url}
         setModalClosed={setModalClosed}
+        bookmarks={bookmarks}
       />
       <Dropdown pullRight id={controller} onClick={loadBookmarks}>
         <Dropdown.Toggle title={__('Bookmarks')}>

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksActions.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/BookmarksActions.js
@@ -13,7 +13,7 @@ export const getBookmarks = (url, controller) => {
   const uri = new URI(url);
 
   // eslint-disable-next-line camelcase
-  uri.setSearch({ search: `controller=${controller}`, per_page: 100 });
+  uri.setSearch({ search: `controller=${controller}`, per_page: 'all' });
 
   return _getBookmarks(uri.toString(), controller);
 };

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
@@ -3,6 +3,15 @@
 exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
 <Fragment>
   <SearchModal
+    bookmarks={
+      Array [
+        Object {
+          "controller": "architectures",
+          "name": "my-bookmark",
+          "query": "name ~ 86",
+        },
+      ]
+    }
     controller="architectures"
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
@@ -76,6 +85,7 @@ exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
 exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
 <Fragment>
   <SearchModal
+    bookmarks={Array []}
     controller="architectures"
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
@@ -154,6 +164,7 @@ exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
 exports[`Bookmarks should render when no bookmarks loaded 1`] = `
 <Fragment>
   <SearchModal
+    bookmarks={Array []}
     controller="architectures"
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
@@ -230,6 +241,7 @@ exports[`Bookmarks should render when no bookmarks loaded 1`] = `
 exports[`Bookmarks should show error 1`] = `
 <Fragment>
   <SearchModal
+    bookmarks={Array []}
     controller="architectures"
     onEnter={[Function]}
     setModalClosed={[MockFunction]}

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/integration.test.js.snap
@@ -10,7 +10,7 @@ Object {
           "payload": Object {
             "controller": "hosts",
           },
-          "url": "/api/v2/hosts?search=controller%3Dhosts&per_page=100",
+          "url": "/api/v2/hosts?search=controller%3Dhosts&per_page=all",
         },
         "type": "API_GET",
       },
@@ -43,7 +43,7 @@ Object {
         "key": "BOOKMARKS",
         "payload": Object {
           "controller": "hosts",
-          "url": "/api/v2/hosts?search=controller%3Dhosts&per_page=100",
+          "url": "/api/v2/hosts?search=controller%3Dhosts&per_page=all",
         },
         "response": Object {
           "results": Array [

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/BookmarkForm.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/BookmarkForm.js
@@ -8,15 +8,6 @@ import TextField from '../../../common/forms/TextField';
 import { translate as __ } from '../../../../../react_app/common/I18n';
 import { maxLengthMsg, requiredMsg } from '../../../common/forms/validators';
 
-const bookmarkFormSchema = Yup.object().shape({
-  name: Yup.string()
-    .max(...maxLengthMsg(254))
-    .required(requiredMsg()),
-  query: Yup.string()
-    .max(...maxLengthMsg(4096))
-    .required(requiredMsg()),
-});
-
 const BookmarkForm = ({
   url,
   submitForm,
@@ -24,7 +15,23 @@ const BookmarkForm = ({
   onCancel,
   initialValues,
   setModalClosed,
+  bookmarks,
 }) => {
+  const existsNamesRegex = new RegExp(
+    `^(?!(${bookmarks.map(({ name }) => name).join('|')})$).+`
+  );
+  const bookmarkFormSchema = Yup.object().shape({
+    name: Yup.string()
+      .max(...maxLengthMsg(254))
+      .required(requiredMsg())
+      .matches(existsNamesRegex, {
+        excludeEmptyString: true,
+        message: __('name already exists'),
+      }),
+    query: Yup.string()
+      .max(...maxLengthMsg(4096))
+      .required(requiredMsg()),
+  });
   const handleSubmit = async (values, actions) => {
     await submitForm({
       url,
@@ -62,10 +69,12 @@ BookmarkForm.propTypes = {
   initialValues: PropTypes.object.isRequired,
   url: PropTypes.string.isRequired,
   setModalClosed: PropTypes.func.isRequired,
+  bookmarks: PropTypes.array,
 };
 
 BookmarkForm.defaultProps = {
   onCancel: noop,
+  bookmarks: [],
 };
 
 export default BookmarkForm;

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/BookmarkForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/__snapshots__/BookmarkForm.test.js.snap
@@ -47,6 +47,7 @@ exports[`BookmarkForm should render bookmarks form with initial values 1`] = `
           "_conditions": Array [],
           "_deps": Array [],
           "_exclusive": Object {
+            "matches": false,
             "max": true,
             "required": true,
           },
@@ -62,6 +63,7 @@ exports[`BookmarkForm should render bookmarks form with initial values 1`] = `
             "refs": Array [],
           },
           "tests": Array [
+            [Function],
             [Function],
             [Function],
           ],

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/__tests__/integration.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import uuidV1 from 'uuid/v1';
 import { IntegrationTestHelper } from '@theforeman/test';
+
 import API from '../../../../../redux/API/API';
 import { APIMiddleware } from '../../../../../redux/API';
 
@@ -16,6 +17,7 @@ import {
   item,
   submitResponse,
   controller,
+  bookmarks,
 } from '../../../Bookmarks.fixtures';
 import { BOOKMARKS_SUCCESS } from '../../../BookmarksConstants';
 
@@ -80,4 +82,19 @@ describe('Bookmark form integration test', () => {
 
     testHelper.takeActionsSnapshot('form submitted');
   });
+
+  it("should run with name validation", async () => {
+    const testHelper = new IntegrationTestHelper(reducers, [APIMiddleware]);
+    const component = testHelper.mount(<BookmarkForm {...props} bookmarks={bookmarks} />);
+    component
+    .find('input[name="name"]')
+    .simulate('change', { target: { name: 'name', value: '1111' } });
+
+    await IntegrationTestHelper.flushAllPromises();
+    component.update();
+    const formError = component.find('CommonForm[label="Name"]').prop('error');
+
+    expect(formError).toBe('name already exists');
+
+  })
 });

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/SearchModal.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/SearchModal.js
@@ -6,7 +6,14 @@ import { translate as __ } from '../../../common/I18n';
 import { noop } from '../../../common/helpers';
 import BookmarkForm from './BookmarkForm';
 
-const SearchModal = ({ setModalClosed, onEnter, title, controller, url }) => (
+const SearchModal = ({
+  setModalClosed,
+  onEnter,
+  title,
+  controller,
+  url,
+  bookmarks,
+}) => (
   <ForemanModal
     id={BOOKMARKS_MODAL}
     title={title}
@@ -18,6 +25,7 @@ const SearchModal = ({ setModalClosed, onEnter, title, controller, url }) => (
       url={url}
       setModalClosed={setModalClosed}
       onCancel={setModalClosed}
+      bookmarks={bookmarks}
     />
   </ForemanModal>
 );
@@ -28,11 +36,13 @@ SearchModal.propTypes = {
   title: PropTypes.string,
   onEnter: PropTypes.func,
   setModalClosed: PropTypes.func.isRequired,
+  bookmarks: PropTypes.array,
 };
 
 SearchModal.defaultProps = {
   title: __('Create Bookmark'),
   onEnter: noop,
+  bookmarks: [],
 };
 
 export default SearchModal;

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/__tests__/__snapshots__/SearchModal.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/__tests__/__snapshots__/SearchModal.test.js.snap
@@ -8,6 +8,7 @@ exports[`SearchModal should show search modal 1`] = `
   title="Create Bookmark"
 >
   <Connect(BookmarkForm)
+    bookmarks={Array []}
     controller="hosts"
     onCancel={[MockFunction]}
     setModalClosed={[MockFunction]}

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -10,7 +10,7 @@ Object {
           "payload": Object {
             "controller": "models",
           },
-          "url": "/api/bookmarks?search=controller%3Dmodels&per_page=100",
+          "url": "/api/bookmarks?search=controller%3Dmodels&per_page=all",
         },
         "type": "API_GET",
       },
@@ -94,7 +94,7 @@ Array [
       "key": "BOOKMARKS",
       "payload": Object {
         "controller": "models",
-        "url": "/api/bookmarks?search=controller%3Dmodels&per_page=100",
+        "url": "/api/bookmarks?search=controller%3Dmodels&per_page=all",
       },
       "type": "BOOKMARKS_REQUEST",
     },
@@ -106,7 +106,7 @@ Array [
         "payload": Object {
           "controller": "models",
         },
-        "url": "/api/bookmarks?search=controller%3Dmodels&per_page=100",
+        "url": "/api/bookmarks?search=controller%3Dmodels&per_page=all",
       },
       "type": "API_GET",
     },


### PR DESCRIPTION
Saving a bookmark with an existing/duplicate bookmark name doesn't show a clear error.