### PR TITLE
Fixes #32458 - Disable katello agent install by default when provisioning

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -82,13 +82,13 @@ snippet: true
 <% if registration_type == 'subscription_manager' %>
   <%
     atomic = @host.operatingsystem.respond_to?(:atomic) ? @host.operatingsystem.atomic? : host_param_true?('atomic')
+    redhat_install_agent = host_param_true?('redhat_install_agent', katello_agent_enabled?)
 
     if host_param('kt_activation_keys')
       subscription_manager_certpkg_url = subscription_manager_configuration_url(@host)
       subscription_manager_atomic_url = subscription_manager_configuration_url(@host, false)
       subscription_manager_org = @host.rhsm_organization_label
       activation_key = host_param('kt_activation_keys')
-      redhat_install_agent = host_param_true?('redhat_install_agent', true)
       redhat_install_host_tools = host_param_true?('redhat_install_host_tools', true)
       redhat_install_host_tracer_tools = host_param_true?('redhat_install_host_tracer_tools')
     else
@@ -96,7 +96,6 @@ snippet: true
       subscription_manager_atomic_url = host_param('subscription_manager_atomic_url')
       subscription_manager_org = host_param('subscription_manager_org')
       activation_key = host_param('activation_key')
-      redhat_install_agent = host_param_true?('redhat_install_agent')
       redhat_install_host_tools = host_param_true?('redhat_install_host_tools')
       redhat_install_host_tracer_tools = host_param_true?('redhat_install_host_tracer_tools')
     end


### PR DESCRIPTION
Requires https://github.com/Katello/katello/pull/9324

There might be a better way to do this than adding a macro that we'll end up removing in the relatively short term, so open to ideas there. But this does work - katello-agent will not be installed _unless_ it's been enabled in the Katello infrastructure to be consistent with current behavior (or if the host param is set to true of course).