### PR TITLE
Fixes #31848 - fix ForemanForm error regression

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/BookmarkForm.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/BookmarkForm.js
@@ -32,19 +32,20 @@ const BookmarkForm = ({
       .max(...maxLengthMsg(4096))
       .required(requiredMsg()),
   });
-  const handleSubmit = async (values, actions) => {
-    await submitForm({
+
+  const handleSubmit = (values, actions) =>
+    submitForm({
       url,
       values: { ...values, controller },
       item: 'Bookmarks',
       message: __('Bookmark was successfully created.'),
+      successCallback: setModalClosed,
+      actions,
     });
-    setModalClosed();
-  };
 
   return (
     <ForemanForm
-      onSubmit={(values, actions) => handleSubmit(values, actions)}
+      onSubmit={handleSubmit}
       initialValues={initialValues}
       validationSchema={bookmarkFormSchema}
       onCancel={onCancel}

--- a/webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingForm/SettingForm.js
+++ b/webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingForm/SettingForm.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Field as FormikField } from 'formik';
-
 import ForemanForm from '../../../common/forms/ForemanForm';
 import SettingValueField from '../SettingValueField';
 import { SETTING_UPDATE_PATH } from '../../SettingUpdateModalConstants';
@@ -14,7 +13,7 @@ const SettingForm = ({
   setModalClosed,
   submitForm,
 }) => {
-  const handleSubmit = async (values, actions) => {
+  const handleSubmit = (values, actions) => {
     let submitValues = { setting: values };
 
     if (setting && setting.settingsType === 'array') {
@@ -22,24 +21,26 @@ const SettingForm = ({
       submitValues = { setting: { value: splitValue } };
     }
 
-    await submitForm({
+    return submitForm({
       url: SETTING_UPDATE_PATH.replace(':id', setting.id),
       values: submitValues,
       item: 'Settings',
       message: __('Setting was successfully updated.'),
       method: 'put',
+      successCallback: setModalClosed,
+      actions,
     });
-    setModalClosed();
   };
 
   return (
     <ForemanForm
-      onSubmit={(values, actions) => handleSubmit(values, actions)}
+      onSubmit={handleSubmit}
       initialValues={initialValues}
       onCancel={setModalClosed}
     >
       <FormikField
         name="value"
+        label={__('Value')}
         component={SettingValueField}
         setting={setting}
       />

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.fixtures.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import * as Yup from 'yup';
 
@@ -16,16 +17,26 @@ export const validationSchema = Yup.object().shape({
 });
 
 export const FormComponent = ({ submitForm, initValues, schema, onCancel }) => (
-  <ForemanForm
-    onSubmit={(values, actions) => submitForm(values)}
-    initialValues={initValues}
-    validationSchema={schema}
-    onCancel={onCancel}
-  >
-    <TextField name="name" type="text" required="true" label="name" />
-    <TextField name="surname" type="text" label="surname" />
-  </ForemanForm>
-);
+    <ForemanForm
+      onSubmit={submitForm}
+      initialValues={initValues}
+      validationSchema={schema}
+      onCancel={onCancel}
+    >
+      <TextField name="name" type="text" required="true" label="name" />
+      <TextField name="surname" type="text" label="surname" />
+    </ForemanForm>
+  );
+
+export const ConnectedFormComponent = props => {
+  const dispatch = useDispatch();
+  return (
+    <FormComponent
+      {...props}
+      submitForm={(values, actions) => dispatch(props.submitForm(values, actions))}
+    />
+  );
+};
 
 FormComponent.propTypes = {
   submitForm: PropTypes.func.isRequired,

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.js
@@ -4,51 +4,42 @@ import PropTypes from 'prop-types';
 import Form from '../Form';
 import { translate as __ } from '../../../../common/I18n';
 
-export const prepareErrors = errors =>
-  Object.keys(errors).reduce((memo, key) => {
-    const errorMessages = errors[key];
-
-    memo[key] =
-      errorMessages && errorMessages.join
-        ? errorMessages.join(', ')
-        : errorMessages;
-    return memo;
-  }, {});
-
 export const isInitialValid = ({ validationSchema, initialValues }) =>
   !validationSchema ? true : validationSchema.isValidSync(initialValues);
 
-const ForemanForm = props => (
+const ForemanForm = ({
+  onSubmit,
+  children,
+  initialValues,
+  validationSchema,
+  enableReinitialize,
+  onCancel,
+}) => (
   <Formik
-    onSubmit={(values, actions) =>
-      props.onSubmit(values, actions).catch(exception => {
-        actions.setSubmitting(false);
-        actions.setErrors(prepareErrors(exception.errors));
-      })
-    }
-    initialValues={props.initialValues}
-    validationSchema={props.validationSchema}
+    onSubmit={onSubmit}
+    initialValues={initialValues}
+    validationSchema={validationSchema}
     isInitialValid={isInitialValid}
-    enableReinitialize={props.enableReinitialize}
+    enableReinitialize={enableReinitialize}
   >
     {formProps => {
       const disabled = formProps.isSubmitting || !formProps.isValid;
-
       const submissionError = formProps.errors._error;
+
       return (
         <Form
           onSubmit={formProps.handleSubmit}
-          onCancel={props.onCancel}
+          onCancel={onCancel}
           disabled={disabled}
           error={submissionError}
           errorTitle={
-            submissionError && submissionError.severity === 'danger'
+            submissionError?.severity === 'danger'
               ? __('Error! ')
               : __('Warning! ')
           }
           submitting={formProps.isSubmitting}
         >
-          {cloneChildren(props.children, { formProps, disabled })}
+          {cloneChildren(children, { formProps, disabled })}
         </Form>
       );
     }}

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/ForemanForm.test.js
@@ -4,7 +4,8 @@ import {
 } from '@theforeman/test';
 import * as Yup from 'yup';
 
-import { prepareErrors, isInitialValid } from './ForemanForm';
+import { prepareErrors } from '../../../../redux/actions/common/forms';
+import { isInitialValid } from './ForemanForm'
 import {
   initialValues,
   FormComponent,

--- a/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/__snapshots__/ForemanForm.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/forms/ForemanForm/__snapshots__/ForemanForm.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Foreman form helper functions should format errors 1`] = `
 Object {
+  "_error": undefined,
   "errors": Object {
     "email": Array [
       "is not a valid format",

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokenForm.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokenForm.js
@@ -28,16 +28,17 @@ const PersonalAccessTokenForm = ({ controller, url, initialValues }) => {
     id: MODAL_ID,
   });
 
-  const handleSubmit = async (values, actions) => {
-    await dispatch(
+  const handleSubmit = (values, actions) => {
+    dispatch(
       submitForm({
         url,
         values: { ...values, controller },
         item: 'personal_access_token',
         message: __('Personal Access Token was successfully created.'),
+        actions,
+        successCallback: setModalClosed,
       })
     );
-    setModalClosed();
   };
 
   return (
@@ -49,7 +50,7 @@ const PersonalAccessTokenForm = ({ controller, url, initialValues }) => {
       <ForemanModal id={MODAL_ID} title={__('Create Personal Access Token')}>
         <ForemanModal.Header />
         <ForemanForm
-          onSubmit={(values, actions) => handleSubmit(values, actions)}
+          onSubmit={handleSubmit}
           initialValues={initialValues}
           validationSchema={tokenFormSchema}
           onCancel={setModalClosed}


### PR DESCRIPTION
APIMiddleware is consumed in the ForemanForm component after a refactoring.
That change wasn't taken into account that the APIMiddleware is not a promise, it doesn't return any exception so using `try-catch` around it isn't useful anymore.

This PR uses the advantages of our `APIMiddleware`, instead of catching an error, `ForemanForm` seek for an error directly from the API store.

Tests failures are related, needs a  rewrite

/cc @xprazak2, @laviro 