### PR TITLE
Fixes #32963 - Load only present categories

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -66,7 +66,8 @@ class SettingRegistry
 
   def load_values
     loaded_names = []
-    Setting.unscoped.all.each do |s|
+    # we are loading only known STIs as we load settings fairly early the first time and plugin classes might not be loaded yet.
+    Setting.unscoped.where(category: Setting.descendants.map(&:name)).all.each do |s|
       unless (definition = find(s.name))
         logger.debug("Setting #{s.name} has no definition, clean up your database")
         next


### PR DESCRIPTION
This got accidently reverted by bad rebase in
3ff1fd27fa32f7a52ecd995417521b5b91c9a093.
I'm reapplying this.

(cherry picked from commit 35fb314eb6636150fa19fc6ebfe03e32daba8a79)
