### PR TITLE
Refs #33639 - Only pull needed data for fact updates

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -137,7 +137,6 @@ class FactImporter
   def update_facts
     time = Time.now.utc
     updated = 0
-    db_facts_names = []
     db_facts = host.fact_values.joins(:fact_name).where(fact_names: {type: fact_name_class_name}).reorder(nil).pluck(:name, :value, :id)
     db_facts.each do |name, value, id|
       next unless fact_names.include?(name)
@@ -147,8 +146,8 @@ class FactImporter
         FactValue.where(id: id).update_all(:value => new_value, :updated_at => time)
         updated += 1
       end
-      db_facts_names << name
     end
+    db_facts_names = db_facts.map(&:first) & fact_names.keys
     @facts_to_create = facts.keys - db_facts_names
     @counters[:updated] = updated
   end


### PR DESCRIPTION
Instead of initializing FactValue and FactName for all facts that need
updating, only pull the required columns from the DB and use them for
the update.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
