### PR TITLE
fixes #32243 - Adding render_pagelet to subnet page

### DIFF
--- a/app/views/subnets/index.html.erb
+++ b/app/views/subnets/index.html.erb
@@ -1,6 +1,7 @@
 <% title _("Subnets") %>
 
 <%= javascript 'subnets' %>
+<% title_actions render_pagelets_for(:subnet_index_title_buttons) %>
 <% title_actions new_link(_("Create Subnet")) %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">
@@ -29,7 +30,7 @@
                                hash_for_subnet_path(:id => subnet).
                                merge(:auth_object => subnet, :authorizer => authorizer),
                                :data => { :confirm => _("Delete %s?") % subnet.name }),
-                             render_pagelets_for(:action_buttons, subject: subnet)
+                             render_pagelets_for(:subnet_index_action_buttons, subject: subnet)
               ) %>
         </td>
       </tr>


### PR DESCRIPTION
This PR introduced a pagelet endpoint at subnet index page. It's placed at the buttons part of every subnet record. So it can be use for further extensibility with plugins. It also adds a pagelet endpoint to title buttons at subnet page.

The complementary PR from Bootdisk plugin (https://github.com/theforeman/foreman_bootdisk/pull/105) requested renaming of created endpoint for better recognition and also adding new endpoint.