### PR TITLE
Fixes #30981 - add a slot in the new host page kebab

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/Selectors.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/Selectors.js
@@ -1,0 +1,4 @@
+import { selectComponentByWeight } from '../../common/Slot/SlotSelectors';
+
+export const selectKebabItems = () =>
+  selectComponentByWeight('host-details-kebab');

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState } from 'react';
+import { useSelector, shallowEqual } from 'react-redux';
 import {
   Button,
   DropdownItem,
@@ -9,10 +10,12 @@ import {
 } from '@patternfly/react-core';
 import { foremanUrl } from '../../../../foreman_navigation';
 import { translate as __ } from '../../../common/I18n';
+import { selectKebabItems } from './Selectors';
 
 const ActionsBar = ({ hostName }) => {
   const [kebabIsOpen, setKebab] = useState(false);
   const onKebabToggle = isOpen => setKebab(isOpen);
+  const registeredItems = useSelector(selectKebabItems, shallowEqual);
 
   const dropdownItems = [
     <DropdownItem key="delete" component="button">
@@ -25,12 +28,6 @@ const ActionsBar = ({ hostName }) => {
       {__('Build')}
     </DropdownItem>,
     <DropdownSeparator key="separator" />,
-    <DropdownItem key="[plugin]-action-1">
-      {__('plugin action 1')}
-    </DropdownItem>,
-    <DropdownItem key="[plugin]-action-2" component="button">
-      {__('plugin action 2')}
-    </DropdownItem>,
   ];
 
   return (
@@ -47,7 +44,7 @@ const ActionsBar = ({ hostName }) => {
         toggle={<KebabToggle onToggle={onKebabToggle} />}
         isOpen={kebabIsOpen}
         isPlain
-        dropdownItems={dropdownItems}
+        dropdownItems={dropdownItems.concat(registeredItems)}
       />
     </>
   );


### PR DESCRIPTION
This allows plugins to add items to the kebab dropdown in the new host details page.
```js
// plugin's global_index.js

addGlobalFill(
  'host-details-kebab',
  <FILL_KEY>,
  <DropdownItem key="[pluign]-key-1" component="button">BUTTON 1</DropdownItem>,
  100
)
addGlobalFill(
  'host-details-kebab',
  <FILL_KEY2>,
  <DropdownItem key="[pluign]-key-2" component="button">BUTTON 2</DropdownItem>,
  101
)
addGlobalFill(
  'host-details-kebab',
  <FILL_KEY3>,
  <DropdownSeparator key="[pluign]-key-3"  />,
  102
)
```