### PR TITLE
Fixes #32452 - Host Registration tweaks and improvements (CP 2.5)

### DIFF
--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -15,6 +15,7 @@ module Api
         param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
         param :jwt_expiration, :number, desc: N_("Expiration of the authorization token (in hours)")
         param :insecure, :bool, desc: N_("Enable insecure argument for the initial curl")
+        param :packages, String, desc: N_("Packages to install on the host when registered. Can be set by `host_packages` parameter. Example: `pkg1 pkg2`")
         param :repo, String, desc: N_("Repository URL / details, for example for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
         param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
       end

--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -21,6 +21,9 @@ module Api
       param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in.")
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems.")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host.")
+      param :packages, String, desc: N_("Packages to install on the host when registered. Can be set by `host_packages` parameter. Example: `pkg1 pkg2`")
+      param :repo, String, desc: N_("Repository URL / details, for example for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
+      param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
       def global
         find_global_registration
 

--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -88,7 +88,7 @@ class Setting::Provisioning < Setting
       ),
       set('maximum_structured_facts', N_("Maximum amount of keys in structured subtree, statistics stored in foreman::dropped_subtree_facts"), 100, N_('Maximum structured facts')),
       set('default_global_registration_item', N_("Global Registration template"), 'Global Registration', N_("Default Global registration template")),
-      set('default_host_init_config_template', N_("Default 'Host intial configuration' template, automatically assigned when new operating system is created"), 'Linux host_init_config default', N_("Default 'Host intial configuration' template")),
+      set('default_host_init_config_template', N_("Default 'Host initial configuration' template, automatically assigned when new operating system is created"), 'Linux host_init_config default', N_("Default 'Host initial configuration' template")),
     ] + default_global_templates + default_local_boot_templates
   end
 

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -26,12 +26,13 @@ set -e
 <% end -%>
 
 <%= install_packages(host_param('host_packages')) -%>
-<%= snippet_if_exists('host_init_config_post') -%>
 
 <% if host_param_true?('host_registration_insights') -%>
 <%= snippet 'insights' %>
 
 <% end -%>
+
+<%= snippet_if_exists('host_init_config_post') -%>
 
 # Call home to exit build mode
 <% built_https = foreman_url('built').start_with?('https') -%>

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -13,12 +13,17 @@ model: ProvisioningTemplate
 <%= "# User: [#{@user.login}]" -%>
 <%= "\n# Organization: [#{@organization.name}]" if @organization -%>
 <%= "\n# Location: [#{@location.name}]" if @location -%>
-<%= "\n# Hostgroup: [#{@hostgroup.name}]" if @hostgroup -%>
-<%= "\n# Operating System: [#{@operatingsystem.name}]" if @operatingsystem -%>
+<%= "\n# Host group: [#{@hostgroup.title}]" if @hostgroup -%>
+<%= "\n# Operating system: [#{@operatingsystem}]" if @operatingsystem -%>
 <%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
-<%= "\n# Setup Remote Execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
+<%= "\n# Setup remote execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
 <%= "\n# Remote execution interface: [#{@remote_execution_interface}]" if @remote_execution_interface.present? -%>
 <%= "\n# Packages: [#{@packages}]" if @packages.present? -%>
+<%= "\n# Repository: [#{@repo}]" if @repo.present? -%>
+<%= "\n# Repository GPG key URL: [#{@repo_gpg_key_url}]" if @repo_gpg_key_url.present? -%>
+<%= "\n# Force: [#{@force}]" unless @force.nil? -%>
+<%= "\n# Ignore subman errors: [#{@ignore_subman_errors}]" unless @ignore_subman_errors.nil? -%>
+<%= "\n# Lifecycle environment id: [#{@lifecycle_environment_id}]" if @lifecycle_environment_id.present? -%>
 <%= "\n# Activation keys: [#{activation_keys}]" if activation_keys.present? -%>
 
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageHelpers.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageHelpers.js
@@ -26,13 +26,6 @@ export const validatedOS = (operatingSystemId, template) => {
   return 'error';
 };
 
-export const formatOSname = os => {
-  if (os?.minor) {
-    return `${os.name} ${os.major}.${os.minor}`;
-  }
-  return `${os.name} ${os.major}`;
-};
-
 export const osHelperText = (
   operatingSystemId,
   operatingSystems,
@@ -91,7 +84,7 @@ const hostGroupOSHelperText = (hostGroupId, hostGroups, operatingSystems) => {
   const hostGroupOS = operatingSystems.find(os => `${os.id}` === `${osId}`);
 
   if (hostGroupOS) {
-    return sprintf('Host group OS: %s', formatOSname(hostGroupOS));
+    return sprintf('Host group OS: %s', hostGroupOS.title);
   }
   return __('No OS from host group');
 };

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
@@ -65,7 +65,7 @@ export const hostGroupProps = {
   hostGroupId: 0,
   handleHostGroup: () => {},
   isLoading: false,
-  hostGroups: [{ id: 0, name: 'test_hg' }],
+  hostGroups: [{ id: 0, title: 'test_hg' }],
 };
 
 export const insecureProps = {

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/helpers.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { shallow, render } from '@theforeman/test';
 import { FormSelectOption } from '@patternfly/react-core';
 
-import { emptyOption, validatedOS, formatOSname, osHelperText } from '../RegistrationCommandsPageHelpers'
+import { emptyOption, validatedOS, osHelperText } from '../RegistrationCommandsPageHelpers'
 
 describe('emptyOption', () => {
   it('when length == 0', () => {
@@ -25,25 +25,6 @@ describe('validatedOS', () => {
 
   it('without template', () => {
     expect(validatedOS(1, {name: ''})).toEqual('error');
-  });
-});
-
-describe('formatOSname', () => {
-  it('with minor version', () => {
-    const os = {
-      name: 'test',
-      major: '1',
-      minor: '23',
-    }
-    expect(formatOSname(os)).toEqual(`${os.name} ${os.major}.${os.minor}`);
-  });
-
-  it('without minor version', () => {
-    const os = {
-      name: 'test',
-      major: '1'
-    }
-    expect(formatOSname(os)).toEqual(`${os.name} ${os.major}`);
   });
 });
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/HostGroup.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/HostGroup.js
@@ -21,7 +21,7 @@ const HostGroup = ({ hostGroupId, hostGroups, handleHostGroup, isLoading }) => (
     >
       {emptyOption(hostGroups.length)}
       {hostGroups.map((hg, i) => (
-        <FormSelectOption key={i} value={hg.id} label={hg.name} />
+        <FormSelectOption key={i} value={hg.id} label={hg.title} />
       ))}
     </FormSelect>
   </FormGroup>

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js
@@ -20,7 +20,6 @@ import {
   osHelperText,
   validatedOS,
   emptyOption,
-  formatOSname,
 } from '../../RegistrationCommandsPageHelpers';
 
 const OperatingSystem = ({
@@ -94,7 +93,7 @@ const OperatingSystem = ({
       >
         {emptyOption(operatingSystems.length)}
         {operatingSystems.map((os, i) => (
-          <FormSelectOption key={i} value={os.id} label={formatOSname(os)} />
+          <FormSelectOption key={i} value={os.id} label={os.title} />
         ))}
       </FormSelect>
     </FormGroup>


### PR DESCRIPTION
- Updated ApiPie documentation
- Fixed typo in `default_host_init_config_template` setting
- Snippet `host_init_config_post` moved at the end of the `host_init_config`
  template, where it should be, not before `insights` snippet
- Use `title` instead of `name` for host groups and operating systems
- Updated list of variables in `global_registration` template

(cherry picked from commit 96c60e9ca61fabc156e394154292bfc9a3d809c4)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
