### PR TITLE
Fixes #33696 - add build review modal in host details

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -241,9 +241,23 @@ class HostsController < ApplicationController
 
   def cancelBuild
     if @host.built(false)
-      process_success :success_msg => _("Canceled pending build for %s") % @host.name, :success_redirect => :back
+      respond_to do |format|
+        format.html do
+          process_success :success_msg => _("Canceled pending build for %s") % @host.name, :success_redirect => :back
+        end
+        format.json do
+          render :json => { :success_msg => _("Canceled pending build for %s") % @host.name }
+        end
+      end
     else
-      process_error :redirect => :back, :error_msg => _("Failed to cancel pending build for %{hostname} with the following errors: %{errors}") % {:hostname => @host.name, :errors => @host.errors.full_messages.join(', ')}
+      respond_to do |format|
+        format.html do
+          process_error :redirect => :back, :error_msg => _("Failed to cancel pending build for %{hostname} with the following errors: %{errors}") % {:hostname => @host.name, :errors => @host.errors.full_messages.join(', ')}
+        end
+        format.json do
+          render :json => { :errors => @host.errors.full_messages.join(', ') }, :status => :internal_server_error
+        end
+      end
     end
   end
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -176,7 +176,14 @@ class HostsController < ApplicationController
 
   def review_before_build
     @build = @host.build_status_checker
-    render :layout => false
+    respond_to do |format|
+      format.html do
+        render :layout => false
+      end
+      format.json do
+        render :json => @build.to_json
+      end
+    end
   end
 
   def setBuild
@@ -189,18 +196,46 @@ class HostsController < ApplicationController
           else
             message = _("Enabled %s for rebuild on next boot, but failed to power cycle the host")
           end
-          process_success :success_msg => message % @host, :success_redirect => :back
+          respond_to do |format|
+            format.html do
+              process_success :success_msg => message % @host, :success_redirect => :back
+            end
+            format.json do
+              render :json => { :success_msg => message % @host }
+            end
+          end
         rescue => error
           message = _('Failed to reboot %s.') % @host
           warning(message)
           Foreman::Logging.exception(message, error)
-          process_success :success_msg => _("Enabled %s for rebuild on next boot") % @host, :success_redirect => :back
+          respond_to do |format|
+            format.html do
+              process_success :success_msg => _("Enabled %s for rebuild on next boot") % @host, :success_redirect => :back
+            end
+            format.json do
+              render :json => { :success_msg => _("Enabled %s for rebuild on next boot") % @host }
+            end
+          end
         end
       else
-        process_success :success_msg => _("Enabled %s for rebuild on next boot") % @host, :success_redirect => :back
+        respond_to do |format|
+          format.html do
+            process_success :success_msg => _("Enabled %s for rebuild on next boot") % @host, :success_redirect => :back
+          end
+          format.json do
+            render :json => { :success_msg => _("Enabled %s for rebuild on next boot") % @host }
+          end
+        end
       end
     else
-      process_error :redirect => :back, :error_msg => _("Failed to enable %{host} for installation: %{errors}") % { :host => @host, :errors => @host.errors.full_messages }
+      respond_to do |format|
+        format.html do
+          process_error :redirect => :back, :error_msg => _("Failed to enable %{host} for installation: %{errors}") % { :host => @host, :errors => @host.errors.full_messages }
+        end
+        format.json do
+          render :json => { :errors => @host.errors.full_messages }, :status => :internal_server_error
+        end
+      end
     end
   end
 

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js
@@ -1,0 +1,123 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  Alert,
+  TreeView,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
+import { translate as __ } from '../../../common/I18n';
+import { useAPI } from '../../../common/hooks/API/APIHooks';
+import { foremanUrl } from '../../../common/helpers';
+import SkeletonLoader from '../../common/SkeletonLoader';
+import { STATUS } from '../../../constants';
+import { API_OPTIONS, SUPPORTED_ERRORS } from './constants';
+import { selectBuildErrorsTree, selectNoErrorState } from './Selectors';
+import { buildHost } from './actions';
+import StatusIcon from '../Status/StatusIcon';
+import { ERROR_STATUS_STATE, OK_STATUS_STATE } from '../Status/Constants';
+
+const BuildModal = ({ isModalOpen, onClose, hostId }) => {
+  const [activeErrors, setActiveErrors] = useState();
+  const errorsTree = useSelector(selectBuildErrorsTree);
+  const noErrors = useSelector(selectNoErrorState);
+  const dispach = useDispatch();
+  const { status } = useAPI(
+    'get',
+    foremanUrl(`/hosts/${hostId}/review_before_build`),
+    API_OPTIONS
+  );
+  const onSelectError = (evt, treeViewItem) => {
+    setActiveErrors([treeViewItem]);
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title={__('Review before build')}
+      isOpen={isModalOpen}
+      onClose={onClose}
+      actions={[
+        <Button
+          key="confirm"
+          variant="primary"
+          onClick={() => {
+            dispach(buildHost(hostId));
+            onClose();
+          }}
+        >
+          {__('Build')}
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          {__('Cancel')}
+        </Button>,
+      ]}
+    >
+      <Stack hasGutter>
+        <StackItem>
+          <FormattedMessage
+            id="build"
+            values={{
+              hostName: <b>{hostId}</b>,
+            }}
+            defaultMessage={__(
+              'Build enables host {hostName} to rebuild on next boot'
+            )}
+          />
+        </StackItem>
+
+        <StackItem>
+          <Alert
+            variant="warning"
+            isInline
+            title={__(
+              'This action will delete this host and all its data (i.e facts, report)'
+            )}
+          />
+        </StackItem>
+        <StackItem>
+          <SkeletonLoader
+            skeletonProps={{ count: Object.keys(SUPPORTED_ERRORS).length }}
+            status={status || STATUS.PENDING}
+          >
+            {noErrors ? (
+              <StatusIcon
+                label={__('No errors detected')}
+                statusNumber={OK_STATUS_STATE}
+              />
+            ) : (
+              <>
+                <StatusIcon
+                  label={__(
+                    'The following errors may prevent a successful build:'
+                  )}
+                  statusNumber={ERROR_STATUS_STATE}
+                />
+
+                <TreeView
+                  data={errorsTree}
+                  activeItems={activeErrors}
+                  onSelect={onSelectError}
+                  hasBadges
+                />
+              </>
+            )}
+          </SkeletonLoader>
+        </StackItem>
+      </Stack>
+    </Modal>
+  );
+};
+
+BuildModal.propTypes = {
+  hostId: PropTypes.string.isRequired,
+  isModalOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default BuildModal;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js
@@ -38,7 +38,7 @@ const BuildModal = ({ isModalOpen, onClose, hostId }) => {
 
   return (
     <Modal
-      variant={ModalVariant.small}
+      variant={ModalVariant.medium}
       title={__('Review before build')}
       isOpen={isModalOpen}
       onClose={onClose}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/Selectors.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/Selectors.js
@@ -1,4 +1,31 @@
+import { selectAPIResponse } from '../../../redux/API/APISelectors';
 import { selectComponentByWeight } from '../../common/Slot/SlotSelectors';
+import { SUPPORTED_ERRORS, API_OPTIONS } from './constants';
 
 export const selectKebabItems = () =>
   selectComponentByWeight('host-details-kebab');
+
+export const selectBuildErrors = state =>
+  selectAPIResponse(state, API_OPTIONS.key)?.errors;
+
+export const selectBuildErrorsTree = state => {
+  const buildErrors = selectBuildErrors(state);
+  return buildErrors
+    ? Object.entries(buildErrors)
+        .map(([key, value]) => ({
+          name: SUPPORTED_ERRORS[key],
+          id: key,
+          children: value.map((item, idx) => ({
+            name: item.message,
+            id: `${key}-${idx}`,
+          })),
+        }))
+        ?.filter(error => error.children.length)
+    : [];
+};
+
+export const selectNoErrorState = state => {
+  const buildErrors = selectBuildErrors(state);
+  const isEmptyArray = currentValue => currentValue.length === 0;
+  return buildErrors ? Object.values(buildErrors).every(isEmptyArray) : false;
+};

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
@@ -57,3 +57,18 @@ export const deleteHost = (
     })
   );
 };
+
+export const buildHost = hostId => dispatch => {
+  const successToast = () =>
+    sprintf(__('Host %s will be built next boot'), hostId);
+  const errorToast = ({ message }) => message;
+  const url = foremanUrl(`/hosts/${hostId}/setBuild`);
+  dispatch(
+    APIActions.put({
+      url,
+      key: `${hostId}-BUILD`,
+      successToast,
+      errorToast,
+    })
+  );
+};

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
@@ -3,6 +3,7 @@ import { foremanUrl } from '../../../common/helpers';
 import { sprintf, translate as __ } from '../../../common/I18n';
 import { openConfirmModal } from '../../ConfirmModal';
 import { APIActions } from '../../../redux/API';
+import { HOST_DETAILS_KEY } from '../consts';
 
 export const deleteHost = (
   hostName,
@@ -58,6 +59,16 @@ export const deleteHost = (
   );
 };
 
+export const updateHost = hostId => dispatch => {
+  const url = foremanUrl(`/api/hosts/${hostId}`);
+  dispatch(
+    APIActions.get({
+      url,
+      key: HOST_DETAILS_KEY,
+    })
+  );
+};
+
 export const buildHost = hostId => dispatch => {
   const successToast = () =>
     sprintf(__('Host %s will be built next boot'), hostId);
@@ -66,9 +77,26 @@ export const buildHost = hostId => dispatch => {
   dispatch(
     APIActions.put({
       url,
-      key: `${hostId}-BUILD`,
+      key: `${hostId}_BUILD`,
       successToast,
       errorToast,
+      handleSuccess: () => dispatch(updateHost(hostId)),
+    })
+  );
+};
+
+export const cancelBuild = hostId => dispatch => {
+  const successToast = () =>
+    sprintf(__('Canceled pending build for %s'), hostId);
+  const errorToast = ({ message }) => message;
+  const url = foremanUrl(`/hosts/${hostId}/cancelBuild`);
+  dispatch(
+    APIActions.get({
+      url,
+      key: `${hostId}_CANCEL_BUILD`,
+      successToast,
+      errorToast,
+      handleSuccess: () => dispatch(updateHost(hostId)),
     })
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/constants.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/constants.js
@@ -1,0 +1,6 @@
+export const SUPPORTED_ERRORS = {
+  host: __('Host'),
+  templates: __('Templates'),
+  proxies: __('Proxies'),
+};
+export const API_OPTIONS = { key: 'BUILD_REVIEW' };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -4,8 +4,8 @@ import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import {
   Button,
   DropdownItem,
-  DropdownSeparator,
   Dropdown,
+  DropdownSeparator,
   KebabToggle,
 } from '@patternfly/react-core';
 import {
@@ -15,6 +15,7 @@ import {
   CommentIcon,
   UndoIcon,
   FileInvoiceIcon,
+  BuildIcon,
 } from '@patternfly/react-icons';
 import { visit } from '../../../../foreman_navigation';
 import { translate as __ } from '../../../common/I18n';
@@ -22,6 +23,7 @@ import { selectKebabItems } from './Selectors';
 import { foremanUrl } from '../../../common/helpers';
 import { deleteHost } from './actions';
 import { useForemanSettings } from '../../../Root/Context/ForemanContext';
+import BuildModal from './BuildModal';
 
 const ActionsBar = ({
   hostId,
@@ -34,6 +36,7 @@ const ActionsBar = ({
   },
 }) => {
   const [kebabIsOpen, setKebab] = useState(false);
+  const [isBuildModalOpen, setBuildModal] = useState(false);
   const onKebabToggle = isOpen => setKebab(isOpen);
   const { destroyVmOnHostDelete } = useForemanSettings();
   const registeredItems = useSelector(selectKebabItems, shallowEqual);
@@ -41,6 +44,14 @@ const ActionsBar = ({
   const deleteHostHandler = () =>
     dispatch(deleteHost(hostId, computeId, destroyVmOnHostDelete));
   const dropdownItems = [
+    <DropdownItem
+      onClick={() => setBuildModal(true)}
+      key="build"
+      component="button"
+      icon={<BuildIcon />}
+    >
+      {__('Build')}
+    </DropdownItem>,
     <DropdownItem
       isDisabled={!canCreate}
       onClick={() => visit(foremanUrl(`/hosts/${hostId}/clone`))}
@@ -59,7 +70,7 @@ const ActionsBar = ({
     >
       {__('Delete')}
     </DropdownItem>,
-    <DropdownSeparator />,
+    <DropdownSeparator key="sp-1" />,
     <DropdownItem
       onClick={() => visit(foremanUrl(`/hosts/${hostId}/facts`))}
       key="fact"
@@ -77,7 +88,7 @@ const ActionsBar = ({
     >
       {__('Reports')}
     </DropdownItem>,
-    <DropdownSeparator />,
+    <DropdownSeparator key="sp-2" />,
     <DropdownItem
       icon={<UndoIcon />}
       href={`/hosts/${hostId}`}
@@ -116,6 +127,13 @@ const ActionsBar = ({
         isPlain
         dropdownItems={dropdownItems.concat(registeredItems)}
       />
+      {isBuildModalOpen && (
+        <BuildModal
+          isModalOpen={isBuildModalOpen}
+          onClose={() => setBuildModal(false)}
+          hostId={hostId}
+        />
+      )}
     </>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -21,13 +21,14 @@ import { visit } from '../../../../foreman_navigation';
 import { translate as __ } from '../../../common/I18n';
 import { selectKebabItems } from './Selectors';
 import { foremanUrl } from '../../../common/helpers';
-import { deleteHost } from './actions';
+import { cancelBuild, deleteHost } from './actions';
 import { useForemanSettings } from '../../../Root/Context/ForemanContext';
 import BuildModal from './BuildModal';
 
 const ActionsBar = ({
   hostId,
   computeId,
+  isBuild,
   hasReports,
   permissions: {
     destroy_hosts: canDestroy,
@@ -43,14 +44,23 @@ const ActionsBar = ({
   const dispatch = useDispatch();
   const deleteHostHandler = () =>
     dispatch(deleteHost(hostId, computeId, destroyVmOnHostDelete));
+
+  const buildHandler = () => {
+    if (isBuild) {
+      dispatch(cancelBuild(hostId));
+      setKebab(false);
+    } else {
+      setBuildModal(true);
+    }
+  };
   const dropdownItems = [
     <DropdownItem
-      onClick={() => setBuildModal(true)}
+      onClick={buildHandler}
       key="build"
       component="button"
       icon={<BuildIcon />}
     >
-      {__('Build')}
+      {isBuild ? __('Cancel build') : __('Build')}
     </DropdownItem>,
     <DropdownItem
       isDisabled={!canCreate}
@@ -143,12 +153,14 @@ ActionsBar.propTypes = {
   computeId: PropTypes.number,
   permissions: PropTypes.object,
   hasReports: PropTypes.bool,
+  isBuild: PropTypes.bool,
 };
 ActionsBar.defaultProps = {
   hostId: undefined,
   computeId: undefined,
   permissions: { destroy_hosts: false, create_hosts: false, edit_hosts: false },
   hasReports: false,
+  isBuild: false,
 };
 
 export default ActionsBar;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -124,6 +124,7 @@ const HostDetails = ({
                     hostId={id}
                     permissions={response.permissions}
                     hasReports={!!response.last_report}
+                    isBuild={response.build}
                   />
                 </FlexItem>
               </Flex>


### PR DESCRIPTION
The strings are taken from the legacy modal, open for changes.

![Screen Shot 2021-10-14 at 19 50 13](https://user-images.githubusercontent.com/11807069/137367089-a1aeef78-6499-473d-bd2c-66fa80a3a3fd.png)

suggestion for `No errors found ` state:
![Screen Shot 2021-10-14 at 19 33 42](https://user-images.githubusercontent.com/11807069/137367110-1d288d39-8ec2-4507-92b4-3cf341238636.png)
