### PR TITLE
Fixes #31944 - remove unused GH actions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
   "extends": "plugin:@theforeman/foreman/core",
   "rules": {
     "spellcheck/spell-checker": [
-      "warn",
+      "error",
       {
         "comments": false,
         "identifiers": false,
@@ -65,6 +65,7 @@
           "loc",
           "locs",
           "lsi",
+          "matcher",
           "menuitem",
           "monokai",
           "mousedown",

--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -10,12 +10,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - 12
-          - 14
     steps:
       - name: Checkout Foreman
         uses: actions/checkout@v2
@@ -25,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
       - name: Install npm dependencies
         run: npm install
       - name: Run linter
@@ -34,8 +28,7 @@ jobs:
         run: npm run lint:spelling
       - name: Run tests
         run: npm run test
-      - name: Publish Coveralls (node v14)
-        if: ${{ matrix.node-version == 14 }}
+      - name: Publish Coveralls
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm install
       - name: Run linter
         run: npm run lint
-      - name: Run Spellcheck (only warnings)
+      - name: Run Spellcheck
         run: npm run lint:spelling
       - name: Run tests
         run: npm run test

--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -19,8 +19,6 @@ jobs:
         include:
           - repo: katello
             org: Katello
-          - repo: foreman-tasks
-            org: theforeman
     steps:
       - name: Use Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
- using only node 14 for testing, for a long time I didn't see any differences in test results between node 12 and 14, I guess it would be enough to run only 14 in tests.
- spelling warnings are sometimes missed and being visible on other PRs after the first gets merged, so I changed it to show the errors instead of warns.
- remove foreman-tasks from plugins tests, as we eventually didn't make it to work with foreman's code during tests yet, once another plugin would work with foreman's code we can add it to the list, or if there would be a generic solution for all plugins then we could add multiple, but for now, it's not used.. so let's save some space for the running GH actions vms.

any thoughts @theforeman/ui-ux? thanks
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
