### PR TITLE
Fixes #33474 - taxable by single Taxonomy

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -18,6 +18,7 @@ class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
   extend AuditAssociations::AssociationsDefinitions
+  include ::Taxable
 
   # Rails use Notifications for own sql logging so we can override sql logger for orchestration
   def self.logger

--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -13,6 +13,7 @@ module AuditExtensions
     scope :untaxed, -> { by_auditable_types(untaxable) }
     scope :by_auditable_types, ->(auditable_types) { where(:auditable_type => auditable_types.map(&:to_s)).readonly(false) }
 
+    include Taxable
     include Authorizable
     include Taxonomix
     include Foreman::TelemetryHelper

--- a/app/models/concerns/taxable.rb
+++ b/app/models/concerns/taxable.rb
@@ -1,0 +1,41 @@
+module Taxable
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def taxable(organization: true, location: true, join_table: :taxable_taxonomies)
+      include DirtyAssociations
+      extend Taxonomix::ClassMethods
+
+      cattr_accessor :taxable_options
+      self.taxable_options = { organization: organization, location: location, join_table: join_table }
+
+      has_many join_table, :dependent => :destroy, :as => :taxable
+      if location
+        has_many :locations, -> { where(:type => 'Location') },
+          :through => join_table, :source => :taxonomy,
+          :validate => false
+
+        scoped_search :relation => :locations, :on => :name, :rename => :location, :complete_value => true, :only_explicit => true
+        scoped_search :relation => :locations, :on => :id, :rename => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+      end
+      if organization
+        has_many :organizations, -> { where(:type => 'Organization') },
+          :through => join_table, :source => :taxonomy,
+          :validate => false
+
+        scoped_search :relation => :organizations, :on => :name, :rename => :organization, :complete_value => true, :only_explicit => true
+        scoped_search :relation => :organizations, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
+      end
+      after_initialize :set_current_taxonomy
+
+      used_assoc = []
+      used_assoc << :organizations if organization
+      used_assoc << :locations if location
+
+      dirty_has_many_associations *used_assoc
+      audit_associations *used_assoc if respond_to? :audit_associations
+
+      validate :ensure_taxonomies_not_escalated, :if => proc { User.current.nil? || !User.current.admin? }
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,6 @@ end
 # load the corresponding bit of fog
 require 'fog/ovirt' if defined?(::OVIRT)
 
-require_dependency File.expand_path('../app/models/application_record.rb', __dir__)
 require_dependency File.expand_path('../lib/foreman.rb', __dir__)
 require_dependency File.expand_path('../lib/timed_cached_store.rb', __dir__)
 require_dependency File.expand_path('../lib/foreman/exception', __dir__)


### PR DESCRIPTION
Allows taxing resource by singular taxonomy and still use `Taxonomix` for it.