### PR TITLE
Fixes #33484 - add setting to opt-in/out the new host details page

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -164,7 +164,6 @@ function submit_with_all_params() {
   $('body').css('cursor', 'progress');
   clear_errors();
   animate_progress();
-
   $.ajax({
     type: 'POST',
     url: $('form').attr('action'),

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -24,7 +24,7 @@ class HostsController < ApplicationController
                         select_multiple_power_state update_multiple_power_state)
 
   before_action :ajax_request, :only => AJAX_REQUESTS
-  before_action :find_resource, :only => [:show, :clone, :edit, :update, :destroy, :review_before_build,
+  before_action :find_resource, :only => [:show, :legacy_show, :clone, :edit, :update, :destroy, :review_before_build,
                                           :setBuild, :cancelBuild, :power, :overview, :bmc, :vm,
                                           :runtime, :resources, :nics, :ipmi_boot, :console,
                                           :toggle_manage, :pxe_config, :disassociate, :build_errors, :forget_status, :statuses]
@@ -60,7 +60,7 @@ class HostsController < ApplicationController
     end
   end
 
-  def show
+  def legacy_show
     respond_to do |format|
       format.html do
         # filter graph time range
@@ -72,6 +72,11 @@ class HostsController < ApplicationController
       format.yaml { render :plain => @host.info.to_yaml }
       format.json
     end
+    render :show
+  end
+
+  def show
+    render template: 'react/index', layout: 'layouts/react_application'
   end
 
   def new
@@ -96,7 +101,7 @@ class HostsController < ApplicationController
     @host.managed = true if (params[:host] && params[:host][:managed].nil?)
     forward_url_options
     if @host.save
-      process_success :success_redirect => host_path(@host)
+      process_success :success_redirect => legacy_host_show_path(@host)
     else
       load_vars_for_ajax
       offer_to_overwrite_conflicts
@@ -114,7 +119,7 @@ class HostsController < ApplicationController
       attributes = @host.apply_inherited_attributes(host_params)
       attributes.delete(:compute_resource_id)
       if @host.update(attributes)
-        process_success :success_redirect => host_path(@host)
+        process_success :success_redirect => legacy_host_show_path(@host)
       else
         taxonomy_scope
         load_vars_for_ajax
@@ -682,7 +687,7 @@ class HostsController < ApplicationController
   end
 
   define_action_permission [
-    'clone', 'overview', 'bmc', 'vm', 'runtime', 'resources', 'templates', 'nics', 'statuses',
+    'clone', 'legacy_show', 'overview', 'bmc', 'vm', 'runtime', 'resources', 'templates', 'nics', 'statuses',
     'pxe_config', 'active', 'errors', 'out_of_sync', 'pending', 'disabled', 'get_power_state', 'preview_host_collection', 'build_errors'
   ], :view
   define_action_permission [

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -439,6 +439,7 @@ module ApplicationHelper
   end
 
   def ui_settings
-    { perPage: Setting['entries_per_page'], destroyVmOnHostDelete: Setting['destroy_vm_on_host_delete'] }
+    { perPage: Setting['entries_per_page'], destroyVmOnHostDelete: Setting['destroy_vm_on_host_delete'],
+      hostDetailsUI: Setting['host_details_ui'] }
   end
 end

--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -136,7 +136,7 @@ module HostDescriptionHelper
       { :button => link_to_if_authorized(_("Audits"), { :controller => 'audits', :action => 'index', :search => "host = #{host.name}" }, :title => _("Host audit entries"), :class => 'btn btn-default'), :priority => 100 },
       ({ :button => link_to_if_authorized(_("Facts"), hash_for_host_facts_path(:host_id => host), :title => _("Browse host facts"), :class => 'btn btn-default'), :priority => 200 } if host.fact_values.any?),
       ({ :button => link_to_if_authorized(_("Reports"), hash_for_host_config_reports_path(:host_id => host), :title => _("Browse host config management reports"), :class => 'btn btn-default'), :priority => 300 } if host.reports.any?),
-      { :button => link_to(_("New UI"), host_details_page_path(host.name), :title => _("Switch to the new host details UI"), :class => 'btn btn-default'), :priority => 50 },
+      { :button => link_to(_("New UI"), "#{host_details_page_path(host.name)}#/Overview", :title => _("Switch to the new host details UI"), :class => 'btn btn-default'), :priority => 50 },
     ].compact
   end
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -230,7 +230,7 @@ Foreman::AccessControl.map do |permission_set|
     subnets_ajax_actions = [:freeip]
     tasks_ajax_actions = [:show]
 
-    map.permission :view_hosts,    {:hosts => [:index, :show, :errors, :active, :out_of_sync, :disabled, :pending, :vm,
+    map.permission :view_hosts,    {:hosts => [:index, :show, :legacy_show, :errors, :active, :out_of_sync, :disabled, :pending, :vm,
                                                :pxe_config, :auto_complete_search, :bmc, :build_errors, :runtime, :resources,
                                                :templates, :overview, :nics, :get_power_state, :preview_host_collection, :welcome, :statuses],
                                     :dashboard => [:OutOfSync, :errors, :active],

--- a/app/registries/foreman/settings/general.rb
+++ b/app/registries/foreman/settings/general.rb
@@ -99,5 +99,10 @@ Foreman::SettingManager.define(:foreman) do
       description: N_('Duration in days to preserve audits for. Leave empty to disable the audits cleanup.'),
       default: nil,
       full_name: N_('Saved audits interval'))
+    setting('host_details_ui',
+      type: :boolean,
+      description: N_("Foreman will load the new UI for host details"),
+      default: false,
+      full_name: N_('New host details UI'))
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -546,6 +546,7 @@ Foreman::Application.routes.draw do
   match 'host_statuses' => 'react#index', :via => :get
   constraints(id: /[^\/]+/) do
     match 'experimental/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
+    get 'legacy/hosts/:id' => 'hosts#legacy_show', :as => :legacy_host_show
   end
   get 'links/:type(/:section)' => 'links#show', :as => 'external_link', :constraints => { section: %r{.*} }
 end

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -16,7 +16,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test 'show' do
-    get :show, params: { :id => Host.first.name }, session: set_session_user
+    get :legacy_show, params: { :id => Host.first.name }, session: set_session_user
     assert_template 'show'
   end
 
@@ -1485,7 +1485,7 @@ class HostsControllerTest < ActionController::TestCase
     end
 
     test '#show renders a pagelet tab' do
-      get :show, params: {:id => Host.first.name}, session: set_session_user
+      get :legacy_show, params: {:id => Host.first.name}, session: set_session_user
       assert @response.body.match /id='my-special-id'/
     end
   end

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -27,6 +27,28 @@ class HostJSTest < IntegrationTestWithJavascript
     Fog.unmock!
   end
 
+  describe "create new host page" do
+    test "tabs are present" do
+      assert_new_button(hosts_path, "Create Host", new_host_path)
+      assert page.has_link?("Host", :href => "#primary")
+      assert page.has_link?("Interfaces", :href => "#network")
+      assert page.has_link?("Operating System", :href => "#os")
+      assert page.has_link?("Parameters", :href => "#params")
+      assert page.has_link?("Additional Information", :href => "#info")
+    end
+  end
+
+  test "destroy redirects to hosts index" do
+    disable_orchestration # Avoid DNS errors
+    visit hosts_path
+    click_link @host.fqdn
+    assert page.has_link?("Delete", :href => "/hosts/#{@host.fqdn}")
+    accept_alert do
+      first(:link, "Delete").click
+    end
+    assert_current_path hosts_path
+  end
+
   describe "show page" do
     test "has proper title and links" do
       visit hosts_path

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -13,26 +13,6 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_link?('Export', href: hosts_path(format: 'csv', search: "name = #{@host.name}"))
   end
 
-  describe "create new host page" do
-    test "tabs are present" do
-      assert_new_button(hosts_path, "Create Host", new_host_path)
-      assert page.has_link?("Host", :href => "#primary")
-      assert page.has_link?("Interfaces", :href => "#network")
-      assert page.has_link?("Operating System", :href => "#os")
-      assert page.has_link?("Parameters", :href => "#params")
-      assert page.has_link?("Additional Information", :href => "#info")
-    end
-  end
-
-  test "destroy redirects to hosts index" do
-    disable_orchestration # Avoid DNS errors
-    visit hosts_path
-    click_link @host.fqdn
-    assert page.has_link?("Delete", :href => "/hosts/#{@host.fqdn}")
-    first(:link, "Delete").click
-    assert_current_path hosts_path
-  end
-
   describe 'edit page' do
     test 'displays warning when vm not found by uuid' do
       ComputeResource.any_instance.stubs(:find_vm_by_uuid).raises(ActiveRecord::RecordNotFound)

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -19,6 +19,7 @@ export const reloadPage = () => {
  * Push a new url to foreman's react router
  * @param {String} url - the base url i.e `/hosts`
  * @param {Object} searchQuery - the query params, i.e {'per_page': 4, 'page': 2}
+ * @param {Object} state - a given state
  */
 export const pushUrl = (url, queryParams = {}) => {
   const urlWithQueries = new URI(url).search(queryParams).toString();

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -24,6 +24,7 @@ import { foremanUrl } from '../../../common/helpers';
 import { cancelBuild, deleteHost } from './actions';
 import { useForemanSettings } from '../../../Root/Context/ForemanContext';
 import BuildModal from './BuildModal';
+import { LEGACY_DETAILS_PATH } from '../consts';
 
 const ActionsBar = ({
   hostId,
@@ -101,7 +102,7 @@ const ActionsBar = ({
     <DropdownSeparator key="sp-2" />,
     <DropdownItem
       icon={<UndoIcon />}
-      href={`/hosts/${hostId}`}
+      onClick={() => visit(foremanUrl(`${LEGACY_DETAILS_PATH}/${hostId}`))}
       key="prev-version"
     >
       {__('Previous UI')}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ExperimentalAlert.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ExperimentalAlert.js
@@ -8,6 +8,7 @@ import {
 import { translate as __ } from '../../common/I18n';
 import { visit } from '../../../foreman_navigation';
 import { foremanUrl } from '../../common/helpers';
+import { LEGACY_DETAILS_PATH } from './consts';
 
 const ExperimentalAlert = ({ hostId }) => {
   const [alertVisibility, setAlertVisibility] = useState(true);
@@ -35,9 +36,11 @@ const ExperimentalAlert = ({ hostId }) => {
             {__('Share your feedback')}
           </AlertActionLink>
           <AlertActionLink
-            onClick={() => visit(foremanUrl(`/hosts/${hostId}`))}
+            onClick={() =>
+              visit(foremanUrl(`${LEGACY_DETAILS_PATH}/${hostId}`))
+            }
           >
-            {__('Switch to previous version')}
+            {__('Switch to previous UI')}
           </AlertActionLink>
         </>
       }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetailsPage.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetailsPage.js
@@ -1,0 +1,189 @@
+/* eslint-disable camelcase */
+import PropTypes from 'prop-types';
+import React, { useEffect } from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
+import {
+  Flex,
+  FlexItem,
+  Grid,
+  Tab,
+  Tabs,
+  GridItem,
+  Badge,
+  Title,
+  Breadcrumb,
+  BreadcrumbItem,
+  Text,
+  TextVariants,
+  PageSection,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+
+import Skeleton from 'react-loading-skeleton';
+import RelativeDateTime from '../../components/common/dates/RelativeDateTime';
+
+import { selectFillsIDs } from '../common/Slot/SlotSelectors';
+import { selectIsCollapsed } from '../Layout/LayoutSelectors';
+import ActionsBar from './ActionsBar';
+import { registerCoreTabs } from './Tabs';
+import { HOST_DETAILS_API_OPTIONS } from './consts';
+
+import { translate as __, sprintf } from '../../common/I18n';
+import HostGlobalStatus from './Status/GlobalStatus';
+import SkeletonLoader from '../common/SkeletonLoader';
+import { STATUS } from '../../constants';
+import './HostDetails.scss';
+import { useAPI } from '../../common/hooks/API/APIHooks';
+import TabRouter from './Tabs/TabRouter';
+import ExperimentalAlert from './ExperimentalAlert';
+
+const HostDetails = ({
+  match: {
+    params: { id },
+  },
+  location: { hash },
+  history,
+}) => {
+  const { response, status } = useAPI(
+    'get',
+    `/api/hosts/${id}`,
+    HOST_DETAILS_API_OPTIONS
+  );
+
+  const isNavCollapsed = useSelector(selectIsCollapsed);
+  const tabs = useSelector(
+    state => selectFillsIDs(state, 'host-details-page-tabs'),
+    shallowEqual
+  );
+
+  // This is a workaround due to the tabs overflow mechanism in PF4
+  useEffect(() => {
+    if (tabs?.length) dispatchEvent(new Event('resize'));
+  }, [tabs]);
+
+  useEffect(() => {
+    registerCoreTabs();
+  }, []);
+
+  return (
+    <>
+      <PageSection
+        className="host-details-header-section"
+        isFilled
+        variant="light"
+      >
+        <div style={{ marginLeft: '18px', marginRight: '18px' }}>
+          <Breadcrumb style={{ marginTop: '15px' }}>
+            <BreadcrumbItem to="/hosts">{__('Hosts')}</BreadcrumbItem>
+            <BreadcrumbItem isActive>
+              {response.name || <Skeleton />}
+            </BreadcrumbItem>
+          </Breadcrumb>
+          {/* TODO: Replace all br with css */}
+          <br />
+          <br />
+          <Grid>
+            <GridItem span={9}>
+              <SkeletonLoader status={status || STATUS.PENDING}>
+                {response && (
+                  <>
+                    <div className="hostname-wrapper">
+                      <SkeletonLoader status={status || STATUS.PENDING}>
+                        {response && (
+                          <Title
+                            className="hostname-truncate"
+                            headingLevel="h5"
+                            size="2xl"
+                          >
+                            {response.name}
+                          </Title>
+                        )}
+                      </SkeletonLoader>
+                    </div>
+                    <Split style={{ display: 'inline-flex' }} hasGutter>
+                      <SplitItem>
+                        <HostGlobalStatus hostName={id} />
+                      </SplitItem>
+                      <SplitItem>
+                        <Badge> {response?.operatingsystem_name}</Badge>
+                      </SplitItem>
+                      <SplitItem>
+                        <Badge>{response?.architecture_name}</Badge>
+                      </SplitItem>
+                    </Split>
+                  </>
+                )}
+              </SkeletonLoader>
+            </GridItem>
+            <GridItem offset={10} span={2}>
+              <Flex>
+                <FlexItem align={{ default: 'alignRight' }}>
+                  <ActionsBar
+                    computeId={response.compute_resource_id}
+                    hostId={id}
+                    permissions={response.permissions}
+                    hasReports={!!response.last_report}
+                    isBuild={response.build}
+                  />
+                </FlexItem>
+              </Flex>
+            </GridItem>
+          </Grid>
+          <SkeletonLoader
+            skeletonProps={{ width: 400 }}
+            status={status || STATUS.PENDING}
+          >
+            {response && (
+              <Text component={TextVariants.span}>
+                <RelativeDateTime date={response.created_at} defaultValue="N/A">
+                  {date =>
+                    sprintf(__('Created %s by %s'), date, response.owner_name)
+                  }
+                </RelativeDateTime>{' '}
+                <RelativeDateTime date={response.updated_at} defaultValue="N/A">
+                  {date => sprintf(__('(updated %s)'), date)}
+                </RelativeDateTime>
+              </Text>
+            )}
+          </SkeletonLoader>
+        </div>
+        <ExperimentalAlert hostId={id} />
+        {tabs && (
+          <TabRouter
+            response={response}
+            hostName={id}
+            status={status}
+            tabs={tabs}
+            router={history}
+          >
+            <Tabs
+              style={{
+                width: window.innerWidth - (isNavCollapsed ? 95 : 220),
+              }}
+              activeKey={hash.slice(2).split('/')[0]}
+            >
+              {tabs.map(tab => (
+                <Tab key={tab} eventKey={tab} title={tab} href={`#/${tab}`} />
+              ))}
+            </Tabs>
+          </TabRouter>
+        )}
+      </PageSection>
+    </>
+  );
+};
+
+HostDetails.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.string,
+    }),
+  }).isRequired,
+  location: PropTypes.shape({
+    hash: PropTypes.string,
+  }).isRequired,
+  history: PropTypes.object.isRequired,
+};
+
+export default HostDetails;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/consts.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/consts.js
@@ -1,3 +1,6 @@
 export const DEFAULT_TAB = 'Overview';
 export const HOST_DETAILS_KEY = 'HOST_DETAILS';
 export const HOST_DETAILS_API_OPTIONS = { key: HOST_DETAILS_KEY };
+export const LEGACY_DETAILS_PATH = '/legacy/hosts'
+export const EXPERIMENTAL_HOST_DETAILS = '/experimental/hosts'
+export const TAB_PREFIX = '#/';

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -1,189 +1,40 @@
-/* eslint-disable camelcase */
+import React from 'react';
 import PropTypes from 'prop-types';
-import React, { useEffect } from 'react';
-import { useSelector, shallowEqual } from 'react-redux';
+import { Redirect } from 'react-router-dom';
+import { useForemanSettings } from '../../Root/Context/ForemanContext';
 import {
-  Flex,
-  FlexItem,
-  Grid,
-  Tab,
-  Tabs,
-  GridItem,
-  Badge,
-  Title,
-  Breadcrumb,
-  BreadcrumbItem,
-  Text,
-  TextVariants,
-  PageSection,
-  Split,
-  SplitItem,
-} from '@patternfly/react-core';
+  EXPERIMENTAL_HOST_DETAILS,
+  LEGACY_DETAILS_PATH,
+  TAB_PREFIX,
+} from './consts';
+import { visit } from '../../../foreman_navigation';
+import { foremanUrl } from '../../common/helpers';
 
-import Skeleton from 'react-loading-skeleton';
-import RelativeDateTime from '../../components/common/dates/RelativeDateTime';
+const HostUISwitcher = props => {
+  const { hostDetailsUI } = useForemanSettings();
+  const {
+    match: {
+      params: { id },
+    },
+    location: { hash },
+  } = props;
 
-import { selectFillsIDs } from '../common/Slot/SlotSelectors';
-import { selectIsCollapsed } from '../Layout/LayoutSelectors';
-import ActionsBar from './ActionsBar';
-import { registerCoreTabs } from './Tabs';
-import { HOST_DETAILS_API_OPTIONS } from './consts';
+  if (hash.startsWith(TAB_PREFIX))
+    return <Redirect to={`${EXPERIMENTAL_HOST_DETAILS}/${id}`} />;
+  if (hostDetailsUI)
+    return <Redirect to={`${EXPERIMENTAL_HOST_DETAILS}/${id}`} />;
 
-import { translate as __, sprintf } from '../../common/I18n';
-import HostGlobalStatus from './Status/GlobalStatus';
-import SkeletonLoader from '../common/SkeletonLoader';
-import { STATUS } from '../../constants';
-import './HostDetails.scss';
-import { useAPI } from '../../common/hooks/API/APIHooks';
-import TabRouter from './Tabs/TabRouter';
-import ExperimentalAlert from './ExperimentalAlert';
-
-const HostDetails = ({
-  match: {
-    params: { id },
-  },
-  location: { hash },
-  history,
-}) => {
-  const { response, status } = useAPI(
-    'get',
-    `/api/hosts/${id}`,
-    HOST_DETAILS_API_OPTIONS
-  );
-
-  const isNavCollapsed = useSelector(selectIsCollapsed);
-  const tabs = useSelector(
-    state => selectFillsIDs(state, 'host-details-page-tabs'),
-    shallowEqual
-  );
-
-  // This is a workaround due to the tabs overflow mechanism in PF4
-  useEffect(() => {
-    if (tabs?.length) dispatchEvent(new Event('resize'));
-  }, [tabs]);
-
-  useEffect(() => {
-    registerCoreTabs();
-  }, []);
-
-  return (
-    <>
-      <PageSection
-        className="host-details-header-section"
-        isFilled
-        variant="light"
-      >
-        <div style={{ marginLeft: '18px', marginRight: '18px' }}>
-          <Breadcrumb style={{ marginTop: '15px' }}>
-            <BreadcrumbItem to="/hosts">{__('Hosts')}</BreadcrumbItem>
-            <BreadcrumbItem isActive>
-              {response.name || <Skeleton />}
-            </BreadcrumbItem>
-          </Breadcrumb>
-          {/* TODO: Replace all br with css */}
-          <br />
-          <br />
-          <Grid>
-            <GridItem span={9}>
-              <SkeletonLoader status={status || STATUS.PENDING}>
-                {response && (
-                  <>
-                    <div className="hostname-wrapper">
-                      <SkeletonLoader status={status || STATUS.PENDING}>
-                        {response && (
-                          <Title
-                            className="hostname-truncate"
-                            headingLevel="h5"
-                            size="2xl"
-                          >
-                            {response.name}
-                          </Title>
-                        )}
-                      </SkeletonLoader>
-                    </div>
-                    <Split style={{ display: 'inline-flex' }} hasGutter>
-                      <SplitItem>
-                        <HostGlobalStatus hostName={id} />
-                      </SplitItem>
-                      <SplitItem>
-                        <Badge> {response?.operatingsystem_name}</Badge>
-                      </SplitItem>
-                      <SplitItem>
-                        <Badge>{response?.architecture_name}</Badge>
-                      </SplitItem>
-                    </Split>
-                  </>
-                )}
-              </SkeletonLoader>
-            </GridItem>
-            <GridItem offset={10} span={2}>
-              <Flex>
-                <FlexItem align={{ default: 'alignRight' }}>
-                  <ActionsBar
-                    computeId={response.compute_resource_id}
-                    hostId={id}
-                    permissions={response.permissions}
-                    hasReports={!!response.last_report}
-                    isBuild={response.build}
-                  />
-                </FlexItem>
-              </Flex>
-            </GridItem>
-          </Grid>
-          <SkeletonLoader
-            skeletonProps={{ width: 400 }}
-            status={status || STATUS.PENDING}
-          >
-            {response && (
-              <Text component={TextVariants.span}>
-                <RelativeDateTime date={response.created_at} defaultValue="N/A">
-                  {date =>
-                    sprintf(__('Created %s by %s'), date, response.owner_name)
-                  }
-                </RelativeDateTime>{' '}
-                <RelativeDateTime date={response.updated_at} defaultValue="N/A">
-                  {date => sprintf(__('(updated %s)'), date)}
-                </RelativeDateTime>
-              </Text>
-            )}
-          </SkeletonLoader>
-        </div>
-        <ExperimentalAlert hostId={id} />
-        {tabs && (
-          <TabRouter
-            response={response}
-            hostName={id}
-            status={status}
-            tabs={tabs}
-            router={history}
-          >
-            <Tabs
-              style={{
-                width: window.innerWidth - (isNavCollapsed ? 95 : 220),
-              }}
-              activeKey={hash.slice(2).split('/')[0]}
-            >
-              {tabs.map(tab => (
-                <Tab key={tab} eventKey={tab} title={tab} href={`#/${tab}`} />
-              ))}
-            </Tabs>
-          </TabRouter>
-        )}
-      </PageSection>
-    </>
-  );
+  visit(foremanUrl(`${LEGACY_DETAILS_PATH}/${id}${hash}`));
+  return null;
 };
 
-HostDetails.propTypes = {
+HostUISwitcher.propTypes = {
   match: PropTypes.shape({
     params: PropTypes.shape({
       id: PropTypes.string,
     }),
   }).isRequired,
-  location: PropTypes.shape({
-    hash: PropTypes.string,
-  }).isRequired,
-  history: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
 };
 
-export default HostDetails;
+export default HostUISwitcher;

--- a/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/OverrideRoutes.js
+++ b/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/OverrideRoutes.js
@@ -1,0 +1,1 @@
+export const OVERRIDE_ROUTES = [{ path: '/hosts/new', exact: true }];

--- a/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/index.js
+++ b/webpack/assets/javascripts/react_app/routes/ForemanSwitcher/index.js
@@ -5,12 +5,16 @@ import { Switch, Route } from 'react-router-dom';
 
 import { fallbackRoute } from '../RoutingService';
 import { selectRoutes } from '../RouterSelector';
+import { OVERRIDE_ROUTES } from './OverrideRoutes';
 
 const ForemanSwitcher = ({ children: coreRoutes }) => {
   const routes = useSelector(() => selectRoutes(coreRoutes), shallowEqual);
 
   return (
     <Switch>
+      {OVERRIDE_ROUTES.map(({ path, exact }) => (
+        <Route path={path} exact={exact} render={fallbackRoute} key={path} />
+      ))}
       {routes}
       <Route render={fallbackRoute} key="default-route" />
     </Switch>

--- a/webpack/assets/javascripts/react_app/routes/HostDetails/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/HostDetails/constants.js
@@ -1,1 +1,2 @@
-export const HOST_DETAILS_PATH = '/experimental/hosts/:id';
+export const HOST_DETAILS_PATH = '/hosts/:id';
+export const HOST_DETAILS_EXPERIMENTAL_PATH = '/experimental/hosts/:id';

--- a/webpack/assets/javascripts/react_app/routes/HostDetails/experimental.js
+++ b/webpack/assets/javascripts/react_app/routes/HostDetails/experimental.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import HostDetailsPage from '../../components/HostDetails/HostDetailsPage';
+import { HOST_DETAILS_EXPERIMENTAL_PATH } from './constants';
+
+export default {
+  path: HOST_DETAILS_EXPERIMENTAL_PATH,
+  render: props => <HostDetailsPage {...props} />,
+};

--- a/webpack/assets/javascripts/react_app/routes/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/routes/HostDetails/index.js
@@ -4,5 +4,6 @@ import { HOST_DETAILS_PATH } from './constants';
 
 export default {
   path: HOST_DETAILS_PATH,
+  exact: true,
   render: props => <HostDetails {...props} />,
 };

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
@@ -15,6 +15,12 @@ exports[`Routes rendering routes with children renders routes with chidlren 1`] 
       render={[Function]}
     />
     <Route
+      exact={true}
+      key="/hosts/:id"
+      path="/hosts/:id"
+      render={[Function]}
+    />
+    <Route
       key="/experimental/hosts/:id"
       path="/experimental/hosts/:id"
       render={[Function]}

--- a/webpack/assets/javascripts/react_app/routes/routes.js
+++ b/webpack/assets/javascripts/react_app/routes/routes.js
@@ -1,13 +1,15 @@
 import Audits from './Audits';
 import Models from './Models';
-import HostDetails from './HostDetails';
+import HostDetailsSwitcher from './HostDetails';
+import ExperimentalHostDetails from './HostDetails/experimental';
 import RegistrationCommands from './RegistrationCommands';
 import HostStatuses from './HostStatuses';
 
 export const routes = [
   Audits,
   Models,
-  HostDetails,
+  HostDetailsSwitcher,
+  ExperimentalHostDetails,
   RegistrationCommands,
   HostStatuses,
 ];


### PR DESCRIPTION
This setting opt-in/out the new host details page. 
When it's off,  any link to `/hosts/:id` redirects to the old host show page