### PR TITLE
Fixes #32490 - proper permission for ansible

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -80,6 +80,7 @@ fi
 
 <% if host_param_true?('ansible_tower_provisioning') -%>
 <%= save_to_file('/root/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh
 <% end -%>
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -115,6 +115,7 @@ echo "Calling Ansible AWX/Tower provisioning callback..."
 /usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
 echo "DONE"
 EOF
+chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh
 
 sync


### PR DESCRIPTION
The file `/root/ansible_provisioning_call.sh` needs to be runnable.

Fixing snapshots for #8487.
Please squash on merge.