### PR TITLE
Fixes #32273 - VMWare compute failure ends up in ArgumentError

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -494,7 +494,7 @@ module Foreman::Model
         e,
         N_(
           'Foreman could not find a required vSphere resource. Check if Foreman has the required permissions and the resource exists. Reason: %s'
-        )
+        ) % e.message
       )
     rescue Fog::Errors::Error => e
       Foreman::Logging.exception("Unhandled VMware error", e)


### PR DESCRIPTION
Hello,

Here is a fix for a long standing issue. See the ticket for more details.
The original root of issue is re-raising of Foreman::WrappedException when Fog::Vsphere::Compute::NotFound occurs is missing "% message" leaving unresolved %s placeholder in exception message.
Later, when rescue is called from app/models/concerns/orchestration/compute.rb, this string is access as "message" property and code try to translate it using provided placeholder but it fails because of the additional remaining %s.
It has been quite a nightmare to debug so I also added some hardened code to not crash with ArgumentError in case message attribute raise an error but instead log a warning and fallback to untranslated_message attribute.

Thanks a lot @ekohl who helped me last time with no luck, at least this time I knew where to NOT look and finally managed to get it fixed ;-)

Best regards, Adam.