### PR TITLE
Fixes #33639 - Reduce object allocations in FactImporter#update_facts

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -4,6 +4,8 @@ class FactImporter
   delegate :logger, :to => :Rails
   attr_reader :counters
 
+  FACT_NAME_TYPE = 'fact_names.type'.freeze
+
   def self.support_background
     false
   end
@@ -138,7 +140,7 @@ class FactImporter
     time = Time.now.utc
     updated = 0
     db_facts_names = []
-    host.fact_values.joins(:fact_name).where('fact_names.type' => fact_name_class_name).reorder('').find_each do |record|
+    host.fact_values.includes([:fact_name]).joins(:fact_name).where(FACT_NAME_TYPE => fact_name_class_name).reorder('').find_each do |record|
       next unless fact_names.include?(record.name)
       new_value = facts[record.name]
       if record.value != new_value


### PR DESCRIPTION
I'm investigating increased memory usage in the app and I noticed this endpoint had a higher # of allocations compared to previous versions. This fix brings the number back down to where it was

Before
```
15:28:45 rails.1   | 2021-10-05T15:28:45 [I|app|b655c1b5] Started PUT "/rhsm/consumers/8c652afb-0cbb-453e-80fb-359002ec97b8" for 192.168.122.243 at 2021-10-05 15:28:45 +0000
15:28:46 rails.1   | 2021-10-05T15:28:46 [I|app|b655c1b5] Completed 200 OK in 1079ms (Views: 0.4ms | ActiveRecord: 119.7ms | Allocations: 362692)
```

After
```
15:26:53 rails.1   | 2021-10-05T15:26:53 [I|app|2b991eee] Started PUT "/rhsm/consumers/8c652afb-0cbb-453e-80fb-359002ec97b8" for 192.168.122.243 at 2021-10-05 15:26:53 +0000
15:26:53 rails.1   | 2021-10-05T15:26:53 [I|app|2b991eee] Completed 200 OK in 536ms (Views: 0.3ms | ActiveRecord: 42.2ms | Allocations: 150510)
```
