### PR TITLE
Fixes #32118 - remove legacy code and update version for jwt gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,7 @@ gem 'daemons'
 gem 'bcrypt', '~> 3.1'
 gem 'get_process_mem'
 gem 'rack-cors', '~> 1.0.2', require: 'rack/cors'
-gem 'jwt', '~> 2.2.1'
+gem 'jwt', '~> 2.2.2'
 gem 'graphql', '~> 1.8.0'
 gem 'graphql-batch'
 

--- a/app/services/oidc_jwt_validate.rb
+++ b/app/services/oidc_jwt_validate.rb
@@ -7,13 +7,6 @@ class OidcJwtValidate
   end
 
   def decoded_payload
-    # OpenSSL#set_key method does not support ruby version < 2.4.0, apparently the JWT gem uses
-    # OpenSSL#set_key method for all ruby version. We must remove this condition once new version
-    # of the JWT(2.2.2) is released.
-    unless OpenSSL::PKey::RSA.new.respond_to?(:set_key)
-      Foreman::Logging.logger('app').error "SSO feature is not available for Ruby < 2.4.0"
-      return nil
-    end
     JWT.decode(@jwt_token, nil, true,
       { aud: Setting['oidc_audience'],
         verify_aud: true,


### PR DESCRIPTION
With this patch Foreman can perform SSO having ruby version ( < 2.4.0 ) also.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
