### PR TITLE
Fixes #32372 - Correct path for logs in kickstart (CP 2.4)

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -62,7 +62,7 @@ reboot
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*pre*log /tmp/sysimage/root/
+cp -vf /tmp/*pre*log /mnt/sysimage/root/
 %end
 
 %post

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -329,7 +329,7 @@ touch /tmp/foreman_built
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*.pre.*.log /tmp/sysimage/root/
+cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 <%= section_end %>
 
 %post --log=/root/install.post.custom.log

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
@@ -26,7 +26,7 @@ reboot
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*pre*log /tmp/sysimage/root/
+cp -vf /tmp/*pre*log /mnt/sysimage/root/
 %end
 
 %post

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -171,7 +171,7 @@ touch /tmp/foreman_built
 
 # copy %pre log files into chroot
 %post --nochroot
-cp -vf /tmp/*.pre.*.log /tmp/sysimage/root/
+cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %end
 
 %post --log=/root/install.post.custom.log


### PR DESCRIPTION
bb4633b refactored the kickstart but
used an incorrect path for logs in the %pre section. This corrects it.

(cherry picked from commits ceb276f and 4a72045)