### PR TITLE
[2.5] Fixes #33640 - Leverage caching of SettingRegistry#load_values

### DIFF
--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -9,7 +9,7 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
     end
 
     test "should render not_found" do
-      Setting::Provisioning.any_instance.stubs(:value).returns('not-existing-template')
+      Setting[:default_global_registration_item] = ""
       get :global
       assert_response :not_found
     end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -20,6 +20,27 @@ class SettingRegistryTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#load_values' do
+    it "doesn't update definitions for unchanged settings" do
+      registry.expects(:find).never
+
+      registry.load_values
+    end
+
+    it "updates definitions for changed settings" do
+      setting.update(value: 100)
+      registry.expects(:find).once
+
+      registry.load_values
+    end
+
+    it "can be forced to load all values" do
+      registry.expects(:find).times(Setting.count)
+
+      registry.load_values(ignore_cache: true)
+    end
+  end
+
   it 'provides default if no value defined' do
     assert_equal 5, registry['foo']
     assert_equal 5, registry[:foo]


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
