### PR TITLE
Fixes #33342 - plugins can avoid lone taxonomies

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -255,8 +255,7 @@ module Api
       # parameters aren't taxable but have a relation to taxonomies because of location and organization params
       return if resource_name.ends_with? 'parameter'
       # reports have a relationship to taxonomies through the host, not directly
-      return if resource_class.ancestors.include? Report
-      return if resource_class == Filter
+      return if resource_class.include?(::Foreman::Controller::AvoidLoneTaxonomies)
       Taxonomy.types.each do |taxonomy|
         tax_name = taxonomy.to_s.downcase
         if resource_class.reflections.has_key? tax_name.pluralize

--- a/app/controllers/concerns/foreman/controller/avoid_lone_taxonomies.rb
+++ b/app/controllers/concerns/foreman/controller/avoid_lone_taxonomies.rb
@@ -1,0 +1,4 @@
+module Foreman::Controller::AvoidLoneTaxonomies
+  # Include this module to prevent assignment of lone taxonomies
+  # in assign_lone_taxonomies base controller (e.g. filter or report)
+end

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -1,6 +1,7 @@
 class Filter < ApplicationRecord
   audited :associated_with => :role
 
+  include ::Foreman::Controller::AvoidLoneTaxonomies
   include Taxonomix
   include Authorizable
   include TopbarCacheExpiry

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -2,6 +2,7 @@ class Report < ApplicationRecord
   LOG_LEVELS = %w[debug info notice warning err alert emerg crit]
 
   prepend Foreman::STI
+  include ::Foreman::Controller::AvoidLoneTaxonomies
   include Authorizable
   include ConfigurationStatusScopedSearch
 


### PR DESCRIPTION
Some model classes treat taxonomies differently and therefore API base controller filter is not applicable. This patch introduces a mechanism (an empty mixin) to opt-in.