### PR TITLE
Fixes #33419 - Introduce Fact Parser Registry

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -40,6 +40,7 @@ module Foreman #:nodoc:
   class Plugin
     DEFAULT_REGISTRIES = {
       fact_importer: 'Foreman::Plugin::FactImporterRegistry',
+      fact_parser: 'Foreman::Plugin::FactParserRegistry',
       report_scanner: 'Foreman::Plugin::ReportScannerRegistry',
       report_origin: 'Foreman::Plugin::ReportOriginRegistry',
       medium_providers: 'Foreman::Plugin::MediumProvidersRegistry',
@@ -205,6 +206,10 @@ module Foreman #:nodoc:
 
     def fact_importer_registry
       self.class.fact_importer_registry
+    end
+
+    def fact_parser_registry
+      self.class.fact_parser_registry
     end
 
     def report_scanner_registry

--- a/app/registries/foreman/plugin/fact_parser_registry.rb
+++ b/app/registries/foreman/plugin/fact_parser_registry.rb
@@ -1,0 +1,45 @@
+module Foreman
+  class Plugin
+    class FactParserRegistry
+      def initialize
+        @parsers = {}.with_indifferent_access
+      end
+
+      # @return Parser class for the given key
+      # If the default parser is registered and unknown +key+ is used,
+      # the default parser is returned
+      #
+      # === Examples
+      #   FactParserRegistry[:puppet] # => PuppetParser
+      #   FactParserRegistry[:no_name] # => NoNameParser
+      #   FactParserRegistry[:unknown_key] # => PuppetParser (Puppet parser is registered as default)
+      def [](key)
+        @parsers[key]
+      end
+
+      # Register a fact parser (at +parser+ variable) to the Parser Registry for a given +key+.
+      # It's possible to mark +parser+ as default. It's then used for unknown +key+s.
+      # +key+ - key symbol to find parser, eg. :puppet
+      # +parser+ - class of parser, eg. PuppetParser
+      # +default+ - mark if the parser will be the default option for unknown keys, false by default.
+      #             There can only be one default.
+      #
+      # === Examples
+      #   FactParserRegistry.registry(:puppet, PuppetParser, true)
+      #   FactParserRegistry.registry(:no_name, NoNameParser)
+      def register(key, parser, default = false)
+        if (old_parser = @parsers[key]) && old_parser != @parsers.default
+          Rails.logger.warn("WARNING: Parser #{old_parser} for type #{key} is replaced with #{parser}")
+        end
+
+        @parsers.default = parser if default
+        @parsers[key.to_sym] = parser
+      end
+
+      # Remove a parser from the registry
+      def unregister(key)
+        @parsers.delete(key)
+      end
+    end
+  end
+end

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -8,16 +8,18 @@ class FactParser
   VIRTUAL_NAMES = /#{ALIASES}|#{VLANS}|#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 
   def self.parser_for(type)
-    parsers[type.to_s]
+    Foreman::Deprecation.deprecation_warning('3.2', 'FactParser.parser_for() is deprecated, use FactParserRegistry[] instead')
+    Foreman::Plugin.fact_parser_registry[type]
   end
 
   def self.parsers
-    @parsers ||= {}.with_indifferent_access
+    Foreman::Deprecation.deprecation_warning('3.2', 'FactParser.parsers is deprecated, use FactParserRegistry.parsers instead')
+    Foreman::Plugin.fact_parser_registry.parsers
   end
 
   def self.register_fact_parser(key, klass, default = false)
-    parsers.default = klass if default
-    parsers[key.to_sym] = klass
+    Foreman::Deprecation.deprecation_warning('3.2', 'FactParser.register_fact_parser() is deprecated, use FactParserRegistry.register() instead')
+    Foreman::Plugin.fact_parser_registry.register(key, klass, default)
   end
 
   attr_reader :facts

--- a/app/services/host_fact_importer.rb
+++ b/app/services/host_fact_importer.rb
@@ -44,7 +44,7 @@ class HostFactImporter
 
     skipping_orchestration do
       unless host.build?
-        parser = FactParser.parser_for(type).new(facts)
+        parser = Foreman::Plugin.fact_parser_registry[type].new(facts)
 
         telemetry_duration_histogram(:importer_facts_import_duration, 1000, type: type) do
           host.populate_fields_from_facts(parser, type, source_proxy)

--- a/config/initializers/puppet.rb
+++ b/config/initializers/puppet.rb
@@ -1,2 +1,0 @@
-Foreman::Plugin.fact_importer_registry.register(:puppet, PuppetFactImporter, true)
-FactParser.register_fact_parser :puppet, PuppetFactParser, true

--- a/config/initializers/z_plugin_parsers.rb
+++ b/config/initializers/z_plugin_parsers.rb
@@ -1,25 +1,19 @@
-class ParserRegistrator
-  def self.register_fact_parser(type, parser)
-    if (old_parser = FactParser.parser_for(type)) && old_parser != FactParser.parsers.default
-      Rails.logger.warn("WARNING: Parser #{old_parser} for type #{type} is replaced with #{parser}")
-    end
-
-    FactParser.register_fact_parser(type, parser)
-  end
-end
+# Puppet, the default parser
+Foreman::Plugin.fact_importer_registry.register(:puppet, PuppetFactImporter, true)
+Foreman::Plugin.fact_parser_registry.register(:puppet, PuppetFactParser, true)
 
 # Ansible
-Foreman::Plugin.fact_importer_registry.register(:ansible, ForemanAnsible::StructuredFactImporter, false)
-ParserRegistrator.register_fact_parser(:ansible, AnsibleFactParser)
+Foreman::Plugin.fact_importer_registry.register(:ansible, ForemanAnsible::StructuredFactImporter)
+Foreman::Plugin.fact_parser_registry.register(:ansible, AnsibleFactParser)
 
 # Katello
-::Foreman::Plugin.fact_importer_registry.register(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactImporter)
-ParserRegistrator.register_fact_parser(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactParser)
+Foreman::Plugin.fact_importer_registry.register(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactImporter)
+Foreman::Plugin.fact_parser_registry.register(Katello::RhsmFactName::FACT_TYPE, Katello::RhsmFactParser)
 
 # Chef
 Foreman::Plugin.fact_importer_registry.register(:foreman_chef, ForemanChef::FactImporter)
-ParserRegistrator.register_fact_parser(:foreman_chef, ForemanChef::FactParser)
+Foreman::Plugin.fact_parser_registry.register(:foreman_chef, ForemanChef::FactParser)
 
 # Salt
 Foreman::Plugin.fact_importer_registry.register(:foreman_salt, ForemanSalt::FactImporter)
-FactParser.register_fact_parser(:foreman_salt, ForemanSalt::FactParser)
+Foreman::Plugin.fact_parser_registry.register(:foreman_salt, ForemanSalt::FactParser)

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -22,24 +22,6 @@ class FactParserTest < ActiveSupport::TestCase
     refute_match FactParser::BRIDGES, 'bridge'
   end
 
-  test "default parsers" do
-    assert_includes FactParser.parsers.keys, 'puppet'
-    assert_equal PuppetFactParser, FactParser.parser_for(:puppet)
-    assert_equal PuppetFactParser, FactParser.parser_for('puppet')
-    assert_equal PuppetFactParser, FactParser.parser_for(:whatever)
-    assert_equal PuppetFactParser, FactParser.parser_for('whatever')
-  end
-
-  test ".register_custom_parser" do
-    chef_parser = Struct.new(:my_method)
-    FactParser.register_fact_parser :chef, chef_parser
-    begin
-      assert_equal chef_parser, FactParser.parser_for(:chef)
-    ensure
-      FactParser.parsers.delete :chef
-    end
-  end
-
   test "#parse_interfaces? should answer based on current setttings" do
     parser.stub(:support_interfaces_parsing?, true) do
       Setting.expects(:[]).with('ignore_puppet_facts_for_provisioning').returns(false)

--- a/test/unit/plugin/parser_registry_test.rb
+++ b/test/unit/plugin/parser_registry_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class FactParserRegistryTest < ActiveSupport::TestCase
+  test "default parsers" do
+    assert_equal PuppetFactParser, Foreman::Plugin.fact_parser_registry[:puppet]
+    assert_equal PuppetFactParser, Foreman::Plugin.fact_parser_registry['puppet']
+    assert_equal PuppetFactParser, Foreman::Plugin.fact_parser_registry[:whatever]
+    assert_equal PuppetFactParser, Foreman::Plugin.fact_parser_registry['whatever']
+  end
+
+  test "register_custom_parser" do
+    chef_parser = Struct.new(:my_method)
+    Foreman::Plugin.fact_parser_registry.register(:chef, chef_parser)
+    begin
+      assert_equal chef_parser, Foreman::Plugin.fact_parser_registry[:chef]
+    ensure
+      Foreman::Plugin.fact_parser_registry.unregister(:chef)
+    end
+  end
+
+  test "replacing parsers" do
+    parser_one = Struct.new(:my_method_one)
+    parser_two = Struct.new(:my_method_two)
+    begin
+      Foreman::Plugin.fact_parser_registry.register(:parser, parser_one)
+      assert_equal parser_one, Foreman::Plugin.fact_parser_registry[:parser]
+      Foreman::Plugin.fact_parser_registry.register(:parser, parser_two)
+      assert_equal parser_two, Foreman::Plugin.fact_parser_registry[:parser]
+    ensure
+      Foreman::Plugin.fact_parser_registry.unregister(:parser)
+    end
+  end
+
+  test 'replacing default parser' do
+    parser_one = Struct.new(:my_method_one)
+    parser_two = Struct.new(:my_method_two)
+
+    begin
+      Foreman::Plugin.fact_parser_registry.register(:parser, parser_one, true)
+      assert_equal parser_one, Foreman::Plugin.fact_parser_registry[:parser]
+      assert_equal parser_one, Foreman::Plugin.fact_parser_registry[:anything]
+      Foreman::Plugin.fact_parser_registry.register(:parser, parser_two, true)
+      assert_equal parser_two, Foreman::Plugin.fact_parser_registry[:parser]
+      assert_equal parser_two, Foreman::Plugin.fact_parser_registry[:anything]
+    ensure
+      Foreman::Plugin.fact_parser_registry.unregister(:parser)
+      Foreman::Plugin.fact_parser_registry.register(:pupper, PuppetFactParser, true)
+    end
+  end
+end


### PR DESCRIPTION
FactParser class has two purposes in current codebase. It acts as parent for other fact parses (PuppetFactParser, AnsibleFactParser, RhsmFactParser...) and also as a registry for registering parsers for given type/key. This PR introduces FactParserRegistry under Foreman::Plugin namespace. Thanks to that, the FactParser can takes care only for facts!


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
