### PR TITLE
Fixes #32372 - Correct path for logs in kickstart

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -324,7 +324,7 @@ touch /tmp/foreman_built
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*.pre.*.log /tmp/sysimage/root/
+cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 <%= section_end %>
 
 %post --log=/root/install.post.custom.log

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -168,7 +168,7 @@ touch /tmp/foreman_built
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*.pre.*.log /tmp/sysimage/root/
+cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %end
 
 %post --log=/root/install.post.custom.log


### PR DESCRIPTION
This pull requests fixes the destination path for pre section logs in kickstart_default.erb.