### PR TITLE
Fixes #32589 - add a support for Oracle Linux registration

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -46,7 +46,7 @@ echo '#'
 echo '# Adding repository'
 echo '#'
 
-if [ x$ID = xrhel ] || [ x$ID = xfedora ] || test "${ID_LIKE#*rhel*}" != "$ID_LIKE" ; then
+if [ x$ID = xrhel ] || [ x$ID = xfedora ] || [ x$ID = xol ] || test "${ID_LIKE#*rhel*}" != "$ID_LIKE" ; then
   cat << EOF > /etc/yum.repos.d/foreman_registration.repo
 [foreman_register]
 name=foreman_register
@@ -97,7 +97,7 @@ echo "# Running registration"
 echo "#"
 
 <% if plugin_present?('katello') -%>
-if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
+if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
         curl --silent --show-error --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \
@@ -117,6 +117,14 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ]; then
     <% if @force -%>
     yum remove -y katello-ca-consumer*
     <% end -%>
+
+    # rhn-client-tools conflicts with subscription-manager package
+    # since rhn tools replaces subscription-manager, we need to explicitly
+    # install subscription-manager after the rhn tools cleanup
+    if [ x$ID = xol ]; then
+      yum remove -y rhn-client-tools
+      yum install -y --setopt=obsoletes=0 subscription-manager
+    fi
 
     CONSUMER_RPM=$(mktemp --suffix .rpm)
     curl --silent --show-error --output $CONSUMER_RPM <%= subscription_manager_configuration_url(hostname: @url_host) %>


### PR DESCRIPTION
The same subscription-manager flow needs to be activated also for OL. We
need to make sure we install the subscription-manager explicitly,
because rhn-client-tools would be installed instead to satistfy the
katello-ca-consumer dependency. Once it is installed, we can proceed
with the regular registration flow.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
