### PR TITLE
Fixes #33011 - Navigation doesn't display Host Wizard without admin

### DIFF
--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -98,6 +98,7 @@ module Menu
         menu.sub_menu :lab_features_menu, :caption => N_('Lab Features'), :icon => 'fa fa-flask' do
           menu.item :host_wizard,
             :caption => 'Host Wizard',
+            :url_hash => { :controller => 'api/v2/hosts', :action => 'create' },
             :url => '/host_wizard'
         end
       end


### PR DESCRIPTION
Steps to Reproduce:

1. Create a non-admin user
2. Login with said user
3. Attempt to view Lab Features > Host Wizard