### PR TITLE
Fixes #32625 - Registration API & OS template

### DIFF
--- a/app/controllers/registration_commands_controller.rb
+++ b/app/controllers/registration_commands_controller.rb
@@ -15,15 +15,14 @@ class RegistrationCommandsController < ApplicationController
 
   def operatingsystem_template
     os = Operatingsystem.authorized(:view_operatingsystems).find(params[:id])
-    template_kind = TemplateKind.find_by(name: 'host_init_config')
-    template = os.os_default_templates
-                 .find_by(template_kind: template_kind)&.provisioning_template
+    template = os.has_default_template?(TemplateKind.find_by(name: 'host_init_config'))
 
-    if template
-      render json: { template: { name: template.name, path: edit_provisioning_template_path(template) } }
-    else
+    unless template
       render json: { template: { name: nil, os_path: edit_operatingsystem_path(os)} }
+      return
     end
+
+    render json: { template: { name: template.name, path: edit_provisioning_template_path(template) } }
   end
 
   def create

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -355,6 +355,10 @@ class Operatingsystem < ApplicationRecord
     medium_provider.medium_uri.to_s
   end
 
+  def has_default_template?(template_kind)
+    os_default_templates.find_by(template_kind: template_kind) || false
+  end
+
   private
 
   def set_family

--- a/test/controllers/api/v2/registration_commands_controller_test.rb
+++ b/test/controllers/api/v2/registration_commands_controller_test.rb
@@ -48,5 +48,13 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
       response = ActiveSupport::JSON.decode(@response.body)['registration_command']
       assert_includes response, "curl -sS --insecure '#{smart_proxies(:one).url}/register'"
     end
+
+    test 'os without host_init_config template' do
+      os = FactoryBot.create(:operatingsystem)
+      os.os_default_templates = []
+
+      post :create, params: { operatingsystem_id: os.id}
+      assert_response :unprocessable_entity
+    end
   end
 end

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -1,6 +1,25 @@
 require 'test_helper'
 
 class RegistrationCommandsControllerTest < ActionController::TestCase
+  describe 'operatingsystem_template' do
+    test 'with template' do
+      os = operatingsystems(:redhat)
+
+      get :operatingsystem_template, params: { id: os.id }, session: set_session_user
+      assert_response :success
+      assert_not_nil JSON.parse(@response.body)['template']['name']
+    end
+
+    test 'without template' do
+      os = FactoryBot.create(:operatingsystem)
+      os.os_default_templates = []
+
+      get :operatingsystem_template, params: { id: os.id }, session: set_session_user
+      assert_response :success
+      assert_nil JSON.parse(@response.body)['template']['name']
+    end
+  end
+
   describe 'create' do
     test 'with params' do
       params = {

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -437,4 +437,24 @@ class OperatingsystemTest < ActiveSupport::TestCase
     os = FactoryBot.create(:operatingsystem)
     assert_equal Setting[:default_host_init_config_template], os.provisioning_templates[0]&.name
   end
+
+  context 'has_default_template?' do
+    setup do
+      @kind = TemplateKind.find_by(name: 'host_init_config')
+    end
+    test 'with template' do
+      os = FactoryBot.create(:operatingsystem)
+
+      assert_not_empty os.os_default_templates
+      assert os.has_default_template?(@kind)
+    end
+
+    test 'without template' do
+      os = FactoryBot.create(:operatingsystem)
+      os.os_default_templates = []
+
+      assert_empty os.os_default_templates
+      refute os.has_default_template?(@kind)
+    end
+  end
 end


### PR DESCRIPTION
Fixed issue when users could create registration command
with OS that doesn't have assigned `host_init_config` template


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
