### PR TITLE
Refs #33551 - fix the searching in audits by user

### DIFF
--- a/app/models/concerns/audit_search.rb
+++ b/app/models/concerns/audit_search.rb
@@ -18,6 +18,9 @@ module AuditSearch
     scoped_search :on => :id, :complete_value => false
     scoped_search :on => :request_uuid, :complete_value => false, :only_explicit => true
     scoped_search :on => [:username, :remote_address, :comment], :complete_value => true
+    scoped_search :relation => :user, :on => :login, :complete_value => true, :rename => :authored_by_user, :only_explicit => true,
+      :special_values => %w[current_user], :value_translation => ->(value) { value == 'current_user' ? User.current.login : value }
+
     scoped_search :on => :audited_changes, :rename => 'changes'
     scoped_search :on => :created_at, :complete_value => true, :rename => :time, :default_order => :desc
     scoped_search :on => :action, :complete_value => true
@@ -41,7 +44,7 @@ module AuditSearch
     scoped_search :relation => :search_settings, :on => :name, :complete_value => true, :rename => :setting, :only_explicit => true
     scoped_search :on => :user_id,
       :complete_value => true,
-      :rename => 'user.id',
+      :rename => 'authored_by_user.id',
       :validator => ->(value) { ScopedSearch::Validators::INTEGER.call(value) },
       :value_translation => ->(value) { value == 'current_user' ? User.current.id : value },
       :special_values => %w[current_user],


### PR DESCRIPTION
The first PR allowed to search in search_users relation, however that
searches on the actual audited objects. So when used in filters, it
would grant access to see all audits of $my account by anyone. While
such search may still be useful, the original intention was to allow
searching by the author of the audit.

Given the user is already a search keyword, we call this
authored_by_user. The correct syntax then is

authored_by_user = admin
authored_by_user = current_user

authored_by_user.id = 2
authored_by_user.id = current_user


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
