### PR TITLE
Fixes #31884 - Correctly warn about wrong logging layout

### DIFF
--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -27,8 +27,8 @@ namespace :errors do
       exit(1)
     end
     if Foreman::Logging.config[:layout] != 'multiline_request_pattern'
-      $STDERR.puts "Warning: Logging layout is not multiline_request_pattern."
-      $STDERR.puts "This output of this command can be incomplete."
+      puts "Warning: Logging layout is not multiline_request_pattern."
+      puts "This output of this command can be incomplete."
     end
     file_path = File.join(Foreman::Logging.log_directory, logfile)
     unless File.exist?(file_path)


### PR DESCRIPTION
When running `rake errors:fetch_log`, if the logging layout isn't set to
`multiline_request_pattern` the task errors out because `$STDERR` doesn't
exist. This is a typo, it should have been `$stderr`, but since we use
stdout for all other messages this has been dropped to be consistant.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
