### PR TITLE
Fixes #31947 - add grub2/ks validation to jenkins rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ npm-debug.log
 .vendor/
 .solargraph.yml
 .nvmrc
+mkmf.log

--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -6,6 +6,7 @@ begin
     task :unit => ['jenkins:setup:minitest', 'rake:test:units', 'rake:test:functionals', 'rake:test:graphql']
     task :integration => ['webpack:compile', 'jenkins:setup:minitest', 'rake:test:integration']
     task :functionals => ["jenkins:setup:minitest", 'rake:test:functionals']
+    task :external => ['rake:test:external']
     task :units => ["jenkins:setup:minitest", 'rake:test:units']
 
     namespace :setup do

--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -16,4 +16,12 @@ namespace :test do
     t.verbose = true
     t.warning = false
   end
+
+  desc "Test via external tools"
+  Rake::TestTask.new(:external) do |t|
+    t.libs << "test"
+    t.pattern = ['test/external/**/*_test.rb']
+    t.verbose = true
+    t.warning = false
+  end
 end

--- a/test/external/grub_syntax_test.rb
+++ b/test/external/grub_syntax_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+require 'mkmf'
+require "English"
+
+class GrubSyntaxTest < ActiveSupport::TestCase
+  Dir.glob('test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/*').each do |file|
+    test file do
+      grub_check(file)
+    end
+  end
+
+  private
+
+  def grub_check(file)
+    skip unless find_executable 'grub2-script-check'
+    output = `grub2-script-check "#{file}" 2>&1`
+    status = $CHILD_STATUS
+    assert_empty output
+    assert status.success?
+  end
+end

--- a/test/external/kickstart_syntax_test.rb
+++ b/test/external/kickstart_syntax_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+require "English"
+
+class KickstartSyntaxTest < ActiveSupport::TestCase
+  # Kickstart snapshots are generated only for EL7
+  ["RHEL7"].each do |version|
+    Dir.glob('test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/*Kickstart*').each do |file|
+      context version do
+        test file do
+          ksvalidator(file, version)
+        end
+      end
+    end
+  end
+
+  private
+
+  def ksvalidator(file, version)
+    skip unless find_executable 'ksvalidator'
+    output = `ksvalidator --version #{version} '#{file}' 2>&1`
+    status = $CHILD_STATUS
+    assert_empty output
+    assert status.success?
+  end
+end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -15,7 +15,7 @@ end
 FactoryBot.define do
   factory :ptable do
     sequence(:name) { |n| "ptable#{n}" }
-    layout { 'zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=<%= 10 * 10 %> --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended' }
+    layout { "zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=<%= 10 * 10 %> --asprimary\npart /     --fstype ext3 --size=1024 --grow\npart swap  --recommended" }
     os_family { 'Redhat' }
     organizations { [Organization.find_by_name('Organization 1')] }
     locations { [Location.find_by_name('Location 1')] }

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -45,8 +45,8 @@ files:
   - provision/rancheros_provision.erb
   - user_data/userdata_default.erb
   - PXELinux/waik_default_pxelinux.erb
-  - provision/xenserver_default_answerfile.erb
   - finish/xenserver_default_finish.erb
+  - provision/xenserver_default_answerfile.erb
   - PXELinux/xenserver_default_pxelinux.erb
   - iPXE/ipxe_intermediate_script.erb
   - snippet/ansible_tower_callback_script.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic_Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic_Kickstart_default.host4dhcp.snap.txt
@@ -6,7 +6,11 @@ timezone --utc UTC
 
 network --bootproto dhcp --hostname snapshot-ipv4-dhcp-el7 --device=00-f0-54-1a-7e-e0
 # Partition table should create /boot and a volume atomicos
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 bootloader --timeout=3
 text

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -31,7 +31,11 @@
     <start_at_boot config:type="boolean">true</start_at_boot>
     <start_in_chroot config:type="boolean">true</start_in_chroot>
   </ntp-client>
-  zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+  zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
   <runlevel>
     <default>3</default>
     <services config:type="list">

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -31,7 +31,11 @@
     <start_at_boot config:type="boolean">true</start_at_boot>
     <start_in_chroot config:type="boolean">true</start_in_chroot>
   </ntp-client>
-  zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+  zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
   <runlevel>
     <default>3</default>
     <services config:type="list">

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -24,7 +24,11 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" 
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 text
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -24,7 +24,11 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" 
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 text
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -24,7 +24,11 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" 
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 text
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -24,7 +24,11 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" 
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 text
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -24,7 +24,11 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 bootloader --location=mbr --append="nofb quiet splash=quiet" 
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 text
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
@@ -36,7 +36,11 @@ d-i clock-setup/ntp-server string 0.debian.pool.ntp.org
 # Choices: cylinder, minimal, optimal
 #d-i partman/alignment select cylinder
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
@@ -36,7 +36,11 @@ d-i clock-setup/ntp-server string 0.debian.pool.ntp.org
 # Choices: cylinder, minimal, optimal
 #d-i partman/alignment select cylinder
 
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer_default_answerfile.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer_default_answerfile.host4dhcp.snap.txt
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <installation mode="fresh" srtype="lvm">
-zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --asprimary\npart /     --f   stype ext3 --size=1024 --grow\npart swap  --recommended  <keymap>us</keymap>
+zerombr
+clearpart --all    --initlabel
+part /boot --fstype ext3 --size=100 --asprimary
+part /     --fstype ext3 --size=1024 --grow
+part swap  --recommended  <keymap>us</keymap>
   <hostname></hostname>
   <root-password type="hash">$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0</root-password>
   <source type="url">url --url http://mirror.centos.org/centos/7/os/x86_64</source>


### PR DESCRIPTION
Adds ksvalidator and grub2 syntax checkers for selected template snapshots.

Currently only RHEL7 profile passes, for RHEL8 we need to fix authconfig which was deprecated and ksvalidator already fails. I added a task but it's not called from the "all" task.

I've found that ptable mock had some errors, I've fixed this as well to make ksvalidator passing.

The patch blindly assumes that both tools are on PATH on our Jenkins nodes. I would like someone from the infra team to help me with setting up the environment. We need latest version of pykickstart installed, for grub2 any version will do as the parsing validation is only shallow.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->