### PR TITLE
Fixes #28311 - use publicURL in openstack resource

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -271,6 +271,7 @@ module Foreman::Model
         :openstack_username => user,
         :openstack_auth_url => url_for_fog,
         :openstack_identity_endpoint => url_for_fog,
+        :openstack_endpoint_type => 'publicURL',
       }.tap do |h|
         if tenant.present?
           if identity_version == 2


### PR DESCRIPTION
It used to be publicURL by default but now fog uses adminURL for some
endpoints. The openstack compute resource does not work if this url is
not accessible from the foreman server.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
