### PR TITLE
refs #31240 - Revert lint changes from previous fix

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js
@@ -1,4 +1,5 @@
 /* eslint-disable camelcase */
+/* eslint-disable react-hooks/exhaustive-deps */
 
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
@@ -51,7 +52,7 @@ const OperatingSystem = ({
       handleOperatingSystem('');
       dispatch(operatingSystemTemplateAction(hostGroupOsId));
     }
-  }, [dispatch, handleOperatingSystem, hostGroupId, hostGroups]);
+  }, [dispatch, hostGroupId]);
 
   // Validate field
   useEffect(() => {
@@ -62,7 +63,7 @@ const OperatingSystem = ({
     if (Object.entries(operatingSystemTemplate).length !== 0) {
       handleInvalidField('Operating system', !!operatingSystemTemplate?.name);
     }
-  }, [handleInvalidField, operatingSystemId, operatingSystemTemplate]);
+  }, [operatingSystemId, operatingSystemTemplate]);
 
   return (
     <FormGroup


### PR DESCRIPTION
Changes in commit 4b36fac cause bug in registration form,
selecting host group with OS doesn't work anymore and
loading host_init_config template doesn't work too.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the pChanges in lint fix commit 4b36fac [0] cause bug 
in registration form - selecting host group with OS doesn't work anymore.

[0] https://github.com/theforeman/foreman/commit/4b36fac6692a5fbae38d647ecee0e3ee5d0a7c59urpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
