### PR TITLE
Fixes #32536 - add valid error when using invalid status type (CP 2.5)

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -195,6 +195,7 @@ module Api
             @status = @host.build_global_status
           else
             @status = @host.get_status(HostStatus.find_status_by_humanized_name(params[:type]))
+            render :json => { :error => _("Status %s does not exist.") % params[:type] }, :status => :unprocessable_entity if @status.type.empty?
         end
       end
 

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -457,6 +457,12 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "should not get nonexistent status" do
+    get :get_status, params: { :id => @host.to_param, :type => 'doesnt_exist' }
+    assert_equal({'error' => 'Status doesnt_exist does not exist.'}, JSON.parse(@response.body))
+    assert_response :unprocessable_entity
+  end
+
   test "should be able to create hosts even when restricted" do
     disable_orchestration
     assert_difference('Host.count') do


### PR DESCRIPTION
(cherry picked from commit dc82c65c535ac0cd405345dd7fa36e64912370d9)