### PR TITLE
Fixes #32673 - deduplicate records prior uniq index

### DIFF
--- a/db/migrate/20200625081552_add_unique_index_to_lookup_value.rb
+++ b/db/migrate/20200625081552_add_unique_index_to_lookup_value.rb
@@ -1,5 +1,13 @@
 class AddUniqueIndexToLookupValue < ActiveRecord::Migration[6.0]
-  def change
+  def up
+    LookupValue.where.not(id: LookupValue.group(:lookup_key_id, :match).select('MAX(id)')).each do |lookup_value|
+      say "Deleting duplicate override value for #{lookup_value.lookup_key.class.humanize_class_name} #{lookup_value.lookup_key.key} with matcher #{lookup_value.match} and value #{lookup_value.value}"
+      lookup_value.destroy
+    end
     add_index :lookup_values, [:lookup_key_id, :match], unique: true
+  end
+
+  def down
+    remove_index :lookup_values, column: [:lookup_key_id, :match], unique: true
   end
 end


### PR DESCRIPTION
In 84cb565af244f56029471700bb313d46c45e5fcf we've introduced unique
index in database, because there is a way in Rails to bypass uniqueness
validation, if the records are being introduced at the same time.

We forgot to deduplicate the records prior introducing this migration so
some installations are failing to run the migration.

I realize this is bit too late, but if we cherry-pick to 2.4, we can still help to a lot of people who have skipped 2.2 and 2.3 upgrade, I believe it is better than nothing :)