### PR TITLE
Fixes #33371 - Fixing personal tokens for users

### DIFF
--- a/app/controllers/api/v2/personal_access_tokens_controller.rb
+++ b/app/controllers/api/v2/personal_access_tokens_controller.rb
@@ -66,6 +66,14 @@ module Api
           super
         end
       end
+
+      def resource_scope(*args)
+        if editing_self?
+          resource_class.where(user: @user).readonly(false)
+        else
+          super
+        end
+      end
     end
   end
 end

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -50,6 +50,11 @@ class PersonalAccessToken < ApplicationRecord
     token_value
   end
 
+  def check_permissions_after_save
+    return true if user == User.current
+    super
+  end
+
   def revoke!
     update!(revoked: true)
   end

--- a/app/views/personal_access_tokens/_personal_access_tokens_tab.html.erb
+++ b/app/views/personal_access_tokens/_personal_access_tokens_tab.html.erb
@@ -1,6 +1,6 @@
 <div class="tab-pane" id="personal_access_tokens">
   <%= react_component('PersonalAccessTokens', {
     url: api_user_personal_access_tokens_path(user_id: @user),
-    canCreate: authorized_for(controller: 'api/v2/personal_access_tokens', auth_action: :create)
+    canCreate: authorized_for(controller: 'api/v2/personal_access_tokens', auth_action: :create, user_id: @user.to_param)
   }) %>
 </div>


### PR DESCRIPTION
Fixing situation where user can see and revoke own personal tokens by remove permissions and only user and admin are able to see personal tokens for given users. Solution is based on overriding the `parent_resource_details` method at controller for personal tokens (suggested by @ezr-ondrej, thanks!) but it doesn't work properly without removing permissions for tokens. 

Since this a big fix in foreman security from my point, it's only a draft. It's possible that I forgot something update as well. 

Every comment regarding to that is welcomed.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
