### PR TITLE
[2.5] Fixes #33639 - Optimize fact parser improvements

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -4,6 +4,8 @@ class FactImporter
   delegate :logger, :to => :Rails
   attr_reader :counters
 
+  FACT_NAME_TYPE = 'fact_names.type'.freeze
+
   def self.support_background
     false
   end
@@ -138,7 +140,7 @@ class FactImporter
     time = Time.now.utc
     updated = 0
     db_facts_names = []
-    host.fact_values.joins(:fact_name).where('fact_names.type' => fact_name_class_name).reorder('').find_each do |record|
+    host.fact_values.includes([:fact_name]).joins(:fact_name).where(FACT_NAME_TYPE => fact_name_class_name).reorder('').find_each do |record|
       next unless fact_names.include?(record.name)
       new_value = facts[record.name]
       if record.value != new_value

--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -137,7 +137,6 @@ class FactImporter
   def update_facts
     time = Time.now.utc
     updated = 0
-    db_facts_names = []
     db_facts = host.fact_values.joins(:fact_name).where(fact_names: {type: fact_name_class_name}).reorder(nil).pluck(:name, :value, :id)
     db_facts.each do |name, value, id|
       next unless fact_names.include?(name)
@@ -147,8 +146,8 @@ class FactImporter
         FactValue.where(id: id).update_all(:value => new_value, :updated_at => time)
         updated += 1
       end
-      db_facts_names << name
     end
+    db_facts_names = db_facts.map(&:first) & fact_names.keys
     @facts_to_create = facts.keys - db_facts_names
     @counters[:updated] = updated
   end


### PR DESCRIPTION
This takes the recent patches to optimize the fact parser improvements to 2.5. Unlike #8820, this doesn't include the settings improvements. There were a bunch on conflicts in the critical part of the code. That's best left to its own PR.