### PR TITLE
Fixes #32140 - Adding scoped search on reported data (CP 2.5)

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -71,6 +71,12 @@ module Hostext
       scoped_search :relation => :search_parameters, :on => :searchable_value, :in_key => :search_parameters, :on_key => :name, :complete_value => true, :rename => :params, :ext_method => :search_by_params, :only_explicit => true, :operators => ['= ', '~ ']
 
       scoped_search :relation => :reported_data, :on => :boot_time, :rename => 'boot_time', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :boot_time, :rename => 'reported.boot_time', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :virtual, :rename => 'reported.virtual', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :ram, :rename => 'reported.ram', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :sockets, :rename => 'reported.sockets', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :cores, :rename => 'reported.cores', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :disks_total, :rename => 'reported.disks_total', :only_explicit => true
 
       scoped_search :relation => :location, :on => :title, :rename => :location, :complete_value => true, :only_explicit => true
       scoped_search :on => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER


### PR DESCRIPTION
Host has many parameters. These parameters are mostly searchable via
scoped search. Since the Reported data was added to host, the boot_time
was only searchable. This PR add others parameters for scoped search via
"reported.*" call.

(cherry picked from commit e35061d00e6870e1970a5b048bef3f59af95da4e)
