### PR TITLE
Fixes #32892 - add rails URL validator

### DIFF
--- a/app/models/concerns/url_validation.rb
+++ b/app/models/concerns/url_validation.rb
@@ -1,4 +1,4 @@
-module UrlValidator
+module UrlValidation
   extend ActiveSupport::Concern
 
   def is_http_url?(url)

--- a/app/models/setting/general.rb
+++ b/app/models/setting/general.rb
@@ -1,5 +1,5 @@
 class Setting::General < Setting
-  include UrlValidator
+  include UrlValidation
 
   # Lazy-load this to avoid loading this during Rails startup
   def self.locales

--- a/app/validators/http_url_validator.rb
+++ b/app/validators/http_url_validator.rb
@@ -1,0 +1,11 @@
+class HttpUrlValidator < ActiveModel::EachValidator
+  include UrlValidation
+
+  def validate_each(record, attribute, value)
+    return if options[:allow_blank] && value.empty?
+
+    if value.empty? || !is_http_url?(value)
+      record.errors.add(attribute, _("Invalid HTTP(S) URL"))
+    end
+  end
+end


### PR DESCRIPTION
We only exposed module implementing the URL validation, we should
provide a proper HTTP URL attributes validation.

This is much more convenient way to expose validations to new setting
DSL, so the only user of this validation `http_proxy` setting
is a cause for this change.