### PR TITLE
Fixes #32264 - Fix bug in vmware disk size field input

### DIFF
--- a/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
+++ b/webpack/assets/javascripts/react_app/components/hosts/storage/vmware/controller/disk/index.js
@@ -89,6 +89,7 @@ const Disk = ({
         value={sizeGb}
         minValue={1}
         format={v => `${v} GB`}
+        parser={str => str.replace(/\D/g, '')}
         className="text-vmware-size"
         onChange={newValues => updateDisk('sizeGb', newValues)}
         label={__('Size (GB)')}


### PR DESCRIPTION
The library that was used in NumericInput react component created a bug in the vmware disk size field input.
So I replaced it to the library that was used before.