### PR TITLE
Fixes #32092 - add puppet safe guard

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -110,9 +110,10 @@ module HostCommon
   end
 
   # The Puppet server FQDN or an empty string. Exposed as a provisioning macro
-  def puppetmaster
+  def puppet_server
     puppet_server_uri.try(:host) || ''
   end
+  alias_method :puppetmaster, :puppet_server
 
   def puppet_ca_server_uri
     return unless puppet_ca_proxy

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -126,7 +126,7 @@ class Host::Managed < Host::Base
     property :provision_method, String, desc: 'Returns a provisioning method used for this host, one of "build", "image". Plugins can add additional methods.'
     property :ptable, 'Ptable', desc: 'Returns a partition table object assigned to the host, returns nil if none is found'
     property :puppet_ca_server, String, desc: 'FQDN of the Puppet CA server used by this host, typically FQDN of the host\'s puppet CA proxy'
-    property :puppetmaster, String, desc: 'FQDN of the Puppet master/server used by this host, typically FQDN of the host\'s puppet proxy'
+    property :puppet_server, String, desc: 'FQDN of the Puppet master/server used by this host, typically FQDN of the host\'s puppet proxy'
     property :realm, 'Realm', desc: 'Returns a realm object assigned to the host primary interface, returns nil if none is found'
     property :shortname, String, desc: 'Host shortname, usually a hostname without the domain part, e.g. my-host'
     property :subnet, 'Subnet', desc: 'Returns an IPv4 subnet object assigned to the host primary interface, returns nil if none is found'
@@ -164,7 +164,7 @@ class Host::Managed < Host::Base
     property :created_at, 'ActiveSupport::TimeWithZone', desc: 'The time when the host was created'
   end
   class Jail < ::Safemode::Jail
-    allow :id, :name, :created_at, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup,
+    allow :id, :name, :created_at, :diskLayout, :puppetmaster, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup,
       :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :ip6, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :subnet6, :token, :location, :organization, :provision_method,
       :image_build?, :pxe_build?, :otp, :realm, :nil?, :indent, :primary_interface,
@@ -173,6 +173,11 @@ class Host::Managed < Host::Base
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
       :ssh_authorized_keys, :pxe_loader, :global_status, :get_status, :puppetca_token, :last_report, :build?, :smart_proxies, :host_param,
       :virtual, :ram, :sockets, :cores, :params, :pxe_loader_efi?
+
+    def puppetmaster
+      Foreman::Deprecation.deprecation_warning('3.0', 'Host#puppetmaster is deprecated, please use host_puppet_server macro instead')
+      @source.puppet_server
+    end
   end
 
   scope :recent, lambda { |interval = Setting[:outofsync_interval]|

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -110,7 +110,7 @@ class Hostgroup < ApplicationRecord
     property :operatingsystem, 'Operatingsystem', desc: 'Returns operating system to be used on hosts within this host group'
     property :os, 'Operatingsystem', desc: 'Returns operating system to be used on hosts within this host group'
     property :ptable, 'Ptable', desc: 'Returns partition table associated with this host group'
-    property :puppetmaster, String, desc: 'Returns host name of the server with Puppet Master'
+    property :puppet_server, String, desc: 'Returns host name of the server with Puppetserver'
     property :params, Hash, desc: 'Returns parameters of this host group'
     property :puppet_proxy, 'SmartProxy', desc: 'Returns Smart proxy with Puppet feature'
     property :puppet_ca_server, 'SmartProxy', desc: 'Returns Smart proxy Puppet CA feature'
@@ -124,11 +124,16 @@ class Hostgroup < ApplicationRecord
     property :title, String, desc: 'Returns full title of this host group, e.g. Base/CentOS 7'
   end
   class Jail < Safemode::Jail
-    allow :id, :name, :diskLayout, :puppetmaster, :operatingsystem, :architecture,
+    allow :id, :name, :diskLayout, :puppet_server, :operatingsystem, :architecture,
       :environment, :ptable, :url_for_boot, :params, :puppet_proxy,
       :puppet_ca_server, :os, :arch, :domain, :subnet, :hosts,
       :subnet6, :realm, :root_pass, :description, :pxe_loader, :title,
       :children, :parent
+
+    def puppetmaster
+      Foreman::Deprecation.deprecation_warning('3.0', 'Hostgroup#puppetmaster is deprecated, please use host_puppet_server macro instead')
+      @source.puppet_server
+    end
   end
 
   # TODO: add a method that returns the valid os for a hostgroup

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -17,9 +17,8 @@ This template accepts the following parameters:
 -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
-  pm_set = @host.puppetmaster.empty? ? false : true
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 -%>
 

--- a/app/views/unattended/provisioning_templates/finish/alterator_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/alterator_default_finish.erb
@@ -18,10 +18,10 @@ cat > /etc/puppet/puppet.conf << EOF
 <%= snippet 'puppet.conf' -%>
 EOF
 
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %> --no-daemonize
-<%= snippet 'built' %>
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= host_puppet_server %> --no-daemonize
 /sbin/chkconfig puppetd on
 
+<%= snippet 'built' %>
 <%= snippet 'schedule_reboot' -%>
 
 exit 0

--- a/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
@@ -7,8 +7,7 @@ oses:
 %>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   proxy_string = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : ''
 %>

--- a/app/views/unattended/provisioning_templates/finish/jumpstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/jumpstart_default_finish.erb
@@ -52,7 +52,8 @@ then
     rm -f /etc/opt/csw/puppet/puppetd.conf
     ln -s /etc/puppet/puppet.conf /etc/opt/csw/puppet/puppetd.conf
 fi
-/opt/csw/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= @host.puppetmaster %> --no-daemonize
+/opt/csw/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= host_puppet_server %> --no-daemonize
+
 echo "Informing Foreman that we are built"
 /opt/csw/bin/wget --no-check-certificate -O /dev/null <%= foreman_url('built') %>
 

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -22,8 +22,7 @@ service network restart
 
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -8,8 +8,7 @@ oses:
 %>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>

--- a/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
@@ -27,8 +27,7 @@ params:
 %>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param('force-puppet') && host_param('force-puppet') == 'true'
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>
@@ -102,7 +101,7 @@ params:
 
   <% if puppet_enabled %>
     echo Installing puppet
-    start /w "" msiexec /qn /i C:\extras\puppet.msi PUPPET_AGENT_STARTUP_MODE=Manual PUPPET_MASTER_SERVER=<%= @host.puppetmaster -%> PUPPET_AGENT_ACCOUNT_DOMAIN=<%= @host.domain -%> PUPPET_AGENT_ACCOUNT_USER=administrator PUPPET_AGENT_ACCOUNT_PASSWORD="<%= host_param('domainAdminAccountPasswd') -%>"
+    start /w "" msiexec /qn /i C:\extras\puppet.msi PUPPET_AGENT_STARTUP_MODE=Manual PUPPET_MASTER_SERVER=<%= host_puppet_server -%> PUPPET_AGENT_ACCOUNT_DOMAIN=<%= @host.domain -%> PUPPET_AGENT_ACCOUNT_USER=administrator PUPPET_AGENT_ACCOUNT_PASSWORD="<%= host_param('domainAdminAccountPasswd') -%>"
     echo set puppet to auto start
     sc config puppet start= auto
     sc query puppet

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -15,7 +15,7 @@ set -e
 # This script enrolls a host with Foreman.
 # Host: <%= @host.name %>
 
-<% if @host.puppetmaster.present? -%>
+<% if host_puppet_server.present? -%>
 <%= snippet 'puppetlabs_repo' %>
 <%= snippet 'puppet_setup' %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -7,8 +7,7 @@ oses:
 -%>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   os_major = @host.operatingsystem.major.to_i
   primary_interface_identifier = @host.primary_interface.identifier.blank? ? 'eth0' : @host.primary_interface.identifier

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -9,9 +9,8 @@ oses:
   os_major = @host.operatingsystem.major.to_i
   os_minor = @host.operatingsystem.minor.to_i
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
   aio_enabled = host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   sles_minor_string = (os_minor == 0) ? '' : "_SP#{os_minor}"
   spacewalk_enabled = host_param('spacewalk_host') ? true : false

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -44,10 +44,9 @@ https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/pe
   os_minor = @host.operatingsystem.minor.to_i
   realm_compatible = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7)
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   proxy_string = proxy_uri ? " --proxy=#{proxy_uri}" : ''
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -41,9 +41,13 @@ ssldir = <%= ssl_dir %>
 [agent]
 pluginsync      = true
 report          = true
-<%- if @host.puppet_ca_server.strip -%>
-ca_server       = <%= @host.puppet_ca_server %>
+<%- if host_puppet_ca_server.present? -%>
+ca_server       = <%= host_puppet_ca_server %>
 <%- end -%>
 certname        = <%= @host.certname %>
-environment     = <%= @host.environment %>
-server          = <%= @host.puppetmaster %>
+<%- if host_puppet_server.present? -%>
+server          = <%= host_puppet_server %>
+<%- end -%>
+<%- if host_puppet_environment.present? -%>
+environment     = <%= host_puppet_environment %>
+<%- end -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -56,10 +56,10 @@ $puppet_install_args = @(
   '/norestart',
   '/i',
   "${puppet_agent_msi}",
-  <%- if @host.puppet_ca_server.strip -%>
-  "PUPPET_CA_SERVER=<%= @host.puppet_ca_server %>",
+  <%- if host_puppet_ca_server.present? -%>
+  "PUPPET_CA_SERVER=<%= host_puppet_ca_server %>",
   <%- end -%>
-  "PUPPET_MASTER_SERVER=<%= @host.puppetmaster %>"
+  "PUPPET_MASTER_SERVER=<%= host_puppet_server %>"
 )
 
 Write-Host "Installing ${puppet_agent_msi} with args ${puppet_install_args}"
@@ -108,7 +108,7 @@ fi
 <% elsif os_family == 'Suse' -%>
 if [ -f "/etc/sysconfig/puppet" ]
 then
-/usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= @host.puppetmaster.blank? ? '' : @host.puppetmaster %>/ /etc/sysconfig/puppet
+/usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= host_puppet_server %>/ /etc/sysconfig/puppet
 fi
 <% end -%>
 <% end -%>
@@ -143,14 +143,14 @@ $puppet_agent_args = @(
   "--config", "<%= etc_path %>\puppet.conf",
   "--onetime",
   <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : '"--tags no_such_tag",' %>
-  <%= @host.puppetmaster.blank? ? '' : "\"--server #{@host.puppetmaster}\"," %>
+  <%= host_puppet_server.blank? ? '' : "\"--server #{host_puppet_server}\"," %>
   "--no-daemonize"
 )
 Start-Process '<%= bin_path %>\puppet' -ArgumentList $puppet_agent_args -Wait -NoNewWindow
 <% else -%>
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-<%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : '--tags no_such_tag' %> <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
+<%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : '--tags no_such_tag' %> <%= host_puppet_server.blank? ? '' : "--server #{host_puppet_server}" %> --no-daemonize
 <% if os_family == 'Suse' || (os_name == 'Debian' && os_major > 8) || (os_name == 'Ubuntu' && os_major >= 15) -%>
 <%= bin_path %>/puppet resource service puppet enable=true
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -8,8 +8,7 @@ oses:
 -%>
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
 -%>
 #!/bin/bash

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -9,8 +9,7 @@ oses:
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 -%>

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -13,9 +13,8 @@ oses:
 
 <%
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 %>

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -19,8 +19,7 @@ This template accepts the following parameters:
   ssh_pwauth = host_param('ssh_pwauth') ? host_param_true?('ssh_pwauth') : !host_param('ssh_authorized_keys')
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   # safemode renderer does not support unary negation
-  pm_set = @host.puppetmaster.empty? ? false : true
-  puppet_enabled = pm_set || host_param_true?('force-puppet')
+  puppet_enabled = host_puppet_server.present? || host_param_true?('force-puppet')
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
 -%>

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -60,6 +60,9 @@ module Foreman
         :match,
         :host_param_true?, :host_param_false?,
         :host_param, :host_param!,
+        :host_puppet_server,
+        :host_puppet_ca_server,
+        :host_puppet_environment,
         :host_puppet_classes,
         :host_enc
       ]

--- a/lib/foreman/renderer/scope/macros/host_template.rb
+++ b/lib/foreman/renderer/scope/macros/host_template.rb
@@ -52,6 +52,30 @@ module Foreman
             host_param(param_name)
           end
 
+          apipie :method, 'Returns Puppetserver\'s hostname configured configured through the ENC or the puppet_server host parameter' do
+            returns String, desc: 'Returns the configured Puppetserver\'s hostname, or nil if not configured'
+          end
+          def host_puppet_server
+            check_host
+            host.try(:puppet_server) || host_param('puppet_server')
+          end
+
+          apipie :method, 'Returns Puppet CA server\'s hostname configured through the ENC or the puppet_ca_server host parameter' do
+            returns String, desc: 'Returns the configured Puppet CA server\'s hostname, or nil if not configured'
+          end
+          def host_puppet_ca_server
+            check_host
+            host.try(:puppet_ca_server) || host_param('puppet_ca_server')
+          end
+
+          apipie :method, 'Returns the Puppet environment configured configured through the ENC or the puppet_environment host parameter' do
+            returns String, desc: 'Returns the configured Puppet environment name, or nil if not configured'
+          end
+          def host_puppet_environment
+            check_host
+            host.respond_to?(:environment) ? host.environment : host_param('puppet_environment')
+          end
+
           apipie :method, 'Returns puppet classes assigned to the host' do
             returns Array, desc: 'Puppet classes assigned to the host'
           end

--- a/test/models/host_jail_test.rb
+++ b/test/models/host_jail_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class HostJailTest < ActiveSupport::TestCase
   def test_jail_should_include_these_methods
-    allowed = [:name, :diskLayout, :puppetmaster, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup,
+    allowed = [:name, :diskLayout, :puppetmaster, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :environment, :ptable, :hostgroup,
                :organization, :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
                :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method, :image_build?,
                :pxe_build?, :otp, :realm, :nil?, :indent, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :facts,
@@ -11,5 +11,11 @@ class HostJailTest < ActiveSupport::TestCase
     allowed.each do |m|
       assert Host::Managed::Jail.allowed?(m), "Method #{m} is not available in Host::Managed::Jail while should be allowed."
     end
+  end
+
+  test '#puppetmaster should be deprecated' do
+    Foreman::Deprecation.expects(:deprecation_warning)
+    host = FactoryBot.build_stubbed(:host)
+    host.to_jail.puppetmaster
   end
 end

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -81,6 +81,51 @@ class HostTemplateTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#host_puppet_server' do
+    test 'should render puppet_server' do
+      host = stub(puppet_server: 'myserver.example.com')
+      @scope.instance_variable_set('@host', host)
+      assert_equal @scope.host_puppet_server, 'myserver.example.com'
+    end
+
+    test 'should render puppet_server parameter when puppet_server not defined' do
+      host = stub()
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_server').returns('myserver.example.com')
+      assert_equal @scope.host_puppet_server, 'myserver.example.com'
+    end
+  end
+
+  describe '#host_puppet_ca_server' do
+    test 'should render puppet_ca_server' do
+      host = stub(puppet_ca_server: 'myserver.example.com')
+      @scope.instance_variable_set('@host', host)
+      assert_equal @scope.host_puppet_ca_server, 'myserver.example.com'
+    end
+
+    test 'should render puppet_ca_server parameter when puppet_ca_server not defined' do
+      host = stub()
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server').returns('myserver.example.com')
+      assert_equal @scope.host_puppet_ca_server, 'myserver.example.com'
+    end
+  end
+
+  describe '#host_puppet_environment' do
+    test 'should render environment' do
+      host = stub(environment: 'production')
+      @scope.instance_variable_set('@host', host)
+      assert_equal @scope.host_puppet_environment, 'production'
+    end
+
+    test 'should render puppet_environment parameter when environment not defined' do
+      host = stub()
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_environment').returns('production')
+      assert_equal @scope.host_puppet_environment, 'production'
+    end
+  end
+
   describe '#host_puppet_classes' do
     test 'should render puppetclasses using host_puppetclasses helper' do
       host = FactoryBot.build(:host, :with_puppetclass)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
@@ -84,10 +84,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  ca_server       = 
   certname        = snapshothost
-  environment     = 
-  server          = 
   
   EOF
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator default finish.snap.txt
@@ -29,13 +29,12 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 EOF
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server  --no-daemonize
+/sbin/chkconfig puppetd on
+
 if [ -x /usr/bin/curl ]; then
   /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
 elif [ -x /usr/bin/wget ]; then
@@ -43,8 +42,6 @@ elif [ -x /usr/bin/wget ]; then
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
 fi
-
-/sbin/chkconfig puppetd on
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD (mfsBSD) finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD (mfsBSD) finish.snap.txt
@@ -36,10 +36,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
@@ -83,10 +83,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
@@ -47,10 +47,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
@@ -125,10 +125,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
@@ -127,10 +127,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -134,10 +134,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.snap.txt
@@ -7,7 +7,4 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.snap.txt
@@ -9,10 +9,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
@@ -59,10 +59,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
@@ -92,10 +92,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
@@ -63,10 +63,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-ca_server       = 
 certname        = snapshothost
-environment     = 
-server          = 
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
@@ -59,10 +59,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  ca_server       = 
   certname        = snapshothost
-  environment     = 
-  server          = 
   
   EOF
   


### PR DESCRIPTION
Hides puppetserver and puppet environment behind macros, that can alter
implementation much more easily and even be patched from plugin.