### PR TITLE
Update preseed_default_pxelinux.erb

### DIFF
--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -31,8 +31,8 @@ test_on:
   else
     options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
   end
-  if @host.provision_interface.vlanid.present?
-    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
+  if @host.provision_interface.virtual? && @host.provision_interface.tag.present?
+    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.tag}"
   end
   options << "locale=#{host_param('lang') || 'en_US'}"
   options = options.join(' ')


### PR DESCRIPTION
Pull request #8201 added vlan tagging configuration to the kernel options. However, it uses "vlanid.present?" as check to decide whether it is necessary. This, however also checks the subnet configuration associated with the interface. However, whether a subnet in the network is a VLAN or not doesn't say anything about whether the interface needs to be tagged or not, because the VLAN may be connected untagged to the host.

The interface configuration for a host includes the "Virtual NIC" configuration options which allows you to set the VLAN tag and the associated interface. I think that should be the correct information to use.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
