### PR TITLE
Host Registration - Repository & GPG keys

### DIFF
--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -15,6 +15,8 @@ module Api
         param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
         param :jwt_expiration, :number, desc: N_("Expiration of the authorization token (in hours)")
         param :insecure, :bool, desc: N_("Enable insecure argument for the initial curl")
+        param :repo, String, desc: N_("Repository URL / details, for example for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
+        param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
       end
       def create
         render json: { registration_command: command }

--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -30,6 +30,8 @@ module Foreman::Controller::Registration
       registration_url: registration_url,
       setup_insights: ActiveRecord::Type::Boolean.new.deserialize(params['setup_insights']),
       setup_remote_execution: ActiveRecord::Type::Boolean.new.deserialize(params['setup_remote_execution']),
+      repo: params['repo'],
+      repo_gpg_key_url: params['repo_gpg_key_url'],
     }
 
     params.permit(permitted)

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -33,6 +33,38 @@ cat << EOF > $SSL_CA_CERT
 <%= foreman_server_ca_cert %>
 EOF
 
+<% unless @repo.blank? -%>
+echo '#'
+echo '# Adding repository'
+echo '#'
+
+if [ x$ID = xrhel ] || [ x$ID = xfedora ] || test "${ID_LIKE#*rhel*}" != "$ID_LIKE" ; then
+  cat << EOF > /etc/yum.repos.d/foreman_registration.repo
+[foreman_register]
+name=foreman_register
+baseurl=<%= @repo %>
+enabled=1
+gpgcheck=<%= @repo_gpg_key_url.present? ? 1 : 0 %>
+gpgkey=<%= @repo_gpg_key_url %>
+EOF
+
+  echo "Building yum metadata cache, this may take a few minutes"
+  yum makecache
+elif [ x$ID = xdebian ] || [ x$ID = xubuntu ]; then
+  cat << EOF > /etc/apt/sources.list.d/foreman_registration.list
+<%= @repo %>
+EOF
+<% if @repo_gpg_key_url.present? -%>
+  apt-get -y install ca-certificates gpg
+  curl --silent --show-error <%= @repo_gpg_key_url %> | apt-key add -
+<% end -%>
+  apt-get update
+
+else
+  echo "Unsupported operating system, can't add repository."
+  exit 1
+fi
+<% end -%>
 
 register_host() {
   curl --silent --cacert $SSL_CA_CERT --request POST <%= @registration_url %> \


### PR DESCRIPTION
New feature in `Global Registration template` for adding
repository & gpg key before the host registration starts.

For adding repository (& key), users needs to specify
two parameters: `repo` & `repo_gpg_key_url`.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
