### PR TITLE
Fixes #30394 - allow non-admins deal with untaxed filters

### DIFF
--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -61,6 +61,10 @@ class Filter < ApplicationRecord
 
   validate :same_resource_type_permissions, :not_empty_permissions, :allowed_taxonomies
 
+  def self.allows_taxonomy_filtering?(_taxonomy)
+    false
+  end
+
   def self.search_by_unlimited(key, operator, value)
     search_by_limited(key, operator, (value == 'true') ? 'false' : 'true')
   end

--- a/app/views/filters/_form.html.erb
+++ b/app/views/filters/_form.html.erb
@@ -26,8 +26,8 @@
 
       <%= selectable_f(f, :resource_type, Permission.resources_with_translations,
                        {:include_blank => _('(Miscellaneous)')}, {:'data-url' => permissions_path,
-                                                                  :'data-allow-organizations' => @filter.allows_organization_filtering?,
-                                                                  :'data-allow-locations' => @filter.allows_location_filtering?,
+                                                                  :'data-allow-organizations' => @filter.resource_taxable_by_organization?,
+                                                                  :'data-allow-locations' => @filter.resource_taxable_by_location?,
                                                                   :autofocus => true}) %>
 
       <%= multiple_selects f, :permissions, Permission.where(:resource_type => f.object.resource_type),
@@ -43,7 +43,7 @@
         </div>
       </div>
 
-      <div id="override_taxonomy_form" class="<%= f.object.allows_taxonomies_filtering? ? '' : 'hidden' %>">
+      <div id="override_taxonomy_form" class="<%= f.object.resource_taxable? ? '' : 'hidden' %>">
         <%= checkbox_f f, :override?,
                        :label_help => _("Filters inherit organizations and locations associated with the role by default. If override field is enabled, <br> the filter can override the set of its organizations and locations. Later role changes will not affect such filter.<br> After disabling the override field, the role organizations and locations apply again.").html_safe,
                        :id => 'override_taxonomy_checkbox' %>

--- a/db/migrate/20210609093404_drop_override_taxonomies_from_filter.rb
+++ b/db/migrate/20210609093404_drop_override_taxonomies_from_filter.rb
@@ -1,0 +1,8 @@
+class DropOverrideTaxonomiesFromFilter < ActiveRecord::Migration[6.0]
+  def up
+    perms = Permission.where(name: %w[view_filters create_filters edit_filters destroy_filters])
+    filters = Filter.joins(:filterings).where(filterings: { permission_id: perms })
+    filters.update_all(override: false)
+    TaxableTaxonomy.where(taxable: filters).delete_all
+  end
+end

--- a/test/controllers/filters_controller_test.rb
+++ b/test/controllers/filters_controller_test.rb
@@ -69,7 +69,7 @@ class FiltersControllerTest < ActionController::TestCase
     org2 = FactoryBot.create(:organization)
     role.organizations = [org1]
     role.filters.reload
-    filter_with_org = role.filters.detect(&:allows_organization_filtering?)
+    filter_with_org = role.filters.detect(&:resource_taxable_by_organization?)
     filter_with_org.update :organizations => [org1, org2], :override => true
 
     patch :disable_overriding, params: { :role_id => role.id, :id => filter_with_org.id }, session: set_session_user

--- a/test/controllers/roles_controller_test.rb
+++ b/test/controllers/roles_controller_test.rb
@@ -73,7 +73,7 @@ class RolesControllerTest < ActionController::TestCase
 
     test 'should disable filter overriding' do
       @role.filters.reload
-      @filter_with_org = @role.filters.detect { |f| f.allows_organization_filtering? }
+      @filter_with_org = @role.filters.detect { |f| f.resource_taxable_by_organization? }
       @filter_with_org.update :organizations => [@org1, @org2], :override => true
 
       patch :disable_filters_overriding, params: { :id => @role.id }, session: set_session_user

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -176,13 +176,14 @@ class FilterTest < ActiveSupport::TestCase
     assert_empty f.taxonomy_search
   end
 
-  test "#allows_*_filtering" do
-    fb = FactoryBot.create(:filter, :resource_type => 'Bookmark')
+  test "#resource_taxable_by_*?" do
+    # Filter is global resource
+    ff = FactoryBot.create(:filter, :resource_type => 'Filter')
     fd = FactoryBot.create(:filter, :resource_type => 'Domain')
-    refute fb.allows_organization_filtering?
-    refute fb.allows_location_filtering?
-    assert fd.allows_organization_filtering?
-    assert fd.allows_location_filtering?
+    refute ff.resource_taxable_by_organization?
+    refute ff.resource_taxable_by_location?
+    assert fd.resource_taxable_by_organization?
+    assert fd.resource_taxable_by_location?
   end
 
   test "search string composition" do

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -366,8 +366,8 @@ class RoleTest < ActiveSupport::TestCase
       @org1 = FactoryBot.create(:organization)
       @org2 = FactoryBot.create(:organization)
       @role.filters.reload
-      @filter_with_org = @role.filters.detect { |f| f.allows_organization_filtering? }
-      @filter_without_org = @role.filters.detect { |f| !f.allows_organization_filtering? }
+      @filter_with_org = @role.filters.detect { |f| f.resource_taxable_by_organization? }
+      @filter_without_org = @role.filters.detect { |f| !f.resource_taxable_by_organization? }
     end
 
     describe '#sync_inheriting_filters' do


### PR DESCRIPTION
Prior this non-admin user would have to have assigned Role without
taxonomies (global role) to be able to manipulate filters.
This allows manipulating Filters to any User with Filter perms.

Filters with taxonomies mean they apply to taxonomy. But given they have
taxonomies relations, they are expected to be taxable in our permission
model. All taxable resources have to have the same taxonomies as Filter
have.

Some filters doesn't have taxonomies as their underlying resource
doesn't have taxonomies. That mean they were unable to be touched by
non-admins prior this patch.

This also renames the taxable checks to express beter what they mean.
