### PR TITLE
Fixes #33626 - use webpack for foreman plugin gems

### DIFF
--- a/script/plugin_webpack_directories.rb
+++ b/script/plugin_webpack_directories.rb
@@ -37,11 +37,14 @@ config = { entries: {}, paths: [], plugins: {} }
 entry_paths = []
 plugin_name_regexp = /foreman.*|katello.*/
 specs.each do |dep|
+  dep = dep.to_spec if gemfile_in
+
   # skip other rails engines that are not plugins
   # TODO: Consider using the plugin registration api?
-  next unless dep.name =~ plugin_name_regexp
-  next if dep.name =~ /.*[_-]core$/
-  dep = dep.to_spec if gemfile_in
+  unless dep.respond_to?("metadata") && dep.metadata.has_key?("is_foreman_plugin") && dep.metadata["is_foreman_plugin"] == "true"
+    next unless dep.name =~ plugin_name_regexp
+    next if dep.name =~ /.*[_-]core$/
+  end
 
   path = "#{dep.to_spec.full_gem_path}/webpack"
 


### PR DESCRIPTION
A plugin can specify by the following line in the gemspec that it is
really a foreman plugin:

s.metadata    = { "is_foreman_plugin" => "true" }

BTW:
Metadata items have the following restrictions:
- The metadata must be a Hash object
- **All keys and values must be Strings**
- Keys can be a maximum of 128 bytes and values can be a maximum of 1024 bytes
- All strings must be UTF-8, no binary data is allowed 


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
