### PR TITLE
Fixes #32214 - Register query field with a resolver

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -593,8 +593,8 @@ module Foreman #:nodoc:
       graphql_types_registry.register_extension(type: type, with_module: with_module, &block)
     end
 
-    def register_graphql_query_field(field_name, type, field_type)
-      graphql_types_registry.register_plugin_query_field(field_name, type, field_type)
+    def register_graphql_query_field(field_name, type, field_type, options = nil)
+      graphql_types_registry.register_plugin_query_field(field_name, type, field_type, options)
     end
 
     def register_graphql_mutation_field(field_name, mutation_class)

--- a/app/registries/foreman/plugin/graphql_plugin_fields.rb
+++ b/app/registries/foreman/plugin/graphql_plugin_fields.rb
@@ -6,7 +6,11 @@ module Foreman
       module ClassMethods
         def realize_plugin_query_extensions(source = Foreman::Plugin.graphql_types_registry.plugin_query_fields)
           source.map do |plugin_type|
-            send plugin_type[:field_type], plugin_type[:field_name], Foreman::Module.resolve(plugin_type[:type])
+            if plugin_type[:options].empty?
+              send plugin_type[:field_type], plugin_type[:field_name], Foreman::Module.resolve(plugin_type[:type])
+            else
+              send plugin_type[:field_type], plugin_type[:field_name], apply_type(plugin_type[:type]), plugin_type[:options]
+            end
           end
         end
 
@@ -14,6 +18,10 @@ module Foreman
           source.map do |plugin_type|
             send :field, plugin_type[:field_name], mutation: Foreman::Module.resolve(plugin_type[:mutation])
           end
+        end
+
+        def apply_type(field_type)
+          field_type.respond_to?(:call) ? field_type.call : Foreman::Module.resolve(field_type)
         end
       end
     end

--- a/app/registries/foreman/plugin/graphql_types_registry.rb
+++ b/app/registries/foreman/plugin/graphql_types_registry.rb
@@ -11,11 +11,14 @@ module Foreman
         @plugin_mutation_fields = []
       end
 
-      def register_plugin_query_field(field_name, type, field_type)
-        unless [:record_field, :collection_field].any? { |field| field == field_type }
-          raise "expected :record_field or :collection_field as a field_type, got #{field_type}"
+      def register_plugin_query_field(field_name, type, field_type, options = {})
+        unless [:record_field, :collection_field, :field].any? { |field| field == field_type }
+          raise "expected :record_field, :collection_field or :field as a field_type, got #{field_type}"
         end
-        @plugin_query_fields << { :field_type => field_type, :field_name => field_name, :type => type }
+        if [:record_field, :collection_field].any? { |field| field == field_type && !options.empty? }
+          raise "options are allowed only for :field"
+        end
+        @plugin_query_fields << { :field_type => field_type, :field_name => field_name, :type => type, :options => options }
       end
 
       def register_plugin_mutation_field(field_name, mutation)

--- a/test/unit/foreman/plugin/graphql_types_registry_test.rb
+++ b/test/unit/foreman/plugin/graphql_types_registry_test.rb
@@ -70,7 +70,7 @@ class Foreman::Plugin::GraphqlTypesRegistryTest < ActiveSupport::TestCase
       err = assert_raises RuntimeError do
         registry.register_plugin_query_field :woof, 'TestType', :custom_field
       end
-      assert_equal err.message, "expected :record_field or :collection_field as a field_type, got custom_field"
+      assert_equal err.message, "expected :record_field, :collection_field or :field as a field_type, got custom_field"
     end
 
     it 'registeres plugin mutation fields' do


### PR DESCRIPTION
```ruby
Foreman::Plugin.register :foreman_plugin do
  register_graphql_query_field :foo, '::Types::Foo', :field, { :resolver => ::Resolvers::Foos::Foo }
  # register with lambda instead of a string if type does not resolve to a contant
  register_graphql_query_field :bars, -> () { [::Types::Bar] }, :field, { :resolver => ::Resolvers::Bars }
end
```


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
