### PR TITLE
Fixes #32456 - Parent host groups in Registration form

### DIFF
--- a/app/controllers/registration_commands_controller.rb
+++ b/app/controllers/registration_commands_controller.rb
@@ -5,7 +5,7 @@ class RegistrationCommandsController < ApplicationController
     render json: {
       organizations: User.current.my_organizations.select(:id, :name),
       locations: User.current.my_locations.select(:id, :name),
-      hostGroups: Hostgroup.authorized(:view_hostgroups).includes([:operatingsystem]),
+      hostGroups: host_groups_json,
       operatingSystems: Operatingsystem.authorized(:view_operatingsystems),
       smartProxies: Feature.find_by(name: 'Registration')&.smart_proxies,
       configParams: host_config_params,
@@ -42,6 +42,11 @@ class RegistrationCommandsController < ApplicationController
     else
       params
     end
+  end
+
+  def host_groups_json
+    Hostgroup.authorized(:view_hostgroups)
+             .map { |hg| hg.as_json(methods: :inherited_operatingsystem_id) }
   end
 
   # Extension point for plugins

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -88,4 +88,16 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       end
     end
   end
+
+  describe 'form_data' do
+    test 'host groups & inherited_operatingsystem_id' do
+      os = operatingsystems(:redhat)
+      child_hg = FactoryBot.create(:hostgroup, parent: FactoryBot.create(:hostgroup, operatingsystem: os))
+      get :form_data, session: set_session_user
+
+      child_hg_from_response = JSON.parse(@response.body)['hostGroups']
+                                   .find { |hg| hg['id'] == child_hg.id }
+      assert_equal os.id, child_hg_from_response['inherited_operatingsystem_id']
+    end
+  end
 end

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageHelpers.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageHelpers.js
@@ -39,7 +39,7 @@ export const osHelperText = (
 
   if (hostGroupId) {
     const osId = hostGroups.find(hg => `${hg.id}` === `${hostGroupId}`)
-      ?.operatingsystem_id;
+      ?.inherited_operatingsystem_id;
     return (
       <>
         {hostGroupOSHelperText(hostGroupId, hostGroups, operatingSystems)}
@@ -80,7 +80,7 @@ const osTemplateHelperText = (operatingSystemId, template) => {
 
 const hostGroupOSHelperText = (hostGroupId, hostGroups, operatingSystems) => {
   const osId = hostGroups.find(hg => `${hg.id}` === `${hostGroupId}`)
-    ?.operatingsystem_id;
+    ?.inherited_operatingsystem_id;
   const hostGroupOS = operatingSystems.find(os => `${os.id}` === `${osId}`);
 
   if (hostGroupOS) {

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/helpers.test.js
@@ -40,21 +40,21 @@ describe('osHelperText', () => {
   });
 
   it('for host group with OS with template', () => {
-    const wrapper = render(osHelperText(null, [{id: 23}], 1, [{ id: 1, operatingsystem_id: 23 }], { name: 'test'}));
+    const wrapper = render(osHelperText(null, [{id: 23}], 1, [{ id: 1, inherited_operatingsystem_id: 23 }], { name: 'test'}));
 
     expect(wrapper.text()).toMatch(/Host group OS/);
     expect(wrapper.text()).toMatch(/Initial configuration template/);
   });
 
   it('for host group with OS without template', () => {
-    const wrapper = render(osHelperText(null, [{id: 23}], 1, [{ id: 1, operatingsystem_id: 23 }], {}));
+    const wrapper = render(osHelperText(null, [{id: 23}], 1, [{ id: 1, inherited_operatingsystem_id: 23 }], {}));
 
     expect(wrapper.text()).toMatch(/Host group OS/);
     expect(wrapper.text()).toMatch(/does not have assigned host_init_config template/);
   });
 
   it('for host group without OS', () => {
-    const wrapper = render(osHelperText(null, [], 1, [{ id: 1, operatingsystem_id: 23 }], {}));
+    const wrapper = render(osHelperText(null, [], 1, [{ id: 1, inherited_operatingsystem_id: 23 }], {}));
     expect(wrapper.text()).toMatch(/No OS from host group/);
   });
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js
@@ -46,7 +46,7 @@ const OperatingSystem = ({
     if (hostGroupId !== undefined) {
       const hostGroupOsId = hostGroups.find(
         hg => `${hg.id}` === `${hostGroupId}`
-      )?.operatingsystem_id;
+      )?.inherited_operatingsystem_id;
 
       handleOperatingSystem('');
       dispatch(operatingSystemTemplateAction(hostGroupOsId));


### PR DESCRIPTION
Fixed issue with (not) inheriting `operatingsystem_id` value from parent host group.

Note: Issue with displaying `name` instead of `title` is fixed here: https://github.com/theforeman/foreman/pull/8519


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
