### PR TITLE
Fixes #32805 - Overwrite outofsync_interval setting as host parameter

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -133,7 +133,11 @@ module HostStatus
     end
 
     def default_report_interval
-      Setting[:outofsync_interval]
+      if host.params.has_key? 'outofsync_interval'
+        host.params['outofsync_interval']
+      else
+        Setting[:outofsync_interval]
+      end
     end
 
     def out_of_sync_disabled?

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -30,7 +30,7 @@ class Setting::General < Setting
       set('http_proxy_except_list', N_('Set hostnames to which requests are not to be proxied. Requests to the local host are excluded by default.'), [], N_('HTTP(S) proxy except hosts')),
       set('lab_features', N_("Whether or not to show a menu to access experimental lab features (requires reload of page)"), false, N_('Show Experimental Labs')),
       set("append_domain_name_for_hosts", N_("Foreman will append domain names when new hosts are provisioned"), true, N_("Append domain names to the host")),
-      set('outofsync_interval', N_("Duration in minutes after servers are classed as out of sync."), 30, N_('Out of sync interval')),
+      set('outofsync_interval', N_('Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter "outofsync_interval".'), 30, N_('Out of sync interval')),
       set('instance_id', N_("Foreman instance ID, uniquely identifies this Foreman instance."), 'uuid', N_('Foreman UUID'), Foreman.uuid),
       set('default_locale', N_("Language to use for new users"), nil, N_('Default language'), nil, { :collection => proc { locales } }),
       set('default_timezone', N_("Timezone to use for new users"), nil, N_('Default timezone'), nil, { :collection => proc { timezones } }),

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -8065,7 +8065,9 @@ msgid "Append domain names to the host"
 msgstr ""
 
 #: ../app/models/setting/general.rb:26
-msgid "Duration in minutes after servers are classed as out of sync."
+msgid ""
+"Duration in minutes after servers are classed as out of sync. You can override"$
+" this on hosts by adding a parameter \"outofsync_interval\"."$
 msgstr ""
 
 #: ../app/models/setting/general.rb:26

--- a/test/models/host_status/configuration_status_test.rb
+++ b/test/models/host_status/configuration_status_test.rb
@@ -160,4 +160,15 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
     assert_equal [@host], Host.search_for('status.applied = false')
     assert_equal [], Host.search_for('status.applied = 1')
   end
+
+  test 'overwrite outofsync_interval as host parameter' do
+    window = 30
+    Setting['puppet_interval'] = 10
+    Setting['outofsync_interval'] = 15
+    @status.reported_at = Time.now.utc - window.minutes
+    assert @status.out_of_sync?
+    # should be not out of sync if Setting['outofsync_interval'] is overwritten by parameter
+    @host.params['outofsync_interval'] = 25
+    refute @status.out_of_sync?
+  end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
