### PR TITLE
Fixes #32397 - changed button type to submit (CP #8543)

### DIFF
--- a/app/views/hosts/_interfaces.html.erb
+++ b/app/views/hosts/_interfaces.html.erb
@@ -62,7 +62,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn btn-default" onclick="close_interface_modal(); return false;"><%= _('Cancel') %></button>
-          <button type="button"  class="btn btn-primary" onclick="save_interface_modal(); return false;"><%= _('Ok') %></button>
+          <button type="submit"  class="btn btn-primary" onclick="save_interface_modal(); return false;"><%= _('Ok') %></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
`<input type="button">` doesn't get the enter event in some cases.
submit type with `return false;` should fix this issue.

(cherry picked from commit 71a331c5d635be24a8c56d69e1ad9ebef0f5e6ac)