### PR TITLE
Fixes #32313 - Bookmarks menu enhancements

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.js
@@ -2,12 +2,15 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import EllipisWithTooltip from 'react-ellipsis-with-tooltip';
 import { Dropdown, MenuItem, Spinner, Icon } from 'patternfly-react';
+import { PlusIcon } from '@patternfly/react-icons';
 import SearchModal from './components/SearchModal';
 import Bookmark from './components/Bookmark';
 import DocumentationUrl from '../common/DocumentationLink';
 import { STATUS } from '../../constants';
 import { noop } from '../../common/helpers';
 import { sprintf, translate as __ } from '../../../react_app/common/I18n';
+import history from '../../history';
+import { stringifyParams } from '../../common/urlHelpers';
 
 const Bookmarks = props => {
   const loadBookmarks = () => {
@@ -16,6 +19,11 @@ const Bookmarks = props => {
     if (bookmarks.length === 0 && status !== STATUS.PENDING) {
       getBookmarks(url, controller);
     }
+  };
+
+  const manageBookmarks = controller => {
+    const query = stringifyParams({ searchQuery: `controller=${controller}` });
+    history.push({ pathname: '/bookmarks', search: query });
   };
 
   const {
@@ -46,10 +54,9 @@ const Bookmarks = props => {
         <Dropdown.Menu className="scrollable-dropdown">
           {canCreate && (
             <MenuItem key="newBookmark" id="newBookmark" onClick={setModalOpen}>
-              {__('Bookmark this search')}
+              <PlusIcon /> {__('Bookmark this search')}
             </MenuItem>
           )}
-          <DocumentationUrl href={documentationUrl} />
           <MenuItem divider />
           <MenuItem header>{__('Saved Bookmarks')}</MenuItem>
           {status === STATUS.PENDING && (
@@ -74,6 +81,17 @@ const Bookmarks = props => {
               </EllipisWithTooltip>
             </MenuItem>
           )}
+          <MenuItem divider />
+          {canCreate && (
+            <MenuItem
+              key="manageBookmarks"
+              id="manageBookmarks"
+              onClick={() => manageBookmarks(controller)}
+            >
+              {__('Manage Bookmarks')}
+            </MenuItem>
+          )}
+          <DocumentationUrl href={documentationUrl} />
         </Dropdown.Menu>
       </Dropdown>
     </React.Fragment>

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
@@ -50,13 +50,14 @@ exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
         key="newBookmark"
         onClick={[MockFunction]}
       >
+        <PlusIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+         
         Bookmark this search
       </MenuItem>
-      <DocumentationLink
-        href="https://test-docs.com"
-      >
-        Documentation
-      </DocumentationLink>
       <MenuItem
         bsClass="dropdown"
         disabled={false}
@@ -77,6 +78,28 @@ exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
         query="name ~ 86"
         text="my-bookmark"
       />
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={true}
+        header={false}
+      />
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={false}
+        header={false}
+        id="manageBookmarks"
+        key="manageBookmarks"
+        onClick={[Function]}
+      >
+        Manage Bookmarks
+      </MenuItem>
+      <DocumentationLink
+        href="https://test-docs.com"
+      >
+        Documentation
+      </DocumentationLink>
     </DropdownMenu>
   </ForwardRef>
 </Fragment>
@@ -124,13 +147,14 @@ exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
         key="newBookmark"
         onClick={[MockFunction]}
       >
+        <PlusIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+         
         Bookmark this search
       </MenuItem>
-      <DocumentationLink
-        href="https://test-docs.com"
-      >
-        Documentation
-      </DocumentationLink>
       <MenuItem
         bsClass="dropdown"
         disabled={false}
@@ -156,6 +180,28 @@ exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
           size="xs"
         />
       </li>
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={true}
+        header={false}
+      />
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={false}
+        header={false}
+        id="manageBookmarks"
+        key="manageBookmarks"
+        onClick={[Function]}
+      >
+        Manage Bookmarks
+      </MenuItem>
+      <DocumentationLink
+        href="https://test-docs.com"
+      >
+        Documentation
+      </DocumentationLink>
     </DropdownMenu>
   </ForwardRef>
 </Fragment>
@@ -203,13 +249,14 @@ exports[`Bookmarks should render when no bookmarks loaded 1`] = `
         key="newBookmark"
         onClick={[MockFunction]}
       >
+        <PlusIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+         
         Bookmark this search
       </MenuItem>
-      <DocumentationLink
-        href="https://test-docs.com"
-      >
-        Documentation
-      </DocumentationLink>
       <MenuItem
         bsClass="dropdown"
         disabled={false}
@@ -233,6 +280,28 @@ exports[`Bookmarks should render when no bookmarks loaded 1`] = `
          
         None found
       </MenuItem>
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={true}
+        header={false}
+      />
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={false}
+        header={false}
+        id="manageBookmarks"
+        key="manageBookmarks"
+        onClick={[Function]}
+      >
+        Manage Bookmarks
+      </MenuItem>
+      <DocumentationLink
+        href="https://test-docs.com"
+      >
+        Documentation
+      </DocumentationLink>
     </DropdownMenu>
   </ForwardRef>
 </Fragment>
@@ -280,13 +349,14 @@ exports[`Bookmarks should show error 1`] = `
         key="newBookmark"
         onClick={[MockFunction]}
       >
+        <PlusIcon
+          color="currentColor"
+          noVerticalAlign={false}
+          size="sm"
+        />
+         
         Bookmark this search
       </MenuItem>
-      <DocumentationLink
-        href="https://test-docs.com"
-      >
-        Documentation
-      </DocumentationLink>
       <MenuItem
         bsClass="dropdown"
         disabled={false}
@@ -312,6 +382,28 @@ exports[`Bookmarks should show error 1`] = `
           Failed to load bookmarks: %s
         </EllipisWithTooltip>
       </MenuItem>
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={true}
+        header={false}
+      />
+      <MenuItem
+        bsClass="dropdown"
+        disabled={false}
+        divider={false}
+        header={false}
+        id="manageBookmarks"
+        key="manageBookmarks"
+        onClick={[Function]}
+      >
+        Manage Bookmarks
+      </MenuItem>
+      <DocumentationLink
+        href="https://test-docs.com"
+      >
+        Documentation
+      </DocumentationLink>
     </DropdownMenu>
   </ForwardRef>
 </Fragment>


### PR DESCRIPTION
- New link _Manage bookmarks_ leading to `/bookmarks`
page with search query set to current controller
- Documentation link moved to the end of the menu
- Added icon to _Bookmark this search_ link

Before | Now
------------ | -------------
![bookmarks_before](https://user-images.githubusercontent.com/59385976/114680821-d9414080-9d0d-11eb-8c7f-0c2f11ec4a99.png) | ![bookmarks_now](https://user-images.githubusercontent.com/59385976/114680857-e2321200-9d0d-11eb-88e4-3156e74bf841.png)
