### PR TITLE
Fixes #22801 - Encrypted spice consoles

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -46,6 +46,7 @@ module ComputeResourcesVmsHelper
 
   def spice_data_attributes(console)
     {
+      :encrypt  => console[:encrypt],
       :port     => console[:port],
       :password => console[:password],
     }

--- a/webpack/assets/javascripts/spice.js
+++ b/webpack/assets/javascripts/spice.js
@@ -13,8 +13,7 @@ import { sprintf, translate as __ } from './react_app/common/I18n';
 let sc = null;
 
 export function startSpice() {
-  const scheme = 'ws://';
-
+  const scheme = $('#spice-area').data('encrypt') ? 'wss' : 'ws';
   const host = window.location.hostname;
   const port = $('#spice-area').data('port');
   const password = $('#spice-area').data('password');
@@ -25,7 +24,7 @@ export function startSpice() {
     return;
   }
 
-  const uri = `${scheme + host}:${port}`;
+  const uri = `${scheme}://${host}:${port}`;
 
   try {
     sc = new SpiceMainConn({
@@ -57,10 +56,7 @@ function spiceError(e) {
 
 function spiceSuccess(m) {
   $('#spice-status').text(
-    sprintf(
-      __('Connected (unencrypted) to: %s'),
-      $('#spice-status').attr('data-host')
-    )
+    sprintf(__('Connected to: %s'), $('#spice-status').attr('data-host'))
   );
   $('#spice-status').addClass('label-success');
 }


### PR DESCRIPTION
While WsProxy already encrypted the connection, the UI was hardcoded to ws://. With this patch it respects the websockets_encrypt setting and uses wss:// if needed.

This is untested and right now I don't have a setup to verify it. Hence it's a draft.