### PR TITLE
Refs #33671 - print apipie warnings on stderr

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -89,13 +89,13 @@ elsif Apipie.configuration.use_cache
       end
     end
     if outdated
-      puts "API controllers newer than Apipie cache! Run apipie:cache rake task to regenerate cache."
+      warn "API controllers newer than Apipie cache! Run apipie:cache rake task to regenerate cache."
     end
   else
-    puts "Apipie cache enabled but not present yet. Run apipie:cache rake task to speed up API calls."
+    warn "Apipie cache enabled but not present yet. Run apipie:cache rake task to speed up API calls."
   end
 else
-  puts "The Apipie cache is turned off. Enable it and run apipie:cache rake task to speed up API calls."
+  warn "The Apipie cache is turned off. Enable it and run apipie:cache rake task to speed up API calls."
 end
 
 # special type of validator: we say that it's not specified


### PR DESCRIPTION
warnings should go to stderr, so callers can filter them out, without
filtering the normal output


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
