### PR TITLE
Fixes #32851  - Add parameter to run attach --auto

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -25,6 +25,8 @@ snippet: true
 #
 #   subscription_manager = 'true'               You're going to use subscription-manager
 #
+#   subscription_manager_auto_attach = 'false'  Run attach --auto after registering. 
+#
 #   subscription_manager_username = <username>  Username for subscription-manager
 #
 #   subscription_manager_password = <password>  Password for subscription-manager
@@ -189,6 +191,10 @@ snippet: true
         fi
       fi
     done
+  <% end %>
+
+  <% if host_param_true?('subscription_manager_auto_attach', false) %>
+    subscription-manager attach --auto
   <% end %>
 
   <% if host_param('subscription_manager_repos') %>

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -193,7 +193,7 @@ snippet: true
     done
   <% end %>
 
-  <% if host_param_true?('subscription_manager_auto_attach', false) %>
+  <% if host_param_true?('subscription_manager_auto_attach', false) -%>
     subscription-manager attach --auto
 
   <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -195,8 +195,8 @@ snippet: true
 
   <% if host_param_true?('subscription_manager_auto_attach', false) %>
     subscription-manager attach --auto
-  <% end %>
 
+  <% end -%>
   <% if host_param('subscription_manager_repos') %>
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null


### PR DESCRIPTION
Add parameter to provisioning templates to run attach --auto after registering

https://projects.theforeman.org/issues/31476

