### PR TITLE
Fixes #33632 - move react-intl to foreman-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,17 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^8.8.0",
-    "eslint-plugin-spellcheck": "0.0.17",
+    "@theforeman/vendor": "^8.15.0",
     "intl": "~1.2.5",
-    "jed": "^1.1.1",
-    "react-intl": "^2.8.0"
+    "jed": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": ">= 8.7, < 8.12.1",
-    "@theforeman/eslint-plugin-foreman": ">= 8.7, < 8.12.1",
-    "@theforeman/stories": ">= 8.7, < 8.12.1",
-    "@theforeman/test": ">= 8.7, < 8.12.1",
-    "@theforeman/vendor-dev": ">= 8.7, < 8.12.1",
+    "@theforeman/builder": "^8.15.0",
+    "@theforeman/eslint-plugin-foreman": "^8.15.0",
+    "@theforeman/stories": "^8.15.0",
+    "@theforeman/test": "^8.15.0",
+    "@theforeman/vendor-dev": "^8.15.0",
     "@types/jest": "<27.0.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
@@ -44,6 +42,7 @@
     "cssnano": "^4.1.10",
     "dotenv": "^5.0.0",
     "eslint": "^6.7.2",
+    "eslint-plugin-spellcheck": "0.0.17",
     "expose-loader": "~0.6.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.9.0",


### PR DESCRIPTION
react-intl is being used in core and also in multiple plugins
and it makes sense to move it into foreman-js

foreman-js PR: https://github.com/theforeman/foreman-js/pull/351


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
