### PR TITLE
Fixes #32004 - Don't ignore use-ntp host param in prov templates

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -51,7 +51,7 @@ https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/pe
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
-  use_ntp = host_param_true?('use-ntp') || (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7)
+  use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7))
   iface = @host.provision_interface
   appstream_present = false
 -%>

--- a/app/views/unattended/provisioning_templates/snippet/ntp.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ntp.erb
@@ -14,7 +14,7 @@ This snippet accepts the following parameters:
 rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
 is_fedora = @host.operatingsystem.name == 'Fedora'
 os_major = @host.operatingsystem.major.to_i
-use_ntp = host_param_true?('use-ntp') || (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7)
+use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7))
 -%>
 
 echo "Updating system time"


### PR DESCRIPTION
Setting use-ntp=false will never work due to short circuit evaluation
of boolean expressions in templates. This patch should make use-ntp
parameter be honored if set to false.


BZ says that the topic was addressed in the past, but the fix was rejected and there is still no actual resolution apparently... I'd say if we use the parameter to make decisions based on the value, why we simply ignore it if it is set to false? Is it just overlook or it is really intentionally to force the last check with OS compatibility?