### PR TITLE
Fixes #32266 - render_error call in userdata fixed

### DIFF
--- a/app/controllers/userdata_controller.rb
+++ b/app/controllers/userdata_controller.rb
@@ -38,7 +38,7 @@ class UserdataController < ApplicationController
     template ||= @host.provisioning_template(kind: 'user_data')
     unless template
       render_error(
-        :message => 'Unable to find user-data or cloud-init template for host %{host} running %{os}',
+        _('Unable to find user-data or cloud-init template for host %{host} running %{os}'),
         :status => :not_found,
         :host => @host.name,
         :os => @host.operatingsystem
@@ -64,7 +64,7 @@ class UserdataController < ApplicationController
     @host = Foreman::UnattendedInstallation::HostFinder.new(query_params: query_params).search
 
     return true if @host
-    render_error('Could not find host for request %{request_ip}',
+    render_error(_('Could not find host for request %{request_ip}'),
       :status => :not_found,
       :request_ip => request.remote_ip
     )


### PR DESCRIPTION
The method requires string and hash not just hash.