### PR TITLE
Fixes #32484 - Translate settings tooltip

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCell.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCell.js
@@ -11,8 +11,6 @@ import './SettingCell.scss';
 
 const SettingCell = ({ setting, onEditClick }) => {
   const fieldProps = { setting, tooltipId: setting.name, onEditClick };
-  const displayName = setting.fullName || setting.name;
-  const defaultStr = defaultToString(setting);
 
   if (setting.readonly) {
     fieldProps.tooltipText = sprintf(
@@ -22,7 +20,8 @@ const SettingCell = ({ setting, onEditClick }) => {
       setting.configFile
     );
   } else {
-    fieldProps.tooltipText = `${displayName} (Default: ${defaultStr})`;
+    const defaultStr = defaultToString(setting);
+    fieldProps.tooltipText = sprintf(__('Default: %s'), defaultStr);
     fieldProps.className = 'editable';
   }
 

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/__snapshots__/SettingCell.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/__snapshots__/SettingCell.test.js.snap
@@ -23,7 +23,7 @@ exports[`SettingCell render encrypted with fullName 1`] = `
     }
   }
   tooltipId="root_pass"
-  tooltipText="Root password (Default: ∙∙∙∙∙∙)"
+  tooltipText="Default: ∙∙∙∙∙∙"
 />
 `;
 
@@ -50,7 +50,7 @@ exports[`SettingCell render ordinary 1`] = `
     }
   }
   tooltipId="email_reply_address"
-  tooltipText="Email reply address (Default: root@example.com)"
+  tooltipText="Default: root@example.com"
 />
 `;
 
@@ -77,6 +77,6 @@ exports[`SettingCell render without fullName 1`] = `
     }
   }
   tooltipId="always_show_configuration_status"
-  tooltipText="always_show_configuration_status (Default: No)"
+  tooltipText="Default: No"
 />
 `;


### PR DESCRIPTION
Remove the settings name from the tooltip as it's already displayed in
the table right next to it. Only show the default value, with the
"Default: " string translated.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
