### PR TITLE
 Fixes #32894 - add types to Setting DSL

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -324,6 +324,7 @@ module Foreman #:nodoc:
     #   settings do
     #     category(:cfgmgmt, N_('Configuration Management')) do
     #       setting(:use_cooler_puppet,
+    #         type: :boolean,
     #         default: true,
     #         description: N_('Use Puppet that goes to 11'),
     #         full_name: N_('Use shiny puppet'),

--- a/app/registries/foreman/setting_manager.rb
+++ b/app/registries/foreman/setting_manager.rb
@@ -37,6 +37,10 @@ module Foreman
         SettingManager.settings
       end
 
+      def available_types
+        [:boolean, :integer, :float, :string, :text, :hash, :array]
+      end
+
       # Adds setting definition
       #
       # ===== Example
@@ -44,6 +48,7 @@ module Foreman
       #   SettingManager.define(:puppet) do
       #     category(:cfgmgmt, N_('Configuration Management')) do
       #       setting(:use_cooler_puppet,
+      #               type: :boolean,
       #               default: true,
       #               description: N_('Use Puppet that goes to 11'),
       #               full_name: N_('Use shiny puppet'),
@@ -51,11 +56,13 @@ module Foreman
       #     end
       #   end
       #
-      def setting(name, default:, description:, full_name: nil, value: nil, collection: nil, encrypted: false, **options)
+      def setting(name, default:, description:, type:, full_name: nil, value: nil, collection: nil, encrypted: false, **options)
         raise ::Foreman::Exception.new(N_("Setting '%s' is already defined, please avoid collisions"), name) if storage.key?(name.to_s)
+        raise ::Foreman::Exception.new(N_("Setting '%s' has an invalid type definition. Please use a valid type."), name) unless available_types.include?(type)
         storage[name.to_s] = {
           context: context_name,
           category: category_name,
+          type: type,
           default: default,
           description: description,
           full_name: full_name,

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1644,6 +1644,7 @@ Foreman::Plugin.register :my_plugin do
     # Following settings will be added to a General category
     category :general do
       setting 'example_setting',
+        type: :string,
         default: 'default value',
         full_name: N_('Example of general setting'),
         description: N_('Example setting that controls something')
@@ -1652,6 +1653,7 @@ Foreman::Plugin.register :my_plugin do
     # Following settings will be added to category name 'cool' with label Cool
     category :cool, N_('Cool') do
       setting 'example_int',
+        type: :integer,
         default: 42,
         full_name: N_('The answer'),
         description: N_('Answer to the life, universe, and everything')
@@ -1660,6 +1662,7 @@ Foreman::Plugin.register :my_plugin do
     # Following settings will be added to existing category named 'cfgmgmt'
     category :cfgmgmt do
       setting 'configure_everything',
+        type: :boolean
         default: true,
         full_name: N_('Configure everything'),
         description: N_('Should configuration management tools configure everything for user, so user can go to the beach?')
@@ -1670,6 +1673,10 @@ end
 
 To access the value of a setting, use `Setting[:example_setting]` from
 anywhere in your plugin.
+
+The settings are strongly typed and you have to define it.
+The basic types supported by Foreman are: `:boolean`, `:integer`, `:float`, `:string`, `:text`, `:hash`, `:array`.
+The `:text` type supports markdown and usage of such setting should expect markdown syntax when using it.
 
 [[config-files]]
 ==== Config files

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -11,7 +11,7 @@ class SettingsControllerTest < ActionController::TestCase
     duped_settings = Foreman::SettingManager.settings.dup
     Foreman::SettingManager.stubs(settings: duped_settings)
     Foreman::SettingManager.define(:test) do
-      category(:valid, 'Valid') { setting('valid_foo', default: 'bar', description: 'test foo') }
+      category(:valid, 'Valid') { setting('valid_foo', type: :string, default: 'bar', description: 'test foo') }
     end
     Foreman.settings.load
     get :index, session: set_session_user

--- a/test/integration/setting_js_test.rb
+++ b/test/integration/setting_js_test.rb
@@ -18,6 +18,7 @@ class SettingJSTest < IntegrationTestWithJavascript
     Foreman.settings._add(name,
       category: 'Setting::CategoryLabelTest',
       context: :test,
+      type: :boolean,
       default: false,
       description: 'Pretty setting',
       full_name: 'Pretty setting')

--- a/test/models/host_status/configuration_status_test.rb
+++ b/test/models/host_status/configuration_status_test.rb
@@ -101,6 +101,7 @@ class ConfigurationStatusTest < ActiveSupport::TestCase
       def stub_outofsync_setting(value)
         Foreman.settings._add('testorigin_out_of_sync_disabled',
           context: :test,
+          type: :boolean,
           category: 'Setting::General',
           full_name: 'Test out of sync',
           description: 'description',

--- a/test/unit/setting_manager_test.rb
+++ b/test/unit/setting_manager_test.rb
@@ -12,6 +12,7 @@ class SettingManagerTest < ActiveSupport::TestCase
     Foreman::SettingManager.define(:test_context) do
       category(:general) do
         setting(:foo,
+          type: :string,
           default: 'bar',
           description: 'This is nicely described foo setting',
           full_name: 'Foo setting')
@@ -25,6 +26,7 @@ class SettingManagerTest < ActiveSupport::TestCase
     Foreman::SettingManager.define(:test_context) do
       category(:my_category, 'Awesome Category') do
         setting(:foo,
+          type: :string,
           default: 'bar',
           description: 'This is nicely described foo setting',
           full_name: 'Foo setting')
@@ -40,12 +42,40 @@ class SettingManagerTest < ActiveSupport::TestCase
       Foreman::SettingManager.define(:test_context) do
         category(:my_category, 'Awesome Category') do
           setting(:foo,
+            type: :string,
             default: 'bar',
             description: 'This is nicely described foo setting',
             full_name: 'Foo setting')
         end
         category(:general) do
           setting(:foo,
+            type: :string,
+            default: 'bar',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting')
+        end
+      end
+    end
+  end
+
+  it 'doesnt allow setting with invalid type' do
+    # no type not allowed
+    assert_raise ArgumentError, "missing keyword: :type" do
+      Foreman::SettingManager.define(:test_context) do
+        category(:my_category, 'Awesome Category') do
+          setting(:foo,
+            default: 'bar',
+            description: 'This is nicely described foo setting',
+            full_name: 'Foo setting')
+        end
+      end
+    end
+    # invalid type not allowed
+    assert_raise ::Foreman::Exception, "Setting 'foo' has invalid type definition. Please use valid type." do
+      Foreman::SettingManager.define(:test_context) do
+        category(:general) do
+          setting(:foo,
+            type: :custom_type,
             default: 'bar',
             description: 'This is nicely described foo setting',
             full_name: 'Foo setting')

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -9,7 +9,7 @@ class SettingRegistryTest < ActiveSupport::TestCase
 
   setup do
     registry.stubs(settings: setting_memo)
-    registry._add('foo', category: 'Setting::General', default: default, full_name: 'test foo', description: 'test foo', context: :test)
+    registry._add('foo', type: :integer, category: 'Setting::General', default: default, full_name: 'test foo', description: 'test foo', context: :test)
     setting.update(value: setting_value)
     registry.load_values
   end


### PR DESCRIPTION
Add required typing for Setting DSL, so we have the types enforced from
the beggining.