### PR TITLE
Fixes #32427 - API should expose report origin

### DIFF
--- a/app/views/api/v2/config_reports/base.json.rabl
+++ b/app/views/api/v2/config_reports/base.json.rabl
@@ -1,3 +1,3 @@
 object @config_report
 
-attributes :id, :host_id, :host_name, :reported_at, :status
+attributes :id, :host_id, :host_name, :reported_at, :status, :origin


### PR DESCRIPTION
The UI shows icon with a tooltip identifying the configuration report
origin. API should also expose that information so people can tell from
the list of reports and the detail of the report, what subsystem this
report came from.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
