### PR TITLE
Fixes #32695 - Fix inconsistent behavior with taxable parameters in API

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -79,6 +79,7 @@ module Api
       if association.nil? && parent_name == 'host'
         association = resource_class.reflect_on_all_associations.detect { |assoc| assoc.class_name == 'Host::Base' }
       end
+      return resource_class.all if association.nil? && Taxonomy.types.include?(resource_class_for(resource_name(parent_name)))
       raise "Association not found for #{parent_name}" unless association
       result_scope = resource_class_join(association, scope).reorder(nil)
       # Check that the scope resolves before return

--- a/test/controllers/api/v2/architectures_controller_test.rb
+++ b/test/controllers/api/v2/architectures_controller_test.rb
@@ -13,12 +13,27 @@ class Api::V2::ArchitecturesControllerTest < ActionController::TestCase
 
   all_per_page_test
 
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:architectures)
-    architectures = ActiveSupport::JSON.decode(@response.body)
-    assert !architectures.empty?
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:architectures)
+      architectures = ActiveSupport::JSON.decode(@response.body)
+      assert !architectures.empty?
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:architectures)
+      architectures = ActiveSupport::JSON.decode(@response.body)
+      assert !architectures.empty?
+    end
   end
 
   test "should show individual record" do

--- a/test/controllers/api/v2/bookmarks_controller_test.rb
+++ b/test/controllers/api/v2/bookmarks_controller_test.rb
@@ -16,10 +16,23 @@ class Api::V2::BookmarksControllerTest < ActionController::TestCase
                                        :query => " facts.architecture = x86_64",
                                      })
 
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:bookmarks)
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:bookmarks)
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:bookmarks)
+    end
   end
 
   test "should show bookmark" do

--- a/test/controllers/api/v2/compute_profiles_controller_test.rb
+++ b/test/controllers/api/v2/compute_profiles_controller_test.rb
@@ -1,12 +1,27 @@
 require 'test_helper'
 
 class Api::V2::ComputeProfilesControllerTest < ActionController::TestCase
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:compute_profiles)
-    compute_profiles = ActiveSupport::JSON.decode(@response.body)
-    assert !compute_profiles.empty?
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:compute_profiles)
+      compute_profiles = ActiveSupport::JSON.decode(@response.body)
+      assert !compute_profiles.empty?
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:compute_profiles)
+      compute_profiles = ActiveSupport::JSON.decode(@response.body)
+      assert !compute_profiles.empty?
+    end
   end
 
   test "should show individual record" do

--- a/test/controllers/api/v2/models_controller_test.rb
+++ b/test/controllers/api/v2/models_controller_test.rb
@@ -3,10 +3,23 @@ require 'test_helper'
 class Api::V2::ModelsControllerTest < ActionController::TestCase
   valid_attrs = { :name => "new model" }
 
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:models)
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:models)
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:models)
+    end
   end
 
   test "should show model" do

--- a/test/controllers/api/v2/operatingsystems_controller_test.rb
+++ b/test/controllers/api/v2/operatingsystems_controller_test.rb
@@ -1,10 +1,23 @@
 require 'test_helper'
 
 class Api::V2::OperatingsystemsControllerTest < ActionController::TestCase
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:operatingsystems)
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:operatingsystems)
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:operatingsystems)
+    end
   end
 
   test "should show os" do

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -1,12 +1,27 @@
 require 'test_helper'
 
 class Api::V2::SettingsControllerTest < ActionController::TestCase
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:settings)
-    settings = ActiveSupport::JSON.decode(@response.body)
-    assert !settings.empty?
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:settings)
+      settings = ActiveSupport::JSON.decode(@response.body)
+      assert !settings.empty?
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:settings)
+      settings = ActiveSupport::JSON.decode(@response.body)
+      assert !settings.empty?
+    end
   end
 
   test "should show individual record" do

--- a/test/controllers/api/v2/usergroups_controller_test.rb
+++ b/test/controllers/api/v2/usergroups_controller_test.rb
@@ -7,12 +7,27 @@ class Api::V2::UsergroupsControllerTest < ActionController::TestCase
 
   valid_attrs = { :name => 'test_usergroup' }
 
-  test "should get index" do
-    get :index
-    assert_response :success
-    assert_not_nil assigns(:usergroups)
-    usergroups = ActiveSupport::JSON.decode(@response.body)
-    assert !usergroups.empty?
+  context 'index test' do
+    def setup
+      @org = FactoryBot.create(:organization)
+      @loc = FactoryBot.create(:location)
+    end
+
+    test "should get index" do
+      get :index
+      assert_response :success
+      assert_not_nil assigns(:usergroups)
+      usergroups = ActiveSupport::JSON.decode(@response.body)
+      assert !usergroups.empty?
+    end
+
+    test "should get index with organization and location params" do
+      get :index, params: { :location_id => @loc.id, :organization_id => @org.id}
+      assert_response :success
+      assert_not_nil assigns(:usergroups)
+      usergroups = ActiveSupport::JSON.decode(@response.body)
+      assert !usergroups.empty?
+    end
   end
 
   test "should show individual record" do


### PR DESCRIPTION
api/os/index directly as per API docs with organization_id then it will fail with 500 saying Association not found for organization. Meanwhile if api/os/create is called with the same param it will work.

