### PR TITLE
Fixes #32881 - expose previous app record through safemode

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,10 +9,16 @@ class ApplicationRecord < ActiveRecord::Base
     name_desc = @meta[:name_desc] || "Name of the #{@meta[:friendly_name] || @meta[:class_scope]}#{meta_example}"
     property :name, String, desc: name_desc
     property :present?, one_of: [true, false], desc: 'Object presence (always true)'
+    property :previous_revision, ApplicationRecord, desc: "Previous revision of the record as tracked in the audit, returns the same object if there is no previous revision"
   end
 
-  class Jail < Safemode::Jail
-    allow :id, :name, :present?
+  class Jail < ::Safemode::Jail
+    allow :id, :name, :present?, :previous_revision
+  end
+
+  # Overriden by audited for some models
+  def previous_revision
+    raise "Class #{self.class.name} is not audited"
   end
 
   self.abstract_class = true

--- a/app/models/concerns/audit_associations.rb
+++ b/app/models/concerns/audit_associations.rb
@@ -8,6 +8,10 @@ module AuditAssociations
       super.merge(associated_attributes)
     end
 
+    def previous_revision
+      revision(:previous)
+    end
+
     protected
 
     # Prevent associations from being set when looking at revisions since

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -56,7 +56,7 @@ class Domain < ApplicationRecord
     prop_group :basic_model_props, ApplicationRecord, meta: { example: 'example.com' }
     property :fullname, String, desc: 'User name for this domain, e.g. "Primary domain for our company"'
   end
-  class Jail < Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :fullname
   end
 

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -161,7 +161,7 @@ class Host::Managed < Host::Base
     property :created_at, 'ActiveSupport::TimeWithZone', desc: 'The time when the host was created'
     property :comment, String, desc: 'Returns comment/description of this host'
   end
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :created_at, :diskLayout, :puppetmaster, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :ptable, :hostgroup,
       :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :ip6, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :subnet6, :token, :location, :organization, :provision_method,

--- a/app/models/host_status/status.rb
+++ b/app/models/host_status/status.rb
@@ -16,7 +16,7 @@ module HostStatus
       ::HostStatusPresenter.new(self)
     end
 
-    class Jail < ::Safemode::Jail
+    class Jail < ApplicationRecord::Jail
       allow :host, :to_global, :to_label, :status, :name, :relevant?
       allow_class_method :status_name, :humanized_name
     end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -107,7 +107,7 @@ class Hostgroup < ApplicationRecord
     property :pxe_loader, String, desc: 'Returns boot loader to be applied on each host within this host group'
     property :title, String, desc: 'Returns full title of this host group, e.g. Base/CentOS 7'
   end
-  class Jail < Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :diskLayout, :puppetmaster, :puppet_server, :operatingsystem, :architecture,
       :ptable, :url_for_boot, :params, :puppet_proxy, :puppet_ca_server,
       :os, :arch, :domain, :subnet, :subnet6, :hosts, :realm,

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -116,7 +116,7 @@ module Nic
       property :bmc?, one_of: [true, false], desc: 'Returns true if the type of the interface is BMC, false otherwise'
       property :link, one_of: [true, false], desc: 'Returns true if the interface is up, false otherwise'
     end
-    class Jail < ::Safemode::Jail
+    class Jail < ApplicationRecord::Jail
       allow :id, :subnet, :subnet6, :virtual?, :physical?, :mac, :ip, :ip6, :identifier, :attached_to,
         :link, :tag, :domain, :vlanid, :mtu, :bond_options, :attached_devices, :mode,
         :attached_devices_identifiers, :primary, :provision, :alias?, :inheriting_mac,

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -90,7 +90,7 @@ class Operatingsystem < ApplicationRecord
     property :pxe_type, String, desc: 'PXE type of the operating system, e.g. kickstart'
     property :password_hash, String, desc: 'Encrypted hash of the operating system password'
   end
-  class Jail < Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :major, :minor, :family, :to_s, :==, :release, :release_name, :kernel, :initrd, :pxe_type, :boot_files_uri, :password_hash, :mediumpath
   end
 

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -64,7 +64,7 @@ class Ptable < Template
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'partition table', example: 'Kickstart default' }
   end
-  class Jail < Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name
   end
 

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -39,7 +39,7 @@ class Realm < ApplicationRecord
     prop_group :basic_model_props, ApplicationRecord, meta: { example: 'EXAMPLE.COM' }
     property :realm_type, String, desc: 'Realm type, e.g. FreeIPA or Active Directory'
   end
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :realm_type
   end
 end

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -206,7 +206,7 @@ class SmartProxy < ApplicationRecord
     property :httpboot_https_port, Integer, desc: 'Returns proxy port for HTTPS boot'
     property :httpboot_https_port!, Integer, desc: 'Same as httpboot_https_port, but raises Foreman::Exception if no port is set'
   end
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port, :httpboot_http_port!, :httpboot_https_port!, :url
   end
 end

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -48,7 +48,7 @@ class SshKey < ApplicationRecord
     property :comment, String, desc: 'Returns a key comment. The comment is usually a user identifier',
                                example: '@ssh-key.comment # => forman@foreman.example.com'
   end
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :user, :key, :to_export, :fingerprint, :length, :ssh_key, :type, :comment
   end
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -155,7 +155,7 @@ class Subnet < ApplicationRecord
     property :to_label, String, desc: 'Returns the the subnet label which is a combination of name and the network address'
     property :vlanid, Integer, desc: 'Returns the VLAN ID for of this subnet'
   end
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name, :network, :mask, :cidr, :title, :to_label, :gateway, :dns_primary, :dns_secondary, :dns_servers,
       :vlanid, :mtu, :nic_delay, :boot_mode, :nil?, :has_vlanid?, :dhcp_boot_mode?, :description, :present?,
       :dhcp, :dhcp?, :tftp, :tftp?, :dns, :dns?, :httpboot, :httpboot?, :template, :template?, :ipam, :ipam?

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -29,7 +29,7 @@ class Template < ApplicationRecord
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord
   end
-  class Jail < Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :name
   end
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -4,7 +4,7 @@ class Token < ApplicationRecord
 
   validates :value, :host_id, :presence => true
 
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :host, :value, :expires, :nil?, :present?
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -161,7 +161,7 @@ class User < ApplicationRecord
     property :last_login_on, 'ActiveSupport::TimeWithZone', desc: 'Returns the user last login time, in UTC time zone'
     property :disabled, one_of: [true, false], desc: 'Returns true if the user account is disabled, false otherwise'
   end
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :login, :ssh_keys, :ssh_authorized_keys, :description, :firstname, :lastname, :mail, :last_login_on, :disabled
   end
 

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -43,7 +43,7 @@ class Usergroup < ApplicationRecord
 
   accepts_nested_attributes_for :external_usergroups, :reject_if => ->(a) { a[:name].blank? }, :allow_destroy => true
 
-  class Jail < ::Safemode::Jail
+  class Jail < ApplicationRecord::Jail
     allow :id, :ssh_keys, :all_users, :ssh_authorized_keys
   end
 

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -639,6 +639,20 @@ module Foreman #:nodoc:
       (@observable_events << events).flatten!.uniq!
     end
 
+    def extend_allowed_instance_methods_for_jail(jail_class, *methods)
+      raise "Jail not defined for #{jail_class}" unless jail_class.const_defined?(:Jail)
+      methods.each do |method|
+        Object.const_get("#{jail_class}::Jail").allow_instance_method method.to_sym
+      end
+    end
+
+    def extend_allowed_class_methods_for_jail(jail_class, *methods)
+      raise "Jail not defined for #{jail_class}" unless jail_class.const_defined?(:Jail)
+      methods.each do |method|
+        Object.const_get("#{jail_class}::Jail").allow_class_method method.to_sym
+      end
+    end
+
     delegate :subscribe, to: ActiveSupport::Notifications
 
     private

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -13,7 +13,7 @@ module MediumProviders
       name
     end
 
-    class Jail < Safemode::Jail
+    class Jail < ::Safemode::Jail
       allow :medium_uri, :unique_id, :errors
     end
 

--- a/test/unit/foreman/renderer/safe_mode_renderer_test.rb
+++ b/test/unit/foreman/renderer/safe_mode_renderer_test.rb
@@ -24,4 +24,15 @@ class SafeModeRendererTest < ActiveSupport::TestCase
 
     assert_include exception.message, 'parse error on value ")"'
   end
+
+  test "application record allowed methods" do
+    assert ::ApplicationRecord::Jail.allowed? :name
+    assert ::ApplicationRecord::Jail.allowed? :present?
+  end
+
+  test "application record child allowed methods" do
+    assert ::Domain::Jail.allowed? :name
+    assert ::Domain::Jail.allowed? :fullname
+    assert ::Domain::Jail.allowed? :present?
+  end
 end


### PR DESCRIPTION
Webhooks plugin needs to allow access to previous revisions which is very useful for hooking to database updates. This is safe to do thanks to audited gem, however, during testing I have found out that Safemode does not work properly. All our application record classes define Jail inner class from Safemode::Jail therefore all allowed methods defined in ApplicationRecord::Jail are completely ignored. Since the previous record revision can be safely enabled for all records, this must be also fixed.

Unfortunately, the change brings incompatibility to plugins which reopens the class, e.g. bootdisk and ansible, the exception is foreman_ansible/app/models/concerns/foreman_ansible/hostgroup_extensions.rb:50:in `<class:Hostgroup>': superclass mismatch for class Jail (TypeError) and to solve that, new plugin API method will be introduced so plugins can be fixed.

Reviewers: Not a cherry-pick candidate, this patch will break all plugins which are reopening Jail classes. I will submit patches to all of them to use the new plugin API method.