### PR TITLE
Fixes #33090 - load AIX OS attributes

### DIFF
--- a/lib/foreman/renderer/scope/variables/base.rb
+++ b/lib/foreman/renderer/scope/variables/base.rb
@@ -36,7 +36,7 @@ module Foreman
             @template_url = params['url']
           end
 
-          %w(coreos fcos rhcos aif memdisk ZTP).each do |name|
+          %w(coreos fcos rhcos aif memdisk ZTP nim).each do |name|
             define_method("#{name}_attributes") do
               @mediapath = mediumpath(@medium_provider) if medium
             end


### PR DESCRIPTION
AIX provisioning does not work due to missing method. There are no attributes availiable for AIX.