### PR TITLE
Fixes #32650 - add resource_type to filter base

### DIFF
--- a/app/views/api/v2/filters/base.json.rabl
+++ b/app/views/api/v2/filters/base.json.rabl
@@ -1,3 +1,3 @@
 object @filter
 
-attributes :id
+attributes :id, :resource_type

--- a/app/views/api/v2/filters/main.json.rabl
+++ b/app/views/api/v2/filters/main.json.rabl
@@ -2,7 +2,7 @@ object @filter
 
 extends "api/v2/filters/base"
 
-attributes :search, :resource_type, :resource_type_label, :unlimited?, :created_at, :updated_at, :override?
+attributes :search, :resource_type_label, :unlimited?, :created_at, :updated_at, :override?
 
 child :role do
   extends "api/v2/roles/base"


### PR DESCRIPTION
In API roles/<id> detail there is only list of filter ids, that is not
very useful to user, we should add at least resource type for the user
to at least get the basic idea.