### PR TITLE
Fixes #32566 - Fix port setting for spice consoles

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -51,7 +51,7 @@ module ComputeResourcesVmsHelper
 
   def spice_data_attributes(console)
     options = {
-      :port     => console[:proxy_port],
+      :port     => console[:port],
       :password => console[:password],
     }
     if supports_spice_xpi?


### PR DESCRIPTION
In 508776ea6dfc7defce8a4e466408629f494da0cf the WsProxy output was changed from proxy_port to port but this was not updated. The result was that it wasn't passed to the UI and no spice connection could be set up.

This means it's a regression fix that should be cherry picked to all supported versions (since 2.2.0 is affected).