### PR TITLE
Fixes #33311 - align host details cards

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
@@ -11,4 +11,7 @@
 .host-details-tab-item {
   padding: 18px;
   background: #f0f0f0;
+  .pf-c-card {
+    height: 100%
+  }
 }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Overview/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Overview/index.js
@@ -12,16 +12,16 @@ import './Details.css';
 const DetailsTab = ({ response, status, hostName }) => (
   <div className="host-details-tab-item details-tab">
     <Grid hasGutter>
-      <GridItem xl2={3} md={6} lg={4} rowSpan={3}>
+      <GridItem xl2={3} xl={4} md={6} lg={4} rowSpan={2}>
         <DetailsCard {...response} status={status} />
       </GridItem>
-      <GridItem xl2={3} md={6} lg={5}>
+      <GridItem xl2={3} xl={4} md={6} lg={4}>
         <AggregateStatus
           hostName={hostName}
           permissions={response.permissions}
         />
       </GridItem>
-      <GridItem xl2={3} md={6} lg={5}>
+      <GridItem xl2={3} xl={4} md={6} lg={4}>
         <AuditCard hostName={hostName} />
       </GridItem>
       <Slot hostDetails={response} id="details-cards" multi />

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -28,7 +28,7 @@ const CardItem = ({
     overrideDropdownProps?.onSelect?.(event);
   };
   return (
-    <GridItem xl2={3} md={6} lg={5} {...overrideGridProps}>
+    <GridItem xl2={3} xl={4} md={6} lg={4} {...overrideGridProps}>
       <Card isHoverable>
         <CardHeader>
           {dropdownItems && (


### PR DESCRIPTION
This PR aligns host details overview cards and makes the grid responsive to screen resolution

### large size resolution
_most common resolution_
![Screen Shot 2021-08-19 at 21 10 53](https://user-images.githubusercontent.com/11807069/130124643-5664baf4-8ae8-467f-9d98-eedd3bccc949.png)

### medium size resolution
_mainly for tablets_
<img width="735" alt="Screen Shot 2021-08-19 at 21 16 16" src="https://user-images.githubusercontent.com/11807069/130124765-5f79b682-8e74-4248-a900-a9c152f8b9b4.png">

### Ultrawide  resolution
![Screen Shot 2021-08-19 at 21 11 40](https://user-images.githubusercontent.com/11807069/130124526-700dfd6e-2596-4845-a35a-5cd2d47c37e4.png)

