### PR TITLE
Fixes #33305 - Fix for yum remove katello-ca-consumer

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -118,7 +118,7 @@ if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ]; then
 }
 
     <% if @force -%>
-    yum remove -y katello-ca-consumer*
+    yum remove -y katello-ca-consumer\*
     <% end -%>
 
     # rhn-client-tools conflicts with subscription-manager package


### PR DESCRIPTION
Fix to resolve the katello-ca-consumer package removal process when using the 'global_registration.erb' template.
