### PR TITLE
Fixes #32840 - Avoid duplicate tooltips on settings

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableFormatters.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableFormatters.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import classNames from 'classnames';
 
 import { withTooltip } from './SettingsTableHelpers';
 
@@ -17,6 +18,11 @@ export const settingNameCellFormatter = (value, { rowData }) => {
   );
 };
 
-export const settingValueCellFormatter = (value, { rowData }) => (
-  <SettingCell value={value} setting={rowData} />
-);
+export const settingValueCellFormatter = (value, { rowData: setting }) => {
+  const cssClasses = classNames('ellipsis', {
+    'editable-empty': !setting.value && setting.settingsType !== 'boolean',
+    'masked-input': setting.encrypted,
+    editable: !setting.readonly,
+  });
+  return <SettingCell value={value} setting={setting} className={cssClasses} />;
+};

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js
@@ -16,9 +16,7 @@ export const withTooltip = Component => componentProps => {
       placement="top"
       rootClose={false}
     >
-      <span>
-        <Component {...rest} />
-      </span>
+      <Component {...rest} />
     </OverlayTrigger>
   );
 };
@@ -171,5 +169,3 @@ export const hasDefault = setting => {
     }
   }
 };
-
-export const inStrong = markup => <strong>{markup}</strong>;

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCell.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCell.js
@@ -9,8 +9,12 @@ import SettingCellInner from './SettingCellInner';
 
 import './SettingCell.scss';
 
-const SettingCell = ({ setting }) => {
-  const fieldProps = { setting, tooltipId: setting.name };
+const SettingCell = ({ setting, className }) => {
+  const fieldProps = {
+    setting,
+    tooltipId: setting.name,
+    className,
+  };
 
   if (setting.readonly) {
     fieldProps.tooltipText = sprintf(
@@ -22,7 +26,6 @@ const SettingCell = ({ setting }) => {
   } else {
     const defaultStr = defaultToString(setting);
     fieldProps.tooltipText = sprintf(__('Default: %s'), defaultStr);
-    fieldProps.className = 'editable';
   }
 
   const Component = withTooltip(SettingCellInner);
@@ -31,6 +34,11 @@ const SettingCell = ({ setting }) => {
 
 SettingCell.propTypes = {
   setting: PropTypes.object.isRequired,
+  className: PropTypes.string,
+};
+
+SettingCell.defaultProps = {
+  className: '',
 };
 
 export default SettingCell;

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCellInner.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCellInner.js
@@ -1,18 +1,17 @@
 import React from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import { useDispatch } from 'react-redux';
 
 import { setSettingEditing } from '../../SettingRecords/SettingRecordsActions';
 import useSettingModal from '../../SettingUpdateModal/useSettingModal';
 
-import { valueToString, hasDefault, inStrong } from '../SettingsTableHelpers';
+import { valueToString, hasDefault } from '../SettingsTableHelpers';
 
 const SettingCellInner = props => {
   const { setting, className, ...rest } = props;
 
-  const cssClasses = classNames(className, {
+  const cssClasses = classNames(className, 'ellipsis', {
     'editable-empty': !setting.value && setting.settingsType !== 'boolean',
     'masked-input': setting.encrypted,
   });
@@ -26,21 +25,19 @@ const SettingCellInner = props => {
     setModalOpen();
   };
 
-  const field = (
-    <span
+  let field = (
+    <div
       onClick={editable ? openModal : undefined}
       {...rest}
       className={cssClasses}
     >
       {valueToString(setting)}
-    </span>
+    </div>
   );
 
-  const value =
-    setting.value !== setting.default && hasDefault(setting)
-      ? inStrong(field)
-      : field;
-  return <EllipsisWithTooltip>{value}</EllipsisWithTooltip>;
+  if (setting.value !== setting.default && hasDefault(setting))
+    field = <strong>{field}</strong>;
+  return field;
 };
 
 SettingCellInner.propTypes = {

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCellInner.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCellInner.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 
@@ -9,12 +8,7 @@ import useSettingModal from '../../SettingUpdateModal/useSettingModal';
 import { valueToString, hasDefault } from '../SettingsTableHelpers';
 
 const SettingCellInner = props => {
-  const { setting, className, ...rest } = props;
-
-  const cssClasses = classNames(className, 'ellipsis', {
-    'editable-empty': !setting.value && setting.settingsType !== 'boolean',
-    'masked-input': setting.encrypted,
-  });
+  const { setting, ...rest } = props;
 
   const { setModalOpen } = useSettingModal();
   const dispatch = useDispatch();
@@ -26,11 +20,7 @@ const SettingCellInner = props => {
   };
 
   let field = (
-    <div
-      onClick={editable ? openModal : undefined}
-      {...rest}
-      className={cssClasses}
-    >
+    <div onClick={editable ? openModal : undefined} {...rest}>
       {valueToString(setting)}
     </div>
   );
@@ -42,11 +32,6 @@ const SettingCellInner = props => {
 
 SettingCellInner.propTypes = {
   setting: PropTypes.object.isRequired,
-  className: PropTypes.string,
-};
-
-SettingCellInner.defaultProps = {
-  className: '',
 };
 
 export default SettingCellInner;

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/__snapshots__/SettingCell.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/__tests__/__snapshots__/SettingCell.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SettingCell render encrypted with fullName 1`] = `
 <Component
-  className="editable"
+  className=""
   setting={
     Object {
       "category": "Setting::Provisioning",
@@ -28,7 +28,7 @@ exports[`SettingCell render encrypted with fullName 1`] = `
 
 exports[`SettingCell render ordinary 1`] = `
 <Component
-  className="editable"
+  className=""
   setting={
     Object {
       "category": "Setting::Email",
@@ -54,7 +54,7 @@ exports[`SettingCell render ordinary 1`] = `
 
 exports[`SettingCell render without fullName 1`] = `
 <Component
-  className="editable"
+  className=""
   setting={
     Object {
       "category": "Setting::Puppet",


### PR DESCRIPTION
EllipsisWithTooltips causes a duplicate tooltip to be shown for setting
values in Firefox. There is no need to show a tooltip for long values,
since there is already a tooltip for showing the default. This removes
the duplicate tooltip and uses `ellipsis` class to only handle overflow
styling correctly.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
