### PR TITLE
Fixes #32263 - AWS EC2: Override IAM instance profile when creating host

### DIFF
--- a/app/models/concerns/fog_extensions.rb
+++ b/app/models/concerns/fog_extensions.rb
@@ -12,6 +12,8 @@ if Foreman::Model::EC2.available?
   Fog::AWS::Compute::Flavor.include FogExtensions::AWS::Flavor
   require 'fog/aws/models/compute/server'
   Fog::AWS::Compute::Server.include FogExtensions::AWS::Server
+  require 'fog/aws/models/iam/instance_profile'
+  Fog::AWS::IAM::InstanceProfile.include FogExtensions::AWS::IAM::InstanceProfile
 end
 
 if Foreman::Model::GCE.available?

--- a/app/models/concerns/fog_extensions/aws/iam/instance_profile.rb
+++ b/app/models/concerns/fog_extensions/aws/iam/instance_profile.rb
@@ -1,0 +1,12 @@
+module FogExtensions
+  module AWS
+    module IAM
+      module InstanceProfile
+        extend ActiveSupport::Concern
+        def to_label
+          name.to_s
+        end
+      end
+    end
+  end
+end

--- a/app/models/concerns/fog_extensions/aws/server.rb
+++ b/app/models/concerns/fog_extensions/aws/server.rb
@@ -36,6 +36,10 @@ module FogExtensions
       def ip_addresses
         [public_ip_address, private_ip_address].flatten.select(&:present?)
       end
+
+      # HACK: For IAM instance profile override on host creation form
+      def iam_instance_profile_name
+      end
     end
   end
 end

--- a/app/views/compute_resources_vms/form/ec2/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ec2/_base.html.erb
@@ -1,4 +1,12 @@
 <%= select_f f, :flavor_id, compute_resource.flavors, :id, :to_label, {}, :label => _('Flavor'), :label_size => "col-md-2" %>
+
+<% if controller_name != "compute_attributes" %>
+  <%= select_f f, :iam_instance_profile_name, compute_resource.instance_profiles, :name, :to_label,
+    {:include_blank => true},
+    {:label => _("IAM instance profile"), :help_inline => _('optional, can be left empty')}
+  %>
+<% end %>
+
 <%
 arch ||= nil ; os ||= nil
 images = possible_images(compute_resource, arch, os)

--- a/app/views/images/form/_ec2.html.erb
+++ b/app/views/images/form/_ec2.html.erb
@@ -1,5 +1,8 @@
 <%= text_f f, :username, :value => @image.username || "root", :help_inline => _("The user that is used to ssh into the instance, normally cloud-user, ec2-user, ubuntu, root etc") %>
 <%= image_field(f) %>
 <%= checkbox_f f, :user_data, :help_inline => _("Does this image support user data input (e.g. via cloud-init)?") %>
-<%# TODO - Get IAM roles from AWS and display in select drop %>
-<%= text_f f, :iam_role, :help_inline => _("(optional) IAM Role for Fog to use when creating this image.") %>
+<%# Sadly this is not an iam role but iam instance profile, name was wrong so I kept it for compat purpose %>
+<%= select_f f, :iam_role, @compute_resource.instance_profiles, :name, :to_label,
+  {:include_blank => true},
+  {:label => _("IAM instance profile"), :help_inline => _('optional, can be left empty')}
+%>


### PR DESCRIPTION
Hello,

This PR implement override of AWS IAM instance profile when creating a new host. I also fixed existing association of instance profile to image that had a TODO to replace a free text box with a select drop down.
If instance profile is associated on image AND provided on host creation, an error will be raised.

Best regards, Adam.