### PR TITLE
Fixes #33640 - Improve caching of SettingRegistry#load_values

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -100,7 +100,7 @@ class SettingRegistry
     load_definitions
 
     # load all db values
-    load_values
+    load_values(ignore_cache: true)
 
     # create missing settings in the database
     @settings.except(*Setting.unscoped.all.pluck(:name)).each do |name, definition|
@@ -131,16 +131,29 @@ class SettingRegistry
     end
   end
 
-  def load_values
+  def known_categories
+    unless @known_descendants == Setting.descendants
+      @known_descendants = Setting.descendants
+      @known_categories = @known_descendants.map(&:name) << 'Setting'
+      @values_loaded_at = nil # force all values to be reloaded
+    end
+    @known_categories
+  end
+
+  def load_values(ignore_cache: false)
     # we are loading only known STIs as we load settings fairly early the first time and plugin classes might not be loaded yet.
-    Setting.unscoped.where(category: Setting.descendants.map(&:name) + %w[Setting]).all.each do |s|
+    settings = Setting.unscoped.where(category: known_categories)
+    settings = settings.where('updated_at >= ?', @values_loaded_at) unless ignore_cache || @values_loaded_at.nil?
+    settings.each do |s|
       unless (definition = find(s.name))
         logger.debug("Setting #{s.name} has no definition, clean up your database")
         next
       end
       definition.updated_at = s.updated_at
       definition.value = s.value
+      logger.debug("Updated cached value for setting=#{s.name}")
     end
+    @values_loaded_at = Time.zone.now if settings.any?
   end
 
   def _add(name, category:, type:, default:, description:, full_name:, context:, value: nil, encrypted: false, collection: nil, options: {})

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -151,7 +151,7 @@ class SettingRegistry
       end
       definition.updated_at = s.updated_at
       definition.value = s.value
-      logger.debug("Updated cached value for setting=#{s.name}")
+      logger.debug("Updated cached value for setting=#{s.name}") unless ignore_cache
     end
     @values_loaded_at = Time.zone.now if settings.any?
   end

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
     end
 
     test "should render not_found" do
-      Setting::Provisioning.any_instance.stubs(:value).returns('not-existing-template')
+      Setting[:default_global_registration_item] = ""
       get :global
       assert_response :not_found
     end

--- a/test/integration/setting_js_test.rb
+++ b/test/integration/setting_js_test.rb
@@ -22,7 +22,8 @@ class SettingJSTest < IntegrationTestWithJavascript
           full_name: 'Pretty setting')
       end
     end
-    Foreman.settings.load_definitions
+
+    Foreman.settings.load
 
     assert_index_page(settings_path, "Settings", false, true, false)
     assert page.has_link?("My Pretty Setting Label", :href => "#category_label_test")

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -14,6 +14,27 @@ class SettingRegistryTest < ActiveSupport::TestCase
     registry.load_values
   end
 
+  describe '#load_values' do
+    it "doesn't update definitions for unchanged settings" do
+      registry.expects(:find).never
+
+      registry.load_values
+    end
+
+    it "updates definitions for changed settings" do
+      setting.update(value: 100)
+      registry.expects(:find).once
+
+      registry.load_values
+    end
+
+    it "can be forced to load all values" do
+      registry.expects(:find).times(Setting.count)
+
+      registry.load_values(ignore_cache: true)
+    end
+  end
+
   describe 'the value getter' do
     context 'with nil default' do
       let(:default) { nil }


### PR DESCRIPTION
While investigating a downstream issue involving greatly increased memory usage over time (something like 2x per puma process) I started comparing the Allocation details for various endpoints. I found that compared to earlier releases (downstream sat 6.9) there was, in some cases, 4x the number of object allocations per request.

Consider this single endpoint in 6.10
```
REQUEST | REQUESTS | TOTAL ALLOCATIONS | AVG ALLOCATIONS
Katello::Api::V2::RootController#rhsm_resource_list | 116028 | 12449524050 | 107297
```

and in 6.9:

```
REQUEST | REQUESTS | TOTAL ALLOCATIONS | AVG ALLOCATIONS
Katello::Api::V2::RootController#rhsm_resource_list | 38 | 910353 | 23956
```

What's interesting is that this endpoint (aside from establishing session, etc) doesn't even hit the DB in its implementation. But I found this with SQL logging:

```
Setting Load (0.9ms)  SELECT "settings".* FROM "settings" WHERE "settings"."category" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9)  [["category", "Setting::ForemanTasks"], ["category"
, "Setting::RemoteExecution"], ["category", "Setting::Email"], ["category", "Setting::Notification"], ["category", "Setting::Provisioning"], ["category", "Setting::Puppet"], ["category", "Setting::Auth"], ["category", "Setting::Content"],
 ["category", "Setting"]]
```

And that led me to this PR which introduced the `SettingRegistry` => https://github.com/theforeman/foreman/pull/8002

Once I commented out the `load_settings` method in BaseController I saw dramatically reduced allocations, and from that came this fix.

With my limited knowledge of the SettingRegistry, it seemed unnecessary that each request should load *every value* for *every setting*. I changed `load_values` to be aware of when it last updated any values in the registry, and updated the query to use that timestamp in order to fetch only updated settings. It seems to work fine, but I think this needs careful examination from @ezr-ondrej 

**To test this PR**

- clear the logs (rake log:clear)
- hit a few API endpoints
- analyze the allocations => https://gist.github.com/jturel/7c22f4017f00c441e22cd90e3a17bd16 (awk -f file_from_gist.awk log/development.log)

- clear the logs
- check out this pr
- perform the same API requests
- analyze the allocations with the AWK script and compare with previous output
- observe that the numbers have gone down (in some cases way down)
- change the value of some settings
- test that the app is aware of those changes