### PR TITLE
Fixes #32641 - Disambiguate column name

### DIFF
--- a/app/services/host_counter.rb
+++ b/app/services/host_counter.rb
@@ -28,6 +28,7 @@ class HostCounter
 
   def counted_hosts
     hosts_scope = Host::Managed.reorder('')
+    grouping = "#{@association}_id"
     case @association.to_s
     when 'organization', 'location'
       # If we are on /organizations or /locations, this allows to display the
@@ -35,7 +36,8 @@ class HostCounter
       hosts_scope = hosts_scope.unscoped
     when 'subnet', 'domain'
       hosts_scope = hosts_scope.joins(:primary_interface)
+      grouping.prepend("#{Nic::Base.table_name}.")
     end
-    hosts_scope.authorized(:view_hosts).group("#{@association}_id").count
+    hosts_scope.authorized(:view_hosts).group(grouping).count
   end
 end


### PR DESCRIPTION
At the time of restricting the list of hosts that the current user can see to then group by domain and do a count, if the user has a role with filters on hosts involving hostgroup filters, like:

![image](https://user-images.githubusercontent.com/131893/119095286-61ec8400-ba12-11eb-9df8-6b7171274028.png)

Then the `hostgroups` table is involved in the generated SQL, creating a conflict as the `domain_id` column is both provided by the `nics` and the `hostgroups` tables.

See the ticket for more details.
