### PR TITLE
Fixes #31830 - support children in SkeletonLoader component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Properties/Properties.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Properties/Properties.test.js
@@ -1,4 +1,5 @@
 import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
+import { STATUS } from '../../../constants';
 import PropertiesCard from './';
 
 const fixtures = {
@@ -13,7 +14,7 @@ const fixtures = {
       location_name: 'Beverly Hills',
       organization_name: '90210',
     },
-    isLoading: false,
+    status: STATUS.RESOLVED,
   },
 };
 

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Properties/__snapshots__/Properties.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Properties/__snapshots__/Properties.test.js.snap
@@ -29,7 +29,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 </span>
               </DataListCell>,
               <DataListCell>
-                windows 3.11
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  windows 3.11
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -57,7 +63,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 alignRight={true}
                 isFilled={true}
               >
-                altavista
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  altavista
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -88,7 +100,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 alignRight={true}
                 isFilled={true}
               >
-                x16
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  x16
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -119,7 +137,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 alignRight={true}
                 isFilled={true}
               >
-                0.0.0.1
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  windows 3.11
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -150,9 +174,11 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
               >
                 <SkeletonLoader
                   emptyState="N/A"
-                  isLoading={false}
                   skeletonProps={Object {}}
-                />
+                  status="RESOLVED"
+                >
+                  
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -183,7 +209,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 alignRight={true}
                 isFilled={true}
               >
-                00:0a:95:9d:68:16
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  00:0a:95:9d:68:16
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -214,7 +246,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 alignRight={true}
                 isFilled={true}
               >
-                Beverly Hills
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  Beverly Hills
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }
@@ -245,7 +283,13 @@ exports[`HostDetails - Interfaces should render UserProfile 1`] = `
                 alignRight={true}
                 isFilled={true}
               >
-                90210
+                <SkeletonLoader
+                  emptyState="N/A"
+                  skeletonProps={Object {}}
+                  status="RESOLVED"
+                >
+                  90210
+                </SkeletonLoader>
               </DataListCell>,
             ]
           }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Properties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Properties/index.js
@@ -9,9 +9,10 @@ import {
   DataListCell,
 } from '@patternfly/react-core';
 import SkeletonLoader from '../../common/SkeletonLoader';
+import { STATUS } from '../../../constants';
 import { translate as __ } from '../../../common/I18n';
 
-const Properties = ({ hostData, isLoading }) => (
+const Properties = ({ hostData, status }) => (
   <Card isHoverable>
     <DataList aria-label="Host Properties" isCompact>
       <DataListItem aria-labelledby="name">
@@ -22,9 +23,9 @@ const Properties = ({ hostData, isLoading }) => (
                 <span> {__('Operating System')}</span>
               </DataListCell>,
               <DataListCell key="os-content">
-                {hostData.operatingsystem_name || (
-                  <SkeletonLoader isLoading={isLoading} />
-                )}
+                <SkeletonLoader status={status}>
+                  {hostData.operatingsystem_name}
+                </SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -38,9 +39,9 @@ const Properties = ({ hostData, isLoading }) => (
                 <span>{__('Domain')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="domain-content">
-                {hostData.domain_name || (
-                  <SkeletonLoader isLoading={isLoading} />
-                )}
+                <SkeletonLoader status={status}>
+                  {hostData.domain_name}
+                </SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -54,9 +55,9 @@ const Properties = ({ hostData, isLoading }) => (
                 <span id="simple-item2">{__('Architecture')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="architecture-content">
-                {hostData.architecture_name || (
-                  <SkeletonLoader isLoading={isLoading} />
-                )}
+                <SkeletonLoader status={status}>
+                  {hostData.architecture_name}
+                </SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -70,7 +71,9 @@ const Properties = ({ hostData, isLoading }) => (
                 <span id="simple-item2">{__('IP Address')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="ip-content">
-                {hostData.ip || <SkeletonLoader isLoading={isLoading} />}
+                <SkeletonLoader status={status}>
+                  {hostData.operatingsystem_name}
+                </SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -84,7 +87,7 @@ const Properties = ({ hostData, isLoading }) => (
                 <span>{__('IP6 Address')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="ip6-content">
-                {hostData.ip6 || <SkeletonLoader isLoading={isLoading} />}
+                <SkeletonLoader status={status}>{hostData.ip6}</SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -98,7 +101,7 @@ const Properties = ({ hostData, isLoading }) => (
                 <span id="simple-item2">{__('MAC')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="mac-content">
-                {hostData.mac || <SkeletonLoader isLoading={isLoading} />}
+                <SkeletonLoader status={status}>{hostData.mac}</SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -112,9 +115,9 @@ const Properties = ({ hostData, isLoading }) => (
                 <span id="simple-item2">{__('Location')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="location-content">
-                {hostData.location_name || (
-                  <SkeletonLoader isLoading={isLoading} />
-                )}
+                <SkeletonLoader status={status}>
+                  {hostData.location_name}
+                </SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -129,9 +132,9 @@ const Properties = ({ hostData, isLoading }) => (
                 <span id="simple-item2">{__('Organization')}</span>
               </DataListCell>,
               <DataListCell isFilled alignRight key="org-content">
-                {hostData.organization_name || (
-                  <SkeletonLoader isLoading={isLoading} />
-                )}
+                <SkeletonLoader status={status}>
+                  {hostData.organization_name}
+                </SkeletonLoader>
               </DataListCell>,
             ]}
           />
@@ -152,7 +155,10 @@ Properties.propTypes = {
     operatingsystem_name: PropTypes.string,
     organization_name: PropTypes.string,
   }).isRequired,
-  isLoading: PropTypes.bool.isRequired,
+  status: PropTypes.string,
 };
 
+Properties.defaultProps = {
+  status: STATUS.PENDING,
+};
 export default Properties;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
@@ -24,7 +24,7 @@ const DetailsTab = ({ response, status }) => (
     </Flex>
     <Grid hasGutter>
       <GridItem xl2={2} md={3} lg={2} rowSpan={3}>
-        <Properties hostData={response} isLoading={status === STATUS.PENDING} />
+        <Properties hostData={response} status={status} />
       </GridItem>
       <GridItem xl2={3} md={6} lg={5}>
         <ParametersCard paramters={response.all_parameters} />

--- a/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/SkeletonLoader.stories.js
+++ b/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/SkeletonLoader.stories.js
@@ -1,25 +1,55 @@
 import React from 'react';
-import { boolean, text } from '@storybook/addon-knobs';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { STATUS } from '../../../constants';
 import Story from '../../../../../../stories/components/Story';
 import SkeletonLoader from '.';
 
 export default {
-  title: 'Components/Common/Empty Line',
+  title: 'Components/Common/SkeletonLoader',
 };
 
 export const defaultStory = () => (
   <Story>
     <ul>
-      <span>
-        This will show a Skeleton if the data is loading and N/A if the data has
-        finished loading
-      </span>
+      <span>Loading:</span>
       <br />
-      <SkeletonLoader isLoading={boolean('is loading', false)} />
+      <SkeletonLoader status={STATUS.PENDING}>Content</SkeletonLoader>
+    </ul>
+    <ul>
+      <span>Loading with multiple lines:</span>
+      <br />
+      <SkeletonLoader
+        skeletonProps={{ count: 3 }}
+        status={STATUS.PENDING}
+      >
+        Content
+      </SkeletonLoader>
+    </ul>
+    <ul>
+      <span>Resolved:</span>
+      <br />
+      <SkeletonLoader status={STATUS.RESOLVED}>Some Content</SkeletonLoader>
+    </ul>
+    <ul>
+      <span>Error:</span>
+      <br />
+      <SkeletonLoader
+        status={STATUS.ERROR}
+        errorNode={
+          <span style={{ color: '#C9190B' }}>
+            <ExclamationCircleIcon /> Error
+          </span>
+        }
+      />
+    </ul>
+    <ul>
+      <span>Empty Value</span>
+      <br />
+      <SkeletonLoader status={STATUS.RESOLVED} />
     </ul>
   </Story>
 );
 
 defaultStory.story = {
-  name: 'Empty Line',
+  name: 'Skeleton Loader',
 };

--- a/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/SkeletonLoader.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/SkeletonLoader.test.js
@@ -1,14 +1,24 @@
+import React from 'react';
 import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
 import SkeletonLoader from '.';
-
+import { STATUS } from '../../../constants';
 const fixtures = {
   'should loading true': {
-    isLoading: true,
+    status: STATUS.PENDING,
     skeletonProps: { count: 3 },
   },
-  'should loading false': {
-    isLoading: false,
+  'should loading finished with no children': {
+    status: STATUS.RESOLVED,
     emptyState: 'custom empty',
+  },
+  'should loading true with a node child': {
+    status: STATUS.RESOLVED,
+    emptyState: 'custom empty',
+    children: <div>a child</div>,
+  },
+  'should render custom error': {
+    status: STATUS.ERROR,
+    errorNode: "custom error node"
   },
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/__snapshots__/SkeletonLoader.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/__snapshots__/SkeletonLoader.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SkeletonLoader should loading false 1`] = `"custom empty"`;
+exports[`SkeletonLoader should loading finished with no children 1`] = `"custom empty"`;
 
 exports[`SkeletonLoader should loading true 1`] = `
 <G
@@ -12,3 +12,11 @@ exports[`SkeletonLoader should loading true 1`] = `
   wrapper={null}
 />
 `;
+
+exports[`SkeletonLoader should loading true with a node child 1`] = `
+<div>
+  a child
+</div>
+`;
+
+exports[`SkeletonLoader should render custom error 1`] = `"custom error node"`;

--- a/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/SkeletonLoader/index.js
@@ -1,23 +1,44 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Skeleton from 'react-loading-skeleton';
+
+import { STATUS } from '../../../constants';
 import { translate as __ } from '../../../../react_app/common/I18n';
 
-const SkeletonLoader = ({ isLoading, skeletonProps, emptyState }) => {
-  if (isLoading) {
-    return <Skeleton {...skeletonProps} />;
+const SkeletonLoader = ({
+  status,
+  skeletonProps,
+  emptyState,
+  children,
+  errorNode,
+}) => {
+  switch (status) {
+    case STATUS.PENDING: {
+      return <Skeleton {...skeletonProps} />;
+    }
+    case STATUS.RESOLVED: {
+      return children || emptyState;
+    }
+    case STATUS.ERROR: {
+      return errorNode || emptyState;
+    }
+    default:
+      return emptyState;
   }
-  return emptyState;
 };
 
 SkeletonLoader.propTypes = {
-  isLoading: PropTypes.bool.isRequired,
+  status: PropTypes.string.isRequired,
   skeletonProps: PropTypes.object,
   emptyState: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  children: PropTypes.node,
+  errorNode: PropTypes.node,
 };
 
 SkeletonLoader.defaultProps = {
   skeletonProps: {},
   emptyState: __('N/A'),
+  children: undefined,
+  errorNode: undefined,
 };
 export default SkeletonLoader;


### PR DESCRIPTION
`SkeletonLoader` should support any kind of node loading:

```js
// current implementation
SOME_VALUE || <SkeletonLoader />  // too complex in some cases and doesn't work with components

// this change loads any kind of node
<SkeletonLoader> {<ContentComponent />} </SkeletonLoader />  // works for any kind of node
```

Also, this change makes the mechanism similar to patternfly 3 loader component and [katello's imlementation](https://github.com/Katello/katello/blob/master/webpack/components/LoadingState/LoadingState.js)