### PR TITLE
Fixes #33574 - resize network field width of vmware/ovirt/libvirt

### DIFF
--- a/app/views/compute_resources_vms/form/libvirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_network.html.erb
@@ -3,33 +3,35 @@
 <% bridges = compute_resource.bridges %>
 
 <%= selectable_f f, :type, libvirt_networks(compute_resource), {},
-                 { :label    => _('Network type'),
-                   :disabled => !new_vm,
-                   :onchange => 'tfm.computeResource.libvirt.networkSelected(this)',
-                   :class => 'libvirt_network',
-                   :label_size => "col-md-3"
-                 } %>
+                 :class => 'libvirt_network',
+                 :size => "col-md-8", :disabled => !new_vm,
+                 :label    => _('Network type'), :label_size => "col-md-3",
+                 :onchange => 'tfm.computeResource.libvirt.networkSelected(this)' %>
 
 <div id='nat' class='<%= 'hide' if f.object.type != 'network' %>'>
   <%= selectable_f f, :network, nat.map { |n| n.name.force_encoding('UTF-8') },
                    { :include_blank => nat.any? ? false : _("No networks") },
-                   { :class => "libvirt_nat", :label => _("Network"), :disabled => (f.object.type != 'network' || !new_vm), :label_size => "col-md-3" } %>
+                   :class => "libvirt_nat",
+                   :size => "col-md-8", :disabled => (f.object.type != 'network' || !new_vm),
+                   :label => _("Network"), :label_size => "col-md-3" %>
 </div>
 
 <div id='bridge' class='<%= 'hide' if f.object.type && (f.object.type != 'bridge') %>'>
   <% if bridges.any? %>
-    <%= selectable_f f, :bridge, bridges.map { |bridge| bridge.name.force_encoding('UTF-8') },
-                     { :class => "libvirt_bridge", :label => _("Network"), :disabled => !new_vm, :label_size => "col-md-3" } %>
+    <%= selectable_f f, :bridge, bridges.map { |bridge| bridge.name.force_encoding('UTF-8') }, {},
+                     :class => "libvirt_bridge",
+                     :size => "col-md-8", :disabled => !new_vm,
+                     :label => _("Network"), :label_size => "col-md-3" %>
   <% else %>
     <%= text_f f, :bridge,
       :class => "libvirt_bridge",
-      :label => _("Network"),
+      :size => "col-md-8", :disabled => !new_vm,
+      :label => _("Network"), :label_size => "col-md-3",
       :label_help => _('There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)'),
-      :label_help_options => { :rel => 'popover-modal' },
-      :disabled => !new_vm,
-      :label_size => "col-md-3" %>
+      :label_help_options => { :rel => 'popover-modal' } %>
   <% end %>
 </div>
 
 <%= selectable_f f, :model, %w(virtio rtl8139 ne2k_pci pcnet e1000), {},
-                 { :label => _('NIC type'), :disabled => !new_vm, :label_size => "col-md-3" } %>
+                 :size => "col-md-8", :disabled => !new_vm,
+                 :label => _('NIC type'), :label_size => "col-md-3" %>

--- a/app/views/compute_resources_vms/form/ovirt/_network.html.erb
+++ b/app/views/compute_resources_vms/form/ovirt/_network.html.erb
@@ -1,17 +1,26 @@
-<%= text_f f, :name, :disabled => !new_vm, :class => "ovirt_name", :label => _('Name'), :label_size => "col-md-3" %>
+<%= text_f f, :name,
+           :class => "ovirt_name",
+           :size => "col-md-8", :disabled => !new_vm,
+           :label => _('Name'), :label_size => "col-md-3" %>
 
 <% selected_cluster ||= params.fetch(:host, {}).fetch(:compute_attributes, {}).fetch(:cluster, nil) %>
 <% selected_cluster ||= compute_resource.clusters.first.try(:id) %>
 <% networks = compute_resource.networks(selected_cluster ? { :cluster_id => selected_cluster } : { }) %>
 <%= select_f f, :vnic_profile, compute_resource.vnic_profiles,
-             :id, :name, {}, :label => _('Vnic Profile'), :label_size => "col-md-3", :disabled => !new_vm,
-             :class => "ovirt_network",
+             :id, :name, {},
+             :class => "ovirt_network", 
+             :size => "col-md-8", :disabled => !new_vm,
+             :label => _('Vnic Profile'), :label_size => "col-md-3",
              :onchange => 'tfm.computeResource.ovirt.vnicSelected(this)',
              :data => {:profiles => JSON.generate(compute_resource.vnic_profiles), :networks => JSON.generate(networks) } %>
-<%= select_f f, :network, networks, :id, :name,
-             { }, :disabled => !new_vm, :class => "ovirt_network",
-             :label         => _('Network'), :label_size => "col-md-3"%>
+<%= select_f f, :network, networks,
+             :id, :name, {},
+             :class => "ovirt_network",
+             :size => "col-md-8", :disabled => !new_vm,
+             :label => _('Network'), :label_size => "col-md-3" %>
 
 <%= select_f f, :interface, compute_resource.nictypes,
-             :id, :name, {}, :label => _('Interface type'), :label_size => "col-md-3", :disabled => !new_vm,
-             :class => "ovirt_network" %>
+             :id, :name, {},
+             :class => "ovirt_network", 
+             :size => "col-md-8",  :disabled => !new_vm,
+             :label => _('Interface type'), :label_size => "col-md-3" %>

--- a/app/views/compute_resources_vms/form/vmware/_network.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_network.html.erb
@@ -1,9 +1,9 @@
 <%= select_f f, :type, compute_resource.nictypes, :first, :last, { },
-  :class => "col-md-3 vmware_type",
-  :label => _('NIC type'), :label_size => "col-md-3", :disabled => !new_vm
-%>
+    :class => "col-md-3 vmware_type",
+    :size => "col-md-8", :disabled => !new_vm,
+    :label => _('NIC type'), :label_size => "col-md-3" %>
 <% cluster_id = params.fetch(:host, {}).fetch(:compute_attributes, {}).fetch(:cluster, nil).presence %>
 <%= select_f f, :network, vsphere_networks(compute_resource), :first, :last, { },
-  :class => "col-md-3 vmware_network",
-  :label => _('Network'), :label_size => "col-md-3", :disabled => !new_vm
-%>
+             :class => "col-md-3 vmware_network",
+             :size => "col-md-8", :disabled => !new_vm,
+             :label => _('Network'), :label_size => "col-md-3" %>


### PR DESCRIPTION
I have only checked vmware, but the same pattern has been found/applied on ovirt/libvirt

Testing needs a vmware/ovirt/libvirt  instance.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
