### PR TITLE
Fixes #32141 - Adding notification about finish of rendering report

### DIFF
--- a/app/jobs/template_render_job.rb
+++ b/app/jobs/template_render_job.rb
@@ -15,6 +15,7 @@ class TemplateRenderJob < ApplicationJob
         ReportMailer.report(composer_params, result, start: start_time, end: end_time).deliver_now
       else
         StoredValue.write(provider_job_id, result, expire_at: Time.now + 1.day)
+        UINotifications::ReportFinished.new(composer, provider_job_id).deliver!
       end
     end
   end

--- a/app/services/ui_notifications/report_finished.rb
+++ b/app/services/ui_notifications/report_finished.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module UINotifications
+  class ReportFinished < UINotifications::Base
+    include Rails.application.routes.url_helpers
+
+    def initialize(composer, job_id)
+      super(User.current)
+
+      @composer = composer
+      @job_id = job_id
+      @template = composer.template
+    end
+
+    private
+
+    def create
+      add_notification
+    end
+
+    def update_notifications
+      blueprint.notifications.
+          where(subject: subject).
+          update_all(expired_at: blueprint.expired_at)
+    end
+
+    def add_notification
+      Notification.create!(
+        initiator: initiator,
+        audience: ::Notification::AUDIENCE_USER,
+        subject: subject,
+        message: N_('Report "%s" is ready to download') % @template.name,
+        notification_blueprint: blueprint,
+        links: [
+          {
+            title: N_('Download Report'),
+            href: report_data_report_template_path(@template, job_id: @job_id),
+          },
+          {
+            title: N_('Regenerate Report'),
+            href: generate_report_template_path(@template, { report_template_report: { input_values: @composer.to_params[:input_values] } }),
+          },
+        ]
+      )
+    end
+
+    def blueprint
+      @blueprint ||= NotificationBlueprint.find_by(name: 'report_finish')
+    end
+  end
+end

--- a/db/seeds.d/170-notification_blueprints.rb
+++ b/db/seeds.d/170-notification_blueprints.rb
@@ -61,6 +61,26 @@ blueprints = [
     message: N_('Support for %{feature} has been deprecated and will be removed in version %{version}'),
     expires_in: 30.days,
   },
+  {
+    group: N_('Reports'),
+    name: 'report_finish',
+    message: N_('Report is ready to download'),
+    level: 'info',
+    actions:
+    {
+      links:
+      [
+        {
+          path_method: :edit_host_path,
+          title: N_('Download Report'),
+        },
+        {
+          path_method: :edit_host_path,
+          title: N_('Regenerate Report'),
+        },
+      ],
+    },
+  },
 ]
 
 blueprints.each { |blueprint| UINotifications::Seed.new(blueprint).configure }


### PR DESCRIPTION
Everyone uses a report templates for render important stuff from foreman instance. Right know, the templates can take long time to render it and when you don't want to send a report by email, you have to have open
window with report rendering due to waiting for start downloading. What happens when you accidentally close that window? You have to do another try...

So this excitedly frustrating experience motivated to make this PR. This code makes an notification for reports when render is done. Notification also contains two links - the download link to produced report and link that redirects you to report generate page in case you're miss the one-day window. Prefilled values of inputs are included!


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
