### PR TITLE
Fixes #32216 - Handle Debian Bullseye Testing facts

### DIFF
--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -50,7 +50,7 @@ class Debian < Operatingsystem
     s.gsub!(/\(.+?\)/, '')
     s.squeeze! " "
     s.strip!
-    s += '.' + minor unless s.include?('.')
+    s += '.' + minor unless minor.blank? || s.include?('.')
     s.presence || description
   end
 

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -219,7 +219,13 @@ class PuppetFactParser < FactParser
       '1.0'
     when /Debian/i
       return "99" if facts[:lsbdistcodename] =~ /sid/
-      facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+      release = facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+      case release
+      when 'bullseye/sid' # Debian Bullseye testing will be 11
+        '11'
+      else
+        release
+      end
     else
       facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
     end


### PR DESCRIPTION
While Bullseye is still testing, it's identified as bullseye/sid:

```console
$ cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux bullseye/sid"
NAME="Debian GNU/Linux"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

The same shows up in Facter:

```console
$ facter os
{
  architecture => "amd64",
  distro => {
    codename => "bullseye",
    description => "Debian GNU/Linux bullseye/sid",
    id => "Debian",
    release => {
      full => "bullseye/sid",
      major => "bullseye/sid"
    }
  },
  family => "Debian",
  hardware => "x86_64",
  name => "Debian",
  release => {
    full => "bullseye/sid",
    major => "bullseye/sid"
  },
  selinux => {
    enabled => false
  }
}
```

This chooses to treat it as version 11 (without a minor). The description is also updated to handle a blank minor. Initially I used version 11.0 and that resulted in a description "Debian bullseye/sid.0".