### PR TITLE
Fixes #32075 - Add domain= on kernel command line in Preseed iPXE template

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -31,7 +31,7 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> domain=<%= @host.domain -%> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
 initrd <%= initrd %>
 
 boot


### PR DESCRIPTION
Fixes [#32075](https://projects.theforeman.org/issues/32075)

This allows debian-installer to complete the installation in full auto. (Currently d-i guesses correctly, but pauses for manual confirmation.)
