### PR TITLE
Fixes #33033 - shell_escape template macro

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -51,21 +51,21 @@ if [ x$ID = xrhel ] || [ x$ID = xfedora ] || [ x$ID = xol ] || test "${ID_LIKE#*
   cat << EOF > /etc/yum.repos.d/foreman_registration.repo
 [foreman_register]
 name=foreman_register
-baseurl=<%= @repo %>
+baseurl=<%= shell_escape @repo %>
 enabled=1
 gpgcheck=<%= @repo_gpg_key_url.present? ? 1 : 0 %>
-gpgkey=<%= @repo_gpg_key_url %>
+gpgkey=<%= shell_escape @repo_gpg_key_url %>
 EOF
 
   echo "Building yum metadata cache, this may take a few minutes"
   yum makecache
 elif [ x$ID = xdebian ] || [ x$ID = xubuntu ]; then
   cat << EOF > /etc/apt/sources.list.d/foreman_registration.list
-<%= @repo %>
+<%= shell_escape @repo %>
 EOF
 <% if @repo_gpg_key_url.present? -%>
   apt-get -y install ca-certificates gpg
-  curl --silent --show-error <%= @repo_gpg_key_url %> | apt-key add -
+  curl --silent --show-error <%= shell_escape @repo_gpg_key_url %> | apt-key add -
 <% end -%>
   apt-get update
 
@@ -85,11 +85,11 @@ register_host() {
 <%= "       --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
 <%= "       --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
 <%= "       --data 'host[operatingsystem_id]=#{@operatingsystem.id}' \\\n" if @operatingsystem -%>
-<%= "       --data 'host[interfaces_attributes][0][identifier]=#{@remote_execution_interface}' \\\n" if @remote_execution_interface.present? -%>
+<%= "       --data host[interfaces_attributes][0][identifier]=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
 <%= "       --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
 <%= "       --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
-<%= "       --data 'remote_execution_interface=#{@remote_execution_interface}' \\\n" if @remote_execution_interface.present? -%>
-<%= "       --data 'packages=#{@packages}' \\\n" if @packages.present? -%>
+<%= "       --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
+<%= "       --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
 <%= "       --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
 
 }
@@ -111,8 +111,8 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ]; then
 <%= "          --data 'host[lifecycle_environment_id]=#{@lifecycle_environment_id}' \\\n" if @lifecycle_environment_id.present? -%>
 <%= "          --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
 <%= "          --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
-<%= "          --data 'remote_execution_interface=#{@remote_execution_interface}' \\\n" if @remote_execution_interface.present? -%>
-<%= "          --data 'packages=#{@packages}' \\\n" if @packages.present? -%>
+<%= "          --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
+<%= "          --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
 <%= "          --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
 
 }
@@ -143,7 +143,10 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ]; then
 
     rm -f $CONSUMER_RPM
 
-    subscription-manager register <%= '--force' if @force %> --org='<%= @organization.label %>' --activationkey='<%= activation_keys %>' || <%= @ignore_subman_errors ? 'true' : 'exit 1' %>
+    subscription-manager register <%= '--force' if @force %> \
+        --org='<%= @organization.label %>' \
+        --activationkey=<%= shell_escape(activation_keys) %> || <%= @ignore_subman_errors ? 'true' : 'exit 1' %>
+
     register_katello_host | bash
 else
     register_host | bash

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -50,7 +50,8 @@ module Foreman
         :to_json,
         :to_yaml,
         :foreman_server_ca_cert,
-        :format_time
+        :format_time,
+        :shell_escape
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/lib/foreman/renderer/scope/macros/helpers.rb
+++ b/lib/foreman/renderer/scope/macros/helpers.rb
@@ -90,6 +90,15 @@ module Foreman
 
             time_to_format.in_time_zone(zone).strftime(format)
           end
+
+          apipie :method, "Escape string to safely use it with a shell" do
+            required :string, String, desc: 'String to escape'
+            returns String
+            example "shell_escape('escaped;string') #=> 'escaped\\;string'"
+          end
+          def shell_escape(string)
+            Shellwords.shellescape(string)
+          end
         end
       end
     end

--- a/test/unit/foreman/renderer/scope/macros/helpers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/helpers_test.rb
@@ -92,4 +92,11 @@ class HelpersTest < ActiveSupport::TestCase
 
     it { assert_equal utc_time.strftime(format_pattern), scope.format_time(unix_timestamp, format: format_pattern) }
   end
+
+  describe '#shell_escape' do
+    string = "how y'all doin?"
+    escaped = "how\\ y\\'all\\ doin\\?"
+
+    it { assert_equal escaped, scope.shell_escape(string) }
+  end
 end


### PR DESCRIPTION
New template macro `shell_escape` using
Ruby's `Shellwords.shellescape` for safe shell strings.

Use `shell_escape` for user input variables
in registration templates (`global` & `host_init`)

**Issue**
Content host registration using command generated from global registration form fails if activation key name contains ' (single quote) in it.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
