### PR TITLE
Fixes: #33408 Add Support for Rocky Linux Registration

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -99,7 +99,7 @@ echo "# Running registration"
 echo "#"
 
 <% if plugin_present?('katello') -%>
-if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ]; then
+if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ] || [ x$ID = xrocky ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
         curl --silent --show-error --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \


### PR DESCRIPTION
Fixes: #33408 Add Support for Rocky Linux Registration

I tested this as working by registering a Rocky Linux 8 host. My test environment was a single Foreman/Katello server running version 4.2.0.rc1 on CentOS 8.