### PR TITLE
POC: Deprecate foremanUrl helper

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -184,7 +184,7 @@ function submit_with_all_params() {
       stop_pooling = true;
       $('body').css('cursor', 'auto');
       $('form input[type="submit"]').attr('disabled', false);
-      if (window.location.pathname !== tfm.tools.foremanUrl('/hosts/new')) {
+      if (window.location.pathname !== '/hosts/new') {
         // We got redirected to the show page, need to clear the title override
         tfm.store.dispatch('updateBreadcrumbTitle');
       }
@@ -407,7 +407,7 @@ function update_provisioning_image() {
   $.ajax({
     data: { operatingsystem_id: os_id, architecture_id: arch_id },
     type: 'get',
-    url: tfm.tools.foremanUrl('/compute_resources/' + compute_id + '/images'),
+    url: '/compute_resources/' + compute_id + '/images',
     dataType: 'json',
     success: function(result) {
       $.each(result, function() {

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -395,7 +395,7 @@ function update_fqdn() {
     .text();
   var pathname = window.location.pathname;
   var name = fqdn(host_name, domain_name);
-  if (name.length > 0 && pathname === tfm.tools.foremanUrl('/hosts/new')) {
+  if (name.length > 0 && pathname === '/hosts/new') {
     name = __('Create Host') + ' | ' + name;
     tfm.store.dispatch('updateBreadcrumbTitle', name);
   }

--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -30,7 +30,7 @@ module Menu
     end
 
     def url
-      add_relative_path(@url || @context.routes.url_for(url_hash.merge(:only_path => true).except(:use_route)))
+      @url || @context.routes.url_for(url_hash.merge(:only_path => true).except(:use_route))
     end
 
     def url_hash
@@ -45,15 +45,6 @@ module Menu
     rescue => error
       Foreman::Logging.exception("Error while evaluating permissions", error)
       false
-    end
-
-    private
-
-    def add_relative_path(path)
-      relative_url = @context.config.action_controller.relative_url_root
-      return path unless relative_url.present?
-      return "#{relative_url}#{path}" unless path.start_with?(relative_url.end_with?('/') ? relative_url : "#{relative_url}/")
-      path
     end
   end
 end

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -19,7 +19,6 @@
     <%= csrf_meta_tags %>
 
     <script type="text/javascript">
-      var URL_PREFIX = '<%= controller.relative_url_root %>';
 
       <% if protect_against_forgery? %>
         var AUTH_TOKEN = '<%= form_authenticity_token %>';

--- a/config.ru
+++ b/config.ru
@@ -4,8 +4,6 @@ require 'rack'
 # load Rails environment
 require ::File.expand_path('../config/environment', __FILE__)
 
-# apply a prefix to the application, if one is defined
-# e.g. http://some.server.com/prefix where '/prefix' is defined by env variable
-map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
+map '/' do
   run Foreman::Application
 end

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -72,10 +72,6 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
     end
 
     context 'with :url parameter' do
-      after do
-        ENV['RAILS_RELATIVE_URL_ROOT'] = nil
-      end
-
       test 'without protocol and without port' do
         get :global, params: { url: 'example.com' }, session: set_session_user
         assert_response :internal_server_error
@@ -112,14 +108,6 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
         get :global, params: { url: url }, session: set_session_user
         assert_response :success
         assert_equal 'https://example.com/register', assigns(:global_registration_vars)[:registration_url].to_s
-      end
-
-      test 'with RAILS_RELATIVE_URL_ROOT' do
-        ENV['RAILS_RELATIVE_URL_ROOT'] = '/foreman'
-        url = 'https://example.com'
-        get :global, params: { url: url }, session: set_session_user
-        assert_response :success
-        assert_equal "#{url}/register", assigns(:global_registration_vars)[:registration_url].to_s
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,7 +136,7 @@ end
 class ActionController::TestCase
   extend Robottelo::Reporter::TestAttributes
   include ::BasicRestResponseTest
-  setup :setup_set_script_name, :set_api_user, :turn_off_login,
+  setup :set_api_user, :turn_off_login,
     :disable_webpack, :set_admin
 
   class << self
@@ -149,10 +149,6 @@ class ActionController::TestCase
 
   def turn_off_login
     SETTINGS[:require_ssl] = false
-  end
-
-  def setup_set_script_name
-    @request.env["SCRIPT_NAME"] = @controller.config.relative_url_root
   end
 
   def set_api_user

--- a/webpack/assets/javascripts/dashboard/index.js
+++ b/webpack/assets/javascripts/dashboard/index.js
@@ -7,13 +7,13 @@
 import $ from 'jquery';
 import { doesDocumentHasFocus } from '../react_app/common/document';
 import { notify } from '../foreman_toast_notifications';
-import { activateTooltips, foremanUrl } from '../foreman_tools';
+import { activateTooltips } from '../foreman_tools';
 import { reloadPage } from '../foreman_navigation';
 import { translate as __ } from '../react_app/common/I18n';
 import './index.scss';
 
 $(document).on('ContentLoad', () => {
-  if (foremanUrl('/') === window.location.pathname) {
+  if (window.location.pathname === '/') {
     startGridster();
     autoRefresh();
   }

--- a/webpack/assets/javascripts/hosts/tableCheckboxes.js
+++ b/webpack/assets/javascripts/hosts/tableCheckboxes.js
@@ -21,7 +21,6 @@ import {
   translate as __,
 } from '../react_app/common/I18n';
 import { getURIsearch } from '../react_app/common/urlHelpers';
-import { foremanUrl } from '../foreman_tools';
 import * as sessionStorage from './HostsSessionStorage';
 
 // Array contains list of host ids
@@ -88,7 +87,7 @@ function toggleActions() {
 
 // setups checkbox values upon document load
 $(document).on('ContentLoad', () => {
-  if (window.location.pathname !== foremanUrl('/hosts')) return;
+  if (window.location.pathname !== '/hosts') return;
 
   const hostQuery = sessionStorage.getHostQuery();
   const uriSearch = getURIsearch();

--- a/webpack/assets/javascripts/react_app/Root/apollo.js
+++ b/webpack/assets/javascripts/react_app/Root/apollo.js
@@ -1,9 +1,7 @@
 import { ApolloClient, ApolloLink, InMemoryCache, from } from '@apollo/client';
 import { BatchHttpLink } from '@apollo/client/link/batch-http';
 
-import { foremanUrl } from '../common/helpers';
-
-const batchLink = new BatchHttpLink({ uri: foremanUrl('/api/graphql') });
+const batchLink = new BatchHttpLink({ uri: '/api/graphql' });
 
 const authLink = new ApolloLink((operation, forward) => {
   operation.setContext({

--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -161,8 +161,8 @@ export const stringIsPositiveNumber = value => {
  * Get manual url based on version
  * @param {String} section - section id for foreman documetation
  */
-export const getManualURL = section => foremanUrl(`/links/manual/${section}`);
-export const getWikiURL = section => foremanUrl(`/links/wiki/${section}`);
+export const getManualURL = section => `/links/manual/${section}`;
+export const getWikiURL = section => `/links/wiki/${section}`;
 
 /**
  * Transform the Date object to date string accepted in the server

--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -1,5 +1,6 @@
 import { snakeCase, camelCase, debounce } from 'lodash';
 import URI from 'urijs';
+import { deprecate } from './DeprecationService';
 import { translate as __ } from './I18n';
 
 /**
@@ -189,7 +190,10 @@ export const formatDateTime = date => {
 };
 
 // generates an absolute, needed in case of running Foreman from a subpath
-export const foremanUrl = path => `${window.URL_PREFIX}${path}`;
+export const foremanUrl = path => {
+  deprecate('foremanUrl', 'plain URL', 3.1);
+  return path;
+};
 
 export default {
   isoCompatibleDate,

--- a/webpack/assets/javascripts/react_app/components/Architectures/Welcome.js
+++ b/webpack/assets/javascripts/react_app/components/Architectures/Welcome.js
@@ -2,12 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from '../../common/I18n';
 import EmptyState from '../common/EmptyState';
-import { foremanUrl } from '../../common/helpers';
 
 export const WelcomeArchitecture = ({ canCreate }) => {
   const action = canCreate && {
     title: __('Create Architecture'),
-    url: foremanUrl('/architectures/new'),
+    url: '/architectures/new',
   };
   const content = __(`Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>.
   Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems.`);

--- a/webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js
+++ b/webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { translate as __ } from '../../common/I18n';
 import EmptyState from '../common/EmptyState';
-import { foremanUrl, getManualURL } from '../../common/helpers';
+import { getManualURL } from '../../common/helpers';
 
 export const WelcomeAuthSource = ({ canCreate }) => {
   const content = __(
@@ -29,7 +29,7 @@ export const WelcomeAuthSource = ({ canCreate }) => {
   );
   const action = canCreate && {
     title: __('Create LDAP Authentication Source'),
-    url: foremanUrl('auth_source_ldaps/new'),
+    url: 'auth_source_ldaps/new',
   };
 
   return (

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -7,7 +7,6 @@ import {
   Dropdown,
   KebabToggle,
 } from '@patternfly/react-core';
-import { foremanUrl } from '../../../../foreman_navigation';
 import { translate as __ } from '../../../common/I18n';
 
 const ActionsBar = ({ hostName }) => {
@@ -35,7 +34,7 @@ const ActionsBar = ({ hostName }) => {
     <>
       <Button
         onClick={() => {
-          window.location = foremanUrl(`/hosts/${hostName}/edit`);
+          window.location = `/hosts/${hostName}/edit`;
         }}
         variant="secondary"
       >

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
@@ -18,7 +18,6 @@ import {
   AccordionToggle,
 } from '@patternfly/react-core';
 
-import { foremanUrl } from '../../../../foreman_tools';
 import { translate as __ } from '../../../common/I18n';
 import { useAPI } from '../../../common/hooks/API/APIHooks';
 
@@ -32,7 +31,7 @@ const AuditCard = ({ hostName }) => {
     }
   };
 
-  const url = hostName && foremanUrl(`/api/audits?search=host+%3D+${hostName}`);
+  const url = hostName && `/api/audits?search=host+%3D+${hostName}`;
   const {
     response: { results },
   } = useAPI('get', url);
@@ -40,7 +39,7 @@ const AuditCard = ({ hostName }) => {
     <Card isHoverable>
       <CardTitle>
         {__('Recent Audits')}{' '}
-        <a href={foremanUrl(`/audits?search=host+%3D+${hostName}`)}>
+        <a href={`/audits?search=host+%3D+${hostName}`}>
           <ArrowIcon />
         </a>
       </CardTitle>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -18,7 +18,6 @@ import {
 import Skeleton from 'react-loading-skeleton';
 import RelativeDateTime from '../../components/common/dates/RelativeDateTime';
 
-import { foremanUrl } from '../../../foreman_tools';
 import { get } from '../../redux/API';
 import {
   selectAPIResponse,
@@ -62,7 +61,7 @@ const HostDetails = ({ match, location: { hash } }) => {
     dispatch(
       get({
         key: 'HOST_DETAILS',
-        url: foremanUrl(`/api/hosts/${match.params.id}`),
+        url: `/api/hosts/${match.params.id}`,
       })
     );
   }, [match.params.id, dispatch]);

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -4,11 +4,7 @@
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { translate as __ } from '../../common/I18n';
-import {
-  removeLastSlashFromPath,
-  noop,
-  foremanUrl,
-} from '../../common/helpers';
+import { removeLastSlashFromPath, noop } from '../../common/helpers';
 
 export const createInitialTaxonomy = (currentTaxonomy, availableTaxonomies) => {
   const taxonomyId = availableTaxonomies.find(
@@ -67,7 +63,7 @@ const createOrgItem = orgs => {
   const anyOrg = {
     name: __('Any Organization'),
     onClick: () => {
-      window.location.assign(foremanUrl('/organizations/clear'));
+      window.location.assign('/organizations/clear');
     },
   };
   const childrenArray = [anyOrg];
@@ -98,7 +94,7 @@ const createLocationItem = locations => {
   const anyLoc = {
     name: __('Any Location'),
     onClick: () => {
-      window.location.assign(foremanUrl('/locations/clear'));
+      window.location.assign('/locations/clear');
     },
   };
   const childrenArray = [anyLoc];

--- a/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIconActions.js
@@ -1,12 +1,11 @@
 import { API } from '../../../../redux/API';
-import { foremanUrl } from '../../../../../foreman_tools';
 
 import { addToast } from '../../../../redux/actions/toasts';
 
 export const stopImpersonating = url => async dispatch => {
   try {
     const { data } = await API.delete(url);
-    window.location.href = foremanUrl('/users');
+    window.location.href = '/users';
     return dispatch(
       addToast({
         type: data.type,

--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/TaxonomyDropdown.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/TaxonomyDropdown.js
@@ -7,14 +7,13 @@ import {
   Button,
 } from '@patternfly/react-core';
 import { CheckIcon } from '@patternfly/react-icons';
-import { foremanUrl } from '../../../../common/helpers';
 import { translate as __ } from '../../../../common/I18n';
 import './TaxonomyDropdown.scss';
 
 const TaxonomyDropdown = ({ taxonomyType, currentTaxonomy, taxonomies }) => {
   const id = `${taxonomyType}-dropdown`;
-  const anyTaxonomyURL = foremanUrl(`/${taxonomyType}s/clear`);
-  const manageTaxonomyURL = foremanUrl(`/${taxonomyType}s`);
+  const anyTaxonomyURL = `/${taxonomyType}s/clear`;
+  const manageTaxonomyURL = `/${taxonomyType}s`;
   const anyTaxonomyText =
     taxonomyType === 'organization'
       ? __('Any Organization')

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js
@@ -15,7 +15,6 @@ import NewPersonalAccessToken from './NewPersonalAccessToken';
 import PersonalAccessTokenForm from './PersonalAccessTokenForm';
 import PersonalAccessTokensList from './PersonalAccessTokensList';
 import { translate as __ } from '../../../common/I18n';
-import { foremanUrl } from '../../../common/helpers';
 
 const PersonalAccessTokens = ({ url, canCreate }) => {
   const dispatch = useDispatch();
@@ -69,9 +68,7 @@ const PersonalAccessTokens = ({ url, canCreate }) => {
                   'Personal Access Tokens allow you to authenticate API requests without using your password, e.g. '
                 )}
                 <p>
-                  <code>{`curl -u admin:token ${foremanUrl(
-                    '/api/v2/hosts'
-                  )}`}</code>
+                  <code>curl -u admin:token &apos;/api/v2/hosts&apos;</code>
                 </p>
                 {canCreate && <PersonalAccessTokenForm url={url} />}
               </td>

--- a/webpack/assets/javascripts/react_app/redux/API/API.js
+++ b/webpack/assets/javascripts/react_app/redux/API/API.js
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import './APITestSetup';
-import { foremanUrl } from '../../../foreman_tools';
 
 const getcsrfToken = () => {
   const token = document.querySelector('meta[name="csrf-token"]');
@@ -13,28 +12,28 @@ axios.defaults.headers.common['X-CSRF-Token'] = getcsrfToken();
 
 export default {
   get(url, headers = {}, params = {}) {
-    return axios.get(foremanUrl(url), {
+    return axios.get(url, {
       headers,
       params,
     });
   },
   put(url, data = {}, headers = {}) {
-    return axios.put(foremanUrl(url), data, {
+    return axios.put(url, data, {
       headers,
     });
   },
   post(url, data = {}, headers = {}) {
-    return axios.post(foremanUrl(url), data, {
+    return axios.post(url, data, {
       headers,
     });
   },
   delete(url, headers = {}) {
-    return axios.delete(foremanUrl(url), {
+    return axios.delete(url, {
       headers,
     });
   },
   patch(url, data = {}, headers = {}) {
-    return axios.patch(foremanUrl(url), data, {
+    return axios.patch(url, data, {
       headers,
     });
   },

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageActions.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageActions.js
@@ -1,4 +1,3 @@
-import { foremanUrl } from '../../../../foreman_tools';
 import { get, post } from '../../../redux/API';
 
 import {
@@ -10,19 +9,19 @@ import {
 export const dataAction = params =>
   get({
     key: REGISTRATION_COMMANDS_DATA,
-    url: foremanUrl('/hosts/register/data'),
+    url: '/hosts/register/data',
     params,
   });
 
 export const operatingSystemTemplateAction = operatingSystemId =>
   get({
     key: REGISTRATION_COMMANDS_OS_TEMPLATE,
-    url: foremanUrl(`/hosts/register/os/${operatingSystemId}`),
+    url: `/hosts/register/os/${operatingSystemId}`,
   });
 
 export const commandAction = params =>
   post({
     key: REGISTRATION_COMMANDS,
-    url: foremanUrl('/hosts/register'),
+    url: '/hosts/register',
     params,
   });

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageHelpers.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageHelpers.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { FormSelectOption } from '@patternfly/react-core';
 
-import { foremanUrl } from '../../../../foreman_tools';
 import { sprintf, translate as __ } from '../../../common/I18n';
 
 // Form helpers
@@ -61,7 +60,7 @@ const osTemplateHelperText = (operatingSystemId, template) => {
     return (
       <span>
         {__('Initial configuration template')}:{' '}
-        <a href={foremanUrl(template.path)} target="_blank" rel="noreferrer">
+        <a href={template.path} target="_blank" rel="noreferrer">
           {template.name}
         </a>
       </span>
@@ -70,7 +69,7 @@ const osTemplateHelperText = (operatingSystemId, template) => {
 
   return (
     <span className="has-error">
-      <a href={foremanUrl(template.os_path)} target="_blank" rel="noreferrer">
+      <a href={template.os_path} target="_blank" rel="noreferrer">
         {__('Operating system')}
       </a>{' '}
       {__('does not have assigned host_init_config template')}

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Actions.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Actions.js
@@ -11,7 +11,6 @@ import {
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { sprintf, translate as __ } from '../../../../common/I18n';
-import { foremanUrl } from '../../../../../foreman_tools';
 
 const Actions = ({ isLoading, isGenerating, handleSubmit, invalidFields }) => (
   <>
@@ -27,7 +26,7 @@ const Actions = ({ isLoading, isGenerating, handleSubmit, invalidFields }) => (
       </Button>
 
       {/* Can't use <RedirectCancelButton> due to infinitive loop */}
-      <Link to={foremanUrl('/hosts')}>
+      <Link to="/hosts">
         <Button variant="link">{__('Cancel')}</Button>
       </Link>
     </ActionGroup>

--- a/webpack/stories/docs/connected-react-router.stories.mdx
+++ b/webpack/stories/docs/connected-react-router.stories.mdx
@@ -17,9 +17,8 @@ This pushed a new url (including querystring) to react router and creates a tran
 
 ```js
 import { pushUrl } from '../foreman_navigation';
-import { foremanUrl } from '../foreman_tools';
 
-<Button onClick={() => pushUrl(foremanUrl('/hosts'))}>
+<Button onClick={() => pushUrl('/hosts')}>
    Click Me!
 </Button>
 ```


### PR DESCRIPTION
This is a POC for the discussion in https://community.theforeman.org/t/rfc-stop-attempting-to-allow-running-foreman-under-a-sub-folder-in-3-0/24526
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
