### PR TITLE
Fixes #27024 - Adding audit cleanup duration and update rake task

### DIFF
--- a/app/registries/foreman/settings.rb
+++ b/app/registries/foreman/settings.rb
@@ -103,5 +103,10 @@ Foreman::SettingManager.define(:foreman) do
       description: N_("The instance title is shown on the top navigation bar (requires reload of page)."),
       default: nil,
       full_name: N_('Instance title'))
+    setting('audits_period',
+      type: :integer,
+      description: N_('Duration in days to preserve audits for. Leave empty to disable the audits cleanup.'),
+      default: nil,
+      full_name: N_('Saved audits interval'))
   end
 end


### PR DESCRIPTION
Adding setting 'audit_period' to know how long saved audits user wants.
Also updating rake task for cleanup to reflect this setting

This is a complementary PR for https://github.com/theforeman/foreman-packaging/pull/7150
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
