### PR TITLE
Fixes #32826 - nonadmin users able to revoke tokens

### DIFF
--- a/app/controllers/api/v2/personal_access_tokens_controller.rb
+++ b/app/controllers/api/v2/personal_access_tokens_controller.rb
@@ -46,6 +46,26 @@ module Api
       def destroy
         process_response @personal_access_token.revoke!
       end
+
+      private
+
+      def action_permission
+        case params[:action]
+        when 'destroy'
+          'revoke'
+        else
+          super
+        end
+      end
+
+      def parent_permission(child_perm)
+        case child_perm.to_s
+        when 'revoke'
+          'edit'
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/test/controllers/api/v2/personal_access_tokens_controller_test.rb
+++ b/test/controllers/api/v2/personal_access_tokens_controller_test.rb
@@ -54,4 +54,14 @@ class Api::V2::PersonalAccessTokensControllerTest < ActionController::TestCase
     assert @personal_access_token.reload.revoked?
     assert_response :success
   end
+
+  context 'with non-admin user' do
+    it 'allows to revoke his token' do
+      setup_user('edit', 'users', nil, @user)
+      setup_user('revoke', 'personal_access_tokens', nil, @user)
+      delete :destroy, params: { id: @personal_access_token.to_param, user_id: @user.id }, session: set_session_user(@user)
+      assert_response :success
+      assert @personal_access_token.reload.revoked?
+    end
+  end
 end

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -754,6 +754,11 @@ escalate_roles:
   resource_type: Role
   created_at: "2014-01-07 15:09:32.783442"
   updated_at: "2014-01-07 15:09:32.783442"
+revoke_personal_access_tokens:
+  name: revoke_personal_access_tokens
+  resource_type: PersonalAccessToken
+  created_at: "2014-01-07 15:09:32.783442"
+  updated_at: "2014-01-07 15:09:32.783442"
 
 <% Foreman::Plugin.all.map(&:permissions).inject({}, :merge).each do |permission,attrs| %>
 <%= permission %>:


### PR DESCRIPTION
Nonadmin users were not able to revoke tokens as we were using wrong
permission for that. This uses the corect (`revoke`) permission instead
of `destroy` for revoking the user tokens.