### PR TITLE
Refs #32025 - fix rerender guard condition

### DIFF
--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -58,7 +58,7 @@ class ReactComponentElement extends HTMLElement {
     switch (name) {
       case 'data-props':
         // if this is not the initial prop set
-        if (oldValue === null) this._render();
+        if (oldValue !== null) this._render();
         break;
       default:
       // We don't know how to react to default attribute change


### PR DESCRIPTION
In 71c10db57f we've added a rerender option for HTML mounted components,
but the guard there was accidently reversed, so it only got rendered
twice on first mount, but never rerendered.
