### PR TITLE
Fixes #33387 - Remove view_tasks permission

### DIFF
--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -593,10 +593,6 @@ Foreman::AccessControl.map do |permission_set|
     }
   end
 
-  permission_set.security_block :tasks do |map|
-    map.permission :view_tasks, {:trends => [:show]}
-  end
-
   permission_set.security_block :plugins do |map|
     map.permission :view_plugins, {:plugins => [:index],
                                       :"api/v2/plugins" => [:index],

--- a/db/migrate/20210901081438_drop_view_tasks_permission.rb
+++ b/db/migrate/20210901081438_drop_view_tasks_permission.rb
@@ -1,0 +1,11 @@
+class DropViewTasksPermission < ActiveRecord::Migration[6.0]
+  def up
+    Permission.where(name: 'view_tasks').destroy_all
+    # clean up any empty filters left behind
+    Filter.where.not(id: Filtering.distinct.select(:filter_id)).destroy_all
+  end
+
+  def down
+    # The permission will get recreated by seeds
+  end
+end

--- a/db/seeds.d/020-permissions_list.rb
+++ b/db/seeds.d/020-permissions_list.rb
@@ -149,7 +149,6 @@ class PermissionsList
         ['Subnet', 'edit_subnets'],
         ['Subnet', 'destroy_subnets'],
         ['Subnet', 'import_subnets'],
-        [nil, 'view_tasks'],
         ['Usergroup', 'view_usergroups'],
         ['Usergroup', 'create_usergroups'],
         ['Usergroup', 'edit_usergroups'],

--- a/db/seeds.d/020-roles_list.rb
+++ b/db/seeds.d/020-roles_list.rb
@@ -37,7 +37,7 @@ class RolesList
 
     def default_role
       {
-        'Default role' => { permissions: [:view_tasks],
+        'Default role' => { permissions: [],
                             description: 'Role that is automatically assigned to every user in the system. Adding a permission grants it to everybody',
         },
       }


### PR DESCRIPTION
This permission was present since the permission model was implemented
in acfbc45886c4 but wasn't really used anywhere. Foreman tasks uses a
different `view_foreman_tasks` permission.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
