### PR TITLE
Fixes #32121 - Puppetclass create audit taxonomy

### DIFF
--- a/app/models/environment_class.rb
+++ b/app/models/environment_class.rb
@@ -3,7 +3,7 @@ class EnvironmentClass < ApplicationRecord
   belongs_to :puppetclass, :inverse_of => :environment_classes
   belongs_to :puppetclass_lookup_key, :inverse_of => :environment_classes
   validates :puppetclass_lookup_key_id, :uniqueness => {:scope => [:environment_id, :puppetclass_id]}
-  validates :puppetclass_id, :environment_id, :presence => true
+  validates :puppetclass, :environment, :presence => true
   after_destroy :delete_orphaned_lookup_keys
 
   scope :parameters_for_class, lambda { |puppetclasses_ids, environment_id|

--- a/app/services/puppet_class_importer.rb
+++ b/app/services/puppet_class_importer.rb
@@ -253,15 +253,11 @@ class PuppetClassImporter
   end
 
   def add_classes_to_foreman(env_name, klasses)
-    env         = find_or_create_env env_name
-    # look for Puppet class in all scopes to make sure we do not try to create a new record
-    # with a name that already exists and hit the uniqueness constraint on name
-    new_classes = klasses.map { |k| find_or_create_puppetclass(name: k[0]) }
+    env = find_or_create_env env_name
 
-    new_classes.each do |new_class|
-      EnvironmentClass.find_or_create_by! :puppetclass_id => new_class.id, :environment_id => env.id
-      class_params = klasses[new_class.to_s]
-      add_new_parameter(env, new_class, class_params) if class_params.any?
+    klasses.each do |klass_name, klass_params|
+      puppetclass = find_or_create_puppetclass_for_env(klass_name, env)
+      add_new_parameter(env, puppetclass, klass_params) if klass_params.any?
     end
   end
 
@@ -348,8 +344,12 @@ class PuppetClassImporter
                                    :key_type => Foreman::ImporterPuppetclass.suggest_key_type(value))
   end
 
-  def find_or_create_puppetclass(name:)
-    puppetclass = Puppetclass.unscoped.find_or_create_by!(name: name)
+  # look for Puppet class in all scopes to make sure we do not try to create a new record
+  # with a name that already exists and hit the uniqueness constraint on name
+  def find_or_create_puppetclass_for_env(klass_name, env)
+    puppetclass = Puppetclass.find_or_initialize_by(name: klass_name)
+    puppetclass.environment_classes.find_or_initialize_by(environment_id: env.id)
+    puppetclass.save
     raise Foreman::Exception.new('Failed to create Puppetclass: %s', puppetclass.errors.full_messages.to_sentence) unless puppetclass.errors.empty?
     puppetclass
   end


### PR DESCRIPTION
On Puppetclass create, there are no persisted EnvironmentClasses yet,
so location_ids and organization_ids were always empty on create.

This allows to save EnvironmentClasses with Puppetclasses together and
thus get the location_ids and organization_ids from the unsaved
EnvironmentClasses. Thus the audit for Puppetclass will get correctly
taxed.

Puppet plugin PR: https://github.com/theforeman/foreman_puppet/pull/127