### PR TITLE
Run 'subscription-manager clean' when force=true

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -118,6 +118,11 @@ if [ -f /etc/redhat-release ]; then
 }
 
     <% if @force -%>
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager unregister || true
+      subscription-manager clean
+    fi
+
     yum remove -y katello-ca-consumer\*
     <% end -%>
 


### PR DESCRIPTION
Registration of `CentOS` & `RHEL` hosts that are already subscribed to another instance (or to cloud) fails with following error:
```
Unregistering from: foreman.example.com
Unable to verify server's identity: [SSL: TLSV1_ALERT_UNKNOWN_CA] tlsv1 alert unknown ca (_ssl.c:897)
```

Running `subscription-manager clean` fix the issue

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
