### PR TITLE
Fixes #33551 - allow searching audits by current_user

### DIFF
--- a/app/models/concerns/audit_search.rb
+++ b/app/models/concerns/audit_search.rb
@@ -33,11 +33,19 @@ module AuditSearch
     scoped_search :relation => :search_hosts, :on => :name, :complete_value => true, :rename => :host, :only_explicit => true
     scoped_search :relation => :search_hostgroups, :on => :name, :complete_value => true, :rename => :hostgroup, :only_explicit => true
     scoped_search :relation => :search_hostgroups, :on => :title, :complete_value => true, :rename => :hostgroup_title, :only_explicit => true
-    scoped_search :relation => :search_users, :on => :login, :complete_value => true, :rename => :user, :only_explicit => true
+    scoped_search :relation => :search_users, :on => :login, :complete_value => true, :rename => :user, :only_explicit => true,
+      :special_values => %w[current_user], :value_translation => ->(value) { value == 'current_user' ? User.current.login : value }
     scoped_search :relation => :search_nics, :on => :name, :complete_value => true, :rename => :interface_fqdn, :only_explicit => true
     scoped_search :relation => :search_nics, :on => :ip, :complete_value => true, :rename => :interface_ip, :only_explicit => true
     scoped_search :relation => :search_nics, :on => :mac, :complete_value => true, :rename => :interface_mac, :only_explicit => true
     scoped_search :relation => :search_settings, :on => :name, :complete_value => true, :rename => :setting, :only_explicit => true
+    scoped_search :on => :user_id,
+      :complete_value => true,
+      :rename => 'user.id',
+      :validator => ->(value) { ScopedSearch::Validators::INTEGER.call(value) },
+      :value_translation => ->(value) { value == 'current_user' ? User.current.id : value },
+      :special_values => %w[current_user],
+      :only_explicit => true
 
     def user_login
       user.login rescue nil

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -97,7 +97,8 @@ class User < ApplicationRecord
   end
 
   validates :login, :presence => true, :uniqueness => {:case_sensitive => false, :message => N_("already exists")},
-                    :format => {:with => /\A[[:alnum:]_\-@\.\\$#+]*\Z/}, :length => {:maximum => 100}
+                    :format => {:with => /\A[[:alnum:]_\-@\.\\$#+]*\Z/}, :length => {:maximum => 100},
+                    :exclusion => { in: %w(current_user) }
   validates :auth_source_id, :presence => true
   validates :password_hash, :presence => true, :if => proc { |user| user.manage_password? }
   validates :password, :confirmation => true, :if => proc { |user| user.manage_password? },


### PR DESCRIPTION
A user would like to define a filter that would allow all users to see
their own audits. The only thing that's missing is to define the
scoped_search on Audit model that would accept the current_user value
for audits' user_id.

This PR allows to search audits by the following terms

```
user.id = 1
user.id = 100
user.id = current_user
```

the syntax is consitent with other places we have similar support (e.g.
the tasks).


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
