### PR TITLE
Fixes #32090 - deprecate flot_bar_chart

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -250,31 +250,40 @@ module ApplicationHelper
   end
 
   def flot_bar_chart(name, xaxis_label, yaxis_label, data, options = {})
-    i = 0
-    ticks = nil
-    if data.is_a?(Array)
-      data = data.map do |kv|
-        ticks ||= []
-        ticks << [i += 1, kv[0].to_s.humanize]
-        [i, kv[1]]
+    Foreman::Deprecation.deprecation_warning('2.6', '#flot_bar_chart is rendering its react version by default now. '\
+                                                    'You can fall back by use_flot=true option, but that will go away in the 3.0. '\
+                                                    'Please move to rendering React Component directly.')
+    if options.delete(:use_flot)
+      i = 0
+      ticks = nil
+      if data.is_a?(Array)
+        data = data.map do |kv|
+          ticks ||= []
+          ticks << [i += 1, kv[0].to_s.humanize]
+          [i, kv[1]]
+        end
+      elsif  data.is_a?(Hash)
+        data = data.map do |k, v|
+          ticks ||= []
+          ticks << [i += 1, k.to_s.humanize]
+          [i, v]
+        end
       end
-    elsif  data.is_a?(Hash)
-      data = data.map do |k, v|
-        ticks ||= []
-        ticks << [i += 1, k.to_s.humanize]
-        [i, v]
+
+      content_tag(:div, nil,
+        { :id   => name,
+          :data => {
+            :'xaxis-label' => xaxis_label,
+            :'yaxis-label' => yaxis_label,
+            :chart   => data,
+            :ticks   => ticks,
+          },
+        }.merge(options))
+    else
+      content_tag(:div, id: name) do
+        react_component('BarChart', data: data, xAxisLabel: xaxis_label, yAxisLabel: yaxis_label)
       end
     end
-
-    content_tag(:div, nil,
-      { :id   => name,
-        :data => {
-          :'xaxis-label' => xaxis_label,
-          :'yaxis-label' => yaxis_label,
-          :chart   => data,
-          :ticks   => ticks,
-        },
-      }.merge(options))
   end
 
   def select_action_button(title, options = {}, *args)


### PR DESCRIPTION
We render react BarChart by default so the plugins take a look how it
works for them. All plugins should move to using React with Foreman 2.6
where the option to render flot chart goes away.

[Still uses that I found](https://github.com/search?q=org%3Atheforeman+flot_bar_chart&type=code)
- foreman_fog_proxmox
- foreman_content
- foreman_abrt