### PR TITLE
Fixes #32657 - Prevent duplicate templates

### DIFF
--- a/db/migrate/20210525144427_enforce_unique_templates.rb
+++ b/db/migrate/20210525144427_enforce_unique_templates.rb
@@ -1,0 +1,17 @@
+class EnforceUniqueTemplates < ActiveRecord::Migration[6.0]
+  def up
+    # Duplicates should only occur when two concurrent seeds hit a race condition,
+    # so it should be safe to drop any duplicates, preferring the newest one
+    Template.where.not(id: Template.group(:name, :type).pluck("max(id)")).each do |template|
+      say "Deleting duplicate #{template.type.underscore.humanize}: #{template.name}"
+      template.update_columns(locked: false)
+      template.destroy
+    end
+
+    add_index :templates, [:type, :name], unique: true
+  end
+
+  def down
+    remove_index :templates, [:type, :name]
+  end
+end


### PR DESCRIPTION
In certain race conditions when two seeds are executed at the same time,
some templates may be seeded twice. Since there is a unique name
validation in AR on templates, this renders such templates uneditable,
and in case they need updating during seeding, it also prevents the seed
from succeeding. To avoid this, an index is introduced to enforce
uniqueness on the DB level as well. Since this is a rare condition that
can only occur during seeding, it is safe to remove any duplicate
templates created in such manner.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
