### PR TITLE
Fixes #32490 - Fixing the permission in the file /root/ansible_provisioning_call.sh

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -76,6 +76,7 @@ fi
 
 <% if host_param_true?('ansible_tower_provisioning') -%>
 <%= save_to_file('/root/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh
 <% end -%>
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart default PXEGrub.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart default PXEGrub.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../ ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+  kernel (nd)/../ ks=http://foreman.example.com/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
   initrd (nd)/../
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub global default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub global default.snap.txt
@@ -58,7 +58,7 @@ title Chainload into bootloader on first disk
 
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart default PXEGrub2.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart default PXEGrub2.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linuxefi  ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+  linuxefi  ks=http://foreman.example.com/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
   initrdefi 
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2 default local boot.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2 default local boot.snap.txt
@@ -140,7 +140,7 @@ menuentry 'Chainload into BIOS bootloader on second disk' --id local_chain_legac
   boot
 }
 
-common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac"
+common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac"
 
 if [ ${grub_platform} == "pc" ]; then
   menuentry 'Foreman Discovery Image' --id discovery {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2 global default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2 global default.snap.txt
@@ -156,7 +156,7 @@ menuentry 'Chainload into BIOS bootloader on second disk' --id local_chain_legac
   boot
 }
 
-common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac"
+common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac"
 
 if [ ${grub_platform} == "pc" ]; then
   menuentry 'Foreman Discovery Image' --id discovery {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed default PXEGrub2.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed default PXEGrub2.snap.txt
@@ -14,7 +14,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linux   interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshothost console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
+  linux   interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshothost console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
   initrd 
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/AutoYaST default PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/AutoYaST default PXELinux.snap.txt
@@ -4,4 +4,4 @@ DEFAULT linux
 
 LABEL linux
     KERNEL 
-    APPEND initrd= ramdisk_size=65536 install= autoyast=http://foreman.some.host.fqdn/unattended/provision textmode=1 
+    APPEND initrd= ramdisk_size=65536 install= autoyast=http://foreman.example.com/unattended/provision textmode=1 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/CoreOS PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/CoreOS PXELinux.snap.txt
@@ -3,4 +3,4 @@ DEFAULT coreos
 
 LABEL coreos
     KERNEL 
-    APPEND initrd= cloud-config-url=http://foreman.some.host.fqdn/unattended/provision
+    APPEND initrd= cloud-config-url=http://foreman.example.com/unattended/provision

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/FreeBSD (mfsBSD) PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/FreeBSD (mfsBSD) PXELinux.snap.txt
@@ -1,5 +1,5 @@
 
-# foreman_url=http://foreman.some.host.fqdn/unattended/provision
+# foreman_url=http://foreman.example.com/unattended/provision
 DEFAULT freebsd
 
 LABEL freebsd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart default PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart default PXELinux.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL 
-APPEND initrd= ks=http://foreman.some.host.fqdn/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
+APPEND initrd= ks=http://foreman.example.com/unattended/provision  BOOTIF=01-00-f0-54-1a-7e-e0 kssendmac ks.sendmac inst.ks.sendmac fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux chain iPXE.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux chain iPXE.snap.txt
@@ -3,5 +3,5 @@
 DEFAULT linux
 LABEL linux
 KERNEL ipxe.lkrn
-APPEND dhcp && chain http://foreman.some.host.fqdn/unattended/iPXE
+APPEND dhcp && chain http://foreman.example.com/unattended/iPXE
 IPAPPEND 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux global default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux global default.snap.txt
@@ -34,12 +34,12 @@ LABEL local_chain_hd1
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman
   IPAPPEND 2
 
 LABEL discovery_ipxe
   MENU LABEL Foreman Discovery Image - iPXE
   KERNEL ipxe.lkrn
-  APPEND dhcp && chain http://foreman.some.host.fqdn/pub/discovery.ipxe
+  APPEND dhcp && chain http://foreman.example.com/pub/discovery.ipxe
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed default PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed default PXELinux.snap.txt
@@ -15,7 +15,7 @@ DEFAULT linux
 
 LABEL linux
     KERNEL 
-    APPEND initrd= interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshothost console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
+    APPEND initrd= interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshothost console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/RancherOS PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/RancherOS PXELinux.snap.txt
@@ -2,5 +2,5 @@ DEFAULT rancheros
 
 LABEL rancheros
     KERNEL 
-    APPEND rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda] rancher.cloud_init.datasources=['url:http://foreman.some.host.fqdn/unattended/provision']
+    APPEND rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda] rancher.cloud_init.datasources=['url:http://foreman.example.com/unattended/provision']
     INITRD 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/XenServer default PXELinux.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/XenServer default PXELinux.snap.txt
@@ -2,5 +2,5 @@
 default xenserver
 label xenserver
 kernel mboot.c32
-append  dom0_max_vcpus=1-2 dom0_mem=752M,max:752M com1=115200,8n1 console=com1,vga ---  xencons=hvc console=hvc0 console=tty0 answerfile=http://foreman.some.host.fqdn/unattended/provision install --- 
+append  dom0_max_vcpus=1-2 dom0_mem=752M,max:752M com1=115200,8n1 console=com1,vga ---  xencons=hvc console=hvc0 console=tty0 answerfile=http://foreman.example.com/unattended/provision install --- 
 IPAPPEND 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/ZTP/Junos default ZTP config.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/ZTP/Junos default ZTP config.snap.txt
@@ -41,7 +41,7 @@ event-options {
         then {
             execute-commands {
                 commands {
-                    "op url http://foreman.some.host.fqdn/unattended/provision.slax";
+                    "op url http://foreman.example.com/unattended/provision.slax";
                 }
             }
         }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit default.snap.txt
@@ -95,6 +95,6 @@ runcmd:
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
   /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
 phone_home:
-  url: http://foreman.some.host.fqdn/unattended/built
+  url: http://foreman.example.com/unattended/built
   post: []
   tries: 10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator default finish.snap.txt
@@ -36,11 +36,11 @@ EOF
 /sbin/chkconfig puppetd on
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart default finish.snap.txt
@@ -103,6 +103,7 @@ echo "Calling Ansible AWX/Tower provisioning callback..."
 /usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
 echo "DONE"
 EOF
+chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed default finish.snap.txt
@@ -76,10 +76,10 @@ EOF
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer default finish.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer default finish.snap.txt
@@ -1,10 +1,10 @@
 #!/bin/bash
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE intermediate script.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE intermediate script.snap.txt
@@ -4,167 +4,167 @@
 :net0
 isset ${net0/mac} || goto no_nic
 dhcp net0 || goto net1
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net0/mac} || goto net1
+chain http://foreman.example.com/unattended/iPXE?mac=${net0/mac} || goto net1
 
 :net1
 isset ${net1/mac} || goto no_nic
 dhcp net1 || goto net2
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net1/mac} || goto net2
+chain http://foreman.example.com/unattended/iPXE?mac=${net1/mac} || goto net2
 
 :net2
 isset ${net2/mac} || goto no_nic
 dhcp net2 || goto net3
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net2/mac} || goto net3
+chain http://foreman.example.com/unattended/iPXE?mac=${net2/mac} || goto net3
 
 :net3
 isset ${net3/mac} || goto no_nic
 dhcp net3 || goto net4
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net3/mac} || goto net4
+chain http://foreman.example.com/unattended/iPXE?mac=${net3/mac} || goto net4
 
 :net4
 isset ${net4/mac} || goto no_nic
 dhcp net4 || goto net5
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net4/mac} || goto net5
+chain http://foreman.example.com/unattended/iPXE?mac=${net4/mac} || goto net5
 
 :net5
 isset ${net5/mac} || goto no_nic
 dhcp net5 || goto net6
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net5/mac} || goto net6
+chain http://foreman.example.com/unattended/iPXE?mac=${net5/mac} || goto net6
 
 :net6
 isset ${net6/mac} || goto no_nic
 dhcp net6 || goto net7
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net6/mac} || goto net7
+chain http://foreman.example.com/unattended/iPXE?mac=${net6/mac} || goto net7
 
 :net7
 isset ${net7/mac} || goto no_nic
 dhcp net7 || goto net8
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net7/mac} || goto net8
+chain http://foreman.example.com/unattended/iPXE?mac=${net7/mac} || goto net8
 
 :net8
 isset ${net8/mac} || goto no_nic
 dhcp net8 || goto net9
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net8/mac} || goto net9
+chain http://foreman.example.com/unattended/iPXE?mac=${net8/mac} || goto net9
 
 :net9
 isset ${net9/mac} || goto no_nic
 dhcp net9 || goto net10
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net9/mac} || goto net10
+chain http://foreman.example.com/unattended/iPXE?mac=${net9/mac} || goto net10
 
 :net10
 isset ${net10/mac} || goto no_nic
 dhcp net10 || goto net11
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net10/mac} || goto net11
+chain http://foreman.example.com/unattended/iPXE?mac=${net10/mac} || goto net11
 
 :net11
 isset ${net11/mac} || goto no_nic
 dhcp net11 || goto net12
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net11/mac} || goto net12
+chain http://foreman.example.com/unattended/iPXE?mac=${net11/mac} || goto net12
 
 :net12
 isset ${net12/mac} || goto no_nic
 dhcp net12 || goto net13
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net12/mac} || goto net13
+chain http://foreman.example.com/unattended/iPXE?mac=${net12/mac} || goto net13
 
 :net13
 isset ${net13/mac} || goto no_nic
 dhcp net13 || goto net14
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net13/mac} || goto net14
+chain http://foreman.example.com/unattended/iPXE?mac=${net13/mac} || goto net14
 
 :net14
 isset ${net14/mac} || goto no_nic
 dhcp net14 || goto net15
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net14/mac} || goto net15
+chain http://foreman.example.com/unattended/iPXE?mac=${net14/mac} || goto net15
 
 :net15
 isset ${net15/mac} || goto no_nic
 dhcp net15 || goto net16
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net15/mac} || goto net16
+chain http://foreman.example.com/unattended/iPXE?mac=${net15/mac} || goto net16
 
 :net16
 isset ${net16/mac} || goto no_nic
 dhcp net16 || goto net17
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net16/mac} || goto net17
+chain http://foreman.example.com/unattended/iPXE?mac=${net16/mac} || goto net17
 
 :net17
 isset ${net17/mac} || goto no_nic
 dhcp net17 || goto net18
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net17/mac} || goto net18
+chain http://foreman.example.com/unattended/iPXE?mac=${net17/mac} || goto net18
 
 :net18
 isset ${net18/mac} || goto no_nic
 dhcp net18 || goto net19
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net18/mac} || goto net19
+chain http://foreman.example.com/unattended/iPXE?mac=${net18/mac} || goto net19
 
 :net19
 isset ${net19/mac} || goto no_nic
 dhcp net19 || goto net20
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net19/mac} || goto net20
+chain http://foreman.example.com/unattended/iPXE?mac=${net19/mac} || goto net20
 
 :net20
 isset ${net20/mac} || goto no_nic
 dhcp net20 || goto net21
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net20/mac} || goto net21
+chain http://foreman.example.com/unattended/iPXE?mac=${net20/mac} || goto net21
 
 :net21
 isset ${net21/mac} || goto no_nic
 dhcp net21 || goto net22
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net21/mac} || goto net22
+chain http://foreman.example.com/unattended/iPXE?mac=${net21/mac} || goto net22
 
 :net22
 isset ${net22/mac} || goto no_nic
 dhcp net22 || goto net23
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net22/mac} || goto net23
+chain http://foreman.example.com/unattended/iPXE?mac=${net22/mac} || goto net23
 
 :net23
 isset ${net23/mac} || goto no_nic
 dhcp net23 || goto net24
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net23/mac} || goto net24
+chain http://foreman.example.com/unattended/iPXE?mac=${net23/mac} || goto net24
 
 :net24
 isset ${net24/mac} || goto no_nic
 dhcp net24 || goto net25
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net24/mac} || goto net25
+chain http://foreman.example.com/unattended/iPXE?mac=${net24/mac} || goto net25
 
 :net25
 isset ${net25/mac} || goto no_nic
 dhcp net25 || goto net26
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net25/mac} || goto net26
+chain http://foreman.example.com/unattended/iPXE?mac=${net25/mac} || goto net26
 
 :net26
 isset ${net26/mac} || goto no_nic
 dhcp net26 || goto net27
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net26/mac} || goto net27
+chain http://foreman.example.com/unattended/iPXE?mac=${net26/mac} || goto net27
 
 :net27
 isset ${net27/mac} || goto no_nic
 dhcp net27 || goto net28
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net27/mac} || goto net28
+chain http://foreman.example.com/unattended/iPXE?mac=${net27/mac} || goto net28
 
 :net28
 isset ${net28/mac} || goto no_nic
 dhcp net28 || goto net29
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net28/mac} || goto net29
+chain http://foreman.example.com/unattended/iPXE?mac=${net28/mac} || goto net29
 
 :net29
 isset ${net29/mac} || goto no_nic
 dhcp net29 || goto net30
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net29/mac} || goto net30
+chain http://foreman.example.com/unattended/iPXE?mac=${net29/mac} || goto net30
 
 :net30
 isset ${net30/mac} || goto no_nic
 dhcp net30 || goto net31
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net30/mac} || goto net31
+chain http://foreman.example.com/unattended/iPXE?mac=${net30/mac} || goto net31
 
 :net31
 isset ${net31/mac} || goto no_nic
 dhcp net31 || goto net32
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net31/mac} || goto net32
+chain http://foreman.example.com/unattended/iPXE?mac=${net31/mac} || goto net32
 
 :net32
 isset ${net32/mac} || goto no_nic
 dhcp net32 || goto net33
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net32/mac} || goto net33
+chain http://foreman.example.com/unattended/iPXE?mac=${net32/mac} || goto net33
 
 :net33
 goto no_nic

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Alterator default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Alterator default.snap.txt
@@ -15,5 +15,5 @@
 ("/net-eth" action "add_iface_address" name "eth0" addip "127.0.0.1" addmask "255.255.255.0")
 ("/net-eth" action "write" commit #t)
 ("/root/change_password" language (en_US") passwd_2 "123" passwd_1 "123")
-("/postinstall/firsttime" action "write" method "url" url "http://foreman.some.host.fqdn/unattended/finish")
+("/postinstall/firsttime" action "write" method "url" url "http://foreman.example.com/unattended/finish")
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic Kickstart default.snap.txt
@@ -80,20 +80,20 @@ touch /tmp/foreman_built
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST SLES default.snap.txt
@@ -139,11 +139,11 @@ export FACTER_is_installer=true
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 rm /etc/resolv.conf

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST default.snap.txt
@@ -141,11 +141,11 @@ export FACTER_is_installer=true
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 rm /etc/resolv.conf

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/CoreOS provision.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/CoreOS provision.snap.txt
@@ -16,7 +16,7 @@ coreos:
           -V 7 \
           -d /dev/sda  \
           -c /home/core/cloud-config.yml 
-        ExecStartPost=/usr/bin/wget -q -O /dev/null --no-check-certificate http://foreman.some.host.fqdn/unattended/built
+        ExecStartPost=/usr/bin/wget -q -O /dev/null --no-check-certificate http://foreman.example.com/unattended/built
         ExecStartPost=/usr/sbin/reboot
         [X-Fleet]
         X-Conflicts=coreos-bootstrap.service

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/FreeBSD (mfsBSD) provision.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/FreeBSD (mfsBSD) provision.snap.txt
@@ -11,10 +11,10 @@ test -z "$first_disk" || echo "First disk: $first_disk"
 
 cp /etc/resolv.conf /mnt/etc/resolv.conf
 mount -t devfs devfs /mnt/dev
-fetch -q --no-verify-hostname --no-verify-peer -o /mnt/tmp/finish.sh -d http://foreman.some.host.fqdn/unattended/finish
+fetch -q --no-verify-hostname --no-verify-peer -o /mnt/tmp/finish.sh -d http://foreman.example.com/unattended/finish
 chroot /mnt /bin/sh /tmp/finish.sh
 rm /mnt/tmp/finish.sh
 
-fetch -q --no-verify-hostname --no-verify-peer -o /dev/null -d http://foreman.some.host.fqdn/unattended/built
+fetch -q --no-verify-hostname --no-verify-peer -o /dev/null -d http://foreman.example.com/unattended/built
 sleep 5
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Junos default SLAX.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Junos default SLAX.snap.txt
@@ -175,10 +175,10 @@ match / {
 <func:function name="fmztp:dl_junos_conf">
 {
   expr jcs:syslog( $SYSLOG, $APPNAME, ": downloading new Junos conf...");
-  expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", 'http://foreman.some.host.fqdn/unattended/finish');
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", 'http://foreman.example.com/unattended/finish');
 
   var $get = <file-copy> {
-    <source> 'http://foreman.some.host.fqdn/unattended/finish';
+    <source> 'http://foreman.example.com/unattended/finish';
     <destination> $JUNOS_CONF;
     <staging-directory> $TMPDIR;
   };
@@ -397,7 +397,7 @@ match / {
 
   expr jcs:syslog( $SYSLOG, $APPNAME, ": sending finish signal to foreman...");  
   var $do_foreman = <file-copy> {
-      <source> 'http://foreman.some.host.fqdn/unattended/provision';
+      <source> 'http://foreman.example.com/unattended/provision';
       <destination> "/tmp";
       <staging-directory> "/tmp";
   };

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart default.snap.txt
@@ -183,20 +183,20 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed default.snap.txt
@@ -68,4 +68,4 @@ d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 
-d-i preseed/late_command string wget -Y off http://foreman.some.host.fqdn/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer default answerfile.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer default answerfile.snap.txt
@@ -10,6 +10,6 @@ zerombr\nclearpart --all    --initlabel\npart /boot --fstype ext3 --size=100 --a
   <timezone>UTC</timezone>
   <time-config-method>ntp</time-config-method>
   <script stage="installation-complete" type="url">
-    http://foreman.some.host.fqdn/unattended/finish
+    http://foreman.example.com/unattended/finish
   </script>
 </installation>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_discovery.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_discovery.snap.txt
@@ -1,4 +1,4 @@
-common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac"
+common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac"
 
 if [ ${grub_platform} == "pc" ]; then
   menuentry 'Foreman Discovery Image' --id discovery {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub_discovery.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub_discovery.snap.txt
@@ -1,4 +1,4 @@
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxelinux_discovery.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxelinux_discovery.snap.txt
@@ -1,10 +1,10 @@
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman
   IPAPPEND 2
 
 LABEL discovery_ipxe
   MENU LABEL Foreman Discovery Image - iPXE
   KERNEL ipxe.lkrn
-  APPEND dhcp && chain http://foreman.some.host.fqdn/pub/discovery.ipxe
+  APPEND dhcp && chain http://foreman.example.com/pub/discovery.ipxe

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST default user data.snap.txt
@@ -74,10 +74,10 @@ export FACTER_is_installer=true
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart default user data.snap.txt
@@ -116,10 +116,10 @@ EOF
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed default user data.snap.txt
@@ -78,10 +78,10 @@ export FACTER_is_installer=true
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData default.snap.txt
@@ -72,7 +72,7 @@ runcmd:
 
 
 phone_home:
-  url: http://foreman.some.host.fqdn/unattended/built
+  url: http://foreman.example.com/unattended/built
   post: []
   tries: 10
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Fixing the permission in the file /root/ansible_provisioning_call.sh. This file created when the customer used the image based and has the ansible tower callback.
