### PR TITLE
Fixes #33066 - add asMutable to useAPI hook

### DIFF
--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import uuid from 'uuid/v1';
 import {
   selectAPIResponse,
@@ -18,6 +18,7 @@ import { APIActions } from '../../../redux/API';
 export const useAPI = (method, url, options) => {
   const dispatch = useDispatch();
   const keyRef = useRef(options?.key);
+  const asMutable = options?.asMutable;
 
   useEffect(() => {
     if (!keyRef.current) keyRef.current = uuid();
@@ -35,8 +36,9 @@ export const useAPI = (method, url, options) => {
     }
   }, [dispatch, url, method, options]);
 
-  const response = useSelector(state =>
-    selectAPIResponse(state, keyRef.current)
+  const response = useSelector(
+    state => selectAPIResponse(state, keyRef.current, asMutable),
+    asMutable ? shallowEqual : undefined
   );
   const status = useSelector(state => selectAPIStatus(state, keyRef.current));
 

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.test.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.test.js
@@ -1,5 +1,5 @@
-import { act } from '@testing-library/react-hooks';
 import { useAPI } from './APIHooks';
+import Immutable from 'seamless-immutable';
 import APIHelper from '../../../redux/API/API';
 import { renderHookWithRedux } from '../testHelper';
 import {
@@ -17,12 +17,12 @@ it('should use default url', async () => {
     useAPI('get', '/lotr')
   );
   await waitForNextUpdate();
-
+  expect(Immutable.isImmutable(result.current.response)).toBe(true);
   expect(result.current.response.results).toEqual(resultFromGOT.data.results);
   expect(result.current.key).toBeDefined();
 });
 
-it('shuold use the given key', async () => {
+it('should use the given key', async () => {
   const options = { key: API_TEST_KEY };
 
   APIHelper.get.mockResolvedValue(resultsFromLOTR);
@@ -33,4 +33,16 @@ it('shuold use the given key', async () => {
 
   await waitForNextUpdate();
   expect(result.current.key).toEqual(API_TEST_KEY);
+});
+
+it('should return mutable data', async () => {
+  const options = { key: API_TEST_KEY, asMutable: true };
+
+  APIHelper.get.mockResolvedValue(resultsFromLOTR);
+  const { result, waitForNextUpdate } = renderHookWithRedux(() =>
+    useAPI('get', '/got', options)
+  );
+
+  await waitForNextUpdate();
+  expect(Immutable.isImmutable(result.current.response)).toBe(false);
 });

--- a/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APISelectors.js
@@ -1,3 +1,4 @@
+import Immutable from 'seamless-immutable';
 import { STATUS } from '../../constants';
 
 export const selectAPI = state => state.API;
@@ -10,8 +11,11 @@ export const selectAPIStatus = (state, key) =>
 export const selectAPIPayload = (state, key) =>
   selectAPIByKey(state, key).payload || {};
 
-export const selectAPIResponse = (state, key) =>
-  selectAPIByKey(state, key).response || {};
+export const selectAPIResponse = (state, key, asMutable = false) => {
+  const { response } = selectAPIByKey(state, key);
+  if (!response) return {};
+  return asMutable ? Immutable.asMutable(response, { deep: true }) : response;
+};
 
 export const selectAPIError = (state, key) =>
   selectAPIStatus(state, key) === STATUS.ERROR


### PR DESCRIPTION
Some components require mutable data, and for that, we use `asMutable` from `seamless-immutable`
we can make it easier and return mutable data from useAPI when needed, just add a `asMutable` to useAPI options:

```js
const OPTIONS = { asMutable: true, //<other options> }
const { response } = useAPI(method, url, OPTIONS) // response is now mutable