### PR TITLE
Correct coloring of zero metrics in report overviews

### DIFF
--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -7,7 +7,7 @@ module ReportsHelper
   end
 
   def report_event_column(event, style = "")
-    style = "label-default" if event == 0
+    style = "label-default" if event.to_i == 0
     content_tag(:span, event, :class => 'label ' + style)
   end
 

--- a/app/views/dashboard/_reports_widget.html.erb
+++ b/app/views/dashboard/_reports_widget.html.erb
@@ -12,12 +12,12 @@
       <% @data.latest_events.each do |report| %>
         <tr>
           <td class='ellipsis'><%= link_to report.host, host_config_reports_path(report.host) %></td>
-          <td class="ca"><%= report_event_column(report.applied, "label-info") %></td>
-          <td class="ca"><%= report_event_column(report.restarted, "label-info") %></td>
-          <td class="ca"><%= report_event_column(report.failed, "label-danger") %></td>
-          <td class="ca"><%= report_event_column(report.failed_restarts, "label-warning") %></td>
-          <td class="ca"><%= report_event_column(report.skipped, "label-info") %></td>
-          <td class="ca"><%= report_event_column(report.pending, "label-info") %></td>
+          <td class="ca"><%= report_event_column(report.applied_s, "label-info") %></td>
+          <td class="ca"><%= report_event_column(report.restarted_s, "label-info") %></td>
+          <td class="ca"><%= report_event_column(report.failed_s, "label-danger") %></td>
+          <td class="ca"><%= report_event_column(report.failed_restarts_s, "label-warning") %></td>
+          <td class="ca"><%= report_event_column(report.skipped_s, "label-info") %></td>
+          <td class="ca"><%= report_event_column(report.pending_s, "label-info") %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
pr #8118 changed to the use of strings for these metrics.
This made the comparison with the integer of 0 fail, resulting in all
metrics being colord even if they were 0

That same pr also failed to apply this change to the reports widget,
which is updated here to have the same behaviour as the
config_reports/_list view

It would be nice to still get this into 2.4