### PR TITLE
Fixes #33177 - Don't store incorrect referrer for redirect

### DIFF
--- a/app/controllers/concerns/foreman/controller/auto_complete_search.rb
+++ b/app/controllers/concerns/foreman/controller/auto_complete_search.rb
@@ -32,6 +32,9 @@ module Foreman::Controller::AutoCompleteSearch
   end
 
   def store_redirect_to_url
+    # Clear the stored url if the referer is the current URL. This can occur due
+    # to client side routing that modifies the history prior to the page load.
+    return reset_redirect_to_url if request.url == request.referer
     session["redirect_to_url_#{controller_name}"] ||= request.referer
   end
 end


### PR DESCRIPTION
When the client side uses `history.push` to navigate to a page that is
not managed by react router, the router fallback will navigate to the
new page. However, the browser URL is updated before the actual
navigation, causing the `document.referrer` to point to the new URL
instead of the previous one. In these cases, we can't reliably know
where the user navigated from so we should clear the `redirect_to_url`
from the session storage and rely on the default fallback (which is
usually the respective index page).


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
