### PR TITLE
Fixes #32398 - Make tabs on Host Detail page routable

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -31,11 +31,12 @@ import Slot from '../common/Slot';
 import { registerCoreTabs } from './Tabs';
 import { translate as __ } from '../../common/I18n';
 
+import { currentTab, handleTabClick } from './routedTabsHelper';
+
 import './HostDetails.scss';
 
-const HostDetails = ({ match, location: { hash } }) => {
+const HostDetails = ({ history, match, location }) => {
   const dispatch = useDispatch();
-  const [activeTab, setActiveTab] = useState('Overview');
   const response = useSelector(state =>
     selectAPIResponse(state, 'HOST_DETAILS')
   );
@@ -45,6 +46,8 @@ const HostDetails = ({ match, location: { hash } }) => {
     selectFillsIDs(state, 'host-details-page-tabs')
   );
 
+  const activeTab = currentTab(location, 0) || 'Overview';
+
   // This is a workaround due to the tabs overflow mechanism in PF4
   useEffect(() => {
     if (tabs?.length) dispatchEvent(new Event('resize'));
@@ -53,10 +56,6 @@ const HostDetails = ({ match, location: { hash } }) => {
   useEffect(() => {
     registerCoreTabs();
   }, []);
-
-  useEffect(() => {
-    if (hash) setActiveTab(hash.slice(1));
-  }, [hash]);
 
   useEffect(() => {
     dispatch(
@@ -73,10 +72,6 @@ const HostDetails = ({ match, location: { hash } }) => {
     document.body.classList.add('pf-gray-background');
     return () => document.body.classList.remove('pf-gray-background');
   }, []);
-
-  const handleTabClick = (event, tabIndex) => {
-    setActiveTab(tabIndex);
-  };
 
   return (
     <>
@@ -137,7 +132,7 @@ const HostDetails = ({ match, location: { hash } }) => {
             width: window.innerWidth - (isNavCollapsed ? 95 : 220),
           }}
           activeKey={activeTab}
-          onSelect={handleTabClick}
+          onSelect={handleTabClick(history, 0)}
         >
           {tabs &&
             tabs.map(tab => (
@@ -145,6 +140,9 @@ const HostDetails = ({ match, location: { hash } }) => {
                 <Slot
                   response={response}
                   status={status}
+                  history={history}
+                  location={location}
+                  match={match}
                   id="host-details-page-tabs"
                   fillID={tab}
                 />

--- a/webpack/assets/javascripts/react_app/components/HostDetails/routedTabsHelper.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/routedTabsHelper.js
@@ -1,0 +1,13 @@
+export const currentTab = (location, level)=> {
+  if (!location.hash) {
+    return ''
+  }
+  return location.hash.replace('#', '').split('-')[level]
+}
+
+export const handleTabClick = (history, level) => (event, value) => {
+  const split = history.location.hash.split('-');
+  split[level] = value;
+  const newHash = split.slice(0, level + 1).join('-');
+  history.push({ pathname: history.location.pathname, hash: `${newHash}` })
+}


### PR DESCRIPTION
This is an alternative take on https://github.com/theforeman/foreman/pull/8495
which uses `#Tab-Subtab` scheme for identifying tabs.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
