### PR TITLE
Fixes #33504 - align hostname title in host details page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
@@ -12,6 +12,20 @@
   padding: 18px;
   background: #f0f0f0;
   .pf-c-card {
-    height: 100%
+    height: 100%;
   }
+}
+
+.hostname-truncate {
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  display: inline-block;
+}
+
+.hostname-wrapper {
+  display: inline-flex;
+  max-width: 60%;
+  margin-right: 8px;
 }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalStatus.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalStatus.js
@@ -31,7 +31,7 @@ const GlobalStatus = ({ hostName }) => {
 
   return (
     <>
-      <a onClick={handleGlobalStatusClick}>
+      <a style={{ fontSize: '18px' }} onClick={handleGlobalStatusClick}>
         <StatusIcon statusNumber={global} />
       </a>
       <StatusesModal

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusIcon.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusIcon.js
@@ -19,26 +19,26 @@ const StatusIcon = ({ statusNumber, label }) => {
     case OK_STATUS_STATE:
       return (
         <span className="status-success">
-          <CheckCircleIcon /> {label}
+          <CheckCircleIcon noVerticalAlign /> {label}
         </span>
       );
     case WARNING_STATUS_STATE:
       return (
         <span className="status-warning">
-          <ExclamationTriangleIcon /> {label}
+          <ExclamationTriangleIcon noVerticalAlign /> {label}
         </span>
       );
 
     case ERROR_STATUS_STATE:
       return (
         <span className="status-error">
-          <ExclamationCircleIcon /> {label}
+          <ExclamationCircleIcon noVerticalAlign /> {label}
         </span>
       );
     case NA_STATUS_STATE:
       return (
         <span className="disabled">
-          <BanIcon /> {label}
+          <BanIcon noVerticalAlign /> {label}
         </span>
       );
     default:

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
@@ -13,6 +14,8 @@ import {
   Text,
   TextVariants,
   PageSection,
+  Split,
+  SplitItem,
 } from '@patternfly/react-core';
 
 import Skeleton from 'react-loading-skeleton';
@@ -78,21 +81,39 @@ const HostDetails = ({
           <br />
           <br />
           <Grid>
-            <GridItem span={3}>
-              <Title headingLevel="h5" size="2xl">
-                {/* TODO: Make a generic Skeleton HOC (withSkeleton) */}
-                {response.name || <Skeleton />}{' '}
-                <HostGlobalStatus hostName={id} />
-              </Title>
+            <GridItem span={9}>
+              <SkeletonLoader status={status || STATUS.PENDING}>
+                {response && (
+                  <>
+                    <div className="hostname-wrapper">
+                      <SkeletonLoader status={status || STATUS.PENDING}>
+                        {response && (
+                          <Title
+                            className="hostname-truncate"
+                            headingLevel="h5"
+                            size="2xl"
+                          >
+                            {response.name}
+                          </Title>
+                        )}
+                      </SkeletonLoader>
+                    </div>
+                    <Split style={{ display: 'inline-flex' }} hasGutter>
+                      <SplitItem>
+                        <HostGlobalStatus hostName={id} />
+                      </SplitItem>
+                      <SplitItem>
+                        <Badge> {response?.operatingsystem_name}</Badge>
+                      </SplitItem>
+                      <SplitItem>
+                        <Badge>{response?.architecture_name}</Badge>
+                      </SplitItem>
+                    </Split>
+                  </>
+                )}
+              </SkeletonLoader>
             </GridItem>
-            <GridItem
-              style={{ marginTop: '5px', marginRight: '30px' }}
-              span={7}
-            >
-              <Badge key={1}>{response.operatingsystem_name}</Badge>{' '}
-              <Badge key={21}>{response.architecture_name}</Badge>
-            </GridItem>
-            <GridItem span={2}>
+            <GridItem offset={10} span={2}>
               <ActionsBar hostId={id} permissions={response.permissions} />
             </GridItem>
           </Grid>


### PR DESCRIPTION
#### Before: 
![Screen Shot 2021-10-03 at 18 26 20](https://user-images.githubusercontent.com/11807069/135760807-a02a3eef-0d13-4715-894f-79f2f97fb456.png)

#### After (long hostname):
![Screen Shot 2021-10-03 at 18 13 06](https://user-images.githubusercontent.com/11807069/135760830-f20dcbde-b268-4713-adf4-9e8e9a9a0074.png)


#### After (short hostname):
![Screen Shot 2021-10-03 at 18 10 40](https://user-images.githubusercontent.com/11807069/135760817-bd617ba6-5038-4e30-9858-b6fea1681a5c.png)
