### PR TITLE
refs #31179 - Host Registration - curl with '--show-error'

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration_commands.rb
+++ b/app/controllers/concerns/foreman/controller/registration_commands.rb
@@ -5,7 +5,7 @@ module Foreman::Controller::RegistrationCommands
 
   def command
     args_query = "?#{registration_args.to_query}"
-    "curl#{insecure} -s '#{endpoint}#{args_query if args_query != '?'}' #{command_headers} | bash"
+    "curl -sS #{insecure} '#{endpoint}#{args_query if args_query != '?'}' #{command_headers} | bash"
   end
 
   def registration_args
@@ -18,7 +18,7 @@ module Foreman::Controller::RegistrationCommands
   end
 
   def insecure
-    registration_params['insecure'] ? ' --insecure' : ''
+    registration_params['insecure'] ? '--insecure' : ''
   end
 
   def endpoint

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -41,7 +41,7 @@ cat << EOF > $SSL_CA_CERT
 <%= foreman_server_ca_cert %>
 EOF
 <% end -%>
-curl --silent <%= '--cacert $SSL_CA_CERT' if built_https -%> -o /dev/null --noproxy \* '<%= foreman_url('built') %>'
+curl --silent --show-error <%= '--cacert $SSL_CA_CERT' if built_https -%> -o /dev/null --noproxy \* '<%= foreman_url('built') %>'
 
 echo "#"
 echo "# Host [<%= @host.name %>] successfully enrolled."

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -70,7 +70,7 @@ fi
 <% end -%>
 
 register_host() {
-  curl --silent --cacert $SSL_CA_CERT --request POST <%= @registration_url %> \
+  curl --silent --show-error --cacert $SSL_CA_CERT --request POST <%= @registration_url %> \
        <%= headers.join(' ') %> \
        --data "host[name]=$(hostname --fqdn)" \
        --data "host[build]=false" \
@@ -95,7 +95,7 @@ echo "#"
 if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
-        curl --silent --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \
+        curl --silent --show-error --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \
              --data "uuid=$UUID" \
              <%= headers.join(' ') %> \
 <%= "          --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
@@ -114,7 +114,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     <% end -%>
 
     CONSUMER_RPM=$(mktemp --suffix .rpm)
-    curl --silent --output $CONSUMER_RPM <%= subscription_manager_configuration_url(hostname: @url_host) %>
+    curl --silent --show-error --output $CONSUMER_RPM <%= subscription_manager_configuration_url(hostname: @url_host) %>
 
     # Workaround for systems with enabled FIPS,
     # where installation of RPM generated on RHEL7 cause 'no digest' error

--- a/test/controllers/api/v2/registration_commands_controller_test.rb
+++ b/test/controllers/api/v2/registration_commands_controller_test.rb
@@ -7,7 +7,7 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
       assert_response :success
       response = ActiveSupport::JSON.decode(@response.body)['registration_command']
 
-      assert_includes response, "curl -s 'http://test.host/register'"
+      assert_includes response, "curl -sS  'http://test.host/register'"
       assert_includes response, "-H 'Authorization: Bearer"
     end
 
@@ -46,7 +46,7 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
       assert_response :success
 
       response = ActiveSupport::JSON.decode(@response.body)['registration_command']
-      assert_includes response, "curl --insecure -s '#{smart_proxies(:one).url}/register'"
+      assert_includes response, "curl -sS --insecure '#{smart_proxies(:one).url}/register'"
     end
   end
 end

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -28,7 +28,7 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       post :create, params: params, session: set_session_user
       command = JSON.parse(@response.body)['command']
 
-      assert_includes command, "curl --insecure -s '#{smart_proxies(:one).url}/register"
+      assert_includes command, "curl -sS --insecure '#{smart_proxies(:one).url}/register"
       refute command.include?('smart_proxy_id')
       refute command.include?('insecure=true')
       refute command.include?('jwt_expiration')


### PR DESCRIPTION
Running curl with `--show-error` & `--silent` options together
disable progress meter but still show error messages


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
