### PR TITLE
Fixes #32389 - Quote taxonomies in search query (CP 2.5)

### DIFF
--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -75,8 +75,8 @@ module HostDescriptionHelper
     fields << { :field => [_("PXE Loader"), host.pxe_loader], :priority => 900 } if host.operatingsystem.present? && !host.image_build?
     fields << { :field => [_("Host group"), link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))], :priority => 1000 } if host.hostgroup.present?
     fields << { :field => [_("Boot time"), (boot_time = host&.reported_data&.boot_time) ? date_time_relative(boot_time) : _('Not reported')], :priority => 1100 }
-    fields << { :field => [_("Location"), link_to(host.location.title, hosts_path(:search => "location = #{host.location}"))], :priority => 1200 } if host.location.present?
-    fields << { :field => [_("Organization"), link_to(host.organization.title, hosts_path(:search => "organization = #{host.organization}"))], :priority => 1300 } if host.organization.present?
+    fields << { :field => [_("Location"), link_to(host.location.title, hosts_path(:search => "location = \"#{host.location}\""))], :priority => 1200 } if host.location.present?
+    fields << { :field => [_("Organization"), link_to(host.organization.title, hosts_path(:search => "organization = \"#{host.organization}\""))], :priority => 1300 } if host.organization.present?
     if host.owner_type == "User"
       fields << { :field => [_("Owner"), (link_to(host.owner, hosts_path(:search => %{user.login = "#{host.owner.login}"})) if host.owner)], :priority => 1400 }
     else


### PR DESCRIPTION
Fixes bug introduced by 377ff66, where we forgot to quote search query strings in links on host details page.

(cherry picked from commit 7fabf78d0f55738ca4a817e0ecaba1189a68fa05)