### PR TITLE
Fixes #31965 - make bmc_credentials_accessible disabled by default

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -702,7 +702,7 @@ autopart"', desc: 'to render the content of host partition table'
   def bmc_available?
     ipmi = bmc_nic
     return false if ipmi.nil?
-    (ipmi.password_unredacted.present? && ipmi.username.present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
+    (ipmi.credentials_present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
   end
   alias_method :bmc_available, :bmc_available?
 

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -40,6 +40,10 @@ module Nic
       Setting[:bmc_credentials_accessible] ? password_unredacted : nil
     end
 
+    def credentials_present?
+      password_unredacted.present? && username.present?
+    end
+
     private
 
     def ensure_physical

--- a/app/registries/foreman/settings/auth.rb
+++ b/app/registries/foreman/settings/auth.rb
@@ -126,12 +126,8 @@ Foreman::SettingManager.define(:foreman) do
     setting('bmc_credentials_accessible',
       type: :boolean,
       description: N_("Permits access to BMC interface passwords through ENC YAML output and in templates"),
-      default: true,
+      default: false,
       full_name: N_('BMC credentials access'))
-    validates('bmc_credentials_accessible',
-      ->(value) { value || Setting[:safemode_render] },
-      message: N_("Unable to disable bmc_credentials_accessible when safemode_render is disabled"))
-
     setting('oidc_jwks_url',
       type: :string,
       description: N_("OpenID Connect JSON Web Key Set(JWKS) URL. Typically https://keycloak.example.com/auth/realms/<realm name>/protocol/openid-connect/certs when using Keycloak as an OpenID provider"),

--- a/app/registries/foreman/settings/provisioning.rb
+++ b/app/registries/foreman/settings/provisioning.rb
@@ -148,8 +148,6 @@ Foreman::SettingManager.define(:foreman) do
         collection: proc { Hash[ProvisioningTemplate.unscoped.of_kind(pxe_kind).pluck(:name).map { |name| [name, name] }] },
         validate: :pxe_template_name)
     end
-
-    validates 'safemode_render', ->(value) { value || Setting[:bmc_credentials_accessible] }, message: N_("Unable to disable safemode_render when bmc_credentials_accessible is disabled")
   end
 end
 

--- a/test/controllers/api/v2/interfaces_controller_test.rb
+++ b/test/controllers/api/v2/interfaces_controller_test.rb
@@ -80,7 +80,7 @@ class Api::V2::InterfacesControllerTest < ActionController::TestCase
 
   test "username and password are set on POST (create)" do
     post :create, params: { :host_id => @host.to_param, :interface => valid_attrs }
-    assert_equal valid_attrs['password'], Nic::BMC.find_by_host_id(@host.id).password
+    assert_equal valid_attrs['password'], Nic::BMC.find_by_host_id(@host.id).password_unredacted
   end
 
   test "update a host interface" do

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1006,7 +1006,7 @@ class HostsControllerTest < ActionController::TestCase
     new_password = "topsecret"
     put :update, params: { :commit => "Update", :id => @host.name, :host => {:interfaces_attributes => {"0" => {:id => bmc1.id, :password => new_password, :mac => bmc1.mac} } } }, session: set_session_user
     @host = Host.find(@host.id)
-    assert_equal new_password, @host.interfaces.bmc.first.password
+    assert_equal new_password, @host.interfaces.bmc.first.password_unredacted
   end
 
   test "test non admin multiple action" do

--- a/test/models/nics/bmc_test.rb
+++ b/test/models/nics/bmc_test.rb
@@ -40,15 +40,23 @@ class BMCTest < ActiveSupport::TestCase
       assert @bmc_nic.password_in_db.include? Encryptable::ENCRYPTION_PREFIX
     end
 
-    test 'BMC password is decrypted in ENC' do
+    test 'BMC password is decrypted in ENC when bmc_credentials_accessible is turned on' do
+      Setting[:bmc_credentials_accessible] = true
       bmc_nic_enc = @bmc_nic.to_export
-      assert_equal bmc_nic_enc['password'], 'admin'
+      assert_equal "admin", bmc_nic_enc['password']
+    ensure
+      Setting[:bmc_credentials_accessible] = false
+    end
+
+    test 'BMC password is not shown via ENC by default' do
+      bmc_nic_enc = @bmc_nic.to_export
+      refute bmc_nic_enc['password']
     end
   end
 
-  test 'BMC password is provided in #password' do
+  test 'BMC password is not provided in #password' do
     bmc_nic = FactoryBot.build_stubbed(:nic_bmc, :provider => 'IPMI', :password => 'secret', :subnet => subnets(:one))
-    assert_equal 'secret', bmc_nic.password
+    refute bmc_nic.password
   end
 
   context 'with bmc_credentials_accessible => false' do

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -488,20 +488,6 @@ class SettingTest < ActiveSupport::TestCase
     assert !setting.save
   end
 
-  test 'bmc_credentials_accessible may not be disabled with safemode_render disabled' do
-    Setting[:safemode_render] = false
-    bmc = Setting.find_by_name('bmc_credentials_accessible')
-    bmc.value = false
-    refute_valid bmc, :value, 'Unable to disable bmc_credentials_accessible when safemode_render is disabled'
-  end
-
-  test 'safemode_render may not be disabled with bmc_credentials_accessible disabled' do
-    Setting[:bmc_credentials_accessible] = false
-    bmc = Setting.find_by_name('safemode_render')
-    bmc.value = false
-    refute_valid bmc, :value, 'Unable to disable safemode_render when bmc_credentials_accessible is disabled'
-  end
-
   test 'orders settings alphabetically' do
     a_name = 'a_foo'
     b_name = 'b_foo'


### PR DESCRIPTION
Also remove the settings check as that would be pretty useless with this new value.