### PR TITLE
Fixes #32822 - Job templates and resource picker

### DIFF
--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -6,7 +6,7 @@ class TemplateInput < ApplicationRecord
   class UnsatisfiedRequiredInput < ::Foreman::Exception
   end
 
-  VALUE_TYPE = ['plain', 'search', 'date']
+  VALUE_TYPE = ['plain', 'search', 'date', 'resource']
 
   attr_exportable(:name, :required, :input_type, :description,
     :options, :advanced, :value_type, :resource_type, :default, :hidden_value)

--- a/app/views/template_inputs/_form.html.erb
+++ b/app/views/template_inputs/_form.html.erb
@@ -4,7 +4,7 @@
       <%= text_f f, :name, :disabled => @template.locked? %>
       <%= checkbox_f f, :required, :disabled => @template.locked? %>
       <%= selectable_f f, :input_type, template_input_types_options(@template.available_input_types), {}, :class => "input_type_selector #{@template.locked? && 'without_select2'}", :disabled => @template.locked? %>
-      <%= selectable_f f, :value_type, [[_('Plain'), 'plain'], [_("Search"), 'search'], [_('Date'), 'date']], {}, {'data-item': f.index || f.object.id, class: "select-value-type #{@template.locked? && 'without_select2'}", onchange: "tfm.templateInputs.inputValueOnchange(this)", disabled: @template.locked? } %>
+      <%= selectable_f f, :value_type, template_input_value_type_options, {}, {'data-item': f.index || f.object.id, class: "select-value-type #{@template.locked? && 'without_select2'}", onchange: "tfm.templateInputs.inputValueOnchange(this)", disabled: @template.locked? } %>
       <%= selectable_f f, :resource_type, Permission.resources_with_translations, {}, {wrapper_class: "#{hide_resource_type_input(f.object)} form-group resource-type-#{f.index || f.object.id}", class: "#{@template.locked? && 'without_select2'}", disabled: @template.locked? } %>
       <% @template.available_input_types.each do |type| %>
       <div class="<%= type %>_input_type custom_input_type_fields" style="<%= f.object.input_type == type ? '' : 'display:none' %>">

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -27,6 +27,7 @@ module Foreman
         :preview?,
         :raise,
         :input,
+        :input_resource,
         :rand,
         :rand_hex,
         :rand_name,

--- a/lib/foreman/renderer/errors.rb
+++ b/lib/foreman/renderer/errors.rb
@@ -39,6 +39,10 @@ module Foreman
         MESSAGE = N_('Rendering failed, no input with name "%{s}" for input macro found').freeze
       end
 
+      class WrongInputValueType < RenderingError
+        MESSAGE = N_('%{name} value is a "%{type}", expected "resource" value type').freeze
+      end
+
       class UnknownReportColumn < RenderingError
         MESSAGE = N_('Rendering failed, one or more unknown columns specified for ordering - "%{unknown}"').freeze
       end
@@ -53,6 +57,10 @@ module Foreman
 
       class UnsupportedOS < RenderingError
         MESSAGE = N_('Unsupported or no operating system found for this host.').freeze
+      end
+
+      class UnknownResource < RenderingError
+        MESSAGE = N_("Unkown '%{klass}' resource class").freeze
       end
     end
   end

--- a/lib/foreman/renderer/scope/macros/inputs.rb
+++ b/lib/foreman/renderer/scope/macros/inputs.rb
@@ -25,6 +25,41 @@ module Foreman
               raise UndefinedInput.new(s: name)
             end
           end
+
+          apipie :method, 'Find and returns resource object from the template input value' do
+            required :name, String, desc: 'name of the template input'
+            raises error: UndefinedInput, desc: 'when there is no input with such name defined for the current template'
+            raises error: WrongInputValueType, desc: 'when the input value type is not "resource"'
+            returns Object, desc: 'The resource object'
+            example 'input_resource("hostgroup") #=> "ActiveRecord object"'
+          end
+          def input_resource(name)
+            @input = template.template_inputs&.find_by_name(name)
+
+            raise UndefinedInput.new(s: name) unless @input
+            raise WrongInputValueType.new(name: name, type: @input.value_type) if @input.value_type != 'resource'
+
+            return @input.preview(self) if preview?
+
+            find_resource
+          end
+
+          private
+
+          def resource_klass
+            @input.resource_type.constantize
+          rescue NameError
+            raise UnknownResource.new(klass: @input.resource_type)
+          end
+
+          def resource_permission
+            "view_#{@input.resource_type.underscore.pluralize}".to_sym
+          end
+
+          def find_resource
+            resource_klass.authorized(resource_permission)
+                          .find(@input.value(self))
+          end
         end
       end
     end

--- a/test/factories/template_input.rb
+++ b/test/factories/template_input.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :template_input do |f|
     f.sequence(:name) { |n| "Template input #{n}" }
     f.input_type { 'user' }
+    f.value_type { 'plain' }
+    f.resource_type {}
   end
 end

--- a/webpack/assets/javascripts/foreman_template_inputs.js
+++ b/webpack/assets/javascripts/foreman_template_inputs.js
@@ -49,11 +49,14 @@ export const pollReportData = url => {
 
 export const inputValueOnchange = input => {
   const searchValue = input.value === 'search';
+  const resourceValue = input.value === 'resource';
   const plainValue = input.value === 'plain';
   const inputId = input.dataset.item;
   const $fields = $(input).closest('.fields');
 
-  $fields.find(`.resource-type-${inputId}`).toggle(searchValue);
+  $fields
+    .find(`.resource-type-${inputId}`)
+    .toggle(searchValue || resourceValue);
   $fields.find(`.input-options-${inputId}`).toggle(plainValue);
   $fields.find(`.input-hidden-value-${inputId}`).toggle(plainValue);
 };


### PR DESCRIPTION
New `resource` user input type for templates with
template macro `input_resource` returning the resource object


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
