### PR TITLE
Fixes #32963 - Load only present categories

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -132,7 +132,8 @@ class SettingRegistry
   end
 
   def load_values
-    Setting.unscoped.all.each do |s|
+    # we are loading only known STIs as we load settings fairly early the first time and plugin classes might not be loaded yet.
+    Setting.unscoped.where(category: Setting.descendants.map(&:name)).all.each do |s|
       unless (definition = find(s.name))
         logger.debug("Setting #{s.name} has no definition, clean up your database")
         next


### PR DESCRIPTION
This got accidently reverted by bad rebase in
3ff1fd27fa32f7a52ecd995417521b5b91c9a093.
I'm reapplying this.

The first PR (#8651) for this was already merged, but bad rebase did remove it 