### PR TITLE
Fixes #31882 - set ENC var hostname to shortname

### DIFF
--- a/app/models/host_info_providers/static_info.rb
+++ b/app/models/host_info_providers/static_info.rb
@@ -4,7 +4,7 @@ module HostInfoProviders
       # Static parameters
       param = {}
 
-      param["hostname"] = host.name unless host.name.nil?
+      param["hostname"] = host.shortname unless host.shortname.nil?
       param["fqdn"] = host.fqdn unless host.fqdn.nil?
       param["hostgroup"] = host.hostgroup.to_label unless host.hostgroup.nil?
       param["comment"] = host.comment if host.comment.present?


### PR DESCRIPTION
The fix for #31168 added the ENC var hostname and sets its value to host.name which is the FQDN in my case. This breaks some old Puppet code where the top scope variable $::hostname is expected to contain the short name.

I fixed this by ensuring that ENC var hostname is always set to the short name.