### PR TITLE
Fixes #31425 - Templates rendering host status

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
 gem 'jwt', '~> 2.2.2'
 gem 'graphql', '~> 1.8.0'
 gem 'graphql-batch'
+gem 'scenic', '~> 1.5.4'
 
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   instance_eval(Bundler.read_file(bundle))

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -187,6 +187,7 @@ module Api
           * global
           * configuration
           * build
+          * rendering
         EOS
       )
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -277,7 +277,7 @@ class HostsController < ApplicationController
   end
 
   def forget_status
-    status = @host.host_statuses.find(params[:status])
+    status = @host.host_statuses_with_rendering_status.find(params[:status])
     status.delete
     respond_to do |format|
       format.html do
@@ -829,9 +829,7 @@ class HostsController < ApplicationController
 
   def find_templates
     find_resource
-    @templates = TemplateKind.order(:name).map do |kind|
-      @host.provisioning_template(:kind => kind.name)
-    end.compact
+    @templates = @host.find_templates
     raise Foreman::Exception.new(N_("No templates found")) if @templates.empty?
   end
 

--- a/app/graphql/resolvers/provisioning_template/path.rb
+++ b/app/graphql/resolvers/provisioning_template/path.rb
@@ -1,0 +1,11 @@
+module Resolvers
+  module ProvisioningTemplate
+    class Path < Resolvers::BaseResolver
+      type String, null: false
+
+      def resolve
+        Rails.application.routes.url_helpers.edit_provisioning_template_path(object)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/rendering_status/label.rb
+++ b/app/graphql/resolvers/rendering_status/label.rb
@@ -1,0 +1,11 @@
+module Resolvers
+  module RenderingStatus
+    class Label < Resolvers::BaseResolver
+      type String, null: false
+
+      def resolve
+        HostStatus::RenderingStatus::LABELS.fetch(object.status, N_('Unknown'))
+      end
+    end
+  end
+end

--- a/app/graphql/types/provisioning_template.rb
+++ b/app/graphql/types/provisioning_template.rb
@@ -1,0 +1,10 @@
+module Types
+  class ProvisioningTemplate < BaseObject
+    description 'A Provisioning Template'
+
+    global_id_field :id
+    timestamps
+    field :name, String
+    field :path, resolver: Resolvers::ProvisioningTemplate::Path
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -94,5 +94,14 @@ module Types
 
     record_field :permission, Types::Permission
     collection_field :permissions, Types::Permission
+
+    record_field :provisioning_template, Types::ProvisioningTemplate
+    collection_field :provisioning_templates, Types::ProvisioningTemplate
+
+    record_field :rendering_status, Types::RenderingStatus
+    collection_field :rendering_statuses, Types::RenderingStatus
+
+    record_field :rendering_status_combination, Types::RenderingStatusCombination
+    collection_field :rendering_status_combinations, Types::RenderingStatusCombination
   end
 end

--- a/app/graphql/types/rendering_status.rb
+++ b/app/graphql/types/rendering_status.rb
@@ -1,0 +1,16 @@
+module Types
+  class RenderingStatus < BaseObject
+    model_class HostStatus::RenderingStatus
+
+    description 'A Rendering Status'
+
+    global_id_field :id
+    field :status, Integer
+    field :safemode_status, Integer
+    field :unsafemode_status, Integer
+    field :label, resolver: Resolvers::RenderingStatus::Label
+
+    belongs_to :host, Types::Host
+    has_many :combinations, Types::RenderingStatusCombination
+  end
+end

--- a/app/graphql/types/rendering_status_combination.rb
+++ b/app/graphql/types/rendering_status_combination.rb
@@ -1,0 +1,15 @@
+module Types
+  class RenderingStatusCombination < BaseObject
+    model_class HostStatus::RenderingStatusCombination
+
+    description 'A Rendering Status Combination'
+
+    global_id_field :id
+    timestamps
+    field :safemode_status, Integer
+    field :unsafemode_status, Integer
+
+    belongs_to :host, Types::Host
+    belongs_to :template, Types::ProvisioningTemplate
+  end
+end

--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -47,7 +47,7 @@ module HostDescriptionHelper
 
   def host_detailed_status_list(host)
     priority = 10
-    host.host_statuses.sort_by(&:type).map do |status|
+    host.host_statuses_with_rendering_status.sort_by(&:type).map do |status|
       next unless status.relevant? && !status.substatus?
       { :field => [
         _(status.name),

--- a/app/models/concerns/hostext/operating_system.rb
+++ b/app/models/concerns/hostext/operating_system.rb
@@ -20,6 +20,12 @@ module Hostext
       end
     end
 
+    def find_templates
+      TemplateKind.order(:name).map do |kind|
+        provisioning_template(kind: kind.name)
+      end.compact
+    end
+
     def available_template_kinds(provisioning = nil)
       kinds = template_kinds(provisioning)
       kinds.map do |kind|

--- a/app/models/concerns/hostext/rendering_status.rb
+++ b/app/models/concerns/hostext/rendering_status.rb
@@ -1,0 +1,45 @@
+module Hostext
+  module RenderingStatus
+    extend ActiveSupport::Concern
+
+    included do
+      has_one :rendering_status, foreign_key: :host_id,
+                                 inverse_of: :host,
+                                 class_name: 'HostStatus::RenderingStatus'
+
+      has_many :rendering_status_combinations, through: :rendering_status,
+                                               source: :combinations,
+                                               dependent: :destroy
+
+      after_save :destroy_stale_rendering_status_combinations, if: :saved_change_to_rendering_status_combinations?
+
+      def destroy_stale_rendering_status_combinations
+        if operatingsystem_id
+          template_ids = find_templates.map(&:id)
+
+          rendering_status_combinations.where.not(template_id: template_ids).destroy_all
+        else
+          rendering_status_combinations.destroy_all
+        end
+      end
+
+      def host_statuses_with_rendering_status
+        host_statuses | [rendering_status].compact
+      end
+
+      private
+
+      def saved_change_to_rendering_status_combinations?
+        attrs = [
+          :organization_id,
+          :location_id,
+          :operatingsystem_id,
+          :environment_id,
+          :hostgroup_id,
+        ]
+
+        (saved_changes.keys & attrs).any?
+      end
+    end
+  end
+end

--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -38,6 +38,15 @@ module Hostext
         build_failed: HostStatus::BuildStatus::BUILD_FAILED,
       }
 
+      scoped_search :relation => :rendering_status_object, :on => :status, :rename => :rendering_status, :only_explicit => true, :operators => ['=', '!=', '<>'], :complete_value => {
+        safemode_ok: HostStatus::RenderingStatus::SAFEMODE_OK,
+        unsafemode_ok: HostStatus::RenderingStatus::UNSAFEMODE_OK,
+        safemode_warn: HostStatus::RenderingStatus::SAFEMODE_WARN,
+        unsafemode_warn: HostStatus::RenderingStatus::UNSAFEMODE_WARN,
+        safemode_error: HostStatus::RenderingStatus::SAFEMODE_ERROR,
+        unsafemode_error: HostStatus::RenderingStatus::UNSAFEMODE_ERROR,
+      }
+
       scoped_search :on => :global_status, :complete_value => { :ok => HostStatus::Global::OK, :warning => HostStatus::Global::WARN, :error => HostStatus::Global::ERROR }, :only_explicit => true
       scoped_search :relation => :model,       :on => :name,    :complete_value => true,  :rename => :model
       scoped_search :relation => :hostgroup,   :on => :name,    :complete_value => true,  :rename => :hostgroup

--- a/app/models/host_status/rendering_status.rb
+++ b/app/models/host_status/rendering_status.rb
@@ -1,0 +1,104 @@
+module HostStatus
+  class RenderingStatus < Status
+    include Authorizable
+
+    self.table_name = 'rendering_statuses_view'
+
+    graphql_type '::Types::RenderingStatus'
+
+    SAFEMODE_OK = 0
+    UNSAFEMODE_OK = 1
+    SAFEMODE_WARN = 2
+    UNSAFEMODE_WARN = 3
+    SAFEMODE_ERROR = 4
+    UNSAFEMODE_ERROR = 5
+
+    OK_STATUSES = [SAFEMODE_OK, UNSAFEMODE_OK]
+    WARN_STATUSES = [SAFEMODE_WARN, UNSAFEMODE_WARN]
+    ERROR_STATUSES = [SAFEMODE_ERROR, UNSAFEMODE_ERROR]
+
+    LABELS = {
+      SAFEMODE_OK => N_('Safe mode OK'),
+      UNSAFEMODE_OK => N_('Unsafe mode OK'),
+      SAFEMODE_WARN => N_('Safe mode warning'),
+      UNSAFEMODE_WARN => N_('Unsafe mode warning'),
+      SAFEMODE_ERROR => N_('Safe mode error'),
+      UNSAFEMODE_ERROR => N_('Unsafe mode error'),
+    }.freeze
+
+    SEARCH = {
+      SAFEMODE_OK => 'rendering_status = safemode_ok',
+      UNSAFEMODE_OK => 'rendering_status = unsafemode_ok',
+      SAFEMODE_WARN => 'rendering_status = safemode_warn',
+      UNSAFEMODE_WARN => 'rendering_status = unsafemode_warn',
+      SAFEMODE_ERROR => 'rendering_status = safemode_error',
+      UNSAFEMODE_ERROR => 'rendering_status = unsafemode_error',
+    }.freeze
+
+    def self.status_name
+      N_('Rendering')
+    end
+
+    has_many :combinations, class_name: 'HostStatus::RenderingStatusCombination',
+                            inverse_of: :host_status,
+                            primary_key: :host_id,
+                            foreign_key: :host_id
+    has_many :templates, through: :combinations
+
+    delegate :destroy_stale_rendering_status_combinations, to: :host
+
+    def self.new(**kwargs, &block)
+      super(kwargs.except(:type), &block)
+    end
+
+    def delete
+      combinations.destroy_all
+    end
+
+    def to_label
+      LABELS.fetch(to_status, N_('Unknown rendering status'))
+    end
+
+    def to_status
+      status
+    end
+
+    def to_global(_options = {})
+      case status
+      when SAFEMODE_ERROR, UNSAFEMODE_ERROR
+        HostStatus::Global::ERROR
+      when SAFEMODE_WARN, UNSAFEMODE_WARN
+        HostStatus::Global::WARN
+      else
+        HostStatus::Global::OK
+      end
+    end
+
+    def readonly?
+      true
+    end
+
+    def refresh
+      combinations.each(&:refresh)
+      destroy_stale_rendering_status_combinations
+    end
+
+    def refresh!
+      refresh
+    end
+
+    def status_link
+      Rails.application.routes.url_helpers.rendering_status_path(global_id)
+    end
+
+    def global_id
+      Foreman::GlobalId.for(self)
+    end
+
+    def type
+      self.class.to_s
+    end
+  end
+end
+
+HostStatus.status_registry.add(HostStatus::RenderingStatus)

--- a/app/models/host_status/rendering_status_combination.rb
+++ b/app/models/host_status/rendering_status_combination.rb
@@ -1,0 +1,22 @@
+module HostStatus
+  class RenderingStatusCombination < ::ApplicationRecord
+    include Authorizable
+
+    graphql_type '::Types::RenderingStatusCombination'
+
+    OK = 0
+    WARN = 1
+    ERROR = 2
+
+    belongs_to_host
+    belongs_to :template, class_name: 'ProvisioningTemplate'
+    belongs_to :host_status, inverse_of: :combinations,
+                             class_name: 'HostStatus::RenderingStatus',
+                             primary_key: :host_id,
+                             foreign_key: :host_id
+
+    validates :host, uniqueness: { scope: :template }
+    validates :host, presence: true
+    validates :template, presence: true
+  end
+end

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -29,6 +29,7 @@ class ProvisioningTemplate < Template
     :reject_if => :reject_template_combination_attributes?
   has_and_belongs_to_many :operatingsystems, :join_table => :operatingsystems_provisioning_templates, :association_foreign_key => :operatingsystem_id, :foreign_key => :provisioning_template_id
   has_many :os_default_templates
+  has_many :rendering_status_combinations, class_name: 'HostStatus::RenderingStatusCombination', foreign_key: :template_id, dependent: :destroy
   before_save :check_for_snippet_assoications
 
   validate :no_os_for_registration

--- a/app/services/refresh_global_statuses.rb
+++ b/app/services/refresh_global_statuses.rb
@@ -1,0 +1,33 @@
+class RefreshGlobalStatuses
+  def self.call(hosts = Host::Managed.all)
+    new(hosts).call
+  end
+
+  def initialize(hosts)
+    @hosts = hosts
+  end
+
+  def call
+    new_global_statuses.map do |status, ids|
+      Host::Managed.where(id: ids).update_all(global_status: status)
+    end
+  end
+
+  private
+
+  attr_reader :hosts
+
+  def new_global_statuses
+    statuses = {}
+
+    hosts.find_each do |host|
+      new_status = host.build_global_status.status
+      if host.global_status != new_status
+        statuses[new_status] ||= []
+        statuses[new_status] << host.id
+      end
+    end
+
+    statuses
+  end
+end

--- a/app/subscribers/foreman/rendering/base_subscriber.rb
+++ b/app/subscribers/foreman/rendering/base_subscriber.rb
@@ -1,0 +1,44 @@
+module Foreman
+  module Rendering
+    class BaseSubscriber < ::Foreman::BaseSubscriber
+      def call(event)
+        @host_id = event.payload[:host_id]
+        @template_id = event.payload[:template_id]
+
+        return unless template_id && host_id
+        return unless Host::Managed.unscoped.exists?(id: template_id)
+        return unless ProvisioningTemplate.unscoped.exists?(id: host_id)
+
+        update_combination
+        update_warnings
+        refresh_global_statuses
+      end
+
+      private
+
+      attr_reader :host_id, :template_id
+
+      def combination
+        @combination ||= HostStatus::RenderingStatusCombination.find_or_initialize_by(host_id: host_id, template_id: template_id)
+      end
+
+      def combinations
+        HostStatus::RenderingStatusCombination.where(template_id: template_id)
+      end
+
+      def refresh_global_statuses
+        hosts = Host::Managed.joins(:rendering_status_combinations)
+                             .where(rendering_status_combinations: { template_id: template_id })
+        RefreshGlobalStatuses.call(hosts)
+      end
+
+      def update_combination
+        raise NotImplementedError
+      end
+
+      def update_warnings
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/app/subscribers/foreman/rendering/safemode_error_subscriber.rb
+++ b/app/subscribers/foreman/rendering/safemode_error_subscriber.rb
@@ -1,0 +1,16 @@
+module Foreman
+  module Rendering
+    class SafemodeErrorSubscriber < Rendering::BaseSubscriber
+      private
+
+      def update_combination
+        combination.update!(safemode_status: HostStatus::RenderingStatusCombination::ERROR)
+      end
+
+      def update_warnings
+        combinations.where(safemode_status: HostStatus::RenderingStatusCombination::OK)
+                    .update_all(safemode_status: HostStatus::RenderingStatusCombination::WARN)
+      end
+    end
+  end
+end

--- a/app/subscribers/foreman/rendering/safemode_rendered_subscriber.rb
+++ b/app/subscribers/foreman/rendering/safemode_rendered_subscriber.rb
@@ -1,0 +1,16 @@
+module Foreman
+  module Rendering
+    class SafemodeRenderedSubscriber < Rendering::BaseSubscriber
+      private
+
+      def update_combination
+        combination.update!(safemode_status: HostStatus::RenderingStatusCombination::OK)
+      end
+
+      def update_warnings
+        combinations.where(safemode_status: HostStatus::RenderingStatusCombination::WARN)
+                    .update_all(safemode_status: HostStatus::RenderingStatusCombination::OK)
+      end
+    end
+  end
+end

--- a/app/subscribers/foreman/rendering/unsafemode_error_subscriber.rb
+++ b/app/subscribers/foreman/rendering/unsafemode_error_subscriber.rb
@@ -1,0 +1,16 @@
+module Foreman
+  module Rendering
+    class UnsafemodeErrorSubscriber < Rendering::BaseSubscriber
+      private
+
+      def update_combination
+        combination.update!(unsafemode_status: HostStatus::RenderingStatusCombination::ERROR)
+      end
+
+      def update_warnings
+        combinations.where(unsafemode_status: HostStatus::RenderingStatusCombination::OK)
+                    .update_all(unsafemode_status: HostStatus::RenderingStatusCombination::WARN)
+      end
+    end
+  end
+end

--- a/app/subscribers/foreman/rendering/unsafemode_rendered_subscriber.rb
+++ b/app/subscribers/foreman/rendering/unsafemode_rendered_subscriber.rb
@@ -1,0 +1,16 @@
+module Foreman
+  module Rendering
+    class UnsafemodeRenderedSubscriber < Rendering::BaseSubscriber
+      private
+
+      def update_combination
+        combination.update!(unsafemode_status: HostStatus::RenderingStatusCombination::OK)
+      end
+
+      def update_warnings
+        combinations.where(unsafemode_status: HostStatus::RenderingStatusCombination::WARN)
+                    .update_all(unsafemode_status: HostStatus::RenderingStatusCombination::OK)
+      end
+    end
+  end
+end

--- a/config/initializers/subscribers.rb
+++ b/config/initializers/subscribers.rb
@@ -1,0 +1,4 @@
+ActiveSupport::Notifications.subscribe("safemode_rendered.#{Foreman::Observable::DEFAULT_NAMESPACE}", ::Foreman::Rendering::SafemodeRenderedSubscriber)
+ActiveSupport::Notifications.subscribe("safemode_rendering_error.#{Foreman::Observable::DEFAULT_NAMESPACE}", ::Foreman::Rendering::SafemodeErrorSubscriber)
+ActiveSupport::Notifications.subscribe("unsafemode_rendered.#{Foreman::Observable::DEFAULT_NAMESPACE}", ::Foreman::Rendering::UnsafemodeRenderedSubscriber)
+ActiveSupport::Notifications.subscribe("unsafemode_rendering_error.#{Foreman::Observable::DEFAULT_NAMESPACE}", ::Foreman::Rendering::UnsafemodeErrorSubscriber)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -548,4 +548,8 @@ Foreman::Application.routes.draw do
     match 'experimental/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
   end
   get 'links/:type(/:section)' => 'links#show', :as => 'external_link', :constraints => { section: %r{.*} }
+
+  constraints(id: /[a-zA-Z0-9]+/) do
+    match 'rendering_statuses/:id' => 'react#index', :via => :get, :as => :rendering_status
+  end
 end

--- a/db/migrate/20210217131001_create_rendering_status_combinations.rb
+++ b/db/migrate/20210217131001_create_rendering_status_combinations.rb
@@ -1,0 +1,12 @@
+class CreateRenderingStatusCombinations < ActiveRecord::Migration[6.0]
+  def change
+    create_table :rendering_status_combinations do |t|
+      t.references :host, null: false, foreign_key: true
+      t.references :template, null: false, foreign_key: true
+      t.integer :safemode_status
+      t.integer :unsafemode_status
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210223220136_create_rendering_statuses_view.rb
+++ b/db/migrate/20210223220136_create_rendering_statuses_view.rb
@@ -1,0 +1,5 @@
+class CreateRenderingStatusesView < ActiveRecord::Migration[6.0]
+  def change
+    create_view :rendering_statuses_view
+  end
+end

--- a/db/views/rendering_statuses_view_v01.sql
+++ b/db/views/rendering_statuses_view_v01.sql
@@ -1,0 +1,23 @@
+SELECT
+  *,
+  CASE
+    WHEN unsafemode_status = 2  THEN 5   --- UNSAFEMODE_ERROR
+    WHEN safemode_status = 2    THEN 4   --- SAFEMODE_ERROR
+    WHEN unsafemode_status = 1  THEN 3   --- UNSAFEMODE_WARN
+    WHEN safemode_status = 1    THEN 2   --- SAFEMODE_WARN
+    WHEN safemode_status = 0    THEN 0   --- SAFEMODE_OK
+    WHEN unsafemode_status = 0  THEN 1   --- UNSAFEMODE_OK
+  ELSE
+    NULL
+  END AS status
+FROM (
+  SELECT
+    md5(host_id::text) AS id,
+    host_id,
+    max(safemode_status) AS safemode_status,
+    max(unsafemode_status) AS unsafemode_status
+  FROM
+    rendering_status_combinations
+  GROUP BY
+    host_id
+) t

--- a/lib/foreman/renderer/unsafe_mode_renderer.rb
+++ b/lib/foreman/renderer/unsafe_mode_renderer.rb
@@ -1,6 +1,24 @@
 module Foreman
   module Renderer
     class UnsafeModeRenderer < BaseRenderer
+      extend Foreman::Observable
+
+      def self.render(source, scope)
+        result = super
+
+        if !scope.preview? && source.template.is_a?(ProvisioningTemplate) && !source.template&.snippet?
+          trigger_hook(:unsafemode_rendered, payload: { host_id: scope.host&.id, template_id: source.template&.id })
+        end
+
+        result
+      rescue StandardError => e
+        if !scope.preview? && source.template.is_a?(ProvisioningTemplate) && !source.template&.snippet?
+          trigger_hook(:unsafemode_rendering_error, payload: { host_id: scope.host&.id, template_id: source.template&.id })
+        end
+
+        raise e
+      end
+
       def render
         erb = ERB.new(source_content, nil, '-')
         erb.location = source_name, 0

--- a/test/factories/rendering_status_combination.rb
+++ b/test/factories/rendering_status_combination.rb
@@ -1,0 +1,30 @@
+FactoryBot.define do
+  factory :rendering_status_combination, class: HostStatus::RenderingStatusCombination do
+    host
+    association :template, factory: :provisioning_template
+
+    trait :safemode_ok do
+      safemode_status { HostStatus::RenderingStatusCombination::OK }
+    end
+
+    trait :unsafemode_ok do
+      unsafemode_status { HostStatus::RenderingStatusCombination::OK }
+    end
+
+    trait :safemode_warn do
+      safemode_status { HostStatus::RenderingStatusCombination::WARN }
+    end
+
+    trait :unsafemode_warn do
+      unsafemode_status { HostStatus::RenderingStatusCombination::WARN }
+    end
+
+    trait :safemode_error do
+      safemode_status { HostStatus::RenderingStatusCombination::ERROR }
+    end
+
+    trait :unsafemode_error do
+      unsafemode_status { HostStatus::RenderingStatusCombination::ERROR }
+    end
+  end
+end

--- a/test/graphql/queries/provisioning_template_query_test.rb
+++ b/test/graphql/queries/provisioning_template_query_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+module Queries
+  class ProvisioningTemplateQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        provisioningTemplate(id: $id) {
+          id
+          createdAt
+          updatedAt
+          name
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:provisioning_template) { FactoryBot.create(:provisioning_template) }
+    let(:global_id) { Foreman::GlobalId.for(provisioning_template) }
+    let(:variables) { { id: global_id } }
+    let(:data) { result['data']['provisioningTemplate'] }
+
+    test 'fetching provisioning template attributes' do
+      assert_empty result['errors']
+
+      assert_equal global_id, data['id']
+      assert_equal provisioning_template.created_at.utc.iso8601, data['createdAt']
+      assert_equal provisioning_template.updated_at.utc.iso8601, data['updatedAt']
+      assert_equal provisioning_template.name, data['name']
+    end
+  end
+end

--- a/test/graphql/queries/provisioning_templates_query_test.rb
+++ b/test/graphql/queries/provisioning_templates_query_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+module Queries
+  class ProvisioningTemplateQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+      query {
+        provisioningTemplates {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:data) { result['data']['provisioningTemplates'] }
+
+    setup do
+      FactoryBot.create_list(:provisioning_template, 2)
+    end
+
+    test 'fetching provisioningTemplates attributes' do
+      assert_empty result['errors']
+
+      expected_count = ProvisioningTemplate.count
+
+      assert_not_equal 0, expected_count
+      assert_equal expected_count, data['totalCount']
+      assert_equal expected_count, data['edges'].count
+    end
+  end
+end

--- a/test/graphql/queries/rendering_status_combination_query_test.rb
+++ b/test/graphql/queries/rendering_status_combination_query_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+module Queries
+  class RenderingStatusCombinationQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        renderingStatusCombination(id: $id) {
+          id
+          createdAt
+          updatedAt
+          safemodeStatus
+          unsafemodeStatus
+          host {
+            id
+          }
+          template {
+            id
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:rendering_status_combination) { FactoryBot.create(:rendering_status_combination, :safemode_ok, :unsafemode_ok) }
+    let(:global_id) { Foreman::GlobalId.for(rendering_status_combination) }
+    let(:variables) { { id: global_id } }
+    let(:data) { result['data']['renderingStatusCombination'] }
+
+    test 'fetching rendering status combination attributes' do
+      assert_empty result['errors']
+
+      assert_equal global_id, data['id']
+      assert_equal rendering_status_combination.created_at.utc.iso8601, data['createdAt']
+      assert_equal rendering_status_combination.updated_at.utc.iso8601, data['updatedAt']
+      assert_equal rendering_status_combination.safemode_status, data['safemodeStatus']
+      assert_equal rendering_status_combination.unsafemode_status, data['unsafemodeStatus']
+
+      assert_record rendering_status_combination.host, data['host']
+      assert_record rendering_status_combination.template, data['template']
+    end
+  end
+end

--- a/test/graphql/queries/rendering_status_combinations_query_test.rb
+++ b/test/graphql/queries/rendering_status_combinations_query_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+module Queries
+  class RenderingStatusCombinationsQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+      query {
+        renderingStatusCombinations {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:data) { result['data']['renderingStatusCombinations'] }
+
+    setup do
+      FactoryBot.create_list(:rendering_status_combination, 2, :safemode_ok)
+    end
+
+    test 'fetching renderingStatuses attributes' do
+      assert_empty result['errors']
+
+      expected_count = HostStatus::RenderingStatusCombination.count
+
+      assert_not_equal 0, expected_count
+      assert_equal expected_count, data['totalCount']
+      assert_equal expected_count, data['edges'].count
+    end
+  end
+end

--- a/test/graphql/queries/rendering_status_query_test.rb
+++ b/test/graphql/queries/rendering_status_query_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+module Queries
+  class RenderingStatusQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+      query (
+        $id: String!
+      ) {
+        renderingStatus(id: $id) {
+          id
+          status
+          safemodeStatus
+          unsafemodeStatus
+          label
+          host {
+            id
+          }
+          combinations {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:rendering_status_combination) { FactoryBot.create(:rendering_status_combination, :safemode_ok) }
+    let(:rendering_status) { rendering_status_combination.host.rendering_status }
+
+    let(:global_id) { Foreman::GlobalId.for(rendering_status) }
+    let(:variables) { { id: global_id } }
+    let(:data) { result['data']['renderingStatus'] }
+
+    test 'fetching rendering status attributes' do
+      assert_empty result['errors']
+
+      assert_equal global_id, data['id']
+      assert_equal rendering_status.status, data['status']
+      assert_equal rendering_status.safemode_status, data['safemodeStatus']
+      assert_equal rendering_status.unsafemode_status, data['unsafemodeStatus']
+      assert_equal rendering_status.to_label, data['label']
+
+      assert_record rendering_status.host, data['host']
+      assert_collection rendering_status.combinations, data['combinations']
+    end
+  end
+end

--- a/test/graphql/queries/rendering_statuses_query_test.rb
+++ b/test/graphql/queries/rendering_statuses_query_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+module Queries
+  class RenderingStatusesQueryTest < GraphQLQueryTestCase
+    let(:query) do
+      <<-GRAPHQL
+      query {
+        renderingStatuses {
+          totalCount
+          pageInfo {
+            startCursor
+            endCursor
+            hasNextPage
+            hasPreviousPage
+          }
+          edges {
+            cursor
+            node {
+              id
+            }
+          }
+        }
+      }
+      GRAPHQL
+    end
+
+    let(:data) { result['data']['renderingStatuses'] }
+
+    setup do
+      FactoryBot.create_list(:rendering_status_combination, 2, :safemode_ok)
+    end
+
+    test 'fetching renderingStatuses attributes' do
+      assert_empty result['errors']
+
+      expected_count = HostStatus::RenderingStatus.count
+
+      assert_not_equal 0, expected_count
+      assert_equal expected_count, data['totalCount']
+      assert_equal expected_count, data['edges'].count
+    end
+  end
+end

--- a/webpack/assets/javascripts/react_app/components/RenderingStatus/StatusIcon.js
+++ b/webpack/assets/javascripts/react_app/components/RenderingStatus/StatusIcon.js
@@ -1,0 +1,42 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  ExclamationCircleIcon,
+} from '@patternfly/react-icons';
+
+const StatusIcon = ({ status }) => {
+  switch (status) {
+    case 0:
+      return (
+        <CheckCircleIcon
+          style={{ color: 'var(--pf-global--success-color--100)' }}
+        />
+      );
+    case 1:
+      return (
+        <ExclamationTriangleIcon
+          style={{ color: 'var(--pf-global--warning-color--100)' }}
+        />
+      );
+    case 2:
+      return (
+        <ExclamationCircleIcon
+          style={{ color: 'var(--pf-global--danger-color--100)' }}
+        />
+      );
+    default:
+      return <Fragment />;
+  }
+};
+
+StatusIcon.propTypes = {
+  status: PropTypes.number,
+};
+
+StatusIcon.defaultProps = {
+  status: null,
+};
+
+export default StatusIcon;

--- a/webpack/assets/javascripts/react_app/components/RenderingStatus/index.js
+++ b/webpack/assets/javascripts/react_app/components/RenderingStatus/index.js
@@ -1,0 +1,168 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import { get, max } from 'lodash';
+import {
+  Grid,
+  GridItem,
+  DataList,
+  DataListItem,
+  DataListItemRow,
+  DataListItemCells,
+  DataListCell,
+} from '@patternfly/react-core';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableVariant,
+} from '@patternfly/react-table';
+import StatusIcon from './StatusIcon';
+import { translate as __ } from '../../common/I18n';
+import RelativeDateTime from '../../components/common/dates/RelativeDateTime';
+
+const RenderingStatus = ({
+  renderingStatus: {
+    safemodeStatus,
+    unsafemodeStatus,
+    label,
+    host: { name: hostName },
+    combinations: { edges: combinations },
+  },
+  settings,
+}) => {
+  const isSafemodeEnabled = get(settings, 'edges[0].node.value') === 'true';
+
+  const columns = [
+    __('Template'),
+    __('Updated at'),
+    __('Safe mode status'),
+    ...(isSafemodeEnabled ? [] : [__('Unsafe mode status')]),
+  ];
+
+  const rows = combinations.map(
+    ({
+      node: {
+        updatedAt,
+        safemodeStatus: safemodeCombinationStatus,
+        unsafemodeStatus: unsafemodeCombinationStatus,
+        template: { name: templateName, path: templatePath },
+      },
+    }) => ({
+      cells: [
+        {
+          title: <a href={templatePath}>{templateName}</a> 
+        },
+        {
+          title: <RelativeDateTime date={updatedAt} defaultValue="N/A" />,
+        },
+        {
+          title: <StatusIcon status={safemodeCombinationStatus} />,
+        },
+        ...(isSafemodeEnabled
+          ? []
+          : [{ title: <StatusIcon status={unsafemodeCombinationStatus} /> }]),
+      ],
+    })
+  );
+
+  return (
+    <Grid hasGutter>
+      <GridItem span={12} lg={8} xl={4}>
+        <DataList>
+          <DataListItem>
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key={1}>{__('Status')}</DataListCell>,
+                  <DataListCell key={2}>
+                    <StatusIcon
+                      status={max([safemodeStatus, unsafemodeStatus])}
+                    />
+                    {label}
+                  </DataListCell>,
+                ]}
+              />
+            </DataListItemRow>
+            {!isSafemodeEnabled && (
+              <Fragment>
+                <DataListItemRow>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key={1}>
+                        {__('Safe mode status')}
+                      </DataListCell>,
+                      <DataListCell key={2}>
+                        <StatusIcon status={safemodeStatus} />
+                      </DataListCell>,
+                    ]}
+                  />
+                </DataListItemRow>
+                <DataListItemRow>
+                  <DataListItemCells
+                    dataListCells={[
+                      <DataListCell key={1}>
+                        {__('Unsafe mode status')}
+                      </DataListCell>,
+                      <DataListCell key={2}>
+                        <StatusIcon status={unsafemodeStatus} />
+                      </DataListCell>,
+                    ]}
+                  />
+                </DataListItemRow>
+              </Fragment>
+            )}
+          </DataListItem>
+        </DataList>
+      </GridItem>
+      <GridItem span={12} xl={8} xl2={6}>
+        <Table
+          aria-label={__('Rendering Combinations')}
+          cells={columns}
+          rows={rows}
+          variant={TableVariant.compact}
+          borders={false}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+      </GridItem>
+    </Grid>
+  );
+};
+
+RenderingStatus.propTypes = {
+  renderingStatus: PropTypes.shape({
+    safemodeStatus: PropTypes.number,
+    unsafemodeStatus: PropTypes.number,
+    label: PropTypes.string.isRequired,
+    host: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+    }).isRequired,
+    combinations: PropTypes.shape({
+      edges: PropTypes.arrayOf(
+        PropTypes.shape({
+          node: PropTypes.shape({
+            updatedAt: PropTypes.string,
+            safemodeStatus: PropTypes.number,
+            unsafemodeStatus: PropTypes.number,
+            template: PropTypes.shape({
+              name: PropTypes.string.isRequired,
+              path: PropTypes.string.isRequired,
+            }).isRequired,
+          }).isRequired,
+        })
+      ).isRequired,
+    }).isRequired,
+  }).isRequired,
+  settings: PropTypes.shape({
+    edges: PropTypes.arrayOf(
+      PropTypes.shape({
+        node: PropTypes.shape({
+          value: PropTypes.string.isRequired,
+        }),
+      })
+    ),
+  }).isRequired,
+};
+
+export default RenderingStatus;

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -47,6 +47,7 @@ import LabelIcon from './common/LabelIcon';
 import { WelcomeAuthSource } from './AuthSource/Welcome';
 import { WelcomeConfigReports } from './ConfigReports/Welcome';
 import { WelcomeArchitecture } from './Architectures/Welcome';
+import RenderingStatus from './RenderingStatus';
 
 const componentRegistry = {
   registry: forceSingleton('component_registry', () => ({})),
@@ -148,6 +149,7 @@ const coreComponets = [
   { name: 'PersonalAccessTokens', type: PersonalAccessTokens },
   { name: 'ClipboardCopy', type: ClipboardCopy },
   { name: 'LabelIcon', type: LabelIcon },
+  { name: 'RenderingStatus', type: RenderingStatus },
   {
     name: 'RelativeDateTime',
     type: RelativeDateTime,

--- a/webpack/assets/javascripts/react_app/routes/RenderingStatus/RenderingStatusPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RenderingStatus/RenderingStatusPage/index.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useQuery } from '@apollo/client';
+import { get } from 'lodash';
+import { Alert } from '@patternfly/react-core';
+import RENDERING_STATUS_QUERY from './renderingStatusQuery.gql';
+import PageLayout from '../../common/PageLayout/PageLayout';
+import RenderingStatus from '../../../components/RenderingStatus';
+import { translate as __, sprintf } from '../../../common/I18n';
+
+const RenderingStatusPage = ({
+  match: {
+    params: { id },
+  },
+}) => {
+  const { loading, error, data } = useQuery(RENDERING_STATUS_QUERY, {
+    variables: { id },
+  });
+
+  const hostName = get(data, 'renderingStatus.host.name', '');
+  const header = loading
+    ? ''
+    : sprintf(__('Rendering Status for %s'), hostName);
+
+  return (
+    <PageLayout header={header} searchable={false} isLoading={loading}>
+      {error && <Alert variant="danger" title={error} />}
+      {!error && !loading && <RenderingStatus {...data} />}
+    </PageLayout>
+  );
+};
+
+RenderingStatusPage.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default RenderingStatusPage;

--- a/webpack/assets/javascripts/react_app/routes/RenderingStatus/RenderingStatusPage/renderingStatusQuery.gql
+++ b/webpack/assets/javascripts/react_app/routes/RenderingStatus/RenderingStatusPage/renderingStatusQuery.gql
@@ -1,0 +1,33 @@
+query (
+  $id: String!
+) {
+  renderingStatus(id: $id) {
+    status
+    safemodeStatus
+    unsafemodeStatus
+    label
+    host {
+      name
+    }
+    combinations {
+      edges {
+        node {
+          safemodeStatus
+          unsafemodeStatus
+          updatedAt
+          template {
+            name
+            path
+          }
+        }
+      }
+    }
+  }
+  settings(search: "name = safemode_render") {
+    edges {
+      node {
+        value
+      }
+    }
+  }
+}

--- a/webpack/assets/javascripts/react_app/routes/RenderingStatus/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/RenderingStatus/constants.js
@@ -1,0 +1,1 @@
+export const RENDERING_STATUS_PATH = '/rendering_statuses/:id';

--- a/webpack/assets/javascripts/react_app/routes/RenderingStatus/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RenderingStatus/index.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import RenderingStatusPage from './RenderingStatusPage';
+import { RENDERING_STATUS_PATH } from './constants';
+
+export default {
+  path: RENDERING_STATUS_PATH,
+  render: props => <RenderingStatusPage {...props} />,
+};

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
@@ -30,6 +30,11 @@ exports[`Routes rendering routes with children renders routes with chidlren 1`] 
       path="/host_statuses"
       render={[Function]}
     />
+    <Route
+      key="/rendering_statuses/:id"
+      path="/rendering_statuses/:id"
+      render={[Function]}
+    />
   </ForemanSwitcher>
   <div
     id="router-child"

--- a/webpack/assets/javascripts/react_app/routes/routes.js
+++ b/webpack/assets/javascripts/react_app/routes/routes.js
@@ -3,6 +3,7 @@ import Models from './Models';
 import HostDetails from './HostDetails';
 import RegistrationCommands from './RegistrationCommands';
 import HostStatuses from './HostStatuses';
+import RenderingStatus from './RenderingStatus';
 
 export const routes = [
   Audits,
@@ -10,4 +11,5 @@ export const routes = [
   HostDetails,
   RegistrationCommands,
   HostStatuses,
+  RenderingStatus,
 ];


### PR DESCRIPTION
The idea is to save a status every time a template is rendered (except preview mode).  We would have information about which templates were rendered, with which hosts and if any errors occurred. Based on this data, we can determine the rendering status for a particular host. 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
