### PR TITLE
Fixes #32438 - tmuxinator and common startup scripts

### DIFF
--- a/.tmuxinator.yml
+++ b/.tmuxinator.yml
@@ -1,0 +1,6 @@
+name: foreman
+windows:
+  - rails: bundle exec ./bin/start-rails
+  - rails-log: tail -F log/development.log
+  - rails-errors: tail -F log/development.log | grep '[EF]|'
+  - webpack: ./bin/start-webpack

--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,2 @@
-# Run Rails & Webpack concurrently
-# If you wish to use a different server then the default, use e.g. `export RAILS_STARTUP='puma -w 3 -p 3000 --preload'`
-rails: [ -n "$RAILS_STARTUP" ] && env PRY_WARNING=1 $RAILS_STARTUP || [ -n "$BIND" ] && bin/rails server -b $BIND || env PRY_WARNING=1 bin/rails server
-# you can use WEBPACK_OPTS to customize webpack server, e.g. 'WEBPACK_OPTS='--https --key /path/to/key --cert /path/to/cert.pem --cacert /path/to/cacert.pem' foreman start '
-webpack: [ -n "$NODE_ENV" ] && ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS || env NODE_ENV=development ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS
+rails: env PRY_WARNING=1 ./bin/start-rails
+webpack: ./bin/start-webpack

--- a/bin/create-env
+++ b/bin/create-env
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cat >.env <<EOF
+# Created with bin/create-env
+
+# The IP address to bind or '*' for all IPv4 or '::' for all IPv6
+#FOREMAN_BIND=::
+
+# Port to bind
+#FOREMAN_PORT=3000
+
+# Extra options for "rails server" command. To turn off Rails logging for
+# better debugging experience make sure to turn off console_inline option
+# in config/settings.yaml:
+# :logging:
+#   :type: file
+#   :console_inline: false
+#RAILS_OPTS=--no-log-to-stdout
+
+# Extra verbose debugging messages
+#FOREMAN_TRACE=1
+
+# NodeJS environment
+#NODE_ENV=development
+
+# Webpack statistics on stdout: none, minimal, errors-only, errors-warnings,
+# normal, verbose, detailed, summary
+#WEBPACK_STATS=minimal
+
+# Additional webpack startup options
+#WEBPACK_OPTS="--host :: --public $(hostname)"
+#WEBPACK_OPTS='--https --key /path/to/key --cert /path/to/cert.pem --cacert /path/to/cacert.pem' foreman start"
+EOF

--- a/bin/start-rails
+++ b/bin/start-rails
@@ -1,0 +1,9 @@
+#!/bin/bash
+[[ -e .env ]] || bin/create-env
+source .env
+
+if [[ -n "$RAILS_STARTUP" ]]; then
+  $RAILS_STARTUP
+else
+  bin/rails server -b ${FOREMAN_BIND:-::} -p ${FOREMAN_PORT:-3000} $RAILS_OPTS
+fi

--- a/bin/start-webpack
+++ b/bin/start-webpack
@@ -1,0 +1,6 @@
+#!/bin/bash
+[[ -e .env ]] || bin/create-env
+source .env
+
+[ -n "$NODE_ENV" ] && ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS || \
+env NODE_ENV=development ./node_modules/.bin/webpack-dev-server --config config/webpack.config.js $WEBPACK_OPTS

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -23,6 +23,7 @@ group :development do
   gem 'spring', '>= 1.0', '< 3'
   gem 'benchmark-ips', '>= 2.8.2'
   gem 'foreman'
+  gem 'tmuxinator'
   gem('bootsnap', :require => false)
   gem 'graphiql-rails', '~> 1.7'
 end

--- a/script/foreman-start-dev
+++ b/script/foreman-start-dev
@@ -1,3 +1,0 @@
-#!/bin/sh
-./node_modules/.bin/webpack-dev-server --config config/webpack.config.js --host "::" --disable-host-check $WEBPACK_OPTS &
-./bin/rails server -b \[::\] "$@"


### PR DESCRIPTION
This patch unifies starting The Foreman via both foreman gem and a shell script. We used to have two entrypoints: Procfile (foreman) and scripts/foreman-start-dev. This is now all replaced with two new very simple scripts start-rails and start-webpack. In Procfile we simply call these.

On top of that, it provides project configuration for tmuxinator gem, a tool to manage tmux sessions via YAML configuration. It is similar to my previous PR ("foreman-cmd") but using a specialized tool makes the patch and code we need to carry very low.

Therefore with this solution, people can choose if they want to keep using "foreman" gem or they want terminal multiplexer (which is REPL/debugger friendly). Also both Procfile and .tmuxinator.yaml are small and startup scripts are clean and the single space holding the startup logic. Optionally, configuration file can be created with custom things like different port etc.

See https://github.com/theforeman/foreman/pull/8476 and https://github.com/tmuxinator/tmuxinator