### PR TITLE
Fixes #28221 - Adding passing of template scope for snippet rendering

### DIFF
--- a/lib/foreman/renderer/scope/macros/snippet_rendering.rb
+++ b/lib/foreman/renderer/scope/macros/snippet_rendering.rb
@@ -53,8 +53,11 @@ module Foreman
             end
 
             begin
-              snippet_variables = variables.merge(options[:variables] || {})
-              template.render(renderer: renderer, host: host, variables: snippet_variables, mode: mode, source_klass: source&.class)
+              snippet_variables = variables_keys.index_with { |key| instance_variable_get("@#{key}") }
+                                                .symbolize_keys
+                                                .merge(variables)
+                                                .merge(options[:variables] || {})
+              template.render(renderer: renderer, host: host, variables: snippet_variables, params: params, mode: mode, source_klass: source&.class)
             rescue ::Foreman::Exception => e
               Foreman::Logging.exception('Error while rendering a snippet', e)
               raise

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -15,7 +15,7 @@ module RenderersSharedTests
       @scope = Class.new(Foreman::Renderer::Scope::Base) do
         include Foreman::Renderer::Scope::Macros::Base
         include Foreman::Renderer::Scope::Macros::SnippetRendering
-      end.send(:new, host: @host, source: source)
+      end.send(:new, host: @host, source: source, variables: { x: 'test' })
     end
 
     test "should evaluate template variables" do
@@ -125,6 +125,13 @@ module RenderersSharedTests
       level1_snippet = FactoryBot.create(:provisioning_template, :snippet, :template => "<%= @level1 -%><%= snippet('#{level2_snippet.name}', :variables => {:level2 => 2}) %><%= @level2 %>")
       source = OpenStruct.new(content: "<%= snippet('#{level1_snippet.name}', :variables => {:level1 => 1}) -%><%= @level1 %>")
       assert_equal '12', renderer.render(source, @scope)
+    end
+
+    test "should pass variables from template to snippet" do
+      snippet = FactoryBot.create(:provisioning_template, :snippet, :template => "<%= @x -%>")
+      template = OpenStruct.new(content: "<%= snippet('#{snippet.name}') %>")
+
+      assert_equal renderer.render(template, @scope), 'test'
     end
 
     test "should render a save_to_file macro" do


### PR DESCRIPTION
In current implementation templates can be much complex by snippet.
Reusable pieces of template code that should be in the same scope like
their templates but they are not. This PR tries to solve that.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
