### PR TITLE
Refs #30862 - do not validate new settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -49,7 +49,7 @@ class Setting < ApplicationRecord
   validates :value, :format => { :with => Resolv::AddressRegex }, :if => proc { |s| IP_ATTRS.include? s.name }
   validates :value, :regexp => true, :if => proc { |s| REGEXP_ATTRS.include? s.name }
   validates :value, :array_type => true, :if => proc { |s| s.settings_type == "array" }
-  validates_with ValueValidator, :if => proc { |s| s.respond_to?("validate_#{s.name}") }
+  validates_with ValueValidator, :if => proc { |s| Foreman.settings.ready? && s.respond_to?("validate_#{s.name}") }
   validates :value, :array_hostnames_ips => true, :if => proc { |s| ARRAY_HOSTNAMES.include? s.name }
   validates :value, :email => true, :if => proc { |s| EMAIL_ATTRS.include? s.name }
   before_validation :set_setting_type_from_value

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -44,6 +44,16 @@ class SettingRegistry
 
   def load
     # add() all setting definitions
+    load_definitions
+
+    # load all db values
+    load_values
+
+    # if create_missing create missing values in DB
+    # not needed now as old load mechanism takes care of that
+  end
+
+  def load_definitions
     Setting.descendants.each do |cat_cls|
       if cat_cls.default_settings.empty?
         # Setting category uses really old way of doing things
@@ -52,12 +62,6 @@ class SettingRegistry
         cat_cls.default_settings.each { |s| _add(s[:name], s.except(:name).merge(category: cat_cls.name)) }
       end
     end
-
-    # load all db values
-    load_values
-
-    # if create_missing create missing values in DB
-    # not needed now as old load mechanism takes care of that
   end
 
   def load_values

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -26,8 +26,9 @@ if (Setting.table_exists? rescue(false))
     require_dependency(f)
   end
 
+  Foreman.settings.load_definitions
   Setting.descendants.each(&:load_defaults)
-  Foreman.settings.load
+  Foreman.settings.load_values
 end
 
 # load topbar


### PR DESCRIPTION
While creating the settings, the definitions are not loaded yet, so the
validations depending on other setting values are failing. We should not
validate on create anyway.

This is fixing a forgotten validation on new setting from 8137b14c.