### PR TITLE
Fixes #33038 - add bmc_available to host show API

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -806,6 +806,7 @@ autopart"', desc: 'to render the content of host partition table'
     return false if ipmi.nil?
     (ipmi.password.present? && ipmi.username.present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
   end
+  alias_method :bmc_available, :bmc_available?
 
   def ipmi_boot(booting_device)
     unless bmc_available?

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -16,7 +16,7 @@ attributes :ip, :ip6, :environment_id, :environment_name, :last_report, :mac, :r
   :compute_resource_id, :compute_resource_name,
   :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
   :certname, :image_id, :image_name, :created_at, :updated_at,
-  :last_compile, :global_status, :global_status_label, :uptime_seconds, :tags
+  :last_compile, :global_status, :global_status_label, :uptime_seconds, :tags, :bmc_available
 attributes :organization_id, :organization_name
 attributes :location_id, :location_name
 


### PR DESCRIPTION
This is needed for the new host details page to enable  BMC power actions  