### PR TITLE
Fixes #32670 - Show configuration status on the host status overview page

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -1,5 +1,31 @@
 module HostStatus
   class ConfigurationStatus < Status
+    ALERTS_DISABLED = 0
+    NO_REPORTS = 1
+    OUT_OF_SYNC = 2
+    PENDING = 3
+    ERROR = 4
+    ACTIVE = 5
+    NO_CHANGES = 6
+
+    OK_STATUSES = [ALERTS_DISABLED, PENDING, ACTIVE, NO_CHANGES]
+    WARN_STATUSES = [OUT_OF_SYNC, NO_REPORTS]
+    ERROR_STATUSES = [ERROR]
+
+    LABELS = {
+      ALERTS_DISABLED => N_("Alerts disabled"),
+      NO_REPORTS => N_("No reports"),
+      OUT_OF_SYNC => N_("Out of sync"),
+      PENDING => N_("Pending"),
+      ERROR => N_("Error"),
+      ACTIVE => N_("Active"),
+      NO_CHANGES => N_("No changes"),
+    }.freeze
+
+    def self.presenter
+      ::ConfigurationStatusPresenter.new(self)
+    end
+
     delegate :error?, :changes?, :pending?, :to => :calculator
     delegate(*ConfigReport::METRIC, :to => :calculator)
 
@@ -63,22 +89,26 @@ module HostStatus
     end
 
     def to_label(options = {})
+      LABELS.fetch(get_status(options))
+    end
+
+    def get_status(options = {})
       handle_options(options)
 
       if host && !host.enabled
-        N_("Alerts disabled")
+        ALERTS_DISABLED
       elsif no_reports?
-        N_("No reports")
+        NO_REPORTS
       elsif error?
-        N_("Error")
+        ERROR
       elsif out_of_sync?
-        N_("Out of sync")
+        OUT_OF_SYNC
       elsif changes?
-        N_("Active")
+        ACTIVE
       elsif pending?
-        N_("Pending")
+        PENDING
       else
-        N_("No changes")
+        NO_CHANGES
       end
     end
 

--- a/app/presenters/configuration_status_presenter.rb
+++ b/app/presenters/configuration_status_presenter.rb
@@ -1,0 +1,29 @@
+class ConfigurationStatusPresenter < HostStatusPresenter
+  private
+
+  def total_data
+    @total_data ||= data
+  end
+
+  def owned_data
+    ids = Host::Managed.search_for('owner = current_user').select(:id)
+    @owned_data ||= data(HostStatus::ConfigurationStatus.where(host_id: { id: ids }))
+  end
+
+  def data(scope = HostStatus::ConfigurationStatus)
+    scope.joins(:host)
+         .includes(
+           host: [
+             :hostgroup,
+             :operatingsystem,
+             :interfaces,
+             :location,
+             :organization,
+             :last_report_object,
+           ]
+         )
+         .select(&:relevant?)
+         .map(&:get_status)
+         .tally
+  end
+end

--- a/test/factories/reports_related.rb
+++ b/test/factories/reports_related.rb
@@ -9,6 +9,10 @@ FactoryBot.define do
 
   factory :config_report, :parent => :report, :class => 'ConfigReport'
 
+  trait :with_origin do
+    sequence(:origin) { |n| "testorigin#{n}" }
+  end
+
   trait :old_report do
     after(:build) do |report|
       report.created_at  = 2.weeks.ago

--- a/test/presenters/configuration_status_presenter_test.rb
+++ b/test/presenters/configuration_status_presenter_test.rb
@@ -1,0 +1,218 @@
+require 'test_helper'
+
+class ConfigurationStatusPresenterTest < ActiveSupport::TestCase
+  describe 'total data' do
+    subject { HostStatus::ConfigurationStatus.presenter.send(:total_data) }
+
+    let(:host) { FactoryBot.create(:host, reports: reports, last_report: reports.first&.reported_at) }
+    let(:reports) { [report] }
+    let(:report) { FactoryBot.build(:report, :with_origin, status: status, reported_at: reported_at) }
+    let(:status) { {} }
+    let(:reported_at) { Time.now.utc }
+
+    setup do
+      Setting[:always_show_configuration_status] = true
+
+      HostStatus::ConfigurationStatus.create(host: host).tap(&:refresh!)
+    end
+
+    context 'when not relevant' do
+      let(:reports) { [] }
+
+      setup do
+        Setting[:always_show_configuration_status] = false
+      end
+
+      it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+      it { assert_empty subject.keys }
+    end
+
+    context 'when alerts disabled' do
+      let(:host) { FactoryBot.create(:host, enabled: false) }
+
+      it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+      it { assert_equal 1, subject[HostStatus::ConfigurationStatus::ALERTS_DISABLED] }
+    end
+
+    context 'when no reports' do
+      let(:reports) { [] }
+
+      it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+      it { assert_equal 1, subject[HostStatus::ConfigurationStatus::NO_REPORTS] }
+    end
+
+    context 'when pending' do
+      let(:status) do
+        {
+          applied: 1,
+          restarted: 1,
+          failed: 1,
+          failed_restarts: 1,
+          skipped: 1,
+          pending: 1,
+        }
+      end
+
+      it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+      it { assert_nil subject[HostStatus::ConfigurationStatus::PENDING] }
+    end
+
+    context 'when out of sync' do
+      let(:reported_at) { Time.now.utc - Setting[:outofsync_interval].minutes - 1.hour }
+
+      it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+      it { assert host.get_status(HostStatus::ConfigurationStatus).out_of_sync? }
+      it { assert_equal 1, subject[HostStatus::ConfigurationStatus::OUT_OF_SYNC] }
+
+      context 'and out of sync disabled' do
+        setup do
+          Foreman.settings._add("#{report.origin}_out_of_sync_disabled",
+            context: :test,
+            type: :boolean,
+            category: 'Setting::General',
+            full_name: 'Test out of sync',
+            description: 'description',
+            default: false)
+          Setting[:"#{report.origin}_out_of_sync_disabled"] = true
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert_not host.get_status(HostStatus::ConfigurationStatus).out_of_sync? }
+        it { assert_nil subject[HostStatus::ConfigurationStatus::OUT_OF_SYNC] }
+      end
+
+      context 'and origin interval set via settings' do
+        let(:origin_interval) { 10 }
+        let(:reported_at) { Time.now.utc - origin_interval.minutes - 5.minutes }
+
+        setup do
+          Foreman.settings._add("#{report.origin}_interval",
+            context: :test,
+            type: :integer,
+            category: 'Setting::General',
+            full_name: 'Origin out of sync interval',
+            description: 'description',
+            default: 0)
+          Setting[:"#{report.origin}_interval"] = origin_interval
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert host.get_status(HostStatus::ConfigurationStatus).out_of_sync? }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::OUT_OF_SYNC] }
+      end
+
+      context 'and origin interval set via host parameters' do
+        let(:origin_interval) { 10 }
+        let(:reported_at) { Time.now.utc - origin_interval.minutes - 5.minutes }
+
+        setup do
+          host.host_parameters.create!(name: "#{report.origin}_interval", value: origin_interval)
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert host.get_status(HostStatus::ConfigurationStatus).out_of_sync? }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::OUT_OF_SYNC] }
+      end
+    end
+
+    context 'when error' do
+      context 'and failed' do
+        let(:status) do
+          {
+            applied: 1,
+            restarted: 1,
+            failed: 1,
+            failed_restarts: 0,
+            skipped: 1,
+            pending: 0,
+          }
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::ERROR] }
+      end
+
+      context 'and failed restart' do
+        let(:status) do
+          {
+            applied: 1,
+            restarted: 1,
+            failed: 0,
+            failed_restarts: 1,
+            skipped: 1,
+            pending: 0,
+          }
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::ERROR] }
+      end
+    end
+
+    context 'when active' do
+      context 'and applied' do
+        let(:status) do
+          {
+            applied: 1,
+            restarted: 0,
+            failed: 0,
+            failed_restarts: 0,
+            skipped: 1,
+            pending: 0,
+          }
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::ACTIVE] }
+      end
+
+      context 'and restarted' do
+        let(:status) do
+          {
+            applied: 0,
+            restarted: 1,
+            failed: 0,
+            failed_restarts: 0,
+            skipped: 1,
+            pending: 0,
+          }
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::ACTIVE] }
+      end
+    end
+
+    context 'when no changes' do
+      let(:status) do
+        {
+          applied: 0,
+          restarted: 0,
+          failed: 0,
+          failed_restarts: 0,
+          skipped: 0,
+          pending: 0,
+        }
+      end
+
+      it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+      it { assert_equal 1, subject[HostStatus::ConfigurationStatus::NO_CHANGES] }
+
+      context 'and skipped' do
+        let(:status) do
+          {
+            applied: 0,
+            restarted: 0,
+            failed: 0,
+            failed_restarts: 0,
+            skipped: 1,
+            pending: 0,
+          }
+        end
+
+        it { assert_equal 1, HostStatus::ConfigurationStatus.count }
+        it { assert_equal 1, subject[HostStatus::ConfigurationStatus::NO_CHANGES] }
+      end
+    end
+  end
+end


### PR DESCRIPTION
~needs #8260 to be merged~

![image](https://user-images.githubusercontent.com/37402924/120318349-09559a80-c2e0-11eb-9746-3e403429222d.png)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
