### PR TITLE
Fixes #32921 - treat empty TFTP servername correctly

### DIFF
--- a/app/models/concerns/orchestration/dhcp.rb
+++ b/app/models/concerns/orchestration/dhcp.rb
@@ -89,13 +89,11 @@ module Orchestration::DHCP
   end
 
   def boot_server_or_proxy_hostname
-    if tftp.bootServer.nil?
-      tftp_proxy_hostname = URI.parse(subnet.tftp.url).host
-      logger.warn "Using TFTP Smart Proxy hostname as the boot server name: #{tftp_proxy_hostname}"
-      return tftp_proxy_hostname
-    end
+    return tftp.bootServer if tftp.bootServer.present?
 
-    tftp.bootServer
+    tftp_proxy_hostname = URI.parse(subnet.tftp.url).host
+    logger.warn "Using TFTP Smart Proxy hostname as the boot server name: #{tftp_proxy_hostname}"
+    tftp_proxy_hostname
   end
 
   private

--- a/test/models/orchestration/dhcp_test.rb
+++ b/test/models/orchestration/dhcp_test.rb
@@ -466,8 +466,14 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
       assert_empty nic.errors
     end
 
-    test 'should use boot server based on proxy url' do
+    test 'should use boot server based on proxy url when nil is returned' do
       ProxyAPI::TFTP.any_instance.stubs(:bootServer).returns(nil)
+      assert_equal URI.parse(host.subnet.tftp.url).host, nic.send(:boot_server)
+      assert_empty nic.errors
+    end
+
+    test 'should use boot server based on proxy url when an empty string is returned' do
+      ProxyAPI::TFTP.any_instance.stubs(:bootServer).returns('')
       assert_equal URI.parse(host.subnet.tftp.url).host, nic.send(:boot_server)
       assert_empty nic.errors
     end


### PR DESCRIPTION
When installer option --foreman-proxy-tftp-servername is unset, smart proxy DHCP module renders next-server as "false". This is caused by expecting serverName is returned as nil, however, it looks like smart proxy can return empty string too.