### PR TITLE
Fixes #33740 - load inital values from DSL

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -111,7 +111,7 @@ class SettingRegistry
       # Creating missing records as we operate over the DB model while updating the setting
       _new_db_record(definition).save(validate: false)
       definition.updated_at = nil
-      definition.value = definition.default
+      definition.value ||= definition.default
     end
   end
 
@@ -163,6 +163,7 @@ class SettingRegistry
 
   def _add(name, category:, type:, default:, description:, full_name:, context:, value: nil, encrypted: false, collection: nil, options: {})
     Setting.select_collection_registry.add(name, collection: collection, **options) if collection
+    Foreman::Deprecation.deprecation_warning('3.3', "initial value of setting '#{name}' should be created in a migration") if value
 
     @settings[name.to_s] = SettingPresenter.new({ name: name,
                                                   context: context,
@@ -170,6 +171,7 @@ class SettingRegistry
                                                   settings_type: type.to_s,
                                                   description: description,
                                                   default: default,
+                                                  value: value,
                                                   full_name: full_name,
                                                   collection: collection,
                                                   encrypted: encrypted })
@@ -184,6 +186,7 @@ class SettingRegistry
     Setting.new(name: definition.name,
                 category: definition.category.safe_constantize&.name || 'Setting',
                 default: definition.default,
+                value: definition.value,
                 description: definition.description)
   end
 

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -11,3 +11,4 @@
     communicate over HTTPS. If needed, you can use `config.ssl_options` to exempt
     matching endpoints from being redirected to HTTPS.
 - message: Initialization autoloaded the constants
+- message: You are using a deprecated behavior, it will be removed in version 3.3, initial value of setting 'instance_id' should be created in a migration

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1678,6 +1678,19 @@ The settings are strongly typed and you have to define it.
 The basic types supported by Foreman are: `:boolean`, `:integer`, `:float`, `:string`, `:text`, `:hash`, `:array`.
 The `:text` type supports markdown and usage of such setting should expect markdown syntax when using it.
 
+==== Initial setting value
+
+If you want the setting to have initial value please use migration to seed it.
+
+[source, ruby]
+```
+class SeedInitialFooSettingValue < ActiveRecord::Migration[6.0]
+  def up
+    Setting.find_or_create(name: 'foo').update(value: Foreman.uuid)
+  end
+end
+```
+
 ==== Validate setting values
 
 To validate setting value, you can use API, that tries to mimic the API of ActiveRecord.

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -8,10 +8,20 @@ class SettingRegistryTest < ActiveSupport::TestCase
   let(:setting) { Setting.create(registry.find('foo').attributes) }
 
   setup do
-    registry.stubs(settings: setting_memo)
     registry._add('foo', type: :integer, category: 'Setting', default: default, full_name: 'test foo', description: 'test foo', context: :test)
     setting.update(value: setting_value)
     registry.load_values
+  end
+
+  describe '#load' do
+    it 'loads initial value from the inventory, tho deprecates it' do
+      uuid = Foreman.uuid
+      registry.stubs(:load_definitions)
+      Foreman::Deprecation.expects(:deprecation_warning)
+      registry._add('test_uuid', type: :string, category: 'general', default: 'uuid', value: uuid, full_name: 'test uuid', description: 'test uuid', context: :test)
+      registry.load
+      assert_equal uuid, Setting['test_uuid'], 'The initial value was not set'
+    end
   end
 
   describe '#load_values' do


### PR DESCRIPTION
The DSL defined inital values has been ignored as those were left out in the transition.
