### PR TITLE
Fixes #33161 - Add useCallback to RegistrationCommandsPage

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
 import {
@@ -94,17 +94,22 @@ const RegistrationCommandsPage = () => {
   // Plugins
   const [pluginValues, setPluginValues] = useState({});
 
-  const handlePluginValue = data => {
-    setPluginValues({ ...pluginValues, ...data });
-  };
+  const handlePluginValue = useCallback(data => {
+    setPluginValues(prevValues => ({ ...prevValues, ...data }));
+  }, []);
 
-  const handleInvalidField = (field, isValid) => {
+  const handleInvalidField = useCallback((field, isValid) => {
     if (isValid) {
-      setInvalidFields(invalidFields.filter(f => f !== field));
-    } else if (!invalidFields.find(f => f === field)) {
-      setInvalidFields([...invalidFields, field].sort());
+      setInvalidFields(prevFields => prevFields.filter(f => f !== field));
+    } else {
+      setInvalidFields(prevFields => {
+        if (!prevFields.find(f => f === field)) {
+          return [...prevFields, field].sort();
+        }
+        return prevFields;
+      });
     }
-  };
+  }, []);
 
   const handleSubmit = e => {
     e.preventDefault();


### PR DESCRIPTION
We're trying to start following the Rules of Hooks properly in Katello, using the react-hooks eslint rules as Foreman already does.

See https://github.com/Katello/katello/pull/9251

On the RegistrationCommands page, this was causing some infinite loops:
```
react-dom.development.js:23093 Uncaught Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.
    at checkForNestedUpdates (react-dom.development.js:23093)
    at scheduleUpdateOnFiber (react-dom.development.js:21164)
    at dispatchAction (react-dom.development.js:15660)
    at handlePluginValue (index.js:98)
    at index.js:20
    at commitHookEffectListMount (react-dom.development.js:19731)
    at commitPassiveHookEffects (react-dom.development.js:19769)
    at HTMLUnknownElement.callCallback (react-dom.development.js:188)
    at HTMLUnknownElement.dispatchEvent (<anonymous>)
    at Object.invokeGuardedCallbackDev (react-dom.development.js:237)
```

See https://github.com/Katello/katello/pull/9251#pullrequestreview-716371399 and https://github.com/Katello/katello/pull/9251#issuecomment-887898312

This change adds `useCallback` where it is needed, preventing `handlePluginValue` and `handleInvalidField` from changing on every render.