### PR TITLE
Fixes #30387 - Remove `view_bookmarks` permission

### DIFF
--- a/app/controllers/concerns/foreman/controller/bookmark_common.rb
+++ b/app/controllers/concerns/foreman/controller/bookmark_common.rb
@@ -1,9 +1,9 @@
 module Foreman::Controller::BookmarkCommon
   def resource_base
-    super.my_bookmarks
+    Bookmark.my_bookmarks
   end
 
   def resource_scope(*args)
-    super.my_bookmarks
+    Bookmark.my_bookmarks
   end
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -5,13 +5,19 @@ Foreman::AccessControl.map do |permission_set|
   permission_set.security_block :public do |map|
     map.permission :user_logout, { :users => [:logout] }, :public => true
     map.permission :view_current_user, { :"api/v2/users" => [:show_current] }, public: :true
-    map.permission :my_account, { :users => [:edit],
+    map.permission :my_account, {
+      :users => [:edit],
       :notification_recipients => [:index, :update, :destroy, :update_group_as_read, :destroy_group],
-      :"api/v2/table_preferences" => [:show, :create, :edit, :delete, :index]}, :public => true
+      :"api/v2/table_preferences" => [:show, :create, :edit, :delete, :index],
+    }, :public => true
     map.permission :api_status, { :"api/v2/home" => [:status]}, :public => true
     map.permission :about_index, { :about => [:index] }, :public => true
     map.permission :user_menu, { :user_menus => [:menu] }, :public => true
     map.permission :links, { :links => [:show] }, :public => true
+    map.permission :bookmarks, {
+      :bookmarks => [:index, :show, :auto_complete_search, :welcome],
+      :"api/v2/bookmarks" => [:index, :show],
+    }, :public => true
   end
 
   permission_set.security_block :architectures do |map|
@@ -52,9 +58,6 @@ Foreman::AccessControl.map do |permission_set|
   end
 
   permission_set.security_block :bookmarks do |map|
-    map.permission :view_bookmarks,
-      :bookmarks => [:index, :show, :auto_complete_search, :welcome],
-      :"api/v2/bookmarks" => [:index, :show]
     map.permission :create_bookmarks,
       :bookmarks => [:new, :create],
       :"api/v2/bookmarks" => [:new, :create]

--- a/db/migrate/20210502113529_drop_view_bookmarks_permission.rb
+++ b/db/migrate/20210502113529_drop_view_bookmarks_permission.rb
@@ -1,0 +1,11 @@
+class DropViewBookmarksPermission < ActiveRecord::Migration[6.0]
+  def up
+    Permission.where(name: 'view_bookmarks').destroy_all
+    # clean up any empty filters left behind
+    Filter.where.not(id: Filtering.distinct.select(:filter_id)).destroy_all
+  end
+
+  def down
+    # Will be recreated automatically by seeds
+  end
+end

--- a/db/seeds.d/020-permissions_list.rb
+++ b/db/seeds.d/020-permissions_list.rb
@@ -11,7 +11,6 @@ class PermissionsList
         ['AuthSource', 'create_authenticators'],
         ['AuthSource', 'edit_authenticators'],
         ['AuthSource', 'destroy_authenticators'],
-        ['Bookmark', 'view_bookmarks'],
         ['Bookmark', 'create_bookmarks'],
         ['Bookmark', 'edit_bookmarks'],
         ['Bookmark', 'destroy_bookmarks'],

--- a/db/seeds.d/020-roles_list.rb
+++ b/db/seeds.d/020-roles_list.rb
@@ -30,7 +30,7 @@ class RolesList
                                              :view_users, :edit_users, :view_realms, :view_mail_notifications,
                                              :view_params, :view_ssh_keys, :view_personal_access_tokens],
                             :description => 'Role granting mostly view permissions but also permissions required for managing hosts in the infrastructure. Users with this role can update puppet parameters, create and edit hosts, manage installation media, subnets, usergroups and edit existing users.' },
-        'Bookmarks manager' => { :permissions => [:view_bookmarks, :create_bookmarks, :edit_bookmarks, :destroy_bookmarks],
+        'Bookmarks manager' => { :permissions => [:create_bookmarks, :edit_bookmarks, :destroy_bookmarks],
                                  :description => 'Role granting permissions for managing search bookmarks. Usually useful in combination with Viewer role. This role also grants the permission to update all public bookmarks.' },
         'Auditor' => { :permissions => [:view_audit_logs],
                        :description => 'Role granting permission to view only the Audit log and nothing else.',
@@ -40,7 +40,7 @@ class RolesList
 
     def default_role
       {
-        'Default role' => { permissions: [:view_bookmarks, :view_tasks],
+        'Default role' => { permissions: [:view_tasks],
                             description: 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody',
         },
       }

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -39,11 +39,6 @@ destroy_authenticators:
   resource_type: AuthSource
   created_at: "2013-12-04 08:41:04.414794"
   updated_at: "2013-12-04 08:41:04.414794"
-view_bookmarks:
-  name: view_bookmarks
-  resource_type: Bookmark
-  created_at: "2013-12-04 08:41:04.423092"
-  updated_at: "2013-12-04 08:41:04.423092"
 create_bookmarks:
   name: create_bookmarks
   resource_type: Bookmark

--- a/test/graphql/mutations/bookmarks/delete_mutation_test.rb
+++ b/test/graphql/mutations/bookmarks/delete_mutation_test.rb
@@ -42,10 +42,10 @@ module Mutations
         end
       end
 
-      context 'with user with view permissions' do
+      context 'with user without permissions' do
         setup do
           bookmark
-          @user = setup_user 'view', 'bookmarks'
+          @user = FactoryBot.create(:user)
         end
 
         test 'cannot delete a bookmark' do


### PR DESCRIPTION
Users should always be able to see public bookmarks and their own
bookmarks, a permission is not needed for this case.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
