### PR TITLE
Fixes #32563 - iPXE bootstrapping fixed

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -133,17 +133,20 @@ class UnattendedController < ApplicationController
   def render_ipxe_template
     return false unless ipxe_request?
 
-    if @host.nil? && params[:bootstrap]
+    # Return immediately if bootstrap was requested
+    if params[:bootstrap]
       render_intermediate_template
       return true
     end
 
-    if @host.nil?
+    # The host is not known and its not the bootstrap script
+    if @host.nil? && !params[:mac]
       render_default_global_template
       return true
     end
 
-    unless @host.try(:build?)
+    # Host not in build was found and its not bootstrap script
+    if @host && !@host.build? && !params[:mac]
       render_local_boot_template
       return true
     end


### PR DESCRIPTION
Bootstrap script should be only returned when boostrap parameter is present regardless if host is found or not, because it can be actually found by a HTTP proxy REMOTE_IP fallback mechanism and bootstrap would be never returned.

Second problem is in global template handling, it should be only returned when host was not found but there wasn't mac argument provided.

More info at: https://community.theforeman.org/t/foreman-2-4-katello-4-ipxe-not-working/23398