### PR TITLE
Fixes #33215 - Registration - link to documentation

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageConstants.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageConstants.js
@@ -1,0 +1,10 @@
+import URI from 'urijs';
+import { foremanUrl } from '../../../../foreman_tools';
+
+export const docUrl = (foremanVersion) => {
+  const rootUrl = `https://docs.theforeman.org/${foremanVersion}/`
+  const section = 'Managing_Hosts/index-foreman-el.html#registering-a-host_managing-hosts'
+
+  const url = new URI({path: '/links/manual', query: { root_url: rootUrl, section: section }});
+  return foremanUrl(url.href());
+}

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -18,6 +18,7 @@ import { translate as __ } from '../../../common/I18n';
 import {
   useForemanOrganization,
   useForemanLocation,
+  useForemanVersion,
 } from '../../../Root/Context/ForemanContext';
 import { STATUS } from '../../../constants';
 import Head from '../../../components/Head';
@@ -37,6 +38,7 @@ import {
   selectPluginData,
 } from './RegistrationCommandsPageSelectors';
 import { dataAction, commandAction } from './RegistrationCommandsPageActions';
+import { docUrl } from './RegistrationCommandsPageConstants';
 
 import General from './components/General';
 import Advanced from './components/Advanced';
@@ -50,6 +52,7 @@ const RegistrationCommandsPage = () => {
   // Context
   const currentOrganization = useForemanOrganization();
   const currentLocation = useForemanLocation();
+  const foremanVersion = useForemanVersion();
 
   // Form tabs
   const [activeTab, setActiveTab] = useState(0);
@@ -185,7 +188,7 @@ const RegistrationCommandsPage = () => {
           </GridItem>
           <GridItem span={6}>
             <a
-              href="https://docs.theforeman.org/nightly/Managing_Hosts/index-foreman-el.html#registering-a-host-to-project-using-the-global-registration-template_managing-hosts"
+              href={docUrl(foremanVersion)}
               target="_blank"
               rel="noreferrer"
               className="pf-c-button pf-m-secondary pf-m-small pull-right"


### PR DESCRIPTION
Link to documentation should not be hardcoded
in the React component but should go through `LinksController`


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
