### PR TITLE
Fixes #33405 - fix unregister fill reducer

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/Fill/FillActions.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/FillActions.js
@@ -19,6 +19,6 @@ export const unregisterFillComponent = (slotId, fillId) => dispatch => {
   SlotsRegistry.remove(slotId, fillId);
   dispatch({
     type: REMOVE_FILLED_COMPONENT,
-    payload: { slotId },
+    payload: { slotId, fillId },
   });
 };

--- a/webpack/assets/javascripts/react_app/components/common/Fill/FillReducer.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/FillReducer.js
@@ -12,7 +12,9 @@ export default (state = initialState, action) => {
       return state.setIn([payload.slotId, payload.fillId], payload.weight);
 
     case REMOVE_FILLED_COMPONENT:
-      return state.setIn([payload.slotId, payload.fillId], false);
+      return state.update(payload.slotId, fills =>
+        fills.without(payload.fillId)
+      );
     default:
       return state;
   }

--- a/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/FillActions.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/FillActions.test.js
@@ -5,17 +5,9 @@ import { registerFillComponent, unregisterFillComponent } from '../FillActions';
 const SomeComponent = () => <div> a component </div>;
 const fixtures = {
   'should regiser a component': () =>
-    registerFillComponent({
-      slotId: 'slot-id',
-      fillId: 'fill-id',
-      component: SomeComponent,
-      weight: 100,
-    }),
+    registerFillComponent('slot-id', undefined, 'fill-id', SomeComponent, 100),
   'should unregiser a component': () =>
-    unregisterFillComponent({
-      slotId: 'slot-id',
-      fillId: 'fill-id',
-    }),
+    unregisterFillComponent('slot-id', 'fill-id'),
 };
 
 describe('AutoComplete actions', () =>

--- a/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/FillReducer.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/FillReducer.test.js
@@ -1,0 +1,21 @@
+import { testReducerSnapshotWithFixtures } from '@theforeman/test';
+import Immutable from 'seamless-immutable';
+import reducer from '../FillReducer';
+import { REMOVE_FILLED_COMPONENT } from '../FillConstants';
+
+const initState = Immutable({
+  slot: { fill1: { weight: 100 }, fill2: { weight: 200 } },
+});
+
+const fixtures = {
+  'should removed a fill': {
+    state: initState,
+    action: {
+      type: REMOVE_FILLED_COMPONENT,
+      payload: { fillId: 'fill1', slotId: 'slot' },
+    },
+  },
+};
+
+describe('FillReducer', () =>
+  testReducerSnapshotWithFixtures(reducer, fixtures));

--- a/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillActions.test.js.snap
@@ -5,14 +5,9 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "fillId": undefined,
-        "slotId": Object {
-          "component": [Function],
-          "fillId": "fill-id",
-          "slotId": "slot-id",
-          "weight": 100,
-        },
-        "weight": undefined,
+        "fillId": "fill-id",
+        "slotId": "slot-id",
+        "weight": 100,
       },
       "type": "SLOT_AND_FILL_REGISTER_FILL",
     },
@@ -25,10 +20,8 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "slotId": Object {
-          "fillId": "fill-id",
-          "slotId": "slot-id",
-        },
+        "fillId": "fill-id",
+        "slotId": "slot-id",
       },
       "type": "SLOT_AND_FILL_REMOVE_FILLED_COMPONENT",
     },

--- a/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillReducer.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/common/Fill/__tests__/__snapshots__/FillReducer.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FillReducer should removed a fill 1`] = `
+Object {
+  "slot": Object {
+    "fill2": Object {
+      "weight": 200,
+    },
+  },
+}
+`;


### PR DESCRIPTION
Consumers can unregister fills dynamically, fills are removed correctly from the slotsRegistery but not from redux's store, this PR removes the unregistered fill object from the store.
