### PR TITLE
Fixes #30215 - Add warning banner about puppet ENC extraction (CP 2.4)

### DIFF
--- a/app/helpers/puppet_related_helper.rb
+++ b/app/helpers/puppet_related_helper.rb
@@ -67,28 +67,24 @@ module PuppetRelatedHelper
     classes.where(:id => class_vars)
   end
 
-  def extraction_warning
-    "being extracted to the foreman_puppet plugin and will be removed from core in 3.0"
-  end
-
   def extraction_warning_puppet_classes_management
-    _("Puppet Classes management is #{extraction_warning}")
+    _("Puppet Classes management is being extracted to the foreman_puppet plugin and will be removed from core in 3.0")
   end
 
   def extraction_warning_config_groups
-    _("Config Groups are #{extraction_warning}")
+    _("Config Groups are being extracted to the foreman_puppet plugin and will be removed from core in 3.0")
   end
 
   def extraction_warning_puppet_environments
-    _("Puppet Environments management is #{extraction_warning}")
+    _("Puppet Environments management is being extracted to the foreman_puppet plugin and will be removed from core in 3.0")
   end
 
   def extraction_warning_smart_class_parameters
-    _("Smart Class Parameters management is  #{extraction_warning}")
+    _("Smart Class Parameters management is being extracted to the foreman_puppet plugin and will be removed from core in 3.0")
   end
 
   def extraction_warning_puppet_enc
-    _("Puppet ENC is  #{extraction_warning}")
+    _("Puppet ENC is being extracted to the foreman_puppet plugin and will be removed from core in 3.0")
   end
 
   def puppetclasses_tab(puppetclasses_receiver)

--- a/app/helpers/puppet_related_helper.rb
+++ b/app/helpers/puppet_related_helper.rb
@@ -67,10 +67,36 @@ module PuppetRelatedHelper
     classes.where(:id => class_vars)
   end
 
+  def extraction_warning
+    "being extracted to the foreman_puppet plugin and will be removed from core in 3.0"
+  end
+
+  def extraction_warning_puppet_classes_management
+    _("Puppet Classes management is #{extraction_warning}")
+  end
+
+  def extraction_warning_config_groups
+    _("Config Groups are #{extraction_warning}")
+  end
+
+  def extraction_warning_puppet_environments
+    _("Puppet Environments management is #{extraction_warning}")
+  end
+
+  def extraction_warning_smart_class_parameters
+    _("Smart Class Parameters management is  #{extraction_warning}")
+  end
+
+  def extraction_warning_puppet_enc
+    _("Puppet ENC is  #{extraction_warning}")
+  end
+
   def puppetclasses_tab(puppetclasses_receiver)
     content_tag(:div, :class => "tab-pane", :id => "puppet_klasses") do
       if @environment.present? ||
           @hostgroup.present? && @hostgroup.environment.present?
+        alert(:class => "alert-info", :header => _("Notice"),
+              :text => extraction_warning_puppet_classes_management)
         render "puppetclasses/class_selection", :obj => puppetclasses_receiver
       else
         alert(:class => "alert-info", :header => _("Notice"),

--- a/app/views/config_groups/index.html.erb
+++ b/app/views/config_groups/index.html.erb
@@ -1,7 +1,8 @@
 <% title _('Config Groups') %>
 
 <% title_actions new_link(_('Create Config Group')), help_button %>
-
+<%= alert :header => '', :class => 'alert-warning', :close => false,
+          :text => extraction_warning_config_groups %>
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>

--- a/app/views/environments/index.html.erb
+++ b/app/views/environments/index.html.erb
@@ -1,5 +1,6 @@
 <% title _('Puppet Environments') %>
-
+<%= alert :header => '', :class => 'alert-warning', :close => false,
+          :text => extraction_warning_puppet_environments %>
 <%= environments_title_actions %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">

--- a/app/views/puppetclass_lookup_keys/index.html.erb
+++ b/app/views/puppetclass_lookup_keys/index.html.erb
@@ -1,4 +1,6 @@
 <% title _("Smart Class Parameters") %>
+<%= alert :header => '', :class => 'alert-warning', :close => false,
+          :text => extraction_warning_smart_class_parameters %>
 <% title_actions documentation_button('4.2.5ParameterizedClasses') %>
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>

--- a/app/views/puppetclasses/_classes_parameters.html.erb
+++ b/app/views/puppetclasses/_classes_parameters.html.erb
@@ -1,3 +1,5 @@
+<%= alert :header => '', :class => 'alert-warning', :close => false,
+          :text => extraction_warning_puppet_enc %>
 <table class="table table-fixed" id="inherited_puppetclasses_parameters">
   <thead class="white-header">
     <tr>

--- a/app/views/puppetclasses/index.html.erb
+++ b/app/views/puppetclasses/index.html.erb
@@ -1,5 +1,6 @@
 <% title _("Puppet Classes") %>
-
+<%= alert :header => '', :class => 'alert-warning', :close => false,
+          :text => extraction_warning_puppet_classes_management %>
 <% title_actions import_proxy_select(hash_for_import_environments_puppetclasses_path),
                  documentation_button('4.2.2Classes') %>
 


### PR DESCRIPTION
(cherry picked from commit ac16209da31ea412e64c53767c7a7acbea728790)

Requesting CP for puppet deprecation. The plugin is already released, so we should start notifying users, so they can start planning for the plugin installation.