### PR TITLE
Fixes #32139 - Inform about Foreman instance in emails

### DIFF
--- a/app/assets/stylesheets/unimported/email.css
+++ b/app/assets/stylesheets/unimported/email.css
@@ -15,6 +15,12 @@ table {
   width: 100%;
 }
 
+.footer {
+  display: block;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+
 table.center {
   text-align: center;
 }

--- a/app/helpers/application_mailer_helper.rb
+++ b/app/helpers/application_mailer_helper.rb
@@ -1,0 +1,12 @@
+module ApplicationMailerHelper
+  def email_footer
+    uuid = Setting[:instance_id]
+    title = Setting[:instance_title]
+
+    if uuid.present? && title.present?
+      _('This email was sent from Foreman instance %{title} identified by %{uuid}') % {title: title, uuid: uuid}
+    elsif uuid.present?
+      _('This email was sent from Foreman identified by UUID %{uuid}') % { uuid: uuid }
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -11,6 +11,7 @@ class ApplicationMailer < ActionMailer::Base
       headers[:to] = utf8_encode(headers[:to])
       headers[:subject] = "#{Setting[:email_subject_prefix]} #{headers[:subject]}" if (headers[:subject] && Setting[:email_subject_prefix].present?)
       headers['X-Foreman-Server'] = URI.parse(Setting[:foreman_url]).host if Setting[:foreman_url].present?
+      headers['X-Foreman-ID'] = Setting[:instance_id] if Setting[:instance_id].present?
     end
     super
   end

--- a/app/views/layouts/application_mailer.html.erb
+++ b/app/views/layouts/application_mailer.html.erb
@@ -8,4 +8,8 @@
   <body>
     <%= yield %>
   </body>
+  <div class="footer">
+    <%= email_footer %>
+    <%= yield :footer %>
+  </div>
 </html>


### PR DESCRIPTION
There is a subject prefix in email settings that is used in subject in
every email. It was only way to recognise a right foreman instance from
many instances. This PR adds a header X-Foreman-ID that includes a
instance_title from Settings, if it's set. Also, this PR adds a footer
for every email where is information about instance_title and
identifier (UUID) of Foreman instance.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
