### PR TITLE
Refs #31100 - Fix typos in DocumentationLink component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/integration.test.js
@@ -54,8 +54,8 @@ describe('Bookmarks integration test', () => {
     expect(component.find('Spinner').exists()).not.toBeTruthy();
     expect(component.find('Bookmark').exists()).toBeTruthy();
     expect(
-      component.find(`a[href="${props.documentationUrl}"]`).exists()
-    ).toBeTruthy();
+      component.find('DocumentationLink').prop('href'))
+      .toBe(props.documentationUrl);
 
     const newBookmark = component.find('a#newBookmark');
     newBookmark.simulate('click');

--- a/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/__snapshots__/DocumentationLink.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/__snapshots__/DocumentationLink.test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`documentation links should have an external link to documentation 1`] = `
 <DropdownItem
-  href="http://theforeman.org"
   key="documentationUrl"
   onClick={[Function]}
 >
@@ -11,6 +10,7 @@ exports[`documentation links should have an external link to documentation 1`] =
     noVerticalAlign={false}
     size="sm"
   />
-   Documentation
+   
+  Documentation
 </DropdownItem>
 `;

--- a/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/index.js
@@ -6,13 +6,8 @@ import { newWindowOnClick } from '../../../common/helpers';
 import { translate as __ } from '../../../../react_app/common/I18n';
 
 const DocumentationLink = ({ href, children }) => (
-  <DropdownItem
-    key="documentationUrl"
-    href={href}
-    onClick={newWindowOnClick(href)}
-  >
-    <QuestionCircleIcon />
-    {` ${children}`}
+  <DropdownItem key="documentationUrl" onClick={newWindowOnClick(href)}>
+    <QuestionCircleIcon /> {children}
   </DropdownItem>
 );
 

--- a/webpack/assets/javascripts/react_app/components/common/DocumentationLink/__snapshots__/DocumentationLink.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/DocumentationLink/__snapshots__/DocumentationLink.test.js.snap
@@ -6,7 +6,6 @@ exports[`documentation links should have an external link to documentation 1`] =
   disabled={false}
   divider={false}
   header={false}
-  href="http://theforeman.org"
   key="documentationUrl"
   onClick={[Function]}
 >
@@ -14,7 +13,7 @@ exports[`documentation links should have an external link to documentation 1`] =
     name="question-circle"
     type="fa"
   />
-   $
+   
   Documentation
 </MenuItem>
 `;

--- a/webpack/assets/javascripts/react_app/components/common/DocumentationLink/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/DocumentationLink/index.js
@@ -5,8 +5,8 @@ import { newWindowOnClick } from '../../../common/helpers';
 import { translate as __ } from '../../../../react_app/common/I18n';
 
 const DocumentationLink = ({ href, children }) => (
-  <MenuItem key="documentationUrl" href={href} onClick={newWindowOnClick(href)}>
-    <Icon type="fa" name="question-circle" /> ${children}
+  <MenuItem key="documentationUrl" onClick={newWindowOnClick(href)}>
+    <Icon type="fa" name="question-circle" /> {children}
   </MenuItem>
 );
 


### PR DESCRIPTION
A couple of typos were missed in the original PR. Also, there is no need
to pass both href and onClick to the menu item, as the onClick disables
the default href behavior.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
