### PR TITLE
Fixes #32999 - add console to host details page

### DIFF
--- a/app/views/hosts/console/log.html.erb
+++ b/app/views/hosts/console/log.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <% search_bar(_("Generated %s ago") % time_ago_in_words(@console['timestamp'])) %>
-  <%= title_actions(link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default')) if @host %>
+  <%= title_actions(link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default', :id => 'back-to-host-btn')) if @host %>
   <% title "#{@console[:name]}" %>
 </div>
 <% if @host && (@host.installed_at.nil? or (@console['timestamp'] - @host.installed_at < 5.minutes)) %>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -40,6 +40,7 @@ const ActionsBar = ({ hostName }) => {
       >
         {__('Edit')}
       </Button>
+
       <Dropdown
         toggle={<KebabToggle onToggle={onKebabToggle} />}
         isOpen={kebabIsOpen}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Console/LegacyLoaderHook.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Console/LegacyLoaderHook.fixtures.js
@@ -1,0 +1,11 @@
+export const basicHtml = {
+  data: '<span> basic html </span>',
+};
+
+export const multipleHtml = {
+  data:
+    '<div> <span id="keep"> this should be visible </span> <span id="delete"> this should be remove </span></div>',
+};
+
+export const chosenElement =
+  '<span id=\"keep\"> this should be visible </span>';

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Console/LegacyLoaderHook.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Console/LegacyLoaderHook.js
@@ -1,0 +1,72 @@
+import { useState, useEffect, useRef } from 'react';
+import { STATUS } from '../../../constants';
+import { getApiResponse } from '../../../redux/API/APIHelpers';
+
+/**
+ * A custom hook for ajax requests, returns html content to be wrapped in a react component
+ * @param  {string} type the  method for the ajax request (i.e 'post', 'get' etc)
+ * @param  {string} url the url for the ajax request
+ * @param  {object} options DOM manipulation helpers
+ * @return {object} returns an object that contains the request's status and the parsed html to renderd in 'dangerouslySetInnerHTML'
+ */
+
+export const useDangerouslyLegacy = (
+  type,
+  url,
+  { chosenElement, elementsToRemove } = {}
+) => {
+  const [parsedHTML, setParsedHTML] = useState();
+  const [rawHTML, setRawHTML] = useState();
+  const [status, setStatus] = useState(STATUS.PENDING);
+
+  // constants
+  const { current: _elementsToRemove } = useRef(elementsToRemove);
+
+  useEffect(() => {
+    if (url) {
+      const fetchLegacy = async () => {
+        try {
+          const { data } = await getApiResponse({
+            type,
+            url,
+          });
+          setRawHTML(data);
+          setStatus(STATUS.RESOLVED);
+        } catch (err) {
+          setStatus(STATUS.ERROR);
+        }
+      };
+      fetchLegacy();
+    }
+  }, [url, type]);
+
+  useEffect(() => {
+    if (rawHTML) {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(rawHTML, 'text/html');
+      let html;
+      if (_elementsToRemove) {
+        removeElements(doc, _elementsToRemove);
+        html = doc.documentElement.innerHTML;
+      }
+      if (chosenElement) {
+        html = doc.getElementById(chosenElement).outerHTML;
+      }
+      setParsedHTML(html || rawHTML);
+    }
+  }, [rawHTML, _elementsToRemove, chosenElement]);
+
+  return {
+    status,
+    html: parsedHTML,
+  };
+};
+
+const removeElements = (doc, removalList) => {
+  // https://github.com/eslint/eslint/issues/12117
+  // eslint-disable-next-line no-unused-vars
+  for (const id of removalList) {
+    const element = doc.getElementById(id);
+    if (element) element.remove();
+  }
+};

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Console/LegacyLoaderHook.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Console/LegacyLoaderHook.test.js
@@ -1,0 +1,50 @@
+import APIHelper from '../../../redux/API/API';
+import { renderHook } from '@testing-library/react-hooks';
+import { useDangerouslyLegacy } from './LegacyLoaderHook';
+import {
+  basicHtml,
+  multipleHtml,
+  chosenElement,
+} from './LegacyLoaderHook.fixtures.js';
+import { STATUS } from '../../../constants';
+import { API_OPERATIONS } from '../../../redux/API';
+jest.mock('axios');
+jest.mock('../../../redux/API/API');
+
+it('should return html', async () => {
+  APIHelper.get.mockResolvedValue(basicHtml);
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useDangerouslyLegacy(API_OPERATIONS.GET, '/some-url')
+  );
+  expect(result.current.status).toEqual(STATUS.PENDING);
+  await waitForNextUpdate();
+  expect(result.current.html).toEqual(basicHtml.data);
+  expect(result.current.status).toEqual(STATUS.RESOLVED);
+});
+
+it('should choose dom element', async () => {
+  APIHelper.get.mockResolvedValue(multipleHtml);
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useDangerouslyLegacy(API_OPERATIONS.GET, '/some-url', {
+      chosenElement: 'keep',
+    })
+  );
+  expect(result.current.status).toEqual(STATUS.PENDING);
+  await waitForNextUpdate();
+  expect(result.current.html).toEqual(chosenElement);
+  expect(result.current.status).toEqual(STATUS.RESOLVED);
+});
+
+it('should remove dom element', async () => {
+  APIHelper.get.mockResolvedValue(multipleHtml);
+  const { result, waitForNextUpdate } = renderHook(() =>
+    useDangerouslyLegacy(API_OPERATIONS.GET, '/some-url', {
+      elementsToRemove: ["delete"],
+    })
+  );
+  expect(result.current.status).toEqual(STATUS.PENDING);
+  await waitForNextUpdate();
+  expect(result.current.html).toContain('visible');
+  expect(result.current.html).not.toContain('remove');
+  expect(result.current.status).toEqual(STATUS.RESOLVED);
+});

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Console/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Console/index.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Text, Bullseye } from '@patternfly/react-core';
+
+import { foremanUrl } from '../../../../common/helpers';
+import { API_OPERATIONS } from '../../../../redux/API';
+import SkeletonLoader from '../../../common/SkeletonLoader';
+import { useDangerouslyLegacy } from '../../Console/LegacyLoaderHook';
+import { translate as __ } from '../../../../common/I18n';
+
+const ConsoleTab = ({ hostName }) => {
+  const url = hostName && foremanUrl(`/hosts/${hostName}/console`);
+  const emptyState = (
+    <Bullseye>
+      <Text style={{ marginTop: '20px' }} component="p">
+        {__('No console support')}
+      </Text>
+    </Bullseye>
+  );
+  const { status, html } = useDangerouslyLegacy(API_OPERATIONS.GET, url, {
+    chosenElement: 'content',
+    elementsToRemove: ['breadcrumb', 'back-to-host-btn'],
+  });
+  return (
+    <div className="host-details-tab-item details-tab">
+      <SkeletonLoader
+        emptyState={emptyState}
+        status={status}
+        skeletonProps={{ count: 10 }}
+      >
+        {html && <div dangerouslySetInnerHTML={{ __html: html }} />}
+      </SkeletonLoader>
+    </div>
+  );
+};
+
+ConsoleTab.propTypes = {
+  hostName: PropTypes.string,
+};
+ConsoleTab.defaultProps = {
+  hostName: '',
+};
+
+export default ConsoleTab;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { addGlobalFill } from '../../common/Fill/GlobalFill';
 import { DEFAULT_TAB } from '../consts';
 import OverviewTab from './Overview';
+import Console from './Console';
+import { unregisterFillComponent } from '../../common/Fill/FillActions';
 
 export const registerCoreTabs = () => {
   addGlobalFill(
@@ -10,4 +12,17 @@ export const registerCoreTabs = () => {
     <OverviewTab key="host-details-overview-tab" />,
     1000
   );
+};
+
+export const registerConsoleTab = () => {
+  addGlobalFill(
+    'host-details-page-tabs',
+    'Console',
+    <Console key="console-tab-content" />,
+    100
+  );
+};
+
+export const unregisterTab = tabID => dispatch => {
+  dispatch(unregisterFillComponent('host-details-page-tabs', tabID));
 };


### PR DESCRIPTION
This POC adds console to the new host details page:

https://user-images.githubusercontent.com/11807069/125000803-dbd7db80-e059-11eb-8341-6dfed68855e3.mov

This PR **is not** transforming the console to react, but adds a generic custom hook (`useLegacyLoader`)  which creates an ajax request for fetching, parsing, and maniplate legacy content.