### PR TITLE
Fixes #32295 - Fix Puppet service for Debian provisioning (CP 2.4)

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -152,7 +152,11 @@ export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
 <%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : '--tags no_such_tag' %> <%= @host.puppetmaster.blank? ? '' : "--server #{@host.puppetmaster}" %> --no-daemonize
 <% if os_family == 'Suse' || (os_name == 'Debian' && os_major > 8) || (os_name == 'Ubuntu' && os_major >= 15) -%>
+<% if os_family == 'Suse'  -%>
 <%= bin_path %>/puppet resource service puppet enable=true
+<% else -%>
+systemctl enable puppet
+<% end -%>
 <% end -%>
 <% if @host.provision_method == 'image' -%>
 <%= bin_path %>/puppet resource service puppet ensure=running


### PR DESCRIPTION
This is a workaround for a Puppet bug where the provider is incorrect
and the service ends up not being enabled.
https://tickets.puppetlabs.com/browse/PUP-10963

(cherry picked from commit 4c47e3dfb88ac68c778d2089874df61eb46d7dc2)