### PR TITLE
fixes #33408 - Add Support for Rocky Linux Registration

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -47,7 +47,7 @@ echo '#'
 echo '# Adding repository'
 echo '#'
 
-if [ x$ID = xrhel ] || [ x$ID = xfedora ] || [ x$ID = xol ] || test "${ID_LIKE#*rhel*}" != "$ID_LIKE" ; then
+if [ x$ID = xfedora ] || [ "${ID_LIKE#*fedora*}" != "$ID_LIKE" ]; then
   cat << EOF > /etc/yum.repos.d/foreman_registration.repo
 [foreman_register]
 name=foreman_register
@@ -99,7 +99,7 @@ echo "# Running registration"
 echo "#"
 
 <% if plugin_present?('katello') -%>
-if [ x$ID = xrhel ] || [ x$ID = xcentos ] || [ x$ID = xol ]; then
+if [ "${ID_LIKE#*fedora*}" != "$ID_LIKE" ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
         curl --silent --show-error --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -47,7 +47,7 @@ echo '#'
 echo '# Adding repository'
 echo '#'
 
-if [ x$ID = xfedora ] || [ "${ID_LIKE#*fedora*}" != "$ID_LIKE" ]; then
+if [ -f /etc/redhat-release ]; then
   cat << EOF > /etc/yum.repos.d/foreman_registration.repo
 [foreman_register]
 name=foreman_register
@@ -99,7 +99,7 @@ echo "# Running registration"
 echo "#"
 
 <% if plugin_present?('katello') -%>
-if [ "${ID_LIKE#*fedora*}" != "$ID_LIKE" ]; then
+if [ -f /etc/redhat-release ]; then
     register_katello_host(){
         UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
         curl --silent --show-error --cacert $SSL_CA_CERT --request POST "<%= @registration_url %>" \


### PR DESCRIPTION
fixes #33408 - Add Support for Rocky Linux Registration

I tested this as working by registering a Rocky Linux 8 host. My test environment was a single Foreman/Katello server running version 4.2.0.rc1 on CentOS 8.

I am resubmitting as I was asked to close pull request and make my changes in a branch.
