### PR TITLE
Refs #24351 - dashboard removals revert

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -91,6 +91,16 @@ module DashboardHelper
     data.map { |label, value| [label.to_s, value] }
   end
 
+  def searchable_links(name, search, counter)
+    search += " and #{@data.filter}" if @data.filter.present?
+    content_tag :li do
+      content_tag(:span, raw('&nbsp;'), :class => 'label', :style => "background-color:" + report_color[counter]) +
+      raw('&nbsp;') +
+      link_to(name, hosts_path(:search => search), :class => "dashboard-links") +
+      content_tag(:h4, @data.report[counter])
+    end
+  end
+
   def translated_header(shortname, longname)
     "<th class='ca'><span class='small' title='' data-original-title='#{longname}'>#{shortname}</span></th>"
   end

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -9,6 +9,73 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
     Setting[:outofsync_interval] = 35
   end
 
+  def assert_dashboard_link(text)
+    visit_dashboard
+    assert page.has_link?(text), "link '#{text}' was expected, but it does not exist"
+    within "li[data-name='Host Configuration Status for All']" do
+      click_link(text)
+    end
+    assert_current_path hosts_path, :ignore_query => true
+    assert_match(/search=/, current_url)
+  end
+
+  def visit_dashboard
+    visit dashboard_path
+    wait_for_ajax
+  end
+
+  test "dashboard page" do
+    assert_index_page(dashboard_path, "Overview", false, true, false)
+    wait_for_ajax
+    assert page.has_content? 'Generated at'
+  end
+
+  test "dashboard link hosts that had performed modifications" do
+    assert_dashboard_link 'Hosts that had performed modifications without error'
+  end
+
+  test "dashboard link hosts in error state" do
+    assert_dashboard_link 'Hosts in error state'
+  end
+
+  test "dashboard link good host reports" do
+    assert_dashboard_link "Good host reports in the last 35 minutes"
+  end
+
+  test "dashboard link hosts that had pending changes" do
+    assert_dashboard_link 'Hosts that had pending changes'
+  end
+
+  test "dashboard link out of sync hosts" do
+    assert_dashboard_link 'Out of sync hosts'
+  end
+
+  context 'with origin' do
+    setup do
+      Setting::Puppet.load_defaults
+      Setting[:puppet_out_of_sync_disabled] = true
+    end
+
+    context 'out of sync disabled' do
+      test 'has no out of sync link' do
+        visit_dashboard
+        within "li[data-name='Host Configuration Status for Puppet']" do
+          assert page.has_no_link?('Out of sync hosts')
+          assert page.has_no_link?('Good host reports in the last')
+          assert page.has_link?('Good host with reports')
+        end
+      end
+    end
+  end
+
+  test "dashboard link hosts with no reports" do
+    assert_dashboard_link 'Hosts with no reports'
+  end
+
+  test "dashboard link hosts with alerts disabled" do
+    assert_dashboard_link 'Hosts with alerts disabled'
+  end
+
   test 'widgets not in dashboard show up in list' do
     deleted_widget = users(:admin).widgets.last
     users(:admin).widgets.destroy(deleted_widget)


### PR DESCRIPTION
Reverts accidental removal of method from befa557.
We are still using the old searchable_links method.