### PR TITLE
Configurable devtool for Webpack

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -234,7 +234,7 @@ module.exports = env => {
       hot: true
     };
     // Source maps
-    config.devtool = 'inline-source-map';
+    config.devtool = (process.env.WEBPACK_DEVTOOL || 'inline-source-map');
   }
 
   return config;

--- a/webpack/stories/docs/getting-started.stories.mdx
+++ b/webpack/stories/docs/getting-started.stories.mdx
@@ -69,6 +69,11 @@ Following steps are required to setup a webpack development environment:
    NOTIFICATIONS_POLLING=${polling_interval_in_ms}
    ```
 
+   Webpack devtool ([docs](https://webpack.js.org/configuration/devtool/#devtool)) can be changed by `WEBPACK_DEVTOOL`
+   ```bash
+   WEBPACK_DEVTOOL=${eval-cheap-module-source-map}
+   ```
+
 ## Directory structure
 
 The webpack processed code is placed in the following folder structure:


### PR DESCRIPTION
Building and rebuilding of js files is sometimes painfully slow,
with a simple change of source mapping style, process can be
significally faster.
    
With `WEBPACK_DEVTOOL` env variable developers can set the `devtool`
like they want to, or they can use the default option: `inline-source-map`.
    
See https://webpack.js.org/configuration/devtool/#devtool