### PR TITLE
fixes #32243 - Adding render_pagelet to subnet page

### DIFF
--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -26,9 +26,11 @@
         <td><%= link_to_if_authorized(hosts_count[subnet], hash_for_hosts_path(:search => "subnet.name=\"#{subnet}\"")) %>
         <td class="col-md-1">
           <%= action_buttons(display_delete_if_authorized(
-            hash_for_subnet_path(:id => subnet).
-            merge(:auth_object => subnet, :authorizer => authorizer),
-            :data => { :confirm => _("Delete %s?") % subnet.name })) %>
+                               hash_for_subnet_path(:id => subnet).
+                               merge(:auth_object => subnet, :authorizer => authorizer),
+                               :data => { :confirm => _("Delete %s?") % subnet.name }),
+                             render_pagelets_for(:action_buttons, subject: subnet)
+              ) %>
         </td>
       </tr>
     <% end %>


### PR DESCRIPTION
This PR introduced a pagelet endpoint at subnet index page. It's placed at the buttons part of every subnet record. So it can be use for further extensibility with plugins.

This was developed during work on bootdisk PR - https://github.com/theforeman/foreman_bootdisk/pull/105
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
