### PR TITLE
Fixes #32166 - reworded ignored interface setting

### DIFF
--- a/app/models/setting/provisioning.rb
+++ b/app/models/setting/provisioning.rb
@@ -59,7 +59,7 @@ class Setting::Provisioning < Setting
       set('access_unattended_without_build', N_("Allow access to unattended URLs without build mode being used"), false, N_('Access unattended without build')),
       set('manage_puppetca', N_("Foreman will automate certificate signing upon provision of new host"), true, N_('Manage PuppetCA')),
       set('ignore_puppet_facts_for_provisioning', N_("Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"), false, N_('Ignore Puppet facts for provisioning')),
-      set('ignored_interface_identifiers', N_("Ignore interfaces that match these values during facts importing, you can use * wildcard to match names with indexes e.g. macvtap*"), IGNORED_INTERFACES, N_('Ignore interfaces with matching identifier')),
+      set('ignored_interface_identifiers', N_("Skip creating or updating host network interfaces objects with identifiers matching these values from incoming facts. You can use * wildcard to match identifiers with indexes e.g. macvtap*. The ignored interfaces raw facts will be still stored in the DB, see the 'Exclude pattern' setting for more details."), IGNORED_INTERFACES, N_('Ignore interfaces with matching identifier')),
       set('ignore_facts_for_operatingsystem', N_("Stop updating Operating System from facts"), false, N_('Ignore facts for operating system')),
       set('ignore_facts_for_domain', N_("Stop updating domain values from facts"), false, N_('Ignore facts for domain')),
       set('query_local_nameservers', N_("Foreman will query the locally configured resolver instead of the SOA/NS authorities"), false, N_('Query local nameservers')),

--- a/db/migrate/20210610134000_update_ignored_interfaces_setting_description.rb
+++ b/db/migrate/20210610134000_update_ignored_interfaces_setting_description.rb
@@ -1,0 +1,8 @@
+class UpdateIgnoredInterfacesSettingDescription < ActiveRecord::Migration[6.0]
+  def up
+    setting = Setting.find_by(name: 'ignored_interface_identifiers')
+    return unless setting
+
+    setting.update(description: N_("Skip creating or updating host network interfaces objects with identifiers matching these values from incoming facts. You can use * wildcard to match identifiers with indexes e.g. macvtap*. The ignored interfaces raw facts will be still stored in the DB, see the 'Exclude pattern' setting for more details."))
+  end
+end


### PR DESCRIPTION
Foreman has two lists where "ignored" facts can be defined. The Ignored Interface Identifiers and Excluded Facts. Both of them actually do almost the same thing so it makes sense to merge them. 

PR contains also migration that takes values from ignored interfaces to excluded facts.
I've in plan to check plugins if the ignored interfaces are used and create PRs to reflect these change. In addition to that. I've added a warning message for Setting call and for Template call of this settings just in case if there are could be something missing from community. 


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
