### PR TITLE
fixes #32770 - add confirm dialogue for revoking of access token 

### DIFF
--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
@@ -31,9 +31,11 @@ const PersonalAccessTokens = ({ url, canCreate }) => {
   const boundClearNewPersonalAccessToken = () =>
     dispatch(clearNewPersonalAccessToken());
 
-  const boundRevokePersonalAccessToken = id =>
-    dispatch(revokePersonalAccessTokenAction({ url, id }));
-
+  const boundRevokePersonalAccessToken = id => {
+    if (window.confirm(__('Do you really want to revoke Access Token?'))) {
+      dispatch(revokePersonalAccessTokenAction({ url, id }));
+    }
+  };
   return (
     <Fragment>
       <NewPersonalAccessToken


### PR DESCRIPTION
Purpose of this commit is to prevent user to accidental revocation of access token, since it can not be un-revoked
