### PR TITLE
Fixes #14536 - single place for compute_attributes

### DIFF
--- a/app/models/compute.rb
+++ b/app/models/compute.rb
@@ -1,0 +1,82 @@
+class Compute
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Dirty
+
+  attr_accessor :compute_resource, :host
+
+  attribute :uuid, :string
+  attribute :name, :string, default: -> { "foreman_#{Time.now.to_i}" }
+
+  def initialize(*attrs)
+    super
+    uuid ||= host.uuid
+    @attrs_loaded = false
+    raise 'host and compute_resource need to be set for Compute' unless host && compute_resource
+  end
+
+  def vm
+    @vm ||= persisted? ? find_vm : compute_resource.new_vm(attributes)
+  end
+
+  def persisted?
+    !uuid.nil?
+  end
+
+  def save
+    @attrs_loaded = false
+    persist_vm
+  end
+
+  def vm_name
+    Setting[:use_shortname_for_vms] ? host.shortname : host.name
+  end
+
+  def attributes
+    return super if @attrs_loaded
+    loaded = load_vm_attributes.merge(super)
+    self.attributes = loaded
+    loaded
+  end
+
+  protected
+
+  def find_vm
+    compute_resource.find_vm_by_uuid(uuid) || raise(ActiveRecord::RecordNotFound.new(nil, Compute, uuid))
+  end
+
+  def persist_vm
+    persisted? ? create_vm : update_vm
+  end
+
+  def create_vm
+    compute_resource.create_vm(attributes.merge(host_create_attributes))
+  end
+
+  def save_vm
+    compute_resource.save_vm(uuid, attributes)
+  end
+
+  # Loads persisted vm attributes
+  def load_vm_attributes
+    @attrs_loaded = true
+    return {} unless persisted?
+    compute_resource.vm_compute_attributes(vm)
+  end
+
+  # This method defines initial VM attributes
+  def host_create_attributes
+    {
+      name: vm_name,
+      provision_method: host.provision_method,
+      firmware_type: host.firmware_type,
+      "#{compute_resource.interfaces_attrs_name}_attributes" => host_interfaces_create_attributes }.with_indifferent_access
+    }
+  end
+
+  def host_interfaces_create_attributes
+    host.interfaces.select(&:physical?).each.with_index.reduce({}) do |hash, (nic, index)|
+      hash.merge(index.to_s => nic.compute_attributes.merge(ip: nic.ip, ip6: nic.ip6))
+    end
+  end
+end

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -189,11 +189,11 @@ module Foreman::Model
       associate_by("mac", vm.interfaces.map(&:mac))
     end
 
-    def vm_compute_attributes_for(uuid)
+    def vm_compute_attributes(vm)
       vm_attrs = super
       if vm_attrs[:memory_size].nil?
         vm_attrs[:memory] = nil
-        logger.debug("Compute attributes for VM '#{uuid}' diddn't contain :memory_size")
+        logger.debug("Compute attributes for VM didn't contain :memory_size")
       else
         vm_attrs[:memory] = vm_attrs[:memory_size] * 1024 # value is returned in megabytes, we need bytes
       end

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -3,6 +3,16 @@ require 'uri'
 
 module Foreman::Model
   class Ovirt < ComputeResource
+    class Compute < ::Compute
+      protected
+
+      def host_create_attributes
+        super.tap do |attrs|
+          attrs[:os] = { type: compute_resource.determine_os_type(host) } if compute_resource.supports_operating_systems?
+        end
+      end
+    end
+
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
 
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true,
@@ -27,12 +37,6 @@ module Foreman::Model
 
     def user_data_supported?
       true
-    end
-
-    def host_compute_attrs(host)
-      super.tap do |attrs|
-        attrs[:os] = { :type => determine_os_type(host) } if supports_operating_systems?
-      end
     end
 
     def capabilities

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -12,6 +12,10 @@ module Foreman::Model
     include ComputeResourceConsoleCommon
     include ComputeResourceCaching
 
+    class Compute < ::Compute
+
+    end
+
     validates :user, :password, :server, :datacenter, :presence => true
     validates :display_type, :inclusion => {
       :in => proc { |cr| cr.class.supported_display_types.keys },

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -744,9 +744,9 @@ autopart"', desc: 'to render the content of host partition table'
     host = selective_clone
 
     host.interfaces = interfaces.map(&:clone)
-    if compute_resource
-      host.compute_attributes = host.compute_resource.vm_compute_attributes_for(uuid)
-    end
+
+    host.compute.attributes = compute.attributes if compute?
+
     host.refresh_global_status
     host
   end
@@ -781,7 +781,7 @@ autopart"', desc: 'to render the content of host partition table'
   end
 
   def vm_compute_attributes
-    compute_resource ? compute_resource.vm_compute_attributes_for(uuid) : nil
+    compute? ? compute.attributes : nil
   end
 
   def bmc_proxy

--- a/app/services/compute_resource_host_importer.rb
+++ b/app/services/compute_resource_host_importer.rb
@@ -54,7 +54,7 @@ class ComputeResourceHostImporter
   end
 
   def vm_interface_attributes
-    vm_attrs = compute_resource.vm_compute_attributes_for(host.uuid)
+    vm_attrs = host.compute.attributes
     attr_name = compute_resource.interfaces_attrs_name
     attr_key = "#{attr_name}_attributes"
     vm_attrs.with_indifferent_access[attr_key].try(:values) || []

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -552,12 +552,12 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
   test "should show hosts vm attributes" do
     host = FactoryBot.create(:host, :compute_resource => compute_resources(:one))
-    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns(:cpus => 4)
+    compute_resources(:one).compute_class.any_instance.stubs(:attributes).returns(:cpus => 4)
     get :vm_compute_attributes, params: { :id => host.to_param }
     assert_response :success
     data = JSON.parse(@response.body)
     assert_equal data, "cpus" => 4, "memory" => nil
-    ComputeResource.any_instance.unstub(:vm_compute_attributes_for)
+    compute_resources(:one).compute_class.any_instance.unstub(:attributes)
   end
 
   def set_remote_user_to(user)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -170,7 +170,7 @@ class HostTest < ActiveSupport::TestCase
 
   test "can fetch vm compute attributes" do
     host = FactoryBot.create(:host, :on_compute_resource)
-    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:cpus => 4})
+    ComputeResource.any_instance.stubs(:vm_compute_attributes).returns({:cpus => 4})
     assert_equal host.vm_compute_attributes, :cpus => 4
   end
 
@@ -2653,14 +2653,14 @@ class HostTest < ActiveSupport::TestCase
 
   test 'clone should create compute_attributes for VM-based hosts' do
     host = FactoryBot.create(:host, :on_compute_resource)
-    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:foo => 'bar'})
+    ComputeResource.any_instance.stubs(:vm_compute_attributes).returns({:foo => 'bar'})
     copy = host.clone
     assert !copy.compute_attributes.nil?
   end
 
   test 'clone should NOT create compute_attributes for bare-metal host' do
     host = FactoryBot.create(:host)
-    ComputeResource.any_instance.stubs(:vm_compute_attributes_for).returns({:foo => 'bar'})
+    ComputeResource.any_instance.stubs(:vm_compute_attributes).returns({:foo => 'bar'})
     copy = host.clone
     assert copy.compute_attributes.nil?
   end


### PR DESCRIPTION
This brings a `Compute` model that is supposed to wrap a fog server.

Before we were defining compute attributes in various places, this aims
to unify the attributes handling to a single model.

This brings possibilities to clean up our ComputeResource code as it
handles both ComputeResources and VMs.