### PR TITLE
Fixes #32272 - Deprecate jquery.ui.custom_spinners

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -149,7 +149,8 @@
           "xml",
           "xpi",
           "xyz",
-          "yaml"
+          "yaml",
+          "cpu"
         ],
         "minLength": 3
       }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -433,7 +433,6 @@ function reloadOnAjaxComplete(element) {
   tfm.tools.hideSpinner();
   tfm.tools.activateTooltips();
   activate_select2(':root');
-  tfm.numFields.initAll();
   tfm.advancedFields.initAdvancedFields();
   tfm.templateInputs.initTypeChanges();
 }

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -108,7 +108,6 @@ function computeResourceSelected(item) {
         if ($('#compute_resource').find('.alert-danger').length > 0)
           $('#compute_resource_tab a').addClass('tab-error');
         update_capabilities($('#capabilities').val());
-        tfm.numFields.initAll();
       },
     });
   }

--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -116,7 +116,6 @@ function add_child_node(item) {
   $('a[rel="popover"]').popover();
   $('a[rel="twipsy"]').tooltip();
   activate_select2($(field).not('.matcher_key'));
-  tfm.numFields.initAll(field);
   return new_id;
 }
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
 
 <%= text_f f, :name, :label => _('Name'), :label_size => "col-md-2", :disabled => !new_vm if show_vm_name? %>
 <div id="cpus_input">

--- a/app/views/compute_resources_vms/form/ovirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_base.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_tag("$(document).on('ContentLoad', tfm.numFields.initAll)"); %>
 
 <%= text_f f, :name, :label => _('Name'), :label_size => "col-md-3" if show_vm_name? %>
 <% clusters = compute_resource.clusters %>

--- a/webpack/assets/javascripts/jquery.ui.custom_spinners.js
+++ b/webpack/assets/javascripts/jquery.ui.custom_spinners.js
@@ -110,6 +110,11 @@ $(() => {
 
 export function initAll(selection = null) {
   // might be called with Event-argument, if used as EventHandler
+  window.tfm.tools.deprecate(
+    'initAll()',
+    'react memory and cpu components',
+    '3.0'
+  );
   if (
     selection !== null &&
     typeof selection === 'object' &&
@@ -124,6 +129,7 @@ export function initAll(selection = null) {
 
 export function initCounter(selection = null) {
   // Do not initialize form_templates
+  window.tfm.tools.deprecate('initCounter()', 'react cpu component', '3.0');
   $('input.counter_spinner', selection)
     .not('.form_template input.counter_spinner')
     .each(function() {
@@ -151,6 +157,7 @@ export function initCounter(selection = null) {
 
 export function initByte(selection = null) {
   // Do not initialize form_templates
+  window.tfm.tools.deprecate('initByte()', 'react memory component', '3.0');
   $('input.byte_spinner', selection)
     .not('.form_template input.byte_spinner')
     .each(function() {


### PR DESCRIPTION
Deprecate jquery.ui.custom_spinners after replacing their usage with two new react components.