### PR TITLE
Handle apipie:cache:index without a DB present

### DIFF
--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -12,6 +12,10 @@ class Permission < ApplicationRecord
 
   def self.resources
     @all_resources ||= Permission.distinct.order(:resource_type).pluck(:resource_type).compact
+  rescue
+    return [] if ActiveRecord::Base.connection.migration_context.needs_migration?
+
+    raise
   end
 
   def self.resources_with_translations

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -74,7 +74,9 @@ Apipie.configure do |config|
 end
 
 # check apipie cache in dev mode
-if Apipie.configuration.use_cache
+if Foreman.in_rake?('apipie:cache', 'apipie:cache:index')
+  # No need to check the cache if we're regenerating
+elsif Apipie.configuration.use_cache
   cache_name = File.join(Apipie.configuration.cache_dir, Apipie.configuration.doc_base_url + '.json')
   if File.exist?(cache_name)
     target = File.mtime(cache_name)


### PR DESCRIPTION
It should be possible to run apipie:cache:index without the database present. This investigates if it should indeed is possible.

Very much a draft, but this is a good place to collaborate.