### PR TITLE
Fixes #31915 - move documentation button in error page

### DIFF
--- a/app/views/common/500.html.erb
+++ b/app/views/common/500.html.erb
@@ -3,10 +3,6 @@
   :text => h(exception_message),
   :close => false %>
 
-<div class="pull-right">
-  <%= documentation_button("7.3GettingHelp")%>
-</div>
-
 <p id="message">
   <%= _("If you feel this is an error with Foreman itself, please open a new issue with") %>
   <%= link_to _("Foreman ticketing system"), "https://projects.theforeman.org/projects/foreman/issues", :rel => "external" %>,
@@ -19,3 +15,7 @@
   <% end %>
     <%= _(" and it is highly recommended to also attach the foreman-debug output.") %>
 </p>
+
+<div class="pull-right">
+  <%= documentation_button("7.3GettingHelp")%>
+</div>


### PR DESCRIPTION
To get to the error page you can open: `https://foreman.example.com/templates/provisioning_templates?search=&page=1"taiyyib '`
Before the documentation button was in the middle of the text:
![Screenshot from 2021-06-01 20-25-22](https://user-images.githubusercontent.com/30431079/120372473-e4811780-c31f-11eb-9cd3-e01795efc96f.png)


New alignment 
![Screenshot from 2021-06-01 20-22-13](https://user-images.githubusercontent.com/30431079/120372194-848a7100-c31f-11eb-87d1-87710e1f6f24.png)

To test need to run in production mode so
```
bundle exec rake assets:precompile  
RAILS_ENV="production" foreman start
```