### PR TITLE
Refs #31370 - simplify factory traits

### DIFF
--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -19,15 +19,15 @@ FactoryBot.define do
       proxy.reload unless proxy.new_record?
     end
 
+    trait :ignore_validations do
+      callback(:after_stub, :after_build) do |proxy|
+        proxy.define_singleton_method(:valid?) { |*_args| true }
+      end
+    end
+
     factory :template_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :templates, :smart_proxy => smart_proxy)
-      end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
       end
     end
 
@@ -35,23 +35,11 @@ FactoryBot.define do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :bmc, :smart_proxy => smart_proxy)
       end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
-      end
     end
 
     factory :dhcp_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :dhcp, :smart_proxy => smart_proxy, :capabilities => ["dhcp_filename_ipv4"])
-      end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
       end
     end
 
@@ -59,35 +47,17 @@ FactoryBot.define do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :dns, :smart_proxy => smart_proxy)
       end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
-      end
     end
 
     factory :ipam_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :external_ipam, :smart_proxy => smart_proxy)
       end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
-      end
     end
 
     factory :httpboot_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :httpboot, :smart_proxy => smart_proxy)
-      end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
       end
     end
 
@@ -98,12 +68,6 @@ FactoryBot.define do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppet, :smart_proxy => smart_proxy)
       end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
-      end
     end
 
     factory :puppet_ca_smart_proxy do
@@ -113,12 +77,6 @@ FactoryBot.define do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppetca, :smart_proxy => smart_proxy)
       end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
-      end
     end
 
     factory :puppet_and_ca_smart_proxy do
@@ -126,23 +84,11 @@ FactoryBot.define do
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppet, :smart_proxy => smart_proxy)
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppetca, :smart_proxy => smart_proxy)
       end
-
-      trait :ignore_validations do
-        callback(:after_stub, :after_build) do |proxy|
-          proxy.define_singleton_method(:valid?) { |*_args| true }
-        end
-      end
     end
 
     factory :realm_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :realm, :smart_proxy => smart_proxy)
-      end
-    end
-
-    trait :ignore_validations do
-      callback(:after_stub, :after_build) do |proxy|
-        proxy.define_singleton_method(:valid?) { |*_args| true }
       end
     end
   end


### PR DESCRIPTION
In 641c3f4a9b we've introduced a factory trait for smart_proxy factory,
but instead of adding it to parent factory we added to all its children.

This is fixing that and simplifying the factories.