### PR TITLE
Fixes #32572 - PBKDF2 password hashing support

### DIFF
--- a/app/registries/foreman/settings/auth.rb
+++ b/app/registries/foreman/settings/auth.rb
@@ -118,11 +118,22 @@ Foreman::SettingManager.define(:foreman) do
       description: N_("Log out idle users after a certain number of minutes"),
       default: 60,
       full_name: N_('Idle timeout'))
+    setting('password_hash',
+      type: :string,
+      description: N_("Password hashing algorithm. A password change is needed effect existing passwords."),
+      default: 'bcrypt',
+      full_name: N_('Password hashing algorithm'),
+      collection: proc { { 'sha1' => _("SHA1"), 'bcrypt' => _("BCrypt"), 'pbkdf2sha1' => _("PBKDF2 SHA1") } })
     setting('bcrypt_cost',
       type: :integer,
       description: N_("Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."),
       default: 4,
       full_name: N_('BCrypt password cost'))
+    setting('pbkdf2_cost',
+      type: :integer,
+      description: N_("Cost value of PBKDF2 password hash function for internal auth-sources. A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."),
+      default: 50000,
+      full_name: N_('PBKDF2 password cost'))
     setting('bmc_credentials_accessible',
       type: :boolean,
       description: N_("Permits access to BMC interface passwords through ENC YAML output and in templates"),

--- a/app/services/foreman/password_hash.rb
+++ b/app/services/foreman/password_hash.rb
@@ -9,12 +9,31 @@ require 'active_support/core_ext/module/delegation'
 #
 module Foreman
   class PasswordHash
+    class PBKDF2Implementation
+      DEFAULT_SALT_LENGTH = 39
+
+      def generate_salt(length = DEFAULT_SALT_LENGTH, cost = Setting[:pbkdf2_cost])
+        "$pbkdf2sha1$#{cost}$#{SecureRandom.base64(length)}"
+      end
+
+      def calculate_salt(object, cost = Setting[:pbkdf2_cost])
+        "$pbkdf2sha1$#{cost}$#{Digest::SHA1.hexdigest(object.to_s)}"
+      end
+
+      def hash_secret(password, salt)
+        raise(Foreman::Exception.new(N_("Salt not in format of $pbkdf2sha1$#{Setting[:pbkdf2_cost]}$SALT: %s"), salt)) unless salt.start_with?('$pbkdf2sha1')
+        _p1, _p2, iters, clean_salt = salt.split('$', 4)
+        hash = OpenSSL::PKCS5.pbkdf2_hmac_sha1(password, clean_salt, iters.to_i, DEFAULT_SALT_LENGTH)
+        "#{salt}$#{Base64.strict_encode64(hash)}"
+      end
+    end
+
     class BCryptImplementation
-      def generate_salt(cost)
+      def generate_salt(cost = Setting[:bcrypt_cost])
         BCrypt::Engine.generate_salt(cost)
       end
 
-      def calculate_salt(object, cost)
+      def calculate_salt(object, cost = Setting[:bcrypt_cost])
         "$2a$#{cost.to_s.rjust(2, '0')}$#{Digest::SHA1.hexdigest(object.to_s)}"
       end
 
@@ -27,11 +46,11 @@ module Foreman
     end
 
     class SHA1Implementation
-      def generate_salt(cost)
+      def generate_salt(_cost = nil)
         Digest::SHA1.hexdigest([Time.now.utc, rand].join)
       end
 
-      def calculate_salt(object, cost)
+      def calculate_salt(object, _cost = nil)
         Digest::SHA1.hexdigest(object.to_s)
       end
 
@@ -40,18 +59,29 @@ module Foreman
       end
     end
 
-    def initialize(implementation = :bcrypt)
-      if implementation == :bcrypt
+    def initialize(implementation = Setting[:password_hash])
+      case implementation&.to_sym
+      when :pbkdf2sha1
+        @implementation = PBKDF2Implementation.new
+      when :bcrypt
         @implementation = BCryptImplementation.new
-      elsif implementation == :sha1
+      when :sha1
         @implementation = SHA1Implementation.new
+      when nil
+        raise(Foreman::Exception.new(N_("Password hash setting was not yet set")))
       else
         raise(Foreman::Exception.new(N_("Unknown password hash method: %s"), implementation))
       end
     end
 
     def self.detect_implementation(password_string)
-      password_string.start_with?('$2') ? :bcrypt : :sha1
+      if password_string.start_with?('$pbkdf2sha1')
+        :pbkdf2sha1
+      elsif password_string.start_with?('$2')
+        :bcrypt
+      else
+        :sha1
+      end
     end
 
     delegate :generate_salt, :calculate_salt, :hash_secret, to: :implementation

--- a/test/unit/foreman/password_hash_test.rb
+++ b/test/unit/foreman/password_hash_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class PasswordHashTest < ActiveSupport::TestCase
-  [:bcrypt, :sha1].each do |type|
+  [:pbkdf2sha1, :bcrypt, :sha1].each do |type|
     test "#{type} generates salt" do
       hasher = Foreman::PasswordHash.new(type)
       refute_empty hasher.generate_salt(1)
@@ -10,20 +10,52 @@ class PasswordHashTest < ActiveSupport::TestCase
     test "#{type} calculates salt" do
       hasher = Foreman::PasswordHash.new(type)
       expected = {
-        bcrypt: '$2a$01$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
         sha1: 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
+        bcrypt: '$2a$01$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
+        pbkdf2sha1: '$pbkdf2sha1$1$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
       }
       assert_equal expected[type], hasher.calculate_salt('test', 1)
     end
 
     test "#{type} calculates secret hash" do
       hasher = Foreman::PasswordHash.new(type)
-      salt = hasher.calculate_salt('test', 6)
+      cost = {
+        sha1: 0,
+        bcrypt: 6,
+        pbkdf2sha1: 1000,
+      }
+      salt = hasher.calculate_salt('test', cost[type])
       expected = {
-        bcrypt: '$2a$06$a94a8fe5ccb19ba61c4c0uwk7Ym1nf2wtDsv067VgkPeQsUuBbfjW',
         sha1: 'da830961dc3af47fff6d1af3be3d66d6f229ef53',
+        bcrypt: '$2a$06$a94a8fe5ccb19ba61c4c0uwk7Ym1nf2wtDsv067VgkPeQsUuBbfjW',
+        pbkdf2sha1: '$pbkdf2sha1$1000$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3$CvVg5fn5f5b15dfMCAoUr4XKmeXmpWa3rz4Yf8a22VzVm+Ni7Ah2',
       }
       assert_equal expected[type], hasher.hash_secret('test', salt)
     end
+
+    test "#{type} is detected from salt" do
+      salts = {
+        sha1: 'a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
+        bcrypt: '$2a$01$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
+        pbkdf2sha1: '$pbkdf2sha1$1$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3',
+      }
+      assert_equal type, Foreman::PasswordHash.detect_implementation(salts[type])
+    end
+  end
+
+  test "different bcrypt costs generate different results" do
+    hasher = Foreman::PasswordHash.new(:bcrypt)
+    h1 = '$2a$04$a94a8fe5ccb19ba61c4c0uZUfqcn0ZV1N1n2vaPu3jltBG.l7rwCO'
+    h2 = '$2a$05$a94a8fe5ccb19ba61c4c0uGMSJMjyrccWFxVlbS7jwCiFRmiZ2f2.'
+    assert_equal h1, hasher.hash_secret('test', hasher.calculate_salt('test', 4))
+    assert_equal h2, hasher.hash_secret('test', hasher.calculate_salt('test', 5))
+  end
+
+  test "different pbkdf2sha1 costs generate different results" do
+    hasher = Foreman::PasswordHash.new(:pbkdf2sha1)
+    h1 = '$pbkdf2sha1$100$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3$jndR81G+UMxHOfxW9sDqhrvNodEBPoLMFhP3dsoOoHJJm+ncfX5d'
+    h2 = '$pbkdf2sha1$200$a94a8fe5ccb19ba61c4c0873d391e987982fbbd3$mUK8prtJkKFlm7KruqIxOIXZTt+niYl0H8zhjmEMqr0sWlEWfxDo'
+    assert_equal h1, hasher.hash_secret('test', hasher.calculate_salt('test', 100))
+    assert_equal h2, hasher.hash_secret('test', hasher.calculate_salt('test', 200))
   end
 end

--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -12,9 +12,15 @@ class SeedsTest < ActiveSupport::TestCase
     # Since we truncate the db, settings getter/setter won't work properly
     Setting.stubs(:[])
     Setting.stubs(:[]=)
+    Setting.stubs(:[]).with(:password_hash).returns(:bcrypt)
+    Setting.stubs(:[]=).with(:password_hash, anything).returns(true)
+    Setting.stubs(:[]=).with(:bcrypt_cost, anything).returns(true)
     Setting.stubs(:[]).with(:bcrypt_cost).returns(1)
     Setting.stubs(:[]=).with(:bcrypt_cost, anything).returns(true)
+    Setting.stubs(:[]).with(:pbkdf2_cost).returns(1000)
+    Setting.stubs(:[]=).with(:pbkdf2_cost, anything).returns(true)
     BCrypt::Engine.stubs(:calibrate).returns(4)
+    BCrypt::Engine.stubs(:password_hash).returns(:bcrypt)
     Foreman.stubs(:in_rake?).returns(true)
   end
 


### PR DESCRIPTION
I changed password and personal token hashing from very weak SHA1 to quite strong bcrypt. But I haven't realized bcrypt is based on blowfish whith is not approved by FIPS/NIST standards. Therefore this patch adds PBKDF2 password hashing while keeping ability to switch between bcrypt and PBKDF2 depending on the use case. Bcrypt is still considered very strong, however, being not approved by FIPS this cannot be used by some of our customers.

I am filing this as a draft, I am currently talking to our crypto team to confirm which hash algorithm to use, how many cycles/passes should be set. BCrypt library has a nice feature to calibrate for a specific time, however this is not available in the PBKDF2 OpenSSL implementation. We can start some decent value like 4096 and probably make this a configurable option.

Recommended setting by the crypto team: PBKDF2-HMAC-SHA512, 256 bit salt and hash minimum and iteration set by performing benchmark to a reasonable count (thousands or tens of thousands). Here are my test results:

https://lukas.zapletalovi.com/2021/05/finding-the-right-cost-for-bcryptpbkdf2.html

https://github.com/theforeman/foreman/pull/5633

Reviewer: To test this, change the password to PBKDF2 and then change password for a user, ensure that in database the password in encrypted in the new format `$pbkdf2$.....$` and that it actually works (user can log in).