### PR TITLE
Fixes #32819 - Add Index page template

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -243,6 +243,46 @@ class ApplicationController < ActionController::Base
     base.paginate(:page => params[:page], :per_page => params[:per_page])
   end
 
+  def can_edit?(model_id)
+    is_authorized_for_action?(:update, model_id)
+  end
+
+  def can_delete?(model_id)
+    is_authorized_for_action?(:destroy, model_id)
+  end
+
+  def is_authorized_for_action?(action, model_id)
+    authorized_for(controller: controller_permission, action: model_of_controller.find_permission_name(action), id: model_id)
+  end
+
+  def js_link_if_can_edit(model_id, path, label)
+    can_edit?(model_id) ? js_link_to(label, path) : label
+  end
+
+  def js_link_to(label, path)
+    { type: 'link', label: label, path: path }
+  end
+
+  def js_component(name, props)
+    { component: name, props: props }
+  end
+
+  def js_sortable_col(label, sort_by)
+    {label: label, sort_by: sort_by}
+  end
+
+  def js_delete_if_authorized(model_id:, label: _("Delete"), message: _("Are you sure?"), path:, operation: "delete", confirm_text: _("Delete"))
+    props = {
+      label: label, disabled: !can_delete?(model_id), message: message,
+      operation: operation, path: path, isWarning: true, confirmButtonText: confirm_text
+    }
+    js_component('TableConfirmModal', props)
+  end
+
+  def js_empty_state_action(title, path)
+    { title: title, path: path }
+  end
+
   private
 
   def require_admin

--- a/app/controllers/architectures_controller.rb
+++ b/app/controllers/architectures_controller.rb
@@ -1,11 +1,28 @@
 class ArchitecturesController < ApplicationController
+  include ApplicationHelper
   include Foreman::Controller::AutoCompleteSearch
   include Foreman::Controller::Parameters::Architecture
 
   before_action :find_resource, :only => [:edit, :update, :destroy]
 
   def index
-    @architectures = resource_base_search_and_page.includes(:operatingsystems)
+    @architectures ||= resource_base_search_and_page.includes(:operatingsystems)
+    respond_to do |format|
+      format.html do
+        render "index"
+      end
+      format.json do
+        render json: {
+          rows: rows(@architectures),
+          columns: columns,
+          total_entries: @architectures.total_entries,
+          global_actions: global_actions,
+          primary_action: primary_action,
+          before_toolbar_content: before_toolbar_content,
+          empty_state: empty_state,
+        }, status: :ok
+      end
+    end
   end
 
   def new
@@ -38,5 +55,56 @@ class ArchitecturesController < ApplicationController
     else
       process_error
     end
+  end
+
+  private
+
+  def columns
+    [js_sortable_col(_('Name'), 'name'), _('Operating systems'), _('Hosts')]
+  end
+
+  def rows(architectures)
+    @architectures_hosts_count ||= hosts_count(:architecture)
+    architectures.map do |arch|
+      name = js_link_if_can_edit(arch, edit_architecture_path(:id => arch), arch.name)
+      os = arch.operatingsystems.map(&:to_label).to_sentence
+      hosts_count = js_link_to(@architectures_hosts_count[arch], hosts_path(:search => "architecture = #{arch}"))
+      { cells: [name, os, hosts_count], actions: row_actions(arch) }
+    end
+  end
+
+  def row_actions(arch)
+    [
+      js_delete_if_authorized(
+        model_id: arch.id,
+        path: architecture_path(:id => arch),
+        message: _("Delete %s?") % arch.name
+      ),
+    ]
+  end
+
+  def global_actions
+    []
+  end
+
+  def primary_action
+    js_link_to(_("Create"), new_architecture_path)
+  end
+
+  def before_toolbar_content
+  end
+
+  def empty_state
+    description = _('Before you proceed to using Foreman you should provide information about one or more architectures.<br>
+    Each entry represents a particular hardware architecture, most commonly <strong>x86_64</strong> or <strong>i386</strong>.<br>
+    Foreman also supports the Solaris operating system family, which includes sparc based systems.<br>
+    Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations.')
+    @empty_state ||= {
+      header: _('Architectures'),
+      icon: 'building',
+      iconType: 'fa',
+      description: description,
+      action: js_empty_state_action(_("Create Architecture"), new_architecture_path),
+    }
   end
 end

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -45,7 +45,13 @@ module LayoutHelper
   end
 
   def routes
-    []
+    [
+      {
+        path: experimental_architectures_path,
+        component: 'IndexPageTemplate',
+        props: { path: architectures_path, header: _("Architectures") },
+      },
+    ]
   end
 
   def layout_data

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -4,6 +4,7 @@ module LayoutHelper
                       layout: layout_data,
                       metadata: app_metadata,
                       toasts: toast_notifications_data,
+                      routes: routes,
                     })
   end
 
@@ -41,6 +42,10 @@ module LayoutHelper
 
   def fetch_user
     { current_user: User.current, user_dropdown: Menu::Manager.to_hash(:side_menu), impersonated_by: User.unscoped.find_by_id(session[:impersonated_by]) }
+  end
+
+  def routes
+    []
   end
 
   def layout_data

--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -96,9 +96,8 @@ module Menu
 
       Manager.map :labs_menu do |menu|
         menu.sub_menu :lab_features_menu, :caption => N_('Lab Features'), :icon => 'fa fa-flask' do
-          menu.item :host_wizard,
-            :caption => 'Host Wizard',
-            :url => '/host_wizard'
+          menu.item :host_wizard, :caption => 'Host Wizard', :url => '/host_wizard'
+          menu.item :architectures, :caption => 'Architectures', :url => '/experimental/architectures'
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -598,6 +598,7 @@ Foreman::Application.routes.draw do
   end
 
   match 'host_wizard' => 'react#index', :via => :get
+  get 'experimental/architectures' => 'react#index'
   constraints(id: /[^\/]+/) do
     match 'experimental/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
   end

--- a/webpack/assets/javascripts/dashboard/index.js
+++ b/webpack/assets/javascripts/dashboard/index.js
@@ -7,7 +7,11 @@
 import $ from 'jquery';
 import { doesDocumentHasFocus } from '../react_app/common/document';
 import { notify } from '../foreman_toast_notifications';
-import { activateTooltips, foremanUrl } from '../foreman_tools';
+import {
+  activateTooltips,
+  foremanUrl,
+  openConfirmModal,
+} from '../foreman_tools';
 import { reloadPage } from '../foreman_navigation';
 import { translate as __ } from '../react_app/common/I18n';
 import './index.scss';
@@ -55,29 +59,33 @@ export function removeWidget(item) {
   const gridster = $('.gridster>ul')
     .gridster()
     .data('gridster');
-  if (
-    window.confirm(
-      __('Are you sure you want to delete this widget from your dashboard?')
-    )
-  ) {
-    $.ajax({
-      type: 'DELETE',
-      url: $(item).data('url'),
-      success() {
-        notify({
-          message: __('Widget removed from dashboard.'),
-          type: 'success',
-        });
-        gridster.remove_widget(widget);
-      },
-      error() {
-        notify({
-          message: __('Error removing widget from dashboard.'),
-          type: 'error',
-        });
-      },
-    });
-  }
+  openConfirmModal({
+    title: __('Remove widget'),
+    message: __(
+      'Are you sure you want to delete this widget from your dashboard?'
+    ),
+    confirmButtonText: __('Delete'),
+    isWarning: true,
+    onConfirm: function onConfirm() {
+      $.ajax({
+        type: 'DELETE',
+        url: $(item).data('url'),
+        success() {
+          notify({
+            message: __('Widget removed from dashboard.'),
+            type: 'success',
+          });
+          gridster.remove_widget(widget);
+        },
+        error() {
+          notify({
+            message: __('Error removing widget from dashboard.'),
+            type: 'error',
+          });
+        },
+      });
+    },
+  });
 }
 
 export function addWidget(name) {

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -3,17 +3,20 @@ import store from './react_app/redux';
 
 import * as editorActions from './react_app/components/Editor/EditorActions';
 import { translate as __ } from './react_app/common/I18n';
+import { openConfirmModal } from './foreman_tools';
 
-export const revertTemplate = async ({ dataset: { version, url } }) => {
-  if (
-    window.confirm(__('Are you sure you would like to revert the Template?'))
-  ) {
-    try {
-      const response = await API.get(url, {}, { version });
-      document.getElementById('primary_tab').click();
-      store.dispatch(editorActions.changeEditorValue(response.data));
-    } catch (err) {
-      alert(__(`Revert Failed, ${err}`));
-    }
-  }
+export const revertTemplate = ({ dataset: { version, url } }) => {
+  openConfirmModal({
+    title: __('Revert template'),
+    message: __('Are you sure you would like to revert the Template?'),
+    onConfirm: async () => {
+      try {
+        const response = await API.get(url, {}, { version });
+        document.getElementById('primary_tab').click();
+        store.dispatch(editorActions.changeEditorValue(response.data));
+      } catch (err) {
+        alert(__(`Revert Failed, ${err}`));
+      }
+    },
+  });
 };

--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -10,7 +10,7 @@ import AppSwitcher from '../routes';
 import apolloClient from './apollo';
 import ToastsList from '../components/ToastsList';
 
-const ReactApp = ({ layout, metadata, toasts }) => {
+const ReactApp = ({ layout, metadata, toasts, routes }) => {
   const contextData = { metadata };
   const ForemanContext = getForemanContext(contextData);
 
@@ -21,7 +21,7 @@ const ReactApp = ({ layout, metadata, toasts }) => {
           <ConnectedRouter history={history}>
             <Layout data={layout}>
               <ToastsList railsMessages={toasts} />
-              <AppSwitcher />
+              <AppSwitcher serverRoutes={routes} />
             </Layout>
           </ConnectedRouter>
         </ApolloProvider>
@@ -34,6 +34,7 @@ ReactApp.propTypes = {
   layout: LayoutPropTypes.data.isRequired,
   metadata: PropTypes.object.isRequired,
   toasts: PropTypes.array.isRequired,
+  routes: PropTypes.array.isRequired,
 };
 
 export default ReactApp;

--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -9,6 +9,7 @@ import AppSwitcher from '../routes';
 
 import apolloClient from './apollo';
 import ToastsList from '../components/ToastsList';
+import ConfirmModal from '../components/ConfirmModal';
 
 const ReactApp = ({ layout, metadata, toasts, routes }) => {
   const contextData = { metadata };
@@ -22,6 +23,7 @@ const ReactApp = ({ layout, metadata, toasts, routes }) => {
             <Layout data={layout}>
               <ToastsList railsMessages={toasts} />
               <AppSwitcher serverRoutes={routes} />
+              <ConfirmModal />
             </Layout>
           </ConnectedRouter>
         </ApolloProvider>

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Modal, Button, ModalVariant } from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+import { closeConfirmModal, selectConfirmModal } from './slice';
+
+const ConfirmModal = () => {
+  const {
+    isOpen,
+    title,
+    message,
+    confirmButtonText,
+    onConfirm,
+    onCancel,
+    modalProps,
+    isWarning,
+  } = useSelector(selectConfirmModal);
+
+  const dispatch = useDispatch();
+
+  const closeModal = () => dispatch(closeConfirmModal());
+
+  const handleCancel = () => {
+    onCancel();
+    closeModal();
+  };
+
+  const handleConfirm = () => {
+    onConfirm();
+    closeModal();
+  };
+
+  const actions = [
+    <Button
+      key="confirm"
+      variant={isWarning ? 'danger' : 'primary'}
+      onClick={handleConfirm}
+    >
+      {confirmButtonText || __('Confirm')}
+    </Button>,
+    <Button key="cancel" variant="link" onClick={handleCancel}>
+      {__('Cancel')}
+    </Button>,
+  ];
+
+  return (
+    <Modal
+      id="app-confirm-modal"
+      aria-label="application confirm modal"
+      variant={ModalVariant.small}
+      title={title}
+      isOpen={isOpen}
+      onClose={closeModal}
+      actions={actions}
+      titleIconVariant={isWarning ? 'warning' : null}
+      {...modalProps}
+    >
+      {message}
+    </Modal>
+  );
+};
+
+export default ConfirmModal;
+
+export * from './slice';

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
@@ -1,0 +1,51 @@
+import Immutable from 'seamless-immutable';
+import { noop } from '../../common/helpers';
+
+const OPEN_CONFIRM_MODAL = 'OPEN_CONFIRM_MODAL';
+const CLOSE_CONFIRM_MODAL = 'CLOSE_CONFIRM_MODAL';
+
+// actions
+export const openConfirmModal = ({
+  title = '',
+  message = '',
+  onConfirm = noop,
+  onCancel = noop,
+  isWarning = false,
+  confirmButtonText = null,
+  modalProps = {},
+}) => ({
+  type: OPEN_CONFIRM_MODAL,
+  payload: {
+    title,
+    message,
+    onConfirm,
+    onCancel,
+    modalProps,
+    isWarning,
+    confirmButtonText,
+  },
+});
+
+export const closeConfirmModal = () => ({
+  type: CLOSE_CONFIRM_MODAL,
+  payload: {},
+});
+
+// reducer
+const initialState = Immutable({ isOpen: false });
+export const reducer = (state = initialState, { type, payload }) => {
+  switch (type) {
+    case OPEN_CONFIRM_MODAL:
+      return state.merge({ isOpen: true, ...payload });
+    case CLOSE_CONFIRM_MODAL:
+      return initialState;
+    default:
+      return state;
+  }
+};
+
+export const storeDomain = 'confirmModal';
+
+export const reducers = { [storeDomain]: reducer };
+
+export const selectConfirmModal = state => state[storeDomain];

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/ActionsDropdown.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/ActionsDropdown.js
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import { DropdownItem, KebabToggle, Dropdown } from '@patternfly/react-core';
+import PropTypes from 'prop-types';
+import * as TableFormatters from './formatters';
+import componentRegistry from '../../../componentRegistry';
+
+const ActionsDropdown = ({ actions, reloadData }) => {
+  const [open, setOpen] = useState(false);
+  const [preventDropdownToggle, setPreventDropdownToggle] = useState(false);
+  const toggleDropdown = () => {
+    !preventDropdownToggle && setOpen(value => !value);
+  };
+  if (actions.length === 0) return null;
+  const dropdownItems = actions.map(
+    ({ component, props: mountedProps, disabled, path, label }) => {
+      const childKey = JSON.stringify(mountedProps);
+      if (component) {
+        const ActualComponent =
+          TableFormatters[component] ||
+          componentRegistry.registry[component]?.type;
+
+        if (ActualComponent) {
+          return (
+            <ActualComponent
+              key={childKey}
+              {...mountedProps}
+              reloadData={reloadData}
+              setPreventDropdownToggle={setPreventDropdownToggle}
+            />
+          );
+        }
+      }
+
+      return (
+        <DropdownItem key={path} isDisabled={disabled} href={path}>
+          {label}
+        </DropdownItem>
+      );
+    }
+  );
+
+  return (
+    <>
+      <Dropdown
+        isPlain
+        isOpen={open}
+        onSelect={setOpen}
+        dropdownItems={dropdownItems}
+        toggle={<KebabToggle onToggle={toggleDropdown} />}
+      />
+    </>
+  );
+};
+
+ActionsDropdown.propTypes = {
+  actions: PropTypes.array,
+  reloadData: PropTypes.func,
+};
+
+ActionsDropdown.defaultProps = {
+  actions: [],
+  reloadData: n => n,
+};
+
+export default ActionsDropdown;

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/PrimaryAction.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/PrimaryAction.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@patternfly/react-core';
+
+const PrimaryAction = ({ label, path }) =>
+  label ? (
+    <Button isInline component="a" href={path}>
+      {label}
+    </Button>
+  ) : null;
+
+PrimaryAction.propTypes = {
+  label: PropTypes.string,
+  path: PropTypes.string,
+};
+
+PrimaryAction.defaultProps = {
+  label: '',
+  path: '',
+};
+
+export default PrimaryAction;

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/TableActions.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/TableActions.js
@@ -1,0 +1,56 @@
+import URI from 'urijs';
+import { push } from 'connected-react-router';
+import { get } from '../../../../../redux/API';
+import { selectQueryParams } from './TableSelectors';
+import { getTableAPIKey } from './TableHelpers';
+
+export const fetchData = (path, queryParams = {}) => (dispatch, getState) => {
+  const state = getState();
+  const { page, perPage, query, sortBy, sortOrder } = {
+    ...selectQueryParams(state),
+    ...queryParams,
+  };
+
+  dispatch(
+    get({
+      key: getTableAPIKey(path),
+      url: path,
+      params: {
+        page,
+        per_page: perPage,
+        search: query,
+        order: `${sortBy} ${sortOrder}`,
+      },
+    })
+  );
+
+  const uri = new URI();
+  uri.search({
+    page,
+    per_page: perPage,
+    search: query,
+    sort_by: sortBy,
+    sort_order: sortOrder,
+  });
+
+  dispatch(
+    push({
+      pathname: uri.pathname(),
+      search: uri.search(),
+    })
+  );
+};
+
+export const onTableSort = (index, direction, columns, path) => {
+  const { sortKey } = columns[index];
+  return fetchData(path, {
+    sortBy: sortKey,
+    sortOrder: direction,
+    page: 1,
+  });
+};
+
+export const onTableSetPage = (page, path) => fetchData(path, { page });
+
+export const onTablePerPageSelect = (perPage, path) =>
+  fetchData(path, { perPage, page: 1 });

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/TableHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/TableHelpers.js
@@ -1,0 +1,19 @@
+export const getSortColumnIndex = (columns, sortBy) => {
+  let colIndex = 0;
+  columns.forEach((col, index) => {
+    if (col.sortKey === sortBy) {
+      colIndex = index;
+    }
+  });
+  return colIndex;
+};
+
+export const getPerPageOptions = (urlPerPage, appPerPage) => {
+  const initialValues = new Set([5, 10, 15, 25, 50]);
+  initialValues.add(appPerPage);
+  urlPerPage && initialValues.add(urlPerPage);
+  const options = [...initialValues].sort((a, b) => a - b);
+  return options.map(value => ({ title: value.toString(), value }));
+};
+
+export const getTableAPIKey = path => `TABLE${path}`;

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/TableSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/TableSelectors.js
@@ -1,0 +1,37 @@
+import URI from 'urijs';
+import { selectRouterLocation } from '../../../../../routes/RouterSelector';
+
+export const selectQuery = state => selectRouterLocation(state).query;
+
+export const selectSearch = state => {
+  const { search = '' } = selectQuery(state);
+  return URI.decodeQuery(search);
+};
+
+export const selectPage = state => {
+  const { page = '1' } = selectQuery(state);
+  return Number(page);
+};
+
+export const selectPerPage = state => {
+  const perPage = selectQuery(state).per_page;
+  return perPage && Number(perPage);
+};
+
+export const selectQueryParams = state => ({
+  page: selectPage(state),
+  perPage: selectPerPage(state),
+  query: selectSearch(state),
+  sortBy: selectSortBy(state),
+  sortOrder: selectSortOrder(state),
+});
+
+export const selectSortBy = state => {
+  const sortBy = selectQuery(state).sort_by;
+  return sortBy ? URI.decodeQuery(sortBy) : '';
+};
+
+export const selectSortOrder = state => {
+  const sortOrder = selectQuery(state).sort_order;
+  return sortOrder ? URI.decodeQuery(sortOrder) : '';
+};

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/components/EmptyState.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/Table/components/EmptyState.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  EmptyState,
+  EmptyStateIcon,
+  Spinner,
+  EmptyStateVariant,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+import { STATUS } from '../../../../../../constants';
+import { translate as __, sprintf } from '../../../../../../common/I18n';
+
+const TableEmptyState = ({ status, error, rowsLength }) => {
+  switch (status) {
+    case STATUS.RESOLVED:
+      return rowsLength === 0 ? (
+        <EmptyState variant={EmptyStateVariant.small}>
+          <EmptyStateIcon
+            variant="container"
+            component={ExclamationCircleIcon}
+          />
+          <Title headingLevel="h2" size="lg">
+            {__('No results were found')}
+          </Title>
+        </EmptyState>
+      ) : null;
+    case STATUS.PENDING:
+      return (
+        <EmptyState variant={EmptyStateVariant.small}>
+          <EmptyStateIcon variant="container" component={Spinner} />
+          <Title headingLevel="h2" size="lg">
+            {__('Loading')}
+          </Title>
+        </EmptyState>
+      );
+    case STATUS.ERROR:
+      return (
+        <EmptyState variant={EmptyStateVariant.small}>
+          <EmptyStateIcon
+            variant="container"
+            component={ExclamationCircleIcon}
+          />
+          <Title headingLevel="h2" size="lg">
+            {sprintf(__('The server returned the following error: %s'), error)}
+          </Title>
+        </EmptyState>
+      );
+    default:
+      return null;
+  }
+};
+
+TableEmptyState.propTypes = {
+  status: PropTypes.string,
+  error: PropTypes.string,
+  rowsLength: PropTypes.number,
+};
+
+TableEmptyState.defaultProps = {
+  status: null,
+  error: null,
+  rowsLength: null,
+};
+
+export default TableEmptyState;

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/formatters/TableConfirmModal.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/formatters/TableConfirmModal.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import { DropdownItem } from '@patternfly/react-core';
+import { APIActions } from '../../../../../redux/API';
+import { openConfirmModal } from '../../../../ConfirmModal';
+
+export const TableConfirmModal = ({
+  disabled,
+  label,
+  message,
+  path,
+  isWarning,
+  confirmButtonText,
+  operation,
+  reloadData,
+}) => {
+  const dispatch = useDispatch();
+  const APIKey = `CONFIRM${path}`;
+  const handleConfirm = () => {
+    dispatch(
+      APIActions[operation]({
+        key: APIKey,
+        url: path,
+        successToast: response => response.data.message,
+        handleSuccess: reloadData,
+      })
+    );
+  };
+
+  const handleClick = () =>
+    dispatch(
+      openConfirmModal({
+        title: label,
+        message,
+        onConfirm: handleConfirm,
+        isWarning,
+        confirmButtonText,
+      })
+    );
+
+  return (
+    <DropdownItem isDisabled={disabled} onClick={handleClick}>
+      {label}
+    </DropdownItem>
+  );
+};
+
+TableConfirmModal.propTypes = {
+  disabled: PropTypes.bool,
+  label: PropTypes.string.isRequired,
+  message: PropTypes.string.isRequired,
+  path: PropTypes.string.isRequired,
+  operation: PropTypes.string.isRequired,
+  reloadData: PropTypes.func.isRequired,
+  isWarning: PropTypes.bool,
+  confirmButtonText: PropTypes.string,
+};
+
+TableConfirmModal.defaultProps = {
+  disabled: false,
+  isWarning: false,
+  confirmButtonText: null,
+};
+
+export default TableConfirmModal;

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/formatters/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/components/formatters/index.js
@@ -1,0 +1,1 @@
+export * from './TableConfirmModal';

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/index.js
@@ -1,0 +1,206 @@
+/* eslint-disable camelcase */
+/* eslint-disable react-hooks/exhaustive-deps */
+import React, { useEffect } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import PropTypes from 'prop-types';
+import { Pagination, PaginationVariant, Text } from '@patternfly/react-core';
+import {
+  TableText,
+  Table as PF4Table,
+  TableHeader,
+  TableBody,
+  sortable,
+  cellWidth,
+} from '@patternfly/react-table';
+
+import { useForemanSettings } from '../../../Root/Context/ForemanContext';
+import PageLayout from '../../../routes/common/PageLayout/PageLayout';
+import { STATUS, getControllerSearchProps } from '../../../constants';
+import { translate as __ } from '../../../common/I18n';
+import TableEmptyState from './components/Table/components/EmptyState';
+import {
+  getSortColumnIndex,
+  getPerPageOptions,
+  getTableAPIKey,
+} from './components/Table/TableHelpers';
+import ActionsDropdown from './components/ActionsDropdown';
+import {
+  fetchData,
+  onTableSetPage,
+  onTablePerPageSelect,
+  onTableSort,
+} from './components/Table/TableActions';
+import PrimaryAction from './components/PrimaryAction';
+import EmptyState from '../EmptyState';
+import {
+  selectAPIErrorMessage,
+  selectAPIResponse,
+  selectAPIStatus,
+} from '../../../redux/API/APISelectors';
+import './index.scss';
+import { selectQueryParams } from './components/Table/TableSelectors';
+
+const IndexPageTemplate = ({ path, header }) => {
+  const [tableRows, setTableRows] = React.useState([]);
+  const [tableColumns, setTableColumns] = React.useState([]);
+  const { perPage: defaultPerPage } = useForemanSettings();
+
+  const { page, perPage: urlPerPage, query, sortBy, sortOrder } = useSelector(
+    selectQueryParams
+  );
+  const perPage = urlPerPage || defaultPerPage;
+  const key = getTableAPIKey(path);
+  const {
+    rows = [],
+    columns = [],
+    total_entries = 0,
+    global_actions,
+    primary_action,
+    before_toolbar_content,
+    empty_state,
+    title,
+  } = useSelector(state => selectAPIResponse(state, key));
+  const error = useSelector(state => selectAPIErrorMessage(state, key));
+  const status = useSelector(state => selectAPIStatus(state, key));
+
+  const dispatch = useDispatch();
+  const reloadData = () =>
+    dispatch(fetchData(path, { page, perPage, query, sortBy, sortOrder }));
+
+  useEffect(() => {
+    reloadData();
+  }, []);
+
+  useEffect(() => {
+    if (status === STATUS.RESOLVED && rows && columns) {
+      const isActions = rows.some(({ actions }) => !!actions);
+      setTableRows(handleRows(rows));
+      setTableColumns(handleColumns(columns, isActions));
+    }
+  }, [rows, columns, status]);
+
+  const handleRows = serverRows =>
+    serverRows.asMutable({ deep: true }).map(({ cells, actions }) => {
+      const nextCells = cells.map(cell => {
+        if (typeof cell !== 'object') return cell;
+        if (cell.type === 'link') {
+          return (
+            <TableText>
+              <a href={cell.path}>{cell.label}</a>
+            </TableText>
+          );
+        }
+        return cell;
+      });
+      actions &&
+        nextCells.push({
+          title: <ActionsDropdown actions={actions} reloadData={reloadData} />,
+        });
+
+      return { cells: nextCells };
+    });
+
+  const handleColumns = (serverColumns, isActions) => {
+    const nextColumns = serverColumns.asMutable({ deep: true }).map(colData => {
+      if (typeof colData !== 'object') {
+        return { title: colData };
+      }
+      const { sort_by, width, label } = colData;
+      const col = { title: label, transforms: [] };
+      if (sort_by) {
+        col.sortKey = sort_by;
+        col.transforms = [sortable];
+      }
+      if (width) {
+        col.transforms = [...col.transforms, cellWidth(width)];
+      }
+      return col;
+    });
+    isActions && nextColumns.push(__('Actions'));
+    return nextColumns;
+  };
+
+  const beforeToolbarComponent = before_toolbar_content && (
+    <Text
+      className="index-page-description"
+      dangerouslySetInnerHTML={{ __html: before_toolbar_content }}
+    />
+  );
+
+  if (total_entries === 0 && empty_state) {
+    return (
+      <EmptyState
+        {...empty_state}
+        description={
+          <div
+            dangerouslySetInnerHTML={{
+              __html: empty_state.description,
+            }}
+          />
+        }
+      />
+    );
+  }
+
+  const paginationProps = variant => ({
+    id: `index-page-${variant}-pagination`,
+    itemCount: total_entries,
+    perPage,
+    page,
+    variant: PaginationVariant[variant],
+    onSetPage: (e, pageNo) => dispatch(onTableSetPage(pageNo, path)),
+    onPerPageSelect: (e, perP) => dispatch(onTablePerPageSelect(perP, path)),
+    perPageOptions: getPerPageOptions(perPage, defaultPerPage),
+  });
+
+  return (
+    <PageLayout
+      className="index_page_template"
+      searchable
+      searchQuery={query}
+      searchProps={getControllerSearchProps(path)}
+      onSearch={nextQuery =>
+        dispatch(fetchData(path, { query: nextQuery, page: 1 }))
+      }
+      header={header}
+      title={title}
+      beforeToolbarComponent={beforeToolbarComponent}
+      toolbarButtons={
+        <>
+          <PrimaryAction {...primary_action} />
+          <ActionsDropdown actions={global_actions} />
+          <Pagination {...paginationProps('top')} />
+        </>
+      }
+    >
+      <PF4Table
+        sortBy={{
+          index: getSortColumnIndex(tableColumns, sortBy),
+          direction: sortOrder,
+        }}
+        onSort={(e, index, direction) =>
+          dispatch(onTableSort(index, direction, tableColumns, path))
+        }
+        rows={tableRows}
+        aria-label={`table${path}`}
+        cells={tableColumns}
+      >
+        <TableHeader />
+        <TableBody />
+      </PF4Table>
+      <TableEmptyState
+        status={status}
+        error={error}
+        rowsLength={tableRows.length}
+      />
+      <Pagination {...paginationProps('bottom')} />
+    </PageLayout>
+  );
+};
+
+IndexPageTemplate.propTypes = {
+  path: PropTypes.string.isRequired,
+  header: PropTypes.string.isRequired,
+};
+
+export default IndexPageTemplate;

--- a/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/index.scss
+++ b/webpack/assets/javascripts/react_app/components/common/IndexPageTemplate/index.scss
@@ -1,0 +1,17 @@
+#main.index_page_template {
+  padding: 0;
+
+  h1 {
+    font-weight: bold;
+    margin-bottom: 0;
+  }
+
+  #index-page-top-pagination {
+    margin-right: 24px;
+  }
+
+  .index-page-description {
+    white-space: nowrap;
+    margin-bottom: 15px;
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -48,6 +48,7 @@ import { WelcomeEnv } from './Enviroments/Welcome';
 import { WelcomeAuthSource } from './AuthSource/Welcome';
 import { WelcomeConfigReports } from './ConfigReports/Welcome';
 import { WelcomeArchitecture } from './Architectures/Welcome';
+import IndexPageTemplate from './common/IndexPageTemplate';
 
 const componentRegistry = {
   registry: forceSingleton('component_registry', () => ({})),
@@ -149,6 +150,7 @@ const coreComponets = [
   { name: 'PersonalAccessTokens', type: PersonalAccessTokens },
   { name: 'ClipboardCopy', type: ClipboardCopy },
   { name: 'LabelIcon', type: LabelIcon },
+  { name: 'IndexPageTemplate', type: IndexPageTemplate },
   {
     name: 'RelativeDateTime',
     type: RelativeDateTime,

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
@@ -16,6 +16,7 @@ import PersonalAccessTokenForm from './PersonalAccessTokenForm';
 import PersonalAccessTokensList from './PersonalAccessTokensList';
 import { translate as __ } from '../../../common/I18n';
 import { foremanUrl } from '../../../common/helpers';
+import { openConfirmModal } from '../../ConfirmModal';
 
 const PersonalAccessTokens = ({ url, canCreate }) => {
   const dispatch = useDispatch();
@@ -32,10 +33,17 @@ const PersonalAccessTokens = ({ url, canCreate }) => {
     dispatch(clearNewPersonalAccessToken());
 
   const boundRevokePersonalAccessToken = id => {
-    if (window.confirm(__('Do you really want to revoke Access Token?'))) {
-      dispatch(revokePersonalAccessTokenAction({ url, id }));
-    }
+    dispatch(
+      openConfirmModal({
+        title: __('Revoke personal access token'),
+        message: __('Do you really want to revoke Access Token?'),
+        confirmButtonText: __('Revoke'),
+        isWarning: true,
+        onConfirm: () => dispatch(revokePersonalAccessTokenAction({ url, id })),
+      })
+    );
   };
+
   return (
     <Fragment>
       <NewPersonalAccessToken

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -23,6 +23,7 @@ import { reducers as apiReducer } from '../API';
 import { reducers as modelsPageReducers } from '../../routes/Models/ModelsPage';
 import { reducers as settingRecordsReducers } from '../../components/SettingRecords';
 import { reducers as personalAccessTokensReducers } from '../../components/users/PersonalAccessTokens';
+import { reducers as confirmModalReducers } from '../../components/ConfirmModal';
 
 export function combineReducersAsync(asyncReducers) {
   return combineReducers({
@@ -43,6 +44,7 @@ export function combineReducersAsync(asyncReducers) {
     ...typeAheadSelectReducers,
     ...settingRecordsReducers,
     ...personalAccessTokensReducers,
+    ...confirmModalReducers,
 
     router: connectRouter(history),
     // Pages

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -4,6 +4,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Audits"
   isLoading={false}
@@ -27,6 +28,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
   }
   searchQuery="search"
   searchable={true}
+  title=""
   toolbarButtons={
     <Button
       active={false}
@@ -80,6 +82,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Audits"
   isLoading={false}
@@ -103,6 +106,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
   }
   searchQuery="search"
   searchable={true}
+  title=""
   toolbarButtons={
     <Button
       active={false}
@@ -158,6 +162,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Audits"
   isLoading={false}
@@ -181,6 +186,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
   }
   searchQuery="search"
   searchable={true}
+  title=""
   toolbarButtons={
     <Button
       active={false}
@@ -236,6 +242,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Audits"
   isLoading={false}
@@ -259,6 +266,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
   }
   searchQuery="search"
   searchable={true}
+  title=""
   toolbarButtons={
     <Button
       active={false}

--- a/webpack/assets/javascripts/react_app/routes/HostWizard/HostWizardPage/__snapshots__/HostWizard.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/HostWizard/HostWizardPage/__snapshots__/HostWizard.test.js.snap
@@ -4,6 +4,7 @@ exports[`HostWizard rendering renders LoginPage 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Host Wizard"
   isLoading={false}
@@ -12,6 +13,7 @@ exports[`HostWizard rendering renders LoginPage 1`] = `
   searchProps={Object {}}
   searchQuery=""
   searchable={false}
+  title=""
   toolbarButtons={null}
 >
   <Button

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
@@ -4,6 +4,7 @@ exports[`ModelsPage redering should render when loading 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Hardware Models"
   isLoading={false}
@@ -27,6 +28,7 @@ exports[`ModelsPage redering should render when loading 1`] = `
   }
   searchQuery="name=foo"
   searchable={false}
+  title=""
   toolbarButtons={
     <Link
       to="/models/new"
@@ -87,6 +89,7 @@ exports[`ModelsPage redering should render with error 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Hardware Models"
   isLoading={false}
@@ -110,6 +113,7 @@ exports[`ModelsPage redering should render with error 1`] = `
   }
   searchQuery="name=foo"
   searchable={true}
+  title=""
   toolbarButtons={
     <Link
       to="/models/new"
@@ -175,6 +179,7 @@ exports[`ModelsPage redering should render with models 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Hardware Models"
   isLoading={false}
@@ -198,6 +203,7 @@ exports[`ModelsPage redering should render with models 1`] = `
   }
   searchQuery="name=foo"
   searchable={true}
+  title=""
   toolbarButtons={
     <Link
       to="/models/new"
@@ -258,6 +264,7 @@ exports[`ModelsPage redering should render with no data 1`] = `
 <PageLayout
   beforeToolbarComponent={null}
   breadcrumbOptions={null}
+  className=""
   customBreadcrumbs={null}
   header="Hardware Models"
   isLoading={false}
@@ -281,6 +288,7 @@ exports[`ModelsPage redering should render with no data 1`] = `
   }
   searchQuery="name=foo"
   searchable={true}
+  title=""
   toolbarButtons={
     <Link
       to="/models/new"

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -20,11 +20,13 @@ const PageLayout = ({
   beforeToolbarComponent,
   isLoading,
   children,
+  className,
+  title,
 }) => (
-  <div id="main">
+  <div id="main" className={className}>
     <div id="react-content">
       <Head>
-        <title>{header}</title>
+        <title>{title || header}</title>
       </Head>
       <div id="breadcrumb">
         {!breadcrumbOptions && (
@@ -65,6 +67,8 @@ const PageLayout = ({
 );
 
 PageLayout.propTypes = {
+  className: PropTypes.string,
+  title: PropTypes.string,
   children: PropTypes.node.isRequired,
   searchable: PropTypes.bool.isRequired,
   header: PropTypes.string,
@@ -115,6 +119,8 @@ PageLayout.propTypes = {
 };
 
 PageLayout.defaultProps = {
+  className: '',
+  title: '',
   searchProps: {},
   header: '',
   searchQuery: '',

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`render pageLayout w/beforeToolbarComponent 1`] = `
 <div
+  className=""
   id="main"
 >
   <div
@@ -95,6 +96,7 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
 
 exports[`render pageLayout w/search 1`] = `
 <div
+  className=""
   id="main"
 >
   <div
@@ -185,6 +187,7 @@ exports[`render pageLayout w/search 1`] = `
 
 exports[`render pageLayout w/toolBar 1`] = `
 <div
+  className=""
   id="main"
 >
   <div
@@ -279,6 +282,7 @@ exports[`render pageLayout w/toolBar 1`] = `
 
 exports[`render pageLayout with custom breadcrumbs 1`] = `
 <div
+  className=""
   id="main"
 >
   <div
@@ -347,6 +351,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
 
 exports[`render pageLayout without breadcrumbs 1`] = `
 <div
+  className=""
   id="main"
 >
   <div
@@ -419,6 +424,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
 
 exports[`render pageLayout without search 1`] = `
 <div
+  className=""
   id="main"
 >
   <div

--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -4,29 +4,46 @@ import PropTypes from 'prop-types';
 import { routes } from './routes';
 import { renderRoute } from './RoutingService';
 import ForemanSwitch from './ForemanSwitcher';
+import componentRegistry from '../components/componentRegistry';
 
-const AppSwitcher = ({ children }) => (
-  <>
-    <ForemanSwitch>
-      {routes.map(({ render, path, ...routeProps }) => (
-        <Route
-          path={path}
-          key={path}
-          {...routeProps}
-          render={renderProps => renderRoute(render, renderProps)}
-        />
-      ))}
-    </ForemanSwitch>
-    {children}
-  </>
-);
+const AppSwitcher = ({ children, serverRoutes }) => {
+  const appRoutes = [
+    ...routes,
+    ...serverRoutes.map(({ path, props: serverProps, component }) => {
+      const Component = componentRegistry.registry[component]?.type;
+      return {
+        path,
+        render: renderProps =>
+          Component && <Component {...renderProps} {...serverProps} />,
+      };
+    }),
+  ];
+
+  return (
+    <>
+      <ForemanSwitch>
+        {appRoutes.map(({ render, path, ...routeProps }) => (
+          <Route
+            path={path}
+            key={path}
+            {...routeProps}
+            render={renderProps => renderRoute(render, renderProps)}
+          />
+        ))}
+      </ForemanSwitch>
+      {children}
+    </>
+  );
+};
 
 AppSwitcher.propTypes = {
   children: PropTypes.object,
+  serverRoutes: PropTypes.array,
 };
 
 AppSwitcher.defaultProps = {
   children: null,
+  serverRoutes: [],
 };
 
 export default AppSwitcher;


### PR DESCRIPTION
A data-driven React template to create index pages that contain search bar and table easily.

blocked by:
- #8619
- #8656
- #8655
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
