### PR TITLE
[WIP] Fixes #32848 - Documentation links and docs.theforeman.org

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -24,6 +24,8 @@ class LinksController < ApplicationController
       'https://projects.theforeman.org/projects/foreman/issues'
     when 'vmrc'
       'https://www.vmware.com/go/download-vmrc'
+    when 'docs'
+      new_documentation_url(options)
     end
   end
 
@@ -36,6 +38,19 @@ class LinksController < ApplicationController
   def documentation_url(section = "", options = {})
     root_url = options[:root_url] || foreman_org_path("manuals/#{SETTINGS[:version].short}/index.html#")
     root_url + (section || '')
+  end
+
+  # For new documentation at docs.theforeman.org
+  # options:
+  #   :section
+  #   :index    'foreman-el' (default), 'foreman-deb' or 'katello'
+  #   :chapter
+  def new_documentation_url(options)
+    version = SETTINGS[:version].short
+    index = options[:index] || 'foreman-el'
+    chapter_hash = "##{options[:chapter]}" if options[:chapter]
+
+    "https://docs.theforeman.org/#{version}/#{options[:section]}/index-#{index}.html#{chapter_hash}"
   end
 
   def plugin_documentation_url

--- a/app/controllers/registration_commands_controller.rb
+++ b/app/controllers/registration_commands_controller.rb
@@ -10,6 +10,7 @@ class RegistrationCommandsController < ApplicationController
       smartProxies: Feature.find_by(name: 'Registration')&.smart_proxies,
       configParams: host_config_params,
       pluginData: plugin_data,
+      documentationUrl: documentation_url,
     }
   end
 
@@ -51,5 +52,11 @@ class RegistrationCommandsController < ApplicationController
   # Extension point for plugins
   def plugin_data
     {}
+  end
+
+  def documentation_url
+    options = { type: 'docs', params: { section: 'Managing_Hosts',
+                                        chapter: 'registering-a-host_managing-hosts' } }
+    main_app.external_link_url(options)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -370,7 +370,12 @@ module ApplicationHelper
   end
 
   def documentation_url(section = "", options = {})
-    main_app.external_link_url(options.merge(type: 'manual', params: { section: section }))
+    options[:type] = options[:type] || 'manual'
+    options[:params] = { section: section,
+                         chapter: options[:chapter],
+                         index: options[:index] }
+
+    main_app.external_link_url(options)
   end
 
   def options_for_puppetclass_selection(klass, type)

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -39,5 +39,18 @@ class LinksControllerTest < ActionController::TestCase
       assert_redirected_to /15.0/
       assert_redirected_to /Usage/
     end
+
+    test '#plugin_documentation_url and new docs page' do
+      get :show, params: {
+        type: 'docs',
+        section: 'TestSection',
+        chapter: 'TestChapter',
+      }
+
+      assert_redirected_to /docs.theforeman.org/
+      assert_redirected_to /TestSection/
+      assert_redirected_to /foreman-el/
+      assert_redirected_to /#TestChapter/
+    end
   end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -32,6 +32,14 @@ class ApplicationHelperTest < ActionView::TestCase
       assert_match /my_plugin/, url
     end
 
+    test '#documentation_url and new docs page' do
+      url = documentation_url('TestSection', { type: 'docs', chapter: 'test_chapter' })
+
+      assert_match /links\/docs/, url
+      assert_match /chapter=test_chapter/, url
+      assert_match /section=TestSection/, url
+    end
+
     test '#documentation_button forwards options to #documentation_url' do
       expects(:icon_text).returns('http://nowhere.com')
       expects(:link_to).returns('<a>test</a>'.html_safe)

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageSelectors.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageSelectors.js
@@ -35,6 +35,9 @@ export const selectSmartProxies = state =>
 export const selectConfigParams = state =>
   selectAPIResponse(state, REGISTRATION_COMMANDS_DATA).configParams || {};
 
+export const selectDocumentationUrl = state =>
+  selectAPIResponse(state, REGISTRATION_COMMANDS_DATA)?.documentationUrl;
+
 export const selectPluginData = state =>
   selectAPIResponse(state, REGISTRATION_COMMANDS_DATA).pluginData || {};
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
@@ -135,6 +135,7 @@ export const spySelector = selectors => {
   jest.spyOn(selectors, 'selectOperatingSystemTemplate');
   jest.spyOn(selectors, 'selectSmartProxies');
   jest.spyOn(selectors, 'selectConfigParams');
+  jest.spyOn(selectors, 'selectDocumentationUrl');
   jest.spyOn(selectors, 'selectPluginData');
   jest.spyOn(selectors, 'selectAPIStatusCommand');
   jest.spyOn(selectors, 'selectCommand');
@@ -149,6 +150,7 @@ export const spySelector = selectors => {
   selectors.selectOperatingSystemTemplate.mockImplementation(() => '');
   selectors.selectSmartProxies.mockImplementation(() => []);
   selectors.selectConfigParams.mockImplementation(() => ({}));
+  selectors.selectDocumentationUrl.mockImplementation(() => (''));
   selectors.selectPluginData.mockImplementation(() => {});
   selectors.selectAPIStatusCommand.mockImplementation(() => undefined);
   selectors.selectCommand.mockImplementation(() => '');

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -34,6 +34,7 @@ import {
   selectOperatingSystems,
   selectOperatingSystemTemplate,
   selectSmartProxies,
+  selectDocumentationUrl,
   selectPluginData,
 } from './RegistrationCommandsPageSelectors';
 import { dataAction, commandAction } from './RegistrationCommandsPageActions';
@@ -70,6 +71,7 @@ const RegistrationCommandsPage = () => {
   const operatingSystemTemplate = useSelector(selectOperatingSystemTemplate);
   const smartProxies = useSelector(selectSmartProxies);
   const configParams = useSelector(selectConfigParams);
+  const documentationUrl = useSelector(selectDocumentationUrl);
   const pluginData = useSelector(selectPluginData);
 
   // Form values
@@ -178,7 +180,7 @@ const RegistrationCommandsPage = () => {
           </GridItem>
           <GridItem span={6}>
             <a
-              href="https://docs.theforeman.org/nightly/Managing_Hosts/index-foreman-el.html#registering-a-host-to-project-using-the-global-registration-template_managing-hosts"
+              href={documentationUrl}
               target="_blank"
               rel="noreferrer"
               className="pf-c-button pf-m-secondary pf-m-small pull-right"


### PR DESCRIPTION
WIP: Waiting for theforeman/foreman-documentation#578

Add support for new docs page (`docs.theforeman.org`)
in `ApplicationHelper#documentation_url` helper and in `Links` controller


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
