### PR TITLE
Fixes #32948 - change slot warning to be more explicit

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/Slot/Slot.js
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/Slot.js
@@ -5,7 +5,9 @@ const Slot = ({ fills, id, multi, children = null, ...props }) => {
   const addProps = object => {
     if (multi && !object.key) {
       // eslint-disable-next-line no-console
-      console.warn('Please add a key attribute to multiple fills');
+      console.warn(
+        `Please add a key attribute to multiple fills [component - ${object.type.name}]`
+      );
     }
 
     if (isValidElement(object)) {


### PR DESCRIPTION
When registering a component with no key, a warning is shown:

`Please add a key attribute to multiple fills`

For better debugging, a more explicit message is required.
Changed to:
`Please add a key attribute to multiple fills [<COMPONENT_NAME>]`