### PR TITLE
Fixes #32213 - inform user about wrong use of admin flag

### DIFF
--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -23,7 +23,7 @@ module Api
       def_param_group :usergroup do
         param :usergroup, Hash, :required => true, :action_aware => true do
           param :name, String, :required => true
-          param :admin, :bool, :required => false, :desc => N_("is an admin user group")
+          param :admin, :bool, :required => false, :desc => N_("is an admin user group, can be modified by admins only")
           param :user_ids, Array, :require => false
           param :usergroup_ids, Array, :require => false
           param :role_ids, Array, :require => false

--- a/app/controllers/concerns/foreman/controller/parameters/usergroup.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/usergroup.rb
@@ -12,7 +12,7 @@ module Foreman::Controller::Parameters::Usergroup
           :usergroup_ids => [], :usergroup_names => []
 
         filter.permit do |ctx|
-          ctx.permit :admin if User.current.try(:admin?) && (ctx.ui? || ctx.api?)
+          ctx.permit :admin if (User.current.try(:admin?) && ctx.ui?) || ctx.api?
         end
       end
     end

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -39,6 +39,7 @@ class Usergroup < ApplicationRecord
   scoped_search :relation => :roles, :on => :name, :rename => :role, :complete_value => true
   scoped_search :relation => :roles, :on => :id, :rename => :role_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   validate :ensure_uniq_name, :ensure_last_admin_remains_admin
+  validate :admin_can_be_set, :if => ->(o) { o.changed.include?('admin') }
 
   accepts_nested_attributes_for :external_usergroups, :reject_if => ->(a) { a[:name].blank? }, :allow_destroy => true
 
@@ -124,5 +125,9 @@ class Usergroup < ApplicationRecord
 
   def other_admins
     User.unscoped.only_admin.except_hidden - all_users
+  end
+
+  def admin_can_be_set
+    errors.add :admin, _('admin flag can only be modified by admins') unless User.current.admin?
   end
 end

--- a/test/controllers/api/v2/usergroups_controller_test.rb
+++ b/test/controllers/api/v2/usergroups_controller_test.rb
@@ -140,4 +140,44 @@ class Api::V2::UsergroupsControllerTest < ActionController::TestCase
     @usergroup.reload
     assert_not_equal usergroup.name, @usergroup.name
   end
+
+  test 'non-admin user with manager role should not be able to modify the user group when touching the admin flag' do
+    usergroup = FactoryBot.create(:usergroup, :admin => false)
+    setup_user 'edit', 'usergroups'
+
+    put :update, params: { :id => usergroup.id, :usergroup => { :admin => true } }, session: set_session_user
+    assert_response :unprocessable_entity
+  end
+
+  test 'non-admin user with manager role should be able to modify the user group without touching the admin flag' do
+    usergroup = FactoryBot.create(:usergroup, :admin => false)
+    setup_user 'edit', 'usergroups'
+
+    put :update, params: { :id => usergroup.id, :usergroup => { :name => usergroup.name + 'x'} }, session: set_session_user
+    assert_response :success
+  end
+
+  test 'non-admin user with manager role should not be able to create the user group with the admin flag' do
+    setup_user 'create', 'usergroups'
+    usergroup = FactoryBot.build(:usergroup)
+
+    post :create, params: { :usergroup => { :name => usergroup.name, :admin => true } }, session: set_session_user
+    assert_response :unprocessable_entity
+  end
+
+  test 'non-admin user with manager role should be able to create the user group even with the false admin flag' do
+    setup_user 'create', 'usergroups'
+    usergroup = FactoryBot.build(:usergroup)
+
+    post :create, params: { :usergroup => { :name => usergroup.name, :admin => false } }, session: set_session_user
+    assert_response :success
+  end
+
+  test 'non-admin user with manager role should be able to create the user group if admin flag is not set' do
+    setup_user 'create', 'usergroups'
+    usergroup = FactoryBot.build(:usergroup)
+
+    post :create, params: { :usergroup => { :name => usergroup.name } }, session: set_session_user
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Our API filters the admin attribute of user group API via strong params
for non-admin users. Therefore when non-admin tries to create or update
a user group admin flag, it is silently ignored even and the user group
correctly remains as is. Only admins can set this attribute.

From user perspective, this is not great. It's confusing why the
explicitly set attribute is ignored. The user should be informed about
the reason.

This patch removes the attribute filtering for the API and adds a
model validation, which register the proper validation error which is
then presented to the user.

The UI does not require any change since the flag is is not even
displayed to the user. For security reason the flag continue to be
filtered for the UI path. The validation in this case is another
security level but in general should never be triggered through UI.

The API in this case returns 422 because the actual model is not valid.
Technically this could also be 403 since user does not have enough
permissions, but that would be confusing, since that status is for the
case users don't have the edit_usergroups permission at all. 422 is more
consistent with other cases, e.g. when user tries to set attribute to
link the object he/she does not have view permission for.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
