### PR TITLE
Fixes #32258 - Change to_status default to noop

### DIFF
--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -26,7 +26,10 @@ module HostStatus
     end
 
     def to_status(options = {})
-      raise NotImplementedError, "Method 'to_status' method needs to be implemented"
+      # By default return the same value the status already has.
+      # Override this method with a way to recalculate the status based on
+      # external values
+      status
     end
 
     def self.status_name


### PR DESCRIPTION
When status calculation is dependent on an event, `to_status` cannot be implemented. This PR adds a default implementation for the method, so the code won't throw an exception for child statuses without implementation.

Example for statuses that depend on events: "If a report was uploaded through foreman, change the status to `uploaded`". There is no way to calculate this status on demand.