### PR TITLE
Fixes #32540 - host_param_(true|false)? cleanup

### DIFF
--- a/lib/foreman/renderer/scope/macros/host_template.rb
+++ b/lib/foreman/renderer/scope/macros/host_template.rb
@@ -78,36 +78,32 @@ module Foreman
 
           apipie :method, 'Checks whether a parameter value is truthly or not' do
             required :name, String, desc: 'name of the parameter'
-            optional :default_value, Object, desc: 'value to be returned if the parameter is not set on host', default: false
+            optional :default_value, Object, desc: 'value to be used for the comparison if the parameter is not set on the host', default: false
             returns one_of: [true, false], desc: 'Returns true if the value of a parameter can be considered as truthly, false otherwise'
             example "host_param_true?('use-ntp') #=> true"
             example "host_param_true?('use-ntp', false) #=> false if a host has no 'use-ntp' parameter"
+            example "host_param_true?('use-ntp', true) #=> true if a host has no 'use-ntp' parameter"
             see 'host_param_false?', description: '#host_param_false?', scope: Foreman::Renderer::Scope::Macros::HostTemplate
           end
           def host_param_true?(name, default_value = false)
             check_host
-            if host.params.has_key?(name)
-              Foreman::Cast.to_bool(host.params[name])
-            else
-              default_value
-            end
+            value = host.params.fetch(name, default_value)
+            Foreman::Cast.to_bool(value) == true
           end
 
           apipie :method, 'Checks whether a parameter value is falsy or not' do
             required :name, String, desc: 'name of the parameter'
-            optional :default_value, Object, desc: 'value to be returned if the parameter is not set on host', default: false
+            optional :default_value, Object, desc: 'value to be used for the comparison if the parameter is not set on the host', default: true
             returns one_of: [true, false], desc: 'Returns false if the value of a parameter can be considered as falsy, true otherwise'
             example "host_param_false?('use-ntp') #=> true"
-            example "host_param_false?('use-ntp', true) #=> true if a host has no 'use-ntp' parameter"
+            example "host_param_false?('use-ntp', false) #=> true if a host has no 'use-ntp' parameter"
+            example "host_param_false?('use-ntp', true) #=> false if a host has no 'use-ntp' parameter"
             see 'host_param_true?', description: '#host_param_true?', scope: Foreman::Renderer::Scope::Macros::HostTemplate
           end
-          def host_param_false?(name, default_value = false)
+          def host_param_false?(name, default_value = true)
             check_host
-            if host.params.has_key?(name)
-              Foreman::Cast.to_bool(host.params[name]) == false
-            else
-              default_value
-            end
+            value = host.params.fetch(name, default_value)
+            Foreman::Cast.to_bool(value) == false
           end
 
           apipie :method, 'Returns root user\'s encrypted password for the host' do

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -142,8 +142,12 @@ class HostTemplateTest < ActiveSupport::TestCase
       host = FactoryBot.create(:host)
       @scope.instance_variable_set('@host', host)
       FactoryBot.create(:parameter, :name => 'true_param', :value => "true")
+      FactoryBot.create(:parameter, :name => 'false_param', :value => "false")
       assert @scope.host_param_true?('true_param')
       refute @scope.host_param_true?('false_param')
+      refute @scope.host_param_true?('missing_param')
+      assert @scope.host_param_true?('missing_param', 'true')
+      refute @scope.host_param_true?('missing_param', 'false')
     end
   end
 
@@ -152,8 +156,12 @@ class HostTemplateTest < ActiveSupport::TestCase
       host = FactoryBot.create(:host)
       @scope.instance_variable_set('@host', host)
       FactoryBot.create(:parameter, :name => 'false_param', :value => "false")
+      FactoryBot.create(:parameter, :name => 'true_param', :value => "true")
       assert @scope.host_param_false?('false_param')
       refute @scope.host_param_false?('true_param')
+      refute @scope.host_param_false?('missing_param')
+      refute @scope.host_param_false?('missing_param', 'true')
+      assert @scope.host_param_false?('missing_param', 'false')
     end
   end
 


### PR DESCRIPTION
let the `default_value` denote what we "read" by default from the host
(in the case the host doesn't have the param) and then compare it with
`true`/`false` (depending on the func) as done with the *existing*
param.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
