### PR TITLE
Fixes #33316 - display toasts messages properly (CP 3.0)

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ToastsList/index.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/index.js
@@ -45,7 +45,7 @@ const ToastsList = ({ railsMessages }) => {
         }
         {...toastProps}
       >
-        {message.length > 60 && message}
+        {(message.length > 60 || React.isValidElement(message)) && message}
       </Alert>
     )
   );


### PR DESCRIPTION
After the refactor to PF4 in #8629 the toast message seem to hide messages under 60 chars,
it also hides messages that contain a React component.

(cherry picked from commit 55cb5bd6b76c4ca6de9f24ae2f5a7386b83226d9)
