### PR TITLE
Fixes #33151 - translate host details tabs title

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
@@ -1,13 +1,15 @@
 import React from 'react';
+import { translate as __ } from '../../../common/I18n';
 import { addGlobalFill } from '../../common/Fill/GlobalFill';
-import { DEFAULT_TAB } from '../consts';
+import { DEFAULT_TAB, TABS_SLOT_ID } from '../consts';
 import OverviewTab from './Overview';
 
 export const registerCoreTabs = () => {
   addGlobalFill(
-    'host-details-page-tabs',
+    TABS_SLOT_ID,
     DEFAULT_TAB,
     <OverviewTab key="host-details-overview-tab" />,
-    1000
+    1000,
+    { title: __('Overview') }
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/consts.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/consts.js
@@ -1,3 +1,4 @@
 export const DEFAULT_TAB = 'Overview';
 export const HOST_DETAILS_KEY = 'HOST_DETAILS';
 export const HOST_DETAILS_API_OPTIONS = { key: HOST_DETAILS_KEY };
+export const TABS_SLOT_ID = 'host-details-page-tabs'

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -22,12 +22,15 @@ import {
 
 import Skeleton from 'react-loading-skeleton';
 import RelativeDateTime from '../../components/common/dates/RelativeDateTime';
+import {
+  selectFillsIDs,
+  selectSlotMetadata,
+} from '../common/Slot/SlotSelectors';
 
-import { selectFillsIDs } from '../common/Slot/SlotSelectors';
 import { selectIsCollapsed } from '../Layout/LayoutSelectors';
 import ActionsBar from './ActionsBar';
 import { registerCoreTabs } from './Tabs';
-import { HOST_DETAILS_API_OPTIONS } from './consts';
+import { HOST_DETAILS_API_OPTIONS, TABS_SLOT_ID } from './consts';
 
 import { translate as __, sprintf } from '../../common/I18n';
 import HostGlobalStatus from './Status/GlobalStatus';
@@ -53,8 +56,12 @@ const HostDetails = ({
 
   const isNavCollapsed = useSelector(selectIsCollapsed);
   const tabs = useSelector(
-    state => selectFillsIDs(state, 'host-details-page-tabs'),
+    state => selectFillsIDs(state, TABS_SLOT_ID),
     shallowEqual
+  );
+
+  const slotMetadata = useSelector(state =>
+    selectSlotMetadata(state, TABS_SLOT_ID)
   );
 
   // This is a workaround due to the tabs overflow mechanism in PF4
@@ -166,7 +173,11 @@ const HostDetails = ({
               activeKey={activeTab}
             >
               {tabs.map(tab => (
-                <Tab key={tab} eventKey={tab} title={tab} />
+                <Tab
+                  key={tab}
+                  eventKey={tab}
+                  title={slotMetadata?.[tab]?.title || tab}
+                />
               ))}
             </Tabs>
           </TabRouter>

--- a/webpack/assets/javascripts/react_app/components/common/Fill/FillActions.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/FillActions.js
@@ -6,12 +6,13 @@ export const registerFillComponent = (
   overrideProps,
   fillId,
   component,
-  weight
+  weight,
+  metadata
 ) => dispatch => {
   SlotsRegistry.add(slotId, fillId, component, weight, overrideProps);
   dispatch({
     type: REGISTER_FILL,
-    payload: { slotId, fillId, weight },
+    payload: { slotId, fillId, weight, metadata },
   });
 };
 

--- a/webpack/assets/javascripts/react_app/components/common/Fill/FillReducer.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/FillReducer.js
@@ -9,7 +9,10 @@ export default (state = initialState, action) => {
 
   switch (action.type) {
     case REGISTER_FILL:
-      return state.setIn([payload.slotId, payload.fillId], payload.weight);
+      return state.setIn([payload.slotId, payload.fillId], {
+        weight: payload.weight,
+        metadata: payload.metadata,
+      });
 
     case REMOVE_FILLED_COMPONENT:
       return state.update(payload.slotId, fills =>

--- a/webpack/assets/javascripts/react_app/components/common/Fill/GlobalFill.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/GlobalFill.js
@@ -1,8 +1,15 @@
 import { registerFillComponent } from '../Fill/FillActions';
 import store from '../../../redux';
 
-export const addGlobalFill = (slotId, fillId, component, weight) => {
+export const addGlobalFill = (slotId, fillId, component, weight, metadata) => {
   store.dispatch(
-    registerFillComponent(slotId, undefined, fillId, component, weight)
+    registerFillComponent(
+      slotId,
+      undefined,
+      fillId,
+      component,
+      weight,
+      metadata
+    )
   );
 };

--- a/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillActions.test.js.snap
@@ -6,6 +6,7 @@ Array [
     Object {
       "payload": Object {
         "fillId": "fill-id",
+        "metadata": undefined,
         "slotId": "slot-id",
         "weight": 100,
       },

--- a/webpack/assets/javascripts/react_app/components/common/Slot/SlotSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/SlotSelectors.js
@@ -16,7 +16,9 @@ export const selectFillsIDs = (state, id) => {
   const registerdFills = state.extendable[id];
   if (registerdFills) {
     const fillIDs = Object.keys(registerdFills);
-    return fillIDs.sort((a, b) => registerdFills[b] - registerdFills[a]);
+    return fillIDs.sort(
+      (a, b) => registerdFills[b].weight - registerdFills[a].weight
+    );
   }
   return null;
 };
@@ -35,4 +37,17 @@ export const selectFillsComponents = (state, props) => {
     return [selectMaxComponent(id)];
   }
   return [];
+};
+
+export const selectSlotMetadata = (state, id) => {
+  const registerdFills = state.extendable[id] || {};
+  const slotMetadata = {};
+  // eslint bug - https://github.com/eslint/eslint/issues/12117
+  /* eslint-disable-next-line no-unused-vars */
+  for (const fill of Object.keys(registerdFills)) {
+    if (registerdFills[fill].metadata)
+      slotMetadata[fill] = registerdFills[fill].metadata;
+  }
+
+  return slotMetadata;
 };

--- a/webpack/assets/javascripts/react_app/components/common/Slot/__snapshots__/Slot.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Slot/__snapshots__/Slot.test.js.snap
@@ -199,6 +199,7 @@ Array [
     Object {
       "payload": Object {
         "fillId": "some-key-1",
+        "metadata": undefined,
         "slotId": "slot-1",
         "weight": 100,
       },
@@ -209,6 +210,7 @@ Array [
     Object {
       "payload": Object {
         "fillId": "some-key-2",
+        "metadata": undefined,
         "slotId": "slot-1",
         "weight": 200,
       },
@@ -222,8 +224,14 @@ exports[`Slot-Fill render multiple fills: Integration test store 1`] = `
 Object {
   "extendable": Object {
     "slot-1": Object {
-      "some-key-1": 100,
-      "some-key-2": 200,
+      "some-key-1": Object {
+        "metadata": undefined,
+        "weight": 100,
+      },
+      "some-key-2": Object {
+        "metadata": undefined,
+        "weight": 200,
+      },
     },
   },
 }

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/RoutingService.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/RoutingService.test.js.snap
@@ -3,8 +3,14 @@
 exports[`PluginRoutes rendering Adding global routes 1`] = `
 Object {
   "routes": Object {
-    "some-id-0": undefined,
-    "some-id-1": undefined,
+    "some-id-0": Object {
+      "metadata": undefined,
+      "weight": undefined,
+    },
+    "some-id-1": Object {
+      "metadata": undefined,
+      "weight": undefined,
+    },
   },
 }
 `;


### PR DESCRIPTION
Host details tabs titles are loaded dynamically and aren't translated.
varialbles cannot be translated:
```js
<Tab title={__(variable)} /> // wrong
``` 

This PR  adds a runtime strings mapper for translation across core and plugins.

### How to use?

```js
// a plugin
TranslateMapper.register({
 var1: __('Translated Tab Title'),
 var2: __('another string')
})
registerFill(slotId, var1, <TabContent />)

// core
<Tab title={TranslateMapper.getTranslatedString(var1)} />
```
