### PR TITLE
Fixes #33514 - correct errorToast type

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIRequest.js
@@ -79,7 +79,7 @@ export const apiRequest = async (
 
     errorToast &&
       dispatch(
-        addToast({ type: 'error', message: errorToast(error), key: FAILURE })
+        addToast({ type: 'danger', message: errorToast(error), key: FAILURE })
       );
 
     handleError(error, stopIntervalCallback);

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/__snapshots__/APIRequest.test.js.snap
@@ -73,7 +73,7 @@ Array [
         "message": Object {
           "key": "SOME_KEY_FAILURE",
           "message": "Oh no! Something went wrong, server returned the error: bad request",
-          "type": "error",
+          "type": "danger",
         },
       },
       "type": "TOASTS_ADD",


### PR DESCRIPTION
When using API middleware's errorToast option, the action dispatched has a type 'error' which is incorrect. This results in a console warning:

```
Toast notification type 'error' is invalid. Please use one of the following types: success,danger,warning,info,default
```

It transforms the error to the 'danger' type, but still displays the warning. It should be 'danger' from the beginning to avoid the console warning.