### PR TITLE
Fixes #32502 - Remove taxonomy params in API for un-taxable resources

### DIFF
--- a/app/controllers/api/v2/auth_source_externals_controller.rb
+++ b/app/controllers/api/v2/auth_source_externals_controller.rb
@@ -3,6 +3,11 @@ module Api
     class AuthSourceExternalsController < V2::BaseController
       include Foreman::Controller::Parameters::AuthSourceExternal
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_resource, :only => %w{show update}
 
       api :GET, "/auth_source_externals/", N_("List external authentication sources")

--- a/app/controllers/api/v2/auth_source_ldaps_controller.rb
+++ b/app/controllers/api/v2/auth_source_ldaps_controller.rb
@@ -3,6 +3,11 @@ module Api
     class AuthSourceLdapsController < V2::BaseController
       include Foreman::Controller::Parameters::AuthSourceLdap
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       wrap_parameters AuthSourceLdap,
         :include => auth_source_ldap_params_filter.
                       accessible_attributes(parameter_filter_context)

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -7,8 +7,6 @@ module Api
       resource_description do
         api_version "v2"
         app_info N_("Foreman API v2 is currently the default API version.")
-        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
-        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
       end
 
       def_param_group :pagination do

--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Api::Version2
       include Foreman::Controller::Parameters::ComputeResource
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       wrap_parameters ComputeResource, :include => compute_resource_params_filter.accessible_attributes(parameter_filter_context)
 
       before_action :find_resource, :only => [:show, :update, :destroy, :available_images, :associate,

--- a/app/controllers/api/v2/domains_controller.rb
+++ b/app/controllers/api/v2/domains_controller.rb
@@ -14,6 +14,8 @@ module Api
           and automatically append this variable to all external node requests made
           by machines at that site.
         DOC
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
       end
 
       before_action :find_optional_nested_object

--- a/app/controllers/api/v2/environments_controller.rb
+++ b/app/controllers/api/v2/environments_controller.rb
@@ -5,6 +5,11 @@ module Api
       include Api::ImportPuppetclassesCommonController
       include Foreman::Controller::Parameters::Environment
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy}
 

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Api::Version2
       include Foreman::Controller::Parameters::Filter
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy}
 

--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -5,6 +5,11 @@ module Api
       include Foreman::Controller::Parameters::Hostgroup
       include ParameterAttributes
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy clone rebuild_config}
       before_action :process_parameter_attributes, :only => %w{update}

--- a/app/controllers/api/v2/http_proxies_controller.rb
+++ b/app/controllers/api/v2/http_proxies_controller.rb
@@ -4,6 +4,11 @@ module Api
       include ::Api::Version2
       include Foreman::Controller::Parameters::HttpProxy
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w(show update destroy)
 

--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Api::Version2
       include Foreman::Controller::Parameters::Medium
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy}
 

--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -6,6 +6,11 @@ module Api
       include Foreman::Controller::Parameters::ProvisioningTemplate
       include Foreman::Controller::TemplateImport
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy clone export}
 

--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Foreman::Controller::Parameters::Ptable
       include Foreman::Controller::TemplateImport
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       wrap_parameters :ptable, :include => ptable_params_filter.accessible_attributes(parameter_filter_context)
 
       before_action :find_optional_nested_object

--- a/app/controllers/api/v2/realms_controller.rb
+++ b/app/controllers/api/v2/realms_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Api::Version2
       include Foreman::Controller::Parameters::Realm
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_resource, :only => %w{show update destroy}
 
       api :GET, "/realms/", N_("List of realms")

--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -4,6 +4,11 @@ module Api
       include Foreman::Controller::Parameters::ReportTemplate
       include Foreman::Controller::TemplateImport
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       wrap_parameters :report_template, :include => report_template_params_filter.accessible_attributes(parameter_filter_context)
 
       before_action :find_optional_nested_object

--- a/app/controllers/api/v2/roles_controller.rb
+++ b/app/controllers/api/v2/roles_controller.rb
@@ -3,6 +3,11 @@ module Api
     class RolesController < V2::BaseController
       include Foreman::Controller::Parameters::Role
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy clone}
 

--- a/app/controllers/api/v2/smart_proxies_controller.rb
+++ b/app/controllers/api/v2/smart_proxies_controller.rb
@@ -5,6 +5,11 @@ module Api
       include Api::ImportPuppetclassesCommonController
       include Foreman::Controller::Parameters::SmartProxy
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_resource, :only => %w{show update destroy refresh version logs}
 
       api :GET, "/smart_proxies/", N_("List all smart proxies")

--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -5,6 +5,11 @@ module Api
       include Foreman::Controller::Parameters::Subnet
       include ParameterAttributes
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy freeip}
       before_action :find_ipam, :only => %w{freeip}

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -7,6 +7,11 @@ module Api
       include Foreman::Controller::Parameters::User
       include Api::Version2
 
+      resource_description do
+        param :location_id, Integer, :required => false, :desc => N_("Set the current location context for the request")
+        param :organization_id, Integer, :required => false, :desc => N_("Set the current organization context for the request")
+      end
+
       wrap_parameters User, :include => user_params_filter.accessible_attributes(
         Foreman::Controller::Parameters::User::Context.new(:api, controller_name, nil, false)) +
         ['compute_attributes']


### PR DESCRIPTION
These resources aren't really taxable while the API does advertise them as such:
architecture
bookmark
compute_profile
config_group
mail_notification
model
operating_system
settings
usergroup

So this PR fixes this bug.
