### PR TITLE
Fixes #32919 - Add Salt Autosign grain to minion configuration

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/saltstack_minion.erb
+++ b/app/views/unattended/provisioning_templates/snippet/saltstack_minion.erb
@@ -11,6 +11,9 @@ description: |
 master: <%= host_param('salt_master') %>
 log_level: warning
 
+autosign_grains:
+  - autosign_key
+
 <%#
 # Grains (http://docs.saltstack.com/en/latest/topics/targeting/grains.html#grains-in-the-minion-config)
 #
@@ -19,5 +22,9 @@ log_level: warning
 # * {'cluster': 'alpha'}
 # * {'roles': ['webserver', 'frontend']}
 #
-%>
-grains: <%= host_param('salt_grains') ? host_param('salt_grains') : '{}' %>
+-%>
+<% if plugin_present?('foreman_salt') -%>
+grains: <%= to_json(@host.derive_salt_grains(use_autosign: true)) %>
+<% else -%>
+grains: <%= host_param('salt_grains') ? to_json(host_param('salt_grains')) : '{}' %>
+<% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_minion.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_minion.host4dhcp.snap.txt
@@ -1,5 +1,7 @@
 master: 
 log_level: warning
 
+autosign_grains:
+  - autosign_key
 
 grains: {}

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_setup.host4dhcp.snap.txt
@@ -10,6 +10,8 @@ cat > /etc/salt/minion.d/minion.conf << EOF
 master: 
 log_level: warning
 
+autosign_grains:
+  - autosign_key
 
 grains: {}
 


### PR DESCRIPTION
This PR changes the Salt Provisioning Template to enable a new authentication procedure. It relates to the corresponding [Foreman Salt PR](https://github.com/theforeman/foreman_salt/pull/136) and [Smart Proxy Salt PR](https://github.com/theforeman/smart_proxy_salt/pull/58). Both PRs are necessary for this PR.
* Use host function .derive_salt_grains to get host_params['salt_grains'] and autosign key


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
