### PR TITLE
Fixes #32880 - Add confirmation modal service

### DIFF
--- a/test/integration/operatingsystem_js_test.rb
+++ b/test/integration/operatingsystem_js_test.rb
@@ -6,9 +6,10 @@ class OperatingsystemJSTest < IntegrationTestWithJavascript
   end
 
   test "delete operating system" do
+    os = FactoryBot.create(:operatingsystem, name: 'aaa')
     visit operatingsystems_path
     first_row = find("table > tbody > tr:nth-child(1)")
-    assert first_row.find("td:nth-child(1)").text, "centos 5.3"
+    assert_equal os.title, first_row.find("td:nth-child(1)").text.strip
     assert has_no_css?("#app-confirm-modal")
 
     actions = first_row.find("td:nth-child(3) > div")
@@ -16,12 +17,16 @@ class OperatingsystemJSTest < IntegrationTestWithJavascript
     actions.find("ul > li > a.delete").click
 
     confirm_modal = page.find("#app-confirm-modal")
-    assert confirm_modal.find(".pf-c-modal-box__title-text").text, "Confirm"
-    assert confirm_modal.find(".pf-c-modal-box__body").text, "Delete centos 5.3?"
+    assert_equal "Confirm", confirm_modal.find(".pf-c-modal-box__title-text").text
+    assert_equal "Delete #{os.title}?", confirm_modal.find(".pf-c-modal-box__body").text
 
     confirm_button = confirm_modal.find("footer > button:nth-child(1)")
-    assert confirm_button.text, "Confirm"
+    assert_equal "Confirm", confirm_button.text
     confirm_button.click
     assert has_no_css?("#app-confirm-modal")
+
+    first_row = find("table > tbody > tr:nth-child(1)")
+    assert_not_equal os.title, first_row.find("td:nth-child(1)").text.strip
+    refute Operatingsystem.find_by_name(os.name).present?
   end
 end

--- a/test/integration/operatingsystem_js_test.rb
+++ b/test/integration/operatingsystem_js_test.rb
@@ -4,4 +4,24 @@ class OperatingsystemJSTest < IntegrationTestWithJavascript
   test "index page" do
     assert_index_page(operatingsystems_path, "Operating Systems", "Create Operating System")
   end
+
+  test "delete operating system" do
+    visit operatingsystems_path
+    first_row = find("table > tbody > tr:nth-child(1)")
+    assert first_row.find("td:nth-child(1)").text, "centos 5.3"
+    assert has_no_css?("#app-confirm-modal")
+
+    actions = first_row.find("td:nth-child(3) > div")
+    actions.find("a.dropdown-toggle").click
+    actions.find("ul > li > a.delete").click
+
+    confirm_modal = page.find("#app-confirm-modal")
+    assert confirm_modal.find(".pf-c-modal-box__title-text").text, "Confirm"
+    assert confirm_modal.find(".pf-c-modal-box__body").text, "Delete centos 5.3?"
+
+    confirm_button = confirm_modal.find("footer > button:nth-child(1)")
+    assert confirm_button.text, "Confirm"
+    confirm_button.click
+    assert has_no_css?("#app-confirm-modal")
+  end
 end

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -25,6 +25,7 @@ import * as spice from './spice';
 import * as autocomplete from './foreman_autocomplete';
 import * as typeAheadSelect from './foreman_type_ahead_select';
 import * as lookupKeys from './foreman_lookup_keys';
+import './foreman_overrides';
 import './bundle_novnc';
 
 const numFieldsDeprecationOnly = {

--- a/webpack/assets/javascripts/dashboard/index.js
+++ b/webpack/assets/javascripts/dashboard/index.js
@@ -66,7 +66,7 @@ export function removeWidget(item) {
     ),
     confirmButtonText: __('Delete'),
     isWarning: true,
-    onConfirm: function onConfirm() {
+    onConfirm: () => {
       $.ajax({
         type: 'DELETE',
         url: $(item).data('url'),

--- a/webpack/assets/javascripts/dashboard/index.js
+++ b/webpack/assets/javascripts/dashboard/index.js
@@ -7,7 +7,11 @@
 import $ from 'jquery';
 import { doesDocumentHasFocus } from '../react_app/common/document';
 import { notify } from '../foreman_toast_notifications';
-import { activateTooltips, foremanUrl } from '../foreman_tools';
+import {
+  activateTooltips,
+  foremanUrl,
+  openConfirmModal,
+} from '../foreman_tools';
 import { reloadPage } from '../foreman_navigation';
 import { translate as __ } from '../react_app/common/I18n';
 import './index.scss';
@@ -55,29 +59,33 @@ export function removeWidget(item) {
   const gridster = $('.gridster>ul')
     .gridster()
     .data('gridster');
-  if (
-    window.confirm(
-      __('Are you sure you want to delete this widget from your dashboard?')
-    )
-  ) {
-    $.ajax({
-      type: 'DELETE',
-      url: $(item).data('url'),
-      success() {
-        notify({
-          message: __('Widget removed from dashboard.'),
-          type: 'success',
-        });
-        gridster.remove_widget(widget);
-      },
-      error() {
-        notify({
-          message: __('Error removing widget from dashboard.'),
-          type: 'error',
-        });
-      },
-    });
-  }
+  openConfirmModal({
+    title: __('Remove widget'),
+    message: __(
+      'Are you sure you want to delete this widget from your dashboard?'
+    ),
+    confirmButtonText: __('Delete'),
+    isWarning: true,
+    onConfirm: function onConfirm() {
+      $.ajax({
+        type: 'DELETE',
+        url: $(item).data('url'),
+        success() {
+          notify({
+            message: __('Widget removed from dashboard.'),
+            type: 'success',
+          });
+          gridster.remove_widget(widget);
+        },
+        error() {
+          notify({
+            message: __('Error removing widget from dashboard.'),
+            type: 'error',
+          });
+        },
+      });
+    },
+  });
 }
 
 export function addWidget(name) {

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -3,17 +3,20 @@ import store from './react_app/redux';
 
 import * as editorActions from './react_app/components/Editor/EditorActions';
 import { translate as __ } from './react_app/common/I18n';
+import { openConfirmModal } from './foreman_tools';
 
-export const revertTemplate = async ({ dataset: { version, url } }) => {
-  if (
-    window.confirm(__('Are you sure you would like to revert the Template?'))
-  ) {
-    try {
-      const response = await API.get(url, {}, { version });
-      document.getElementById('primary_tab').click();
-      store.dispatch(editorActions.changeEditorValue(response.data));
-    } catch (err) {
-      alert(__(`Revert Failed, ${err}`));
-    }
-  }
+export const revertTemplate = ({ dataset: { version, url } }) => {
+  openConfirmModal({
+    title: __('Revert template'),
+    message: __('Are you sure you would like to revert the Template?'),
+    onConfirm: async () => {
+      try {
+        const response = await API.get(url, {}, { version });
+        document.getElementById('primary_tab').click();
+        store.dispatch(editorActions.changeEditorValue(response.data));
+      } catch (err) {
+        alert(__(`Revert Failed, ${err}`));
+      }
+    },
+  });
 };

--- a/webpack/assets/javascripts/foreman_overrides.js
+++ b/webpack/assets/javascripts/foreman_overrides.js
@@ -1,0 +1,32 @@
+import $ from 'jquery';
+import store from './react_app/redux';
+import { translate as __ } from './react_app/common/I18n';
+
+import { openConfirmModal } from './react_app/components/ConfirmModal';
+
+$(document).on('ContentLoad', () => {
+  if (!$.rails) return;
+  // override the jQuery UJS $.rails.allowAction
+  $.rails.allowAction = element => {
+    const message = element.data('confirm');
+    const isWarning = element.data('method') === 'delete';
+    if (!message) return true;
+
+    if ($.rails.fire(element, 'confirm')) {
+      store.dispatch(
+        openConfirmModal({
+          title: __('Confirm'),
+          message,
+          isWarning,
+          onConfirm: () => {
+            const oldAllowAction = $.rails.allowAction;
+            $.rails.allowAction = () => true;
+            element.trigger('click');
+            $.rails.allowAction = oldAllowAction;
+          },
+        })
+      );
+    }
+    return false;
+  };
+});

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -19,24 +19,19 @@ export const openConfirmModal = options =>
 // override the jQuery UJS $.rails.allowAction
 $.rails.allowAction = function railsConfirmOverride(element) {
   const message = element.data('confirm');
-  const answer = false;
-  let callback;
+  const isWarning = element.data('method') === 'delete';
   if (!message) return true;
 
   if ($.rails.fire(element, 'confirm')) {
     openConfirmModal({
       title: __('Confirm'),
       message,
+      isWarning,
       onConfirm: () => {
-        callback = $.rails.fire(element, 'confirm:complete', [answer]);
-        if (callback) {
-          const oldAllowAction = $.rails.allowAction;
-          $.rails.allowAction = function allowAction() {
-            return true;
-          };
-          element.trigger('click');
-          $.rails.allowAction = oldAllowAction;
-        }
+        const oldAllowAction = $.rails.allowAction;
+        $.rails.allowAction = () => true;
+        element.trigger('click');
+        $.rails.allowAction = oldAllowAction;
       },
     });
   }

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -16,30 +16,6 @@ import { openConfirmModal as coreOpenConfirmModal } from './react_app/components
 export const openConfirmModal = options =>
   store.dispatch(coreOpenConfirmModal(options));
 
-if ($.rails) {
-  // override the jQuery UJS $.rails.allowAction
-  $.rails.allowAction = element => {
-    const message = element.data('confirm');
-    const isWarning = element.data('method') === 'delete';
-    if (!message) return true;
-
-    if ($.rails.fire(element, 'confirm')) {
-      openConfirmModal({
-        title: __('Confirm'),
-        message,
-        isWarning,
-        onConfirm: () => {
-          const oldAllowAction = $.rails.allowAction;
-          $.rails.allowAction = () => true;
-          element.trigger('click');
-          $.rails.allowAction = oldAllowAction;
-        },
-      });
-    }
-    return false;
-  };
-}
-
 export * from './react_app/common/DeprecationService';
 
 export function showSpinner() {

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -10,6 +10,32 @@ import { sprintf, translate as __ } from './react_app/common/I18n';
 
 import { showLoading, hideLoading } from './foreman_navigation';
 
+import store from './react_app/redux';
+import { openConfirmModal as coreOpenConfirmModal } from './react_app/components/ConfirmModal';
+import { noop } from './react_app/common/helpers';
+
+export function openConfirmModal({
+  title = '',
+  message = '',
+  onConfirm = noop,
+  onCancel = noop,
+  modalProps = {},
+  isWarning = false,
+  confirmButtonText = null,
+}) {
+  return store.dispatch(
+    coreOpenConfirmModal({
+      title,
+      message,
+      onConfirm,
+      onCancel,
+      modalProps,
+      isWarning,
+      confirmButtonText,
+    })
+  );
+}
+
 export * from './react_app/common/DeprecationService';
 
 export function showSpinner() {

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -16,27 +16,29 @@ import { openConfirmModal as coreOpenConfirmModal } from './react_app/components
 export const openConfirmModal = options =>
   store.dispatch(coreOpenConfirmModal(options));
 
-// override the jQuery UJS $.rails.allowAction
-$.rails.allowAction = function railsConfirmOverride(element) {
-  const message = element.data('confirm');
-  const isWarning = element.data('method') === 'delete';
-  if (!message) return true;
+if ($.rails) {
+  // override the jQuery UJS $.rails.allowAction
+  $.rails.allowAction = element => {
+    const message = element.data('confirm');
+    const isWarning = element.data('method') === 'delete';
+    if (!message) return true;
 
-  if ($.rails.fire(element, 'confirm')) {
-    openConfirmModal({
-      title: __('Confirm'),
-      message,
-      isWarning,
-      onConfirm: () => {
-        const oldAllowAction = $.rails.allowAction;
-        $.rails.allowAction = () => true;
-        element.trigger('click');
-        $.rails.allowAction = oldAllowAction;
-      },
-    });
-  }
-  return false;
-};
+    if ($.rails.fire(element, 'confirm')) {
+      openConfirmModal({
+        title: __('Confirm'),
+        message,
+        isWarning,
+        onConfirm: () => {
+          const oldAllowAction = $.rails.allowAction;
+          $.rails.allowAction = () => true;
+          element.trigger('click');
+          $.rails.allowAction = oldAllowAction;
+        },
+      });
+    }
+    return false;
+  };
+}
 
 export * from './react_app/common/DeprecationService';
 

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -12,29 +12,9 @@ import { showLoading, hideLoading } from './foreman_navigation';
 
 import store from './react_app/redux';
 import { openConfirmModal as coreOpenConfirmModal } from './react_app/components/ConfirmModal';
-import { noop } from './react_app/common/helpers';
 
-export function openConfirmModal({
-  title = '',
-  message = '',
-  onConfirm = noop,
-  onCancel = noop,
-  modalProps = {},
-  isWarning = false,
-  confirmButtonText = null,
-}) {
-  return store.dispatch(
-    coreOpenConfirmModal({
-      title,
-      message,
-      onConfirm,
-      onCancel,
-      modalProps,
-      isWarning,
-      confirmButtonText,
-    })
-  );
-}
+export const openConfirmModal = options =>
+  store.dispatch(coreOpenConfirmModal(options));
 
 // override the jQuery UJS $.rails.allowAction
 $.rails.allowAction = function railsConfirmOverride(element) {
@@ -47,7 +27,7 @@ $.rails.allowAction = function railsConfirmOverride(element) {
     openConfirmModal({
       title: __('Confirm'),
       message,
-      onConfirm: function onConfirm() {
+      onConfirm: () => {
         callback = $.rails.fire(element, 'confirm:complete', [answer]);
         if (callback) {
           const oldAllowAction = $.rails.allowAction;

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -36,6 +36,33 @@ export function openConfirmModal({
   );
 }
 
+// override the jQuery UJS $.rails.allowAction
+$.rails.allowAction = function railsConfirmOverride(element) {
+  const message = element.data('confirm');
+  const answer = false;
+  let callback;
+  if (!message) return true;
+
+  if ($.rails.fire(element, 'confirm')) {
+    openConfirmModal({
+      title: __('Confirm'),
+      message,
+      onConfirm: function onConfirm() {
+        callback = $.rails.fire(element, 'confirm:complete', [answer]);
+        if (callback) {
+          const oldAllowAction = $.rails.allowAction;
+          $.rails.allowAction = function allowAction() {
+            return true;
+          };
+          element.trigger('click');
+          $.rails.allowAction = oldAllowAction;
+        }
+      },
+    });
+  }
+  return false;
+};
+
 export * from './react_app/common/DeprecationService';
 
 export function showSpinner() {

--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -10,6 +10,7 @@ import AppSwitcher from '../routes';
 import apolloClient from './apollo';
 import ToastsList from '../components/ToastsList';
 import ErrorBoundary from '../components/common/ErrorBoundary';
+import ConfirmModal from '../components/ConfirmModal';
 
 const ReactApp = ({ layout, metadata, toasts }) => {
   const contextData = { metadata };
@@ -24,6 +25,7 @@ const ReactApp = ({ layout, metadata, toasts }) => {
               <ErrorBoundary history={history}>
                 <ToastsList railsMessages={toasts} />
                 <AppSwitcher />
+                <ConfirmModal />
               </ErrorBoundary>
             </Layout>
           </ConnectedRouter>

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/ConfirmModal.stories.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/ConfirmModal.stories.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { Button } from '@patternfly/react-core';
+import { action } from '@storybook/addon-actions';
+import { boolean, text, object } from '@storybook/addon-knobs';
+import storeDecorator from '../../../../../stories/storeDecorator';
+import Story from '../../../../../stories/components/Story';
+import ConfirmModal, { openConfirmModal } from '.';
+
+export default {
+  title: 'Components/Confirm modal',
+  decorators: [storeDecorator],
+};
+
+export const ConfirmBasicUsage = () =>
+  React.createElement(() => {
+    const dispatch = useDispatch();
+    const isWarning = boolean('isWarning', false);
+    const title = text('title', 'Confirm');
+    const message = text('message', 'Are you sure?');
+    const confirmButtonText = text('confirmButtonText', null);
+    const handleConfirmClick = () => {
+      dispatch(
+        openConfirmModal({
+          title,
+          message,
+          isWarning,
+          confirmButtonText,
+          onConfirm: action('Confirmed!'),
+          onCancel: action('Canceled!'),
+        })
+      )
+    };
+    
+    return (
+      <Story>
+        <Button onClick={handleConfirmClick}>
+          Trigger confirm !
+        </Button>
+        {/* The confirm modal is already declared on the app's root */}
+        <ConfirmModal /> 
+      </Story>
+    );
+  });
+
+  ConfirmBasicUsage.story = {
+  name: 'Basic usage',
+};

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -43,6 +43,8 @@ const ConfirmModal = () => {
     </Button>,
   ];
 
+  if (!isOpen) return null;
+
   return (
     <Modal
       id="app-confirm-modal"

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -46,6 +46,7 @@ const ConfirmModal = () => {
   return (
     <Modal
       id="app-confirm-modal"
+      aria-label="application confirm modal"
       variant={ModalVariant.small}
       title={title}
       isOpen={isOpen}

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -21,12 +21,12 @@ const ConfirmModal = () => {
   const closeModal = () => dispatch(closeConfirmModal());
 
   const handleCancel = () => {
-    onCancel && onCancel();
+    onCancel();
     closeModal();
   };
 
   const handleConfirm = () => {
-    onConfirm && onConfirm();
+    onConfirm();
     closeModal();
   };
 

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Modal, Button, ModalVariant } from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+import { closeConfirmModal, selectConfirmModal } from './slice';
+
+const ConfirmModal = () => {
+  const {
+    isOpen,
+    title,
+    message,
+    confirmButtonText,
+    onConfirm,
+    onCancel,
+    modalProps,
+    isWarning,
+  } = useSelector(selectConfirmModal);
+
+  const dispatch = useDispatch();
+
+  const closeModal = () => dispatch(closeConfirmModal());
+
+  const handleCancel = () => {
+    onCancel && onCancel();
+    closeModal();
+  };
+
+  const handleConfirm = () => {
+    onConfirm && onConfirm();
+    closeModal();
+  };
+
+  const actions = [
+    <Button
+      key="confirm"
+      variant={isWarning ? 'danger' : 'primary'}
+      onClick={handleConfirm}
+    >
+      {confirmButtonText || __('Confirm')}
+    </Button>,
+    <Button key="cancel" variant="link" onClick={handleCancel}>
+      {__('Cancel')}
+    </Button>,
+  ];
+
+  return (
+    <Modal
+      id="app-confirm-modal"
+      variant={ModalVariant.small}
+      title={title}
+      isOpen={isOpen}
+      onClose={closeModal}
+      actions={actions}
+      titleIconVariant={isWarning ? 'warning' : null}
+      {...modalProps}
+    >
+      {message}
+    </Modal>
+  );
+};
+
+export default ConfirmModal;
+
+export * from './slice';

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/integration.test.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/integration.test.js
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { mount } from '@theforeman/test';
+import { Button } from '@patternfly/react-core';
+import store from '../../redux';
+import ConfirmModal, { openConfirmModal } from './index';
+
+describe('Confirm modal', () => {
+  it('should flow', async () => {
+    const btnText = 'Trigger confirm!';
+    const modalMessage = 'Are you sure?';
+    const modalTitle = 'Hello there';
+    const onConfirm = jest.fn();
+    const handleConfirmClick = () => {
+      store.dispatch(
+        openConfirmModal({title: modalTitle, message: modalMessage, onConfirm })
+      )
+    };
+
+    const wrapper = mount(
+      <Provider store={store}>
+        <ConfirmModal />
+        <Button id="btn-confirm-trigger" onClick={handleConfirmClick}>{btnText}</Button>
+      </Provider>
+    );
+    
+    wrapper
+        .find('#btn-confirm-trigger')
+        .first()
+        .simulate('click');
+    
+    expect(wrapper.find('.pf-c-modal-box__body').text()).toEqual(modalMessage);
+    expect(wrapper.find('.pf-c-modal-box__title-text').text()).toEqual(modalTitle);
+
+    expect(onConfirm).toBeCalledTimes(0);
+
+    wrapper
+        .find('.pf-c-modal-box__footer > Button')
+        .first()
+        .simulate('click');
+    
+    expect(onConfirm).toBeCalledTimes(1);
+
+    // The modal should be hidden
+    expect(wrapper.find('.pf-c-modal-box__body')).toHaveLength(0);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
@@ -1,51 +1,43 @@
-import Immutable from 'seamless-immutable';
+import { createSlice } from '@reduxjs/toolkit';
 import { noop } from '../../common/helpers';
 
-const OPEN_CONFIRM_MODAL = 'OPEN_CONFIRM_MODAL';
-const CLOSE_CONFIRM_MODAL = 'CLOSE_CONFIRM_MODAL';
+const initialState = { isOpen: false };
 
-// actions
-export const openConfirmModal = ({
-  title = '',
-  message = '',
-  onConfirm = noop,
-  onCancel = noop,
-  isWarning = false,
-  confirmButtonText = null,
-  modalProps = {},
-}) => ({
-  type: OPEN_CONFIRM_MODAL,
-  payload: {
-    title,
-    message,
-    onConfirm,
-    onCancel,
-    modalProps,
-    isWarning,
-    confirmButtonText,
+const confirmModalSlice = createSlice({
+  name: 'confirmModal',
+  initialState,
+  reducers: {
+    openConfirmModal(state, action) {
+      const {
+        title = '',
+        message = '',
+        onConfirm = noop,
+        onCancel = noop,
+        isWarning = false,
+        confirmButtonText = null,
+        modalProps = {},
+      } = action.payload;
+      return {
+        isOpen: true,
+        title,
+        message,
+        onConfirm,
+        onCancel,
+        modalProps,
+        isWarning,
+        confirmButtonText,
+      };
+    },
+    closeConfirmModal(state) {
+      return initialState;
+    },
   },
 });
 
-export const closeConfirmModal = () => ({
-  type: CLOSE_CONFIRM_MODAL,
-  payload: {},
-});
+const { name, reducer, actions } = confirmModalSlice;
 
-// reducer
-const initialState = Immutable({ isOpen: false });
-export const reducer = (state = initialState, { type, payload }) => {
-  switch (type) {
-    case OPEN_CONFIRM_MODAL:
-      return state.merge({ isOpen: true, ...payload });
-    case CLOSE_CONFIRM_MODAL:
-      return initialState;
-    default:
-      return state;
-  }
-};
+export const { openConfirmModal, closeConfirmModal } = actions;
 
-export const storeDomain = 'confirmModal';
+export const reducers = { [name]: reducer };
 
-export const reducers = { [storeDomain]: reducer };
-
-export const selectConfirmModal = state => state[storeDomain];
+export const selectConfirmModal = state => state[name];

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
@@ -1,0 +1,51 @@
+import Immutable from 'seamless-immutable';
+import { noop } from '../../common/helpers';
+
+export const OPEN_CONFIRM_MODAL = 'OPEN_CONFIRM_MODAL';
+export const CLOSE_CONFIRM_MODAL = 'CLOSE_CONFIRM_MODAL';
+
+// actions
+export const openConfirmModal = ({
+  title = '',
+  message = '',
+  onConfirm = noop,
+  onCancel = noop,
+  isWarning = false,
+  confirmButtonText = null,
+  modalProps = {},
+}) => ({
+  type: OPEN_CONFIRM_MODAL,
+  payload: {
+    title,
+    message,
+    onConfirm,
+    onCancel,
+    modalProps,
+    isWarning,
+    confirmButtonText,
+  },
+});
+
+export const closeConfirmModal = () => ({
+  type: CLOSE_CONFIRM_MODAL,
+  payload: {},
+});
+
+// reducer
+const initialState = Immutable({ isOpen: false });
+export const reducer = (state = initialState, { type, payload }) => {
+  switch (type) {
+    case OPEN_CONFIRM_MODAL:
+      return state.merge({ isOpen: true, ...payload });
+    case CLOSE_CONFIRM_MODAL:
+      return initialState;
+    default:
+      return state;
+  }
+};
+
+export const storeDomain = 'confirmModal';
+
+export const reducers = { [storeDomain]: reducer };
+
+export const selectConfirmModal = state => state[storeDomain];

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
@@ -1,8 +1,8 @@
 import Immutable from 'seamless-immutable';
 import { noop } from '../../common/helpers';
 
-export const OPEN_CONFIRM_MODAL = 'OPEN_CONFIRM_MODAL';
-export const CLOSE_CONFIRM_MODAL = 'CLOSE_CONFIRM_MODAL';
+const OPEN_CONFIRM_MODAL = 'OPEN_CONFIRM_MODAL';
+const CLOSE_CONFIRM_MODAL = 'CLOSE_CONFIRM_MODAL';
 
 // actions
 export const openConfirmModal = ({

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
@@ -16,6 +16,7 @@ import PersonalAccessTokenForm from './PersonalAccessTokenForm';
 import PersonalAccessTokensList from './PersonalAccessTokensList';
 import { translate as __ } from '../../../common/I18n';
 import { foremanUrl } from '../../../common/helpers';
+import { openConfirmModal } from '../../ConfirmModal';
 
 const PersonalAccessTokens = ({ url, canCreate }) => {
   const dispatch = useDispatch();
@@ -32,10 +33,17 @@ const PersonalAccessTokens = ({ url, canCreate }) => {
     dispatch(clearNewPersonalAccessToken());
 
   const boundRevokePersonalAccessToken = id => {
-    if (window.confirm(__('Do you really want to revoke Access Token?'))) {
-      dispatch(revokePersonalAccessTokenAction({ url, id }));
-    }
+    dispatch(
+      openConfirmModal({
+        title: __('Revoke personal access token'),
+        message: __('Do you really want to revoke Access Token?'),
+        confirmButtonText: __('Revoke'),
+        isWarning: true,
+        onConfirm: () => dispatch(revokePersonalAccessTokenAction({ url, id })),
+      })
+    );
   };
+
   return (
     <Fragment>
       <NewPersonalAccessToken

--- a/webpack/assets/javascripts/react_app/redux/reducers/index.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/index.js
@@ -23,6 +23,7 @@ import { reducers as apiReducer } from '../API';
 import { reducers as modelsPageReducers } from '../../routes/Models/ModelsPage';
 import { reducers as settingRecordsReducers } from '../../components/SettingRecords';
 import { reducers as personalAccessTokensReducers } from '../../components/users/PersonalAccessTokens';
+import { reducers as confirmModalReducers } from '../../components/ConfirmModal';
 
 export function combineReducersAsync(asyncReducers) {
   return combineReducers({
@@ -43,6 +44,7 @@ export function combineReducersAsync(asyncReducers) {
     ...typeAheadSelectReducers,
     ...settingRecordsReducers,
     ...personalAccessTokensReducers,
+    ...confirmModalReducers,
 
     router: connectRouter(history),
     // Pages


### PR DESCRIPTION
The confirmation modal will be placed on the app's root
and can be triggered from everywhere. e.g: `openConfirmModal({ title, message, onConfirm })`

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
