### PR TITLE
Fixes #32979 - passing react routes from server

### DIFF
--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -4,6 +4,7 @@ module LayoutHelper
                       layout: layout_data,
                       metadata: app_metadata,
                       toasts: toast_notifications_data,
+                      routes: routes,
                     })
   end
 
@@ -41,6 +42,10 @@ module LayoutHelper
 
   def fetch_user
     { current_user: User.current, user_dropdown: Menu::Manager.to_hash(:side_menu), impersonated_by: User.unscoped.find_by_id(session[:impersonated_by]) }
+  end
+
+  def routes
+    []
   end
 
   def layout_data

--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -10,7 +10,7 @@ import AppSwitcher from '../routes';
 import apolloClient from './apollo';
 import ToastsList from '../components/ToastsList';
 
-const ReactApp = ({ layout, metadata, toasts }) => {
+const ReactApp = ({ layout, metadata, toasts, routes }) => {
   const contextData = { metadata };
   const ForemanContext = getForemanContext(contextData);
 
@@ -21,7 +21,7 @@ const ReactApp = ({ layout, metadata, toasts }) => {
           <ConnectedRouter history={history}>
             <Layout data={layout}>
               <ToastsList railsMessages={toasts} />
-              <AppSwitcher />
+              <AppSwitcher serverRoutes={routes} />
             </Layout>
           </ConnectedRouter>
         </ApolloProvider>
@@ -34,6 +34,7 @@ ReactApp.propTypes = {
   layout: LayoutPropTypes.data.isRequired,
   metadata: PropTypes.object.isRequired,
   toasts: PropTypes.array.isRequired,
+  routes: PropTypes.array.isRequired,
 };
 
 export default ReactApp;

--- a/webpack/assets/javascripts/react_app/common/__snapshots__/withReactRoutes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/common/__snapshots__/withReactRoutes.test.js.snap
@@ -23,7 +23,9 @@ exports[`withReactRoutes should render and pass props: should render and pass pr
     }
   }
 >
-  <AppSwitcher>
+  <AppSwitcher
+    serverRoutes={Array []}
+  >
     <Component
       name="foo"
     />

--- a/webpack/assets/javascripts/react_app/routes/index.js
+++ b/webpack/assets/javascripts/react_app/routes/index.js
@@ -4,29 +4,46 @@ import PropTypes from 'prop-types';
 import { routes } from './routes';
 import { renderRoute } from './RoutingService';
 import ForemanSwitch from './ForemanSwitcher';
+import templates from './routerTemplates';
 
-const AppSwitcher = ({ children }) => (
-  <>
-    <ForemanSwitch>
-      {routes.map(({ render, path, ...routeProps }) => (
-        <Route
-          path={path}
-          key={path}
-          {...routeProps}
-          render={renderProps => renderRoute(render, renderProps)}
-        />
-      ))}
-    </ForemanSwitch>
-    {children}
-  </>
-);
+const AppSwitcher = ({ children, serverRoutes }) => {
+  const appRoutes = [
+    ...routes,
+    ...serverRoutes.map(({ path, props: serverProps, component }) => {
+      const Template = templates[component];
+      return {
+        path,
+        render: renderProps =>
+          Template && <Template {...renderProps} {...serverProps} />,
+      };
+    }),
+  ];
+
+  return (
+    <>
+      <ForemanSwitch>
+        {appRoutes.map(({ render, path, ...routeProps }) => (
+          <Route
+            path={path}
+            key={path}
+            {...routeProps}
+            render={renderProps => renderRoute(render, renderProps)}
+          />
+        ))}
+      </ForemanSwitch>
+      {children}
+    </>
+  );
+};
 
 AppSwitcher.propTypes = {
   children: PropTypes.object,
+  serverRoutes: PropTypes.array,
 };
 
 AppSwitcher.defaultProps = {
   children: null,
+  serverRoutes: [],
 };
 
 export default AppSwitcher;

--- a/webpack/assets/javascripts/react_app/routes/routerTemplates.js
+++ b/webpack/assets/javascripts/react_app/routes/routerTemplates.js
@@ -1,0 +1,7 @@
+import PageLayout from './common/PageLayout/PageLayout';
+
+const templates = {
+  PageLayout,
+};
+
+export default templates;


### PR DESCRIPTION
Enable to pass a react route from the server
which will render a component from a template
and pass props from the server to it.

used in #8596 


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
