### PR TITLE
Fixes #32056 - Open EmptyState documentation links in new tab

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
@@ -38,7 +38,9 @@ const EmptyStatePattern = props => {
     return (
       <span>
         {label}
-        <a href={url}>{buttonLabel}</a>
+        <a href={url} target="_blank" rel="external noreferrer noopener">
+          {buttonLabel}
+        </a>
       </span>
     );
   };


### PR DESCRIPTION
This link points to external documentation and should not lead users out
of Foreman in their current browser tab.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
