### PR TITLE
Fixes #32286 - new settings definition DSL

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -6,6 +6,7 @@ class SettingPresenter
 
   attribute :id, :integer
   attribute :category, :string, default: 'Setting::General'
+  attribute :context
   attribute :name, :string
   attribute :default
   attribute :value
@@ -15,6 +16,8 @@ class SettingPresenter
   attribute :settings_type, :string
   attribute :config_file, :string
   attribute :updated_at
+
+  attr_accessor :collection
 
   def self.model_name
     Setting.model_name
@@ -63,7 +66,7 @@ class SettingPresenter
   # ----- UI helpers ------
 
   def category_label
-    category.safe_constantize&.humanized_category || category_name
+    Foreman::SettingManager.categories[category] || category.safe_constantize&.humanized_category || category_name
   end
 
   def category_name

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -317,6 +317,25 @@ module Foreman #:nodoc:
       end
     end
 
+    # Adds setting definition
+    #
+    # ===== Example
+    #
+    #   settings do
+    #     category(:cfgmgmt, N_('Configuration Management')) do
+    #       setting(:use_cooler_puppet,
+    #         default: true,
+    #         description: N_('Use Puppet that goes to 11'),
+    #         full_name: N_('Use shiny puppet'),
+    #         encrypt: true)
+    #       end
+    #     end
+    #   end
+    #
+    def settings(&block)
+      SettingManager.define(id, &block)
+    end
+
     def security_block(name, &block)
       @security_block = name
       instance_eval(&block)

--- a/app/registries/foreman/setting_manager.rb
+++ b/app/registries/foreman/setting_manager.rb
@@ -1,0 +1,70 @@
+module Foreman
+  class SettingManager
+    class << self
+      # Holds all the setting definitions for application
+      def settings
+        @settings ||= {}
+      end
+
+      # Holds all setting categories with their labels
+      def categories
+        @categories ||= { 'general' => N_('General') }
+      end
+
+      def define(context_name, &block)
+        new(context_name).instance_eval(&block)
+      end
+    end
+
+    def initialize(context_name)
+      @context_name = context_name
+    end
+
+    def category(category_name, category_label = nil, &block)
+      self.class.categories[category_name.to_s] ||= category_label
+      CategoryMapper.new(@context_name, category_name.to_s).instance_eval(&block)
+    end
+
+    class CategoryMapper
+      attr_reader :context_name, :category_name
+
+      def initialize(context_name, category_name)
+        @context_name = context_name
+        @category_name = category_name
+      end
+
+      def storage
+        SettingManager.settings
+      end
+
+      # Adds setting definition
+      #
+      # ===== Example
+      #
+      #   SettingManager.define(:puppet) do
+      #     category(:cfgmgmt, N_('Configuration Management')) do
+      #       setting(:use_cooler_puppet,
+      #               default: true,
+      #               description: N_('Use Puppet that goes to 11'),
+      #               full_name: N_('Use shiny puppet'),
+      #               encrypt: true)
+      #     end
+      #   end
+      #
+      def setting(name, default:, description:, full_name: nil, value: nil, collection: nil, encrypted: false, **options)
+        raise ::Foreman::Exception.new(N_("Setting '%s' is already defined, please avoid collisions"), name) if storage.key?(name.to_s)
+        storage[name.to_s] = {
+          context: context_name,
+          category: category_name,
+          default: default,
+          description: description,
+          full_name: full_name,
+          value: value,
+          collection: collection,
+          encrypted: encrypted,
+          options: options,
+        }
+      end
+    end
+  end
+end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1629,63 +1629,46 @@ end
 
 Plugins can store Foreman-wide settings either in the database or a
 config file. The DB should be preferred as it can be managed from the UI
-(under Administer > Settings), CLI, API and Puppet, and changed on the
+(under Administer > Settings), CLI and API. It also can be changed on the
 fly, while the config file is usually only used for settings that change
 behaviour during app startup and require a restart.
 
-To add new DB settings, the plugin should define a Setting class named
-after the plugin. For foreman_example, this would be at
-`app/models/setting/example.rb` and should look like:
+To add DB settings, the plugin should define them in it's registration block:
 
 [source, ruby]
 ....
-class Setting::Example < ::Setting
-  def self.load_defaults
-    return unless ActiveRecord::Base.connection.table_exists?('settings')
-    return unless super
+Foreman::Plugin.register :my_plugin do
+  # ....
 
-    Setting.transaction do
-      [
-        self.set('example_string', N_('Example setting that controls something'), 'default value'),
-        self.set('example_int', N_('Answer to the life, universe, and everything'), 42),
-      ].compact.each { |s| self.create s.update(:category => "Setting::Example") }
+  settings do
+    # Following settings will be added to a General category
+    category :general do
+      setting 'example_setting',
+        default: 'default value',
+        full_name: N_('Example of general setting'),
+        description: N_('Example setting that controls something')
     end
 
-    true
+    # Following settings will be added to category name 'cool' with label Cool
+    category :cool, N_('Cool') do
+      setting 'example_int',
+        default: 42,
+        full_name: N_('The answer'),
+        description: N_('Answer to the life, universe, and everything')
+    end
+
+    # Following settings will be added to existing category named 'cfgmgmt'
+    category :cfgmgmt do
+      setting 'configure_everything',
+        default: true,
+        full_name: N_('Configure everything'),
+        description: N_('Should configuration management tools configure everything for user, so user can go to the beach?')
+    end
   end
-
-  def self.humanized_category
-    N_('My Example')
-  end
 end
 ....
 
-Settings are listed in the transaction block and are initialised at app
-startup, with three arguments. The name is first - it should be unique
-and be prefixed with the plugin name. The second is a human readable
-description which will be translated. The third is the default value of
-the setting, which can be a string, integer, boolean or nil.
-
-If supporting Foreman 1.11+ only, add the following initialiser to
-engine.rb to load it:
-
-[source, ruby]
-....
-initializer 'foreman_example.load_default_settings', :before => :load_config_initializers do |app|
-  require_dependency File.expand_path("../../../app/models/setting/example.rb", __FILE__)
-end
-....
-
-To support 1.10 and lower _as well_ then use:
-
-[source, ruby]
-....
-initializer 'foreman_example.load_default_settings', :before => :load_config_initializers do |app|
-  require_dependency File.expand_path("../../../app/models/setting/example.rb", __FILE__) if (Setting.table_exists? rescue(false))
-end
-....
-
-To access the value of a setting, use `Setting[:example_string]` from
+To access the value of a setting, use `Setting[:example_setting]` from
 anywhere in your plugin.
 
 [[config-files]]

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -8,9 +8,14 @@ class SettingsControllerTest < ActionController::TestCase
   end
 
   test "can render a new category setting" do
-    Foreman.settings._add("foo", default: "bar", description: "test foo", category: "Valid")
+    duped_settings = Foreman::SettingManager.settings.dup
+    Foreman::SettingManager.stubs(settings: duped_settings)
+    Foreman::SettingManager.define(:test) do
+      category(:valid, 'Valid') { setting('valid_foo', default: 'bar', description: 'test foo') }
+    end
+    Foreman.settings.load
     get :index, session: set_session_user
-    assert_match /id='Valid'/, @response.body
+    assert_match /id='valid'/, @response.body
   end
 
   test "does not render an old sti type setting" do

--- a/test/integration/setting_js_test.rb
+++ b/test/integration/setting_js_test.rb
@@ -10,14 +10,19 @@ class SettingJSTest < IntegrationTestWithJavascript
   end
 
   test "humanized tab label for setting category" do
-    class Setting::Test < Setting
+    class Setting::CategoryLabelTest < Setting
       def self.humanized_category
         "My Pretty Setting Label"
       end
     end
-    Foreman.settings._add(name, category: 'Setting::Test', default: false, description: 'Pretty setting', full_name: 'Pretty setting')
+    Foreman.settings._add(name,
+      category: 'Setting::CategoryLabelTest',
+      context: :test,
+      default: false,
+      description: 'Pretty setting',
+      full_name: 'Pretty setting')
 
     assert_index_page(settings_path, "Settings", false, true, false)
-    assert page.has_link?("My Pretty Setting Label", :href => "#Test")
+    assert page.has_link?("My Pretty Setting Label", :href => "#CategoryLabelTest")
   end
 end

--- a/test/models/host_status/configuration_status_test.rb
+++ b/test/models/host_status/configuration_status_test.rb
@@ -99,10 +99,12 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
       end
 
       def stub_outofsync_setting(value)
-        Setting.create(name: :testorigin_out_of_sync_disabled,
-                       description: 'description', default: false)
-        Foreman.settings._add('testorigin_out_of_sync_disabled', category: 'Setting::General', description: 'description', default: false)
-        Foreman.settings.load
+        Foreman.settings._add('testorigin_out_of_sync_disabled',
+          context: :test,
+          category: 'Setting::General',
+          full_name: 'Test out of sync',
+          description: 'description',
+          default: false)
         Setting[:testorigin_out_of_sync_disabled] = value
       end
     end

--- a/test/models/settings/email_setting_test.rb
+++ b/test/models/settings/email_setting_test.rb
@@ -5,37 +5,24 @@ class EmailSettingTest < ActiveSupport::TestCase
     Setting[:delivery_method] = :smtp
     Setting[:smtp_address] = "sm@example.com"
     Setting[:smtp_authentication] = "plain"
-    assert_equal({"address" => "sm@example.com", "authentication" => "plain"}, Setting::Email.delivery_settings)
+    assert_equal({"address" => "sm@example.com", "authentication" => "plain", "enable_starttls_auto" => true, "port" => 25}, Setting::Email.delivery_settings)
   end
 
   test 'setting should be clear from delivery settings when it empty' do
     Setting[:delivery_method] = :smtp
     Setting[:smtp_address] = "sm@example.com"
     Setting[:smtp_authentication] = ''
-    assert_equal({"address" => "sm@example.com"}, Setting::Email.delivery_settings)
+    assert_equal({"address" => "sm@example.com", "enable_starttls_auto" => true, "port" => 25}, Setting::Email.delivery_settings)
   end
 
   test 'delivery_method setting value can be a string' do
     Setting[:delivery_method] = 'smtp'
     Setting[:smtp_address] = "string@example.com"
     Setting[:smtp_authentication] = 'plain'
-    assert_equal({"address" => "string@example.com", "authentication" => 'plain'}, Setting::Email.delivery_settings)
+    assert_equal({"address" => "string@example.com", "authentication" => 'plain', "enable_starttls_auto" => true, "port" => 25}, Setting::Email.delivery_settings)
   end
 
   test 'value of email_subject_prefix should not be more than 255 characters' do
     assert_raises(ActiveRecord::RecordInvalid) { Setting[:email_subject_prefix] = 'p' * 256 }
-  end
-
-  private
-
-  def load_defaults
-    Setting::Email.transaction do
-      [
-        Setting::Email.set('delivery_method', N_("Method used to deliver email"), 'test', nil, nil, { :collection => proc { {'Sendmail' => :sendmail, 'SMTP' => :smtp} }}),
-        Setting::Email.set('smtp_address', N_("Address to connect to"), '', nil),
-        Setting::Email.set('smtp_authentication', N_("Specify authentication type, if required"), 'none', nil, nil, { :collection => proc { {'plain' => :plain, 'login' => :login, 'cram_md5' => :cram_md5, 'none' => :none} }}),
-        Setting::Email.set('sendmail_arguments', N_("Specify additional options to sendmail"), '-i', nil),
-      ].each { |s| Setting::Email.create! s.update(:category => "Setting::Email") }
-    end
   end
 end

--- a/test/unit/classification_test.rb
+++ b/test/unit/classification_test.rb
@@ -587,9 +587,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct merged override to host when multiple overrides for inherited hostgroups exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'array', :merge_overrides => true,
                              :path => "organization\nhostgroup\nlocation",
@@ -620,9 +618,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct merged override to host when multiple overrides for inherited organizations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'array', :merge_overrides => true,
                              :path => "location\norganization\nhostgroup",
@@ -651,9 +647,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct merged override to host when multiple overrides for inherited locations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'array', :merge_overrides => true,
                              :path => "organization\nhostgroup\nlocation",
@@ -682,9 +676,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct merged override to host when multiple overrides for inherited hostgroups exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'array', :merge_overrides => true,
                              :path => "organization\nhostgroup\nlocation",
@@ -719,9 +711,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct merged override to host when multiple overrides for inherited organizations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'array', :merge_overrides => true,
                              :path => "location\norganization\nhostgroup",
@@ -754,9 +744,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct merged override to host when multiple overrides for inherited locations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'array', :merge_overrides => true,
                              :path => "organization\nhostgroup\nlocation",
@@ -789,9 +777,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct override to host when multiple overrides for inherited hostgroups exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "organization\nhostgroup\nlocation",
@@ -826,9 +812,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct override to host when multiple overrides for inherited organizations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "location\norganization\nhostgroup",
@@ -862,9 +846,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct override to host when multiple overrides for inherited locations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "organization\nlocation\nhostgroup",
@@ -898,9 +880,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct override to host when multiple overrides for inherited hostgroups exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "organization\nhostgroup\nlocation",
@@ -934,9 +914,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct override to host when multiple overrides for inherited organizations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "organization\nhostgroup\nlocation",
@@ -969,9 +947,7 @@ class ClassificationTest < ActiveSupport::TestCase
   end
 
   test "#enc should return correct override to host when multiple overrides for inherited locations exist" do
-    FactoryBot.create(:setting,
-      :name => 'matchers_inheritance',
-      :value => true)
+    Setting['matchers_inheritance'] = true
     key = FactoryBot.create(:puppetclass_lookup_key, :as_smart_class_param, :omit => true,
                              :override => true, :key_type => 'string', :merge_overrides => false,
                              :path => "location\norganization\nhostgroup",

--- a/test/unit/setting_manager_test.rb
+++ b/test/unit/setting_manager_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class SettingManagerTest < ActiveSupport::TestCase
+  let(:setting_memo) { {} }
+  let(:category_memo) { { 'general' => N_('General') } }
+
+  setup do
+    Foreman::SettingManager.stubs(settings: setting_memo, categories: category_memo)
+  end
+
+  it 'adds setting to category general by default' do
+    Foreman::SettingManager.define(:test_context) do
+      category(:general) do
+        setting(:foo,
+          default: 'bar',
+          description: 'This is nicely described foo setting',
+          full_name: 'Foo setting')
+      end
+    end
+    assert_not_nil setting_memo['foo']
+    assert_equal setting_memo['foo'][:category], 'general'
+  end
+
+  it 'adds setting to defined category within block and sets it\'s label' do
+    Foreman::SettingManager.define(:test_context) do
+      category(:my_category, 'Awesome Category') do
+        setting(:foo,
+          default: 'bar',
+          description: 'This is nicely described foo setting',
+          full_name: 'Foo setting')
+      end
+    end
+    assert_not_nil setting_memo['foo']
+    assert_equal setting_memo['foo'][:category], 'my_category'
+    assert_equal category_memo['my_category'], 'Awesome Category'
+  end
+
+  it 'doesnt allow setting redefinition' do
+    assert_raise ::Foreman::Exception, "Setting 'foo' is already defined, please avoid collisions" do
+      Foreman::SettingManager.define(:test_context) do
+        category(:my_category, 'Awesome Category') do
+          setting(:foo,
+            default: 'bar',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting')
+        end
+        category(:general) do
+          setting(:foo,
+            default: 'bar',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting')
+        end
+      end
+    end
+  end
+end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -4,12 +4,14 @@ class SettingRegistryTest < ActiveSupport::TestCase
   let(:registry) { SettingRegistry.instance }
   let(:default) { 5 }
   let(:setting_value) { nil }
-  let(:setting) { Setting.create(registry.find('foo').attributes.merge(value: setting_value)) }
+  let(:setting_memo) { {} }
+  let(:setting) { Setting.create(registry.find('foo').attributes) }
 
   setup do
-    registry._add('foo', category: 'Setting::General', default: default, description: 'test foo')
-    setting
-    registry.load
+    registry.stubs(settings: setting_memo)
+    registry._add('foo', category: 'Setting::General', default: default, full_name: 'test foo', description: 'test foo', context: :test)
+    setting.update(value: setting_value)
+    registry.load_values
   end
 
   context 'with nil default' do
@@ -36,7 +38,7 @@ class SettingRegistryTest < ActiveSupport::TestCase
     assert_equal 5, registry['foo']
 
     setting.save
-    registry.load
+    registry.load_values
     assert_equal 3, setting.value
     assert_equal 3, registry['foo']
   end


### PR DESCRIPTION
Introduces a new DSL to define settings, so we don't need to define
STI classes for every setting category and we have more control over
settings from the plugins.

~~Should follow #8002~~

This is not full implementation, just the basics for it. Follow-ups:
- validations: #8470
- types: #8625