### PR TITLE
Refs #32372 - correct remaining paths

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -62,7 +62,7 @@ reboot
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*pre*log /tmp/sysimage/root/
+cp -vf /tmp/*pre*log /mnt/sysimage/root/
 %end
 
 %post

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
@@ -26,7 +26,7 @@ reboot
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*pre*log /tmp/sysimage/root/
+cp -vf /tmp/*pre*log /mnt/sysimage/root/
 %end
 
 %post


### PR DESCRIPTION
Fixes the remaining paths in the atomic kickstart template like in PR #8154