### PR TITLE
Fixes #33347 - Fix settings index API

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -56,7 +56,7 @@ class SettingPresenter
 
   def matches_search_query?(query)
     if (res = query.match(/name\s*=\s*(\S+)/))
-      name == res[1]
+      name == ScopedSearch::QueryLanguage::Compiler.tokenize(query)[2]
     elsif (res = query.match(/description\s*~\s*(\S+)/))
       description.include? res[1]
     else

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -14,8 +14,8 @@ class SettingRegistry
   end
 
   def paginate(page: nil, per_page: nil)
-    page ||= 1
-    per_page ||= Setting[:entries_per_page]
+    page = (page || 1).to_i
+    per_page = (per_page || Setting[:entries_per_page]).to_i
     subset_keys = @settings.keys[((page - 1) * per_page)..(page * per_page - 1)]
     self.class.subset_registry(@settings.slice(*subset_keys))
   end

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -22,6 +22,14 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
       settings = ActiveSupport::JSON.decode(@response.body)
       assert !settings.empty?
     end
+
+    test "should get index with pagination string params" do
+      get :index, params: { :page => "1", :per_page => "5"}
+      assert_response :success
+      assert_not_nil assigns(:settings)
+      settings = ActiveSupport::JSON.decode(@response.body)
+      assert !settings.empty?
+    end
   end
 
   test "should show individual record" do

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -96,6 +96,12 @@ class SettingRegistryTest < ActiveSupport::TestCase
       assert_equal 'foo', result.first.name
     end
 
+    it 'can find setting by name common match' do
+      result = registry.search_for('name = "foo"').to_a
+      assert_equal 1, result.size
+      assert_equal 'foo', result.first.name
+    end
+
     it 'can find setting by description' do
       result = registry.search_for('test f').to_a
       assert_equal 1, result.size


### PR DESCRIPTION
Since we're dropping `search_for` from `scoped_search` for settings and re-defining `paginate`, we can encounter few hidden issues described in https://projects.theforeman.org/issues/33347.

This fix should ensure that 
 - `paginate` variables such as `page` and `per_page` will always be integers
 - search by name supports old/default/standard behaviour we have elsewhere for such cases as `"search": "name = \"setting_name\""`