### PR TITLE
[WIP] Fixes #32404 - Register OS without 'hostname' command

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -33,6 +33,12 @@ cat << EOF > $SSL_CA_CERT
 <%= foreman_server_ca_cert %>
 EOF
 
+if [ -f /usr/bin/hostname ]; then
+  hostname=$(hostname -f)
+else
+  hostname=$(cat /etc/HOSTNAME);
+fi
+
 <% unless @repo.blank? -%>
 echo '#'
 echo '# Adding repository'
@@ -69,7 +75,7 @@ fi
 register_host() {
   curl --silent --cacert $SSL_CA_CERT --request POST <%= @registration_url %> \
        <%= headers.join(' ') %> \
-       --data "host[name]=$(hostname --fqdn)" \
+       --data "host[name]=$hostname" \
        --data "host[build]=false" \
        --data "host[managed]=false" \
 <%= "       --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>


### PR DESCRIPTION
Support host registration for operating systems without
`hostname` command, use value from `/etc/HOSTNAME` instead.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
