### PR TITLE
Refs #31080 - fix react-hooks/exhaustive-deps warning

### DIFF
--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
@@ -20,7 +20,7 @@ const PersonalAccessTokens = ({ url, canCreate }) => {
   const dispatch = useDispatch();
   useEffect(() => {
     dispatch(getPersonalAccessTokens({ url }));
-  }, [url]);
+  }, [url, dispatch]);
 
   const newPersonalAccessToken = useSelector(state =>
     selectNewPersonalAccessToken(state)


### PR DESCRIPTION
`dispatch` is used in this `useEffect`, hence it should be added to the dependency array.
This also triggers a `react-hooks/exhaustive-deps` eslint warning.