### PR TITLE
Fixes #33560 - Pin @types/jest

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -9,6 +9,7 @@
         "@theforeman/test",
         "@theforeman/vendor-dev",
         "@theforeman/find-foreman",
+        "@types/jest",
         "axios-mock-adapter",
         "babel-eslint",
         "babel-jest",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@theforeman/stories": ">= 8.7, < 8.12.1",
     "@theforeman/test": ">= 8.7, < 8.12.1",
     "@theforeman/vendor-dev": ">= 8.7, < 8.12.1",
+    "@types/jest": "<27.0.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",


### PR DESCRIPTION
RTL jest-dom publishes its types in `@types/testing-lib__jest-dom`, which has open-ended dependency on `@types/jest`. That causes `@types/jest` 27.y.z to be pulled in, which in turns brings `jest-diff` and `jest-get-type` from the 27 release while other jest packages remain at version 26, which derails the tests.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
