### PR TITLE
Fixes #33769 - Windows client installation type

### DIFF
--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -195,6 +195,8 @@ class PuppetFactParser < FactParser
 
     if os_name == 'RedHat' && facts[:lsbdistid] == 'RedHatEnterpriseWorkstation'
       os_name += '_Workstation'
+    elsif os_name == 'windows' && facts.dig(:os, :windows, :installation_type) == 'Client'
+      os_name += '_client'
     end
 
     os_name

--- a/test/static_fixtures/facts/puppet_facts_windows_10.json
+++ b/test/static_fixtures/facts/puppet_facts_windows_10.json
@@ -1,0 +1,79 @@
+{
+  "dmi": {
+    "manufacturer": "HP",
+    "product": {
+      "name": "HP EliteDesk 800 G2 SFF",
+      "serial_number": "ABCDEF1234",
+      "uuid": "4BBF7647-0551-4D17-9796-FAE6CACA344B"
+    }
+  },
+  "facterversion": "4.2.5",
+  "fips_enabled": false,
+  "identity": {
+    "privileged": false,
+    "user": "AD\\user"
+  },
+  "is_virtual": false,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.19043",
+  "kernelversion": "10.0.19043",
+  "memory": {
+    "system": {
+      "available": "5.19 GiB",
+      "available_bytes": 5573398528,
+      "capacity": "67.32%",
+      "total": "15.88 GiB",
+      "total_bytes": 17054482432,
+      "used": "10.69 GiB",
+      "used_bytes": 11481083904
+    }
+  },
+  "networking": {
+    "domain": "ad",
+    "fqdn": "client.ad",
+    "hostname": "client"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "10",
+      "major": "10"
+    },
+    "windows": {
+      "display_version": "21H1",
+      "edition_id": "Education",
+      "installation_type": "Client",
+      "product_name": "Windows 10 Education",
+      "release_id": "21H1",
+      "system32": "C:\\WINDOWS\\system32"
+    }
+  },
+  "path": "C:/Program Files/Puppet Labs/DevelopmentKit/private/ruby/2.5.9/bin;C:/Program Files/Puppet Labs/DevelopmentKit/private/ruby/2.5.9/lib/ruby/gems/2.5.0/bin;C:/Program Files/Puppet Labs/DevelopmentKit/share/cache/ruby/2.5.0/bin;C:/Program Files/Puppet Labs/DevelopmentKit/private/puppet/ruby/2.5.0/bin;C:/Program Files/Puppet Labs/DevelopmentKit/bin;C:/Program Files/Puppet Labs/DevelopmentKit/private/git/cmd;C:/Program Files/Puppet Labs/DevelopmentKit/private/git/mingw64/bin;C:/Program Files/Puppet Labs/DevelopmentKit/private/git/mingw64/libexec/git-core;C:/Program Files/Puppet Labs/DevelopmentKit/private/git/usr/bin;C:\\Program Files\\PowerShell\\7;C:\\Program Files\\Java\\bin;C:\\Ruby25-x64\\bin;C:\\WINDOWS\\system32;C:\\WINDOWS;C:\\WINDOWS\\System32\\Wbem;C:\\WINDOWS\\System32\\WindowsPowerShell\\v1.0\\;C:\\ProgramData\\chocolatey\\bin;C:\\Program Files\\Microsoft VS Code\\bin;C:\\Program Files\\Notepad++;C:\\Program Files\\Microsoft VS Code;C:\\Program Files\\nmap;C:\\Program Files\\PowerShell\\6.1.0-preview.1\\;C:\\WINDOWS\\System32\\OpenSSH\\;C:\\Program Files\\PowerShell\\6\\;C:\\Program Files\\Puppet Labs\\DevelopmentKit\\private\\ruby\\2.4.9\\bin;C:\\Program Files (x86)\\Windows Kits\\10\\Windows Performance Toolkit\\;C:\\Program Files\\PowerShell\\7-preview\\preview;C:\\Program Files\\OpenJDK\\openjdk-11.0.12_7\\bin;C:\\Program Files\\PuTTY\\;C:\\Program Files\\Docker\\Docker\\resources\\bin;C:\\ProgramData\\DockerDesktop\\version-bin;C:\\Program Files\\Git\\cmd;C:\\Program Files\\PowerShell\\7\\;C:\\tools\\Cmder;C:\\Program Files\\@boxcli\\bin;C:\\tools\\msys64;C:\\Program Files\\OpenSSL-Win64\\bin",
+  "processors": {
+    "cores": 4,
+    "count": 4,
+    "isa": "x64",
+    "models": [
+      "Intel(R) Core(TM) i5-6500 CPU @ 3.20GHz"
+    ],
+    "physicalcount": 1,
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/DevelopmentKit/private/ruby/2.5.9/lib/ruby/site_ruby/2.5.0",
+    "version": "2.5.9"
+  },
+  "system_uptime": {
+    "days": 7,
+    "hours": 180,
+    "seconds": 650519,
+    "uptime": "7 days"
+  },
+  "timezone": "W. Europe Daylight Time",
+  "virtual": "physical"
+}

--- a/test/static_fixtures/facts/puppet_facts_windows_server_2019.json
+++ b/test/static_fixtures/facts/puppet_facts_windows_server_2019.json
@@ -1,0 +1,140 @@
+{
+  "aio_agent_version": "6.24.0",
+  "dmi": {
+    "manufacturer": "Dell Inc.",
+    "product": {
+      "name": "PowerEdge R630",
+      "serial_number": "ABCDEF1234",
+      "uuid": "A84CAF65-FC46-4823-A885-2B408DFDB42B"
+    }
+  },
+  "facterversion": "3.14.19",
+  "fips_enabled": false,
+  "identity": {
+    "privileged": true,
+    "user": "AD\\adm_user"
+  },
+  "is_virtual": false,
+  "kernel": "windows",
+  "kernelmajversion": "10.0",
+  "kernelrelease": "10.0.17763",
+  "kernelversion": "10.0.17763",
+  "memory": {
+    "system": {
+      "available": "27.94 GiB",
+      "available_bytes": 29998473216,
+      "capacity": "12.44%",
+      "total": "31.91 GiB",
+      "total_bytes": 34259439616,
+      "used": "3.97 GiB",
+      "used_bytes": 4260966400
+    }
+  },
+  "networking": {
+    "domain": "ad",
+    "fqdn": "server.ad",
+    "hostname": "server",
+    "interfaces": {
+      "Ethernet": {
+        "bindings": [
+          {
+            "address": "169.254.0.2",
+            "netmask": "255.255.255.0",
+            "network": "169.254.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::854e:9550:6d1a:3fc5",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "dhcp": "169.254.0.1",
+        "ip": "169.254.0.2",
+        "ip6": "fe80::854e:9550:6d1a:3fc5",
+        "mac": "44:44:44:44:44:45",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "169.254.0.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "NIC1": {
+        "bindings": [
+          {
+            "address": "172.28.5.105",
+            "netmask": "255.255.254.0",
+            "network": "172.28.4.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::d192:626d:440b:2b9a",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::"
+          }
+        ],
+        "ip": "172.28.5.105",
+        "ip6": "fe80::d192:626d:440b:2b9a",
+        "mac": "44:44:44:44:44:44",
+        "mtu": 1500,
+        "netmask": "255.255.254.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "172.28.4.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      }
+    },
+    "ip": "172.28.5.105",
+    "ip6": "fe80::d192:626d:440b:2b9a",
+    "mac": "44:44:44:44:44:44",
+    "mtu": 1500,
+    "netmask": "255.255.254.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "172.28.4.0",
+    "network6": "fe80::",
+    "primary": "NIC1",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x64",
+    "family": "windows",
+    "hardware": "x86_64",
+    "name": "windows",
+    "release": {
+      "full": "2019",
+      "major": "2019"
+    },
+    "windows": {
+      "edition_id": "ServerStandard",
+      "installation_type": "Server",
+      "product_name": "Windows Server 2019 Standard",
+      "release_id": "1809",
+      "system32": "C:\\Windows\\system32"
+    }
+  },
+  "path": "C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\ProgramData\\chocolatey\\bin;C:\\Program Files\\Dell\\SysMgt\\oma\\bin;C:\\Program Files\\Dell\\SysMgt\\shared\\bin;C:\\Program Files\\Dell\\SysMgt\\idrac;C:\\Program Files\\PowerShell\\7\\;C:\\Program Files\\Dell\\DELL EMC System Update\\;C:\\Program Files\\Dell\\SysMgt\\sm\\dellvl;C:\\Program Files\\Dell\\SysMgt\\sm;C:\\Program Files\\Dell\\SysMgt\\OM_iDRACTools\\racadm;C:\\Program Files\\PuTTY\\;C:\\Program Files\\Puppet Labs\\Puppet\\bin;C:\\Program Files\\Puppet Labs\\Puppet\\puppet\\bin",
+  "processors": {
+    "count": 12,
+    "isa": "x64",
+    "models": [
+      "Intel(R) Xeon(R) CPU E5-2620 v3 @ 2.40GHz"
+    ],
+    "physicalcount": 1
+  },
+  "ruby": {
+    "platform": "x64-mingw32",
+    "sitedir": "C:/Program Files/Puppet Labs/Puppet/puppet/lib/ruby/site_ruby/2.5.0",
+    "version": "2.5.9"
+  },
+  "system_uptime": {
+    "days": 9,
+    "hours": 225,
+    "seconds": 810557,
+    "uptime": "9 days"
+  },
+  "timezone": "W. Europe Daylight Time",
+  "virtual": "physical"
+}

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -117,6 +117,18 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
       assert_equal "RedHat", first_os.name
     end
 
+    test "should not mix Windows with Windows Server" do
+      @importer = PuppetFactParser.new(windows_10_facts)
+      first_os = @importer.operatingsystem
+      assert first_os.present?
+      assert_equal "windows_client", first_os.name
+
+      @importer = PuppetFactParser.new(windows_server_2019_facts)
+      first_os = @importer.operatingsystem
+      assert first_os.present?
+      assert_equal "windows", first_os.name
+    end
+
     test "should not alter description field if already set" do
       # Need to instantiate @importer once with normal facts
       first_os = @importer.operatingsystem
@@ -459,6 +471,14 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
 
   def rhel_7_server_facts
     read_json_fixture('facts/facts_rhel_7_server.json').with_indifferent_access
+  end
+
+  def windows_server_2019_facts
+    read_json_fixture('facts/puppet_facts_windows_server_2019.json').with_indifferent_access
+  end
+
+  def windows_10_facts
+    read_json_fixture('facts/puppet_facts_windows_10.json').with_indifferent_access
   end
 
   def sles_facts


### PR DESCRIPTION
This will currently only handle a single difference - Windows Server vs Windows.
Not things like Windows Server Standard vs Windows Server Core, or Windows vs Windows Education, etc.

As Windows has a rather ridiculous list of permutations in that regard I feel that keeping the difference down to Client vs Server is the more apt choice, as that's likely to be the most major difference.