### PR TITLE
Fixes #31792 - make the configuration status clickable

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -108,6 +108,13 @@ module HostStatus
       "#{ConfigReport::BIT_NUM * ConfigReport::METRIC.index(config_status)} & #{ConfigReport::MAX}"
     end
 
+    def status_link
+      return nil if last_report.nil?
+      return nil unless User.current.can?(:view_config_reports, last_report)
+
+      last_report && Rails.application.routes.url_helpers.config_report_path(last_report)
+    end
+
     private
 
     def handle_options(options)


### PR DESCRIPTION
The host substatuses can optionally define a link. In case of
configuration status, it's handy to link the last configuration report
for the host. This PR adds exactly that. Since reports can be deleted
while the status may still exists, we don't link anything in case there
no report. Also we don't set the link in case the user does not have
permissions to see the config report.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
