### PR TITLE
Fixes #32345 - Provide non-DB model methods for FactParser

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -33,18 +33,38 @@ class FactParser
   end
 
   def environment
+    name = environment_name
+    Environment.unscoped.where(:name => name).first_or_create
+  end
+
+  def environment_name
     raise NotImplementedError, not_implemented_error(__method__)
   end
 
   def architecture
+    name = architecture_name
+    Architecture.where(:name => name).first_or_create if name.present?
+  end
+
+  def architecture_name
     raise NotImplementedError, not_implemented_error(__method__)
   end
 
   def model
+    name = model_name
+    Model.where(:name => name.strip).first_or_create if name.present?
+  end
+
+  def model_name
     raise NotImplementedError, not_implemented_error(__method__)
   end
 
   def domain
+    name = domain_name
+    Domain.unscoped.where(:name => name).first_or_create if name.present?
+  end
+
+  def domain_name
     raise NotImplementedError, not_implemented_error(__method__)
   end
 
@@ -61,8 +81,12 @@ class FactParser
   end
 
   def hostgroup
-    hostgroup_title = facts[:foreman_hostgroup]
+    hostgroup_title = hostgroup_name
     Hostgroup.unscoped.where(:title => hostgroup_title).first_or_create if hostgroup_title.present?
+  end
+
+  def hostgroup_name
+    facts[:foreman_hostgroup]
   end
 
   # should return hash with indifferent access in following format:

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -40,13 +40,12 @@ class PuppetFactParser < FactParser
     end
   end
 
-  def environment
+  def environment_name
     # by default, puppet doesn't store an env name in the database
-    name = facts[:environment] || facts[:agent_specified_environment] || Setting[:default_puppet_environment]
-    Environment.unscoped.where(:name => name).first_or_create
+    facts[:environment] || facts[:agent_specified_environment] || Setting[:default_puppet_environment]
   end
 
-  def architecture
+  def architecture_name
     # On solaris and junos architecture fact is hardwareisa
     name = case os_name
              when /(sunos|solaris|junos)/i
@@ -57,19 +56,18 @@ class PuppetFactParser < FactParser
     # ensure that we convert debian legacy to standard
     name = "x86_64" if name == "amd64"
     name = "aarch64" if name == "arm64"
-    Architecture.where(:name => name).first_or_create if name.present?
+    name
   end
 
-  def model
+  def model_name
     name = facts[:productname] || facts[:model] || facts[:boardproductname]
     # if its a virtual machine and we didn't get a model name, try using that instead.
     name ||= facts[:virtual] if virtual
-    Model.where(:name => name.strip).first_or_create if name.present?
+    name
   end
 
-  def domain
-    name = facts[:domain]
-    Domain.unscoped.where(:name => name).first_or_create if name.present?
+  def domain_name
+    facts[:domain]
   end
 
   def ipmi_interface


### PR DESCRIPTION
As a preparation for removel of the DB model methods, there should be an alternative for DB model methods (Architecture, Domain, Environment & Model) while also deprecating the DB model methods.

Currently it doesn't have the deprecations and no code has been modified to use the new methods, but it's to split off some part of https://github.com/theforeman/foreman/pull/8449 to make that PR smaller.