### PR TITLE
Fixes #32635 - fix already initialized constant

### DIFF
--- a/app/models/concerns/facets/base.rb
+++ b/app/models/concerns/facets/base.rb
@@ -1,4 +1,4 @@
-require 'facets'
+require_dependency 'facets'
 
 module Facets
   module Base

--- a/app/models/concerns/facets/base_host_extensions.rb
+++ b/app/models/concerns/facets/base_host_extensions.rb
@@ -1,4 +1,4 @@
-require 'facets'
+require_dependency 'facets'
 
 module Facets
   module BaseHostExtensions

--- a/app/models/concerns/facets/hostgroup_extensions.rb
+++ b/app/models/concerns/facets/hostgroup_extensions.rb
@@ -1,4 +1,4 @@
-require 'facets'
+require_dependency 'facets'
 
 module Facets
   module HostgroupExtensions

--- a/app/models/concerns/facets/hostgroup_facet.rb
+++ b/app/models/concerns/facets/hostgroup_facet.rb
@@ -1,4 +1,4 @@
-require 'facets'
+require_dependency 'facets'
 
 module Facets
   module HostgroupFacet

--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -1,4 +1,4 @@
-require 'facets'
+require_dependency 'facets'
 
 module Facets
   module ManagedHostExtensions

--- a/app/models/concerns/facets/model_extensions_base.rb
+++ b/app/models/concerns/facets/model_extensions_base.rb
@@ -1,4 +1,4 @@
-require 'facets'
+require_dependency 'facets'
 
 module Facets
   module ModelExtensionsBase

--- a/app/services/foreman/env_settings_loader.rb
+++ b/app/services/foreman/env_settings_loader.rb
@@ -1,7 +1,5 @@
 module Foreman
   class EnvSettingsLoader
-    LOGGERS_FROM_ENV_REGEX = /^FOREMAN_LOGGERS_([A-Z0-9_]+)_[A-Z]+$/
-
     attr_reader :env
 
     def initialize(env: ENV)
@@ -73,7 +71,10 @@ module Foreman
     end
 
     def loggers_from_env
-      env.keys.grep(LOGGERS_FROM_ENV_REGEX).map { |key| key.gsub(LOGGERS_FROM_ENV_REGEX, '\1').downcase.gsub('__', '/').to_sym }.uniq
+      @loggers_from_env ||= begin
+        loggers_from_env_regexp = /^FOREMAN_LOGGERS_([A-Z0-9_]+)_[A-Z]+$/
+        env.keys.grep(loggers_from_env_regexp).map { |key| key.gsub(loggers_from_env_regexp, '\1').downcase.gsub('__', '/').to_sym }.uniq
+      end
     end
 
     def cast_value(type:, value:)

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,15 +100,9 @@ module Foreman
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    # Custom directories with classes and modules you want to be autoloadable.
-    # config.autoload_paths += %W(#{config.root}/extras)
-    config.autoload_paths += Dir["#{config.root}/lib"]
-    config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
-    config.autoload_paths += Dir[Rails.root.join('app', 'models', 'power_manager')]
-    config.autoload_paths += Dir["#{config.root}/app/models/concerns"]
-    config.autoload_paths += Dir["#{config.root}/app/services"]
-    config.autoload_paths += Dir["#{config.root}/app/mailers"]
-
+    # Autoloading
+    config.autoload_paths += %W(#{config.root}/lib)
+    config.autoload_paths += %W(#{config.root}/app/models/power_manager)
     config.autoload_paths += %W(#{config.root}/app/models/auth_sources)
     config.autoload_paths += %W(#{config.root}/app/models/compute_resources)
     config.autoload_paths += %W(#{config.root}/app/models/fact_names)

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -1,15 +1,18 @@
 require 'securerandom'
+
 module Foreman
   # generate a UUID
   def self.uuid
     SecureRandom.uuid
   end
 
-  UUID_REGEXP = Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-" +
-                           "([0-9a-f]{4})-([0-9a-f]{12})$")
+  def self.uuid_regexp
+    @uuid_regexp ||= Regexp.new("^([0-9a-f]{8})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{4})-([0-9a-f]{12})$")
+  end
+
   # does this look like a UUID?
   def self.is_uuid?(str)
-    str.is_a?(String) && str.length == 36 && str.match?(UUID_REGEXP)
+    str.is_a?(String) && str.length == 36 && str.match?(uuid_regexp)
   end
 
   def self.in_rake?(*rake_tasks)


### PR DESCRIPTION
I am seing the following warning during startup:

```
app/services/facets.rb:2: warning: already initialized constant Facets::SUPPORTED_CORE_OBJECTS
app/services/facets.rb:2: warning: previous definition of SUPPORTED_CORE_OBJECTS was here
```

To reproduce, you might need to enable foreman_webhooks which performs eager loading in the plugin initializer to get list of all classes.

This change fixes the issue, however I do not know what consequences of this change might be. We do use `require_dependency` pretty much everywhere in the codebase for our files, except for facets. Was this intentional? Perhaps not.