### PR TITLE
Fixes #31934 - correct redirection after user update

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       update_sub_hostgroups_owners
 
-      process_success((editing_self? && !current_user.allowed_to?({:controller => 'users', :action => 'index'})) ? { :success_redirect => hosts_path } : {})
+      process_success((editing_self? && !current_user.allowed_to?({:controller => 'users', :action => 'index'})) ? { :success_redirect => hosts_path } : { :success_redirect => users_path })
     else
       process_error
     end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -321,6 +321,16 @@ class UsersControllerTest < ActionController::TestCase
     assert_response :redirect
   end
 
+  test 'user with no permission should be able to update himself or herself' do
+    user = FactoryBot.create(:user, :mail => nil)
+    setup_user 'view', 'hosts', nil, user
+    put :update, params: { :id => user.id, :user => { :mail => 'test@example.com' } },
+      session: set_session_user(user)
+
+    assert_response :redirect
+    assert_redirected_to hosts_path
+  end
+
   test "#login sets the session user and bumps last log in time" do
     time = Time.zone.now
     post :login, params: { :login => {'login' => users(:admin).login, 'password' => 'secret'} }


### PR DESCRIPTION
Saving the existing user form can lead to 404 under specific
circumstances. The reason is, we rely on HTTP Referer header to return
the user to where he entered the form from. This can be problematic in
case they had to resubmit the form because of validation error. That
sets /users/$id in the referer, however that route is only defined with
PATCH. The rails support for `return_back` does not take the HTTP method
into the consideration, therefore user is routed back to GET
/users/$id. Such route does not exist. The exact steps to reproduce

1) login as a user without email address, make sure you have access to
   /users/index which is checked before redirecting
2) when you enter the form, create the poisoned Referer header by
   submitting invalid form (e.g. empty email)
3) submit the form with valid data now
4) rails redirects you to previous page through /users/login and
   verification before filter, in this case the page does not exists

This could be a problem elsewhere too, one can enter the page from other
page which is not accesible through GET. Therefore if the user has
permissions for user index page, we should redirect him or her to this
page (even though this may not be the page they come from). If they
don't have permission, we redirect them to the default landing page.

The impact is when I e.g. enter "My Account" from Subnets list, I'll end
up on Users list after I save my changes. I think that's acceptable
comparing to issues I'd see if I enter "My Account" from any invalid
form (and other pages).


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
