### PR TITLE
Fixes #32321 - allow dualstack provisioning

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -45,101 +45,53 @@ module Foreman
       files.map { |path| Foreman::Renderer::Source::Snapshot.load_file(path) }
     end
 
-    def define_host_params(host)
-      host_params = {
-        "enable-epel" => "true",
-        "package_upgrade" => "true",
-        "ansible_tower_provisioning" => "true",
-        "schedule_reboot" => "true",
-        "fips_enabled" => "true",
-        "force-puppet" => "true",
-        "remote_execution_create_user" => "true",
-        "blacklist_kernel_modules" => "amodule",
-      }
-      host_params.each_pair do |name, value|
-        FactoryBot.build(:host_parameter, host: host, name: name, value: value)
-      end
-      host.define_singleton_method(:params) { host_params }
-      host.define_singleton_method(:host_param) do |name|
-        host_params[name]
-      end
-      host
-    end
-
-    def ipv4_interface
-      FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '192.168.42.42')
-    end
-
-    def ipv6_interface
-      FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '2001:db8:42::42')
-    end
-
-    def ipv46_interface
-      FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '192.168.42.42',
-        ip6: '2001:db8:42::42')
-    end
-
     def host4dhcp
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_el7,
-        name: 'snapshot-ipv4-dhcp-el7',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_dhcp4,
+        :with_snapshot_os_el7,
+        :with_snapshot_puppet)
     end
 
     def host4static
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_el7,
-        name: 'snapshot-ipv4-static-el7',
-        subnet: FactoryBot.build(:subnet_ipv4_static_for_snapshots),
-        interfaces: [ipv4_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_static4,
+        :with_snapshot_os_el7,
+        :with_snapshot_puppet)
     end
 
     def host6dhcp
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_el7,
-        name: 'snapshot-ipv6-dhcp-el7',
-        subnet: FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots),
-        interfaces: [ipv6_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_dhcp6,
+        :with_snapshot_os_el7,
+        :with_snapshot_puppet)
     end
 
     def host6static
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_el7,
-        name: 'snapshot-ipv6-static-el7',
-        subnet: FactoryBot.build(:subnet_ipv6_static_for_snapshots),
-        interfaces: [ipv6_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_static6,
+        :with_snapshot_os_el7,
+        :with_snapshot_puppet)
     end
 
     def host4and6dhcp
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_el7,
-        name: 'snapshot-ipv4-6-dhcp-el7',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        subnet6: FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots),
-        interfaces: [ipv46_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_dhcp_dualstack,
+        :with_snapshot_os_el7,
+        :with_snapshot_puppet)
     end
 
     def debian4dhcp
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_deb10,
-        name: 'snapshot-ipv4-dhcp-deb10',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_dhcp_dualstack,
+        :with_snapshot_os_debian10,
+        :with_snapshot_puppet)
     end
 
     def ubuntu4dhcp
-      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_ubuntu20,
-        name: 'snapshot-ipv4-dhcp-ubuntu20',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      define_host_params(host)
+      FactoryBot.build(:snapshot_host,
+        :with_snapshot_dhcp_dualstack,
+        :with_snapshot_os_ubuntu20,
+        :with_snapshot_puppet)
     end
 
     private

--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -21,6 +21,7 @@ test_on:
 - host6static
 -%>
 # This file was deployed via '<%= template_name %>' template
+<%= snippet("header") -%>
 
 default=0
 timeout=<%= host_param('loader_timeout') || 10 %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -20,6 +20,7 @@ test_on:
 - host6static
 -%>
 # This file was deployed via '<%= template_name %>' template
+<%= snippet("header") -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -12,8 +12,7 @@ description: |
   The template to render Grub2 bootloader configuration for preseed based distributions.
   The output is deployed on the host's subnet TFTP proxy.
 -%>
-#
-# This file was deployed via '<%= template_name %>' template
+<%= snippet("header") -%>
 #
 # Supported host/hostgroup parameters:
 #
@@ -38,7 +37,7 @@ description: |
     options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
   end
   options << "locale=#{host_param('lang') || 'en_US'}"
-  
+
   # send PXELinux "IPAPPEND 2" option along
   options.push("BOOTIF=01-$net_default_mac")
   if host_param('pxe_kernel_options')

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -20,6 +20,7 @@ test_on:
 - host6static
 -%>
 # This file was deployed via '<%= template_name %>' template
+<%= snippet("header") -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -12,8 +12,7 @@ description: |
   The template to render PXELinux bootloader configuration for preseed based distributions.
   The output is deployed on the host's subnet TFTP proxy.
 -%>
-#
-# This file was deployed via '<%= template_name %>' template
+<%= snippet("header") -%>
 #
 # Supported host/hostgroup parameters:
 #

--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -21,6 +21,8 @@ test_on:
 - host4static
 - host6static
 -%>
+# This file was deployed via '<%= template_name %>' template
+<%= snippet("header") -%>
 <%
   iface = @host.provision_interface
   subnet4 = iface.subnet

--- a/app/views/unattended/provisioning_templates/snippet/header.erb
+++ b/app/views/unattended/provisioning_templates/snippet/header.erb
@@ -1,0 +1,25 @@
+<%#
+kind: snippet
+name: header
+model: ProvisioningTemplate
+snippet: true
+-%>
+# Host: <%= @host.name %>
+# Organization: <%= @host.organization %>
+# Location: <%= @host.location %>
+# Interfaces: <%= @host.interfaces.size %>
+# IPv4 subnet: <%= @host.subnet || "unset" %>
+# IPv6 subnet: <%= @host.subnet6 || "unset" %>
+# Provision interface: <%= @host.provision_interface.mac %>
+# Primary interface: <%= @host.primary_interface.mac %>
+# Provision IPv4: <%= @host.provision_interface.ip || "unset" %>
+# Primary IPv4: <%= @host.primary_interface.ip || "unset" %>
+# Provision IPv6: <%= @host.provision_interface.ip6 || "unset" %>
+# Primary IPv6: <%= @host.primary_interface.ip6 || "unset" %>
+<%
+if plugin_present?('katello')
+-%>
+# Lifecycle environment: <%= @host.lifecycle_environment %>
+# Content View: <%= @host.content_view %>
+# Content Source: <%= @host.content_source %>
+<% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -40,11 +40,10 @@ description: |
   end
 
   # networking credentials
-  raise("Dual-stack provisioning not supported") if subnet4 && subnet6
-  options.push("dualstack!") if subnet4 && subnet6
-  if subnet4 && subnet4.dhcp_boot_mode?
+  raise("Both IPv4 and IPv6 subnets are set on a provisioning interface, create a 'install-protocol' parameter with either 'force-ipv4' or 'force-ipv6' to identify which protocol to use.") if subnet4 && subnet6 && !host_param("install-protocol").present?
+  if subnet4 && subnet4.dhcp_boot_mode? && host_param("install-protocol") != "force-ipv6"
     options.push("ip=dhcp") if rhel_compatible && major >= 7
-  elsif subnet4 && !subnet4.dhcp_boot_mode?
+  elsif subnet4 && !subnet4.dhcp_boot_mode? && host_param("install-protocol") != "force-ipv6"
     if rhel_compatible && major < 7
       dns_servers = subnet4.dns_servers.join(',')
       if @ipxe_net
@@ -73,7 +72,7 @@ description: |
 
   # nameservers - must be present even for DHCP subnets because of bug:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1795276
-  if subnet4 && !@ipxe_net
+  if subnet4 && !@ipxe_net && host_param("install-protocol") != "force-ipv6"
     subnet4.dns_servers.each { |server|
       options.push("nameserver=#{server}")
     }
@@ -127,7 +126,7 @@ description: |
     options.push('fips=1')
   end
 
-  nic_delay = subnet4 ? subnet4.nic_delay : nil
+  nic_delay = (subnet4 && host_param("install-protocol") != "force-ipv6") ? subnet4.nic_delay : nil
   nic_delay ||= subnet6 ? subnet6.nic_delay : nil
   if nic_delay && rhel_compatible && major >= 7
     ["dhcp", "iflink", "ifup", "route", "ipv6dad", "ipv6auto", "carrier"].each do |type|

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -40,7 +40,7 @@ description: |
   end
 
   # networking credentials
-  raise("Both IPv4 and IPv6 subnets are set on a provisioning interface, create a 'install-protocol' parameter with either 'force-ipv4' or 'force-ipv6' to identify which protocol to use.") if subnet4 && subnet6 && !host_param("install-protocol").present?
+  raise("Both IPv4 and IPv6 subnets are set on a provisioning interface, create an 'install-protocol' parameter with either 'force-ipv4' or 'force-ipv6' to identify which protocol to use.") if subnet4 && subnet6 && !host_param("install-protocol").present?
   if subnet4 && subnet4.dhcp_boot_mode? && host_param("install-protocol") != "force-ipv6"
     options.push("ip=dhcp") if rhel_compatible && major >= 7
   elsif subnet4 && !subnet4.dhcp_boot_mode? && host_param("install-protocol") != "force-ipv6"

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -99,7 +99,7 @@ FactoryBot.define do
       gateway { '192.168.42.1' }
       dns_primary { '192.168.42.2' }
       dns_secondary { '192.168.42.3' }
-      mtu { '1142' }
+      mtu { '1280' }
       boot_mode { :DHCP }
       domains { [FactoryBot.build(:domain_for_snapshots)] }
       proxies_for_snapshots
@@ -112,7 +112,7 @@ FactoryBot.define do
       gateway { '192.168.42.1' }
       dns_primary { '192.168.42.2' }
       dns_secondary { '192.168.42.3' }
-      mtu { '1242' }
+      mtu { '1280' }
       boot_mode { :Static }
       domains { [FactoryBot.build(:domain_for_snapshots)] }
       proxies_for_snapshots
@@ -125,7 +125,7 @@ FactoryBot.define do
       gateway { '2001:db8:42::1' }
       dns_primary { '2001:db8:42::8' }
       dns_secondary { '2001:db8:42::4' }
-      mtu { '1342' }
+      mtu { '1280' }
       boot_mode { :DHCP }
       domains { [FactoryBot.build(:domain_for_snapshots)] }
       proxies_for_snapshots
@@ -138,7 +138,7 @@ FactoryBot.define do
       gateway { '2001:db8:42::1' }
       dns_primary { '2001:db8:42::8' }
       dns_secondary { '2001:db8:42::4' }
-      mtu { '1442' }
+      mtu { '1280' }
       boot_mode { :Static }
       domains { [FactoryBot.build(:domain_for_snapshots)] }
       proxies_for_snapshots

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4and6dhcp.snap.txt
@@ -1,11 +1,23 @@
 # This file was deployed via 'Kickstart default PXEGrub' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 
 default=0
 timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e4 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4dhcp.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXEGrub' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: unset
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: unset
+# Primary IPv6: unset
 
 default=0
 timeout=10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
@@ -1,11 +1,23 @@
 # This file was deployed via 'Kickstart default PXEGrub' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: snapshot-ipv4-static
+# IPv6 subnet: unset
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: unset
+# Primary IPv6: unset
 
 default=0
 timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-host.snap.example.com:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6dhcp.snap.txt
@@ -1,11 +1,23 @@
 # This file was deployed via 'Kickstart default PXEGrub' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: unset
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 2001:db8:42::42
+# Primary IPv4: 2001:db8:42::42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 
 default=0
 timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
@@ -1,11 +1,23 @@
 # This file was deployed via 'Kickstart default PXEGrub' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: unset
+# IPv6 subnet: snapshot-ipv6-static
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 2001:db8:42::42
+# Primary IPv4: 2001:db8:42::42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 
 default=0
 timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=[2001:db8:42::42]::[2001:db8:42::1]:48:snapshot-host.snap.example.com:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
@@ -1,10 +1,22 @@
 # This file was deployed via 'Kickstart default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 
 set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e4 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: unset
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: unset
+# Primary IPv6: unset
 
 set default=0
 set timeout=10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -1,10 +1,22 @@
 # This file was deployed via 'Kickstart default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: snapshot-ipv4-static
+# IPv6 subnet: unset
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: unset
+# Primary IPv6: unset
 
 set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-host.snap.example.com:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
@@ -1,10 +1,22 @@
 # This file was deployed via 'Kickstart default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: unset
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 2001:db8:42::42
+# Primary IPv4: 2001:db8:42::42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 
 set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -1,10 +1,22 @@
 # This file was deployed via 'Kickstart default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: unset
+# IPv6 subnet: snapshot-ipv6-static
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 2001:db8:42::42
+# Primary IPv4: 2001:db8:42::42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 
 set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=[2001:db8:42::42]::[2001:db8:42::1]:48:snapshot-host.snap.example.com:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
@@ -1,5 +1,15 @@
-#
-# This file was deployed via 'Preseed default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 #
 # Supported host/hostgroup parameters:
 #
@@ -13,7 +23,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US BOOTIF=01-$net_default_mac
+  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-host.snap.example.com auto=true domain=snap.example.com locale=en_US BOOTIF=01-$net_default_mac
   initrdefi boot/debian-mirror-RpV7E2zxrKHe-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -1,5 +1,15 @@
-#
-# This file was deployed via 'Preseed default PXEGrub2' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 #
 # Supported host/hostgroup parameters:
 #
@@ -13,7 +23,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/ubuntu-mirror-c5UKFnM0aX6y-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu20 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
+  linuxefi  boot/ubuntu-mirror-c5UKFnM0aX6y-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-host.snap.example.com console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
   initrdefi boot/ubuntu-mirror-c5UKFnM0aX6y-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/AutoYaST_default_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/AutoYaST_default_PXELinux.host4dhcp.snap.txt
@@ -1,6 +1,8 @@
 
+  
 DEFAULT linux
 
 LABEL linux
     KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
     APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ramdisk_size=65536 install=url --url http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.some.host.fqdn/unattended/provision textmode=1 
+

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 DEFAULT menu
 MENU TITLE Booting into OS installer (ESC to stop)
 TIMEOUT 100
@@ -7,7 +19,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e4 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4dhcp.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: unset
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: unset
+# Primary IPv6: unset
 DEFAULT menu
 MENU TITLE Booting into OS installer (ESC to stop)
 TIMEOUT 100

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: snapshot-ipv4-static
+# IPv6 subnet: unset
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: unset
+# Primary IPv6: unset
 DEFAULT menu
 MENU TITLE Booting into OS installer (ESC to stop)
 TIMEOUT 100
@@ -7,7 +19,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-host.snap.example.com:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: unset
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 2001:db8:42::42
+# Primary IPv4: 2001:db8:42::42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 DEFAULT menu
 MENU TITLE Booting into OS installer (ESC to stop)
 TIMEOUT 100
@@ -7,7 +19,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
@@ -1,4 +1,16 @@
 # This file was deployed via 'Kickstart default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 1
+# IPv4 subnet: unset
+# IPv6 subnet: snapshot-ipv6-static
+# Provision interface: 00-f0-54-1a-7e-e0
+# Primary interface: 00-f0-54-1a-7e-e0
+# Provision IPv4: 2001:db8:42::42
+# Primary IPv4: 2001:db8:42::42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 DEFAULT menu
 MENU TITLE Booting into OS installer (ESC to stop)
 TIMEOUT 100
@@ -7,7 +19,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=[2001:db8:42::42]::[2001:db8:42::1]:48:snapshot-host.snap.example.com:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
@@ -1,5 +1,15 @@
-#
-# This file was deployed via 'Preseed default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 #
 # Supported host/hostgroup parameters:
 #
@@ -12,7 +22,7 @@
 DEFAULT linux
 LABEL linux
     KERNEL boot/debian-mirror-RpV7E2zxrKHe-linux
-    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US
+    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-host.snap.example.com auto=true domain=snap.example.com locale=en_US
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
@@ -1,5 +1,15 @@
-#
-# This file was deployed via 'Preseed default PXELinux' template
+# Host: snapshot-host.snap.example.com
+# Organization: Organization 1
+# Location: Location 1
+# Interfaces: 2
+# IPv4 subnet: snapshot-ipv4-dhcp
+# IPv6 subnet: snapshot-ipv6-dhcp
+# Provision interface: 00-f0-54-1a-7e-e4
+# Primary interface: 00-f0-54-1a-7e-e4
+# Provision IPv4: 192.168.42.42
+# Primary IPv4: 192.168.42.42
+# Provision IPv6: 2001:db8:42::42
+# Primary IPv6: 2001:db8:42::42
 #
 # Supported host/hostgroup parameters:
 #
@@ -12,7 +22,7 @@
 DEFAULT linux
 LABEL linux
     KERNEL boot/ubuntu-mirror-c5UKFnM0aX6y-linux
-    APPEND initrd=boot/ubuntu-mirror-c5UKFnM0aX6y-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu20 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
+    APPEND initrd=boot/ubuntu-mirror-c5UKFnM0aX6y-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-host.snap.example.com console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -1,7 +1,7 @@
 
 #cloud-config
-hostname: snapshot-ipv4-dhcp-deb10
-fqdn: snapshot-ipv4-dhcp-deb10
+hostname: snapshot-host.snap.example.com
+fqdn: snapshot-host.snap.example.com
 manage_etc_hosts: true
 users: {}
 runcmd:
@@ -11,7 +11,7 @@ runcmd:
   hostname 
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-deb10  localhost localhost.localdomain
+  127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix
@@ -57,7 +57,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  certname        = snapshot-ipv4-dhcp-deb10
+  certname        = snapshot-host.snap.example.com
   
   EOF
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -1,7 +1,7 @@
 
 #cloud-config
-hostname: snapshot-ipv4-dhcp-el7
-fqdn: snapshot-ipv4-dhcp-el7
+hostname: snapshot-host.snap.example.com
+fqdn: snapshot-host.snap.example.com
 manage_etc_hosts: true
 users: {}
 runcmd:
@@ -11,7 +11,7 @@ runcmd:
   hostname 
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+  127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix
@@ -61,7 +61,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  certname        = snapshot-ipv4-dhcp-el7
+  certname        = snapshot-host.snap.example.com
   
   EOF
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -1,7 +1,7 @@
 
 #cloud-config
-hostname: snapshot-ipv4-dhcp-ubuntu20
-fqdn: snapshot-ipv4-dhcp-ubuntu20
+hostname: snapshot-host.snap.example.com
+fqdn: snapshot-host.snap.example.com
 manage_etc_hosts: true
 users: {}
 runcmd:
@@ -11,7 +11,7 @@ runcmd:
   hostname 
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-ubuntu20  localhost localhost.localdomain
+  127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix
@@ -57,7 +57,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  certname        = snapshot-ipv4-dhcp-ubuntu20
+  certname        = snapshot-host.snap.example.com
   
   EOF
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
@@ -28,7 +28,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 EOF
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server  --no-daemonize

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
@@ -1,7 +1,7 @@
 
 /bin/echo '$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0' | pw usermod root -H 0
 cat >> /etc/rc.conf <<EOF
-hostname="snapshot-ipv4-dhcp-el7"
+hostname="snapshot-host.snap.example.com"
 sshd_enable="YES"
 ntpd_enable="YES"
 EOF
@@ -10,7 +10,7 @@ echo ifconfig_`ifconfig -l | cut -d ' ' -f 1`=DHCP >>/etc/rc.conf
 
 echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 
-/bin/hostname snapshot-ipv4-dhcp-el7
+/bin/hostname snapshot-host.snap.example.com
 cp /usr/share/zoneinfo/UTC /etc/localtime
 adjkerntz -a
 ntpdate 0.freebsd.pool.ntp.org
@@ -40,7 +40,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Junos_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Junos_default_finish.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 system {
-    host-name snapshot-ipv4-dhcp-el7;
+    host-name snapshot-host.snap.example.com;
     time-zone Etc/UTC;
     root-authentication {
         encrypted-password "$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0"; ## SECRET-DATA

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -58,7 +58,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -22,7 +22,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-deb10
+certname        = snapshot-host.snap.example.com
 
 EOF
 
@@ -42,7 +42,7 @@ systemctl enable puppet
 
 
 
-real=`ip -o link | awk '/00-f0-54-1a-7e-e0/ {print $2;}' | sed s/://`
+real=`ip -o link | awk '/00-f0-54-1a-7e-e4/ {print $2;}' | sed s/://`
 cat << EOF > /etc/network/interfaces
 #loopback
 auto lo

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -22,7 +22,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-ubuntu20
+certname        = snapshot-host.snap.example.com
 
 EOF
 
@@ -42,7 +42,7 @@ systemctl enable puppet
 
 
 
-real=`ip -o link | awk '/00-f0-54-1a-7e-e0/ {print $2;}' | sed s/://`
+real=`ip -o link | awk '/00-f0-54-1a-7e-e4/ {print $2;}' | sed s/://`
 cat << EOF > /etc/network/interfaces
 #loopback
 auto lo

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Alterator_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Alterator_default.host4dhcp.snap.txt
@@ -11,7 +11,7 @@
 ("/preinstall" action "write")
 ("/grub" action "write" language ("en_US") device "/dev/sda")
 ("/net-eth" action "write" reset #t)
-("/net-eth" action "write" name "eth0" configuration "static" default "192.168.42.1" search "snap.example.com" dns "192.168.42.2 192.168.42.3" computer_name "snapshot-ipv4-dhcp-el7")
+("/net-eth" action "write" name "eth0" configuration "static" default "192.168.42.1" search "snap.example.com" dns "192.168.42.2 192.168.42.3" computer_name "snapshot-host.snap.example.com")
 ("/net-eth" action "add_iface_address" name "eth0" addip "192.168.42.42" addmask "255.255.255.0")
 ("/net-eth" action "write" commit #t)
 ("/root/change_password" language (en_US") passwd_2 "123" passwd_1 "123")

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic_Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic_Kickstart_default.host4dhcp.snap.txt
@@ -4,7 +4,7 @@ keyboard us
 timezone --utc UTC
 
 
-network --bootproto dhcp --hostname snapshot-ipv4-dhcp-el7 --device=00-f0-54-1a-7e-e0
+network --bootproto dhcp --hostname snapshot-host.snap.example.com --device=00-f0-54-1a-7e-e0
 # Partition table should create /boot and a volume atomicos
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -9,7 +9,7 @@
   </general>
   <networking>
     <dns>
-      <hostname>snapshot-ipv4-dhcp-el7</hostname>
+      <hostname>snapshot-host.snap.example.com</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">
         <search>snap.example.com</search>
@@ -85,7 +85,7 @@ cp /etc/resolv.conf /mnt/etc
         <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
         <source><![CDATA[
-/bin/hostname snapshot-ipv4-dhcp-el7
+/bin/hostname snapshot-host.snap.example.com
 
 
 
@@ -110,7 +110,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -9,7 +9,7 @@
   </general>
   <networking>
     <dns>
-      <hostname>snapshot-ipv4-dhcp-el7</hostname>
+      <hostname>snapshot-host.snap.example.com</hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <searchlist config:type="list">
         <search>snap.example.com</search>
@@ -88,7 +88,7 @@ cp /etc/resolv.conf /mnt/etc
         <interpreter>shell</interpreter>
         <notification>Setting up Puppet / Foreman ...</notification>
         <source><![CDATA[
-/bin/hostname snapshot-ipv4-dhcp-el7
+/bin/hostname snapshot-host.snap.example.com
 
 
 
@@ -112,7 +112,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -11,7 +11,7 @@ selinux --enforcing
 keyboard us
 skipx
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-6-dhcp-el7 --noipv6 --bootproto dhcp --mtu=1142 --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e4 --hostname snapshot-host.snap.example.com --bootproto dhcp --mtu=1280 --ipv6 dhcp --mtu=1280 --nameserver=192.168.42.2,192.168.42.3,2001:db8:42::8,2001:db8:42::4
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
@@ -63,7 +63,7 @@ chvt 1
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
-logger "Starting anaconda snapshot-ipv4-6-dhcp-el7 postinstall"
+logger "Starting anaconda snapshot-host.snap.example.com postinstall"
 
 
 
@@ -120,7 +120,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-6-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -11,7 +11,7 @@ selinux --enforcing
 keyboard us
 skipx
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-el7 --noipv6 --bootproto dhcp --mtu=1142 --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-host.snap.example.com --noipv6 --bootproto dhcp --mtu=1280 --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
@@ -63,7 +63,7 @@ chvt 1
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
-logger "Starting anaconda snapshot-ipv4-dhcp-el7 postinstall"
+logger "Starting anaconda snapshot-host.snap.example.com postinstall"
 
 
 
@@ -120,7 +120,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -11,7 +11,7 @@ selinux --enforcing
 keyboard us
 skipx
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-static-el7 --noipv6 --bootproto static --ip=192.168.42.42 --netmask=255.255.255.0 --gateway=192.168.42.1 --mtu=1242 --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-host.snap.example.com --noipv6 --bootproto static --ip=192.168.42.42 --netmask=255.255.255.0 --gateway=192.168.42.1 --mtu=1280 --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
@@ -63,7 +63,7 @@ chvt 1
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
-logger "Starting anaconda snapshot-ipv4-static-el7 postinstall"
+logger "Starting anaconda snapshot-host.snap.example.com postinstall"
 
 
 
@@ -120,7 +120,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-static-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -11,7 +11,7 @@ selinux --enforcing
 keyboard us
 skipx
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-dhcp-el7 --noipv6 --bootproto dhcp --mtu=1342 --nameserver=2001:db8:42::8,2001:db8:42::4
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-host.snap.example.com --noipv4 --ipv6 dhcp --mtu=1280 --nameserver=2001:db8:42::8,2001:db8:42::4
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
@@ -63,7 +63,7 @@ chvt 1
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
-logger "Starting anaconda snapshot-ipv6-dhcp-el7 postinstall"
+logger "Starting anaconda snapshot-host.snap.example.com postinstall"
 
 
 
@@ -120,7 +120,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv6-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -11,7 +11,7 @@ selinux --enforcing
 keyboard us
 skipx
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-static-el7 --noipv6 --bootproto static --ip=2001:db8:42::42 --netmask=ffff:ffff:ffff:: --gateway=2001:db8:42::1 --mtu=1442 --nameserver=2001:db8:42::8,2001:db8:42::4
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-host.snap.example.com --noipv4 --ipv6=2001:db8:42::42/48 --ipv6gateway=2001:db8:42::1 --mtu=1280 --nameserver=2001:db8:42::8,2001:db8:42::4
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
@@ -63,7 +63,7 @@ chvt 1
 exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
-logger "Starting anaconda snapshot-ipv6-static-el7 postinstall"
+logger "Starting anaconda snapshot-host.snap.example.com postinstall"
 
 
 
@@ -120,7 +120,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv6-static-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
@@ -8,7 +8,7 @@ d-i keyboard-configuration/xkb-keymap seen true
 
 # Network configuration
 d-i netcfg/choose_interface select auto
-d-i netcfg/get_hostname string snapshot-ipv4-dhcp-deb10
+d-i netcfg/get_hostname string snapshot-host.snap.example.com
 d-i netcfg/get_domain string snap.example.com
 d-i netcfg/wireless_wep string
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
@@ -8,7 +8,7 @@ d-i keyboard-configuration/xkb-keymap seen true
 
 # Network configuration
 d-i netcfg/choose_interface select auto
-d-i netcfg/get_hostname string snapshot-ipv4-dhcp-ubuntu20
+d-i netcfg/get_hostname string snapshot-host.snap.example.com
 d-i netcfg/get_domain string snap.example.com
 d-i netcfg/wireless_wep string
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/coreos_cloudconfig.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/coreos_cloudconfig.host4dhcp.snap.txt
@@ -10,7 +10,7 @@
             command: start
           - name: fleet.service
             command: start
-      hostname: snapshot-ipv4-dhcp-el7
+      hostname: snapshot-host.snap.example.com
       users:
         - name: core
           passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/fix_hosts.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/fix_hosts.host4dhcp.snap.txt
@@ -3,7 +3,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
@@ -7,4 +7,4 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
@@ -14,7 +14,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_setup.host4dhcp.snap.txt
@@ -17,7 +17,7 @@ grains: {}
 
 EOF
 
-echo snapshot-ipv4-dhcp-el7 > /etc/salt/minion_id
+echo snapshot-host.snap.example.com > /etc/salt/minion_id
 
 /sbin/chkconfig --level 345 salt-minion on
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -6,7 +6,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
@@ -39,7 +39,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -6,7 +6,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
@@ -68,7 +68,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-el7
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -6,7 +6,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-deb10  localhost localhost.localdomain
+127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
@@ -40,7 +40,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-deb10
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -6,7 +6,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-ubuntu20  localhost localhost.localdomain
+127.0.0.1   snapshot-host.snap.example.com  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
@@ -40,7 +40,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-ubuntu20
+certname        = snapshot-host.snap.example.com
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -1,6 +1,6 @@
 #cloud-config
 hostname: 
-fqdn: snapshot-ipv4-dhcp-el7
+fqdn: snapshot-host.snap.example.com
 manage_etc_hosts: true
 ssh_pwauth: true
 groups:
@@ -43,7 +43,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  certname        = snapshot-ipv4-dhcp-el7
+  certname        = snapshot-host.snap.example.com
   
   EOF
   


### PR DESCRIPTION
A customer reports that dual-stack provisioning does work. IPv4 is used for provisioning. We do not have capacity to test those workflows at the moment, but we can actually allow provisioning in these cases via a host parameter to determine which stack to configure for provisioning.

@ekohl