### PR TITLE
Fixes #32193 - enable byebug in development

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -7,12 +7,14 @@ group :development do
   # for generating foreign key migrations
   gem 'immigrant', '~> 0.1'
 
+  # debugging and REPL tools
+  gem 'byebug'
   gem 'pry'
   gem 'pry-rails'
   gem 'pry-byebug'
   gem 'pry-doc'
   gem 'pry-stack_explorer'
-  gem 'pry-remote'
+  gem 'pry-remote' # will not work when running via foreman
 
   gem 'rainbow', '>= 2.2.1'
 


### PR DESCRIPTION
We already pull byebug debugger as pry-byebug dependency. Unfortunately, pry remote debugger (pry-remote) does not work properly when rails is started without an interactive terminal and also pry is a REPL tool not a full debugger.

I propose to add byebug gem explicitly into the development gem group and also including an initializer which will start remote debugger if an environment variable is set. Note this is not meant for production deployments.

This will unify debugging possibilities and enable anyone with little effort to start a debugging session. I plan to include instructions in our Contributing guide.