### PR TITLE
Fixes #32287 - setting index loads from registry

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -2,6 +2,6 @@ class SettingsController < ApplicationController
   include Foreman::Controller::AutoCompleteSearch
 
   def index
-    @settings = Setting.live_descendants.search_for(params[:search])
+    @settings = Foreman.settings.search_for(params[:search])
   end
 end

--- a/app/helpers/settings_helper.rb
+++ b/app/helpers/settings_helper.rb
@@ -1,44 +1,22 @@
 module SettingsHelper
-  def short_cat(category)
-    category.gsub(/Setting::/, '')
-  end
-
-  def cat_label(category)
-    category.constantize.humanized_category || short_cat(category)
-  end
-
   def grouped_settings(settings)
-    settings.each_with_object({}) do |setting, memo|
-      hash = setting_to_hash(setting)
-      next unless hash
-      if memo[setting.category]
-        memo[setting.category] << hash
-      else
-        memo[setting.category] = [hash]
-      end
-      memo
-    end
+    settings.map { |s| setting_to_hash(s) }.group_by { |s| s[:category] }
   end
 
   def setting_to_hash(setting)
-    presenter = Foreman.settings.find(setting.name)
-    if presenter.nil?
-      logger.warn("Setting #{setting.name} doesn't exist anymore, clean up your database")
-      return nil
-    end
     {
       :id => setting.id,
-      :name => presenter.name,
-      :category => presenter.category,
-      :description => presenter.description,
-      :settings_type => presenter.settings_type,
-      :default => presenter.default,
-      :readonly => presenter.readonly?,
-      :full_name => presenter.full_name,
-      :config_file => presenter.config_file,
-      :select_values => presenter.select_values,
-      :value => presenter.safe_value,
-      :encrypted => presenter.encrypted?,
+      :name => setting.name,
+      :category => setting.category_name,
+      :description => setting.description,
+      :settings_type => setting.settings_type,
+      :default => setting.default,
+      :readonly => setting.readonly?,
+      :full_name => setting.full_name,
+      :config_file => setting.config_file,
+      :select_values => setting.select_values,
+      :value => setting.safe_value,
+      :encrypted => setting.encrypted?,
     }
   end
 end

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -52,10 +52,18 @@ class SettingPresenter
     attribute(:settings_type) || Setting.setting_type_from_value(default)
   end
 
+  def matches_search_query?(query)
+    if (res = query.match(/name\s*=\s*(\S+)/))
+      name == res[1]
+    else
+      description.include?(query) || name.include?(query) || full_name&.include?(query)
+    end
+  end
+
   # ----- UI helpers ------
 
   def category_label
-    category.constantize.humanized_category || _(category_name)
+    category.safe_constantize&.humanized_category || category_name
   end
 
   def category_name

--- a/app/views/api/v2/settings/main.json.rabl
+++ b/app/views/api/v2/settings/main.json.rabl
@@ -2,10 +2,14 @@ object @setting
 
 extends "api/v2/settings/base"
 
-attributes :description, :category, :settings_type, :default, :created_at, :updated_at
+attributes :description, :settings_type, :default, :created_at, :updated_at
 
 node :value do |s|
   s.safe_value
+end
+
+node :category do |s|
+  s.category_name
 end
 
 node :category_name do |s|

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -1,25 +1,21 @@
 <% title _("Settings") %>
 <% title_actions documentation_button('3.5.2ConfigurationOptions') %>
-<%
-ordered_settings = @settings.stick_general_first
-first_category = ordered_settings.values.flatten.first.try(:category)
-%>
 
-<%= react_component('SettingRecords', { :settings => grouped_settings(@settings) }) %>
+<%= react_component('SettingRecords', { settings: grouped_settings(@settings) }) %>
 
 <ul class="nav nav-tabs" data-tabs="tabs">
-  <% ordered_settings.each do |category, _setting| %>
-    <li class='<%= category == first_category ? "active" : ""%>'>
-      <a href='<%= "##{short_cat(category)}" %>' data-toggle="tab"><%= _(cat_label(category)) %></a>
+  <% @settings.categories.each do |category, label| %>
+    <li class="<%= 'active' if category == @settings.categories.keys.first %>">
+      <a href="#<%= category %>" data-toggle="tab"><%= _(label) %></a>
     </li>
   <% end %>
 </ul>
 <div class="tab-content">
-  <% ordered_settings.each do |category, setting| %>
-    <div class="tab-pane <%= "active" if category == first_category %>" id='<%= short_cat(category) %>' >
-      <%= render_if_partial_exists "settings/category/#{category.demodulize.downcase}", setting %>
+  <% @settings.categories.each do |category, _label| %>
+    <div class="tab-pane<%= ' active' if category == @settings.categories.keys.first %>" id='<%= category %>' >
+      <%= render_if_partial_exists "settings/category/#{category.downcase}", category %>
 
-      <%= react_component('SettingsTable', { :category => category }) %>
+      <%= react_component('SettingsTable', { category: category }) %>
 
     </div>
   <% end %>

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -7,9 +7,8 @@ class SettingsControllerTest < ActionController::TestCase
     assert_template 'index'
   end
 
-  test "can render a new sti type setting" do
-    class Setting::Valid < Setting; end
-    assert Setting.create(:name => "foo", :default => "bar", :description => "test foo", :category => "Setting::Valid")
+  test "can render a new category setting" do
+    Foreman.settings._add("foo", default: "bar", description: "test foo", category: "Valid")
     get :index, session: set_session_user
     assert_match /id='Valid'/, @response.body
   end

--- a/test/integration/setting_js_test.rb
+++ b/test/integration/setting_js_test.rb
@@ -15,8 +15,7 @@ class SettingJSTest < IntegrationTestWithJavascript
         "My Pretty Setting Label"
       end
     end
-
-    FactoryBot.create(:setting, :settings_type => "boolean", :category => "Setting::Test", :name => 'test_setting', :default => false)
+    Foreman.settings._add(name, category: 'Setting::Test', default: false, description: 'Pretty setting', full_name: 'Pretty setting')
 
     assert_index_page(settings_path, "Settings", false, true, false)
     assert page.has_link?("My Pretty Setting Label", :href => "#Test")

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -48,4 +48,18 @@ class SettingRegistryTest < ActiveSupport::TestCase
       assert_equal setting_value, registry['foo']
     end
   end
+
+  describe '#search_for' do
+    it 'can find setting by exact name match' do
+      result = registry.search_for('name = foo').to_a
+      assert_equal 1, result.size
+      assert_equal 'foo', result.first.name
+    end
+
+    it 'can find setting by description' do
+      result = registry.search_for('test f').to_a
+      assert_equal 1, result.size
+      assert_equal 'foo', result.first.name
+    end
+  end
 end


### PR DESCRIPTION
The values provided on the Setting index page are now served from
registry, with simple search API, that can be easily improved to support
more querying features.