### PR TITLE
Fixes #32842: Don't disable MAC address input for VMs being imported

### DIFF
--- a/app/views/nic/_base_form.html.erb
+++ b/app/views/nic/_base_form.html.erb
@@ -7,7 +7,7 @@
               :label => _("MAC Address"),
               :label_help => _("Media access control address for this interface. Format must be six groups of two hexadecimal digits <br/> separated by colons (:), e.g. 00:11:22:33:44:55. Most virtualization compute resources (e.g. VMware, oVirt, libvirt) <br/> will provide new random MAC address.").html_safe,
               :label_help_options => { :rel => 'popover-modal' },
-              :disabled => f.object.host.try(:compute_provides?, :mac),
+              :disabled => f.object.host.try(:compute_provides?, :mac) && ! (f.object.new_record? && f.object.host.uuid.present?),
               :class => :interface_mac, :'data-url' => random_name_interfaces_path, :size => "col-md-8", :label_size => "col-md-3" %>
 <%= text_f f, :identifier,
               :label => _("Device Identifier"),


### PR DESCRIPTION
This PR should fix the problem during VM import where the MAC address gets removed due to the disabled field.
I'm not really sure though, if there is a better way to detect if the host is being imported or not.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
