### PR TITLE
Fixes #32360 - remove array destruction

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -6,7 +6,8 @@ class IntlLoader {
   constructor(locale, timezone) {
     this.fallbackIntl = !global.Intl;
 
-    [this.locale] = locale.split('-');
+    // eslint-disable-next-line prefer-destructuring
+    this.locale = locale.split('-')[0];
     this.timezone = this.fallbackIntl ? 'UTC' : timezone;
     this.ready = this.init();
   }
@@ -31,7 +32,7 @@ class IntlLoader {
   }
 }
 
-const [htmlElemnt] = document.getElementsByTagName('html');
+const htmlElemnt = document.getElementsByTagName('html')[0];
 const langAttr = htmlElemnt.getAttribute('lang') || 'en';
 const timezoneAttr = htmlElemnt.getAttribute('data-timezone') || 'UTC';
 


### PR DESCRIPTION
This removes usage of array destructuring as babel is unable to handle it
for some reason and given we have just two usecases, it is easier to
drop it, then figure out what's wrong with babel.