### PR TITLE
Fixes #32605 - normalize subnet address

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -120,7 +120,7 @@ module Orchestration::DHCP
       :ip => ip,
       :mac => record_mac,
       :proxy => subnet.dhcp_proxy,
-      :network => subnet.network,
+      :network => subnet.masked_subnet_address.to_s,
       :related_macs => mac_addresses_for_provisioning - [record_mac],
     }
 

--- a/lib/net/validations.rb
+++ b/lib/net/validations.rb
@@ -119,6 +119,13 @@ module Net
       IPAddr.new(ip, Socket::AF_INET6).to_s rescue ip
     end
 
+    def self.normalize_network_address(ip, mask)
+      IPAddr.new(ip).mask(mask).to_s
+    rescue StandardError => e
+      Foreman::Logging.logger('app').info "Unable to normalize network address '#{ip}' with mask '#{mask}': #{e}"
+      ip
+    end
+
     def self.normalize_mac(mac)
       return unless mac.present?
       m = mac.downcase

--- a/test/models/subnet_test.rb
+++ b/test/models/subnet_test.rb
@@ -102,17 +102,26 @@ class SubnetTest < ActiveSupport::TestCase
 
   test "should strip whitespace before save" do
     s = subnets(:one)
-    s.network = " 10.0.0.22   "
+    s.network = " 10.0.22.0   "
     s.mask = " 255.255.255.0   "
-    s.gateway = " 10.0.0.138   "
+    s.gateway = " 10.0.22.138   "
     s.dns_primary = " 10.0.0.50   "
     s.dns_secondary = " 10.0.0.60   "
     assert s.save
-    assert_equal "10.0.0.22", s.network
+    assert_empty s.errors.full_messages
+    assert_equal "10.0.22.0", s.network
     assert_equal "255.255.255.0", s.mask
-    assert_equal "10.0.0.138", s.gateway
+    assert_equal "10.0.22.138", s.gateway
     assert_equal "10.0.0.50", s.dns_primary
     assert_equal "10.0.0.60", s.dns_secondary
+  end
+
+  test "should normalize network address" do
+    s = subnets(:one)
+    s.network = "10.1.2.3"
+    s.mask = "255.255.255.0"
+    assert s.save
+    assert_equal "10.1.2.0", s.network
   end
 
   test "should not destroy if hostgroup uses it" do


### PR DESCRIPTION
User who accidentally entered incorrect subnet address was struggling with DHCP conflicts, because subnet address must match exactly with what's set in DHCP which obviously does not allow incorrectly formatted subnet addresses.

This ensures that subnet address is masked before saving, so there are no trail nonsense numbers. It ignores incorrectly entered addresses as they are handled in different validators.

https://community.theforeman.org/t/deleting-a-provisionned-host-then-rediscover-and-reprovision-fails-at-dhcp/23422/29

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->