### PR TITLE
Fixes #32398 - Make tabs on Host Detail page routable

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -599,7 +599,7 @@ Foreman::Application.routes.draw do
 
   match 'host_wizard' => 'react#index', :via => :get
   constraints(id: /[^\/]+/) do
-    match 'experimental/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
+    match 'experimental/hosts/:id(/*path)' => 'react#index', :via => :get, :as => :host_details_page
   end
   get 'links/:type(/:section)' => 'links#show', :as => 'external_link', :constraints => { section: %r{.*} }
 end

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import {
   Grid,
@@ -30,12 +30,12 @@ import ActionsBar from './ActionsBar';
 import Slot from '../common/Slot';
 import { registerCoreTabs } from './Tabs';
 import { translate as __ } from '../../common/I18n';
+import { handleTabClick } from './routedTabsHelper';
 
 import './HostDetails.scss';
 
-const HostDetails = ({ match, location: { hash } }) => {
+const HostDetails = ({ match, location: { hash }, history }) => {
   const dispatch = useDispatch();
-  const [activeTab, setActiveTab] = useState('Overview');
   const response = useSelector(state =>
     selectAPIResponse(state, 'HOST_DETAILS')
   );
@@ -54,9 +54,12 @@ const HostDetails = ({ match, location: { hash } }) => {
     registerCoreTabs();
   }, []);
 
-  useEffect(() => {
-    if (hash) setActiveTab(hash.slice(1));
-  }, [hash]);
+  const capitalize = tabName =>
+    `${tabName[0].toUpperCase()}${tabName.slice(1)}`;
+
+  const activeTab = match.params.tab
+    ? capitalize(match.params.tab)
+    : 'Overview';
 
   useEffect(() => {
     dispatch(
@@ -73,10 +76,6 @@ const HostDetails = ({ match, location: { hash } }) => {
     document.body.classList.add('pf-gray-background');
     return () => document.body.classList.remove('pf-gray-background');
   }, []);
-
-  const handleTabClick = (event, tabIndex) => {
-    setActiveTab(tabIndex);
-  };
 
   return (
     <>
@@ -137,7 +136,7 @@ const HostDetails = ({ match, location: { hash } }) => {
             width: window.innerWidth - (isNavCollapsed ? 95 : 220),
           }}
           activeKey={activeTab}
-          onSelect={handleTabClick}
+          onSelect={handleTabClick(history, match, ':tab?')}
         >
           {tabs &&
             tabs.map(tab => (
@@ -145,6 +144,8 @@ const HostDetails = ({ match, location: { hash } }) => {
                 <Slot
                   response={response}
                   status={status}
+                  history={history}
+                  match={match}
                   id="host-details-page-tabs"
                   fillID={tab}
                 />
@@ -157,14 +158,11 @@ const HostDetails = ({ match, location: { hash } }) => {
 };
 
 HostDetails.propTypes = {
-  match: PropTypes.shape({
-    params: PropTypes.shape({
-      id: PropTypes.string,
-    }),
-  }).isRequired,
+  match: PropTypes.object.isRequired,
   location: PropTypes.shape({
     hash: PropTypes.string,
   }).isRequired,
+  history: PropTypes.object.isRequired,
 };
 
 export default HostDetails;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/routedTabsHelper.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/routedTabsHelper.js
@@ -1,0 +1,19 @@
+// react-router uses path-to-regexp, should we use it as well?
+// https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#compile-reverse-path-to-regexp
+const resolvePath = (path, params) =>
+  Object.entries(params).reduce(
+    (memo, [key, value]) => memo.replace(key, value || ''),
+    path
+  );
+
+export const handleTabClick = (history, match, toReplace) => (event, value) => {
+  const replaceHash = { [toReplace]: value.toLowerCase() };
+  history.push(
+    resolvePath(match.path, {
+      ':id': match.params.id,
+      ':tab?': match.params.tab,
+      ':subtab?': match.params.subtab,
+      ...replaceHash,
+    })
+  );
+};

--- a/webpack/assets/javascripts/react_app/routes/HostDetails/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/HostDetails/constants.js
@@ -1,1 +1,1 @@
-export const HOST_DETAILS_PATH = '/experimental/hosts/:id';
+export const HOST_DETAILS_PATH = '/experimental/hosts/:id/:tab?/:subtab?';

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
@@ -20,8 +20,8 @@ exports[`Routes rendering routes with children renders routes with chidlren 1`] 
       render={[Function]}
     />
     <Route
-      key="/experimental/hosts/:id"
-      path="/experimental/hosts/:id"
+      key="/experimental/hosts/:id/:tab?/:subtab?"
+      path="/experimental/hosts/:id/:tab?/:subtab?"
       render={[Function]}
     />
     <Route


### PR DESCRIPTION
Default route shows overview:
![tabs-default](https://user-images.githubusercontent.com/2664090/116997423-11202000-acdd-11eb-94d2-a2451633723d.png)

There is an explicit path for overiview as well:
![tabs-overview](https://user-images.githubusercontent.com/2664090/116997480-21d09600-acdd-11eb-9449-2b389c3431bc.png)

And routes pointing to other tabs as well:
![tabs-plugin](https://user-images.githubusercontent.com/2664090/116997609-4e84ad80-acdd-11eb-8f2a-5bf5a0702b81.png)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
