### PR TITLE
Fixes #29681 - Fixing bad regex for excluding facts

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -18,7 +18,7 @@ class FactImporter
     Setting.convert_array_to_regexp(
       Setting[:excluded_facts],
       {
-        :prefix => '(\A|.*::|.*_)',
+        :prefix => '(\A|.*::|\A(facter_)?(mtu|macaddress|(ipaddress|network|netmask)6?)_)',
         :suffix => '(\Z|::.*)',
       }
     )

--- a/test/fact_importer_test_helper.rb
+++ b/test/fact_importer_test_helper.rb
@@ -77,7 +77,6 @@ module FactsData
     def good_facts
       {
         'something_filter_something_else' => 'hello',
-        'fact_bad_something' => 'hello',
         'filter_something' => 'hello',
       }
     end
@@ -85,10 +84,13 @@ module FactsData
     def ignored_facts
       {
         'ignored_fact_something' => 'will_not_show',
-        'something_ignored_fact' => 'will_not_show',
-        'something_ignored_fact_something_else' => 'will_not_show',
         'something_fact_bad' => 'will_not_show',
-        'something_filter' => 'will_not_show',
+        'filter' => 'will_not_show',
+        'mtu_filter' => 'will_not_show',
+        'facter_mtu_filter' => 'will_not_show',
+        'ipaddress_filter' => 'will_not_show',
+        'ipaddress6_filter' => 'will_not_show',
+        'facter_ipaddress6_filter' => 'will_not_show',
       }
     end
   end
@@ -143,6 +145,7 @@ module FactsData
       {
         'macaddress_virbr4' => 'fe:54:00:59:4e:bf',
         'mtu_virbr4' => '1500',
+        'non_docker_host' => 'non_docker_host',
         'net::interface::virbr4::ipv6_address::link' => 'fe80::fc54:ff:fe59:4ebf',
         'net::interface::virbr4::ipv6_address::link_list' => 'fe80::fc54:ff:fe59:4ebf',
         'net::interface::virbr4::ipv6_netmask::link' => '64',
@@ -156,6 +159,7 @@ module FactsData
       {
         'macaddress_vnet4' => 'fe:54:00:59:4e:bf',
         'mtu_vnet4' => '1500',
+        'docker_host' => 'ignored_host',
         'net::interface::vnet4::ipv6_address::link' => 'fe80::fc54:ff:fe59:4ebf',
         'net::interface::macvtap1::ipv6_address::link_list' => 'fe80::fc54:ff:fe59:4ebf',
         'net::interface::veth4::ipv6_netmask::link' => '64',


### PR DESCRIPTION
Foreman uses facts from many tools like Ansible or Puppet to gather facts about hosts. These facts are also full of facts that foreman don't care about. That's why Excluded facts setting exist. It has some bugs that makes fact definition for excluding hard. This PR tries to solve that by removing underscore '_' from regex generation.

It's also requires to update the tests also some provision settings to fits to new "understanding". If it's there anything that shloud be updated too, drop me a comment and I'll update it. 


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
