### PR TITLE
Fixes #33680 - removed AppStream Pulp2 workaround

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -84,17 +84,7 @@ liveimg --url=<%= liveimg_url %> <%= proxy_string %>
 <% else %>
 <%= @mediapath %><%= proxy_string %>
 <% @additional_media.each do |medium| -%>
-<% if rhel_compatible && @host.operatingsystem.name.downcase.include?("centos") && os_major >= 8 && medium[:url] && medium[:url].include?("AppStream") -%>
-<% appstream_present = true -%>
-# renamed from "<%= medium[:url] %>" for CentOS Anaconda to work
-repo --name AppStream --baseurl <%= medium[:url] %>
-<% else -%>
 repo --name <%= medium[:name] %> --baseurl <%= medium[:url] %> <%= medium[:install] ? ' --install' : '' %><%= proxy_string %>
-<% end -%>
-<% end -%>
-<% if rhel_compatible && @host.operatingsystem.name.downcase.include?("centos") && os_major >= 8 && medium_uri && medium_uri.to_s.include?("BaseOS") && !appstream_present -%>
-# repository added using BaseOS to AppStream string replacement
-repo --name AppStream --baseurl <%= medium_uri.to_s.gsub("BaseOS", "AppStream") %>
 <% end -%>
 <%= snippet_if_exists(template_name + " custom repositories") %>
 <% end %>


### PR DESCRIPTION
This is no longer necessary, Pulp 3.10+ correctly recognizes and sync AppStream variant as part of the BaseOS repo. Tested on CentOS 8 Stream and Rocky Linux.

For more info: https://community.theforeman.org/t/testing-of-centos-alma-rocky-8-apprepo/25649

Pulp2 users might still need this in their templates, but in our develop branch this is not an issue anymore.