### PR TITLE
Fixes #32715: add custom snippets to Kickstart default finish template

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -17,6 +17,7 @@ oses:
   - package_upgrade: boolean (default=true)
   - salt_master: string (default=undef)
   %>
+<%= snippet_if_exists(template_name + " custom pre") -%>
 <% if @host.subnet.respond_to?(:dhcp_boot_mode?) -%>
 <%= snippet 'kickstart_networking_setup' %>
 service network restart
@@ -61,6 +62,7 @@ fi
 
 <%= snippet "blacklist_kernel_modules" %>
 
+<%= snippet_if_exists(template_name + " custom post") -%>
 <% if chef_enabled %>
 <%= snippet 'chef_client' %>
 <% end -%>


### PR DESCRIPTION
Implement an early-stage and a late-stage snippet_if_exists() loader for the Kickstart default finish template.

This allows one to extend this shipped Finish template without having to fork it into a custom Finish template. The outcome is to allow users to upgrade Foreman without breaking provisioning and without having users rebase custom Finish templates on top of later Finish template code.

Placement of the snippet_if_exists() calls can certainly be changed in this PR; please let me know if you'd like me to change their place in the code.