### PR TITLE
Fixes #31962 - Preseed ipxe bootdisk domainfix

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -8,7 +8,7 @@ oses:
 - Ubuntu
 %>
 <% if @host.operatingsystem.name == 'Debian' -%>
-  <%- keyboard_params = "auto=true domain=#{@host.domain}" -%>
+  <%- keyboard_params = "auto=true" -%>
 <% else -%>
   <%- keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
 <% end -%>
@@ -31,7 +31,7 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> domain=<%= @host.domain %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
 initrd <%= initrd %>
 
 boot


### PR DESCRIPTION
With this change it is possible to deploy Ubuntu and Debian using bootdisk-deployment without DHCP in a non-interactive way.

That means with the setting of the domain at the kernel-options you can set the domain without getting the question during the preseed-installation to verify if the domain is correctly set if it does not end with ".com, .org, .net" or something similar.
So you can use every domain you wish to use.

The template has been tested for deployments for Ubuntu 20.04 and Debian 10 in combination with foreman 2.1.3 and bootdisk 17.0.2
If the domain has a common ending or your deployment sets the domain via DHCP this problem should not occur - however the change in the template also should not break anything if that is the case.