### PR TITLE
Fixes #29960 - set PrivateTmp=true in services (CP 2.4)

### DIFF
--- a/extras/systemd/dynflow-sidekiq@.service
+++ b/extras/systemd/dynflow-sidekiq@.service
@@ -7,6 +7,7 @@ After=network.target remote-fs.target nss-lookup.target
 Type=notify
 User=foreman
 TimeoutSec=300
+PrivateTmp=true
 Environment=RAILS_ENV=production
 Environment=DYNFLOW_SIDEKIQ_SCRIPT=/usr/share/foreman/extras/dynflow-sidekiq.rb
 Environment=DYNFLOW_REDIS_URL=redis://localhost:6379/0

--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -8,6 +8,7 @@ Requires=foreman.socket
 Type=notify
 User=foreman
 TimeoutSec=300
+PrivateTmp=true
 WorkingDirectory=/usr/share/foreman
 ExecStart=/usr/share/foreman/bin/rails server --environment $FOREMAN_ENV
 Environment=FOREMAN_ENV=production


### PR DESCRIPTION
Cherry-pick for:

- set PrivateTmp=true in foreman.service (#8345)
- set PrivateTmp=true for dynflow-sidekiq (#8351)