### PR TITLE
Fixes #32394 - Use grub_pass macro instead of variable

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -28,6 +28,7 @@ This template accepts the following parameters:
 - disable-uek: boolean (default=false)
 - use-ntp: boolean (default depends on OS release)
 - fips_enabled: boolean (default=false)
+- encrypt_grub: boolean (default=false)
 
 Reference links:
 https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/installation_guide/s1-kickstart2-options
@@ -203,10 +204,10 @@ repo --name="Server-Mysql"
 
 <% if @host.operatingsystem.name == 'Fedora' && os_major <= 16 -%>
 # Bootloader exception for Fedora 16:
-bootloader --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %> <%= ks_console %>" <%= @grub_pass %>
+bootloader --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %> <%= ks_console %>" <%= grub_pass %>
 part biosboot --fstype=biosboot --size=1
 <% else -%>
-bootloader --location=mbr --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %>" <%= @grub_pass %>
+bootloader --location=mbr --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %>" <%= grub_pass %>
 <% if os_major == 5 -%>
 key --skip
 <% end -%>

--- a/lib/foreman/renderer/scope/macros/host_template.rb
+++ b/lib/foreman/renderer/scope/macros/host_template.rb
@@ -127,13 +127,15 @@ module Foreman
             host.root_pass
           end
 
-          apipie :method, 'Returns options for GRUB bootloader containing password' do
+          apipie :method, 'Returns options for GRUB bootloader containing encrypted password' do
+            desc 'Options are returned based on *encrypt_grub* host parameter being set.
+                  Returns empty string if the parameter set to false'
             returns String, desc: 'Returns options for GRUB bootloader containing password'
             example 'grub_pass #=> "--md5pass=$1$org$9yxjIDK8FYVlQzHGhasqW/"'
             example 'grub_pass #=> "--iscrypted --password=9yxjIDK8FYVlQzHGhasqW/"'
           end
           def grub_pass
-            return '' unless @grub
+            return '' unless host_param_true?('encrypt_grub')
             host.grub_pass.start_with?('$1$') ? "--md5pass=#{host.grub_pass}" : "--iscrypted --password=#{host.grub_pass}"
           end
 

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -172,8 +172,14 @@ class HostTemplateTest < ActiveSupport::TestCase
 
     test 'grub_pass helper returns the grub password if enabled' do
       @scope.instance_variable_set('@host', host)
-      @scope.instance_variable_set('@grub', true)
+      FactoryBot.create(:parameter, name: 'encrypt_grub', value: 'true')
       assert_equal "--iscrypted --password=#{host.grub_pass}", @scope.grub_pass
+    end
+
+    test "grub_pass helper doesn't return the grub password if disabled" do
+      @scope.instance_variable_set('@host', host)
+      FactoryBot.create(:parameter, name: 'encrypt_grub', value: 'false')
+      assert_equal '', @scope.grub_pass
     end
   end
 


### PR DESCRIPTION
The default Kickstart template uses obsolete @grub_pass variable
which are not being set anywhere. Maybe it's due to typo or else.
I suggest to use macro instead so it's possible to set the password
via host params and do not clone the template for this purpose only.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
