### PR TITLE
Fixes #33223 - Improving Job Invocation Report Template (CP 3.0)

### DIFF
--- a/app/views/unattended/report_templates/jobs_-_invocation_report_template.erb
+++ b/app/views/unattended/report_templates/jobs_-_invocation_report_template.erb
@@ -23,6 +23,7 @@ require:
 - plugin: foreman_remote_execution
 ￼ version: 4.4.0
 -%>
+<%- report_headers 'Host', 'stdout', 'stderr', 'debug', 'Result', 'Finished' %>
 <%- invocation = find_job_invocation_by_id(input('job_id')) -%>
 <%- parts = ["job_invocation.id = #{input('job_id')}"] %>
 <%- parts << input('hosts') unless input('hosts').blank? %>
@@ -30,15 +31,18 @@ require:
 <%- load_hosts(search: search).each do |batch| -%>
 <%-   batch.each do |host|  -%>
 <%-     task = invocation.sub_task_for_host(host) -%>
+<%-     outputs = { 'stdout' => [], 'stderr' => [], 'debug' => [] }  -%>
 <%-     task.action_continuous_output.each do |output| -%>
-<%-       report_row(
-            host: host.name,
-            result: task.result,
-            type: output['output_type'],
-            message: output['output'],
-            time: format_time(output['timestamp']),
-          ) -%>
+<%-       outputs[output['output_type']] << output['output'] -%>
 <%-     end -%>
+<%-     report_row(
+            'Host': host.name,
+            'stdout': join_with_line_break(outputs['stdout']),
+            'stderr': join_with_line_break(outputs['stderr']),
+            'debug': join_with_line_break(outputs['debug']),
+            'Result': task.result,
+            'Finished': format_time(task.ended_at),
+        ) -%>
 <%-   end -%>
 <%- end -%>
 <%= report_render -%>

--- a/lib/foreman/renderer/configuration.rb
+++ b/lib/foreman/renderer/configuration.rb
@@ -51,7 +51,8 @@ module Foreman
         :to_yaml,
         :foreman_server_ca_cert,
         :format_time,
-        :shell_escape
+        :shell_escape,
+        :join_with_line_break
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/lib/foreman/renderer/scope/macros/base.rb
+++ b/lib/foreman/renderer/scope/macros/base.rb
@@ -363,6 +363,28 @@ module Foreman
                      rand(100) #=> 72'
           end
 
+          apipie :method, "Return the concatenated array with correct line break" do
+            desc 'This method returns concatenated array with correct line break with the respect of output format.
+                  For HTML output, it joins array members with <br> tag otherwise it uses a \n character.
+                  It works as new line at CSV but at YAML and JSON it is used for separating of lines
+                  because of structure of these formats'
+            required :array, Array, desc: 'Array of values to concatenate'
+            returns ::String
+            example "join_with_line_break(values) # => 1<br>2<br>3 for HTML"
+            example 'join_with_line_break(values) # => 1\n2\n3 for CSV,JSON,YAML'
+          end
+          def join_with_line_break(array)
+            case report_format.mime_type
+            when 'text/csv'
+              array.join("\n")
+            when 'application/json', 'text/yaml'
+              array.join("\\n")
+            when 'text/html'
+              array.map! { |str| CGI.escapeHTML(str) }
+              array.join("<br>").html_safe
+            end
+          end
+
           private
 
           def validate_subnet(subnet)


### PR DESCRIPTION
Updating the template to merge outputs lines to one batch to show them
at one line.

(cherry picked from commit 76dd50df37e8131e4c55ed365d3c0e2d30a1616b)