### PR TITLE
Fixes #33758 - update foreman-js 8.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,19 +21,17 @@
     "create-react-component": "yo react-domain"
   },
   "dependencies": {
-    "@theforeman/vendor": "^8.8.0",
-    "eslint-plugin-spellcheck": "0.0.17",
+    "@theforeman/vendor": "^8.16.0",
     "intl": "~1.2.5",
-    "jed": "^1.1.1",
-    "react-intl": "^2.8.0"
+    "jed": "^1.1.1"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
-    "@theforeman/builder": ">= 8.7, < 8.12.1",
-    "@theforeman/eslint-plugin-foreman": ">= 8.7, < 8.12.1",
-    "@theforeman/stories": ">= 8.7, < 8.12.1",
-    "@theforeman/test": ">= 8.7, < 8.12.1",
-    "@theforeman/vendor-dev": ">= 8.7, < 8.12.1",
+    "@theforeman/builder": "^8.16.0",
+    "@theforeman/eslint-plugin-foreman": "^8.16.0",
+    "@theforeman/stories": "^8.16.0",
+    "@theforeman/test": "^8.16.0",
+    "@theforeman/vendor-dev": "^8.16.0",
     "@types/jest": "<27.0.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",
@@ -44,6 +42,7 @@
     "cssnano": "^4.1.10",
     "dotenv": "^5.0.0",
     "eslint": "^6.7.2",
+    "eslint-plugin-spellcheck": "0.0.17",
     "expose-loader": "~0.6.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.9.0",

--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/__snapshots__/TaxonomyDropdown.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/__snapshots__/TaxonomyDropdown.test.js.snap
@@ -88,6 +88,8 @@ exports[`TaxonomyDropdown rendering rendering 1`] = `
   }
   id="organization-dropdown"
   isOpen={false}
+  isPlain={false}
+  isText={false}
   menuAppendTo="inline"
   onSearchButtonClick={[Function]}
   onSearchInputChange={[Function]}

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/Insecure.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/Insecure.test.js.snap
@@ -20,6 +20,7 @@ exports[`RegistrationCommandsPage fields - Insecure renders 1`] = `
       </span>
     }
     onChange={[Function]}
+    ouiaSafe={true}
   />
 </FormGroup>
 `;

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/TokenLifeTime.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/TokenLifeTime.test.js.snap
@@ -36,6 +36,7 @@ exports[`RegistrationCommandsPage fields - TokenLifeTime renders 1`] = `
         isValid={true}
         label="unlimited"
         onChange={[Function]}
+        ouiaSafe={true}
       />
     </InputGroupText>
   </InputGroup>


### PR DESCRIPTION
packaging pr:https://github.com/theforeman/foreman-packaging/pull/7188
new pf4 has flyouts navigation, will open a pr for it soon :)
Also has a small fix for thats needed for REX select components.
Looks like the jest revert worked as Katello tests are running ok except for 3 snapshot failures 