### PR TITLE
Fixes #33026 - Add React error boundary

### DIFF
--- a/webpack/assets/javascripts/react_app/Root/ReactApp.js
+++ b/webpack/assets/javascripts/react_app/Root/ReactApp.js
@@ -9,6 +9,7 @@ import AppSwitcher from '../routes';
 
 import apolloClient from './apollo';
 import ToastsList from '../components/ToastsList';
+import ErrorBoundary from '../components/common/ErrorBoundary';
 
 const ReactApp = ({ layout, metadata, toasts }) => {
   const contextData = { metadata };
@@ -20,8 +21,10 @@ const ReactApp = ({ layout, metadata, toasts }) => {
         <ApolloProvider client={apolloClient}>
           <ConnectedRouter history={history}>
             <Layout data={layout}>
-              <ToastsList railsMessages={toasts} />
-              <AppSwitcher />
+              <ErrorBoundary history={history}>
+                <ToastsList railsMessages={toasts} />
+                <AppSwitcher />
+              </ErrorBoundary>
             </Layout>
           </ConnectedRouter>
         </ApolloProvider>

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
@@ -45,11 +45,17 @@ const EmptyStatePattern = props => {
     );
   };
 
+  const EmptyStateIcon = () =>
+    React.isValidElement(icon) ? (
+      icon
+    ) : (
+      <Icon name={icon} type={iconType} size="2x" />
+    );
+
   return (
     <EmptyState variant={EmptyStateVariant.xl}>
       <span className="empty-state-icon">
-        {/* TODO: Add pf4 icons, Redmine issue: #30865 */}
-        <Icon name={icon} type={iconType} size="2x" />
+        <EmptyStateIcon />
       </span>
       <Title headingLevel="h5" size="4xl">
         {header}

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
@@ -7,7 +7,7 @@ export const actionButtonPropTypes = {
 };
 
 export const emptyStatePatternPropTypes = {
-  icon: PropTypes.string,
+  icon: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   iconType: PropTypes.string,
   header: PropTypes.string.isRequired,
   documentation: PropTypes.oneOfType([

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/__snapshots__/EmptyState.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/__snapshots__/EmptyState.test.js.snap
@@ -61,11 +61,7 @@ exports[`Empty State Pattern should render with props 1`] = `
   <span
     className="empty-state-icon"
   >
-    <Icon
-      name="printer"
-      size="2x"
-      type="pf"
-    />
+    <EmptyStateIcon />
   </span>
   <Title
     headingLevel="h5"

--- a/webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import {
+  ClipboardCopy,
+  ClipboardCopyVariant,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core';
+
+import { translate as __ } from '../../../common/I18n';
+import EmptyState from '../EmptyState';
+import { foremanUrl } from '../../../common/helpers';
+import './index.scss';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+    props.history.listen(() => {
+      if (this.state.hasError) {
+        this.setState({
+          hasError: false,
+        });
+      }
+    });
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ hasError: true, error, info });
+  }
+
+  render() {
+    const { history, children } = this.props;
+    const { hasError, error, info } = this.state;
+
+    if (!hasError) return children;
+
+    const description = (
+      <>
+        <p>
+          {__('There was a problem processing the request. Please try again.')}
+        </p>
+        <p
+          dangerouslySetInnerHTML={{
+            __html: __(
+              `To report an issue <a target="_blank" rel="noopener noreferrer" href=${foremanUrl(
+                '/links/issues'
+              )}>click here</a>`
+            ),
+          }}
+        />
+      </>
+    );
+
+    const action = {
+      title: __('Return to last page'),
+      onClick: history.goBack,
+    };
+
+    return (
+      <Grid className="error-boundary-foreman-app">
+        <GridItem sm={12}>
+          <EmptyState
+            icon={<ExclamationCircleIcon />}
+            header={__('Something went wrong')}
+            description={description}
+            action={action}
+          />
+        </GridItem>
+        <GridItem sm={8} smOffset={2}>
+          <ClipboardCopy isReadOnly variant={ClipboardCopyVariant.expansion}>
+            {error.toString()}
+            {info.componentStack}
+          </ClipboardCopy>
+        </GridItem>
+      </Grid>
+    );
+  }
+}
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
+  history: PropTypes.object.isRequired,
+};
+
+export default ErrorBoundary;

--- a/webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.scss
+++ b/webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.scss
@@ -1,0 +1,9 @@
+.error-boundary-foreman-app {
+  .empty-state-icon {
+    color: var(--pf-global--palette--red-200);
+  }
+
+  .pf-c-clipboard-copy__expandable-content {
+    white-space: pre-wrap;
+  }
+}


### PR DESCRIPTION
A JavaScript error in a part of the UI shouldn’t break the whole app. To solve this problem for React users, React 16 introduces a new concept of an “error boundary”.

Error boundaries are React components that **catch JavaScript errors anywhere in their child component tree, log those errors, and display a fallback UI** instead of the component tree that crashed. Error boundaries catch errors during rendering, in lifecycle methods, and in constructors of the whole tree below them.

https://reactjs.org/docs/error-boundaries.html

I've used the Empty State design from patternfly-react: https://www.patternfly.org/v4/components/empty-state/design-guidelines#back-end-failure

and this is how it looks like at the moment:

https://user-images.githubusercontent.com/26363699/126156527-e2762d73-7ae3-4c68-ad79-bb1623f0a619.mp4


any suggestions or concerns?
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
