### PR TITLE
Fixes #<rm_ticket_id> - permit facet params properly

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/host.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/host.rb
@@ -26,7 +26,9 @@ module Foreman::Controller::Parameters::Host
         add_host_common_params_filter(filter)
 
         facets = Facets.registered_facets.values.map { |facet_config| "#{facet_config.name}_attributes" }
-        filter.permit(*facets) if facets.present?
+        facets.each do |facet|
+          filter.permit(facet => {})
+        end if facets.present?
       end
     end
   end


### PR DESCRIPTION
We were permitting just facet list, but that doesnt work for rails, so
facet params were not permitted by default.
This fixes it and permits all the facets params.


This would be great to test with puppet plugin, as there the facets are most used