### PR TITLE
Fixes #32192 - Handle special characters in HTTP proxy credentials 

### DIFF
--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -1,3 +1,5 @@
+require 'cgi'
+
 class HttpProxy < ApplicationRecord
   audited
   include Authorizable
@@ -31,8 +33,10 @@ class HttpProxy < ApplicationRecord
 
   def full_url
     uri = URI(url)
-    uri.user = username if username.present?
-    uri.password = password if username.present?
+    if username.present?
+      uri.user = CGI.escape(username)
+      uri.password = CGI.escape(password) if password
+    end
     uri.to_s
   end
 

--- a/lib/foreman/http_proxy/rest_client_extension.rb
+++ b/lib/foreman/http_proxy/rest_client_extension.rb
@@ -12,18 +12,13 @@ module Foreman
       def net_http_object(hostname, port)
         p_uri = proxy_uri
 
-        if p_uri.nil?
-          # no proxy set
-          Net::HTTP.new(hostname, port)
-        elsif !p_uri
-          # proxy explicitly set to none
-          Net::HTTP.new(hostname, port, nil, nil, nil, nil)
-        else
-          proxy_pass = CGI.unescape(p_uri.password) if p_uri.password
-          proxy_user = CGI.unescape(p_uri.user) if p_uri.user
-          Net::HTTP.new(hostname, port,
-            p_uri.hostname, p_uri.port, proxy_user, proxy_pass)
-        end
+        # no proxy set or proxy explicitly set to none
+        return super unless p_uri
+
+        proxy_pass = CGI.unescape(p_uri.password) if p_uri.password
+        proxy_user = CGI.unescape(p_uri.user) if p_uri.user
+        Net::HTTP.new(hostname, port,
+          p_uri.hostname, p_uri.port, proxy_user, proxy_pass)
       end
     end
   end

--- a/lib/foreman/http_proxy/rest_client_extension.rb
+++ b/lib/foreman/http_proxy/rest_client_extension.rb
@@ -8,6 +8,23 @@ module Foreman
         end
         super
       end
+
+      def net_http_object(hostname, port)
+        p_uri = proxy_uri
+
+        if p_uri.nil?
+          # no proxy set
+          Net::HTTP.new(hostname, port)
+        elsif !p_uri
+          # proxy explicitly set to none
+          Net::HTTP.new(hostname, port, nil, nil, nil, nil)
+        else
+          proxy_pass = CGI.unescape(p_uri.password) if p_uri.password
+          proxy_user = CGI.unescape(p_uri.user) if p_uri.user
+          Net::HTTP.new(hostname, port,
+            p_uri.hostname, p_uri.port, proxy_user, proxy_pass)
+        end
+      end
     end
   end
 end

--- a/test/unit/http_proxy_test.rb
+++ b/test/unit/http_proxy_test.rb
@@ -36,4 +36,20 @@ class HttpProxyTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context '#full_url' do
+    let(:special_chars) { '#$@&{}[]+%' }
+    let(:proxy) { FactoryBot.build(:http_proxy, :with_auditing) }
+
+    test 'allows having special characters in username' do
+      proxy.username = special_chars
+      assert_nothing_raised { proxy.full_url }
+    end
+
+    test 'allows having special characters in password' do
+      proxy.username = 'admin'
+      proxy.password = special_chars
+      assert_nothing_raised { proxy.full_url }
+    end
+  end
 end


### PR DESCRIPTION
Originally we tried to using user provided credentials verbatim, leading to
errors when they contained special characters. This is resolved by escaping them
first as required by section 2.4.3 of RFC2396.

Restclient as of version 2.1.0 uses provided credentials stored in a proxy URI
object verbatim. If the credentials are escaped as they should be, then this
leads to errors when we try to use the credentials because restclient sends the
escaped form.

There is a PR[1] in upstream restclient, which addresses this issue, but last
movement there was in October 2018. ManageIQ folks decided to monkey patch
restclient when they ran into the same issue, this commit is a loose adaptation
of the original[1] and ManageIQ patches[2].

[1] - rest-client/rest-client#665
[2] - ManageIQ/manageiq#18105