### PR TITLE
Fixes #33757 - reports button link to new reports

### DIFF
--- a/app/views/config_reports/index.html.erb
+++ b/app/views/config_reports/index.html.erb
@@ -14,6 +14,11 @@
     },
   ]
 ) if @host %>
+<%= alert class: 'alert-warning',
+  header: _('Migrate Reports to new format'),
+  text: "</br>".html_safe +
+        _("Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in") +
+        ' <a href="https://community.theforeman.org/t/migrating-reports-to-the-new-format-in-foreman-3-1/25846">our tutorial</a>.'.html_safe %>
 <% title _("Reports") %>
 <% title_actions csv_link, documentation_button('3.5.4PuppetReports') %>
 <%= render :partial => 'list' %>


### PR DESCRIPTION
Reports are changing to Host Reports:

https://community.theforeman.org/t/host-reports-plugin-in-foreman-3-1/25796

Let's advertise this on the old page and allow people to migrate to the new endpoint and format.

(Edit: Previously this patch was also about redirecting Reports button on the host detail page, but I changed my mind. We can do this via Deface if we decide it is too confusing to have two Reports button on the page.)