### PR TITLE
Fixes #33672 - drop unnecessary timestamps

### DIFF
--- a/db/migrate/20211011093749_drop_unnecessary_timestamps.rb
+++ b/db/migrate/20211011093749_drop_unnecessary_timestamps.rb
@@ -1,0 +1,27 @@
+class DropUnnecessaryTimestamps < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      [
+        :cached_user_roles,
+        :cached_usergroup_members,
+        :fact_names,
+        :fact_values,
+        :settings,
+        :taxable_taxonomies,
+        :taxonomies,
+      ].each do |table|
+        change_table table do |t|
+          dir.up do
+            remove_column table, :created_at
+            remove_column table, :updated_at
+          end
+          dir.down do
+            t.timestamps
+            table.classify.constantize.update_all(created_at: Time.now.utc, updated_at: Time.now.utc)
+          end
+        end
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
I've reviewed `db/schema.rb` and found these. I do believe these are useless, let's see if it breaks any tests.