### PR TITLE
Fixes #33025 - allow filtering hosts by user id

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -11,6 +11,7 @@ class Report < ApplicationRecord
   has_many :messages, :through => :logs
   has_many :sources, :through => :logs
   has_one :hostgroup, :through => :host
+  has_one :host_owner, through: :host, source: :owner, source_type: 'User'
 
   has_one :organization, :through => :host
   has_one :location, :through => :host
@@ -21,6 +22,14 @@ class Report < ApplicationRecord
   def self.inherited(child)
     child.instance_eval do
       scoped_search :relation => :host,         :on => :name,  :complete_value => true, :rename => :host
+      scoped_search :relation => :host_owner,
+        :on => :id,
+        :complete_value => true,
+        :rename => :host_owner_id,
+        :only_explicit => true,
+        :validator => ->(value) { ScopedSearch::Validators::INTEGER.call(value) },
+        :value_translation => ->(value) { value == 'current_user' ? User.current.id : value },
+        :special_values => %w[current_user]
       scoped_search :relation => :organization, :on => :name,  :complete_value => true, :rename => :organization
       scoped_search :relation => :location,     :on => :name,  :complete_value => true, :rename => :location
       scoped_search :relation => :messages,     :on => :value,                          :rename => :log, :only_explicit => true

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -21,7 +21,7 @@ class Report < ApplicationRecord
 
   def self.inherited(child)
     child.instance_eval do
-      scoped_search :relation => :host,         :on => :name,  :complete_value => true, :rename => :host
+      scoped_search :relation => :host, :on => :name, :complete_value => true, :rename => :host
       scoped_search :relation => :host_owner,
         :on => :id,
         :complete_value => true,
@@ -30,16 +30,16 @@ class Report < ApplicationRecord
         :validator => ->(value) { ScopedSearch::Validators::INTEGER.call(value) },
         :value_translation => ->(value) { value == 'current_user' ? User.current.id : value },
         :special_values => %w[current_user]
-      scoped_search :relation => :organization, :on => :name,  :complete_value => true, :rename => :organization
-      scoped_search :relation => :location,     :on => :name,  :complete_value => true, :rename => :location
-      scoped_search :relation => :messages,     :on => :value,                          :rename => :log, :only_explicit => true
-      scoped_search :relation => :sources,      :on => :value,                          :rename => :resource, :only_explicit => true
-      scoped_search :relation => :hostgroup,    :on => :name,  :complete_value => true, :rename => :hostgroup
-      scoped_search :relation => :hostgroup,    :on => :title, :complete_value => true, :rename => :hostgroup_fullname
-      scoped_search :relation => :hostgroup,    :on => :title, :complete_value => true, :rename => :hostgroup_title
+      scoped_search :relation => :organization, :on => :name, :complete_value => true, :rename => :organization
+      scoped_search :relation => :location, :on => :name, :complete_value => true, :rename => :location
+      scoped_search :relation => :messages, :on => :value, :rename => :log, :only_explicit => true
+      scoped_search :relation => :sources, :on => :value, :rename => :resource, :only_explicit => true
+      scoped_search :relation => :hostgroup, :on => :name, :complete_value => true, :rename => :hostgroup
+      scoped_search :relation => :hostgroup, :on => :title, :complete_value => true, :rename => :hostgroup_fullname
+      scoped_search :relation => :hostgroup, :on => :title, :complete_value => true, :rename => :hostgroup_title
 
       scoped_search :on => :reported_at, :complete_value => true, :default_order => :desc, :rename => :reported, :only_explicit => true, :aliases => [:last_report]
-      scoped_search :on => :host_id,     :complete_value => false, :only_explicit => true
+      scoped_search :on => :host_id, :complete_value => false, :only_explicit => true
       scoped_search :on => :origin
     end
     super


### PR DESCRIPTION
Users would like to set filters so users can only see reports of hosts
they own.

For that we can define an association on a Report based on the Host
ownership. Then we can add a scoped search definition that could be used
in Filter definition. The resulting scoped search term that can be used
on any Report subclass is

```
host_owner_id = current_user
```

Instead of `current_user`, a specific user ID can be used too.

This will not take user group ownership into the consideration due to
the complexity, especially when tree structure of user groups is
considered.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
