### PR TITLE
Fixes #32437 - fix webpack-dev-server h2 issue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@
 # If you wish to use a different server then the default, use e.g. `export RAILS_STARTUP='puma -w 3 -p 3000 --preload'`
 rails: [ -n "$RAILS_STARTUP" ] && env PRY_WARNING=1 $RAILS_STARTUP || [ -n "$BIND" ] && bin/rails server -b $BIND || env PRY_WARNING=1 bin/rails server
 # you can use WEBPACK_OPTS to customize webpack server, e.g. 'WEBPACK_OPTS='--https --key /path/to/key --cert /path/to/cert.pem --cacert /path/to/cacert.pem' foreman start '
-webpack: [ -n "$NODE_ENV" ] && ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS || env NODE_ENV=development ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS
+webpack: [ -n "$NODE_ENV" ] && ./node_modules/.bin/webpack-dev-server-without-h2 --config config/webpack.config.js $WEBPACK_OPTS || env NODE_ENV=development ./node_modules/.bin/webpack-dev-server-without-h2 --config config/webpack.config.js $WEBPACK_OPTS

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "url-loader": "^1.0.1",
     "webpack": "^3.4.1",
     "webpack-bundle-analyzer": ">=3.3.2",
-    "webpack-dev-server": "^2.5.1",
+    "webpack-dev-server-without-h2": "^2.11.8",
     "webpack-stats-plugin": "^0.1.5"
   }
 }

--- a/script/foreman-start-dev
+++ b/script/foreman-start-dev
@@ -1,3 +1,3 @@
 #!/bin/sh
-./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host "::" --disable-host-check $WEBPACK_OPTS &
+./node_modules/.bin/webpack-dev-server-without-h2 --config config/webpack.config.js --host "::" $WEBPACK_OPTS &
 ./bin/rails server -b \[::\] "$@"


### PR DESCRIPTION
The issue today is that our old `webpack-dev-server` doesn't support the h2 protocol for node > v10
there is a workaround that all devs have to do in order to make it work, at least in the forklift's environment,
which is to go into `node_modules/webpack-dev-server/lib/Server.js` after each `npm install` and remove the `h2` protocol from the default list - which is exactly what I did in https://github.com/laviro/webpack-dev-server-without-h2
though it will make all our devs happier I assume.

The better solution would be to upgrade `webpack` and `webpack-dev-server`,
though this can take a while... sorry for this hack, I prefer having a node module that does it for us, instead of changing an existing node_module almost every day.

@theforeman/ui-ux I would appreciate your help on this one, thanks!

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
