### PR TITLE
Fixes #33597 - add an experimental banner on host details page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -29,6 +29,21 @@ const ActionsBar = ({ hostId, permissions: { edit_hosts: canEdit } }) => {
       {__('Build')}
     </DropdownItem>,
     <DropdownSeparator key="separator" />,
+    <DropdownItem href={`/hosts/${hostId}`} key="prev-version">
+      {__('Previous version')}
+    </DropdownItem>,
+    <DropdownItem
+      onClick={() =>
+        window.open(
+          'https://community.theforeman.org/t/foreman-3-0-new-host-detail-page-feedback/25281',
+          '_blank'
+        )
+      }
+      key="feedback"
+      component="button"
+    >
+      {__('Share feedback')}
+    </DropdownItem>,
   ];
 
   return (
@@ -41,6 +56,7 @@ const ActionsBar = ({ hostId, permissions: { edit_hosts: canEdit } }) => {
         {__('Edit')}
       </Button>
       <Dropdown
+        alignments={{ default: 'right' }}
         toggle={<KebabToggle onToggle={onKebabToggle} />}
         isOpen={kebabIsOpen}
         isPlain

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ExperimentalAlert.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ExperimentalAlert.js
@@ -1,0 +1,55 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import {
+  Alert,
+  AlertActionCloseButton,
+  AlertActionLink,
+} from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+import { visit } from '../../../foreman_navigation';
+import { foremanUrl } from '../../common/helpers';
+
+const ExperimentalAlert = ({ hostId }) => {
+  const [alertVisibility, setAlertVisibility] = useState(true);
+  if (!alertVisibility) return null;
+  return (
+    <Alert
+      isInline
+      variant="info"
+      title={__(
+        'This page redesign is experimental and under active development.'
+      )}
+      actionClose={
+        <AlertActionCloseButton onClose={() => setAlertVisibility(false)} />
+      }
+      actionLinks={
+        <>
+          <AlertActionLink
+            onClick={() =>
+              window.open(
+                'https://community.theforeman.org/t/foreman-3-0-new-host-detail-page-feedback/25281',
+                '_blank'
+              )
+            }
+          >
+            {__('Share your feedback')}
+          </AlertActionLink>
+          <AlertActionLink
+            onClick={() => visit(foremanUrl(`/hosts/${hostId}`))}
+          >
+            {__('Switch to previous version')}
+          </AlertActionLink>
+        </>
+      }
+    />
+  );
+};
+
+ExperimentalAlert.propTypes = {
+  hostId: PropTypes.string,
+};
+ExperimentalAlert.defaultProps = {
+  hostId: undefined,
+};
+
+export default ExperimentalAlert;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
@@ -29,3 +29,7 @@
   max-width: 60%;
   margin-right: 8px;
 }
+
+.host-details-header-section .pf-c-alert {
+  margin: 15px 24px;
+}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
 import {
+  Flex,
+  FlexItem,
   Grid,
   Tab,
   Tabs,
@@ -34,6 +36,7 @@ import { STATUS } from '../../constants';
 import './HostDetails.scss';
 import { useAPI } from '../../common/hooks/API/APIHooks';
 import TabRouter from './Tabs/TabRouter';
+import ExperimentalAlert from './ExperimentalAlert';
 
 const HostDetails = ({
   match: {
@@ -114,7 +117,11 @@ const HostDetails = ({
               </SkeletonLoader>
             </GridItem>
             <GridItem offset={10} span={2}>
-              <ActionsBar hostId={id} permissions={response.permissions} />
+              <Flex>
+                <FlexItem align={{ default: 'alignRight' }}>
+                  <ActionsBar hostId={id} permissions={response.permissions} />
+                </FlexItem>
+              </Flex>
             </GridItem>
           </Grid>
           <SkeletonLoader
@@ -134,8 +141,8 @@ const HostDetails = ({
               </Text>
             )}
           </SkeletonLoader>
-          <br />
         </div>
+        <ExperimentalAlert hostId={id} />
         {tabs && (
           <TabRouter
             response={response}


### PR DESCRIPTION
This banner specifies that the page is under development and also use as a call for feedback.

![Screen Shot 2021-09-30 at 0 29 35](https://user-images.githubusercontent.com/11807069/135351639-b4401815-77b7-439b-95d9-16ccf0eb8240.png)
