### PR TITLE
Restrict search operators for Settings

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -64,8 +64,8 @@ class Setting < ApplicationRecord
 
   scope :order_by, ->(attr) { except(:order).order(attr) }
 
-  scoped_search :on => :name, :complete_value => :true
-  scoped_search :on => :description, :complete_value => :true
+  scoped_search on: :name, complete_value: :true, operators: ['=']
+  scoped_search on: :description, complete_value: :true, operators: ['~']
 
   def self.config_file
     'settings.yaml'

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -57,6 +57,8 @@ class SettingPresenter
   def matches_search_query?(query)
     if (res = query.match(/name\s*=\s*(\S+)/))
       name == res[1]
+    elsif (res = query.match(/description\s*~\s*(\S+)/))
+      description.include? res[1]
     else
       description.include?(query) || name.include?(query) || full_name&.include?(query)
     end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -80,6 +80,16 @@ class SettingRegistryTest < ActiveSupport::TestCase
   end
 
   describe '#search_for' do
+    setup do
+      registry._add('desc_set_test',
+        category: 'Setting::General',
+        default: default,
+        type: :integer,
+        full_name: 'Desc set test',
+        description: 'unique desc23x description',
+        context: :test)
+    end
+
     it 'can find setting by exact name match' do
       result = registry.search_for('name = foo').to_a
       assert_equal 1, result.size
@@ -90,6 +100,12 @@ class SettingRegistryTest < ActiveSupport::TestCase
       result = registry.search_for('test f').to_a
       assert_equal 1, result.size
       assert_equal 'foo', result.first.name
+    end
+
+    it 'can find setting by "description ~ value"' do
+      result = registry.search_for('description ~ desc23x').to_a
+      assert_equal 1, result.size
+      assert_equal 'desc_set_test', result.first.name
     end
   end
 end


### PR DESCRIPTION
Search method from 'setting index loads from registry' PR https://github.com/theforeman/foreman/pull/8438
support only few search operators, `SearchBar` component 
at Settings page should not display other unsupported operators

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
