### PR TITLE
Fixes #33396 - Filter out vms with missing instanceUuid

### DIFF
--- a/app/services/fog_extensions/vsphere/mini_servers.rb
+++ b/app/services/fog_extensions/vsphere/mini_servers.rb
@@ -19,7 +19,7 @@ module FogExtensions
 
         folder_inventory = generate_folder_inventory(folders)
 
-        vms = results.select { |result| result.obj.is_a?(RbVmomi::VIM::VirtualMachine) && result['config.template'] == templates && !result['config.instanceUuid'].nil? }
+        vms = results.select { |result| result.obj.is_a?(RbVmomi::VIM::VirtualMachine) && result['config.template'] == templates && result['config.instanceUuid'].present? }
 
         vms.map do |vm|
           attrs = attribute_mapping.map do |key, value|


### PR DESCRIPTION
The previous fix handled cases where the instanceUuid was set to nil,
but in some cases it could be set to an empty string.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
