### PR TITLE
Fixes #33469 - current stream for Flatcar

### DIFF
--- a/app/models/operatingsystems/coreos.rb
+++ b/app/models/operatingsystems/coreos.rb
@@ -28,7 +28,11 @@ class Coreos < Operatingsystem
   end
 
   def pxedir(medium_provider = nil)
-    '$arch-usr/$version'
+    if medium_provider&.os_major&.to_s == "0"
+      '$arch-usr/current'
+    else
+      '$arch-usr/$version'
+    end
   end
 
   def boot_file_sources(medium_provider, &block)
@@ -54,7 +58,7 @@ class Coreos < Operatingsystem
 
   # Helper text shown next to major version (do not use i18n)
   def major_version_help
-    '2512.3'
+    '2512.3 or set to 0 to use current'
   end
 
   # Helper text shown next to minor version (do not use i18n)

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -74,6 +74,14 @@ module MediumProviders
       architecture.try(:name)
     end
 
+    def os_major
+      entity.try(:operatingsystem).try(:major)
+    end
+
+    def os_minor
+      entity.try(:operatingsystem).try(:minor)
+    end
+
     def interpolate_vars(pattern)
       pattern
     end

--- a/test/models/operatingsystems/coreos_test.rb
+++ b/test/models/operatingsystems/coreos_test.rb
@@ -78,4 +78,35 @@ class CoreosTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context 'Flatcar Container Linux current version' do
+    let(:operatingsystem) { FactoryBot.create(:flatcar, major: "0") }
+    let(:medium) { FactoryBot.create(:medium, :flatcar) }
+
+    describe '#bootfile' do
+      test 'returns the bootfile' do
+        assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'flatcar_production_pxe.vmlinuz'
+      end
+    end
+
+    describe '#boot_file_sources' do
+      test 'returns all boot file sources' do
+        expected = {
+          kernel: 'http://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz',
+          initrd: 'http://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz',
+        }
+        assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+      end
+    end
+
+    describe '#url_for_boot' do
+      test 'generates kernel url' do
+        assert_equal 'http://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe.vmlinuz', operatingsystem.url_for_boot(medium_provider, :kernel)
+      end
+
+      test 'generates initrd url' do
+        assert_equal 'http://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_pxe_image.cpio.gz', operatingsystem.url_for_boot(medium_provider, :initrd)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Flatcar OS only supports version numbers and it is not possible to define an OS with current stream:

https://stable.release.flatcar-linux.net/amd64-usr/current/

This patch enables that by allowing 0.0 version. Release name cannot be used for that. It provides a help hint for the UI as well.