### PR TITLE
Fixes #33155 - Drop Spice XPI support

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -44,26 +44,11 @@ module ComputeResourcesVmsHelper
     end
   end
 
-  def supports_spice_xpi?
-    user_agent = request.env['HTTP_USER_AGENT']
-    user_agent =~ /linux/i && user_agent =~ /firefox/i
-  end
-
   def spice_data_attributes(console)
-    options = {
+    {
       :port     => console[:port],
       :password => console[:password],
     }
-    if supports_spice_xpi?
-      options.merge!(
-        :address     => console[:address],
-        :secure_port => console[:secure_port],
-        :subject     => console[:subject],
-        :title       => _("%s - Press Shift-F12 to release the cursor.") % console[:name]
-      )
-    end
-    options[:ca_cert] = URI.escape(console[:ca_cert]) if console[:ca_cert].present?
-    options
   end
 
   def libvirt_networks(compute_resource)

--- a/app/models/compute_resources/foreman/model/ovirt.rb
+++ b/app/models/compute_resources/foreman/model/ovirt.rb
@@ -386,17 +386,12 @@ module Foreman::Model
     def console(uuid)
       vm = find_vm_by_uuid(uuid)
       raise "VM is not running!" if vm.status == "down"
-      if vm.display[:type] =~ /spice/i
-        xpi_opts = {:name => vm.name, :address => vm.display[:address], :secure_port => vm.display[:secure_port], :ca_cert => public_key, :subject => vm.display[:subject] }
-        opts = if vm.display[:secure_port]
-                 { :host_port => vm.display[:secure_port], :ssl_target => true }
-               else
-                 { :host_port => vm.display[:port] }
-               end
-        WsProxy.start(opts.merge(:host => vm.display[:address], :password => vm.ticket)).merge(xpi_opts).merge(:type => 'spice')
-      else
-        WsProxy.start(:host => vm.display[:address], :host_port => vm.display[:port], :password => vm.ticket).merge(:name => vm.name, :type => 'vnc')
-      end
+      opts = if vm.display[:secure_port]
+               { :host_port => vm.display[:secure_port], :ssl_target => true }
+             else
+               { :host_port => vm.display[:port] }
+             end
+      WsProxy.start(opts.merge(:host => vm.display[:address], :password => vm.ticket)).merge(:name => vm.name, :type => vm.display[:type])
     end
 
     def update_required?(old_attrs, new_attrs)

--- a/app/views/hosts/console/spice.html.erb
+++ b/app/views/hosts/console/spice.html.erb
@@ -1,9 +1,6 @@
 <% title "#{@console[:name]}" %>
 <%= title_actions(
         button_group(link_to(_("Ctrl-Alt-Del"), "#", :id => "sendCtrlAltDelButton", :onclick => 'tfm.spice.sendCtrlAltDel()', :class => "btn btn-default"),
-                     if supports_spice_xpi?
-                       link_to(_("New window"), "#", :id => "disconnect", :class => "btn btn-default", :onclick => 'tfm.spice.connectXPI()', :title => _("Open Spice in a new window"))
-                     end,
                      if @host
                        link_to_if_authorized(_("Back to host"), hash_for_host_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default')
                      end

--- a/webpack/assets/javascripts/spice.js
+++ b/webpack/assets/javascripts/spice.js
@@ -65,27 +65,6 @@ function spiceSuccess(m) {
   $('#spice-status').addClass('label-success');
 }
 
-export function connectXPI() {
-  if ($('#spice-xpi').length === 0) {
-    $('#spice-area').append(
-      '<embed type="application/x-spice" height=0 width=0 id="spice-xpi">'
-    );
-  }
-  const attrs = $('#spice-area');
-  // we close down the other WebSocket connection when opening the XPI
-  disconnect();
-  const pluginobj = document.embeds[0];
-  pluginobj.hostIP = attrs.data('address');
-  pluginobj.SecurePort = attrs.data('secure-port');
-  pluginobj.Password = attrs.data('password');
-  pluginobj.TrustStore = decodeURIComponent(attrs.data('ca-cert'));
-  pluginobj.SSLChannels = String('all');
-  pluginobj.fullScreen = false;
-  pluginobj.Title = attrs.data('title');
-  pluginobj.HostSubject = attrs.data('subject');
-  pluginobj.connect();
-}
-
 export function sendCtrlAltDel() {
   window.sc = sc;
   _sendCtrlAltDel();


### PR DESCRIPTION
This plugin is no longer maintained and relied on Xulrunner support in Firefox. That means that with Firefox 60 or newer it's broken.