### PR TITLE
Fixes #31946 - support for IBM Z (S390x)

### DIFF
--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -311,8 +311,12 @@ class Operatingsystem < ApplicationRecord
     boot_file_sources(medium_provider, &block)[file]
   end
 
+  def pxe_file_names(medium_provider)
+    family.constantize::PXEFILES
+  end
+
   def boot_file_sources(medium_provider, &block)
-    @boot_file_sources ||= family.constantize::PXEFILES.transform_values do |img|
+    @boot_file_sources ||= pxe_file_names(medium_provider).transform_values do |img|
       "#{medium_provider.medium_uri(pxedir(medium_provider), &block)}/#{img}"
     end
   end

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -25,9 +25,22 @@ class Redhat < Operatingsystem
     "kickstart"
   end
 
+  def pxe_file_names(medium_provider)
+    if medium_provider.try(:architecture).try(:name) =~ /^[Ss]390/
+      {
+        kernel: "kernel.img",
+        initrd: "initrd.img",
+      }
+    else
+      family.constantize::PXEFILES
+    end
+  end
+
   def pxedir(medium_provider = nil)
     if medium_provider.try(:architecture).try(:name) =~ /^ppc64/
       "ppc/ppc64"
+    elsif medium_provider.try(:architecture).try(:name) =~ /^[Ss]390/
+      "images"
     else
       "images/pxeboot"
     end

--- a/test/fixtures/architectures.yml
+++ b/test/fixtures/architectures.yml
@@ -8,6 +8,9 @@ sparc:
 s390:
   name: s390
 
+s390x:
+  name: s390x
+
 ASIC:
   name: ASIC
 

--- a/test/models/operatingsystems/redhat_test.rb
+++ b/test/models/operatingsystems/redhat_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class RedhatTest < ActiveSupport::TestCase
+  let(:operatingsystem) { FactoryBot.create(:rhel7_5) }
+  let(:medium) { FactoryBot.create(:medium, path: "http://mirror.example.com/rh/7.5") }
+  let(:mock_entity) do
+    OpenStruct.new(
+      operatingsystem: operatingsystem,
+      architecture: architecture,
+      medium: medium
+    )
+  end
+  let(:medium_provider) { MediumProviders::Default.new(mock_entity) }
+
+  context 'Red Hat on Intel x86_64' do
+    let(:architecture) { architectures(:x86_64) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'vmlinuz'
+        assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.img'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://mirror.example.com/rh/7.5/images/pxeboot/vmlinuz',
+          initrd: 'http://mirror.example.com/rh/7.5/images/pxeboot/initrd.img',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#mediumpath' do
+      test 'generates medium path url' do
+        assert_equal 'url --url http://mirror.example.com/rh/7.5', operatingsystem.mediumpath(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/pxeboot/vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/pxeboot/initrd.img', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
+
+  context 'Red Hat on IBM POWER' do
+    let(:architecture) { architectures(:ppc64) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'vmlinuz'
+        assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.img'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://mirror.example.com/rh/7.5/ppc/ppc64/vmlinuz',
+          initrd: 'http://mirror.example.com/rh/7.5/ppc/ppc64/initrd.img',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#mediumpath' do
+      test 'generates medium path url' do
+        assert_equal 'url --url http://mirror.example.com/rh/7.5', operatingsystem.mediumpath(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/ppc/ppc64/vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/ppc/ppc64/initrd.img', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
+
+  context 'Red Hat on IBM Z' do
+    let(:architecture) { architectures(:s390x) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'vmlinuz'
+        assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.img'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://mirror.example.com/rh/7.5/images/kernel.img',
+          initrd: 'http://mirror.example.com/rh/7.5/images/initrd.img',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#mediumpath' do
+      test 'generates medium path url' do
+        assert_equal 'url --url http://mirror.example.com/rh/7.5', operatingsystem.mediumpath(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/kernel.img', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/initrd.img', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
+end


### PR DESCRIPTION
On S390 kernel and initramdisk are at a different path and with different names: images/kernel.img and images/initrd.img. Foreman operating system model must reflect that in order to download Anaconda installer to TFTP.