### PR TITLE
Fixes #30724 - Remove console errors from ForemanModal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalActions.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalActions.js
@@ -10,20 +10,17 @@ import { selectModalExists } from './ForemanModalSelectors';
 export const addModal = ({ id, isOpen = false, isSubmitting = false }) => (
   dispatch,
   getState
-) => {
-  if (selectModalExists(getState(), id)) {
-    throw new Error(`ForemanModal with ID ${id} already exists`);
-  }
-  return dispatch({
+) =>
+  dispatch({
     type: ADD_MODAL,
     payload: { id, isOpen, isSubmitting },
   });
-};
 
 const modalAction = actionType => ({ id }) => (dispatch, getState) => {
   if (!selectModalExists(getState(), id)) {
-    throw new Error(
-      `${actionType} error: Modal with id '${id}' does not exist`
+    // eslint-disable-next-line no-console
+    console.warn(
+      `${actionType} action received, but ForemanModal with id '${id}' does not exist.`
     );
   }
   return dispatch({

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalActions.test.js
@@ -21,26 +21,4 @@ const fixtures = {
 
 describe('ForemanModal actions', () => {
   testActionSnapshotWithFixtures(fixtures);
-
-  describe('addModal', () => {
-    it('throws an error if the modal already exists', () => {
-      expect(() => store.dispatch(addModal({ id: 'modal1' }))).toThrow(
-        'already exists'
-      );
-    });
-  });
-  describe('setModalOpen', () => {
-    it('throws an error if the modal does not exist', () => {
-      expect(() => store.dispatch(setModalOpen({ id: 'modal42' }))).toThrow(
-        'does not exist'
-      );
-    });
-  });
-  describe('setModalClosed', () => {
-    it('throws an error if the modal does not exist', () => {
-      expect(() => store.dispatch(setModalClosed({ id: 'modal42' }))).toThrow(
-        'does not exist'
-      );
-    });
-  });
 });


### PR DESCRIPTION
Currently ForemanModal has Redux actions which behave in the following ways:

When you try to use `ADD_MODAL` for a modal that exists already: JS error thrown
When you try to `SET_MODAL_OPEN` for a modal that doesn't exist: JS error thrown
When you try to `SET_MODAL_CLOSED` for a modal that doesn't exist: JS error thrown

This causes a bad developer experience, and has already caused at least one Katello bug (see https://github.com/Katello/katello/pull/9158)

Therefore, I am changing the behavior as follows:

When you try to use `ADD_MODAL` for a modal that exists already: No error; change is idempotent and Redux store is unchanged
When you try to `SET_MODAL_OPEN` for a modal that doesn't exist: Console warning; modal is created for you
When you try to `SET_MODAL_CLOSED` for a modal that doesn't exist: Console warning; modal is created for you