### PR TITLE
Fixes #32883 - Menu::Item doesn't use conditional option

### DIFF
--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -23,6 +23,9 @@ module Menu
     end
 
     def to_hash
+      if @condition.present?
+        return unless @condition.call
+      end
       {type: :item, exact: @exact, html_options: @html_options, name: @caption || @name, url: url} if authorized?
     end
 

--- a/app/registries/menu/toggle.rb
+++ b/app/registries/menu/toggle.rb
@@ -17,7 +17,7 @@ module Menu
         index = list.index(child)
         child.is_a?(Menu::Divider) && (index == list.size - 1 || list[index + 1].is_a?(Menu::Divider))
       end
-      list.map(&:to_hash)
+      list.map(&:to_hash).compact
     end
 
     def authorized?


### PR DESCRIPTION
Allows developers to send a `Proc` to conditionally show a menu item.  It seems it was half-implemented years ago. Here's the last of it.

Related Katello PR that needs this feature: https://github.com/Katello/katello/pull/9394