### PR TITLE
Fixes #33637 - Correctly redirect hostgroup create page

### DIFF
--- a/app/controllers/concerns/foreman/controller/set_redirection_path.rb
+++ b/app/controllers/concerns/foreman/controller/set_redirection_path.rb
@@ -13,6 +13,9 @@ module Foreman::Controller::SetRedirectionPath
   end
 
   def set_redirect_path
+    # Clear the stored url if the referer is the current URL. This can occur due
+    # to client side routing that modifies the history prior to the page load.
+    return reset_redirect_path if request.url == request.referer
     session[:redirect_path] = request.referer
   end
 end


### PR DESCRIPTION
When creating the first hostgroup from the welcome page, submit does not
redirect back to the hostgroups index page due to incorrect referer
being stored in the session `redirect_path` value. This is similar to
the fix in 03a6981cd, but for pages that use the `SetRedirectionPath`
concern to control their form redirections.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
