### PR TITLE
Fixes #32772 - allow present? on ApplicationRecord

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -8,6 +8,11 @@ class ApplicationRecord < ActiveRecord::Base
     meta_example = ", e.g. #{@meta[:example]}" if @meta[:example]
     name_desc = @meta[:name_desc] || "Name of the #{@meta[:friendly_name] || @meta[:class_scope]}#{meta_example}"
     property :name, String, desc: name_desc
+    property :present?, one_of: [true, false], desc: 'Object presence (always true)'
+  end
+
+  class Jail < Safemode::Jail
+    allow :id, :name, :present?
   end
 
   self.abstract_class = true


### PR DESCRIPTION
This is partial cherry-pick of 641c3f4a9bb5401a8ac06e70b925918125193957.

We do not allow `present?` on ApplicationRecord in safemode.
This caused Environment#present? failures in puppet.conf on Foreman 2.5
because it got introduced in 2.6 by 641c3f4a9bb5401a8ac06e70b925918125193957