### PR TITLE
Fixes #32645 - Add descendants field to hostgroup

### DIFF
--- a/app/graphql/types/hostgroup.rb
+++ b/app/graphql/types/hostgroup.rb
@@ -27,5 +27,9 @@ module Types
     field :children, Types::Hostgroup.connection_type, null: true, resolve: (proc do |object|
       RecordLoader.for(model_class).load_many(object.child_ids)
     end)
+
+    field :descendants, Types::Hostgroup.connection_type, null: true, resolve: (proc do |object|
+      RecordLoader.for(model_class).load_many(object.descendant_ids)
+    end)
   end
 end

--- a/test/graphql/queries/hostgroup_query_test.rb
+++ b/test/graphql/queries/hostgroup_query_test.rb
@@ -83,6 +83,14 @@ module Queries
               }
             }
           }
+          descendants {
+            totalCount
+            edges {
+              node {
+                id
+              }
+            }
+          }
         }
       }
       GRAPHQL
@@ -106,6 +114,8 @@ module Queries
       )
     end
     let(:child_hostgroup) { FactoryBot.create(:hostgroup, parent: hostgroup) }
+    let(:second_child_hostgroup) { FactoryBot.create(:hostgroup, :parent => hostgroup) }
+    let(:grandchild_hostgroup) { FactoryBot.create(:hostgroup, :parent => child_hostgroup) }
 
     let(:global_id) { Foreman::GlobalId.for(hostgroup) }
     let(:variables) { { id: global_id } }
@@ -113,6 +123,8 @@ module Queries
 
     setup do
       child_hostgroup
+      second_child_hostgroup
+      grandchild_hostgroup
       FactoryBot.create(:host, hostgroup: hostgroup)
     end
 
@@ -141,6 +153,7 @@ module Queries
 
       assert_record hostgroup.parent, data['parent']
       assert_collection hostgroup.children, data['children']
+      assert_collection hostgroup.descendants, data['descendants']
     end
   end
 end


### PR DESCRIPTION
Adds a field for descendants into graphql type
for hostgroup.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
