### PR TITLE
Fixes #21640 - drop jquery-ui

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,3 @@
-@import 'jquery-ui/theme';
-@import 'jquery-ui/core';
-@import 'jquery-ui/menu';
-//we need to import all the above because we are using jquery-ui-rails and it uses sprockets require instaed of sass import.
 @import 'patternfly-sprockets';
 @import 'colors';
 @import 'patternfly';

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,5 +1,4 @@
 group :assets do
-  gem 'jquery-ui-rails', '~> 6.0'
   gem 'patternfly-sass', '~> 3.59.4'
   gem 'gettext_i18n_rails_js', '~> 1.0'
   gem 'execjs', '>= 1.4.0', '< 3.0'


### PR DESCRIPTION
We've moved autocomplete to React in a97a313
and we've moved byte size fields in db15a67.

We can finally drop jquery-ui dependency.

This is waiting for #8538