### PR TITLE
Fixes #32051 - Change exit status in iPXE templates

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/ipxe_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/ipxe_default_local_boot.erb
@@ -7,4 +7,4 @@ snippet: false
 #!ipxe
 
 # Skips booting from network and continues booting from next device
-exit
+exit 1

--- a/app/views/unattended/provisioning_templates/iPXE/ipxe_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/ipxe_default_local_boot.erb
@@ -7,4 +7,4 @@ snippet: false
 #!ipxe
 
 # Skips booting from network and continues booting from next device
-exit 1
+exit

--- a/app/views/unattended/provisioning_templates/iPXE/ipxe_global_default.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/ipxe_global_default.erb
@@ -42,7 +42,7 @@ goto shell
 reboot
 
 :local
-exit 1
+exit
 
 :discovery
 dhcp

--- a/app/views/unattended/provisioning_templates/iPXE/ipxe_global_default.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/ipxe_global_default.erb
@@ -42,7 +42,7 @@ goto shell
 reboot
 
 :local
-exit
+exit 1
 
 :discovery
 dhcp


### PR DESCRIPTION
iPXE in UEFI env need exit with status code to attempt boot from other
device, i.e. netboot -> local disk

ref: https://forum.ipxe.org/showthread.php?tid=10327&pid=16696#pid16696
