### PR TITLE
Fixes #33229 - BMC feature error reports correctly

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -236,7 +236,7 @@ class HostsController < ApplicationController
       bmc_proxy: @host.bmc_proxy,
     }
   rescue Foreman::BMCFeatureException
-    render partial: 'bmc_missing_proxy', locals: { bmc_proxy: @host.subnet.bmc, bmc_count: SmartProxy.with_features('BMC').count }
+    render partial: 'bmc_missing_proxy', locals: { bmc_proxy: @host&.subnet&.bmc, bmc_count: SmartProxy.with_features('BMC')&.count }
   rescue Foreman::Exception => exception
     process_ajax_error exception, 'fetch bmc information'
   rescue ActionView::Template::Error => exception


### PR DESCRIPTION
When there is an error in BMC and subnet is not set for a host, nil pointer exception is thrown instead of properly rendered BMC feature error. This patch fixes it.

For the reporter: this will not fix your misconfiguration, you need to make sure every host has a subnet associated and a BMC NIC with subnet too.