### PR TITLE
Fixes #32776 - Fixing subtotal count at Hosts controller

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -42,7 +42,11 @@ module Api
         @hosts = action_scope_for(:index, resource_scope_for_index)
 
         if params[:thin]
-          @subtotal = @hosts.total_entries
+          @subtotal = if @hosts.respond_to?(:total_entries)
+                        @hosts.total_entries
+                      else
+                        @hosts.size
+                      end
           @hosts = @hosts.reorder(:name).distinct.pluck(:id, :name)
           render 'thin'
           return

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -107,6 +107,16 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal Host.all.pluck(:id, :name), hosts['results'].map(&:values)
   end
 
+  test "should get thin index even the will paginate scope is not defined" do
+    # this test is based on bug: https://projects.theforeman.org/issues/32776
+    get :index, params: { thin: true, per_page: :all}
+    assert_response :success
+    assert_not_nil assigns(:hosts)
+    hosts = ActiveSupport::JSON.decode(@response.body)
+    assert !hosts.empty?
+    assert_equal Host.all.pluck(:id, :name), hosts['results'].map(&:values)
+  end
+
   test "subtotal should be the same as the search count with thin" do
     FactoryBot.create_list(:host, 2)
     Host.last.update_attribute(:name, 'test')


### PR DESCRIPTION
Foreman uses will_paginate gem for pagination. When the user wants all results in one page by API, this gem is not used.
That causes interferences with thin parameter at the Hosts controller. When the thin parameter is used there method call 'total_entries' that is method from will_paginate gem. It's works great until user wants all results in page. In that case will_paginate gem is not used. Logically is causes NoMethodError. This PR fixes it by calling size instead and only in case when the will_paginate gem is not used. 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
