### PR TITLE
Fixes #33236 - optimize useAPI hook

### DIFF
--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.test.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.test.js
@@ -23,14 +23,29 @@ it('should use default url', async () => {
 });
 
 it('shuold use the given key', async () => {
-  const options = { key: API_TEST_KEY };
-
   APIHelper.get.mockResolvedValue(resultsFromLOTR);
   const { result, waitForNextUpdate } = renderHookWithRedux(() =>
-    useAPI('get', '/got', options)
+    useAPI('get', '/got', { key: API_TEST_KEY })
   );
   expect(result.current.response).toEqual({});
 
   await waitForNextUpdate();
   expect(result.current.key).toEqual(API_TEST_KEY);
+});
+
+it('shuold update APIOptions', async () => {
+  const spy = jest.spyOn(APIHelper, 'get');
+  APIHelper.get.mockResolvedValue(resultsFromLOTR);
+  const { result } = renderHookWithRedux(() =>
+    useAPI('get', '/lotr', { params: { a: 'a param' } })
+  );
+
+  await act(async () => {
+    result.current.setAPIOptions(prevOptions => ({
+      ...prevOptions,
+      params: { a: 'updated param' },
+    }));
+  });
+
+  expect(spy).toHaveBeenLastCalledWith('/lotr', {}, { a: 'updated param' });
 });


### PR DESCRIPTION
`useAPI` creates an infinite loop unless the options object is constant or memorized
This PR makes `useAPI` easier to use but still dynamic enough for changes.
With this, the options object is initialized as an inner state, and the consumer gets `setAPIOptions` for controlling it if needed.

examples:
```js
//  options can be created inline:
const Component = () => {
  const { response } = useAPI('get', '/url', { key: 'uniqeKey', params: { a: 'a' } }
}

// when  some options are depended on some props, the consumer can update the APIOptions
const Component = ({ foo, bar }) => {
  const { response, setAPIOptions } = useAPI('get', '/url', {
    params: { foo },
    headers: { bar },
  });
  useEffect(() => {
    setAPIOptions(prevOptions => ({
      ...prevOptions,
      params: { foo },
      headers: { bar },
    }));
  }, [foo, bar]);
};

```