### PR TITLE
Fixes #32238 - Bind systemd socket to IPv6

### DIFF
--- a/extras/systemd/foreman.socket
+++ b/extras/systemd/foreman.socket
@@ -2,11 +2,7 @@
 Description=Foreman HTTP Server Accept Sockets
 
 [Socket]
-# Note Puma must be configured to listen on the same IP/port. If there's a
-# mismatch, it will bind again. The port can already be in use, for example when
-# systemd is configured with [::]:3000 but Puma with 0.0.0.0:3000. The port is
-# then already in use.
-ListenStream=0.0.0.0:3000
+ListenStream=3000
 
 # Socket options matching Puma defaults
 NoDelay=true


### PR DESCRIPTION
By default foreman.socket binds to IPv4 only. This was done to make matching it in Puma easier, but it's not really what should be done in 2021 where everything should be dual stack by default.

In aecc3187253ada61a311b5229d215452bd6d67b7 the need for this matching in Puma was removed which makes it much more flexible. The default should be updated.

Note that the installer currently always overrides it so it's not really a difference for most, but I want to modify the installer to rely on the default.

Given that this is not used by default, I'm setting this as a target for 2.4.1. It can't be picked to an earlier release since aecc3187253ada61a311b5229d215452bd6d67b7 was merged in 2.4.0. This really is fixing something that should have been part of it.