### PR TITLE
Fixes #32245 - No host by default in database.yml.example

### DIFF
--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -1,8 +1,8 @@
 development:
   adapter: postgresql
-  host: localhost
+  #host: localhost
   port: 5432
-  database : foreman
+  database: foreman
   encoding: utf8
   pool: 10
 
@@ -11,16 +11,16 @@ development:
 # Do not set this db to the same as development or production.
 test:
   adapter: postgresql
-  host: localhost
+  #host: localhost
   port: 5432
-  database : foreman-test
+  database: foreman-test
   encoding: utf8
   pool: 10
 
 production:
   adapter: postgresql
-  host: localhost
+  #host: localhost
   port: 5432
-  database : foreman
+  database: foreman
   encoding: utf8
   pool: 10


### PR DESCRIPTION
In dc0983d58937a064d74d96f311ca10a88569480b the example database configuration file always sets a host. Using a host means PostgreSQL can't use ident auth which means you must set a password. By commenting it out, you can simplify the instructions to (on EL but similar on Debian):

```console
$ sudo yum -y install postgresql-server
$ sudo postgresql-setup --initdb
$ sudo systemctl enable --now postgresql
$ sudo -u postgres createuser $USERNAME
$ sudo -u postgres createdb --owner=$USERNAME foreman
```

Otherwise you need to provide a username/password as well and possibly set that up.