### PR TITLE
Fixes #33671 - hide apipie warning in config

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -74,8 +74,8 @@ Apipie.configure do |config|
 end
 
 # check apipie cache in dev mode
-if Foreman.in_rake?('apipie:cache', 'apipie:cache:index')
-  # No need to check the cache if we're regenerating
+if Foreman.in_rake?('apipie:cache', 'apipie:cache:index', 'config')
+  # No need to check the cache if we're regenerating or handling config
 elsif Apipie.configuration.use_cache
   cache_name = File.join(Apipie.configuration.cache_dir, Apipie.configuration.doc_base_url + '.json')
   if File.exist?(cache_name)


### PR DESCRIPTION
before this patch:

    # foreman-rake config -- -k use_shortname_for_vms
    API controllers newer than Apipie cache! Run apipie:cache rake task to regenerate cache.
    false

after this patch:

    # foreman-rake config -- -k use_shortname_for_vms
    false


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
