### PR TITLE
Fixes #32860 - move toast list to app's root

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -476,7 +476,7 @@ module ApplicationHelper
   end
 
   def notifications
-    react_component('ToastNotifications', {railsMessages: toast_notifications_data})
+    Foreman::Deprecation.deprecation_warning('3.1', 'notifications method is deprecated, and instead, toasts alerts are handled in the root of the React app.')
   end
 
   def toast_notifications_data

--- a/app/views/layouts/_application_content.html.erb
+++ b/app/views/layouts/_application_content.html.erb
@@ -1,6 +1,5 @@
 <div id="main">
   <div id="content">
-    <%= notifications %>
     <div id="breadcrumb">
       <% if content_for?(:breadcrumbs) %>
         <%= yield(:breadcrumbs) %>

--- a/app/views/layouts/login.html.erb
+++ b/app/views/layouts/login.html.erb
@@ -1,7 +1,6 @@
 <% title(_("Login")) %>
 
 <%= content_for(:content) do %>
-  <%= notifications %>
   <%= yield %>
 <% end %>
 

--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -11,7 +11,7 @@ import apolloClient from './apollo';
 import ToastsList from '../components/ToastsList';
 
 const ReactApp = ({ layout, metadata, toasts }) => {
-  const contextData = { metadata, toasts };
+  const contextData = { metadata };
   const ForemanContext = getForemanContext(contextData);
 
   return (

--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -8,6 +8,7 @@ import Layout, { propTypes as LayoutPropTypes } from '../components/Layout';
 import AppSwitcher from '../routes';
 
 import apolloClient from './apollo';
+import ToastsList from '../components/ToastsList';
 
 const ReactApp = ({ layout, metadata, toasts }) => {
   const contextData = { metadata, toasts };
@@ -19,6 +20,7 @@ const ReactApp = ({ layout, metadata, toasts }) => {
         <ApolloProvider client={apolloClient}>
           <ConnectedRouter history={history}>
             <Layout data={layout}>
+              <ToastsList railsMessages={toasts} />
               <AppSwitcher />
             </Layout>
           </ConnectedRouter>

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -27,7 +27,6 @@ exports[`AuditsPage rendering render audits page 1`] = `
   }
   searchQuery="search"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Button
       active={false}
@@ -104,7 +103,6 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
   }
   searchQuery="search"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Button
       active={false}
@@ -183,7 +181,6 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
   }
   searchQuery="search"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Button
       active={false}
@@ -262,7 +259,6 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
   }
   searchQuery="search"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Button
       active={false}

--- a/webpack/assets/javascripts/react_app/routes/HostWizard/HostWizardPage/__snapshots__/HostWizard.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/HostWizard/HostWizardPage/__snapshots__/HostWizard.test.js.snap
@@ -12,7 +12,6 @@ exports[`HostWizard rendering renders LoginPage 1`] = `
   searchProps={Object {}}
   searchQuery=""
   searchable={false}
-  toastNotifications={Array []}
   toolbarButtons={null}
 >
   <Button

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
@@ -21,7 +21,6 @@ const ModelsPage = ({
   itemCount,
   message,
   canCreate,
-  toasts,
 }) => {
   const handleSearch = query => fetchAndPush({ searchQuery: query, page: 1 });
 
@@ -41,7 +40,6 @@ const ModelsPage = ({
       onSearch={handleSearch}
       onBookmarkClick={handleSearch}
       toolbarButtons={canCreate && createBtn}
-      toastNotifications={toasts}
     >
       <ModelsPageContent
         models={models}
@@ -73,7 +71,6 @@ ModelsPage.propTypes = {
   itemCount: PropTypes.number.isRequired,
   message: PropTypes.object,
   canCreate: PropTypes.bool.isRequired,
-  toasts: PropTypes.array.isRequired,
 };
 
 ModelsPage.defaultProps = {

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
@@ -27,7 +27,6 @@ exports[`ModelsPage redering should render when loading 1`] = `
   }
   searchQuery="name=foo"
   searchable={false}
-  toastNotifications={Array []}
   toolbarButtons={
     <Link
       to="/models/new"
@@ -111,7 +110,6 @@ exports[`ModelsPage redering should render with error 1`] = `
   }
   searchQuery="name=foo"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Link
       to="/models/new"
@@ -200,7 +198,6 @@ exports[`ModelsPage redering should render with models 1`] = `
   }
   searchQuery="name=foo"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Link
       to="/models/new"
@@ -284,7 +281,6 @@ exports[`ModelsPage redering should render with no data 1`] = `
   }
   searchQuery="name=foo"
   searchable={true}
-  toastNotifications={Array []}
   toolbarButtons={
     <Link
       to="/models/new"

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { connect } from 'react-redux';
 import { compose, bindActionCreators } from 'redux';
 
@@ -6,8 +5,6 @@ import ModelsPage from './ModelsPage';
 import * as actions from './ModelsPageActions';
 
 import { callOnMount, callOnPopState } from '../../../common/HOC';
-
-import { useForemanContext } from '../../../Root/Context/ForemanContext';
 
 import {
   selectModels,
@@ -39,14 +36,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 
-const callWithToastsContext = Component => props => {
-  const { toasts } = useForemanContext();
-  return <Component {...props} toasts={toasts} />;
-};
-
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
-  callWithToastsContext,
   callOnMount(({ initializeModels }) => initializeModels()),
   callOnPopState(({ initializeModels }) => initializeModels())
 )(ModelsPage);

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Row, Col, Spinner } from 'patternfly-react';
 import { changeQuery } from '../../../common/urlHelpers';
 
-import ToastsList from '../../../components/ToastsList';
 import BreadcrumbBar from '../../../components/BreadcrumbBar';
 import SearchBar from '../../../components/SearchBar';
 import Head from '../../../components/Head';
@@ -18,7 +17,6 @@ const PageLayout = ({
   breadcrumbOptions,
   toolbarButtons,
   header,
-  toastNotifications,
   beforeToolbarComponent,
   isLoading,
   children,
@@ -28,7 +26,6 @@ const PageLayout = ({
       <Head>
         <title>{header}</title>
       </Head>
-      <ToastsList railsMessages={toastNotifications} />
       <div id="breadcrumb">
         {!breadcrumbOptions && (
           <div className="row form-group">
@@ -110,7 +107,6 @@ PageLayout.propTypes = {
     ),
   }),
   toolbarButtons: PropTypes.node,
-  toastNotifications: PropTypes.array,
   onSearch: PropTypes.func,
   onBookmarkClick: PropTypes.func,
   searchQuery: PropTypes.string,
@@ -122,7 +118,6 @@ PageLayout.defaultProps = {
   searchProps: {},
   header: '',
   searchQuery: '',
-  toastNotifications: [],
   customBreadcrumbs: null,
   toolbarButtons: null,
   breadcrumbOptions: null,

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.test.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 import PageLayout from './PageLayout';
 import { pageLayoutMock } from './PageLayout.fixtures';
-import { toast } from '../../../components/ToastsList/ToastList.fixtures';
 
 jest.unmock('react-helmet');
 
@@ -16,10 +15,6 @@ const pageLayoutFixtures = {
   'render pageLayout without breadcrumbs': {
     ...pageLayoutMock,
     breadcrumbOptions: null,
-  },
-  'render pageLayout w/toastNotifications': {
-    ...pageLayoutMock,
-    toastNotifications: [toast],
   },
   'render pageLayout w/toolBar': {
     ...pageLayoutMock,

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -10,9 +10,6 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
     <Head>
       <title />
     </Head>
-    <Connect(ToastsList)
-      railsMessages={Array []}
-    />
     <div
       id="breadcrumb"
     >
@@ -106,110 +103,6 @@ exports[`render pageLayout w/search 1`] = `
     <Head>
       <title />
     </Head>
-    <Connect(ToastsList)
-      railsMessages={Array []}
-    />
-    <div
-      id="breadcrumb"
-    >
-      <Connect(BreadcrumbBar)
-        breadcrumbItems={
-          Array [
-            Object {
-              "caption": "root",
-              "url": "/some-url",
-            },
-            Object {
-              "caption": "child with onClick",
-              "onClick": [MockFunction],
-            },
-            Object {
-              "caption": "active child",
-            },
-          ]
-        }
-        isSwitchable={false}
-        resource={
-          Object {
-            "nameField": "name",
-            "resourceUrl": "some/url",
-            "switcherItemUrl": "some/url/:id",
-          }
-        }
-      />
-    </div>
-    <Row
-      bsClass="row"
-      componentClass="div"
-    >
-      <Col
-        bsClass="col"
-        className="title_filter"
-        componentClass="div"
-        md={6}
-      >
-        <Connect(SearchBar)
-          data={
-            Object {
-              "data": Object {
-                "autocomplete": Object {
-                  "id": "searchBar",
-                  "searchQuery": null,
-                  "url": "model/auto_complete_search",
-                  "useKeyShortcuts": true,
-                },
-                "bookmarks": Object {
-                  "canCreate": true,
-                  "documentationUrl": "/doc/url",
-                  "url": "/api/bookmarks",
-                },
-                "controller": "models",
-              },
-            }
-          }
-          initialQuery=""
-          onBookmarkClick={[Function]}
-          onSearch={[Function]}
-        />
-         
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        id="title_action"
-        md={6}
-      >
-        <div
-          className="btn-toolbar pull-right"
-        />
-      </Col>
-    </Row>
-    body
-  </div>
-</div>
-`;
-
-exports[`render pageLayout w/toastNotifications 1`] = `
-<div
-  id="main"
->
-  <div
-    id="react-content"
-  >
-    <Head>
-      <title />
-    </Head>
-    <Connect(ToastsList)
-      railsMessages={
-        Array [
-          Object {
-            "key": "test-key",
-            "message": "Widget positions successfully saved.",
-            "type": "success",
-          },
-        ]
-      }
-    />
     <div
       id="breadcrumb"
     >
@@ -300,9 +193,6 @@ exports[`render pageLayout w/toolBar 1`] = `
     <Head>
       <title />
     </Head>
-    <Connect(ToastsList)
-      railsMessages={Array []}
-    />
     <div
       id="breadcrumb"
     >
@@ -397,9 +287,6 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
     <Head>
       <title />
     </Head>
-    <Connect(ToastsList)
-      railsMessages={Array []}
-    />
     <div
       id="breadcrumb"
     >
@@ -468,9 +355,6 @@ exports[`render pageLayout without breadcrumbs 1`] = `
     <Head>
       <title />
     </Head>
-    <Connect(ToastsList)
-      railsMessages={Array []}
-    />
     <div
       id="breadcrumb"
     >
@@ -543,9 +427,6 @@ exports[`render pageLayout without search 1`] = `
     <Head>
       <title />
     </Head>
-    <Connect(ToastsList)
-      railsMessages={Array []}
-    />
     <div
       id="breadcrumb"
     >


### PR DESCRIPTION
Toasts were triggered only from pages that used the PageLayout component,
but now they will be triggered directly from the root of the app.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
