### PR TITLE
Refs #32398 - Pass router history to tabs

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/TabRouter/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/TabRouter/index.js
@@ -5,7 +5,7 @@ import { STATUS } from '../../../../constants';
 import Slot from '../../../common/Slot';
 import { DEFAULT_TAB } from '../../consts';
 
-const TabRouter = ({ children, tabs, hostName, response, status }) => (
+const TabRouter = ({ children, tabs, hostName, response, status, router }) => (
   <HashRouter>
     <>
       {children}
@@ -24,6 +24,7 @@ const TabRouter = ({ children, tabs, hostName, response, status }) => (
                 status={status}
                 id="host-details-page-tabs"
                 fillID={tab}
+                router={router}
                 {...props}
               />
             )}
@@ -40,6 +41,7 @@ TabRouter.propTypes = {
   status: PropTypes.string,
   response: PropTypes.object,
   tabs: PropTypes.array.isRequired,
+  router: PropTypes.object.isRequired,
 };
 
 TabRouter.defaultProps = {

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -37,6 +37,7 @@ const HostDetails = ({
     params: { id },
   },
   location: { hash },
+  history,
 }) => {
   const { response, status } = useAPI(
     'get',
@@ -127,6 +128,7 @@ const HostDetails = ({
             hostName={id}
             status={status}
             tabs={tabs}
+            router={history}
           >
             <Tabs
               style={{
@@ -154,6 +156,7 @@ HostDetails.propTypes = {
   location: PropTypes.shape({
     hash: PropTypes.string,
   }).isRequired,
+  history: PropTypes.object.isRequired,
 };
 
 export default HostDetails;


### PR DESCRIPTION
Needed for proper navigation from tabs, based on https://github.com/theforeman/foreman/pull/8670/files#r673134856
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
