### PR TITLE
Fixes #33723 - Make dynflow-sidekiq services PartOf foreman.service

### DIFF
--- a/extras/systemd/dynflow-sidekiq@.service
+++ b/extras/systemd/dynflow-sidekiq@.service
@@ -2,6 +2,7 @@
 Description=Foreman jobs daemon - %i on sidekiq
 Documentation=https://theforeman.org
 After=network.target remote-fs.target nss-lookup.target
+PartOf=foreman.service
 
 [Service]
 Type=notify


### PR DESCRIPTION
By doing so systemd stops all dynflow-sidekiq services before stopping
foreman itself and then starts everything in reverse order on restart.
This circumvents the issue with services being restarted at different
times.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
