### PR TITLE
Fixes #32153 - Hide tooltip on multiselect all buttons

### DIFF
--- a/app/assets/javascripts/jquery.multi-select.js
+++ b/app/assets/javascripts/jquery.multi-select.js
@@ -74,13 +74,18 @@ function sanitize(value){
 
 $(document).on('click', '.ms-select-all', function () {
   // can't use multiSelect('select_all') because it adds filtered out items too.
-    $(this).closest('.form-group').find('.ms-selectable .ms-list :visible').click();
+    $(this).tooltip('hide')
+      .closest('.form-group')
+      .find('.ms-selectable .ms-list :visible')
+      .click();
     return false;
 });
 
 $(document).on('click', '.ms-deselect-all', function () {
     // can't use multiSelect('deselect_all') because it is deselecting disabled items too.
-    var ms = $(this).closest('.form-group').find('select[multiple]');
+    var ms = $(this).tooltip('hide')
+      .closest('.form-group')
+      .find('select[multiple]');
     ms.find('option:not(":disabled")').prop('selected', false);
     ms.multiSelect('refresh');
     return false;

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -63,6 +63,7 @@ export function activateTooltips(elParam = 'body') {
   el.tooltip({
     selector: '[rel="twipsy"],*[title]:not(*[rel],.fa,.pficon)',
     container: 'body',
+    trigger: 'hover',
   });
   // Ellipsis have to be initialized for each element for title() to work
   el.find('.ellipsis').tooltip({


### PR DESCRIPTION
The tooltips remain shown on click because the elemnt they are attached
to is a `a` tag, which remains in focus until the user clicks elsewhere
so there is no `focusout` event fired.
For the deselect all button, the click handler calls
`multiSelect('refresh')` which in turn removes the multiselect element
(with the tooltip event handlers) from the DOM[1], leaving the tooltip
always displayed.

[1] https://github.com/lou/multi-select/blob/0.9.12/js/jquery.multi-select.js#L335


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
