### PR TITLE
Fixes #32681 - avoid naked echo statements in grub

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -24,7 +24,7 @@ insmod fat
 insmod chain
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
-  echo Chainloading Grub2 EFI from ESP, enabled devices for booting:
+  echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
 <%
   paths.each do |path|
@@ -41,18 +41,18 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
 <%
   end
 -%>
-  echo Partition with known EFI file not found, you may want to drop to grub shell
-  echo and investigate available files updating 'pxegrub2_chainload' template and
-  echo the list of known filepaths for probing. Available devices are:
+  echo "Partition with known EFI file not found, you may want to drop to grub shell"
+  echo "and investigate available files updating 'pxegrub2_chainload' template and"
+  echo "the list of known filepaths for probing. Available devices are:"
   echo
   ls
   echo
-  echo If you cannot see the HDD, make sure the drive is marked as bootable in EFI and
-  echo not hidden. Boot order must be the following:
-  echo 1) NETWORK
-  echo 2) HDD
+  echo "If you cannot see the HDD, make sure the drive is marked as bootable in EFI and"
+  echo "not hidden. Boot order must be the following:"
+  echo "1) NETWORK"
+  echo "2) HDD"
   echo
-  echo The system will halt in 2 minutes or press ESC to halt immediately.
+  echo "The system will halt in 2 minutes or press ESC to halt immediately."
   sleep -i 120
   halt --no-apm
 }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -11,7 +11,7 @@ insmod fat
 insmod chain
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
-  echo Chainloading Grub2 EFI from ESP, enabled devices for booting:
+  echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
   unset chroot
@@ -112,18 +112,18 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
-  echo Partition with known EFI file not found, you may want to drop to grub shell
-  echo and investigate available files updating 'pxegrub2_chainload' template and
-  echo the list of known filepaths for probing. Available devices are:
+  echo "Partition with known EFI file not found, you may want to drop to grub shell"
+  echo "and investigate available files updating 'pxegrub2_chainload' template and"
+  echo "the list of known filepaths for probing. Available devices are:"
   echo
   ls
   echo
-  echo If you cannot see the HDD, make sure the drive is marked as bootable in EFI and
-  echo not hidden. Boot order must be the following:
-  echo 1) NETWORK
-  echo 2) HDD
+  echo "If you cannot see the HDD, make sure the drive is marked as bootable in EFI and"
+  echo "not hidden. Boot order must be the following:"
+  echo "1) NETWORK"
+  echo "2) HDD"
   echo
-  echo The system will halt in 2 minutes or press ESC to halt immediately.
+  echo "The system will halt in 2 minutes or press ESC to halt immediately."
   sleep -i 120
   halt --no-apm
 }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -27,7 +27,7 @@ insmod fat
 insmod chain
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
-  echo Chainloading Grub2 EFI from ESP, enabled devices for booting:
+  echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
   unset chroot
@@ -128,18 +128,18 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
-  echo Partition with known EFI file not found, you may want to drop to grub shell
-  echo and investigate available files updating 'pxegrub2_chainload' template and
-  echo the list of known filepaths for probing. Available devices are:
+  echo "Partition with known EFI file not found, you may want to drop to grub shell"
+  echo "and investigate available files updating 'pxegrub2_chainload' template and"
+  echo "the list of known filepaths for probing. Available devices are:"
   echo
   ls
   echo
-  echo If you cannot see the HDD, make sure the drive is marked as bootable in EFI and
-  echo not hidden. Boot order must be the following:
-  echo 1) NETWORK
-  echo 2) HDD
+  echo "If you cannot see the HDD, make sure the drive is marked as bootable in EFI and"
+  echo "not hidden. Boot order must be the following:"
+  echo "1) NETWORK"
+  echo "2) HDD"
   echo
-  echo The system will halt in 2 minutes or press ESC to halt immediately.
+  echo "The system will halt in 2 minutes or press ESC to halt immediately."
   sleep -i 120
   halt --no-apm
 }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -4,7 +4,7 @@ insmod fat
 insmod chain
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
-  echo Chainloading Grub2 EFI from ESP, enabled devices for booting:
+  echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
   unset chroot
@@ -105,18 +105,18 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
-  echo Partition with known EFI file not found, you may want to drop to grub shell
-  echo and investigate available files updating 'pxegrub2_chainload' template and
-  echo the list of known filepaths for probing. Available devices are:
+  echo "Partition with known EFI file not found, you may want to drop to grub shell"
+  echo "and investigate available files updating 'pxegrub2_chainload' template and"
+  echo "the list of known filepaths for probing. Available devices are:"
   echo
   ls
   echo
-  echo If you cannot see the HDD, make sure the drive is marked as bootable in EFI and
-  echo not hidden. Boot order must be the following:
-  echo 1) NETWORK
-  echo 2) HDD
+  echo "If you cannot see the HDD, make sure the drive is marked as bootable in EFI and"
+  echo "not hidden. Boot order must be the following:"
+  echo "1) NETWORK"
+  echo "2) HDD"
   echo
-  echo The system will halt in 2 minutes or press ESC to halt immediately.
+  echo "The system will halt in 2 minutes or press ESC to halt immediately."
   sleep -i 120
   halt --no-apm
 }


### PR DESCRIPTION
This is causing issues when we edit those lines and drop characters like `'` which then introduce syntax errors.