### PR TITLE
Fixes #33324 - fix host details tabs redundant re-render

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import {
   Grid,
   Tab,
@@ -47,8 +47,9 @@ const HostDetails = ({
   );
   const status = useSelector(state => selectAPIStatus(state, 'HOST_DETAILS'));
   const isNavCollapsed = useSelector(selectIsCollapsed);
-  const tabs = useSelector(state =>
-    selectFillsIDs(state, 'host-details-page-tabs')
+  const tabs = useSelector(
+    state => selectFillsIDs(state, 'host-details-page-tabs'),
+    shallowEqual
   );
 
   // This is a workaround due to the tabs overflow mechanism in PF4


### PR DESCRIPTION
The new host details tabs re-render on every redux change, even if the store hasn't changed (like the notifications update every 10 seconds), this  redundant re-render creates a different tab id in pf4:

https://user-images.githubusercontent.com/11807069/130510487-a7d9439c-6b65-45f4-be77-f32f02fdf196.mov

