### PR TITLE
Refs #29507 - use /usr/share/foreman/tmp not /run/foreman

### DIFF
--- a/script/foreman-puma-status
+++ b/script/foreman-puma-status
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Intended for a production environment only
-puma-status /run/foreman/puma.state
+puma-status /usr/share/foreman/tmp/puma.state


### PR DESCRIPTION
/usr/share/foreman/tmp is a symlink to /run/foreman on EL, and
/var/cache/foreman on Debian

As we create the state file in {Rails.root}/tmp, let's also look for it in
{Rails.root}/tmp, and not something it might or might not link to.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
