### PR TITLE
Fixes #32242 - Drop db_pending_migration setting

### DIFF
--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -15,7 +15,6 @@ class Setting::General < Setting
       set('foreman_url', N_("URL where your Foreman instance is reachable (see also Provisioning > unattended_url)"), foreman_url, N_('Foreman URL')),
       set('entries_per_page', N_("Number of records shown per page in Foreman"), 20, N_('Entries per page')),
       set('fix_db_cache', N_('Fix DB cache on next Foreman restart'), false, N_('Fix DB cache')),
-      set('db_pending_migration', N_("Should the `foreman-rake db:migrate` be executed on the next run of the installer modules?"), true, N_('DB pending migration')),
       set('db_pending_seed', N_("Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"), true, N_('DB pending seed')),
       set('proxy_request_timeout', N_("Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"), 60, N_('Smart Proxy request timeout')),
       set('login_text', N_("Text to be shown in the login-page footer"), nil, N_('Login page footer text')),

--- a/db/migrate/20210401124332_drop_db_pending_migration_setting.rb
+++ b/db/migrate/20210401124332_drop_db_pending_migration_setting.rb
@@ -1,0 +1,5 @@
+class DropDbPendingMigrationSetting < ActiveRecord::Migration[6.0]
+  def up
+    Setting.where(name: 'db_pending_migration').delete_all
+  end
+end

--- a/lib/tasks/config.rake
+++ b/lib/tasks/config.rake
@@ -168,17 +168,15 @@ task :config => :environment do
   exit
 end
 
-# The db_pending_* settings are handled by the installer. For case
+# The db_pending_seed setting is handled by the installer. For case
 # of not installing with installer, we want to ensure the settings to false
 # at the end of the seeding
 Rake::Task['db:seed'].enhance do
-  %w(db_pending_migration db_pending_seed).each do |setting_name|
-    if !Setting[setting_name].nil?
-      Setting[setting_name] = false
-    else
-      setting = Setting::General.default_settings.detect { |s| s[:name] == setting_name }
-      setting[:value] = false
-      Setting.create! setting.update(:category => "Setting::General")
-    end
+  if !Setting['db_pending_seed'].nil?
+    Setting['db_pending_seed'] = false
+  else
+    setting = Setting::General.default_settings.detect { |s| s[:name] == 'db_pending_seed' }
+    setting[:value] = false
+    Setting.create! setting.update(:category => "Setting::General")
   end
 end

--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -12,7 +12,7 @@ namespace :upgrade do
   task :run => :environment do
     ENV['FOREMAN_UPGRADE'] = '1'
 
-    raise "DB migration has not run" if Setting['db_pending_migration']
+    raise "DB migration has not run" if ActiveRecord::Base.connection.migration_context.needs_migration?
     raise "DB seed has not run" if Setting['db_pending_seed']
 
     total = UpgradeTask.needing_run.count


### PR DESCRIPTION
This setting was used in the past by the installer to determine whether
or not the database needs to be migrated, but that is no longer the
case.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
