### PR TITLE
Revert "Fixes #32952 - Set upper version of rake to avoid failures"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,6 @@ else
   raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"
 end
 
-# REFS #32952 - Newest version (13.0.4) of rake causes test failures in that issue
-gem 'rake', '< 13.0.4'
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '>= 4.9.0', '< 5'
 gem 'will_paginate', '>= 3.1.7', '< 4'


### PR DESCRIPTION
This reverts commit 9ca7c1e572dc52b59453d1844a801bf5b8ece443. Rake 13.0.6 should be released and fix it.