### PR TITLE
Fixes #32415 - access only through SettingRegistry

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -104,6 +104,10 @@ class Setting < ApplicationRecord
     return "boolean" if value_for_type.is_a?(TrueClass) || value_for_type.is_a?(FalseClass)
   end
 
+  def to_param
+    name
+  end
+
   def value=(v)
     v = v.to_yaml unless v.nil?
     # the has_attribute is for enabling DB migrations on older versions

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -4,7 +4,6 @@ class SettingPresenter
 
   include HiddenValue
 
-  attribute :id, :integer
   attribute :category, :string, default: 'Setting::General'
   attribute :context
   attribute :name, :string

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -44,45 +44,43 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
   end
 
   test "should parse string values to integers" do
-    setting_id = Setting.where(:settings_type => 'integer').first.id
-    put :update, params: { :id => setting_id, :setting => { :value => "100" } }
+    setting = Setting.where(:settings_type => 'integer').first
+    put :update, params: { :id => setting.to_param, :setting => { :value => "100" } }
     assert_response :success
-    assert_equal 100, Setting.find(setting_id).value
+    assert_equal 100, Setting[setting.name]
   end
 
   test "should accept integer values" do
-    setting_id = Setting.where(:settings_type => 'integer').first.id
-    put :update, params: { :id => setting_id, :setting => { :value => 120 } }
+    setting = Setting.where(:settings_type => 'integer').first
+    put :update, params: { :id => setting.to_param, :setting => { :value => 120 } }
     assert_response :success
-    assert_equal 120, Setting.find(setting_id).value
+    assert_equal 120, Setting[setting.name]
   end
 
   test "should parse string values to ararys" do
-    setting_id = Setting.where(:settings_type => 'array').first.id
-    put :update, params: { :id => setting_id, :setting => { :value => "['baz','foo']" } }
+    setting = Setting.where(:settings_type => 'array').first
+    put :update, params: { :id => setting.to_param, :setting => { :value => "['baz','foo']" } }
     assert_response :success
-    assert_equal ['baz', 'foo'], Setting.find(setting_id).value
+    assert_equal ['baz', 'foo'], Setting[setting.name]
   end
 
   test "should accept array values" do
-    setting_id = Setting.where(:settings_type => 'array').first.id
-    put :update, params: { :id => setting_id, :setting => { :value => ['foo', 'bar'] } }
+    setting = Setting.where(:settings_type => 'array').first
+    put :update, params: { :id => setting.to_param, :setting => { :value => ['foo', 'bar'] } }
     assert_response :success
-    assert_equal ['foo', 'bar'], Setting.find(setting_id).value
+    assert_equal ['foo', 'bar'], Setting[setting.name]
   end
 
   test_attributes :pid => 'fb8b0bf1-b475-435a-926b-861aa18d31f1'
   test "should update login page footer text with long value" do
     value = RFauxFactory.gen_alpha 1000
-    setting = Setting.find_by_name("login_text")
-    put :update, params: { :id => setting.id, :setting => { :value => value } }
+    put :update, params: { :id => 'login_text', :setting => { :value => value } }
     assert_equal JSON.parse(@response.body)['value'], value, "Can't update login_text setting with valid value #{value}"
   end
 
   test_attributes :pid => '7a56f194-8bde-4dbf-9993-62eb6ab10733'
   test "should update login page footer text with empty value" do
-    setting = Setting.find_by_name("login_text")
-    put :update, params: { :id => setting.id, :setting => { :value => "" } }
+    put :update, params: { :id => 'login_text', :setting => { :value => "" } }
     assert_equal JSON.parse(@response.body)['value'], "", "Can't update login_text setting with empty value"
   end
 
@@ -95,18 +93,18 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
 
   test "should update setting as system admin" do
     user = user_one_as_system_admin
-    setting_id = Setting.where(:settings_type => 'integer').first.id
+    setting = Setting.where(:settings_type => 'integer').first
     as_user user do
-      put :update, params: { :id => setting_id, :setting => { :value => "100" } }
+      put :update, params: { :id => setting.to_param, :setting => { :value => "100" } }
     end
     assert_response :success
   end
 
   test "should view setting as system admin" do
     user = user_one_as_system_admin
-    setting_id = Setting.first.id
+    setting = Setting.first
     as_user user do
-      get :show, params: { :id => setting_id }
+      get :show, params: { :id => setting.to_param }
     end
     assert_response :success
   end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -14,40 +14,68 @@ class SettingRegistryTest < ActiveSupport::TestCase
     registry.load_values
   end
 
-  context 'with nil default' do
-    let(:default) { nil }
+  describe 'the value getter' do
+    context 'with nil default' do
+      let(:default) { nil }
 
-    it 'allows nil default value' do
-      assert_nil registry['foo']
+      it 'allows nil default value' do
+        assert_nil registry['foo']
+      end
+    end
+
+    it 'provides default if no value defined' do
+      assert_equal 5, registry['foo']
+      assert_equal 5, registry[:foo]
+    end
+
+    it 'saves the value on assignment' do
+      registry[:foo] = 3
+      assert Setting.find_by(name: 'foo').persisted?
+      assert_equal 3, registry['foo']
+    end
+
+    it 'returns updated value only after it is saved' do
+      setting.value = 3
+      assert_equal 5, registry['foo']
+
+      setting.save
+      registry.load_values
+      assert_equal 3, setting.value
+      assert_equal 3, registry['foo']
+    end
+
+    context 'with value' do
+      let(:setting_value) { 10 }
+
+      it 'retrieves the value' do
+        assert_equal setting_value, registry['foo']
+      end
     end
   end
 
-  it 'provides default if no value defined' do
-    assert_equal 5, registry['foo']
-    assert_equal 5, registry[:foo]
-  end
+  describe '#set_user_value' do
+    setup do
+      registry._add('test',
+        category: 'Setting::General',
+        default: default,
+        type: :integer,
+        full_name: 'Test Foo',
+        description: 'test update',
+        context: :test)
+    end
 
-  it 'saves the value on assignment' do
-    registry[:foo] = 3
-    assert Setting.find_by(name: 'foo').persisted?
-    assert_equal 3, registry['foo']
-  end
+    it 'initiates the DB model if none exists yet' do
+      model = registry.set_user_value('test', '10')
+      assert_not_nil model
+      assert model.valid?
+      assert model.save
+      assert_equal 10, model.reload.value
+    end
 
-  it 'returns updated value only after it is saved' do
-    setting.value = 3
-    assert_equal 5, registry['foo']
-
-    setting.save
-    registry.load_values
-    assert_equal 3, setting.value
-    assert_equal 3, registry['foo']
-  end
-
-  context 'with value' do
-    let(:setting_value) { 10 }
-
-    it 'retrieves the value' do
-      assert_equal setting_value, registry['foo']
+    it 'updates the DB model if already exists' do
+      model = Setting.create(registry.find('test').attributes.merge(value: setting_value))
+      registry.set_user_value('test', '10').save
+      assert_equal 10, model.reload.value
     end
   end
 


### PR DESCRIPTION
Update and read the settings through SettingRegistry.
Adds a layer between controller and Model.
SettingRegistry is proxying the value parsing method to the model.

This lifts blocker for settings without DB record.

~~Blocked by #8438~~