### PR TITLE
Fixes #31831 - avoid delay casued by webmock on request

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,6 +21,9 @@ FactoryBot.use_parent_strategy = false
 # Do not allow network connections and external processes
 WebMock.disable_net_connect!(allow_localhost: true)
 
+# When there are no requests, avoid delays caused my HTTP connect
+WebMock.disable_net_connect!(net_http_connect_on_start: true)
+
 # Configure shoulda
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|


### PR DESCRIPTION
While running the integration tests, one might face errors like `Failed to open TCP connection (Too many open files - socket(2) for "127.0.0.1" port 9515`. This is because the way Webmock works with the Net::HTTP.start connection call. 

reference: https://github.com/bblimke/webmock/blob/master/README.md#connecting-on-nethttpstart