### PR TITLE
Refs #33639 - use upsert for fact updates

### DIFF
--- a/test/benchmark/puppet_fact_importer_benchmark.rb
+++ b/test/benchmark/puppet_fact_importer_benchmark.rb
@@ -12,32 +12,39 @@ class StructuredFactImporter
   end
 end
 
-def generate_facts(total, unique_names = 0, structured_names = 0)
-  facts = Hash[(1..total).map { |i| ["fact_#{i}", "value_#{i}"] }]
-  (total..total + unique_names).map { |i| facts["fact_#{i}_#{Foreman.uuid}"] = "value_#{i}" }
-  (total..total + structured_names).map { |i| facts[(["f#{i}"] * (i % 10)).join('::') + i.to_s] = "value_#{i}" }
-  facts
+def random_facts(total, &block)
+  Hash[(1..total).map(&block)]
 end
 
 Rails.logger.level = Logger::ERROR
 
 foreman_benchmark do
   Benchmark.ips do |x|
-    x.config(:time => 10, :warmup => 0)
+    x.config(:time => 10, :warmup => 1)
+    size = 300
 
-    [::PuppetFactImporter, ::StructuredFactImporter].each do |importer|
-      [200, 500].each do |total_facts|
-        [0, 50].each do |unique_names|
-          [0, 25].each do |structured_names|
-            facts = generate_facts(total_facts, unique_names, structured_names)
-            x.report("#{importer} (#{total_facts}) - #{unique_names} UN #{structured_names} SN") do
-              host = FactoryBot.create(:host, :name => "benchmark-#{Foreman.uuid}")
-              importer.new(host, facts).import!
-              importer.new(host, {}).import!
-            end
-          end
-        end
-      end
+    facts = random_facts(size) { |i| ["fact_#{i}", "value_#{i}"] }
+    x.report("Plain puppet same facts: #{size}") do
+      host = FactoryBot.create(:host, :name => "benchmark-#{Foreman.uuid}")
+      PuppetFactImporter.new(host, facts).import!
+    end
+
+    host = FactoryBot.create(:host, :name => "benchmark-#{Foreman.uuid}")
+    x.report("Plain puppet unique values: #{size}") do
+      facts = random_facts(size) { |i| ["fact_#{i}", "value_#{i}_#{Foreman.uuid}"] }
+      PuppetFactImporter.new(host, facts).import!
+    end
+
+    facts = random_facts(size) { |i| ["fact_#{i}_#{Foreman.uuid}", "value_#{i}_#{Foreman.uuid}"] }
+    x.report("Plain puppet unique all: #{size}") do
+      host = FactoryBot.create(:host, :name => "benchmark-#{Foreman.uuid}")
+      PuppetFactImporter.new(host, facts).import!
+    end
+
+    facts = random_facts(size) { |i| ["a::b::c::d::ee::fact_#{i}_#{Foreman.uuid}", "value_#{i}_#{Foreman.uuid}"] }
+    host = FactoryBot.create(:host, :name => "benchmark-#{Foreman.uuid}")
+    x.report("Structured puppet unique all: #{size}") do
+      PuppetFactImporter.new(host, facts).import!
     end
   end
 end


### PR DESCRIPTION
Since Rails 6 supports `upsert_all` I was hoping to get some performance boots, but I could not find many places for use of this. The only use case is `update_facts` method but unfortunately, it does not show any performance benefits:

```
Calculating -------------------------------------
Plain puppet same facts: 300
                         12.552  (± 0.0%) i/s -    126.000  in  10.055716s
Plain puppet unique values: 300
                         17.250  (±17.4%) i/s -    167.000  in  10.092047s
Plain puppet unique all: 300
                         12.409  (± 8.1%) i/s -    123.000  in  10.010812s
Structured puppet unique all: 300
                         18.031  (±11.1%) i/s -    177.000  in  10.005997s
Memory stats
Total objects allocated: 46164589
Total heap pages allocated: 9525
```

Which is the same after my patch:

```
Calculating -------------------------------------
Plain puppet same facts: 300
                         12.436  (± 8.0%) i/s -    125.000  in  10.071976s
Plain puppet unique values: 300
                         17.079  (±17.6%) i/s -    165.000  in  10.035237s
Plain puppet unique all: 300
                         12.308  (± 8.1%) i/s -    122.000  in  10.021320s
Structured puppet unique all: 300
                         17.944  (±11.1%) i/s -    177.000  in  10.049742s
Memory stats
Total objects allocated: 45845912
Total heap pages allocated: 9512
```

I wish we stored facts in more straightforward way like `FACTS(ID, HOST_ID, TYPE, NAME, VALUE)` then we could leverage `upsert_all` to its full potential.

Unless @jturel sees some boost in his workload, we can close this. I thought I'd share this since I spent some time digging into this and I managed to accidentally delete my development database. Have no backup this time! Yay.