### PR TITLE
Fixes #32959 - Unassign OS from registration templates

### DIFF
--- a/db/migrate/20210115124508_template_kind_registration.rb
+++ b/db/migrate/20210115124508_template_kind_registration.rb
@@ -14,6 +14,11 @@ class TemplateKindRegistration < ActiveRecord::Migration[6.0]
                         .where(name: 'Linux registration default')
                         .update_all(name: Setting[:default_host_init_config_template])
 
+    # Unassign operating systems from registration templates
+    # (Registration templates are not allowed to be assigned to OS)
+    registration_templates = ProvisioningTemplate.unscoped.where(template_kind: registration_kind)
+    registration_templates.each { |rt| rt.operatingsystems = [] }
+
     # Assign default host_init_config template to all operating systems
     # and change registration association to the host_init_config
     template = ProvisioningTemplate.unscoped.find_by_name(Setting[:default_host_init_config_template])


### PR DESCRIPTION
Operating systems cannot be assigned to registration templates,
so the migration file should also remove these associations.

How to reproduce the issue
* Checkout `2.4-stable` branch
* Assign OS to registration template
* Checkout `develop` branch
* Run `rails db:migrate` & then `rails db:seed`
```
ActiveRecord::RecordInvalid: 
Validation failed: Operatingsystems can't assign operating system to Registration template
```

From https://community.theforeman.org/t/foreman-update-2-5-1-foreman-rake-db-seed-fails/24242

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
