### PR TITLE
Fixes #32465 - serial_console host parameter added

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -38,7 +38,7 @@ description: |
     options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
   end
   options << "locale=#{host_param('lang') || 'en_US'}"
-  
+
   # send PXELinux "IPAPPEND 2" option along
   options.push("BOOTIF=01-$net_default_mac")
 
@@ -48,6 +48,10 @@ description: |
     efi_suffix = 'efi'
   else
     efi_suffix = ''
+  end
+
+  if host_param_true?("serial_console")
+    options.push("console=#{host_param("serial_console_dev", "ttyS0")}")
   end
 -%>
 set default=0

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -39,6 +39,10 @@ description: |
   end
   options << "locale=#{host_param('lang') || 'en_US'}"
   options = options.join(' ')
+
+  if host_param_true?("serial_console")
+    options.push("console=#{host_param("serial_console_dev", "ttyS0")}")
+  end
 -%>
 DEFAULT linux
 LABEL linux

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -45,9 +45,9 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet 'freeipa_register' %>
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
-
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet 'remote_execution_ssh_keys' -%>
+<%= snippet 'serial_console' -%>
+<%= snippet "blacklist_kernel_modules" -%>
 
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -297,6 +297,8 @@ logger "Starting anaconda <%= @host %> postinstall"
 <%= snippet 'freeipa_register' %>
 <% end -%>
 
+<%= snippet('serial_console') -%>
+
 <% unless host_param_false?('package_upgrade') -%>
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -136,6 +136,10 @@ description: |
   elsif nic_delay
     options.push("nicdelay=#{nic_delay} linksleep=#{nic_delay}")
   end
+
+  if host_param_true?("serial_console")
+    options.push("console=#{host_param("serial_console_dev", "ttyS0")}")
+  end
 -%>
 <%# do not add newline after the next line %>
 <%= options.join(' ') -%>

--- a/app/views/unattended/provisioning_templates/snippet/serial_console.erb
+++ b/app/views/unattended/provisioning_templates/snippet/serial_console.erb
@@ -1,0 +1,33 @@
+<%#
+kind: snippet
+name: serial_console
+model: ProvisioningTemplate
+snippet: true
+-%>
+<%
+device = host_param("serial_console_dev", "ttyS0")
+if host_param_true?("serial_console")
+-%>
+# launch getty on serial console
+echo "Configuring getty on ttyS0"
+systemctl enable --now serial-getty@<%= device %>.service
+
+# configure kernel to send messages to serial console
+echo "Configuring linux kernel to serial console"
+sed -ie "s/GRUB_CMDLINE_LINUX=\"\(.*\)\"/GRUB_CMDLINE_LINUX=\"\1 console=<%= device %>\"/" /etc/default/grub
+
+# configure both input and output in grub to serial console
+echo "Configuring grub to serial console"
+if grep -q GRUB_TERMINAL= /etc/default/grub; then
+  if grep -q 'GRUB_TERMINAL=.*serial' /etc/default/grub; then
+    echo "Grub config already contains 'serial', skipped"
+  else
+    sed -ie "s/GRUB_TERMINAL=\"\(.*\)\"/GRUB_TERMINAL=\"\1 serial\"/" /etc/default/grub
+  fi
+else
+  echo "Configured grub to serial console"
+  echo 'GRUB_TERMINAL="console serial"' >> /etc/default/grub
+fi
+<%
+end
+-%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -2,10 +2,7 @@
 
 
 
-
-
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -2,10 +2,7 @@
 
 
 
-
-
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -85,6 +85,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -85,6 +85,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -85,6 +85,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -85,6 +85,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -85,6 +85,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then
   dnf -y update


### PR DESCRIPTION
To set serial console in grub, linux kernel and spawn getty.

Tested with CentOS, according to all docs this should work just fine under Debian too so I am adding it there too.

I did not care adding additional serial options like speed, parity and word width. These days serial consoles are mostly virtualized and it "just works" with the default values. The main goal is to allow convinient access for VMs.