### PR TITLE
Fixes #33316 - display toasts messages properly

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ToastsList/index.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/index.js
@@ -45,7 +45,7 @@ const ToastsList = ({ railsMessages }) => {
         }
         {...toastProps}
       >
-        {message.length > 60 && message}
+        {(message.length > 60 || React.isValidElement(message)) && message}
       </Alert>
     )
   );


### PR DESCRIPTION
After the refactor to PF4 in #8629 the toast message seem to hide messages under 60 chars,
it also hides messages that contain a React component.

with this PR:
![Screenshot - 2021-08-23T145741 134](https://user-images.githubusercontent.com/26363699/130443254-53b05e55-4489-490f-9c2b-c0067f051239.png)

before:
![Screenshot - 2021-08-23T213623 296](https://user-images.githubusercontent.com/26363699/130499673-eb1e8f0b-3daa-4ae1-b9af-32b63df4a606.png)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
