### PR TITLE
Fixes #31946 - support for S390x

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -27,6 +27,12 @@ module Foreman::Model
       super.merge({:mac => :mac})
     end
 
+    def host_compute_attrs(host)
+      super.tap do |attrs|
+        attrs[:arch] = host.architecture.try(:name) || "x86_64"
+      end
+    end
+
     def interfaces_attrs_name
       :nics
     end

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -226,7 +226,7 @@ class Operatingsystem < ApplicationRecord
     unless medium_provider.is_a? MediumProviders::Provider
       raise Foreman::Exception.new(N_('Please provide a medium provider. It can be found as @medium_provider in templates, or Foreman::Plugin.medium_providers_registry.find_provider(host)'))
     end
-    pxe_prefix(medium_provider) + "-" + family.constantize::PXEFILES[type.to_sym]
+    pxe_prefix(medium_provider) + "-" + pxe_file_names(medium_provider)[type.to_sym]
   end
 
   # Does this OS family support a build variant that is constructed from a prebuilt archive
@@ -313,8 +313,12 @@ class Operatingsystem < ApplicationRecord
     boot_file_sources(medium_provider, &block)[file]
   end
 
+  def pxe_file_names(medium_provider)
+    family.constantize::PXEFILES
+  end
+
   def boot_file_sources(medium_provider, &block)
-    @boot_file_sources ||= family.constantize::PXEFILES.transform_values do |img|
+    @boot_file_sources ||= pxe_file_names(medium_provider).transform_values do |img|
       "#{medium_provider.medium_uri(pxedir(medium_provider), &block)}/#{img}"
     end
   end

--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -25,9 +25,23 @@ class Redhat < Operatingsystem
     "kickstart"
   end
 
+  def pxe_file_names(medium_provider)
+    if medium_provider&.architecture_name&.match?(/^[Ss]390/)
+      {
+        kernel: "kernel.img",
+        initrd: "initrd.img",
+      }
+    else
+      super
+    end
+  end
+
   def pxedir(medium_provider = nil)
-    if medium_provider.try(:architecture).try(:name) =~ /^ppc64/
+    case medium_provider.try(:architecture_name)
+    when /^ppc64/i
       "ppc/ppc64"
+    when /^s390/i
+      "images"
     else
       "images/pxeboot"
     end

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -70,6 +70,10 @@ module MediumProviders
       entity.try(:architecture)
     end
 
+    def architecture_name
+      architecture.try(:name)
+    end
+
     private
 
     def parse_media(media)

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -21,9 +21,12 @@ TIMEOUT <%= timeout %>
 ONTIMEOUT installer
 
 LABEL installer
-  MENU LABEL <%= template_name %>
-  KERNEL <%= @kernel %>
-  APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-  IPAPPEND 2
+MENU LABEL <%= template_name %>
+KERNEL <%= @kernel %>
+APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+<% if @host.architecture.to_s.match(/s390x?/i) %>
+INITRD <%= @initrd %>
+<% end %>
+IPAPPEND 2
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
@@ -2,9 +2,19 @@
 kind: PXELinux
 name: PXELinux default local boot
 model: ProvisioningTemplate
-%>
-<%# Used to boot provisioned hosts, do not associate or change the name. %>
-
+-%>
+<%# Used to boot provisioned hosts, do not associate or change the name. -%>
+<% if @host.architecture.to_s.match(/s390x?/i) -%>
+# pxelinux
+# Reboot dracut image must be manually built and copied over to the TFTP
+# https://github.com/lzap/dracut-reboot-s390x
+default reboot
+label reboot
+kernel kernel-reboot.img
+initrd initrd-reboot.img
+# Uncomment to customize chreipl arguments
+#append rd.shell rd.chreipl=ccw rd.chreipl=0.0.0000XXX
+<% else -%>
 UI menu.c32
 MENU TITLE Booting local disk (ESC to stop)
 TIMEOUT 200
@@ -12,3 +22,4 @@ ONTIMEOUT <%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
 DEFAULT <%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
 
 <%= snippet "pxelinux_chainload" %>
+<% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -98,6 +98,14 @@ snippet: true
     options.push("inst.stage2=#{medium_uri}")
   end
 
+  # S390x architecture has a different stage two image:
+  # https://access.redhat.com/solutions/4206591
+  if @host.architecture.to_s.match(/s390x?/i)
+    options.push("inst.cmdline")
+    options.push("inst.repo=#{medium_uri}")
+  end
+
+  # FIPS
   if !is_fedora && os_major >= 7 && host_param_true?('fips_enabled')
     options.push('fips=1')
   end

--- a/test/fixtures/architectures.yml
+++ b/test/fixtures/architectures.yml
@@ -8,6 +8,9 @@ sparc:
 s390:
   name: s390
 
+s390x:
+  name: s390x
+
 ASIC:
   name: ASIC
 

--- a/test/models/operatingsystems/redhat_test.rb
+++ b/test/models/operatingsystems/redhat_test.rb
@@ -1,0 +1,125 @@
+require 'test_helper'
+
+class RedhatTest < ActiveSupport::TestCase
+  let(:operatingsystem) { FactoryBot.create(:rhel7_5) }
+  let(:medium) { FactoryBot.create(:medium, path: "http://mirror.example.com/rh/7.5") }
+  let(:mock_entity) do
+    OpenStruct.new(
+      operatingsystem: operatingsystem,
+      architecture: architecture,
+      medium: medium
+    )
+  end
+  let(:medium_provider) { MediumProviders::Default.new(mock_entity) }
+
+  context 'Red Hat on Intel x86_64' do
+    let(:architecture) { architectures(:x86_64) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'vmlinuz'
+        assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.img'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://mirror.example.com/rh/7.5/images/pxeboot/vmlinuz',
+          initrd: 'http://mirror.example.com/rh/7.5/images/pxeboot/initrd.img',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#mediumpath' do
+      test 'generates medium path url' do
+        assert_equal 'url --url http://mirror.example.com/rh/7.5', operatingsystem.mediumpath(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/pxeboot/vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/pxeboot/initrd.img', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
+
+  context 'Red Hat on IBM POWER' do
+    let(:architecture) { architectures(:ppc64) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'vmlinuz'
+        assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.img'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://mirror.example.com/rh/7.5/ppc/ppc64/vmlinuz',
+          initrd: 'http://mirror.example.com/rh/7.5/ppc/ppc64/initrd.img',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#mediumpath' do
+      test 'generates medium path url' do
+        assert_equal 'url --url http://mirror.example.com/rh/7.5', operatingsystem.mediumpath(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/ppc/ppc64/vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/ppc/ppc64/initrd.img', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
+
+  context 'Red Hat on IBM Z' do
+    let(:architecture) { architectures(:s390x) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'kernel'
+        assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.img'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://mirror.example.com/rh/7.5/images/kernel.img',
+          initrd: 'http://mirror.example.com/rh/7.5/images/initrd.img',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#mediumpath' do
+      test 'generates medium path url' do
+        assert_equal 'url --url http://mirror.example.com/rh/7.5', operatingsystem.mediumpath(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/kernel.img', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://mirror.example.com/rh/7.5/images/initrd.img', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
+end

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart default PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart default PXELinux.snap.txt
@@ -5,9 +5,10 @@ TIMEOUT 100
 ONTIMEOUT installer
 
 LABEL installer
-  MENU LABEL Kickstart default PXELinux
-  KERNEL 
-  APPEND initrd= ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
-  IPAPPEND 2
+MENU LABEL Kickstart default PXELinux
+KERNEL 
+APPEND initrd= ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+
+IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux default local boot.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux default local boot.snap.txt
@@ -1,6 +1,3 @@
-
-
-
 UI menu.c32
 MENU TITLE Booting local disk (ESC to stop)
 TIMEOUT 200


### PR DESCRIPTION
On S390 kernel and initramdisk are at a different path and with different names: images/kernel.img and images/initrd.img. Foreman operating system model must reflect that in order to download Anaconda installer to TFTP.

Another change is to expose architecture name as a plain string so it can be easily be overriden in katello medium provider.

Another change is to send architecture into libvirt attribute.

A template change will be also probably needed. Do not merge yet, I am still testing.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->