### PR TITLE
Fixes #32055 - Don't show missing doc link on EmptyState

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
@@ -33,7 +33,7 @@ const EmptyStatePattern = props => {
     const {
       label = __('For more information please see '), // eslint-disable-line react/prop-types
       buttonLabel = __('documentation'), // eslint-disable-line react/prop-types
-      url, // eslint-disable-line react/prop-types
+      url = '#', // eslint-disable-line react/prop-types
     } = documentation;
     return (
       <span>
@@ -69,9 +69,7 @@ EmptyStatePattern.propTypes = emptyStatePatternPropTypes;
 EmptyStatePattern.defaultProps = {
   icon: 'add-circle-o',
   secondaryActions: [],
-  documentation: {
-    url: '#',
-  },
+  documentation: null,
   action: null,
   iconType: 'pf',
 };


### PR DESCRIPTION
When `documentation` prop is not passed to the EmptyState component, the
default prop `{url: '#'}` was being used causing a useless help link to
be displayed.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
