### PR TITLE
Fixes #31990 - Optimize tooltip and popover initialization

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -36,6 +36,10 @@ function onContentLoad() {
   // highlight tabs with errors
   tfm.tools.highlightTabErrors();
 
+  $('body').popover({selector: 'a[rel="popover"]'});
+  tfm.tools.activateTooltips();
+  tfm.tools.activateDatatables();
+
   // allow opening new window for selected links
   $('a[rel="external"]').attr('target', '_blank');
 

--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -65,7 +65,7 @@
           <%= spinner(_('Loading VM information ...')) %>
         </div>
       <% end %>
-      <div id="nics" class="tab-pane" data-ajax-url='<%= nics_host_path(@host)%>' data-on-complete='tfm.tools.activateTooltips'>
+      <div id="nics" class="tab-pane" data-ajax-url='<%= nics_host_path(@host)%>'>
         <%= spinner(_('Loading NICs information ...')) %>
       </div>
       <% if @host.bmc_available? %>

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -200,6 +200,7 @@ class HostJSTest < IntegrationTestWithJavascript
       assert page.has_link?('Parameters', :href => '#params')
       click_link 'Parameters'
       assert page.has_no_selector?(id)
+      page.find('#global_parameters_table a[title="Remove Parameter"]').hover
       page.find('#global_parameters_table a[data-original-title="Remove Parameter"]').click
       assert page.has_selector?(id)
     end

--- a/test/integration/organization_js_test.rb
+++ b/test/integration/organization_js_test.rb
@@ -28,6 +28,7 @@ class OrganizationJSTest < IntegrationTestWithJavascript
       within "#locations" do
         find(".ms-selection").assert_no_selector("li[selected='selected']")
         find(".ms-selectable").find("input").set("Location 1")
+        find("a[title='Select All']").hover
         find("a[data-original-title='Select All']").click
         find(".ms-selection").find(".ms-selected").find("span").has_text? "Location 1"
       end

--- a/test/integration/puppetclass_test.rb
+++ b/test/integration/puppetclass_test.rb
@@ -8,6 +8,7 @@ class PuppetclassIntegrationTest < IntegrationTestWithJavascript
     visit puppetclasses_path
     click_link "vim"
     assert page.has_no_link? 'Common'
+    find(:xpath, "//a[@title='Select All']").hover
     find(:xpath, "//a[@data-original-title='Select All']").click
     assert_submit_button(puppetclasses_path)
     assert page.has_link? 'vim'
@@ -20,6 +21,7 @@ class PuppetclassIntegrationTest < IntegrationTestWithJavascript
     smart_class_parameter_long = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :puppetclass => puppet_class_long, :variable => "a" * 50)
     visit edit_puppetclass_path(puppet_class_long)
     click_link 'Smart Class Parameter'
+    page.find("#pill_#{smart_class_parameter_long.id}-#{smart_class_parameter_long.key}").hover
     assert_equal smart_class_parameter_long.key, page.find("#pill_#{smart_class_parameter_long.id}-#{smart_class_parameter_long.key}")['data-original-title']
   end
 
@@ -29,6 +31,7 @@ class PuppetclassIntegrationTest < IntegrationTestWithJavascript
     smart_class_parameter_short = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :puppetclass => puppet_class_short, :variable => "a" * 40)
     visit edit_puppetclass_path(puppet_class_short)
     click_link 'Smart Class Parameter'
+    page.find("#pill_#{smart_class_parameter_short.id}-#{smart_class_parameter_short.key}").hover
     assert_empty page.find("#pill_#{smart_class_parameter_short.id}-#{smart_class_parameter_short.key}")['data-original-title']
   end
 end

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -59,16 +59,18 @@ export function activateDatatables() {
 
 export function activateTooltips(elParam = 'body') {
   const el = $(elParam);
-  el.find('[rel="twipsy"]').tooltip({ container: 'body' });
+
+  el.tooltip({
+    selector: '[rel="twipsy"],*[title]:not(*[rel],.fa,.pficon)',
+    container: 'body',
+  });
+  // Ellipsis have to be initialized for each element for title() to work
   el.find('.ellipsis').tooltip({
     container: 'body',
     title() {
       return this.scrollWidth > this.clientWidth ? this.textContent : null;
     },
   });
-  el.find('*[title]')
-    .not('*[rel],.fa,.pficon')
-    .tooltip({ container: 'body' });
 }
 
 export function initTypeAheadSelect(input) {
@@ -133,8 +135,4 @@ export function highlightTabErrors() {
     .first()
     .find('.form-control')
     .focus();
-
-  $('a[rel="popover"]').popover();
-  activateTooltips();
-  activateDatatables();
 }

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -48,19 +48,6 @@ describe('activateDatatables', () => {
   });
 });
 
-describe('activateTooltips', () => {
-  it('calls $.fn.tooltip on all matching elements', () => {
-    const elements = `<div rel='twipsy'></div>
-      <div class='ellipsis'></div>
-      <div title='test'></div>
-      <div title='test' rel='popover'></div>`;
-
-    $.fn.tooltip = jest.fn();
-    tools.activateTooltips(elements);
-    expect($.fn.tooltip).toHaveBeenCalledTimes(3);
-  });
-});
-
 /* eslint-disable no-console, max-len */
 describe('deprecate', () => {
   it('Logs the correct deprecation message', () => {


### PR DESCRIPTION
Instead of iterating over all elements with tooltips or popovers and
initializing each one seperately, initialize them once with a selector
to identify which elements should have them. On pages with hundreds or
thousands of tooltips and popovers this could have a significant
performance impact on the page rendering.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
