### PR TITLE
Registration command API & params with false values

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration_commands.rb
+++ b/app/controllers/concerns/foreman/controller/registration_commands.rb
@@ -9,12 +9,10 @@ module Foreman::Controller::RegistrationCommands
   end
 
   def registration_args
-    args = registration_params.except(*ignored_query_args)
-    args['setup_insights'] = registration_params['setup_insights']
-    args['setup_remote_execution'] = registration_params['setup_remote_execution']
-
-    args.delete_if { |_, v| v.blank? }
-        .permit!
+    registration_params.except(*ignored_query_args)
+                       .transform_values! { |v| v == false ? v.to_s : v }
+                       .delete_if { |_, v| v.blank? }
+                       .permit!
   end
 
   def insecure

--- a/test/controllers/api/v2/registration_commands_controller_test.rb
+++ b/test/controllers/api/v2/registration_commands_controller_test.rb
@@ -17,8 +17,8 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
         location_id: taxonomies(:location1).id,
         hostgroup_id: hostgroups(:common).id,
         operatingsystem_id: operatingsystems(:redhat).id,
-        setup_insights: 'false',
-        setup_remote_execution: 'false',
+        setup_insights: false,
+        setup_remote_execution: false,
         packages: 'pkg1',
         update_packages: true,
       }


### PR DESCRIPTION
Registration API for generating registration command
incorrectly ignores parameters with `false` boolean value.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
