### PR TITLE
Fixes #32042 - Remove :host_param_true? from REX & insights snippets

### DIFF
--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -20,9 +20,15 @@ set -e
 <%= snippet 'puppet_setup' %>
 <% end -%>
 
+<% if host_param_true?('host_registration_remote_execution') -%>
 <%= snippet 'remote_execution_ssh_keys' %>
-<%= snippet 'insights' -%>
 
+<% end -%>
+
+<% if host_param_true?('host_registration_insights') -%>
+<%= snippet 'insights' %>
+
+<% end -%>
 
 # Call home to exit build mode
 <% built_https = foreman_url('built').start_with?('https') -%>

--- a/app/views/unattended/provisioning_templates/snippet/insights.erb
+++ b/app/views/unattended/provisioning_templates/snippet/insights.erb
@@ -4,7 +4,7 @@ name: insights
 model: ProvisioningTemplate
 snippet: true
 %>
-<% if @host.operatingsystem.name == 'RedHat' && host_param_true?('host_registration_insights') -%>
+<% if @host.operatingsystem.name == 'RedHat' -%>
 echo '#'
 echo '# Installing Insights client'
 echo '#'

--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -28,7 +28,6 @@ snippet: true
 # file.
 
 
-<% if host_param_true?('host_registration_remote_execution') -%>
 <% if !host_param('remote_execution_ssh_keys').blank? %>
 <% ssh_user = host_param('remote_execution_ssh_user') || 'root' %>
 
@@ -69,5 +68,4 @@ Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers
 else
   echo 'The remote_execution_ssh_user does not exist and remote_execution_create_user is not set to true.  remote_execution_ssh_keys snippet will not install keys'
 fi
-<% end %>
 <% end -%>


### PR DESCRIPTION
Move the `:host_param_true?` conditions for Host registration params
outside of the snippets to the Host registration template.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
