### PR TITLE
Fixes #33481 - fix login footer on small screens

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ExternalLogout/externalLogout.scss
+++ b/webpack/assets/javascripts/react_app/components/ExternalLogout/externalLogout.scss
@@ -3,6 +3,7 @@
 .external-logout {
   height: 100%;
   background-image: $background_image;
+  background-size: contain;
 
   header {
     text-align: center;

--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js
@@ -14,6 +14,9 @@ const LoginPage = ({
   version,
 }) => {
   const { modifiedAlerts, submitErrors } = adjustAlerts(alerts);
+  const footerLinks = caption
+    ? [{ children: caption, href: 'foreman-login-footer-text' }] // The href text is detected in our css to disable it from being an actual link.
+    : [];
   return (
     <div id="login-page">
       <PFLoginPage
@@ -40,8 +43,8 @@ const LoginPage = ({
             ),
           },
         }}
+        footerLinks={footerLinks}
       />
-      {caption && <div id="login-footer-text">{caption}</div>}
     </div>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
@@ -1,15 +1,7 @@
 @import '~@theforeman/vendor/scss/variables';
 
 $caption_font_weight: 600;
-/* stylelint-disable-next-line */
-$background_image: linear-gradient(
-  to right,
-  #005e8c,
-  #084c75,
-  #0a3a5e,
-  #082948,
-  #041a33
-);
+$background_image: url('../LoginPage/background.svg');
 
 #login-page {
   height: 100%;
@@ -22,6 +14,7 @@ $background_image: linear-gradient(
   .login-pf {
     background: none;
     background-image: $background_image;
+    background-size: contain;
 
     .login-pf-header {
       margin-bottom: 0 !important; // conflicts with patternfly-sass gem.

--- a/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.scss
@@ -14,12 +14,9 @@ $background_image: linear-gradient(
 #login-page {
   height: 100%;
 
-  #login-footer-text {
-    position: fixed;
-    bottom: 0;
-    padding: 30px;
-    color: $color-pf-white;
-    font-size: 14px;
+  .login-pf-page-footer-link[href*='foreman-login-footer-text'] {
+    pointer-events: none;
+    cursor: default;
   }
 
   .login-pf {

--- a/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/__snapshots__/LoginPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/__tests__/__snapshots__/LoginPage.test.js.snap
@@ -54,7 +54,14 @@ exports[`LoginPage rendering renders LoginPage 1`] = `
         "backgroundUrl": "/some-background",
       }
     }
-    footerLinks={Array []}
+    footerLinks={
+      Array [
+        Object {
+          "children": "some caption",
+          "href": "foreman-login-footer-text",
+        },
+      ]
+    }
     header={
       Object {
         "caption": <React.Fragment>
@@ -73,10 +80,5 @@ exports[`LoginPage rendering renders LoginPage 1`] = `
       }
     }
   />
-  <div
-    id="login-footer-text"
-  >
-    some caption
-  </div>
 </div>
 `;

--- a/webpack/assets/javascripts/react_app/components/LoginPage/background.svg
+++ b/webpack/assets/javascripts/react_app/components/LoginPage/background.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600px" height="200px" >
+  <defs>
+   <linearGradient id="lgrad" x1="0%" y1="50%" x2="100%" y2="50%" >
+    
+          <stop offset="0%" style="stop-color:rgb(0,94,140);stop-opacity:1.00" />
+          <stop offset="100%" style="stop-color:rgb(4,26,51);stop-opacity:1.00" />
+
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="100%" height="100%" fill="url(#lgrad)"/>
+</svg>


### PR DESCRIPTION
on smaller screens, the login footer can jump and override the login form.
it can cause the button or inputs to become not reachable by the mouse.

This is how it looks with the fix:
![Login](https://user-images.githubusercontent.com/26363699/133268956-0d1de229-c2c3-4050-bbdf-140f0a7d8984.gif)



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
