### PR TITLE
Fixes #33660 - ignore dynflow tables for dump

### DIFF
--- a/config/initializers/dynflow.rb
+++ b/config/initializers/dynflow.rb
@@ -1,2 +1,14 @@
 # Ignore Dynflow tables when schema-dumping. Dynflow tables are handled automatically by Dynflow.
-ActiveRecord::SchemaDumper.ignore_tables << '^dynflow_*'
+# Ruby dumper recognizes table names and regular expression (as string), PostgreSQL dumper only
+# recognizes table names as it passes this to pg_dump via arguments.
+#
+ActiveRecord::SchemaDumper.ignore_tables = [
+  'dynflow_actions',
+  'dynflow_coordinator_records',
+  'dynflow_delayed_plans',
+  'dynflow_envelopes',
+  'dynflow_execution_plans',
+  'dynflow_output_chunks',
+  'dynflow_schema_info',
+  'dynflow_steps',
+]


### PR DESCRIPTION
Ruby schema dump contains dynflow tables again, which is causing issues with foreign keys with multi-column PKs.

Regression introduced in https://github.com/theforeman/foreman/pull/8660