### PR TITLE
Fixes #29614 - add search to ace editor

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorView.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorView.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AceEditor from 'react-ace';
 import classNames from 'classnames';
-
+import 'brace/ext/searchbox';
 import { noop } from '../../../common/helpers';
 
 const EditorView = ({


### PR DESCRIPTION
A user can now search inside an editor by clicking ctrl+F.
React ace docs for the version we use: https://github.com/securingsincity/react-ace/blob/6.3.2/docs/FAQ.md#how-do-i-add-the-search-box
![Screenshot from 2021-06-24 15-21-22](https://user-images.githubusercontent.com/30431079/123270141-4ccead80-d508-11eb-80a7-3f3ea290a1ed.png)
