### PR TITLE
Fixes #32013 - improve the UX for adding host parameters

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -148,10 +148,15 @@ function mark_params_override() {
   $('a[rel="popover"]').popover();
 }
 
-function add_fields(target, association, content) {
+function add_fields(target, association, content, direction) {
+  direction = direction ? direction : 'append';
   var new_id = new Date().getTime();
   var regexp = new RegExp('new_' + association, 'g');
-  $(target).append(content.replace(regexp, new_id));
+  if (direction == 'append') {
+    $(target).append(content.replace(regexp, new_id));
+  } else {
+    $(target).prepend(content.replace(regexp, new_id));
+  }
 }
 
 $(document).ready(function() {

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -354,7 +354,7 @@ module FormHelper
         { :f => builder }.merge(locals_option))
     end
     options[:class] = link_to_add_fields_classes(options)
-    link_to_function(name, "add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}')".html_safe, options)
+    link_to_function(name, "add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}', '#{options[:direction] || 'append'}')".html_safe, options)
   end
 
   def field(f, attr, options = {})

--- a/app/views/common_parameters/_parameters.html.erb
+++ b/app/views/common_parameters/_parameters.html.erb
@@ -1,4 +1,9 @@
+<%
+  parameters_by_type = f.object.send(type)
+  params_authorizer = Authorizer.new(User.current, :collection => parameters_by_type)
+%>
 <div id="parameters">
+  <%= authorized_via_my_scope("host_editing", "create_params") ? link_to_add_fields('+ ' + _("Add Parameter"), f, type, "common_parameters/parameter", { :target => '#global_parameters_table tbody', :direction => 'prepend', :locals => { :params_authorizer => params_authorizer }}) : "" %>
   <table class="table" id="global_parameters_table">
     <thead class="white-header">
     <tr>
@@ -9,10 +14,6 @@
     </tr>
     </thead>
     <tbody>
-      <%
-        parameters_by_type = f.object.send(type)
-        params_authorizer = Authorizer.new(User.current, :collection => parameters_by_type)
-      %>
       <% authorized_resource_parameters(params_authorizer, parameters_by_type).each do |parameter| %>
         <%= f.fields_for type, parameter do |builder| %>
           <%= render "common_parameters/parameter", :f => builder, :params_authorizer => params_authorizer %>
@@ -20,5 +21,4 @@
       <% end %>
     </tbody>
   </table>
-  <%= authorized_via_my_scope("host_editing", "create_params") ? link_to_add_fields('+ ' + _("Add Parameter"), f, type, "common_parameters/parameter", { :target => '#global_parameters_table tbody', :locals => { :params_authorizer => params_authorizer }}) : "" %>
 </div>


### PR DESCRIPTION
In the host form when there's a lot of puppet parameters, it's a lot of
scrolling for a user to add host parameters. Once new is added, use need
to scroll to the botton to the add param button, then they fill in the
value and again needs to go to botton to add another. This allows to
specify whether we append or prepend new form and moves the button above
the host parameters table.

before the fix
![params_before](https://user-images.githubusercontent.com/109773/125639801-fa87d2ef-25f4-4a7f-b238-5a1fa7a9b9b0.gif)

with the fix
![params_after](https://user-images.githubusercontent.com/109773/125639803-378d9621-149e-46cc-b680-900866ddddef.gif)

please don't ask me for any kind of tests :-)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
