### PR TITLE
Refs #32840 - Fix setting editing

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js
@@ -16,7 +16,10 @@ export const withTooltip = Component => componentProps => {
       placement="top"
       rootClose={false}
     >
-      <Component {...rest} />
+      {/* The span is needed because OverlayTrigger overrides child events */}
+      <span>
+        <Component {...rest} />
+      </span>
     </OverlayTrigger>
   );
 };


### PR DESCRIPTION
OverlayTrigger does some wired magic with children event handlers,
causing the onClick event of the direct child to be overriden. That
means that we must have a "dummy" child element to avoid the actual
onClick event from being overriden. See
https://github.com/react-bootstrap/react-bootstrap/blob/v0.33.1/src/OverlayTrigger.js#L272
for details.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
