### PR TITLE
Fixes #32618 - pin psych to 3.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,9 @@
 # foreman plugins import this file therefore __FILE__ cannot be used
 FOREMAN_GEMFILE = __FILE__ unless defined? FOREMAN_GEMFILE
 
+# pin YAML library before we even load YAML configuration
+gem 'psych', '< 4'
+
 require_relative 'config/boot_settings'
 
 source 'https://rubygems.org'


### PR DESCRIPTION
Psych 4.0 turns the default behavior to safely load YAML files, Ruby classes now must be explicitly allowed.