### PR TITLE
Fixes #32026 - cloned role throws error 500 if invalid

### DIFF
--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -35,20 +35,18 @@ class RolesController < ApplicationController
     if @role.save
       process_success
     else
-      if cloning?
-        @cloned_role = true
-        @original_role_id = params[:original_role_id]
-      end
+      @cloned_role = true if cloning?
       process_error
     end
   end
 
   def clone
     @cloned_role = true
-    @original_role = @role
+    original_role = @role
     @role = Role.new
-    @role.locations = @original_role.locations
-    @role.organizations = @original_role.organizations
+    @role.cloned_from_id = original_role.id
+    @role.locations = original_role.locations
+    @role.organizations = original_role.organizations
     render :action => :new
   end
 

--- a/app/views/roles/_form.html.erb
+++ b/app/views/roles/_form.html.erb
@@ -25,7 +25,7 @@
       <%= text_f f, :name, :class => @role.builtin? ? "disabled" : ""  %>
       <%= textarea_f f, :description, :rows=> 5, :size => "col-md-4" %>
 
-      <%= hidden_field_tag :original_role_id, @original_role.id if @cloned_role %>
+      <%= hidden_field_tag :original_role_id, @role.cloned_from_id if @cloned_role %>
 
       <% tax_help = N_("When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.
                          Filters that are set to override <br> will remain untouched. Overriding of role filters can be easily disabled by <br> pressing the \"Disable overriding\" button.


### PR DESCRIPTION
In e61362d1a103b4fbd79c838a6bb6f01986ab02a9 (#6181) we've accidently forgot about the create action, but now
save of invalid role would have end up with 500 error.

This moves to using `cloned_from_id` instead of `@original_role` as
source of the original role id as this information is easier to pass to
the form.