### PR TITLE
Fixes #32403 - Add validations to a setting DSL

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -328,7 +328,8 @@ module Foreman #:nodoc:
     #         default: true,
     #         description: N_('Use Puppet that goes to 11'),
     #         full_name: N_('Use shiny puppet'),
-    #         encrypt: true)
+    #         encrypted: true,
+    #         validate: /^cool/)
     #       end
     #     end
     #   end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1678,6 +1678,38 @@ The settings are strongly typed and you have to define it.
 The basic types supported by Foreman are: `:boolean`, `:integer`, `:float`, `:string`, `:text`, `:hash`, `:array`.
 The `:text` type supports markdown and usage of such setting should expect markdown syntax when using it.
 
+==== Validate setting values
+
+To validate setting value, you can use API, that tries to mimic the API of ActiveRecord.
+We can use most of the perks offered by ActiveRecord, only defining on setting name instead of attribute.
+We are adding just some shorthands like direct regexp validations.
+The attribute is always `value`, you can't validate anything else as it is the only user input.
+
+You have two ways to define the validations:
+* inline with setting definition by symbol matching ActiveRecord validator, RegExp on strings, or lambda function that gets value to validate as argument.
+* using `validates` of `validates_with` methods, that mimic [Rails validation methods](https://api.rubyonrails.org/classes/ActiveModel/Validations/ClassMethods.html), but are using setting names instead of attribute names, as the validated attribute is always value in this case.
+
+[source, ruby]
+....
+settings do
+  category(:cfgmgmt) do
+    # Following definitions are missing full names for simplification
+
+    setting(:blank_setting, type: :string,  default: '', description: 'Unnecessary setting')
+
+    setting(:cool_setting, type: :string, default: 'cool' description: 'Setting with only cool values', validate: /^cool.*/)
+
+    setting(:cooler_puppet, type: :integer, default: 5, description: 'Use Puppet that goes to 11', validate: ->(value) { value <= 11 })
+
+    validates(:cooler_puppet, numericality: { greater_than: 10 }, if: -> { Setting[:cool_setting] == 'coolest' }, allow_blank: true)
+
+    # the validator needs to be ActiveModel::Validator
+    validates_with :cool_setting, MyCoolnessValidator
+  end
+end
+....
+
+
 [[config-files]]
 ==== Config files
 

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class SettingTest < ActiveSupport::TestCase
   should validate_presence_of(:name)
-  should validate_presence_of(:default)
   should validate_uniqueness_of(:name)
   should validate_inclusion_of(:settings_type).in_array(Setting::TYPES)
 
@@ -228,11 +227,6 @@ class SettingTest < ActiveSupport::TestCase
   def test_should_autoselect_correct_type_for_boolean_value
     check_correct_type_for "boolean", true
     check_correct_type_for "boolean", false
-  end
-
-  # tests for default type constraints
-  test "arrays cannot be empty by default" do
-    check_setting_did_not_save_with :name => "foo", :value => [], :default => ["a", "b", "c"], :description => "test foo"
   end
 
   test "hashes can be empty by default" do

--- a/test/unit/setting_manager_test.rb
+++ b/test/unit/setting_manager_test.rb
@@ -83,4 +83,78 @@ class SettingManagerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe 'Validations' do
+    setup do
+      @validation_backup = Setting._validators[:value].dup
+    end
+
+    teardown do
+      Setting._validators[:value] = @validation_backup
+    end
+
+    it 'defines validation on Setting model for given setting name' do
+      Foreman::SettingManager.define(:test_context) do
+        category(:general) do
+          setting(:validfoo,
+            type: :string,
+            default: 'bar@example.com',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting',
+            validate: :email)
+        end
+      end
+      Foreman.settings.load_definitions
+      setting = Setting.new(name: 'validfoo', default: '-omited-', description: 'Omited', value: 'notanemail')
+      assert_not setting.valid?
+    end
+
+    it 'defines validation through validates' do
+      Foreman::SettingManager.define(:test_context) do
+        category(:general) do
+          setting(:validfoo,
+            type: :string,
+            default: 'bar@example.com',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting')
+          validates(:validfoo, email: true)
+        end
+      end
+      Foreman.settings.load_definitions
+      setting = Setting.new(name: 'validfoo', default: '-omited-', description: 'Omited', value: 'notanemail')
+      assert_not setting.valid?
+    end
+
+    it 'defines validation through RegExp' do
+      Foreman::SettingManager.define(:test_context) do
+        category(:general) do
+          setting(:validfoo2,
+            type: :string,
+            default: 'bar@include.com',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting',
+            validate: /.*@include.com/)
+        end
+      end
+      Foreman.settings.load_definitions
+      setting = Setting.new(name: 'validfoo2', default: '-omited-', description: 'Omited', value: 'bar@notvalid.com')
+      assert_not setting.valid?
+    end
+
+    it 'defines validation through Proc' do
+      Foreman::SettingManager.define(:test_context) do
+        category(:general) do
+          setting(:validfoo3,
+            type: :string,
+            default: 'bar@example.com',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting',
+            validate: ->(value) { !value.nil? && value.starts_with?('bar') })
+        end
+      end
+      Foreman.settings.load_definitions
+      setting = Setting.new(name: 'validfoo3', default: '-omited-', description: 'Omited', value: 'notvalid@example.com')
+      assert_not setting.valid?
+    end
+  end
 end


### PR DESCRIPTION
Add ability to define validation per Setting through DSL.
It tries to keep similar syntax to rails model validations.

~~Blocked by the DSL definition PR #8437~~