### PR TITLE
Fixes #32837 - drop unwanted URI parsing from extension

### DIFF
--- a/lib/foreman/http_proxy/net_http_extension.rb
+++ b/lib/foreman/http_proxy/net_http_extension.rb
@@ -2,9 +2,8 @@ module Foreman
   module HttpProxy
     module NetHttpExtension
       def request(req, body = nil, &block)
-        host = URI.parse(@address).host
-        if proxy_http_request?(@proxy_address, host, @socket)
-          log_proxied_request("NetHttp", http_proxy, host)
+        if proxy_http_request?(@proxy_address, address, @socket)
+          log_proxied_request("NetHttp", http_proxy, address)
           @proxy_address = URI.parse(http_proxy)
           http_proxied_rescue do
             super(req, body, &block)


### PR DESCRIPTION
Ruby Net::HTTP object does not contain URI, it contains address and port attributes which is documented to only old IP address or hostname and port, not URI or URL at all.

In our NetHttpExtension we parse the address into URI and then extract hostname part from there. This works fine for IPv4, however it fails for IPv6 as addresses must be enclosed within square brackets. The patch is removing the not-needed conversion to URI and back.

See the issue for full backtrace.