### PR TITLE
Fixes #31883 - Validate compute attributes before API creation

### DIFF
--- a/app/controllers/api/v2/compute_attributes_controller.rb
+++ b/app/controllers/api/v2/compute_attributes_controller.rb
@@ -49,7 +49,7 @@ module Api
         @compute_attribute = ComputeAttribute.new(compute_attribute_params.merge(
           :compute_profile_id => params[:compute_profile_id],
           :compute_resource_id => params[:compute_resource_id]))
-        process_response @compute_attribute.save
+        process_response @compute_attribute.save if @compute_attribute.normalized_vm_attrs
       end
 
       api :PUT, "/compute_resources/:compute_resource_id/compute_profiles/:compute_profile_id/compute_attributes/:id", N_("Update a compute attributes set")
@@ -64,7 +64,7 @@ module Api
       param_group :compute_attribute
 
       def update
-        process_response @compute_attribute.update(compute_attribute_params)
+        process_response @compute_attribute.update(compute_attribute_params) if @compute_attribute.normalized_new_vm_attrs(compute_attribute_params[:vm_attrs])
       end
 
       private

--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -36,6 +36,10 @@ class ComputeAttribute < ApplicationRecord
     compute_resource.normalize_vm_attrs(vm_attrs)
   end
 
+  def normalized_new_vm_attrs(new_vm_attrs)
+    compute_resource.normalize_vm_attrs(new_vm_attrs)
+  end
+
   def vm_interfaces
     attribute_values(compute_resource.interfaces_attrs_name)
   end

--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -172,44 +172,44 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
     end
 
     test 'cluster validation - id entered' do
-      assert_equal('c2', cr.get_ovirt_id(cr.clusters, 'c2'))
+      assert_equal('c2', cr.get_ovirt_id(cr.clusters, 'cluster', 'c2'))
     end
 
     test 'cluster validation - name entered' do
-      assert_equal('c2', cr.get_ovirt_id(cr.clusters, 'cluster 2'))
+      assert_equal('c2', cr.get_ovirt_id(cr.clusters, 'cluster', 'cluster 2'))
     end
 
     test 'cluster validation - not valid' do
       assert_raise Foreman::Exception do
-        cr.get_ovirt_id(cr.clusters, 'c3')
+        cr.get_ovirt_id(cr.clusters, 'cluster', 'c3')
       end
     end
 
     test 'storage domain validation - id entered' do
-      assert_equal('312f6', cr.get_ovirt_id(cr.storage_domains, '312f6'))
+      assert_equal('312f6', cr.get_ovirt_id(cr.storage_domains, 'storage domain', '312f6'))
     end
 
     test 'storage domain validation - name entered' do
-      assert_equal('382ec', cr.get_ovirt_id(cr.storage_domains, 'domain 2'))
+      assert_equal('382ec', cr.get_ovirt_id(cr.storage_domains, 'storage domain', 'domain 2'))
     end
 
     test 'storage domain validation - not valid' do
       assert_raise Foreman::Exception do
-        cr.get_ovirt_id(cr.storage_domains, 'domain 3')
+        cr.get_ovirt_id(cr.storage_domains, 'storage domain', 'domain 3')
       end
     end
 
     test 'network validation - id entered' do
-      assert_equal('net1', cr.get_ovirt_id(cr.networks, 'net1'))
+      assert_equal('net1', cr.get_ovirt_id(cr.networks, 'network', 'net1'))
     end
 
     test 'network validation - name entered' do
-      assert_equal('net2', cr.get_ovirt_id(cr.networks, 'network 2'))
+      assert_equal('net2', cr.get_ovirt_id(cr.networks, 'network', 'network 2'))
     end
 
     test 'network validation - not valid' do
       assert_raise Foreman::Exception do
-        cr.get_ovirt_id(cr.networks, 'network 3')
+        cr.get_ovirt_id(cr.networks, 'network', 'network 3')
       end
     end
   end
@@ -238,7 +238,13 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
     end
 
     test 'maps cluster to cluster_id' do
-      assert_attrs_mapped(cr, 'cluster', 'cluster_id')
+      vm_attrs = {
+        'cluster' => 'cluster 1',
+      }
+      normalized = cr.normalize_vm_attrs(vm_attrs)
+
+      refute(normalized.has_key?('cluster'))
+      assert_equal('c1', normalized['cluster_id'])
     end
 
     test 'finds cluster_name' do
@@ -251,7 +257,13 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
     end
 
     test 'maps template to template_id' do
-      assert_attrs_mapped(cr, 'template', 'template_id')
+      vm_attrs = {
+        'template' => 'template 1',
+      }
+      normalized = cr.normalize_vm_attrs(vm_attrs)
+
+      refute(normalized.has_key?('template'))
+      assert_equal('tpl1', normalized['template_id'])
     end
 
     test 'finds template_name' do


### PR DESCRIPTION
The bug occurred when trying to add invalid compute attribute values to a compute profile that is connected to ovirt compute resource via the CLI.
If the cluster attribute was invalid a non-indicative error returned and also the compute attributes were saved anyway causing the compute resource and compute profile to be wrong.
In this PR I fixed this issue - the error is now indicative and the compute attributes are not saved if an error occurred. 