### PR TITLE
Fixes #32486 - Fedora 34 / RHEL 9 - Ignore Anaconda kernel boot parameters without 'inst.' prefix

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -20,7 +20,7 @@ timeout=<%= host_param('loader_timeout') || 10 %>
 
 title <%= template_name %>
   root (nd)
-  kernel (nd)/../<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  kernel (nd)/../<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
   initrd (nd)/../<%= @initrd %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -32,7 +32,7 @@ set default=<%= host_param('default_grub_install_entry') || 0 %>
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= linuxcmd %> <%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
   <%= initrdcmd %> <%= @initrd %>
 }
 
@@ -47,7 +47,7 @@ if subnet && subnet.httpboot
 -%>
 <% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
-  <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
   <%= initrdcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>
@@ -56,7 +56,7 @@ menuentry '<%= template_name %> EFI HTTP' --id efi_http {
 
 <% if proxy_https_port -%>
 menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
-  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
   <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -29,7 +29,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL <%= template_name %>
 KERNEL <%= @kernel %>
-APPEND initrd=<%= @initrd %> ks=<%= foreman_url('provision') %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+APPEND initrd=<%= @initrd %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
 <% if @host.architecture.to_s.match(/s390x?/i) %>
 INITRD <%= @initrd %>
 <% end %>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -29,7 +29,11 @@ snippet: true
 
   # tell Anaconda what to pass off to kickstart server
   # both current and legacy syntax provided
-  options.push("kssendmac", "ks.sendmac", "inst.ks.sendmac")
+  if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
+    options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+  else
+    options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")  
+  end
 
   # networking credentials
   raise("Dual-stack provisioning not supported") if subnet4 && subnet6

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4and6dhcp.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6dhcp.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ks=http://foreman.some.host.fqdn/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 


### PR DESCRIPTION
Fixes [#32486](https://projects.theforeman.org/issues/32486)

Summary: Fedora 34 & RHEL 9 have removed support for deprecated kernel install parameters.  This breaks install with default kickstart templates.
This pull request adds some If/Else logic to provide the expected presentation of the kernel parameters.

An additional item that needs thought/review should this PR be accepted is if it applies to other templates that I do not have experience with from my environment.