### PR TITLE
Fixes #32612 - Add some extra metadata to the default kickstart

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -47,8 +47,6 @@ description: |
   - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-kickstart-syntax
   - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user
 -%>
-# This kickstart file was rendered from the Foreman provisioning template "<%= @template_name %>".
-
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   is_fedora = @host.operatingsystem.name == 'Fedora'
@@ -66,6 +64,17 @@ description: |
   iface = @host.provision_interface
   appstream_present = false
 -%>
+# This kickstart file was rendered from the Foreman provisioning template "<%= @template_name %>".
+# for <%= @host %> running <%= @host.operatingsystem.name %> <%= os_major %> <%= @arch %>
+# Organization: <%= @host.organization %>
+# Location: <%= @host.location %>
+<%
+if plugin_present?('katello')
+-%>
+# Lifecycle environment: <%= @host.lifecycle_environment %>
+# Content View: <%= @host.content_view %>
+# Content Source: <%= @host.content_source %>
+<% end -%>
 
 <% if (is_fedora && os_major < 29) || (rhel_compatible && os_major <= 7) -%>
 install

--- a/app/views/unattended/provisioning_templates/provision/preseed_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/preseed_default.erb
@@ -26,6 +26,11 @@ description: |
   additional_packages << 'eject' if @host.respond_to?(:bootdisk_build?) && @host.bootdisk_build?
   additional_packages = additional_packages.join(" ").split().uniq().join(" ")
 %>
+# This preseed file was rendered from the Foreman provisioning template "<%= @template_name %>".
+# for <%= @host %> running <%= @host.operatingsystem.name %> <%= os_major %> <%= @arch %>
+# Organization: <%= @host.organization %>
+# Location: <%= @host.location %>
+
 # Locale
 d-i debian-installer/locale string <%= host_param('lang') || 'en_US' %>
 # country and keyboard settings are automatic. Keep them ...

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -1,5 +1,7 @@
 # This kickstart file was rendered from the Foreman provisioning template "Kickstart default".
-
+# for snapshot-ipv4-6-dhcp-el7 running CentOS 7 x86_64
+# Organization: Organization 1
+# Location: Location 1
 
 install
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -1,5 +1,7 @@
 # This kickstart file was rendered from the Foreman provisioning template "Kickstart default".
-
+# for snapshot-ipv4-dhcp-el7 running CentOS 7 x86_64
+# Organization: Organization 1
+# Location: Location 1
 
 install
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -1,5 +1,7 @@
 # This kickstart file was rendered from the Foreman provisioning template "Kickstart default".
-
+# for snapshot-ipv4-static-el7 running CentOS 7 x86_64
+# Organization: Organization 1
+# Location: Location 1
 
 install
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -1,5 +1,7 @@
 # This kickstart file was rendered from the Foreman provisioning template "Kickstart default".
-
+# for snapshot-ipv6-dhcp-el7 running CentOS 7 x86_64
+# Organization: Organization 1
+# Location: Location 1
 
 install
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -1,5 +1,7 @@
 # This kickstart file was rendered from the Foreman provisioning template "Kickstart default".
-
+# for snapshot-ipv6-static-el7 running CentOS 7 x86_64
+# Organization: Organization 1
+# Location: Location 1
 
 install
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
@@ -1,4 +1,9 @@
 
+# This preseed file was rendered from the Foreman provisioning template "Preseed default".
+# for snapshot-ipv4-dhcp-deb10 running Debian 10 
+# Organization: Organization 1
+# Location: Location 1
+
 # Locale
 d-i debian-installer/locale string en_US
 # country and keyboard settings are automatic. Keep them ...

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
@@ -1,4 +1,9 @@
 
+# This preseed file was rendered from the Foreman provisioning template "Preseed default".
+# for snapshot-ipv4-dhcp-ubuntu18 running Ubuntu 18 
+# Organization: Organization 1
+# Location: Location 1
+
 # Locale
 d-i debian-installer/locale string en_US
 # country and keyboard settings are automatic. Keep them ...


### PR DESCRIPTION
This adds a clear comment on the host's targeted OS, version, and arch.

It should optionally note the Organization if enabled.

On Katello systems, it should also add information about the Content View in use.