### PR TITLE
Fixes #32434 - Fix warn about oudated apipie cache

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -74,7 +74,9 @@ Apipie.configure do |config|
 end
 
 # check apipie cache in dev mode
-if Apipie.configuration.use_cache
+if Foreman.in_rake?('apipie:cache', 'apipie:cache:index')
+  # No need to check the cache if we're regenerating
+elsif Apipie.configuration.use_cache
   cache_name = File.join(Apipie.configuration.cache_dir, Apipie.configuration.doc_base_url + '.json')
   if File.exist?(cache_name)
     target = File.mtime(cache_name)
@@ -86,7 +88,7 @@ if Apipie.configuration.use_cache
         File.mtime(e) > target
       end
     end
-    if !$ARGV.nil? && $ARGV.first != "apipie:cache" && outdated
+    if outdated
       puts "API controllers newer than Apipie cache! Run apipie:cache rake task to regenerate cache."
     end
   else


### PR DESCRIPTION
When you run the rake task apipie:cache:index it prints a message that the cache is out of date:

    API controllers newer than Apipie cache! Run apipie:cache rake task to regenerate cache.

Since this is the command to actually generate that cache, the user shouldn't be bothered with it.

This approach uses `Foreman.in_rake?` to determine which task runs rather than parsing ARGV manually.