### PR TITLE
Fixes #33771 - Corrects regexes to identify virtual NICs

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,10 +1,10 @@
 class FactParser
   delegate :logger, :to => :Rails
   VIRTUAL = /\A([a-z0-9]+)[_|\.|:]([a-z0-9]+)\Z/
-  BRIDGES = /\A(vir|lxc)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
+  BRIDGES = /\A([a-z0-9_-])*br((\d+|-[a-z0-9]+)(_nic)?)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
   ALIASES = /(\A[a-z0-9\.]+):([a-z0-9]+)\Z/
-  VLANS = /\A([a-z0-9]+)\.([0-9]+)\Z/
+  VLANS = /\A([a-z0-9_-]+)\.([0-9]+)\Z/
   VIRTUAL_NAMES = /#{ALIASES}|#{VLANS}|#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 
   def self.parser_for(type)


### PR DESCRIPTION
The existing virtual NIC name regexes only allow network bridges to be named something like br0, br1, br2, or virbr or lxcbr. This is somewhat unrealistic given how e.g. NetworkManager allows one to choose **any** name for a virtual device such as a bridge.

Likewise, the existing regex for VLAN device names is limiting in that it forbids e.g. hyphens and underscores in the parent device name, i.e. `br0.222` is OK but `my-br.222` is not.

As a result, registering a new host to foreman using `subscription-manager register` will fail if the host has a VLAN-tagged bridge device named e.g. `my-br.222`. Its parent bridge, `my-br`, will also silently fail to be recognized by foreman as a bridge and will instead be added to the host as a physical device.

This slight modification to the `BRIDGES` AND `VLANS` regexes allow them some additional flexibility:
`BRIDGES` now accepts most anything with `br` anywhere in the name, including names with hyphens and underscores.
`VLANS` now accepts any physical device name with hyphens and underscores, as long as it has a dot followed by 1 or more digits. (Note: the dot nomenclature would ideally be optional as well as I've seen software proposing VLAN interface names be simply `vlan1`, `vlan2`, and so on with no dot or reference to the parent device.)