### PR TITLE
Fixes #33727 - Fixed gathering of allowed actions for permission

### DIFF
--- a/app/registries/foreman/access_control.rb
+++ b/app/registries/foreman/access_control.rb
@@ -22,7 +22,14 @@ module Foreman
         mapper = Mapper.new
         yield mapper
         @permissions ||= []
-        @permissions += mapper.mapped_permissions
+        mapper.mapped_permissions.each do |permission|
+          if (perm = permission(permission.name))
+            Rails.logger.warn "You are trying to replace #{perm.name} from #{permission.engine}. Adding allowed actions from plugin permissions to the existing one."
+            perm.actions.concat(permission.actions)
+          else
+            @permissions << permission
+          end
+        end
       end
 
       attr_reader :permissions


### PR DESCRIPTION
Plugins can define own permissions. They can also extend existing permissions with own actions (https://github.com/theforeman/foreman_ansible/blob/master/lib/foreman_ansible/register.rb#L149). Or not? I figured out that the definition of existing permission in plugin causes creating another Permission with the same name as the core counterpart but with only plugin-specific actions. Then, when you try to do some action defined by that plugin you end up with the permission error.
It's happen because method `allowed_actions` method look for the permission by `permission` method and it's find only first occurrence (that's the behavior of the `detect` method) of that permission and that's the core one without action defined in plugin and that's never end good.

I'm marking this PR as draft because bad move in roles and permissions can cause a nice security problem but even that the bug is caused by `permission()` method I didn't fixed it there. This method is public and it's used in plugin for extending existing permissions (https://github.com/theforeman/foreman_puppet/blob/master/lib/foreman_puppet/register.rb#L9). 

This topic is complex and I think that's great topic for further discussion because I that foreman deserve better way how to handle extending of existing permissions by plugins but now I just try to fix the bug until we find a better way. 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
