### PR TITLE
Fixes #32753 - Remote code execution through Sendmail

### DIFF
--- a/db/migrate/20210610131920_restrict_sendmail_location.rb
+++ b/db/migrate/20210610131920_restrict_sendmail_location.rb
@@ -1,0 +1,12 @@
+class RestrictSendmailLocation < ActiveRecord::Migration[6.0]
+  def up
+    Setting.without_auditing do
+      existing = Setting.find_by_name("sendmail_location")
+      if existing && !Setting::Email::SENDMAIL_LOCATIONS.include?(existing.value)
+        say "Sendmail location '#{existing.value}' not allowed, resetting to default"
+        existing.value = nil
+        existing.save!
+      end
+    end
+  end
+end


### PR DESCRIPTION
CVE-2021-3584: Sendmail location and arguments, available via Administer - Settings, both accept arbitrary strings and pass them into shell. By default, only Foreman super administrator can access settings.

Mitigation: Verify the both settings and remove edit_settings permissions to all roles and users until fixed. Alternatively, create settings named sendmail_location and sendmail_arguments in settings.yaml file to override the UI and make the values read-only.

Solution: Limit the possible values for location to just expected paths. Use shellescaping for arguments as there is currently no way to pass arguments to the 'mail' gem in a safely manner.