### PR TITLE
Fixes #33098 - update fog-libvirt to 0.9.0

### DIFF
--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '>= 0.8.0'
+  gem 'fog-libvirt', '>= 0.9.0'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end


### PR DESCRIPTION
The following changes were released upstream:

* Shell escape vulnerability
* Support for S390x
* Modernized Ruby 2.X syntax
* Updated compatibility with Ruby 3.X
* Changes in the CI infrastructure (Github Actions)
* Fix for MacOS (Darwin) UNIX socket path
* Fix for rescue in listing network

Packaging PR:

https://github.com/theforeman/foreman-packaging/pull/6927