### PR TITLE
Fix #32517 - Moving rhsm parser and importer to core

### DIFF
--- a/app/models/fact_names/katello/rhsm_fact_name.rb
+++ b/app/models/fact_names/katello/rhsm_fact_name.rb
@@ -1,0 +1,17 @@
+module Katello
+  class RhsmFactName < ::FactName
+    FACT_TYPE = :rhsm
+
+    def set_name
+      self.short_name = name.split(SEPARATOR).last
+    end
+
+    def origin
+      'RHSM'
+    end
+
+    def icon_path
+      "icons16x16/redhat.png"
+    end
+  end
+end

--- a/app/services/katello/rhsm_fact_importer.rb
+++ b/app/services/katello/rhsm_fact_importer.rb
@@ -1,0 +1,20 @@
+module Katello
+  class RhsmFactImporter < ::StructuredFactImporter
+    def fact_name_class
+      Katello::RhsmFactName
+    end
+
+    def normalize(facts)
+      facts = change_separator(facts)
+      super(facts)
+    end
+
+    def change_separator(facts)
+      to_ret = {}
+      facts.each do |key, value|
+        to_ret[key.split('.').join(RhsmFactName::SEPARATOR)] = value
+      end
+      to_ret
+    end
+  end
+end

--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -1,0 +1,151 @@
+module Katello
+  REDHAT_ATOMIC_HOST_DISTRO_NAME = "Red Hat Enterprise Linux Atomic Host".freeze
+  REDHAT_ATOMIC_HOST_OS = "RedHat_Enterprise_Linux_Atomic_Host".freeze
+
+  class RhsmFactParser < ::FactParser
+    def architecture
+      name = facts['lscpu.architecture'] || facts['uname.machine']
+      name = "x86_64" if name == "amd64"
+      name = "i386" if name == "i686"
+      Architecture.where(:name => name).first_or_create if name.present?
+    end
+
+    def model
+      if facts['virt::is_guest'] == "true"
+        name = facts['lscpu.hypervisor_vendor']
+      else
+        name = facts['dmi.system.product_name']
+      end
+      ::Model.where(:name => name.strip).first_or_create if name.present?
+    end
+
+    def support_interfaces_parsing?
+      true
+    end
+
+    def get_facts_for_interface(interface)
+      {
+        'link' => true,
+        'macaddress' => get_rhsm_mac(interface),
+        'ipaddress' => get_rhsm_ip(interface),
+      }
+    end
+
+    def interfaces
+      virtual_interface_regexp = /\A([^.]*?)\.(\d+)\z/
+      super.tap do |interfaces|
+        interfaces.each do |name, attributes|
+          attributes[:virtual] = true if name =~ virtual_interface_regexp
+        end
+      end
+    end
+
+    def get_interfaces
+      mac_keys = facts.keys.select { |f| f =~ /net\.interface\..*\.mac_address/ }
+      names = mac_keys.map do |key|
+        key.sub('net.interface.', '').sub('.mac_address', '') if facts[key] != 'none'
+      end
+      names.compact
+    end
+
+    def operatingsystem
+      name = facts['distribution.name']
+      version = facts['distribution.version']
+      return nil if name.nil? || version.nil?
+
+      os_name = distribution_to_puppet_os(name)
+      major, minor = version.split('.')
+      unless facts['ignore_os']
+        os_attributes = {:major => major, :minor => minor || '', :name => os_name}
+
+        release_name = os_release_name(os_name)
+        if release_name
+          os_attributes[:release_name] = release_name
+        end
+
+        if facts['distribution.name'] == 'Red Hat Enterprise Linux Workstation'
+          os_attributes[:name] = os_name + '_Workstation'
+        end
+
+        ::Operatingsystem.find_by(os_attributes) || ::Operatingsystem.create!(os_attributes)
+      end
+    end
+
+    def os_release_name(os_name)
+      if os_name&.match(::Operatingsystem::FAMILIES['Debian'])
+        facts['distribution.id']&.split&.first&.downcase
+      end
+    end
+
+    # required to be defined, even if they return nil
+    def domain
+    end
+
+    def environment
+    end
+
+    def ipmi_interface
+    end
+
+    def boot_timestamp
+      facts['proc_stat.btime']&.to_i
+    end
+
+    def virtual
+      facts['virt.is_guest']
+    end
+
+    def ram
+      facts['memory.memtotal'].to_i / 1024 if facts['memory.memtotal']
+    end
+
+    def sockets
+      facts['cpu.cpu_socket(s)']
+    end
+
+    def cores
+      facts['cpu.core(s)_per_socket']
+    end
+
+    private
+
+    def get_rhsm_ip(interface)
+      ip = facts["net.interface.#{interface}.ipv4_address"]
+      Net::Validations.validate_ip(ip) ? ip : nil
+    end
+
+    def get_rhsm_mac(interface)
+      # if secondary then permanent_mac_address contains the physical mac
+      facts["net.interface.#{interface}.permanent_mac_address"] || facts["net.interface.#{interface}.mac_address"]
+    end
+
+    def distribution_to_puppet_os(name)
+      return REDHAT_ATOMIC_HOST_OS if name == REDHAT_ATOMIC_HOST_DISTRO_NAME
+
+      name = name.downcase
+      if name =~ /red\s*hat/
+        'RedHat'
+      elsif name =~ /centos/
+        'CentOS'
+      elsif name =~ /fedora/
+        'Fedora'
+      elsif name =~ /sles/ || name =~ /suse.*enterprise.*/
+        'SLES'
+      elsif name =~ /debian/
+        'Debian'
+      elsif name =~ /ubuntu/
+        'Ubuntu'
+      elsif name =~ /oracle/
+        'OracleLinux'
+      elsif name =~ /almalinux/
+        'AlmaLinux'
+      elsif name =~ /rocky/
+        'Rocky'
+      elsif name =~ /amazon/
+        'Amazon'
+      else
+        'Unknown'
+      end
+    end
+  end
+end

--- a/config/initializers/z_plugin_parsers.rb
+++ b/config/initializers/z_plugin_parsers.rb
@@ -11,3 +11,7 @@ end
 # Ansible
 Foreman::Plugin.fact_importer_registry.register(:ansible, ForemanAnsible::StructuredFactImporter, false)
 ParserRegistrator.register_fact_parser(:ansible, AnsibleFactParser)
+
+# Katello
+::Foreman::Plugin.fact_importer_registry.register(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactImporter)
+ParserRegistrator.register_fact_parser(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactParser)

--- a/test/unit/katello/rhsm_fact_importer_test.rb
+++ b/test/unit/katello/rhsm_fact_importer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+module Katello
+  class RhsmFactImporterTest < ActiveSupport::TestCase
+    def setup
+      @separator = RhsmFactName::SEPARATOR
+      @facts = {
+        'interesting.key' => 'value_one',
+        'another.interesting.key' => 'value_two',
+        'just_key' => 'nothing',
+      }
+      @host = Host::Managed.new(name: "my.great.host", managed: false)
+    end
+
+    def test_importer_separator_change
+      importer = Katello::RhsmFactImporter.new(@host)
+      new_facts = importer.change_separator(@facts)
+
+      assert_equal new_facts['interesting::key'], 'value_one'
+      assert_equal new_facts['another::interesting::key'], 'value_two'
+      assert_equal new_facts['just_key'], 'nothing'
+    end
+  end
+end

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -1,0 +1,181 @@
+require 'test_helper'
+
+module Katello
+  class RhsmFactParserTest < ActiveSupport::TestCase
+    def setup
+      @facts = {
+        'net.interface.bond0.mac_address' => '52:54:00:6D:40:72',
+        'net.interface.eth0.mac_address' => '00:00:00:00:00:12',
+        'net.interface.eth0.ipv4_address' => '192.168.0.1',
+        'net.interface.eth0.1.mac_address' => '00:00:00:00:00:12',
+        'net.interface.eth0.1.ipv4_address' => '192.168.0.2',
+        'net.interface.eth1.permanent_mac_address' => '52:54:00:6D:40:72',
+        'net.interface.ethnone.mac_address' => 'none',
+        'net.interface.eth2.mac_address' => '00:00:00:00:00:13',
+        'net.interface.eth2.permanent_mac_address' => '52:54:00:D8:27:F7',
+        'net.interface.eth3.ipv4_address' => 'Unknown',
+        'net.interface.eth3.mac_address' => '00:00:00:00:00:14',
+      }
+    end
+    let(:parser) { RhsmFactParser.new(@facts) }
+
+    def test_virtual_interfaces
+      assert parser.interfaces['eth0.1'][:virtual]
+      refute parser.interfaces['eth0'][:virtual]
+    end
+
+    def test_get_interfaces
+      interfaces = parser.get_interfaces
+      assert_includes interfaces, 'eth0'
+      refute_includes interfaces, 'ethnone'
+      assert_includes interfaces, 'eth2'
+    end
+
+    def test_get_facts_for_interface_with_ip
+      expected_eth0 = {
+        'link' => true,
+        'macaddress' => @facts['net.interface.eth0.mac_address'],
+        'ipaddress' => @facts['net.interface.eth0.ipv4_address'],
+      }
+      assert_equal expected_eth0, parser.get_facts_for_interface('eth0')
+    end
+
+    def test_get_facts_for_interface_without_ip
+      expected_eth2 = {
+        'link' => true,
+        'macaddress' => @facts['net.interface.eth2.permanent_mac_address'],
+        'ipaddress' => nil,
+      }
+      assert_equal expected_eth2, parser.get_facts_for_interface('eth2')
+    end
+
+    def test_get_facts_for_bonded_interface
+      # if an interface is part of a bond, it should report the physical mac and not the bond's mac
+      expected_mac_address = @facts['net.interface.eth2.permanent_mac_address']
+      actual_mac_address = parser.get_facts_for_interface('eth2')['macaddress']
+
+      assert_equal actual_mac_address, expected_mac_address
+      assert_not_equal actual_mac_address, @facts['net.interface.eth2.mac_address']
+    end
+
+    def test_get_facts_for_interface_with_invalid_ip
+      assert_equal @facts['net.interface.eth3.mac_address'], parser.get_facts_for_interface('eth3')['macaddress']
+      assert_empty parser.get_facts_for_interface('eth3')['ipaddress']
+    end
+
+    def test_valid_centos_os
+      @facts['distribution.name'] = 'CentOS'
+      @facts['distribution.version'] = '7.2'
+
+      assert parser.operatingsystem.is_a?(::Operatingsystem)
+    end
+
+    def test_invalid_centos_os
+      @facts['ignore_os'] = true
+      @facts['distribution.name'] = 'CentOS'
+      @facts['distribution.version'] = '7'
+
+      refute parser.operatingsystem
+    end
+
+    def test_operatingsystem_oel
+      @facts['distribution.name'] = 'Oracle Linux Server'
+      @facts['distribution.version'] = '7.7'
+      @facts['distribution.id'] = '7.7'
+
+      os = parser.operatingsystem
+
+      assert_equal os.name, 'OracleLinux'
+      assert_equal os.title, 'OracleLinux 7.7'
+      assert_nil os.release_name
+    end
+
+    def test_operatingsystem_rockylinux
+      @facts['distribution.name'] = 'Rocky Linux'
+      @facts['distribution.version'] = '8.3'
+
+      assert_equal parser.operatingsystem.name, 'Rocky'
+      assert_equal parser.operatingsystem.major, '8'
+      assert_equal parser.operatingsystem.minor, '3'
+    end
+
+    def test_operatingsystem_debian
+      @facts['distribution.name'] = 'Debian GNU/Linux'
+      @facts['distribution.version'] = '9'
+      @facts['distribution.id'] = 'stretch'
+
+      assert_equal parser.operatingsystem.release_name, 'stretch'
+      assert_equal parser.operatingsystem.name, 'Debian'
+      assert_equal parser.operatingsystem.type, 'Debian'
+    end
+
+    def test_operatingsystem_ubuntu
+      @facts['distribution.name'] = 'Ubuntu GNU/Linux'
+      @facts['distribution.version'] = '19.04'
+      @facts['distribution.id'] = 'Disco Dingo'
+
+      assert_equal parser.operatingsystem.release_name, 'disco'
+      assert_equal parser.operatingsystem.name, 'Ubuntu'
+      assert_equal parser.operatingsystem.type, 'Debian'
+      assert_equal parser.operatingsystem.major, '19'
+      assert_equal parser.operatingsystem.minor, '04'
+    end
+
+    def test_operatingsystem_release
+      existing_os = FactoryBot.create(:operatingsystem, name: 'CentOS', major: '7', release_name: 'Core')
+      @facts['distribution.name'] = 'CentOS'
+      @facts['distribution.version'] = '7'
+
+      assert_equal existing_os.id, parser.operatingsystem.id
+    end
+
+    def test_operatingsystem_rhel_workstation
+      @facts['distribution.name'] = 'Red Hat Enterprise Linux Workstation'
+      @facts['distribution.version'] = '7.7'
+      @facts['distribution.id'] = 'Maipo'
+
+      assert_equal parser.operatingsystem.name, 'RedHat_Workstation'
+      assert_equal parser.operatingsystem.type, 'Redhat'
+      assert_equal parser.operatingsystem.major, '7'
+      assert_equal parser.operatingsystem.minor, '7'
+    end
+
+    def test_operatingsystem_rhel_server
+      @facts['distribution.name'] = 'Red Hat Enterprise Linux Server'
+      @facts['distribution.version'] = '7.7'
+      @facts['distribution.id'] = 'Maipo'
+
+      assert_equal parser.operatingsystem.name, 'RedHat'
+      assert_equal parser.operatingsystem.type, 'Redhat'
+      assert_equal parser.operatingsystem.major, '7'
+      assert_equal parser.operatingsystem.minor, '7'
+    end
+
+    def test_operatingsystem_almalinux
+      @facts['distribution.name'] = 'AlmaLinux'
+      @facts['distribution.version'] = '8.3'
+      @facts['distribution.id'] = 'Purple Manul'
+
+      assert_equal parser.operatingsystem.name, 'AlmaLinux'
+      assert_equal parser.operatingsystem.type, 'Redhat'
+      assert_equal parser.operatingsystem.major, '8'
+      assert_equal parser.operatingsystem.minor, '3'
+    end
+
+    def test_operatingsystem_amazon
+      @facts['distribution.name'] = 'Amazon'
+      @facts['distribution.version'] = '2.2'
+      @facts['distribution.id'] = 'Karoo'
+
+      assert_equal parser.operatingsystem.name, 'Amazon'
+      assert_equal parser.operatingsystem.major, '2'
+      assert_equal parser.operatingsystem.minor, '2'
+    end
+
+    def test_uname_architecture
+      @facts['uname.machine'] = 'i686'
+
+      assert 'i386', parser.architecture.name
+    end
+  end
+end


### PR DESCRIPTION
This PR continues from https://github.com/theforeman/foreman/pull/8491 and adding rshm parser with importer to core. 

It lacks a test for impoter. However, moving test for importer means also means move `Host::SuscriptionFacet` model (https://github.com/Katello/katello/blob/master/test/models/rhsm_fact_importer_test.rb#L20) and I don't think it's a good idea. 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
