### PR TITLE
Fixes #14854 - connection libvirt leak fixed

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -83,6 +83,7 @@ require_dependency File.expand_path('../lib/foreman/middleware/catch_json_parse_
 require_dependency File.expand_path('../lib/foreman/middleware/logging_context_request', __dir__)
 require_dependency File.expand_path('../lib/foreman/middleware/logging_context_session', __dir__)
 require_dependency File.expand_path('../lib/foreman/middleware/telemetry', __dir__)
+require_dependency File.expand_path('../lib/foreman/middleware/libvirt_connection_cleaner', __dir__)
 
 if SETTINGS[:support_jsonp]
   if File.exist?(File.expand_path('../Gemfile.in', __dir__))
@@ -214,8 +215,9 @@ module Foreman
     # Add apidoc hash in headers for smarter caching
     config.middleware.use Apipie::Middleware::ChecksumInHeaders
 
-    # Add telemetry
+    # Add telemetry and connection cleaner
     config.middleware.use Foreman::Middleware::Telemetry
+    config.middleware.use Foreman::Middleware::LibvirtConnectionCleaner
 
     # New config option to opt out of params "deep munging" that was used to address security vulnerability CVE-2013-0155.
     config.action_dispatch.perform_deep_munge = false

--- a/lib/foreman/middleware/libvirt_connection_cleaner.rb
+++ b/lib/foreman/middleware/libvirt_connection_cleaner.rb
@@ -1,0 +1,19 @@
+module Foreman
+  module Middleware
+    class LibvirtConnectionCleaner
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        result = @app.call(env)
+
+        # Libvirt compute resource does rely on TCP+SSH tunnel which needs to be
+        # properly closed at the end of each request to prevent connection leaks.
+        Foreman::Model::Libvirt.terminate_connection
+
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
Most (if not all) compute resources use HTTP clients to communicate with API, however libvirt use tcp+ssh connection which needs to be closed properly. Foreman does not care.

There are several approaches I could took, the cleanest solution would be to provide a block and make all operations to be within blocks ensuring terminating of connection. However, Foreman performs several actions during a single request and this could cause multiple connections per request slowing down already slow integration.

Another option would be to implement some sort of connection pooling, but this is error prone and it would be time consuming.

The method I am going for is an explicit connection cleaner that will terminate the libvirt connection which was already stored in thread local variable. This ensures all connections are correctly closed at the very end of a HTTP request.

Example:

```
2021-07-08T15:58:19 [I|app|096381ac] Started GET "/compute_resources/2-libvirt-local/vms" for ::ffff:192.168.1.5 at 2021-07-08 15:58:19 +0200
2021-07-08T15:58:19 [I|app|096381ac] Processing by ComputeResourcesVmsController#index as HTML
2021-07-08T15:58:19 [I|app|096381ac]   Parameters: {"compute_resource_id"=>"2-libvirt-local"}
2021-07-08T15:58:19 [D|app|096381ac] Setting remote_addr has no definition, clean up your database
2021-07-08T15:58:19 [D|app|096381ac] Setting db_pending_migration has no definition, clean up your database
2021-07-08T15:58:19 [D|app|096381ac] Setting password_hash has no definition, clean up your database
2021-07-08T15:58:19 [I|per|096381ac] Current user set to admin (admin)
2021-07-08T15:58:19 [D|tax|096381ac] Current location set to Default Location
2021-07-08T15:58:19 [D|tax|096381ac] Current organization set to Default Organization
2021-07-08T15:58:19 [D|app|096381ac] Created libvirt connection 218520
2021-07-08T15:58:19 [I|app|096381ac]   Rendering compute_resources_vms/index.html.erb within layouts/application
2021-07-08T15:58:19 [I|app|096381ac]   Rendered compute_resources_vms/index/_libvirt.html.erb (Duration: 14.4ms | Allocations: 11646)
2021-07-08T15:58:19 [I|app|096381ac]   Rendered compute_resources_vms/index.html.erb within layouts/application (Duration: 16.5ms | Allocations: 12569)
2021-07-08T15:58:19 [I|app|096381ac]   Rendered layouts/_application_content.html.erb (Duration: 0.1ms | Allocations: 67)
2021-07-08T15:58:19 [I|app|096381ac]   Rendering layouts/base.html.erb
2021-07-08T15:58:20 [I|app|096381ac]   Rendered layouts/base.html.erb (Duration: 291.1ms | Allocations: 203233)
2021-07-08T15:58:20 [I|app|096381ac] Completed 200 OK in 772ms (Views: 309.5ms | ActiveRecord: 4.6ms | Allocations: 263164)
2021-07-08T15:58:20 [D|app|096381ac] Terminating libvirt connection 218520
```