### PR TITLE
Fixes #33706 - dont fail build on old Setting categories

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -115,7 +115,8 @@ class SettingRegistry
     @settings = {}
 
     Setting.descendants.each do |cat_cls|
-      if cat_cls.default_settings.empty? && (Setting.table_exists? rescue(false))
+      if cat_cls.default_settings.empty?
+        next unless (Setting.table_exists? rescue(false))
         # Setting category uses really old way of doing things
         _load_category_from_db(cat_cls)
       else


### PR DESCRIPTION
Old setting categories are redirected to an bad branch when the setting table does not exists.