### PR TITLE
Fixes #32499 - Webpack DEV server minimal logs

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -231,7 +231,8 @@ module.exports = env => {
       host: devServer.host,
       port: devServer.port,
       headers: { 'Access-Control-Allow-Origin': '*' },
-      hot: true
+      hot: true,
+      stats: (process.env.WEBPACK_STATS || 'minimal'),
     };
     // Source maps
     config.devtool = 'inline-source-map';

--- a/webpack/stories/docs/getting-started.stories.mdx
+++ b/webpack/stories/docs/getting-started.stories.mdx
@@ -69,6 +69,11 @@ Following steps are required to setup a webpack development environment:
    NOTIFICATIONS_POLLING=${polling_interval_in_ms}
    ```
 
+   Webpack stats ([docs](https://webpack.js.org/configuration/stats/)) can be changed by `WEBPACK_STATS`. Default value is `minimal`.
+   ```bash
+   WEBPACK_STATS=${verbose}
+   ```
+
 ## Directory structure
 
 The webpack processed code is placed in the following folder structure:


### PR DESCRIPTION
Reduce log pollution of Webpack DEV server by logging
only compilation status, warnings and errors.

This is useful for users with many plugins where the Webpack log can be pretty huge and early compilation errors are quickly lost in useless information about the all compiled components.
 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
