### PR TITLE
Fixes #31798 - Fix error notifications in react forms

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -53,6 +53,8 @@ export const submitForm = ({
   method = 'post',
   headers,
   apiActionTypes: actionTypes,
+  errorToast,
+  successToast,
 }) => {
   verifyProps(item, params);
   return async dispatch => {
@@ -66,16 +68,17 @@ export const submitForm = ({
         payload: { item, data },
       });
     };
-
-    const successToast = response =>
+    const defaultSuccessToast = () =>
       message || sprintf('%s was successfully created.', __(item));
 
-    const errorToast = error =>
+    const defaultErrorToast = error =>
       sprintf(
-        'Oh no! Something went wrong while submitting the form, the server returned the following error: %s',
-        error
+        __(
+          'Oh no! Something went wrong while submitting the form, the server returned the following error: %s'
+        ),
+        // eslint-disable-next-line camelcase
+        error?.response?.data?.error?.full_messages?.join(', ')
       );
-
     dispatch(
       APIActions[method]({
         key: uniqueAPIKey,
@@ -85,8 +88,8 @@ export const submitForm = ({
         actionTypes,
         handleError,
         handleSuccess,
-        successToast,
-        errorToast,
+        successToast: successToast || defaultSuccessToast,
+        errorToast: errorToast || defaultErrorToast,
       })
     );
   };

--- a/webpack/stories/docs/creating-a-form.stories.mdx
+++ b/webpack/stories/docs/creating-a-form.stories.mdx
@@ -54,3 +54,23 @@ const FlavorForm = ({
 - `initialValues` - object with initial values for the fields. For the example above, it could be: `{ name: 'Strawberry Super Sweetness' }`
 
 You can also pass a [Yup](https://github.com/jquense/yup) object as a `validationSchema`, which will take care of validations.
+
+### Toast Notifications
+
+Toast Notifications are enabled by default after a success or a failure.
+- `errorToast` - creates a toast notification based on `error.full_messages` object 
+- `successToast` - creates a toast notification with the given `meesage` or the given `item` props
+
+You can override the default `successToast` or `errorToast` functions if needed:
+
+```js
+  <ForemanForm
+    onSubmit={(values, actions) =>
+      submitForm({
+        ...otherProps,
+        successToast: response => __(`a custom success message with ${response.data.item}`),
+        errorToast: error => __(`a custom error message with ${error.response.data.error.item}`),
+      })
+    }
+  >
+```


### PR DESCRIPTION
Following https://github.com/theforeman/foreman/pull/8304, this PR fixes a bug in react forms which creates a toast notification with an unclear error after a failed submission.
