### PR TITLE
Fixes #27906 - Always prefer modern facts in Facter

### DIFF
--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -11,8 +11,8 @@ class PuppetFactParser < FactParser
       args = {:name => os_name, :major => major, :minor => minor}
       os = Operatingsystem.find_or_initialize_by(args)
       if os_name[/debian|ubuntu/i] || os.family == 'Debian'
-        if facts.dig(:os, :distro, :codename).presence || facts[:lsbdistcodename]
-          os.release_name = facts.dig(:os, :distro, :codename).presence || facts[:lsbdistcodename]
+        if distro_codename
+          os.release_name = distro_codename
         elsif os.release_name.blank?
           os.release_name = 'unknown'
         end
@@ -24,10 +24,10 @@ class PuppetFactParser < FactParser
     if os.description.blank?
       if os_name == 'SLES'
         os.description = os_name + ' ' + orel.gsub('.', ' SP')
-      elsif facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription]
+      elsif distro_description
         family = os.deduce_family || 'Operatingsystem'
         os = os.becomes(family.constantize)
-        os.description = os.shorten_description(facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription])
+        os.description = os.shorten_description(distro_description)
       end
     end
 
@@ -51,29 +51,32 @@ class PuppetFactParser < FactParser
     # On solaris and junos architecture fact is hardwareisa
     name = case os_name
              when /(sunos|solaris|junos)/i
-               facts[:hardwareisa]
+               hardware_isa
              else
-               facts[:architecture] || facts[:hardwareisa]
+               architecture_fact || hardware_isa
            end
-    # ensure that we convert debian legacy to standard
+    # Normalize some output, like on Debian and FreeBSD
     name = "x86_64" if name == "amd64"
     name = "aarch64" if name == "arm64"
     Architecture.where(:name => name).first_or_create if name.present?
   end
 
   def model
-    name = facts[:productname] || facts[:model] || facts[:boardproductname]
+    # TODO: not sure where model comes from, not Facter
+    name = dmi_product_name || facts[:model] || dmi_board_product
     # if its a virtual machine and we didn't get a model name, try using that instead.
     name ||= facts[:virtual] if virtual
     Model.where(:name => name.strip).first_or_create if name.present?
   end
 
   def domain
-    name = facts[:domain]
+    # Facter 3.0 introduced the networking fact
+    name = facts.dig(:networking, :domain).presence || facts[:domain].presence
     Domain.unscoped.where(:name => name).first_or_create if name.present?
   end
 
   def ipmi_interface
+    # ipmi_ facts are custom facts in foreman-discovery-image
     ipmi = facts.select { |name, _| name =~ /\Aipmi_(.*)\Z/ }.map { |name, value| [name.sub(/\Aipmi_/, ''), value] }
     Hash[ipmi].with_indifferent_access
   end
@@ -102,7 +105,7 @@ class PuppetFactParser < FactParser
 
   def suggested_primary_interface(host)
     # facter 3.x: find 'primary' fact in 'networking' structure
-    facter3_primary = facts.try(:fetch, "networking", nil).try(:fetch, "primary", nil)
+    facter3_primary = facts.dig(:networking, :primary).presence
     return [facter3_primary, interfaces[facter3_primary]] if facter3_primary
     super
   end
@@ -116,8 +119,8 @@ class PuppetFactParser < FactParser
   end
 
   def boot_timestamp
-    # system_uptime::seconds is Facter 3, we also fallback to Facter 2 uptime_seconds
-    uptime_seconds = facts.fetch('system_uptime', {}).fetch('seconds', nil) || facts[:uptime_seconds]
+    # Facter 2.2 introduced the system_uptime fact
+    uptime_seconds = facts.dig(:system_uptime, :seconds) || facts[:uptime_seconds]
     uptime_seconds.nil? ? nil : (Time.zone.now.to_i - uptime_seconds.to_i)
   end
 
@@ -126,6 +129,7 @@ class PuppetFactParser < FactParser
   end
 
   def ram
+    # Facter 3.0 introduced the memory fact
     if (value = facts.dig('memory', 'system', 'total_bytes'))
       value / 1.megabyte
     else
@@ -134,14 +138,17 @@ class PuppetFactParser < FactParser
   end
 
   def sockets
+    # Facter 2.2 introduced the processors.physicalcount fact
     facts.dig('processors', 'physicalcount') || facts['physicalprocessorcount']
   end
 
   def cores
+    # Facter 2.2 introduced the processors.count fact
     facts.dig('processors', 'count') || facts['processorcount']
   end
 
   def disks_total
+    # Facter 3.0 introduced the disks fact
     facts['disks']&.values&.sum { |disk| disk&.fetch('size_bytes', 0).to_i }
   end
 
@@ -191,42 +198,46 @@ class PuppetFactParser < FactParser
   end
 
   def os_name
+    # Facter 2.2 introduced the os fact
     os_name = facts.dig(:os, :name).presence || facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
 
-    if os_name == 'RedHat' && facts[:lsbdistid] == 'RedHatEnterpriseWorkstation'
+    if os_name == 'RedHat' && distro_id == 'RedHatEnterpriseWorkstation'
       os_name += '_Workstation'
     elsif os_name == 'windows' && facts.dig(:os, :windows, :installation_type) == 'Client'
       os_name += '_client'
     end
 
     os_name
+  rescue ::Foreman::Exception
+    raise
+  rescue StandardError => e
+    logger.error { "Failed to read the OS name: #{e}" }
+    raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
   end
 
   def os_release
     case os_name
-    when /(suse|sles|gentoo)/i
-      facts[:operatingsystemrelease]
     when /(windows)/i
       facts[:kernelrelease]
     when /AIX/i
-      majoraix, tlaix, spaix, _yearaix = facts[:operatingsystemrelease].split("-")
+      majoraix, tlaix, spaix, _yearaix = os_release_full.split("-")
       majoraix + "." + tlaix + spaix
     when /JUNOS/i
-      majorjunos, minorjunos = facts[:operatingsystemrelease].split("R")
+      majorjunos, minorjunos = os_release_full.split("R")
       majorjunos + "." + minorjunos
     when /FreeBSD/i
-      facts[:operatingsystemrelease].gsub(/\-RELEASE\-p[0-9]+/, '')
+      os_release_full.gsub(/\-RELEASE\-p[0-9]+/, '')
     when /Solaris/i
-      facts[:operatingsystemrelease].gsub(/_u/, '.')
+      os_release_full.gsub(/_u/, '.')
     when /PSBM/i
-      majorpsbm, minorpsbm = facts[:operatingsystemrelease].split(".")
+      majorpsbm, minorpsbm = os_release_full.split(".")
       majorpsbm + "." + minorpsbm
     when /Archlinux/i
       # Archlinux is a rolling release, so it has no releases. 1.0 is always used
       '1.0'
     when /Debian/i
-      return "99" if facts[:lsbdistcodename] =~ /sid/
-      release = facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+      return "99" if distro_codename =~ /sid/
+      release = os_release_full
       case release
       when 'bullseye/sid' # Debian Bullseye testing will be 11
         '11'
@@ -234,7 +245,82 @@ class PuppetFactParser < FactParser
         release
       end
     else
-      facts.dig(:os, :release, :full) || facts[:lsbdistrelease] || facts[:operatingsystemrelease]
+      os_release_full
     end
+  end
+
+  # The full OS release (7 / 7.9 / 7.6.1810 / 2012 R2 / 20.04)
+  def os_release_full
+    # Facter 2.2 introduced the os.release fact
+    facts.dig(:os, :release, :full) || facts[:operatingsystemrelease]
+  rescue StandardError => e
+    logger.error { "Failed to read the full OS release: #{e}" }
+    nil
+  end
+
+  # This fact returns the distribution's id, which typically relies on
+  # lsb-release to be installed. As such, it's an optional fact
+  def distro_id
+    # Facter 3.0 introduced the os.distro fact
+    facts.dig(:os, :distro, :id).presence || facts[:lsbdistid].presence
+  rescue StandardError => e
+    logger.warning { "Failed to the read distribution id: #{e}" }
+    nil
+  end
+
+  # This fact returns the distribution's codename, which typically relies on
+  # lsb-release to be installed. As such, it's an optional fact
+  def distro_codename
+    # Facter 3.0 introduced the os.distro fact
+    facts.dig(:os, :distro, :codename).presence || facts[:lsbdistcodename].presence
+  rescue StandardError => e
+    logger.warning { "Failed to read the distribution codename: #{e}" }
+    nil
+  end
+
+  # This fact returns the distribution's description, which typically relies on
+  # lsb-release to be installed. As such, it's an optional fact
+  def distro_description
+    # Facter 3.0 introduced the os.distro fact
+    facts.dig(:os, :distro, :description).presence || facts[:lsbdistdescription].presence
+  rescue StandardError => e
+    logger.warning { "Failed to read the distribution description: #{e}" }
+    nil
+  end
+
+  # Product name from DMI
+  def dmi_product_name
+    # Facter 3.0 introduced the dmi fact
+    facts.dig(:dmi, :product, :name).presence || facts[:productname]
+  rescue StandardError => e
+    logger.warning { "Failed to read the product name: #{e}" }
+    nil
+  end
+
+  # Board product name as the DMI board reports it.
+  def dmi_board_product
+    # Facter 3.0 introduced the dmi fact
+    facts.dig(:dmi, :board, :product).presence || facts[:boardproductname]
+  rescue StandardError => e
+    logger.warning { "Failed to read the board product: #{e}" }
+    nil
+  end
+
+  # Architecture (x86_64 / amd64 /x64 / i386 / x64).
+  def architecture_fact
+    # Facter 3.0 introduced the os.architecture fact
+    facts.dig(:os, :architecture).presence || facts[:architecture].presence
+  rescue StandardError => e
+    logger.error { "Failed to read the architecture: #{e}" }
+    nil
+  end
+
+  # Hardware ISA (x86_64 / i686 / i386).
+  def hardware_isa
+    # Facter 3.0 introduced the processors.isa fact
+    facts.dig(:processors, :isa).presence || facts[:hardwareisa].presence
+  rescue StandardError => e
+    logger.error { "Failed to read the hardware ISA: #{e}" }
+    nil
   end
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -10,6 +10,7 @@ group :test do
   gem 'show_me_the_cookies', '~> 5.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'
+  gem 'facterdb', '~> 1.7'
   gem 'factory_bot_rails', '~> 5.0', :require => false
   gem 'selenium-webdriver', :require => false
   gem 'shoulda-matchers', '>= 4.0', '< 4.4'

--- a/test/unit/host_fact_importer_test.rb
+++ b/test/unit/host_fact_importer_test.rb
@@ -85,9 +85,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
     assert_equal 'host', host.name
   end
 
-  test 'import_facts only needs operatingsystem and lsbdistrelease fact' do
+  test 'import_facts only needs operatingsystem and operatingsystemrelease fact' do
     host = Host.import_host('host', 'puppet')
-    assert HostFactImporter.new(host).import_facts(:lsbdistrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
   end
 
   test 'should import facts from json of a new host when certname is not specified' do
@@ -110,7 +110,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
   test 'domain updated from facts' do
     host = FactoryBot.create(:host, :with_operatingsystem)
     FactoryBot.create(:domain, :name => 'foo.bar')
-    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :lsbdistrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
     assert_equal 'foo.bar', host.domain.to_s
   end
 
@@ -118,9 +118,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
     domain = FactoryBot.create(:domain)
     host = FactoryBot.create(:host, :managed, :domain => domain)
     FactoryBot.create(:domain, :name => 'foo.bar')
-    assert HostFactImporter.new(host).import_facts(:domain => domain.name, :lsbdistrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts(:domain => domain.name, :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
     Setting[:ignore_facts_for_domain] = true
-    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :lsbdistrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
     assert_equal domain.name, host.domain.name
     Setting[:ignore_facts_for_domain] =
       Setting.find_by_name('ignore_facts_for_domain').default
@@ -274,13 +274,13 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'comment updated from facts when present' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(foreman_comment: 'new comment', lsbdistrelease: '6.7', operatingsystem: 'CentOS')
+    assert HostFactImporter.new(host).import_facts(foreman_comment: 'new comment', operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
     assert_equal 'new comment', host.comment
   end
 
   test 'operatingsystem updated from facts' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(:lsbdistrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
     assert_equal 'CentOS 6.7', host.operatingsystem.to_s
   end
 
@@ -289,7 +289,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
     os2 = FactoryBot.create(:operatingsystem)
     medium = os1.media.first
     host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
-    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :lsbdistrelease => os2.major.to_s)
+    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s)
 
     assert_equal host.operatingsystem, os2
     assert_nil host.medium
@@ -302,7 +302,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
     medium.operatingsystems << os2
 
     host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
-    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :lsbdistrelease => os2.major.to_s)
+    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s)
 
     assert_equal host.operatingsystem, os2
     assert_equal host.medium, medium
@@ -310,9 +310,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'operatingsystem not updated from facts when ignore_facts_for_operatingsystem false' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(:lsbdistrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
     Setting[:ignore_facts_for_operatingsystem] = true
-    assert HostFactImporter.new(host).import_facts(:lsbdistrelease => '6.8', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.8', :operatingsystem => 'CentOS')
     assert_equal 'CentOS 6.7', host.operatingsystem.to_s
     Setting[:ignore_facts_for_operatingsystem] =
       Setting.find_by_name('ignore_facts_for_operatingsystem').default


### PR DESCRIPTION
Facter started to introduce structured facts in Facter 2. Since Facter 3, the old facts are deprecated. This introduces helper methods to provide the abstraction and always prefers modern facts.

It does make a change that it no longer considers the lsbdistrelease fact. 5d61c18fa7bdee314ac146ba6b35353c16c63b37 already preferred the os.release.full fact which is present with Facter 2.2 or newer. It should also fall back to the operatingsystemrelease fact which is present since Facter 1.5 and a more reliable fact.

To make things easier, it annotates which for each fact which version of Facter introduced it.
