### PR TITLE
Fixes #33470 - Adding support for CentOS Stream

### DIFF
--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -6,6 +6,8 @@ module ForemanAnsible
     def operatingsystem
       args = { :name => os_name, :major => os_major, :minor => os_minor }
       args[:release_name] = os_release_name if os_name == 'Debian' || os_name == 'Ubuntu'
+      # for Ansible, the CentOS Stream can be identified by missing minor version only
+      args[:name] = "CentOS_Stream" if os_name == 'CentOS' && os_minor.blank?
       return @local_os if local_os(args).present?
       return @new_os if new_os(args).present?
       logger.debug do

--- a/app/services/foreman_chef/fact_parser.rb
+++ b/app/services/foreman_chef/fact_parser.rb
@@ -35,6 +35,9 @@ module ForemanChef
             # get the minor.build number, e.g. 7.2.1511 -> 2.1511
             minor = release[2..-1]
           end
+        when 'centos'
+          # Centos Stream doesn't have minor version on need to replace blank spaces due to name restriction
+          os_name = facts.dig(:os_release, :name).tr(' ', '_') unless minor
       end
 
       begin

--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -90,10 +90,14 @@ module ForemanSalt
       name = facts[:os]
       (_, major, minor, sub) = /(\d+)\.?(\d+)?\.?(\d+)?/.match(facts[:osrelease]).to_a
       minor = "" if minor.nil?
-      if name == 'CentOS'
+      if name == 'CentOS Stream'
+        return { :name => name.tr(' ', '_'), :major => major, :minor => minor }
+      end
+      if name == 'CentOS' || name == 'CentOS Linux'
         if sub
           minor += '.' + sub
         end
+        return { :name => 'CentOS', :major => major, :minor => minor }
       end
       { :name => name, :major => major, :minor => minor }
     end

--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -67,6 +67,14 @@ module Katello
           os_attributes[:name] = os_name + '_Workstation'
         end
 
+        if facts['distribution.name'] == 'CentOS Stream'
+          os_attributes[:name] = "CentOS_Stream"
+        end
+
+        if facts['distribution.name'] == 'CentOS Linux'
+          os_attributes[:name] = "CentOS"
+        end
+
         ::Operatingsystem.find_by(os_attributes) || ::Operatingsystem.create!(os_attributes)
       end
     end

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -192,6 +192,9 @@ class PuppetFactParser < FactParser
 
   def os_name
     os_name = facts.dig(:os, :name).presence || facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
+    # CentOS Stream doesn't have a minor version so it's good to check it at two places according to version of Facter that produced facts
+    has_no_minor = facts[:lsbdistrelease]&.exclude?('.') || (facts.dig(:os, :name).presence && facts.dig(:os, :release, :minor).nil?)
+    return 'CentOS_Stream' if os_name == 'CentOSStream' || (os_name == 'CentOS' && has_no_minor)
 
     if os_name == 'RedHat' && facts[:lsbdistid] == 'RedHatEnterpriseWorkstation'
       os_name += '_Workstation'

--- a/test/static_fixtures/facts/ansible_centos_8.json
+++ b/test/static_fixtures/facts/ansible_centos_8.json
@@ -1,0 +1,1163 @@
+{
+    "ansible_facts": {
+        "ansible_all_ipv4_addresses": [
+            "192.168.88.15"
+        ],
+        "ansible_all_ipv6_addresses": [
+            "fe80::5054:ff:fe2a:fa7a"
+        ],
+        "ansible_apparmor": {
+            "status": "disabled"
+        },
+        "ansible_architecture": "x86_64",
+        "ansible_bios_date": "04/01/2014",
+        "ansible_bios_version": "1.11.0-2.el7",
+        "ansible_cmdline": {
+            "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-305.19.1.el8_4.x86_64",
+            "crashkernel": "auto",
+            "quiet": true,
+            "rd.lvm.lv": "cl_foreman/swap",
+            "resume": "/dev/mapper/cl_foreman-swap",
+            "rhgb": true,
+            "ro": true,
+            "root": "/dev/mapper/cl_foreman-root"
+        },
+        "ansible_date_time": {
+            "date": "2021-11-05",
+            "day": "05",
+            "epoch": "1636117255",
+            "hour": "09",
+            "iso8601": "2021-11-05T13:00:55Z",
+            "iso8601_basic": "20211105T090055291396",
+            "iso8601_basic_short": "20211105T090055",
+            "iso8601_micro": "2021-11-05T13:00:55.291396Z",
+            "minute": "00",
+            "month": "11",
+            "second": "55",
+            "time": "09:00:55",
+            "tz": "EDT",
+            "tz_offset": "-0400",
+            "weekday": "Friday",
+            "weekday_number": "5",
+            "weeknumber": "44",
+            "year": "2021"
+        },
+        "ansible_default_ipv4": {
+            "address": "192.168.88.15",
+            "alias": "ens3",
+            "broadcast": "192.168.88.255",
+            "gateway": "192.168.88.1",
+            "interface": "ens3",
+            "macaddress": "52:54:00:2a:fa:7a",
+            "mtu": 1500,
+            "netmask": "255.255.255.0",
+            "network": "192.168.88.0",
+            "type": "ether"
+        },
+        "ansible_default_ipv6": {},
+        "ansible_device_links": {
+            "ids": {
+                "dm-0": [
+                    "dm-name-cl_foreman-root",
+                    "dm-uuid-LVM-1SYObF1NmVO2QfhuBeSXmS4M4oPhBftyJtxzVwljN6hXsE1USUoov3jhBstzZ6QG"
+                ],
+                "dm-1": [
+                    "dm-name-cl_foreman-swap",
+                    "dm-uuid-LVM-1SYObF1NmVO2QfhuBeSXmS4M4oPhBfty6HUx4M6dK37tlnmOnre5duDINS94IOIx"
+                ],
+                "sda": [
+                    "ata-QEMU_HARDDISK_QM00001",
+                    "scsi-0ATA_QEMU_HARDDISK_QM00001",
+                    "scsi-1ATA_QEMU_HARDDISK_QM00001",
+                    "scsi-SATA_QEMU_HARDDISK_QM00001"
+                ],
+                "sda1": [
+                    "ata-QEMU_HARDDISK_QM00001-part1",
+                    "scsi-0ATA_QEMU_HARDDISK_QM00001-part1",
+                    "scsi-1ATA_QEMU_HARDDISK_QM00001-part1",
+                    "scsi-SATA_QEMU_HARDDISK_QM00001-part1"
+                ],
+                "sda2": [
+                    "ata-QEMU_HARDDISK_QM00001-part2",
+                    "lvm-pv-uuid-qE9NTM-TAa1-9mSq-bfz1-gnvb-KeDV-fs1qQ9",
+                    "scsi-0ATA_QEMU_HARDDISK_QM00001-part2",
+                    "scsi-1ATA_QEMU_HARDDISK_QM00001-part2",
+                    "scsi-SATA_QEMU_HARDDISK_QM00001-part2"
+                ],
+                "sr0": [
+                    "ata-QEMU_DVD-ROM_QM00002"
+                ]
+            },
+            "labels": {},
+            "masters": {
+                "sda2": [
+                    "dm-0",
+                    "dm-1"
+                ]
+            },
+            "uuids": {
+                "dm-0": [
+                    "d227e051-0a78-4598-a07c-6b1cda2b3cec"
+                ],
+                "dm-1": [
+                    "88a8f999-83e4-4bd7-8307-34c312e19c3b"
+                ],
+                "sda1": [
+                    "cda15c21-642c-46e7-87d9-3506279a8bcb"
+                ]
+            }
+        },
+        "ansible_devices": {
+            "dm-0": {
+                "holders": [],
+                "host": "",
+                "links": {
+                    "ids": [
+                        "dm-name-cl_foreman-root",
+                        "dm-uuid-LVM-1SYObF1NmVO2QfhuBeSXmS4M4oPhBftyJtxzVwljN6hXsE1USUoov3jhBstzZ6QG"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": [
+                        "d227e051-0a78-4598-a07c-6b1cda2b3cec"
+                    ]
+                },
+                "model": null,
+                "partitions": {},
+                "removable": "0",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "",
+                "sectors": "73392128",
+                "sectorsize": "512",
+                "serial": "QM00001",
+                "size": "35.00 GB",
+                "support_discard": "512",
+                "vendor": null,
+                "virtual": 1
+            },
+            "dm-1": {
+                "holders": [],
+                "host": "",
+                "links": {
+                    "ids": [
+                        "dm-name-cl_foreman-swap",
+                        "dm-uuid-LVM-1SYObF1NmVO2QfhuBeSXmS4M4oPhBfty6HUx4M6dK37tlnmOnre5duDINS94IOIx"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": [
+                        "88a8f999-83e4-4bd7-8307-34c312e19c3b"
+                    ]
+                },
+                "model": null,
+                "partitions": {},
+                "removable": "0",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "",
+                "sectors": "8388608",
+                "sectorsize": "512",
+                "serial": "QM00001",
+                "size": "4.00 GB",
+                "support_discard": "512",
+                "vendor": null,
+                "virtual": 1
+            },
+            "sda": {
+                "holders": [],
+                "host": "IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]",
+                "links": {
+                    "ids": [
+                        "ata-QEMU_HARDDISK_QM00001",
+                        "scsi-0ATA_QEMU_HARDDISK_QM00001",
+                        "scsi-1ATA_QEMU_HARDDISK_QM00001",
+                        "scsi-SATA_QEMU_HARDDISK_QM00001"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": []
+                },
+                "model": "QEMU HARDDISK",
+                "partitions": {
+                    "sda1": {
+                        "holders": [],
+                        "links": {
+                            "ids": [
+                                "ata-QEMU_HARDDISK_QM00001-part1",
+                                "scsi-0ATA_QEMU_HARDDISK_QM00001-part1",
+                                "scsi-1ATA_QEMU_HARDDISK_QM00001-part1",
+                                "scsi-SATA_QEMU_HARDDISK_QM00001-part1"
+                            ],
+                            "labels": [],
+                            "masters": [],
+                            "uuids": [
+                                "cda15c21-642c-46e7-87d9-3506279a8bcb"
+                            ]
+                        },
+                        "sectors": "2097152",
+                        "sectorsize": 512,
+                        "size": "1.00 GB",
+                        "start": "2048",
+                        "uuid": "cda15c21-642c-46e7-87d9-3506279a8bcb"
+                    },
+                    "sda2": {
+                        "holders": [
+                            "cl_foreman-swap",
+                            "cl_foreman-root"
+                        ],
+                        "links": {
+                            "ids": [
+                                "ata-QEMU_HARDDISK_QM00001-part2",
+                                "lvm-pv-uuid-qE9NTM-TAa1-9mSq-bfz1-gnvb-KeDV-fs1qQ9",
+                                "scsi-0ATA_QEMU_HARDDISK_QM00001-part2",
+                                "scsi-1ATA_QEMU_HARDDISK_QM00001-part2",
+                                "scsi-SATA_QEMU_HARDDISK_QM00001-part2"
+                            ],
+                            "labels": [],
+                            "masters": [
+                                "dm-0",
+                                "dm-1"
+                            ],
+                            "uuids": []
+                        },
+                        "sectors": "81786880",
+                        "sectorsize": 512,
+                        "size": "39.00 GB",
+                        "start": "2099200",
+                        "uuid": null
+                    }
+                },
+                "removable": "0",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "mq-deadline",
+                "sectors": "83886080",
+                "sectorsize": "512",
+                "serial": "QM00001",
+                "size": "40.00 GB",
+                "support_discard": "512",
+                "vendor": "ATA",
+                "virtual": 1
+            },
+            "sr0": {
+                "holders": [],
+                "host": "IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]",
+                "links": {
+                    "ids": [
+                        "ata-QEMU_DVD-ROM_QM00002"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": []
+                },
+                "model": "QEMU DVD-ROM",
+                "partitions": {},
+                "removable": "1",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "mq-deadline",
+                "sectors": "2097151",
+                "sectorsize": "512",
+                "size": "1024.00 MB",
+                "support_discard": "0",
+                "vendor": "QEMU",
+                "virtual": 1
+            }
+        },
+        "ansible_distribution": "CentOS",
+        "ansible_distribution_file_parsed": true,
+        "ansible_distribution_file_path": "/etc/redhat-release",
+        "ansible_distribution_file_variety": "RedHat",
+        "ansible_distribution_major_version": "8",
+        "ansible_distribution_release": "NA",
+        "ansible_distribution_version": "8.4",
+        "ansible_dns": {
+            "nameservers": [
+                "192.168.88.30",
+                "192.168.88.1"
+            ],
+            "search": [
+                "cluster.local"
+            ]
+        },
+        "ansible_domain": "cluster.local",
+        "ansible_effective_group_id": 0,
+        "ansible_effective_user_id": 0,
+        "ansible_ens3": {
+            "active": true,
+            "device": "ens3",
+            "features": {
+                "esp_hw_offload": "off [fixed]",
+                "esp_tx_csum_hw_offload": "off [fixed]",
+                "fcoe_mtu": "off [fixed]",
+                "generic_receive_offload": "on",
+                "generic_segmentation_offload": "on",
+                "highdma": "on [fixed]",
+                "hw_tc_offload": "off [fixed]",
+                "l2_fwd_offload": "off [fixed]",
+                "large_receive_offload": "off [fixed]",
+                "loopback": "off [fixed]",
+                "netns_local": "off [fixed]",
+                "ntuple_filters": "off [fixed]",
+                "receive_hashing": "off [fixed]",
+                "rx_all": "off [fixed]",
+                "rx_checksumming": "on",
+                "rx_fcs": "off [fixed]",
+                "rx_gro_hw": "off [fixed]",
+                "rx_gro_list": "off",
+                "rx_udp_tunnel_port_offload": "off [fixed]",
+                "rx_vlan_filter": "off [fixed]",
+                "rx_vlan_offload": "on",
+                "rx_vlan_stag_filter": "off [fixed]",
+                "rx_vlan_stag_hw_parse": "off [fixed]",
+                "scatter_gather": "on",
+                "tcp_segmentation_offload": "on",
+                "tls_hw_record": "off [fixed]",
+                "tls_hw_rx_offload": "off [fixed]",
+                "tls_hw_tx_offload": "off [fixed]",
+                "tx_checksum_fcoe_crc": "off [fixed]",
+                "tx_checksum_ip_generic": "off [fixed]",
+                "tx_checksum_ipv4": "on",
+                "tx_checksum_ipv6": "off [fixed]",
+                "tx_checksum_sctp": "off [fixed]",
+                "tx_checksumming": "on",
+                "tx_esp_segmentation": "off [fixed]",
+                "tx_fcoe_segmentation": "off [fixed]",
+                "tx_gre_csum_segmentation": "off [fixed]",
+                "tx_gre_segmentation": "off [fixed]",
+                "tx_gso_list": "off [fixed]",
+                "tx_gso_partial": "off [fixed]",
+                "tx_gso_robust": "off [fixed]",
+                "tx_ipxip4_segmentation": "off [fixed]",
+                "tx_ipxip6_segmentation": "off [fixed]",
+                "tx_lockless": "off [fixed]",
+                "tx_nocache_copy": "off",
+                "tx_scatter_gather": "on",
+                "tx_scatter_gather_fraglist": "off [fixed]",
+                "tx_sctp_segmentation": "off [fixed]",
+                "tx_tcp6_segmentation": "off [fixed]",
+                "tx_tcp_ecn_segmentation": "off [fixed]",
+                "tx_tcp_mangleid_segmentation": "off",
+                "tx_tcp_segmentation": "on",
+                "tx_tunnel_remcsum_segmentation": "off [fixed]",
+                "tx_udp_segmentation": "off [fixed]",
+                "tx_udp_tnl_csum_segmentation": "off [fixed]",
+                "tx_udp_tnl_segmentation": "off [fixed]",
+                "tx_vlan_offload": "on",
+                "tx_vlan_stag_hw_insert": "off [fixed]",
+                "vlan_challenged": "off [fixed]"
+            },
+            "hw_timestamp_filters": [],
+            "ipv4": {
+                "address": "192.168.88.15",
+                "broadcast": "192.168.88.255",
+                "netmask": "255.255.255.0",
+                "network": "192.168.88.0"
+            },
+            "ipv6": [
+                {
+                    "address": "fe80::5054:ff:fe2a:fa7a",
+                    "prefix": "64",
+                    "scope": "link"
+                }
+            ],
+            "macaddress": "52:54:00:2a:fa:7a",
+            "module": "8139cp",
+            "mtu": 1500,
+            "pciid": "0000:00:03.0",
+            "promisc": false,
+            "speed": 100,
+            "timestamping": [],
+            "type": "ether"
+        },
+        "ansible_env": {
+            "COCKPIT_REMOTE_PEER": "::ffff:192.168.88.248",
+            "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/0/bus",
+            "GSETTINGS_BACKEND": "memory",
+            "HOME": "/root",
+            "LANG": "C",
+            "LC_ALL": "C",
+            "LC_NUMERIC": "C",
+            "LESSOPEN": "||/usr/bin/lesspipe.sh %s",
+            "LS_COLORS": "rs=0:di=38;5;33:ln=38;5;51:mh=00:pi=40;38;5;11:so=38;5;13:do=38;5;5:bd=48;5;232;38;5;11:cd=48;5;232;38;5;3:or=48;5;232;38;5;9:mi=01;05;37;41:su=48;5;196;38;5;15:sg=48;5;11;38;5;16:ca=48;5;196;38;5;226:tw=48;5;10;38;5;16:ow=48;5;10;38;5;21:st=48;5;21;38;5;15:ex=38;5;40:*.tar=38;5;9:*.tgz=38;5;9:*.arc=38;5;9:*.arj=38;5;9:*.taz=38;5;9:*.lha=38;5;9:*.lz4=38;5;9:*.lzh=38;5;9:*.lzma=38;5;9:*.tlz=38;5;9:*.txz=38;5;9:*.tzo=38;5;9:*.t7z=38;5;9:*.zip=38;5;9:*.z=38;5;9:*.dz=38;5;9:*.gz=38;5;9:*.lrz=38;5;9:*.lz=38;5;9:*.lzo=38;5;9:*.xz=38;5;9:*.zst=38;5;9:*.tzst=38;5;9:*.bz2=38;5;9:*.bz=38;5;9:*.tbz=38;5;9:*.tbz2=38;5;9:*.tz=38;5;9:*.deb=38;5;9:*.rpm=38;5;9:*.jar=38;5;9:*.war=38;5;9:*.ear=38;5;9:*.sar=38;5;9:*.rar=38;5;9:*.alz=38;5;9:*.ace=38;5;9:*.zoo=38;5;9:*.cpio=38;5;9:*.7z=38;5;9:*.rz=38;5;9:*.cab=38;5;9:*.wim=38;5;9:*.swm=38;5;9:*.dwm=38;5;9:*.esd=38;5;9:*.jpg=38;5;13:*.jpeg=38;5;13:*.mjpg=38;5;13:*.mjpeg=38;5;13:*.gif=38;5;13:*.bmp=38;5;13:*.pbm=38;5;13:*.pgm=38;5;13:*.ppm=38;5;13:*.tga=38;5;13:*.xbm=38;5;13:*.xpm=38;5;13:*.tif=38;5;13:*.tiff=38;5;13:*.png=38;5;13:*.svg=38;5;13:*.svgz=38;5;13:*.mng=38;5;13:*.pcx=38;5;13:*.mov=38;5;13:*.mpg=38;5;13:*.mpeg=38;5;13:*.m2v=38;5;13:*.mkv=38;5;13:*.webm=38;5;13:*.ogm=38;5;13:*.mp4=38;5;13:*.m4v=38;5;13:*.mp4v=38;5;13:*.vob=38;5;13:*.qt=38;5;13:*.nuv=38;5;13:*.wmv=38;5;13:*.asf=38;5;13:*.rm=38;5;13:*.rmvb=38;5;13:*.flc=38;5;13:*.avi=38;5;13:*.fli=38;5;13:*.flv=38;5;13:*.gl=38;5;13:*.dl=38;5;13:*.xcf=38;5;13:*.xwd=38;5;13:*.yuv=38;5;13:*.cgm=38;5;13:*.emf=38;5;13:*.ogv=38;5;13:*.ogx=38;5;13:*.aac=38;5;45:*.au=38;5;45:*.flac=38;5;45:*.m4a=38;5;45:*.mid=38;5;45:*.midi=38;5;45:*.mka=38;5;45:*.mp3=38;5;45:*.mpc=38;5;45:*.ogg=38;5;45:*.ra=38;5;45:*.wav=38;5;45:*.oga=38;5;45:*.opus=38;5;45:*.spx=38;5;45:*.xspf=38;5;45:",
+            "MANPATH": ":/opt/puppetlabs/puppet/share/man",
+            "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin",
+            "PWD": "/root",
+            "SHELL": "/bin/bash",
+            "SHLVL": "3",
+            "SSH_AGENT_PID": "169075",
+            "SSH_AUTH_SOCK": "/tmp/ssh-pdYBEPf4vm59/agent.169074",
+            "TERM": "xterm-256color",
+            "USER": "root",
+            "XDG_RUNTIME_DIR": "/run/user/0",
+            "XDG_SESSION_CLASS": "user",
+            "XDG_SESSION_ID": "134",
+            "XDG_SESSION_TYPE": "web",
+            "_": "/usr/libexec/platform-python"
+        },
+        "ansible_fibre_channel_wwn": [],
+        "ansible_fips": false,
+        "ansible_form_factor": "Other",
+        "ansible_fqdn": "foreman.cluster.local",
+        "ansible_hostname": "foreman",
+        "ansible_hostnqn": "nqn.2014-08.org.nvmexpress:uuid:0298c31d-2322-4fc5-8539-76a430244da9",
+        "ansible_interfaces": [
+            "ens3",
+            "lo"
+        ],
+        "ansible_is_chroot": false,
+        "ansible_iscsi_iqn": "iqn.1994-05.com.redhat:4c593354452",
+        "ansible_kernel": "4.18.0-305.19.1.el8_4.x86_64",
+        "ansible_kernel_version": "#1 SMP Wed Sep 15 15:39:39 UTC 2021",
+        "ansible_lo": {
+            "active": true,
+            "device": "lo",
+            "features": {
+                "esp_hw_offload": "off [fixed]",
+                "esp_tx_csum_hw_offload": "off [fixed]",
+                "fcoe_mtu": "off [fixed]",
+                "generic_receive_offload": "on",
+                "generic_segmentation_offload": "on",
+                "highdma": "on [fixed]",
+                "hw_tc_offload": "off [fixed]",
+                "l2_fwd_offload": "off [fixed]",
+                "large_receive_offload": "off [fixed]",
+                "loopback": "on [fixed]",
+                "netns_local": "on [fixed]",
+                "ntuple_filters": "off [fixed]",
+                "receive_hashing": "off [fixed]",
+                "rx_all": "off [fixed]",
+                "rx_checksumming": "on [fixed]",
+                "rx_fcs": "off [fixed]",
+                "rx_gro_hw": "off [fixed]",
+                "rx_gro_list": "off",
+                "rx_udp_tunnel_port_offload": "off [fixed]",
+                "rx_vlan_filter": "off [fixed]",
+                "rx_vlan_offload": "off [fixed]",
+                "rx_vlan_stag_filter": "off [fixed]",
+                "rx_vlan_stag_hw_parse": "off [fixed]",
+                "scatter_gather": "on",
+                "tcp_segmentation_offload": "on",
+                "tls_hw_record": "off [fixed]",
+                "tls_hw_rx_offload": "off [fixed]",
+                "tls_hw_tx_offload": "off [fixed]",
+                "tx_checksum_fcoe_crc": "off [fixed]",
+                "tx_checksum_ip_generic": "on [fixed]",
+                "tx_checksum_ipv4": "off [fixed]",
+                "tx_checksum_ipv6": "off [fixed]",
+                "tx_checksum_sctp": "on [fixed]",
+                "tx_checksumming": "on",
+                "tx_esp_segmentation": "off [fixed]",
+                "tx_fcoe_segmentation": "off [fixed]",
+                "tx_gre_csum_segmentation": "off [fixed]",
+                "tx_gre_segmentation": "off [fixed]",
+                "tx_gso_list": "off [fixed]",
+                "tx_gso_partial": "off [fixed]",
+                "tx_gso_robust": "off [fixed]",
+                "tx_ipxip4_segmentation": "off [fixed]",
+                "tx_ipxip6_segmentation": "off [fixed]",
+                "tx_lockless": "on [fixed]",
+                "tx_nocache_copy": "off [fixed]",
+                "tx_scatter_gather": "on [fixed]",
+                "tx_scatter_gather_fraglist": "on [fixed]",
+                "tx_sctp_segmentation": "on",
+                "tx_tcp6_segmentation": "on",
+                "tx_tcp_ecn_segmentation": "on",
+                "tx_tcp_mangleid_segmentation": "on",
+                "tx_tcp_segmentation": "on",
+                "tx_tunnel_remcsum_segmentation": "off [fixed]",
+                "tx_udp_segmentation": "off [fixed]",
+                "tx_udp_tnl_csum_segmentation": "off [fixed]",
+                "tx_udp_tnl_segmentation": "off [fixed]",
+                "tx_vlan_offload": "off [fixed]",
+                "tx_vlan_stag_hw_insert": "off [fixed]",
+                "vlan_challenged": "on [fixed]"
+            },
+            "hw_timestamp_filters": [],
+            "ipv4": {
+                "address": "127.0.0.1",
+                "broadcast": "",
+                "netmask": "255.0.0.0",
+                "network": "127.0.0.0"
+            },
+            "ipv6": [
+                {
+                    "address": "::1",
+                    "prefix": "128",
+                    "scope": "host"
+                }
+            ],
+            "mtu": 65536,
+            "promisc": false,
+            "timestamping": [],
+            "type": "loopback"
+        },
+        "ansible_local": {},
+        "ansible_lsb": {},
+        "ansible_lvm": {
+            "lvs": {
+                "root": {
+                    "size_g": "35.00",
+                    "vg": "cl_foreman"
+                },
+                "swap": {
+                    "size_g": "4.00",
+                    "vg": "cl_foreman"
+                }
+            },
+            "pvs": {
+                "/dev/sda2": {
+                    "free_g": "0",
+                    "size_g": "39.00",
+                    "vg": "cl_foreman"
+                }
+            },
+            "vgs": {
+                "cl_foreman": {
+                    "free_g": "0",
+                    "num_lvs": "2",
+                    "num_pvs": "1",
+                    "size_g": "39.00"
+                }
+            }
+        },
+        "ansible_machine": "x86_64",
+        "ansible_machine_id": "5d33f1d45b774d26b22a76ffcc26d275",
+        "ansible_memfree_mb": 468,
+        "ansible_memory_mb": {
+            "nocache": {
+                "free": 1011,
+                "used": 8772
+            },
+            "real": {
+                "free": 468,
+                "total": 9783,
+                "used": 9315
+            },
+            "swap": {
+                "cached": 426,
+                "free": 3180,
+                "total": 4095,
+                "used": 915
+            }
+        },
+        "ansible_memtotal_mb": 9783,
+        "ansible_mounts": [
+            {
+                "block_available": 8033177,
+                "block_size": 4096,
+                "block_total": 9169537,
+                "block_used": 1136360,
+                "device": "/dev/mapper/cl_foreman-root",
+                "fstype": "xfs",
+                "inode_available": 18179233,
+                "inode_total": 18348032,
+                "inode_used": 168799,
+                "mount": "/",
+                "options": "rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota",
+                "size_available": 32903892992,
+                "size_total": 37558423552,
+                "uuid": "d227e051-0a78-4598-a07c-6b1cda2b3cec"
+            },
+            {
+                "block_available": 208011,
+                "block_size": 4096,
+                "block_total": 259584,
+                "block_used": 51573,
+                "device": "/dev/sda1",
+                "fstype": "xfs",
+                "inode_available": 523979,
+                "inode_total": 524288,
+                "inode_used": 309,
+                "mount": "/boot",
+                "options": "rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota",
+                "size_available": 852013056,
+                "size_total": 1063256064,
+                "uuid": "cda15c21-642c-46e7-87d9-3506279a8bcb"
+            }
+        ],
+        "ansible_nodename": "foreman.cluster.local",
+        "ansible_os_family": "RedHat",
+        "ansible_pkg_mgr": "dnf",
+        "ansible_proc_cmdline": {
+            "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-305.19.1.el8_4.x86_64",
+            "crashkernel": "auto",
+            "quiet": true,
+            "rd.lvm.lv": [
+                "cl_foreman/root",
+                "cl_foreman/swap"
+            ],
+            "resume": "/dev/mapper/cl_foreman-swap",
+            "rhgb": true,
+            "ro": true,
+            "root": "/dev/mapper/cl_foreman-root"
+        },
+        "ansible_processor": [
+            "0",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)",
+            "1",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)",
+            "2",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)",
+            "3",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)",
+            "4",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)",
+            "5",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)"
+        ],
+        "ansible_processor_cores": 3,
+        "ansible_processor_count": 1,
+        "ansible_processor_threads_per_core": 2,
+        "ansible_processor_vcpus": 6,
+        "ansible_product_name": "KVM",
+        "ansible_product_serial": "NA",
+        "ansible_product_uuid": "5d33f1d4-5b77-4d26-b22a-76ffcc26d275",
+        "ansible_product_version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+        "ansible_python": {
+            "executable": "/usr/libexec/platform-python",
+            "has_sslcontext": true,
+            "type": "cpython",
+            "version": {
+                "major": 3,
+                "micro": 8,
+                "minor": 6,
+                "releaselevel": "final",
+                "serial": 0
+            },
+            "version_info": [
+                3,
+                6,
+                8,
+                "final",
+                0
+            ]
+        },
+        "ansible_python_version": "3.6.8",
+        "ansible_real_group_id": 0,
+        "ansible_real_user_id": 0,
+        "ansible_selinux": {
+            "config_mode": "enforcing",
+            "mode": "enforcing",
+            "policyvers": 33,
+            "status": "enabled",
+            "type": "targeted"
+        },
+        "ansible_selinux_python_present": true,
+        "ansible_service_mgr": "systemd",
+        "ansible_ssh_host_key_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKo3INMUZ/UbvGA4tQzaEAFZjrUwtKHCz4gHk3RjdNVcG1HvvRo9HkLrO9bCt1jorz38JDX5iifPcfYnU/c7tSY=",
+        "ansible_ssh_host_key_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIABUOP592JUbSLVfWz3W5VQ90gk0hmnPz9pGwVp2LfcX",
+        "ansible_ssh_host_key_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC5FSCrvEZC+ilJZkP9f02AV7TMyfLr6rWSzkfPkKLpkDKcvDl4uM8B8DzzAexoLo08JXIcsgDEJTky/OC8S0cMsN4udgCC4bY5cJyX1Bm1+99N/6uMXXMxiYkRWTVt5ysJQ6fRmGefo6RIy0v+AjTLk7MIwwzpESY2D7JKzN8dGnhfJit3+DFZigLfvGaNFkSF3JiPPNLQXH53SbEUJUdxPsZ+lnmx7daRoZrqsnBGCfmBsbUKbWMFeRknPrAEFF91AE2S5h1J0KbiKTSWlmyKSssGh3DMXOG/YZ3oKY+6DgodGLJymlBxo7wwKydGy2w4Wi0jhGErYRLoJ5/4gkYLG14yFIJqLCDGJmyULl7L04xv7+3we7qJnv/3RPJVHYHQUUK6uhZ4GItuFjNTFxOu+oZFIzhrWoFFFU9iJtBRYHMvYoi4zws0ieDrtRjDEJprLH3UwwSBoVuCaO4dwHblud7eNKvg/ncHkukWWkHzryrlYoWj9rS7XmBgFDLn38k=",
+        "ansible_swapfree_mb": 3180,
+        "ansible_swaptotal_mb": 4095,
+        "ansible_system": "Linux",
+        "ansible_system_capabilities": [
+            "cap_chown",
+            "cap_dac_override",
+            "cap_dac_read_search",
+            "cap_fowner",
+            "cap_fsetid",
+            "cap_kill",
+            "cap_setgid",
+            "cap_setuid",
+            "cap_setpcap",
+            "cap_linux_immutable",
+            "cap_net_bind_service",
+            "cap_net_broadcast",
+            "cap_net_admin",
+            "cap_net_raw",
+            "cap_ipc_lock",
+            "cap_ipc_owner",
+            "cap_sys_module",
+            "cap_sys_rawio",
+            "cap_sys_chroot",
+            "cap_sys_ptrace",
+            "cap_sys_pacct",
+            "cap_sys_admin",
+            "cap_sys_boot",
+            "cap_sys_nice",
+            "cap_sys_resource",
+            "cap_sys_time",
+            "cap_sys_tty_config",
+            "cap_mknod",
+            "cap_lease",
+            "cap_audit_write",
+            "cap_audit_control",
+            "cap_setfcap",
+            "cap_mac_override",
+            "cap_mac_admin",
+            "cap_syslog",
+            "cap_wake_alarm",
+            "cap_block_suspend",
+            "cap_audit_read",
+            "38",
+            "39+ep"
+        ],
+        "ansible_system_capabilities_enforced": "True",
+        "ansible_system_vendor": "Red Hat",
+        "ansible_uptime_seconds": 170789,
+        "ansible_user_dir": "/root",
+        "ansible_user_gecos": "root",
+        "ansible_user_gid": 0,
+        "ansible_user_id": "root",
+        "ansible_user_shell": "/bin/bash",
+        "ansible_user_uid": 0,
+        "ansible_userspace_architecture": "x86_64",
+        "ansible_userspace_bits": "64",
+        "ansible_virtualization_role": "guest",
+        "ansible_virtualization_type": "kvm",
+        "facter_agent_specified_environment": "production",
+        "facter_aio_agent_version": "6.25.0",
+        "facter_augeas": {
+            "version": "1.12.0"
+        },
+        "facter_disks": {
+            "sda": {
+                "model": "QEMU HARDDISK",
+                "size": "40.00 GiB",
+                "size_bytes": 42949672960,
+                "vendor": "ATA"
+            },
+            "sr0": {
+                "model": "QEMU DVD-ROM",
+                "size": "1.00 GiB",
+                "size_bytes": 1073741312,
+                "vendor": "QEMU"
+            }
+        },
+        "facter_dmi": {
+            "bios": {
+                "release_date": "04/01/2014",
+                "vendor": "SeaBIOS",
+                "version": "1.11.0-2.el7"
+            },
+            "chassis": {
+                "type": "Other"
+            },
+            "manufacturer": "Red Hat",
+            "product": {
+                "name": "KVM",
+                "uuid": "5d33f1d4-5b77-4d26-b22a-76ffcc26d275"
+            }
+        },
+        "facter_facterversion": "3.14.20",
+        "facter_filesystems": "xfs",
+        "facter_fips_enabled": false,
+        "facter_hypervisors": {
+            "kvm": {}
+        },
+        "facter_identity": {
+            "gid": 0,
+            "group": "root",
+            "privileged": true,
+            "uid": 0,
+            "user": "root"
+        },
+        "facter_is_virtual": true,
+        "facter_kernel": "Linux",
+        "facter_kernelmajversion": "4.18",
+        "facter_kernelrelease": "4.18.0-305.19.1.el8_4.x86_64",
+        "facter_kernelversion": "4.18.0",
+        "facter_load_averages": {
+            "15m": 0.1,
+            "1m": 0.2,
+            "5m": 0.21
+        },
+        "facter_memory": {
+            "swap": {
+                "available": "3.11 GiB",
+                "available_bytes": 3335360512,
+                "capacity": "22.34%",
+                "total": "4.00 GiB",
+                "total_bytes": 4294963200,
+                "used": "915.15 MiB",
+                "used_bytes": 959602688
+            },
+            "system": {
+                "available": "971.95 MiB",
+                "available_bytes": 1019166720,
+                "capacity": "90.07%",
+                "total": "9.55 GiB",
+                "total_bytes": 10259075072,
+                "used": "8.61 GiB",
+                "used_bytes": 9239908352
+            }
+        },
+        "facter_mountpoints": {
+            "/": {
+                "available": "30.64 GiB",
+                "available_bytes": 32903954432,
+                "capacity": "12.39%",
+                "device": "/dev/mapper/cl_foreman-root",
+                "filesystem": "xfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "relatime",
+                    "attr2",
+                    "inode64",
+                    "logbufs=8",
+                    "logbsize=32k",
+                    "noquota"
+                ],
+                "size": "34.98 GiB",
+                "size_bytes": 37558423552,
+                "used": "4.33 GiB",
+                "used_bytes": 4654469120
+            },
+            "/boot": {
+                "available": "812.54 MiB",
+                "available_bytes": 852013056,
+                "capacity": "19.87%",
+                "device": "/dev/sda1",
+                "filesystem": "xfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "relatime",
+                    "attr2",
+                    "inode64",
+                    "logbufs=8",
+                    "logbsize=32k",
+                    "noquota"
+                ],
+                "size": "1014.00 MiB",
+                "size_bytes": 1063256064,
+                "used": "201.46 MiB",
+                "used_bytes": 211243008
+            },
+            "/dev": {
+                "available": "4.76 GiB",
+                "available_bytes": 5109043200,
+                "capacity": "0%",
+                "device": "devtmpfs",
+                "filesystem": "devtmpfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "nosuid",
+                    "size=4989300k",
+                    "nr_inodes=1247325",
+                    "mode=755"
+                ],
+                "size": "4.76 GiB",
+                "size_bytes": 5109043200,
+                "used": "0 bytes",
+                "used_bytes": 0
+            },
+            "/dev/hugepages": {
+                "available": "0 bytes",
+                "available_bytes": 0,
+                "capacity": "100%",
+                "device": "hugetlbfs",
+                "filesystem": "hugetlbfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "relatime",
+                    "pagesize=2M"
+                ],
+                "size": "0 bytes",
+                "size_bytes": 0,
+                "used": "0 bytes",
+                "used_bytes": 0
+            },
+            "/dev/mqueue": {
+                "available": "0 bytes",
+                "available_bytes": 0,
+                "capacity": "100%",
+                "device": "mqueue",
+                "filesystem": "mqueue",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "relatime"
+                ],
+                "size": "0 bytes",
+                "size_bytes": 0,
+                "used": "0 bytes",
+                "used_bytes": 0
+            },
+            "/dev/pts": {
+                "available": "0 bytes",
+                "available_bytes": 0,
+                "capacity": "100%",
+                "device": "devpts",
+                "filesystem": "devpts",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "nosuid",
+                    "noexec",
+                    "relatime",
+                    "gid=5",
+                    "mode=620",
+                    "ptmxmode=000"
+                ],
+                "size": "0 bytes",
+                "size_bytes": 0,
+                "used": "0 bytes",
+                "used_bytes": 0
+            },
+            "/dev/shm": {
+                "available": "4.78 GiB",
+                "available_bytes": 5129347072,
+                "capacity": "0.00%",
+                "device": "tmpfs",
+                "filesystem": "tmpfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "nosuid",
+                    "nodev"
+                ],
+                "size": "4.78 GiB",
+                "size_bytes": 5129535488,
+                "used": "184.00 KiB",
+                "used_bytes": 188416
+            },
+            "/run": {
+                "available": "4.76 GiB",
+                "available_bytes": 5112057856,
+                "capacity": "0.34%",
+                "device": "tmpfs",
+                "filesystem": "tmpfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "nosuid",
+                    "nodev",
+                    "mode=755"
+                ],
+                "size": "4.78 GiB",
+                "size_bytes": 5129535488,
+                "used": "16.67 MiB",
+                "used_bytes": 17477632
+            },
+            "/run/user/0": {
+                "available": "978.38 MiB",
+                "available_bytes": 1025904640,
+                "capacity": "0%",
+                "device": "tmpfs",
+                "filesystem": "tmpfs",
+                "options": [
+                    "rw",
+                    "seclabel",
+                    "nosuid",
+                    "nodev",
+                    "relatime",
+                    "size=1001860k",
+                    "mode=700"
+                ],
+                "size": "978.38 MiB",
+                "size_bytes": 1025904640,
+                "used": "0 bytes",
+                "used_bytes": 0
+            },
+            "/sys/fs/cgroup": {
+                "available": "4.78 GiB",
+                "available_bytes": 5129535488,
+                "capacity": "0%",
+                "device": "tmpfs",
+                "filesystem": "tmpfs",
+                "options": [
+                    "ro",
+                    "seclabel",
+                    "nosuid",
+                    "nodev",
+                    "noexec",
+                    "mode=755"
+                ],
+                "size": "4.78 GiB",
+                "size_bytes": 5129535488,
+                "used": "0 bytes",
+                "used_bytes": 0
+            }
+        },
+        "facter_networking": {
+            "domain": "cluster.local",
+            "fqdn": "foreman.cluster.local",
+            "hostname": "foreman",
+            "interfaces": {
+                "ens3": {
+                    "bindings": [
+                        {
+                            "address": "192.168.88.15",
+                            "netmask": "255.255.255.0",
+                            "network": "192.168.88.0"
+                        }
+                    ],
+                    "bindings6": [
+                        {
+                            "address": "fe80::5054:ff:fe2a:fa7a",
+                            "netmask": "ffff:ffff:ffff:ffff::",
+                            "network": "fe80::"
+                        }
+                    ],
+                    "ip": "192.168.88.15",
+                    "ip6": "fe80::5054:ff:fe2a:fa7a",
+                    "mac": "52:54:00:2a:fa:7a",
+                    "mtu": 1500,
+                    "netmask": "255.255.255.0",
+                    "netmask6": "ffff:ffff:ffff:ffff::",
+                    "network": "192.168.88.0",
+                    "network6": "fe80::",
+                    "scope6": "link"
+                },
+                "lo": {
+                    "bindings": [
+                        {
+                            "address": "127.0.0.1",
+                            "netmask": "255.0.0.0",
+                            "network": "127.0.0.0"
+                        }
+                    ],
+                    "bindings6": [
+                        {
+                            "address": "::1",
+                            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+                            "network": "::1"
+                        }
+                    ],
+                    "ip": "127.0.0.1",
+                    "ip6": "::1",
+                    "mtu": 65536,
+                    "netmask": "255.0.0.0",
+                    "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+                    "network": "127.0.0.0",
+                    "network6": "::1",
+                    "scope6": "host"
+                }
+            },
+            "ip": "192.168.88.15",
+            "ip6": "fe80::5054:ff:fe2a:fa7a",
+            "mac": "52:54:00:2a:fa:7a",
+            "mtu": 1500,
+            "netmask": "255.255.255.0",
+            "netmask6": "ffff:ffff:ffff:ffff::",
+            "network": "192.168.88.0",
+            "network6": "fe80::",
+            "primary": "ens3",
+            "scope6": "link"
+        },
+        "facter_os": {
+            "architecture": "x86_64",
+            "family": "RedHat",
+            "hardware": "x86_64",
+            "name": "CentOS",
+            "release": {
+                "full": "8.4.2105",
+                "major": "8",
+                "minor": "4"
+            },
+            "selinux": {
+                "config_mode": "enforcing",
+                "config_policy": "targeted",
+                "current_mode": "enforcing",
+                "enabled": true,
+                "enforced": true,
+                "policy_version": "33"
+            }
+        },
+        "facter_partitions": {
+            "/dev/mapper/cl_foreman-root": {
+                "filesystem": "xfs",
+                "mount": "/",
+                "size": "35.00 GiB",
+                "size_bytes": 37576769536,
+                "uuid": "d227e051-0a78-4598-a07c-6b1cda2b3cec"
+            },
+            "/dev/mapper/cl_foreman-swap": {
+                "filesystem": "swap",
+                "size": "4.00 GiB",
+                "size_bytes": 4294967296,
+                "uuid": "88a8f999-83e4-4bd7-8307-34c312e19c3b"
+            },
+            "/dev/sda1": {
+                "filesystem": "xfs",
+                "mount": "/boot",
+                "partuuid": "425195af-01",
+                "size": "1.00 GiB",
+                "size_bytes": 1073741824,
+                "uuid": "cda15c21-642c-46e7-87d9-3506279a8bcb"
+            },
+            "/dev/sda2": {
+                "filesystem": "LVM2_member",
+                "partuuid": "425195af-02",
+                "size": "39.00 GiB",
+                "size_bytes": 41874882560,
+                "uuid": "qE9NTM-TAa1-9mSq-bfz1-gnvb-KeDV-fs1qQ9"
+            }
+        },
+        "facter_path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/puppetlabs/bin",
+        "facter_processors": {
+            "count": 6,
+            "isa": "x86_64",
+            "models": [
+                "Westmere E56xx/L56xx/X56xx (IBRS update)",
+                "Westmere E56xx/L56xx/X56xx (IBRS update)",
+                "Westmere E56xx/L56xx/X56xx (IBRS update)",
+                "Westmere E56xx/L56xx/X56xx (IBRS update)",
+                "Westmere E56xx/L56xx/X56xx (IBRS update)",
+                "Westmere E56xx/L56xx/X56xx (IBRS update)"
+            ],
+            "physicalcount": 1
+        },
+        "facter_puppetversion": "6.25.0",
+        "facter_ruby": {
+            "platform": "x86_64-linux",
+            "sitedir": "/opt/puppetlabs/puppet/lib/ruby/site_ruby/2.5.0",
+            "version": "2.5.9"
+        },
+        "facter_ssh": {
+            "ecdsa": {
+                "fingerprints": {
+                    "sha1": "SSHFP 3 1 dfc0afb0e5024d4a165e1ae873de439cbdd0f823",
+                    "sha256": "SSHFP 3 2 ea0706c051f332063d645da1e4aab9af1b69a05344ca473ef3379431ea62c5e9"
+                },
+                "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKo3INMUZ/UbvGA4tQzaEAFZjrUwtKHCz4gHk3RjdNVcG1HvvRo9HkLrO9bCt1jorz38JDX5iifPcfYnU/c7tSY=",
+                "type": "ecdsa-sha2-nistp256"
+            },
+            "ed25519": {
+                "fingerprints": {
+                    "sha1": "SSHFP 4 1 142d14b7f1bdc9212e61aa85657005d24662b24b",
+                    "sha256": "SSHFP 4 2 5810e7996c414ff070e043dd7b7979135df38039a1ac481ae1d5c6d56c5306ac"
+                },
+                "key": "AAAAC3NzaC1lZDI1NTE5AAAAIABUOP592JUbSLVfWz3W5VQ90gk0hmnPz9pGwVp2LfcX",
+                "type": "ssh-ed25519"
+            },
+            "rsa": {
+                "fingerprints": {
+                    "sha1": "SSHFP 1 1 4d94addf271ab92cb57c1a6757033efb3b68c7c5",
+                    "sha256": "SSHFP 1 2 8746d33b05b66ae12f248fa20bc397d3d7585f9181af600bc5c2caa120b14c7a"
+                },
+                "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC5FSCrvEZC+ilJZkP9f02AV7TMyfLr6rWSzkfPkKLpkDKcvDl4uM8B8DzzAexoLo08JXIcsgDEJTky/OC8S0cMsN4udgCC4bY5cJyX1Bm1+99N/6uMXXMxiYkRWTVt5ysJQ6fRmGefo6RIy0v+AjTLk7MIwwzpESY2D7JKzN8dGnhfJit3+DFZigLfvGaNFkSF3JiPPNLQXH53SbEUJUdxPsZ+lnmx7daRoZrqsnBGCfmBsbUKbWMFeRknPrAEFF91AE2S5h1J0KbiKTSWlmyKSssGh3DMXOG/YZ3oKY+6DgodGLJymlBxo7wwKydGy2w4Wi0jhGErYRLoJ5/4gkYLG14yFIJqLCDGJmyULl7L04xv7+3we7qJnv/3RPJVHYHQUUK6uhZ4GItuFjNTFxOu+oZFIzhrWoFFFU9iJtBRYHMvYoi4zws0ieDrtRjDEJprLH3UwwSBoVuCaO4dwHblud7eNKvg/ncHkukWWkHzryrlYoWj9rS7XmBgFDLn38k=",
+                "type": "ssh-rsa"
+            }
+        },
+        "facter_system_uptime": {
+            "days": 1,
+            "hours": 47,
+            "seconds": 170924,
+            "uptime": "1 day"
+        },
+        "facter_timezone": "EDT",
+        "facter_virtual": "kvm",
+        "gather_subset": [
+            "all"
+        ],
+        "module_setup": true
+    },
+    "changed": false
+}

--- a/test/static_fixtures/facts/ansible_centos_stream.json
+++ b/test/static_fixtures/facts/ansible_centos_stream.json
@@ -1,0 +1,8549 @@
+{
+    "ansible_facts": {
+        "ansible_all_ipv4_addresses": [
+            "192.168.88.20"
+        ],
+        "ansible_all_ipv6_addresses": [
+            "fe80::5054:ff:fee3:8d8b"
+        ],
+        "ansible_apparmor": {
+            "status": "disabled"
+        },
+        "ansible_architecture": "x86_64",
+        "ansible_bios_date": "04/01/2014",
+        "ansible_bios_version": "1.11.0-2.el7",
+        "ansible_cmdline": {
+            "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-338.el8.x86_64",
+            "crashkernel": "auto",
+            "quiet": true,
+            "rd.lvm.lv": "cs_stream/swap",
+            "resume": "/dev/mapper/cs_stream-swap",
+            "rhgb": true,
+            "ro": true,
+            "root": "/dev/mapper/cs_stream-root"
+        },
+        "ansible_date_time": {
+            "date": "2021-10-20",
+            "day": "20",
+            "epoch": "1634737914",
+            "hour": "09",
+            "iso8601": "2021-10-20T13:51:54Z",
+            "iso8601_basic": "20211020T095154564245",
+            "iso8601_basic_short": "20211020T095154",
+            "iso8601_micro": "2021-10-20T13:51:54.564245Z",
+            "minute": "51",
+            "month": "10",
+            "second": "54",
+            "time": "09:51:54",
+            "tz": "EDT",
+            "tz_offset": "-0400",
+            "weekday": "Wednesday",
+            "weekday_number": "3",
+            "weeknumber": "42",
+            "year": "2021"
+        },
+        "ansible_default_ipv4": {
+            "address": "192.168.88.20",
+            "alias": "ens3",
+            "broadcast": "192.168.88.255",
+            "gateway": "192.168.88.1",
+            "interface": "ens3",
+            "macaddress": "52:54:00:e3:8d:8b",
+            "mtu": 1500,
+            "netmask": "255.255.255.0",
+            "network": "192.168.88.0",
+            "type": "ether"
+        },
+        "ansible_default_ipv6": {},
+        "ansible_device_links": {
+            "ids": {
+                "dm-0": [
+                    "dm-name-cs_stream-root",
+                    "dm-uuid-LVM-O3jBRZb4GblfRNW5k5yTrWIrpHaRJTKSrNSFQoxJkw2od3xXcwifnoffZsQOsQfd"
+                ],
+                "dm-1": [
+                    "dm-name-cs_stream-swap",
+                    "dm-uuid-LVM-O3jBRZb4GblfRNW5k5yTrWIrpHaRJTKSeXlcxFfFB26GYN92mu3CTvsSBBD2KnFj"
+                ],
+                "sr0": [
+                    "ata-QEMU_DVD-ROM_QM00001"
+                ],
+                "vda2": [
+                    "lvm-pv-uuid-iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL"
+                ]
+            },
+            "labels": {},
+            "masters": {
+                "vda2": [
+                    "dm-0",
+                    "dm-1"
+                ]
+            },
+            "uuids": {
+                "dm-0": [
+                    "50d1cc90-1804-4026-b473-58da96d64156"
+                ],
+                "dm-1": [
+                    "0d782303-3cd7-451a-b5fd-083ba57fb696"
+                ],
+                "vda1": [
+                    "9900694f-e73a-4e83-83e9-042cce34a5ee"
+                ]
+            }
+        },
+        "ansible_devices": {
+            "dm-0": {
+                "holders": [],
+                "host": "",
+                "links": {
+                    "ids": [
+                        "dm-name-cs_stream-root",
+                        "dm-uuid-LVM-O3jBRZb4GblfRNW5k5yTrWIrpHaRJTKSrNSFQoxJkw2od3xXcwifnoffZsQOsQfd"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": [
+                        "50d1cc90-1804-4026-b473-58da96d64156"
+                    ]
+                },
+                "model": null,
+                "partitions": {},
+                "removable": "0",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "",
+                "sectors": "16769024",
+                "sectorsize": "512",
+                "size": "8.00 GB",
+                "support_discard": "0",
+                "vendor": null,
+                "virtual": 1
+            },
+            "dm-1": {
+                "holders": [],
+                "host": "",
+                "links": {
+                    "ids": [
+                        "dm-name-cs_stream-swap",
+                        "dm-uuid-LVM-O3jBRZb4GblfRNW5k5yTrWIrpHaRJTKSeXlcxFfFB26GYN92mu3CTvsSBBD2KnFj"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": [
+                        "0d782303-3cd7-451a-b5fd-083ba57fb696"
+                    ]
+                },
+                "model": null,
+                "partitions": {},
+                "removable": "0",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "",
+                "sectors": "2097152",
+                "sectorsize": "512",
+                "size": "1.00 GB",
+                "support_discard": "0",
+                "vendor": null,
+                "virtual": 1
+            },
+            "sr0": {
+                "holders": [],
+                "host": "IDE interface: Intel Corporation 82371SB PIIX3 IDE [Natoma/Triton II]",
+                "links": {
+                    "ids": [
+                        "ata-QEMU_DVD-ROM_QM00001"
+                    ],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": []
+                },
+                "model": "QEMU DVD-ROM",
+                "partitions": {},
+                "removable": "1",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "mq-deadline",
+                "sectors": "2097151",
+                "sectorsize": "512",
+                "size": "1024.00 MB",
+                "support_discard": "0",
+                "vendor": "QEMU",
+                "virtual": 1
+            },
+            "vda": {
+                "holders": [],
+                "host": "SCSI storage controller: Red Hat, Inc. Virtio block device",
+                "links": {
+                    "ids": [],
+                    "labels": [],
+                    "masters": [],
+                    "uuids": []
+                },
+                "model": null,
+                "partitions": {
+                    "vda1": {
+                        "holders": [],
+                        "links": {
+                            "ids": [],
+                            "labels": [],
+                            "masters": [],
+                            "uuids": [
+                                "9900694f-e73a-4e83-83e9-042cce34a5ee"
+                            ]
+                        },
+                        "sectors": "2097152",
+                        "sectorsize": 512,
+                        "size": "1.00 GB",
+                        "start": "2048",
+                        "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+                    },
+                    "vda2": {
+                        "holders": [
+                            "cs_stream-swap",
+                            "cs_stream-root"
+                        ],
+                        "links": {
+                            "ids": [
+                                "lvm-pv-uuid-iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL"
+                            ],
+                            "labels": [],
+                            "masters": [
+                                "dm-0",
+                                "dm-1"
+                            ],
+                            "uuids": []
+                        },
+                        "sectors": "18872320",
+                        "sectorsize": 512,
+                        "size": "9.00 GB",
+                        "start": "2099200",
+                        "uuid": null
+                    }
+                },
+                "removable": "0",
+                "rotational": "1",
+                "sas_address": null,
+                "sas_device_handle": null,
+                "scheduler_mode": "mq-deadline",
+                "sectors": "20971520",
+                "sectorsize": "512",
+                "size": "10.00 GB",
+                "support_discard": "0",
+                "vendor": "0x1af4",
+                "virtual": 1
+            }
+        },
+        "ansible_distribution": "CentOS",
+        "ansible_distribution_file_parsed": true,
+        "ansible_distribution_file_path": "/etc/redhat-release",
+        "ansible_distribution_file_variety": "RedHat",
+        "ansible_distribution_major_version": "8",
+        "ansible_distribution_release": "NA",
+        "ansible_distribution_version": "8",
+        "ansible_dns": {
+            "nameservers": [
+                "192.168.88.30",
+                "192.168.88.1"
+            ],
+            "search": [
+                "dl360.cluster.com"
+            ]
+        },
+        "ansible_domain": "dl360.cluster.com",
+        "ansible_effective_group_id": 0,
+        "ansible_effective_user_id": 0,
+        "ansible_ens3": {
+            "active": true,
+            "device": "ens3",
+            "features": {
+                "esp_hw_offload": "off [fixed]",
+                "esp_tx_csum_hw_offload": "off [fixed]",
+                "fcoe_mtu": "off [fixed]",
+                "generic_receive_offload": "on",
+                "generic_segmentation_offload": "on",
+                "highdma": "on [fixed]",
+                "hw_tc_offload": "off [fixed]",
+                "l2_fwd_offload": "off [fixed]",
+                "large_receive_offload": "off [fixed]",
+                "loopback": "off [fixed]",
+                "netns_local": "off [fixed]",
+                "ntuple_filters": "off [fixed]",
+                "receive_hashing": "off [fixed]",
+                "rx_all": "off [fixed]",
+                "rx_checksumming": "on [fixed]",
+                "rx_fcs": "off [fixed]",
+                "rx_gro_hw": "off [fixed]",
+                "rx_gro_list": "off",
+                "rx_udp_gro_forwarding": "off",
+                "rx_udp_tunnel_port_offload": "off [fixed]",
+                "rx_vlan_filter": "on [fixed]",
+                "rx_vlan_offload": "off [fixed]",
+                "rx_vlan_stag_filter": "off [fixed]",
+                "rx_vlan_stag_hw_parse": "off [fixed]",
+                "scatter_gather": "on",
+                "tcp_segmentation_offload": "on",
+                "tls_hw_record": "off [fixed]",
+                "tls_hw_rx_offload": "off [fixed]",
+                "tls_hw_tx_offload": "off [fixed]",
+                "tx_checksum_fcoe_crc": "off [fixed]",
+                "tx_checksum_ip_generic": "on",
+                "tx_checksum_ipv4": "off [fixed]",
+                "tx_checksum_ipv6": "off [fixed]",
+                "tx_checksum_sctp": "off [fixed]",
+                "tx_checksumming": "on",
+                "tx_esp_segmentation": "off [fixed]",
+                "tx_fcoe_segmentation": "off [fixed]",
+                "tx_gre_csum_segmentation": "off [fixed]",
+                "tx_gre_segmentation": "off [fixed]",
+                "tx_gso_list": "off [fixed]",
+                "tx_gso_partial": "off [fixed]",
+                "tx_gso_robust": "on [fixed]",
+                "tx_ipxip4_segmentation": "off [fixed]",
+                "tx_ipxip6_segmentation": "off [fixed]",
+                "tx_lockless": "off [fixed]",
+                "tx_nocache_copy": "off",
+                "tx_scatter_gather": "on",
+                "tx_scatter_gather_fraglist": "off [fixed]",
+                "tx_sctp_segmentation": "off [fixed]",
+                "tx_tcp6_segmentation": "on",
+                "tx_tcp_ecn_segmentation": "on",
+                "tx_tcp_mangleid_segmentation": "off",
+                "tx_tcp_segmentation": "on",
+                "tx_tunnel_remcsum_segmentation": "off [fixed]",
+                "tx_udp_segmentation": "off [fixed]",
+                "tx_udp_tnl_csum_segmentation": "off [fixed]",
+                "tx_udp_tnl_segmentation": "off [fixed]",
+                "tx_vlan_offload": "off [fixed]",
+                "tx_vlan_stag_hw_insert": "off [fixed]",
+                "vlan_challenged": "off [fixed]"
+            },
+            "hw_timestamp_filters": [],
+            "ipv4": {
+                "address": "192.168.88.20",
+                "broadcast": "192.168.88.255",
+                "netmask": "255.255.255.0",
+                "network": "192.168.88.0"
+            },
+            "ipv6": [
+                {
+                    "address": "fe80::5054:ff:fee3:8d8b",
+                    "prefix": "64",
+                    "scope": "link"
+                }
+            ],
+            "macaddress": "52:54:00:e3:8d:8b",
+            "module": "virtio_net",
+            "mtu": 1500,
+            "pciid": "virtio0",
+            "promisc": false,
+            "speed": -1,
+            "timestamping": [],
+            "type": "ether"
+        },
+        "ansible_env": {
+            "BASH_FUNC_which%%": "() {  ( alias;\n eval ${which_declare} ) | /usr/bin/which --tty-only --read-alias --read-functions --show-tilde --show-dot \"$@\"\n}",
+            "COCKPIT_REMOTE_PEER": "::ffff:192.168.88.251",
+            "DBUS_SESSION_BUS_ADDRESS": "unix:path=/run/user/0/bus",
+            "GEM_HOME": "/usr/local/rvm/gems/ruby-2.6.6",
+            "GEM_PATH": "/usr/local/rvm/gems/ruby-2.6.6:/usr/local/rvm/gems/ruby-2.6.6@global",
+            "GSETTINGS_BACKEND": "memory",
+            "HOME": "/root",
+            "IRBRC": "/usr/local/rvm/rubies/ruby-2.6.6/.irbrc",
+            "LANG": "C.UTF-8",
+            "LESSOPEN": "||/usr/bin/lesspipe.sh %s",
+            "LS_COLORS": "rs=0:di=38;5;33:ln=38;5;51:mh=00:pi=40;38;5;11:so=38;5;13:do=38;5;5:bd=48;5;232;38;5;11:cd=48;5;232;38;5;3:or=48;5;232;38;5;9:mi=01;05;37;41:su=48;5;196;38;5;15:sg=48;5;11;38;5;16:ca=48;5;196;38;5;226:tw=48;5;10;38;5;16:ow=48;5;10;38;5;21:st=48;5;21;38;5;15:ex=38;5;40:*.tar=38;5;9:*.tgz=38;5;9:*.arc=38;5;9:*.arj=38;5;9:*.taz=38;5;9:*.lha=38;5;9:*.lz4=38;5;9:*.lzh=38;5;9:*.lzma=38;5;9:*.tlz=38;5;9:*.txz=38;5;9:*.tzo=38;5;9:*.t7z=38;5;9:*.zip=38;5;9:*.z=38;5;9:*.dz=38;5;9:*.gz=38;5;9:*.lrz=38;5;9:*.lz=38;5;9:*.lzo=38;5;9:*.xz=38;5;9:*.zst=38;5;9:*.tzst=38;5;9:*.bz2=38;5;9:*.bz=38;5;9:*.tbz=38;5;9:*.tbz2=38;5;9:*.tz=38;5;9:*.deb=38;5;9:*.rpm=38;5;9:*.jar=38;5;9:*.war=38;5;9:*.ear=38;5;9:*.sar=38;5;9:*.rar=38;5;9:*.alz=38;5;9:*.ace=38;5;9:*.zoo=38;5;9:*.cpio=38;5;9:*.7z=38;5;9:*.rz=38;5;9:*.cab=38;5;9:*.wim=38;5;9:*.swm=38;5;9:*.dwm=38;5;9:*.esd=38;5;9:*.jpg=38;5;13:*.jpeg=38;5;13:*.mjpg=38;5;13:*.mjpeg=38;5;13:*.gif=38;5;13:*.bmp=38;5;13:*.pbm=38;5;13:*.pgm=38;5;13:*.ppm=38;5;13:*.tga=38;5;13:*.xbm=38;5;13:*.xpm=38;5;13:*.tif=38;5;13:*.tiff=38;5;13:*.png=38;5;13:*.svg=38;5;13:*.svgz=38;5;13:*.mng=38;5;13:*.pcx=38;5;13:*.mov=38;5;13:*.mpg=38;5;13:*.mpeg=38;5;13:*.m2v=38;5;13:*.mkv=38;5;13:*.webm=38;5;13:*.ogm=38;5;13:*.mp4=38;5;13:*.m4v=38;5;13:*.mp4v=38;5;13:*.vob=38;5;13:*.qt=38;5;13:*.nuv=38;5;13:*.wmv=38;5;13:*.asf=38;5;13:*.rm=38;5;13:*.rmvb=38;5;13:*.flc=38;5;13:*.avi=38;5;13:*.fli=38;5;13:*.flv=38;5;13:*.gl=38;5;13:*.dl=38;5;13:*.xcf=38;5;13:*.xwd=38;5;13:*.yuv=38;5;13:*.cgm=38;5;13:*.emf=38;5;13:*.ogv=38;5;13:*.ogx=38;5;13:*.aac=38;5;45:*.au=38;5;45:*.flac=38;5;45:*.m4a=38;5;45:*.mid=38;5;45:*.midi=38;5;45:*.mka=38;5;45:*.mp3=38;5;45:*.mpc=38;5;45:*.ogg=38;5;45:*.ra=38;5;45:*.wav=38;5;45:*.oga=38;5;45:*.opus=38;5;45:*.spx=38;5;45:*.xspf=38;5;45:",
+            "MY_RUBY_HOME": "/usr/local/rvm/rubies/ruby-2.6.6",
+            "PATH": "/usr/local/rvm/gems/ruby-2.6.6/bin:/usr/local/rvm/gems/ruby-2.6.6@global/bin:/usr/local/rvm/rubies/ruby-2.6.6/bin:/usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "PWD": "/root",
+            "RUBY_VERSION": "ruby-2.6.6",
+            "SHELL": "/bin/bash",
+            "SHLVL": "3",
+            "SSH_AGENT_PID": "18581",
+            "SSH_AUTH_SOCK": "/tmp/ssh-YHS1POnW9XpD/agent.18580",
+            "TERM": "xterm-256color",
+            "USER": "root",
+            "XDG_RUNTIME_DIR": "/run/user/0",
+            "XDG_SESSION_CLASS": "user",
+            "XDG_SESSION_ID": "5",
+            "XDG_SESSION_TYPE": "web",
+            "_": "/usr/bin/python3.6",
+            "install_flag": "1",
+            "rvm_bin_path": "/usr/local/rvm/bin",
+            "rvm_delete_flag": "0",
+            "rvm_path": "/usr/local/rvm",
+            "rvm_prefix": "/usr/local",
+            "rvm_ruby_string": "ruby-2.6.6",
+            "rvm_version": "1.29.12 (latest)",
+            "which_declare": "declare -f"
+        },
+        "ansible_fibre_channel_wwn": [],
+        "ansible_fips": false,
+        "ansible_form_factor": "Other",
+        "ansible_fqdn": "stream.dl360.cluster.com",
+        "ansible_hostname": "stream",
+        "ansible_hostnqn": "nqn.2014-08.org.nvmexpress:uuid:b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+        "ansible_interfaces": [
+            "ens3",
+            "lo"
+        ],
+        "ansible_is_chroot": false,
+        "ansible_iscsi_iqn": "iqn.1994-05.com.redhat:ba4973ffd86",
+        "ansible_kernel": "4.18.0-338.el8.x86_64",
+        "ansible_kernel_version": "#1 SMP Fri Aug 27 17:32:14 UTC 2021",
+        "ansible_lo": {
+            "active": true,
+            "device": "lo",
+            "features": {
+                "esp_hw_offload": "off [fixed]",
+                "esp_tx_csum_hw_offload": "off [fixed]",
+                "fcoe_mtu": "off [fixed]",
+                "generic_receive_offload": "on",
+                "generic_segmentation_offload": "on",
+                "highdma": "on [fixed]",
+                "hw_tc_offload": "off [fixed]",
+                "l2_fwd_offload": "off [fixed]",
+                "large_receive_offload": "off [fixed]",
+                "loopback": "on [fixed]",
+                "netns_local": "on [fixed]",
+                "ntuple_filters": "off [fixed]",
+                "receive_hashing": "off [fixed]",
+                "rx_all": "off [fixed]",
+                "rx_checksumming": "on [fixed]",
+                "rx_fcs": "off [fixed]",
+                "rx_gro_hw": "off [fixed]",
+                "rx_gro_list": "off",
+                "rx_udp_gro_forwarding": "off",
+                "rx_udp_tunnel_port_offload": "off [fixed]",
+                "rx_vlan_filter": "off [fixed]",
+                "rx_vlan_offload": "off [fixed]",
+                "rx_vlan_stag_filter": "off [fixed]",
+                "rx_vlan_stag_hw_parse": "off [fixed]",
+                "scatter_gather": "on",
+                "tcp_segmentation_offload": "on",
+                "tls_hw_record": "off [fixed]",
+                "tls_hw_rx_offload": "off [fixed]",
+                "tls_hw_tx_offload": "off [fixed]",
+                "tx_checksum_fcoe_crc": "off [fixed]",
+                "tx_checksum_ip_generic": "on [fixed]",
+                "tx_checksum_ipv4": "off [fixed]",
+                "tx_checksum_ipv6": "off [fixed]",
+                "tx_checksum_sctp": "on [fixed]",
+                "tx_checksumming": "on",
+                "tx_esp_segmentation": "off [fixed]",
+                "tx_fcoe_segmentation": "off [fixed]",
+                "tx_gre_csum_segmentation": "off [fixed]",
+                "tx_gre_segmentation": "off [fixed]",
+                "tx_gso_list": "on",
+                "tx_gso_partial": "off [fixed]",
+                "tx_gso_robust": "off [fixed]",
+                "tx_ipxip4_segmentation": "off [fixed]",
+                "tx_ipxip6_segmentation": "off [fixed]",
+                "tx_lockless": "on [fixed]",
+                "tx_nocache_copy": "off [fixed]",
+                "tx_scatter_gather": "on [fixed]",
+                "tx_scatter_gather_fraglist": "on [fixed]",
+                "tx_sctp_segmentation": "on",
+                "tx_tcp6_segmentation": "on",
+                "tx_tcp_ecn_segmentation": "on",
+                "tx_tcp_mangleid_segmentation": "on",
+                "tx_tcp_segmentation": "on",
+                "tx_tunnel_remcsum_segmentation": "off [fixed]",
+                "tx_udp_segmentation": "on",
+                "tx_udp_tnl_csum_segmentation": "off [fixed]",
+                "tx_udp_tnl_segmentation": "off [fixed]",
+                "tx_vlan_offload": "off [fixed]",
+                "tx_vlan_stag_hw_insert": "off [fixed]",
+                "vlan_challenged": "on [fixed]"
+            },
+            "hw_timestamp_filters": [],
+            "ipv4": {
+                "address": "127.0.0.1",
+                "broadcast": "",
+                "netmask": "255.0.0.0",
+                "network": "127.0.0.0"
+            },
+            "ipv6": [
+                {
+                    "address": "::1",
+                    "prefix": "128",
+                    "scope": "host"
+                }
+            ],
+            "mtu": 65536,
+            "promisc": false,
+            "timestamping": [],
+            "type": "loopback"
+        },
+        "ansible_local": {},
+        "ansible_lsb": {},
+        "ansible_lvm": {
+            "lvs": {
+                "root": {
+                    "size_g": "8.00",
+                    "vg": "cs_stream"
+                },
+                "swap": {
+                    "size_g": "1.00",
+                    "vg": "cs_stream"
+                }
+            },
+            "pvs": {
+                "/dev/vda2": {
+                    "free_g": "0",
+                    "size_g": "9.00",
+                    "vg": "cs_stream"
+                }
+            },
+            "vgs": {
+                "cs_stream": {
+                    "free_g": "0",
+                    "num_lvs": "2",
+                    "num_pvs": "1",
+                    "size_g": "9.00"
+                }
+            }
+        },
+        "ansible_machine": "x86_64",
+        "ansible_machine_id": "b9ea0f0a5ce445dc9a0e4979ea4911c1",
+        "ansible_memfree_mb": 89,
+        "ansible_memory_mb": {
+            "nocache": {
+                "free": 270,
+                "used": 539
+            },
+            "real": {
+                "free": 89,
+                "total": 809,
+                "used": 720
+            },
+            "swap": {
+                "cached": 18,
+                "free": 316,
+                "total": 1023,
+                "used": 707
+            }
+        },
+        "ansible_memtotal_mb": 809,
+        "ansible_mounts": [
+            {
+                "block_available": 1198584,
+                "block_size": 4096,
+                "block_total": 2093568,
+                "block_used": 894984,
+                "device": "/dev/mapper/cs_stream-root",
+                "fstype": "xfs",
+                "inode_available": 4089349,
+                "inode_total": 4192256,
+                "inode_used": 102907,
+                "mount": "/",
+                "options": "rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota",
+                "size_available": 4909400064,
+                "size_total": 8575254528,
+                "uuid": "50d1cc90-1804-4026-b473-58da96d64156"
+            },
+            {
+                "block_available": 204167,
+                "block_size": 4096,
+                "block_total": 259584,
+                "block_used": 55417,
+                "device": "/dev/vda1",
+                "fstype": "xfs",
+                "inode_available": 523979,
+                "inode_total": 524288,
+                "inode_used": 309,
+                "mount": "/boot",
+                "options": "rw,seclabel,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota",
+                "size_available": 836268032,
+                "size_total": 1063256064,
+                "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+            }
+        ],
+        "ansible_nodename": "stream.dl360.cluster.com",
+        "ansible_os_family": "RedHat",
+        "ansible_pkg_mgr": "dnf",
+        "ansible_proc_cmdline": {
+            "BOOT_IMAGE": "(hd0,msdos1)/vmlinuz-4.18.0-338.el8.x86_64",
+            "crashkernel": "auto",
+            "quiet": true,
+            "rd.lvm.lv": [
+                "cs_stream/root",
+                "cs_stream/swap"
+            ],
+            "resume": "/dev/mapper/cs_stream-swap",
+            "rhgb": true,
+            "ro": true,
+            "root": "/dev/mapper/cs_stream-root"
+        },
+        "ansible_processor": [
+            "0",
+            "GenuineIntel",
+            "Westmere E56xx/L56xx/X56xx (IBRS update)"
+        ],
+        "ansible_processor_cores": 1,
+        "ansible_processor_count": 1,
+        "ansible_processor_threads_per_core": 1,
+        "ansible_processor_vcpus": 1,
+        "ansible_product_name": "KVM",
+        "ansible_product_serial": "NA",
+        "ansible_product_uuid": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+        "ansible_product_version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+        "ansible_python": {
+            "executable": "/usr/bin/python3.6",
+            "has_sslcontext": true,
+            "type": "cpython",
+            "version": {
+                "major": 3,
+                "micro": 8,
+                "minor": 6,
+                "releaselevel": "final",
+                "serial": 0
+            },
+            "version_info": [
+                3,
+                6,
+                8,
+                "final",
+                0
+            ]
+        },
+        "ansible_python_version": "3.6.8",
+        "ansible_real_group_id": 0,
+        "ansible_real_user_id": 0,
+        "ansible_selinux": {
+            "config_mode": "enforcing",
+            "mode": "enforcing",
+            "policyvers": 33,
+            "status": "enabled",
+            "type": "targeted"
+        },
+        "ansible_selinux_python_present": true,
+        "ansible_service_mgr": "systemd",
+        "ansible_ssh_host_key_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLdk3JuvO4JtWAGg9jIqEDpeYc8ofaX5N6XwN0qyIW3iF12S9eNv6TZKTVLfZk7kF3n5MXTIkjJkfh+C2U9f4ic=",
+        "ansible_ssh_host_key_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAICNdD7XD7S1/I6b1nve57M+9r53NRt4fFYP3F1XSfiUN",
+        "ansible_ssh_host_key_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDId3dwByYgssoJLLqDZNkweT+TscVl2htpObYaWqIBfTH6rur0rXvOrRclEn+ZbZhvnAoUwNHUvIK6LZDL1Ji+mnAC8//P09HMMflHDDhrpZXEEfyN5yqG6Pc2CAPFlaiBatlThVZmo3RiHAQAZ2daBAZs9w6wgb2ImS+Lor5kyyFzVfEba7moDTBo09C7eG2k0O2dm70c9j3ArBs++LQc7BGSfL+GODADHXraJ8SFWkiXxKXMd7rLgOhEXEtnP9IksZBqeS/R1v7Vg8eErHhxUYRQDAPtJ4uaQCCGOIeUqcgzimY5hpi8kiyd7VK5P96MaRsr4Dv5X7MzwhUF+1vM8mkl2FX+zXfOA9m+KwA+EgmYCRsLqLugRTDEQBd/MzYz7uzUo+4nWZYUe4+N+1V9Dm6BbayPh+RT9dN1y1Luvm3nXpdPlj+6Wmo1LywNWwRWIXEj/zhVKK165Jh/5EOju0yO07IB9N0g1IzZSvHb6BGkw7OhwTKIoQ7D/O8buEs=",
+        "ansible_swapfree_mb": 316,
+        "ansible_swaptotal_mb": 1023,
+        "ansible_system": "Linux",
+        "ansible_system_capabilities": [
+            "cap_chown",
+            "cap_dac_override",
+            "cap_dac_read_search",
+            "cap_fowner",
+            "cap_fsetid",
+            "cap_kill",
+            "cap_setgid",
+            "cap_setuid",
+            "cap_setpcap",
+            "cap_linux_immutable",
+            "cap_net_bind_service",
+            "cap_net_broadcast",
+            "cap_net_admin",
+            "cap_net_raw",
+            "cap_ipc_lock",
+            "cap_ipc_owner",
+            "cap_sys_module",
+            "cap_sys_rawio",
+            "cap_sys_chroot",
+            "cap_sys_ptrace",
+            "cap_sys_pacct",
+            "cap_sys_admin",
+            "cap_sys_boot",
+            "cap_sys_nice",
+            "cap_sys_resource",
+            "cap_sys_time",
+            "cap_sys_tty_config",
+            "cap_mknod",
+            "cap_lease",
+            "cap_audit_write",
+            "cap_audit_control",
+            "cap_setfcap",
+            "cap_mac_override",
+            "cap_mac_admin",
+            "cap_syslog",
+            "cap_wake_alarm",
+            "cap_block_suspend",
+            "cap_audit_read",
+            "cap_perfmon",
+            "cap_bpf",
+            "cap_checkpoint_restore+ep"
+        ],
+        "ansible_system_capabilities_enforced": "True",
+        "ansible_system_vendor": "Red Hat",
+        "ansible_uptime_seconds": 84117,
+        "ansible_user_dir": "/root",
+        "ansible_user_gecos": "root",
+        "ansible_user_gid": 0,
+        "ansible_user_id": "root",
+        "ansible_user_shell": "/bin/bash",
+        "ansible_user_uid": 0,
+        "ansible_userspace_architecture": "x86_64",
+        "ansible_userspace_bits": "64",
+        "ansible_virtualization_role": "guest",
+        "ansible_virtualization_type": "kvm",
+        "gather_subset": [
+            "all"
+        ],
+        "module_setup": true,
+        "ohai_IPAddress": "192.168.88.0/24",
+        "ohai_block_device": {
+            "dm-0": {
+                "logical_block_size": "512",
+                "physical_block_size": "512",
+                "removable": "0",
+                "rotational": "1",
+                "size": "16769024"
+            },
+            "dm-1": {
+                "logical_block_size": "512",
+                "physical_block_size": "512",
+                "removable": "0",
+                "rotational": "1",
+                "size": "2097152"
+            },
+            "sr0": {
+                "logical_block_size": "512",
+                "model": "QEMU DVD-ROM",
+                "physical_block_size": "512",
+                "queue_depth": "1",
+                "removable": "1",
+                "rev": "2.5+",
+                "rotational": "1",
+                "size": "2097151",
+                "state": "running",
+                "timeout": "30",
+                "vendor": "QEMU"
+            },
+            "vda": {
+                "logical_block_size": "512",
+                "physical_block_size": "512",
+                "removable": "0",
+                "rotational": "1",
+                "size": "20971520",
+                "vendor": "0x1af4"
+            }
+        },
+        "ohai_chef_packages": {
+            "ohai": {
+                "ohai_root": "/usr/local/rvm/gems/ruby-2.6.6/gems/ohai-16.13.0/lib/ohai",
+                "version": "16.13.0"
+            }
+        },
+        "ohai_cloud": null,
+        "ohai_command": {
+            "ps": "ps -ef"
+        },
+        "ohai_counters": {
+            "network": {
+                "interfaces": {
+                    "ens3": {
+                        "rx": {
+                            "bytes": "473386723",
+                            "drop": "44867",
+                            "errors": "0",
+                            "overrun": "0",
+                            "packets": "433421"
+                        },
+                        "tx": {
+                            "bytes": "44070649",
+                            "carrier": "0",
+                            "collisions": "0",
+                            "drop": "0",
+                            "errors": "0",
+                            "packets": "170928",
+                            "queuelen": "1000"
+                        }
+                    },
+                    "lo": {
+                        "rx": {
+                            "bytes": "8328368",
+                            "drop": "0",
+                            "errors": "0",
+                            "overrun": "0",
+                            "packets": "2394"
+                        },
+                        "tx": {
+                            "bytes": "8328368",
+                            "carrier": "0",
+                            "collisions": "0",
+                            "drop": "0",
+                            "errors": "0",
+                            "packets": "2394",
+                            "queuelen": "1000"
+                        }
+                    }
+                }
+            }
+        },
+        "ohai_cpu": {
+            "0": {
+                "cache_size": "16384 KB",
+                "core_id": "0",
+                "cores": "1",
+                "family": "6",
+                "flags": [
+                    "fpu",
+                    "vme",
+                    "de",
+                    "pse",
+                    "tsc",
+                    "msr",
+                    "pae",
+                    "mce",
+                    "cx8",
+                    "apic",
+                    "sep",
+                    "mtrr",
+                    "pge",
+                    "mca",
+                    "cmov",
+                    "pat",
+                    "pse36",
+                    "clflush",
+                    "mmx",
+                    "fxsr",
+                    "sse",
+                    "sse2",
+                    "syscall",
+                    "nx",
+                    "pdpe1gb",
+                    "rdtscp",
+                    "lm",
+                    "constant_tsc",
+                    "rep_good",
+                    "nopl",
+                    "xtopology",
+                    "cpuid",
+                    "tsc_known_freq",
+                    "pni",
+                    "pclmulqdq",
+                    "ssse3",
+                    "cx16",
+                    "pcid",
+                    "sse4_1",
+                    "sse4_2",
+                    "x2apic",
+                    "popcnt",
+                    "tsc_deadline_timer",
+                    "aes",
+                    "hypervisor",
+                    "lahf_lm",
+                    "pti",
+                    "ssbd",
+                    "ibrs",
+                    "ibpb",
+                    "stibp",
+                    "tsc_adjust",
+                    "arat"
+                ],
+                "mhz": "2266.746",
+                "model": "44",
+                "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+                "physical_id": "0",
+                "stepping": "1",
+                "vendor_id": "GenuineIntel"
+            },
+            "cores": 1,
+            "real": 1,
+            "total": 1
+        },
+        "ohai_dmi": {
+            "bios": {
+                "address": "0xE8000",
+                "all_records": [
+                    {
+                        "Address": "0xE8000",
+                        "BIOS Revision": "0.0",
+                        "Characteristics": {
+                            "Targeted content distribution is supported": null
+                        },
+                        "ROM Size": "64 kB",
+                        "Release Date": "04/01/2014",
+                        "Runtime Size": "96 kB",
+                        "Vendor": "SeaBIOS",
+                        "Version": "1.11.0-2.el7",
+                        "application_identifier": "BIOS Information",
+                        "record_id": "0x0000",
+                        "size": "0"
+                    }
+                ],
+                "bios_revision": "0.0",
+                "release_date": "04/01/2014",
+                "rom_size": "64 kB",
+                "runtime_size": "96 kB",
+                "vendor": "SeaBIOS",
+                "version": "1.11.0-2.el7"
+            },
+            "chassis": {
+                "all_records": [
+                    {
+                        "Asset Tag": "Not Specified",
+                        "Boot-up State": "Safe",
+                        "Contained Elements": "0",
+                        "Height": "Unspecified",
+                        "Lock": "Not Present",
+                        "Manufacturer": "Red Hat",
+                        "Number Of Power Cords": "Unspecified",
+                        "OEM Information": "0x00000000",
+                        "Power Supply State": "Safe",
+                        "Security Status": "Unknown",
+                        "Serial Number": "Not Specified",
+                        "Thermal State": "Safe",
+                        "Type": "Other",
+                        "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+                        "application_identifier": "Chassis Information",
+                        "record_id": "0x0300",
+                        "size": "3"
+                    }
+                ],
+                "asset_tag": "Not Specified",
+                "boot_up_state": "Safe",
+                "contained_elements": "0",
+                "height": "Unspecified",
+                "lock": "Not Present",
+                "manufacturer": "Red Hat",
+                "number_of_power_cords": "Unspecified",
+                "oem_information": "0x00000000",
+                "power_supply_state": "Safe",
+                "security_status": "Unknown",
+                "serial_number": "Not Specified",
+                "thermal_state": "Safe",
+                "type": "Other",
+                "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)"
+            },
+            "dmidecode_version": "3.2",
+            "processor": {
+                "all_records": [
+                    {
+                        "Asset Tag": "Not Specified",
+                        "Characteristics": "None",
+                        "Core Count": "1",
+                        "Core Enabled": "1",
+                        "Current Speed": "2000 MHz",
+                        "External Clock": "Unknown",
+                        "Family": "Other",
+                        "ID": "C1 06 02 00 FF FB 8B 0F",
+                        "L1 Cache Handle": "Not Provided",
+                        "L2 Cache Handle": "Not Provided",
+                        "L3 Cache Handle": "Not Provided",
+                        "Manufacturer": "Red Hat",
+                        "Max Speed": "2000 MHz",
+                        "Part Number": "Not Specified",
+                        "Serial Number": "Not Specified",
+                        "Socket Designation": "CPU 0",
+                        "Status": "Populated, Enabled",
+                        "Thread Count": "1",
+                        "Type": "Central Processor",
+                        "Upgrade": "Other",
+                        "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+                        "Voltage": "Unknown",
+                        "application_identifier": "Processor Information",
+                        "record_id": "0x0400",
+                        "size": "4"
+                    }
+                ],
+                "asset_tag": "Not Specified",
+                "characteristics": "None",
+                "core_count": "1",
+                "core_enabled": "1",
+                "current_speed": "2000 MHz",
+                "external_clock": "Unknown",
+                "family": "Other",
+                "id": "C1 06 02 00 FF FB 8B 0F",
+                "l1_cache_handle": "Not Provided",
+                "l2_cache_handle": "Not Provided",
+                "l3_cache_handle": "Not Provided",
+                "manufacturer": "Red Hat",
+                "max_speed": "2000 MHz",
+                "part_number": "Not Specified",
+                "serial_number": "Not Specified",
+                "socket_designation": "CPU 0",
+                "status": "Populated, Enabled",
+                "thread_count": "1",
+                "type": "Central Processor",
+                "upgrade": "Other",
+                "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+                "voltage": "Unknown"
+            },
+            "smbios_version": "2.8",
+            "structures": {
+                "count": "9",
+                "size": "450"
+            },
+            "system": {
+                "all_records": [
+                    {
+                        "Family": "Red Hat Enterprise Linux",
+                        "Manufacturer": "Red Hat",
+                        "Product Name": "KVM",
+                        "SKU Number": "Not Specified",
+                        "Serial Number": "Not Specified",
+                        "UUID": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+                        "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+                        "Wake-up Type": "Power Switch",
+                        "application_identifier": "System Information",
+                        "record_id": "0x0100",
+                        "size": "1"
+                    }
+                ],
+                "family": "Red Hat Enterprise Linux",
+                "manufacturer": "Red Hat",
+                "product_name": "KVM",
+                "serial_number": "Not Specified",
+                "sku_number": "Not Specified",
+                "uuid": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+                "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+                "wake_up_type": "Power Switch"
+            }
+        },
+        "ohai_domain": "dl360.cluster.com",
+        "ohai_filesystem": {
+            "by_device": {
+                "/dev/mapper/cs_stream-root": {
+                    "fs_type": "xfs",
+                    "inodes_available": "4089353",
+                    "inodes_percent_used": "3%",
+                    "inodes_used": "102903",
+                    "kb_available": "4794340",
+                    "kb_size": "8374272",
+                    "kb_used": "3579932",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "attr2",
+                        "inode64",
+                        "logbufs=8",
+                        "logbsize=32k",
+                        "noquota"
+                    ],
+                    "mounts": [
+                        "/"
+                    ],
+                    "percent_used": "43%",
+                    "total_inodes": "4192256",
+                    "uuid": "50d1cc90-1804-4026-b473-58da96d64156"
+                },
+                "/dev/mapper/cs_stream-swap": {
+                    "fs_type": "swap",
+                    "mounts": [],
+                    "uuid": "0d782303-3cd7-451a-b5fd-083ba57fb696"
+                },
+                "/dev/sr0": {
+                    "mounts": []
+                },
+                "/dev/vda": {
+                    "mounts": []
+                },
+                "/dev/vda1": {
+                    "fs_type": "xfs",
+                    "inodes_available": "523979",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "309",
+                    "kb_available": "816668",
+                    "kb_size": "1038336",
+                    "kb_used": "221668",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "attr2",
+                        "inode64",
+                        "logbufs=8",
+                        "logbsize=32k",
+                        "noquota"
+                    ],
+                    "mounts": [
+                        "/boot"
+                    ],
+                    "percent_used": "22%",
+                    "total_inodes": "524288",
+                    "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+                },
+                "/dev/vda2": {
+                    "fs_type": "LVM2_member",
+                    "mounts": [],
+                    "uuid": "iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL"
+                },
+                "bpf": {
+                    "fs_type": "bpf",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "mode=700"
+                    ],
+                    "mounts": [
+                        "/sys/fs/bpf"
+                    ]
+                },
+                "cgroup": {
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "rdma"
+                    ],
+                    "mounts": [
+                        "/sys/fs/cgroup/systemd",
+                        "/sys/fs/cgroup/devices",
+                        "/sys/fs/cgroup/cpuset",
+                        "/sys/fs/cgroup/blkio",
+                        "/sys/fs/cgroup/hugetlb",
+                        "/sys/fs/cgroup/memory",
+                        "/sys/fs/cgroup/perf_event",
+                        "/sys/fs/cgroup/cpu,cpuacct",
+                        "/sys/fs/cgroup/freezer",
+                        "/sys/fs/cgroup/pids",
+                        "/sys/fs/cgroup/net_cls,net_prio",
+                        "/sys/fs/cgroup/rdma"
+                    ]
+                },
+                "configfs": {
+                    "fs_type": "configfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ],
+                    "mounts": [
+                        "/sys/kernel/config"
+                    ]
+                },
+                "debugfs": {
+                    "fs_type": "debugfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ],
+                    "mounts": [
+                        "/sys/kernel/debug"
+                    ]
+                },
+                "devpts": {
+                    "fs_type": "devpts",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "gid=5",
+                        "mode=620",
+                        "ptmxmode=000"
+                    ],
+                    "mounts": [
+                        "/dev/pts"
+                    ]
+                },
+                "devtmpfs": {
+                    "fs_type": "devtmpfs",
+                    "inodes_available": "98384",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "370",
+                    "kb_available": "395016",
+                    "kb_size": "395016",
+                    "kb_used": "0",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "seclabel",
+                        "size=395016k",
+                        "nr_inodes=98754",
+                        "mode=755"
+                    ],
+                    "mounts": [
+                        "/dev"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "98754"
+                },
+                "fusectl": {
+                    "fs_type": "fusectl",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ],
+                    "mounts": [
+                        "/sys/fs/fuse/connections"
+                    ]
+                },
+                "hugetlbfs": {
+                    "fs_type": "hugetlbfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "pagesize=2M"
+                    ],
+                    "mounts": [
+                        "/dev/hugepages"
+                    ]
+                },
+                "mqueue": {
+                    "fs_type": "mqueue",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ],
+                    "mounts": [
+                        "/dev/mqueue"
+                    ]
+                },
+                "none": {
+                    "fs_type": "tracefs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ],
+                    "mounts": [
+                        "/sys/kernel/tracing"
+                    ]
+                },
+                "proc": {
+                    "fs_type": "proc",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime"
+                    ],
+                    "mounts": [
+                        "/proc"
+                    ]
+                },
+                "pstore": {
+                    "fs_type": "pstore",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel"
+                    ],
+                    "mounts": [
+                        "/sys/fs/pstore"
+                    ]
+                },
+                "securityfs": {
+                    "fs_type": "securityfs",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime"
+                    ],
+                    "mounts": [
+                        "/sys/kernel/security"
+                    ]
+                },
+                "selinuxfs": {
+                    "fs_type": "selinuxfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ],
+                    "mounts": [
+                        "/sys/fs/selinux"
+                    ]
+                },
+                "sysfs": {
+                    "fs_type": "sysfs",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel"
+                    ],
+                    "mounts": [
+                        "/sys"
+                    ]
+                },
+                "systemd-1": {
+                    "fs_type": "autofs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "fd=34",
+                        "pgrp=1",
+                        "timeout=0",
+                        "minproto=5",
+                        "maxproto=5",
+                        "direct",
+                        "pipe_ino=18891"
+                    ],
+                    "mounts": [
+                        "/proc/sys/fs/binfmt_misc"
+                    ]
+                },
+                "tmpfs": {
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103535",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "28",
+                    "kb_available": "82848",
+                    "kb_size": "82848",
+                    "kb_used": "0",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "relatime",
+                        "seclabel",
+                        "size=82848k",
+                        "mode=700"
+                    ],
+                    "mounts": [
+                        "/dev/shm",
+                        "/run",
+                        "/sys/fs/cgroup",
+                        "/run/user/0"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "103563"
+                },
+                "tracefs": {
+                    "fs_type": "tracefs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ],
+                    "mounts": [
+                        "/sys/kernel/debug/tracing"
+                    ]
+                }
+            },
+            "by_mountpoint": {
+                "/": {
+                    "devices": [
+                        "/dev/mapper/cs_stream-root"
+                    ],
+                    "fs_type": "xfs",
+                    "inodes_available": "4089353",
+                    "inodes_percent_used": "3%",
+                    "inodes_used": "102903",
+                    "kb_available": "4794340",
+                    "kb_size": "8374272",
+                    "kb_used": "3579932",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "attr2",
+                        "inode64",
+                        "logbufs=8",
+                        "logbsize=32k",
+                        "noquota"
+                    ],
+                    "percent_used": "43%",
+                    "total_inodes": "4192256",
+                    "uuid": "50d1cc90-1804-4026-b473-58da96d64156"
+                },
+                "/boot": {
+                    "devices": [
+                        "/dev/vda1"
+                    ],
+                    "fs_type": "xfs",
+                    "inodes_available": "523979",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "309",
+                    "kb_available": "816668",
+                    "kb_size": "1038336",
+                    "kb_used": "221668",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "attr2",
+                        "inode64",
+                        "logbufs=8",
+                        "logbsize=32k",
+                        "noquota"
+                    ],
+                    "percent_used": "22%",
+                    "total_inodes": "524288",
+                    "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+                },
+                "/dev": {
+                    "devices": [
+                        "devtmpfs"
+                    ],
+                    "fs_type": "devtmpfs",
+                    "inodes_available": "98384",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "370",
+                    "kb_available": "395016",
+                    "kb_size": "395016",
+                    "kb_used": "0",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "seclabel",
+                        "size=395016k",
+                        "nr_inodes=98754",
+                        "mode=755"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "98754"
+                },
+                "/dev/hugepages": {
+                    "devices": [
+                        "hugetlbfs"
+                    ],
+                    "fs_type": "hugetlbfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "pagesize=2M"
+                    ]
+                },
+                "/dev/mqueue": {
+                    "devices": [
+                        "mqueue"
+                    ],
+                    "fs_type": "mqueue",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "/dev/pts": {
+                    "devices": [
+                        "devpts"
+                    ],
+                    "fs_type": "devpts",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "gid=5",
+                        "mode=620",
+                        "ptmxmode=000"
+                    ]
+                },
+                "/dev/shm": {
+                    "devices": [
+                        "tmpfs"
+                    ],
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103447",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "116",
+                    "kb_available": "413792",
+                    "kb_size": "414252",
+                    "kb_used": "460",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "seclabel"
+                    ],
+                    "percent_used": "1%",
+                    "total_inodes": "103563"
+                },
+                "/proc": {
+                    "devices": [
+                        "proc"
+                    ],
+                    "fs_type": "proc",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime"
+                    ]
+                },
+                "/proc/sys/fs/binfmt_misc": {
+                    "devices": [
+                        "systemd-1"
+                    ],
+                    "fs_type": "autofs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "fd=34",
+                        "pgrp=1",
+                        "timeout=0",
+                        "minproto=5",
+                        "maxproto=5",
+                        "direct",
+                        "pipe_ino=18891"
+                    ]
+                },
+                "/run": {
+                    "devices": [
+                        "tmpfs"
+                    ],
+                    "fs_type": "tmpfs",
+                    "inodes_available": "102943",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "620",
+                    "kb_available": "403276",
+                    "kb_size": "414252",
+                    "kb_used": "10976",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "seclabel",
+                        "mode=755"
+                    ],
+                    "percent_used": "3%",
+                    "total_inodes": "103563"
+                },
+                "/run/user/0": {
+                    "devices": [
+                        "tmpfs"
+                    ],
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103535",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "28",
+                    "kb_available": "82848",
+                    "kb_size": "82848",
+                    "kb_used": "0",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "relatime",
+                        "seclabel",
+                        "size=82848k",
+                        "mode=700"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "103563"
+                },
+                "/sys": {
+                    "devices": [
+                        "sysfs"
+                    ],
+                    "fs_type": "sysfs",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "/sys/fs/bpf": {
+                    "devices": [
+                        "bpf"
+                    ],
+                    "fs_type": "bpf",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "mode=700"
+                    ]
+                },
+                "/sys/fs/cgroup": {
+                    "devices": [
+                        "tmpfs"
+                    ],
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103546",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "17",
+                    "kb_available": "414252",
+                    "kb_size": "414252",
+                    "kb_used": "0",
+                    "mount_options": [
+                        "ro",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "seclabel",
+                        "mode=755"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "103563"
+                },
+                "/sys/fs/cgroup/blkio": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "blkio"
+                    ]
+                },
+                "/sys/fs/cgroup/cpu,cpuacct": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "cpu",
+                        "cpuacct"
+                    ]
+                },
+                "/sys/fs/cgroup/cpuset": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "cpuset"
+                    ]
+                },
+                "/sys/fs/cgroup/devices": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "devices"
+                    ]
+                },
+                "/sys/fs/cgroup/freezer": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "freezer"
+                    ]
+                },
+                "/sys/fs/cgroup/hugetlb": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "hugetlb"
+                    ]
+                },
+                "/sys/fs/cgroup/memory": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "memory"
+                    ]
+                },
+                "/sys/fs/cgroup/net_cls,net_prio": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "net_cls",
+                        "net_prio"
+                    ]
+                },
+                "/sys/fs/cgroup/perf_event": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "perf_event"
+                    ]
+                },
+                "/sys/fs/cgroup/pids": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "pids"
+                    ]
+                },
+                "/sys/fs/cgroup/rdma": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "rdma"
+                    ]
+                },
+                "/sys/fs/cgroup/systemd": {
+                    "devices": [
+                        "cgroup"
+                    ],
+                    "fs_type": "cgroup",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "xattr",
+                        "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+                        "name=systemd"
+                    ]
+                },
+                "/sys/fs/fuse/connections": {
+                    "devices": [
+                        "fusectl"
+                    ],
+                    "fs_type": "fusectl",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ]
+                },
+                "/sys/fs/pstore": {
+                    "devices": [
+                        "pstore"
+                    ],
+                    "fs_type": "pstore",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "/sys/fs/selinux": {
+                    "devices": [
+                        "selinuxfs"
+                    ],
+                    "fs_type": "selinuxfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ]
+                },
+                "/sys/kernel/config": {
+                    "devices": [
+                        "configfs"
+                    ],
+                    "fs_type": "configfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ]
+                },
+                "/sys/kernel/debug": {
+                    "devices": [
+                        "debugfs"
+                    ],
+                    "fs_type": "debugfs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "/sys/kernel/debug/tracing": {
+                    "devices": [
+                        "tracefs"
+                    ],
+                    "fs_type": "tracefs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "/sys/kernel/security": {
+                    "devices": [
+                        "securityfs"
+                    ],
+                    "fs_type": "securityfs",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime"
+                    ]
+                },
+                "/sys/kernel/tracing": {
+                    "devices": [
+                        "none"
+                    ],
+                    "fs_type": "tracefs",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                }
+            },
+            "by_pair": {
+                "/dev/mapper/cs_stream-root,/": {
+                    "device": "/dev/mapper/cs_stream-root",
+                    "fs_type": "xfs",
+                    "inodes_available": "4089353",
+                    "inodes_percent_used": "3%",
+                    "inodes_used": "102903",
+                    "kb_available": "4794340",
+                    "kb_size": "8374272",
+                    "kb_used": "3579932",
+                    "mount": "/",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "attr2",
+                        "inode64",
+                        "logbufs=8",
+                        "logbsize=32k",
+                        "noquota"
+                    ],
+                    "percent_used": "43%",
+                    "total_inodes": "4192256",
+                    "uuid": "50d1cc90-1804-4026-b473-58da96d64156"
+                },
+                "/dev/mapper/cs_stream-swap,": {
+                    "device": "/dev/mapper/cs_stream-swap",
+                    "fs_type": "swap",
+                    "uuid": "0d782303-3cd7-451a-b5fd-083ba57fb696"
+                },
+                "/dev/sr0,": {
+                    "device": "/dev/sr0"
+                },
+                "/dev/vda,": {
+                    "device": "/dev/vda"
+                },
+                "/dev/vda1,/boot": {
+                    "device": "/dev/vda1",
+                    "fs_type": "xfs",
+                    "inodes_available": "523979",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "309",
+                    "kb_available": "816668",
+                    "kb_size": "1038336",
+                    "kb_used": "221668",
+                    "mount": "/boot",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "attr2",
+                        "inode64",
+                        "logbufs=8",
+                        "logbsize=32k",
+                        "noquota"
+                    ],
+                    "percent_used": "22%",
+                    "total_inodes": "524288",
+                    "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+                },
+                "/dev/vda2,": {
+                    "device": "/dev/vda2",
+                    "fs_type": "LVM2_member",
+                    "uuid": "iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL"
+                },
+                "bpf,/sys/fs/bpf": {
+                    "device": "bpf",
+                    "fs_type": "bpf",
+                    "mount": "/sys/fs/bpf",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "mode=700"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/blkio": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/blkio",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "blkio"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/cpu,cpuacct",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "cpu",
+                        "cpuacct"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/cpuset": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/cpuset",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "cpuset"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/devices": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/devices",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "devices"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/freezer": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/freezer",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "freezer"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/hugetlb": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/hugetlb",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "hugetlb"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/memory": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/memory",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "memory"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/net_cls,net_prio",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "net_cls",
+                        "net_prio"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/perf_event": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/perf_event",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "perf_event"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/pids": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/pids",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "pids"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/rdma": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/rdma",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "rdma"
+                    ]
+                },
+                "cgroup,/sys/fs/cgroup/systemd": {
+                    "device": "cgroup",
+                    "fs_type": "cgroup",
+                    "mount": "/sys/fs/cgroup/systemd",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "xattr",
+                        "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+                        "name=systemd"
+                    ]
+                },
+                "configfs,/sys/kernel/config": {
+                    "device": "configfs",
+                    "fs_type": "configfs",
+                    "mount": "/sys/kernel/config",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ]
+                },
+                "debugfs,/sys/kernel/debug": {
+                    "device": "debugfs",
+                    "fs_type": "debugfs",
+                    "mount": "/sys/kernel/debug",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "devpts,/dev/pts": {
+                    "device": "devpts",
+                    "fs_type": "devpts",
+                    "mount": "/dev/pts",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "noexec",
+                        "relatime",
+                        "seclabel",
+                        "gid=5",
+                        "mode=620",
+                        "ptmxmode=000"
+                    ]
+                },
+                "devtmpfs,/dev": {
+                    "device": "devtmpfs",
+                    "fs_type": "devtmpfs",
+                    "inodes_available": "98384",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "370",
+                    "kb_available": "395016",
+                    "kb_size": "395016",
+                    "kb_used": "0",
+                    "mount": "/dev",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "seclabel",
+                        "size=395016k",
+                        "nr_inodes=98754",
+                        "mode=755"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "98754"
+                },
+                "fusectl,/sys/fs/fuse/connections": {
+                    "device": "fusectl",
+                    "fs_type": "fusectl",
+                    "mount": "/sys/fs/fuse/connections",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ]
+                },
+                "hugetlbfs,/dev/hugepages": {
+                    "device": "hugetlbfs",
+                    "fs_type": "hugetlbfs",
+                    "mount": "/dev/hugepages",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel",
+                        "pagesize=2M"
+                    ]
+                },
+                "mqueue,/dev/mqueue": {
+                    "device": "mqueue",
+                    "fs_type": "mqueue",
+                    "mount": "/dev/mqueue",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "none,/sys/kernel/tracing": {
+                    "device": "none",
+                    "fs_type": "tracefs",
+                    "mount": "/sys/kernel/tracing",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "proc,/proc": {
+                    "device": "proc",
+                    "fs_type": "proc",
+                    "mount": "/proc",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime"
+                    ]
+                },
+                "pstore,/sys/fs/pstore": {
+                    "device": "pstore",
+                    "fs_type": "pstore",
+                    "mount": "/sys/fs/pstore",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "securityfs,/sys/kernel/security": {
+                    "device": "securityfs",
+                    "fs_type": "securityfs",
+                    "mount": "/sys/kernel/security",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime"
+                    ]
+                },
+                "selinuxfs,/sys/fs/selinux": {
+                    "device": "selinuxfs",
+                    "fs_type": "selinuxfs",
+                    "mount": "/sys/fs/selinux",
+                    "mount_options": [
+                        "rw",
+                        "relatime"
+                    ]
+                },
+                "sysfs,/sys": {
+                    "device": "sysfs",
+                    "fs_type": "sysfs",
+                    "mount": "/sys",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "relatime",
+                        "seclabel"
+                    ]
+                },
+                "systemd-1,/proc/sys/fs/binfmt_misc": {
+                    "device": "systemd-1",
+                    "fs_type": "autofs",
+                    "mount": "/proc/sys/fs/binfmt_misc",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "fd=34",
+                        "pgrp=1",
+                        "timeout=0",
+                        "minproto=5",
+                        "maxproto=5",
+                        "direct",
+                        "pipe_ino=18891"
+                    ]
+                },
+                "tmpfs,/dev/shm": {
+                    "device": "tmpfs",
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103447",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "116",
+                    "kb_available": "413792",
+                    "kb_size": "414252",
+                    "kb_used": "460",
+                    "mount": "/dev/shm",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "seclabel"
+                    ],
+                    "percent_used": "1%",
+                    "total_inodes": "103563"
+                },
+                "tmpfs,/run": {
+                    "device": "tmpfs",
+                    "fs_type": "tmpfs",
+                    "inodes_available": "102943",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "620",
+                    "kb_available": "403276",
+                    "kb_size": "414252",
+                    "kb_used": "10976",
+                    "mount": "/run",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "seclabel",
+                        "mode=755"
+                    ],
+                    "percent_used": "3%",
+                    "total_inodes": "103563"
+                },
+                "tmpfs,/run/user/0": {
+                    "device": "tmpfs",
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103535",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "28",
+                    "kb_available": "82848",
+                    "kb_size": "82848",
+                    "kb_used": "0",
+                    "mount": "/run/user/0",
+                    "mount_options": [
+                        "rw",
+                        "nosuid",
+                        "nodev",
+                        "relatime",
+                        "seclabel",
+                        "size=82848k",
+                        "mode=700"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "103563"
+                },
+                "tmpfs,/sys/fs/cgroup": {
+                    "device": "tmpfs",
+                    "fs_type": "tmpfs",
+                    "inodes_available": "103546",
+                    "inodes_percent_used": "1%",
+                    "inodes_used": "17",
+                    "kb_available": "414252",
+                    "kb_size": "414252",
+                    "kb_used": "0",
+                    "mount": "/sys/fs/cgroup",
+                    "mount_options": [
+                        "ro",
+                        "nosuid",
+                        "nodev",
+                        "noexec",
+                        "seclabel",
+                        "mode=755"
+                    ],
+                    "percent_used": "0%",
+                    "total_inodes": "103563"
+                },
+                "tracefs,/sys/kernel/debug/tracing": {
+                    "device": "tracefs",
+                    "fs_type": "tracefs",
+                    "mount": "/sys/kernel/debug/tracing",
+                    "mount_options": [
+                        "rw",
+                        "relatime",
+                        "seclabel"
+                    ]
+                }
+            }
+        },
+        "ohai_fips": {
+            "kernel": {
+                "enabled": true
+            }
+        },
+        "ohai_fqdn": "stream.dl360.cluster.com",
+        "ohai_hostname": "stream",
+        "ohai_hostnamectl": {
+            "architecture": "x86-64",
+            "boot_id": "0f8f6635fc0d4b7e85eb17ec27b341df",
+            "chassis": "vm",
+            "cpe_os_name": "cpe:/o:centos:centos:8",
+            "icon_name": "computer-vm",
+            "kernel": "Linux 4.18.0-338.el8.x86_64",
+            "machine_id": "b9ea0f0a5ce445dc9a0e4979ea4911c1",
+            "operating_system": "CentOS Stream 8",
+            "static_hostname": "stream.dl360.cluster.com",
+            "virtualization": "kvm"
+        },
+        "ohai_idletime": "22 hours 53 minutes 00 seconds",
+        "ohai_idletime_seconds": 82380,
+        "ohai_init_package": "systemd",
+        "ohai_ip6address": "fe80::5054:ff:fee3:8d8b",
+        "ohai_ipaddress": "192.168.88.20",
+        "ohai_kernel": {
+            "machine": "x86_64",
+            "modules": {
+                "ata_generic": {
+                    "refcount": "0",
+                    "size": "16384",
+                    "version": "0.2.15"
+                },
+                "ata_piix": {
+                    "refcount": "0",
+                    "size": "36864",
+                    "version": "2.13"
+                },
+                "cdrom": {
+                    "refcount": "1",
+                    "size": "65536"
+                },
+                "crc32_pclmul": {
+                    "refcount": "0",
+                    "size": "16384"
+                },
+                "crc32c_intel": {
+                    "refcount": "1",
+                    "size": "24576"
+                },
+                "crct10dif_pclmul": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "dm_log": {
+                    "refcount": "2",
+                    "size": "20480"
+                },
+                "dm_mirror": {
+                    "refcount": "0",
+                    "size": "28672"
+                },
+                "dm_mod": {
+                    "refcount": "9",
+                    "size": "151552"
+                },
+                "dm_region_hash": {
+                    "refcount": "1",
+                    "size": "20480"
+                },
+                "drm": {
+                    "refcount": "5",
+                    "size": "573440"
+                },
+                "drm_kms_helper": {
+                    "refcount": "3",
+                    "size": "253952"
+                },
+                "drm_ttm_helper": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "failover": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "fb_sys_fops": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "fuse": {
+                    "refcount": "1",
+                    "size": "155648"
+                },
+                "ghash_clmulni_intel": {
+                    "refcount": "0",
+                    "size": "16384"
+                },
+                "i2c_piix4": {
+                    "refcount": "0",
+                    "size": "24576"
+                },
+                "ip_set": {
+                    "refcount": "0",
+                    "size": "49152"
+                },
+                "joydev": {
+                    "refcount": "0",
+                    "size": "24576"
+                },
+                "ledtrig_audio": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "libata": {
+                    "refcount": "2",
+                    "size": "270336",
+                    "version": "3.00"
+                },
+                "libcrc32c": {
+                    "refcount": "4",
+                    "size": "16384"
+                },
+                "net_failover": {
+                    "refcount": "1",
+                    "size": "24576"
+                },
+                "nf_conntrack": {
+                    "refcount": "1",
+                    "size": "172032"
+                },
+                "nf_defrag_ipv4": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "nf_defrag_ipv6": {
+                    "refcount": "1",
+                    "size": "20480"
+                },
+                "nf_nat": {
+                    "refcount": "1",
+                    "size": "45056"
+                },
+                "nf_tables": {
+                    "refcount": "1",
+                    "size": "172032"
+                },
+                "nfnetlink": {
+                    "refcount": "2",
+                    "size": "16384"
+                },
+                "nft_chain_nat": {
+                    "refcount": "8",
+                    "size": "16384"
+                },
+                "pcspkr": {
+                    "refcount": "0",
+                    "size": "16384"
+                },
+                "qxl": {
+                    "refcount": "0",
+                    "size": "69632"
+                },
+                "serio_raw": {
+                    "refcount": "0",
+                    "size": "16384"
+                },
+                "sg": {
+                    "refcount": "0",
+                    "size": "40960",
+                    "version": "3.5.36"
+                },
+                "snd": {
+                    "refcount": "6",
+                    "size": "94208"
+                },
+                "snd_hda_codec": {
+                    "refcount": "2",
+                    "size": "151552"
+                },
+                "snd_hda_codec_generic": {
+                    "refcount": "1",
+                    "size": "86016"
+                },
+                "snd_hda_core": {
+                    "refcount": "3",
+                    "size": "102400"
+                },
+                "snd_hda_intel": {
+                    "refcount": "0",
+                    "size": "49152"
+                },
+                "snd_hwdep": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "snd_intel_dspcfg": {
+                    "refcount": "1",
+                    "size": "24576"
+                },
+                "snd_intel_sdw_acpi": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "snd_pcm": {
+                    "refcount": "3",
+                    "size": "118784"
+                },
+                "snd_timer": {
+                    "refcount": "1",
+                    "size": "36864"
+                },
+                "soundcore": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "sr_mod": {
+                    "refcount": "0",
+                    "size": "28672"
+                },
+                "syscopyarea": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "sysfillrect": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "sysimgblt": {
+                    "refcount": "1",
+                    "size": "16384"
+                },
+                "ttm": {
+                    "refcount": "2",
+                    "size": "77824"
+                },
+                "virtio_balloon": {
+                    "refcount": "0",
+                    "size": "20480"
+                },
+                "virtio_blk": {
+                    "refcount": "3",
+                    "size": "20480"
+                },
+                "virtio_console": {
+                    "refcount": "0",
+                    "size": "36864"
+                },
+                "virtio_net": {
+                    "refcount": "0",
+                    "size": "53248"
+                },
+                "xfs": {
+                    "refcount": "2",
+                    "size": "1544192"
+                }
+            },
+            "name": "Linux",
+            "os": "GNU/Linux",
+            "processor": "x86_64",
+            "release": "4.18.0-338.el8.x86_64",
+            "version": "#1 SMP Fri Aug 27 17:32:14 UTC 2021"
+        },
+        "ohai_keys": {
+            "ssh": {
+                "host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLdk3JuvO4JtWAGg9jIqEDpeYc8ofaX5N6XwN0qyIW3iF12S9eNv6TZKTVLfZk7kF3n5MXTIkjJkfh+C2U9f4ic=",
+                "host_ecdsa_type": "ecdsa-sha2-nistp256",
+                "host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAICNdD7XD7S1/I6b1nve57M+9r53NRt4fFYP3F1XSfiUN",
+                "host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDId3dwByYgssoJLLqDZNkweT+TscVl2htpObYaWqIBfTH6rur0rXvOrRclEn+ZbZhvnAoUwNHUvIK6LZDL1Ji+mnAC8//P09HMMflHDDhrpZXEEfyN5yqG6Pc2CAPFlaiBatlThVZmo3RiHAQAZ2daBAZs9w6wgb2ImS+Lor5kyyFzVfEba7moDTBo09C7eG2k0O2dm70c9j3ArBs++LQc7BGSfL+GODADHXraJ8SFWkiXxKXMd7rLgOhEXEtnP9IksZBqeS/R1v7Vg8eErHhxUYRQDAPtJ4uaQCCGOIeUqcgzimY5hpi8kiyd7VK5P96MaRsr4Dv5X7MzwhUF+1vM8mkl2FX+zXfOA9m+KwA+EgmYCRsLqLugRTDEQBd/MzYz7uzUo+4nWZYUe4+N+1V9Dm6BbayPh+RT9dN1y1Luvm3nXpdPlj+6Wmo1LywNWwRWIXEj/zhVKK165Jh/5EOju0yO07IB9N0g1IzZSvHb6BGkw7OhwTKIoQ7D/O8buEs="
+            }
+        },
+        "ohai_languages": {
+            "c": {
+                "gcc": {
+                    "configured_with": "../configure --enable-bootstrap --enable-languages=c,c++,fortran,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl --disable-libmpx --enable-offload-targets=nvptx-none --without-cuda-driver --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=x86-64 --build=x86_64-redhat-linux",
+                    "description": "gcc version 8.5.0 20210514 (Red Hat 8.5.0-3) (GCC) ",
+                    "target": "x86_64-redhat-linux",
+                    "thread_model": "posix",
+                    "version": "8.5.0"
+                },
+                "glibc": {
+                    "description": "GNU C Library (GNU libc) stable release version 2.28.",
+                    "version": "2.28."
+                }
+            },
+            "perl": {
+                "archname": "x86_64-linux-thread-multi",
+                "version": "5.26.3"
+            },
+            "ruby": {
+                "bin_dir": "/usr/local/rvm/rubies/ruby-2.6.6/bin",
+                "gem_bin": "/usr/local/rvm/rubies/ruby-2.6.6/bin/gem",
+                "gems_dir": "/usr/local/rvm/gems/ruby-2.6.6",
+                "host": "x86_64-pc-linux-gnu",
+                "host_cpu": "x86_64",
+                "host_os": "linux-gnu",
+                "host_vendor": "pc",
+                "platform": "x86_64-linux",
+                "release_date": "2020-03-31",
+                "ruby_bin": "/usr/local/rvm/rubies/ruby-2.6.6/bin/ruby",
+                "target": "x86_64-pc-linux-gnu",
+                "target_cpu": "x86_64",
+                "target_os": "linux",
+                "target_vendor": "pc",
+                "version": "2.6.6"
+            },
+            "rust": {
+                "version": "1.54.0"
+            }
+        },
+        "ohai_lsb": {},
+        "ohai_macaddress": "52:54:00:E3:8D:8B",
+        "ohai_machine_id": "b9ea0f0a5ce445dc9a0e4979ea4911c1",
+        "ohai_machinename": "stream.dl360.cluster.com",
+        "ohai_memory": {
+            "active": "208724kB",
+            "anon_pages": "438736kB",
+            "available": "122696kB",
+            "bounce": "0kB",
+            "buffers": "3164kB",
+            "cached": "158720kB",
+            "commit_limit": "1462824kB",
+            "committed_as": "2305324kB",
+            "directmap": {
+                "1G": "0kB",
+                "2M": "894976kB",
+                "4k": "153444kB"
+            },
+            "dirty": "712kB",
+            "free": "61268kB",
+            "hugepage_size": "2048kB",
+            "hugepages": {
+                "free": "0",
+                "reserved": "0",
+                "surplus": "0",
+                "total": "0"
+            },
+            "hugetlb": "0kB",
+            "inactive": "413556kB",
+            "mapped": "34052kB",
+            "nfs_unstable": "0kB",
+            "page_tables": "25928kB",
+            "slab": "75424kB",
+            "slab_reclaimable": "29448kB",
+            "slab_unreclaim": "45976kB",
+            "swap": {
+                "cached": "22440kB",
+                "free": "344448kB",
+                "total": "1048572kB"
+            },
+            "total": "828508kB",
+            "vmalloc_chunk": "0kB",
+            "vmalloc_total": "34359738367kB",
+            "vmalloc_used": "0kB",
+            "writeback": "0kB"
+        },
+        "ohai_network": {
+            "default_gateway": "192.168.88.1",
+            "default_interface": "ens3",
+            "interfaces": {
+                "ens3": {
+                    "addresses": {
+                        "192.168.88.20": {
+                            "broadcast": "192.168.88.255",
+                            "family": "inet",
+                            "netmask": "255.255.255.0",
+                            "prefixlen": "24",
+                            "scope": "Global"
+                        },
+                        "52:54:00:E3:8D:8B": {
+                            "family": "lladdr"
+                        },
+                        "fe80::5054:ff:fee3:8d8b": {
+                            "family": "inet6",
+                            "prefixlen": "64",
+                            "scope": "Link",
+                            "tags": [
+                                "noprefixroute"
+                            ]
+                        }
+                    },
+                    "arp": {
+                        "192.168.88.1": "08:55:31:bc:a1:ad",
+                        "192.168.88.248": "04:d3:b0:c3:a1:db",
+                        "192.168.88.251": "18:1d:ea:94:6b:dc",
+                        "192.168.88.30": "e4:5f:01:2a:62:53"
+                    },
+                    "auto_negotiation": "off",
+                    "channel_params": {
+                        "current_combined": 1,
+                        "current_other": 0,
+                        "current_rx": 0,
+                        "current_tx": 0,
+                        "max_combined": 1,
+                        "max_other": 0,
+                        "max_rx": 0,
+                        "max_tx": 0
+                    },
+                    "coalesce_params": {},
+                    "driver_info": {
+                        "bus-info": "0000:00:03.0",
+                        "driver": "virtio_net",
+                        "expansion-rom-version": "",
+                        "firmware-version": "",
+                        "supports-eeprom-access": "no",
+                        "supports-priv-flags": "no",
+                        "supports-register-dump": "no",
+                        "supports-statistics": "yes",
+                        "supports-test": "no",
+                        "version": "1.0.0"
+                    },
+                    "duplex": "Unknown! (255)",
+                    "encapsulation": "Ethernet",
+                    "flags": [
+                        "BROADCAST",
+                        "MULTICAST",
+                        "UP",
+                        "LOWER_UP"
+                    ],
+                    "link_speed": 0,
+                    "mtu": "1500",
+                    "number": "3",
+                    "pause_params": {},
+                    "port": "Other",
+                    "ring_params": {
+                        "current_rx": 256,
+                        "current_rx_jumbo": 0,
+                        "current_rx_mini": 0,
+                        "current_tx": 256,
+                        "max_rx": 256,
+                        "max_rx_jumbo": 0,
+                        "max_rx_mini": 0,
+                        "max_tx": 256
+                    },
+                    "routes": [
+                        {
+                            "destination": "default",
+                            "family": "inet",
+                            "metric": "100",
+                            "proto": "dhcp",
+                            "via": "192.168.88.1"
+                        },
+                        {
+                            "destination": "192.168.88.0/24",
+                            "family": "inet",
+                            "metric": "100",
+                            "proto": "kernel",
+                            "scope": "link",
+                            "src": "192.168.88.20"
+                        },
+                        {
+                            "destination": "fe80::/64",
+                            "family": "inet6",
+                            "metric": "100",
+                            "proto": "kernel"
+                        }
+                    ],
+                    "state": "up",
+                    "transceiver": "internal",
+                    "type": "ens"
+                },
+                "lo": {
+                    "addresses": {
+                        "127.0.0.1": {
+                            "family": "inet",
+                            "netmask": "255.0.0.0",
+                            "prefixlen": "8",
+                            "scope": "Node"
+                        },
+                        "::1": {
+                            "family": "inet6",
+                            "prefixlen": "128",
+                            "scope": "Node",
+                            "tags": []
+                        }
+                    },
+                    "encapsulation": "Loopback",
+                    "flags": [
+                        "LOOPBACK",
+                        "UP",
+                        "LOWER_UP"
+                    ],
+                    "mtu": "65536",
+                    "routes": [
+                        {
+                            "destination": "::1",
+                            "family": "inet6",
+                            "metric": "256",
+                            "proto": "kernel"
+                        }
+                    ],
+                    "state": "unknown"
+                }
+            }
+        },
+        "ohai_ohai_time": 1634737911.9282553,
+        "ohai_os": "linux",
+        "ohai_os_release": {
+            "ansi_color": "0;31",
+            "bug_report_url": "https://bugzilla.redhat.com/",
+            "cpe_name": "cpe:/o:centos:centos:8",
+            "home_url": "https://centos.org/",
+            "id": "centos",
+            "id_like": [
+                "rhel",
+                "fedora"
+            ],
+            "name": "CentOS Stream",
+            "platform_id": "platform:el8",
+            "pretty_name": "CentOS Stream 8",
+            "redhat_support_product": "Red Hat Enterprise Linux 8",
+            "redhat_support_product_version": "CentOS Stream",
+            "version": "8",
+            "version_id": "8"
+        },
+        "ohai_os_version": "4.18.0-338.el8.x86_64",
+        "ohai_packages": {
+            "NetworkManager": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653207",
+                "release": "0.2.el8",
+                "version": "1.34.0"
+            },
+            "NetworkManager-config-server": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653339",
+                "release": "0.2.el8",
+                "version": "1.34.0"
+            },
+            "NetworkManager-libnm": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653206",
+                "release": "0.2.el8",
+                "version": "1.34.0"
+            },
+            "NetworkManager-team": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653302",
+                "release": "0.2.el8",
+                "version": "1.34.0"
+            },
+            "NetworkManager-tui": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653324",
+                "release": "0.2.el8",
+                "version": "1.34.0"
+            },
+            "PackageKit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "6.el8",
+                "version": "1.1.12"
+            },
+            "PackageKit-glib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "6.el8",
+                "version": "1.1.12"
+            },
+            "abattis-cantarell-fonts": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653135",
+                "release": "6.el8",
+                "version": "0.0.25"
+            },
+            "acl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "1.el8",
+                "version": "2.2.53"
+            },
+            "adcli": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "12.el8",
+                "version": "0.8.2"
+            },
+            "alsa-sof-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653339",
+                "release": "1.el8",
+                "version": "1.8"
+            },
+            "ansible": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730553",
+                "release": "1.el8",
+                "version": "2.9.25"
+            },
+            "at": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653324",
+                "release": "11.el8",
+                "version": "3.1.20"
+            },
+            "attr": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "3.el8",
+                "version": "2.4.48"
+            },
+            "audit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "0.17.20191104git1c2f876.el8",
+                "version": "3.0"
+            },
+            "audit-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "0.17.20191104git1c2f876.el8",
+                "version": "3.0"
+            },
+            "authselect": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "3.el8",
+                "version": "1.2.2"
+            },
+            "authselect-compat": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "3.el8",
+                "version": "1.2.2"
+            },
+            "authselect-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "3.el8",
+                "version": "1.2.2"
+            },
+            "autoconf": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728008",
+                "release": "29.el8",
+                "version": "2.69"
+            },
+            "automake": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728009",
+                "release": "7.el8",
+                "version": "1.16.1"
+            },
+            "avahi-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "20.el8",
+                "version": "0.7"
+            },
+            "basesystem": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653159",
+                "release": "5.el8",
+                "version": "11"
+            },
+            "bash": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "3.el8",
+                "version": "4.4.20"
+            },
+            "bash-completion": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653332",
+                "release": "5.el8",
+                "version": "2.7"
+            },
+            "bc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "5.el8",
+                "version": "1.07.1"
+            },
+            "bind-libs": {
+                "arch": "x86_64",
+                "epoch": "32",
+                "installdate": "1634653314",
+                "release": "6.el8",
+                "version": "9.11.26"
+            },
+            "bind-libs-lite": {
+                "arch": "x86_64",
+                "epoch": "32",
+                "installdate": "1634653314",
+                "release": "6.el8",
+                "version": "9.11.26"
+            },
+            "bind-license": {
+                "arch": "noarch",
+                "epoch": "32",
+                "installdate": "1634653135",
+                "release": "6.el8",
+                "version": "9.11.26"
+            },
+            "bind-utils": {
+                "arch": "x86_64",
+                "epoch": "32",
+                "installdate": "1634653315",
+                "release": "6.el8",
+                "version": "9.11.26"
+            },
+            "binutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653302",
+                "release": "108.el8",
+                "version": "2.30"
+            },
+            "biosdevname": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653332",
+                "release": "2.el8",
+                "version": "0.7.3"
+            },
+            "bison": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728012",
+                "release": "10.el8",
+                "version": "3.0.4"
+            },
+            "blktrace": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653331",
+                "release": "10.el8",
+                "version": "1.2.0"
+            },
+            "bolt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653324",
+                "release": "1.el8",
+                "version": "0.9.1"
+            },
+            "bpftool": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "brotli": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "3.el8",
+                "version": "1.0.6"
+            },
+            "buildah": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653322",
+                "release": "0.7.module_el8.6.0+944+d413f95e",
+                "version": "1.24.0"
+            },
+            "bzip2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "26.el8",
+                "version": "1.0.6"
+            },
+            "bzip2-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "26.el8",
+                "version": "1.0.6"
+            },
+            "c-ares": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "5.el8",
+                "version": "1.13.0"
+            },
+            "ca-certificates": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653187",
+                "release": "82.el8",
+                "version": "2021.2.50"
+            },
+            "cairo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653310",
+                "release": "3.el8",
+                "version": "1.15.12"
+            },
+            "cairo-gobject": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653310",
+                "release": "3.el8",
+                "version": "1.15.12"
+            },
+            "cargo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634729578",
+                "release": "2.module_el8.5.0+910+9ca45234",
+                "version": "1.54.0"
+            },
+            "centos-gpg-keys": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653158",
+                "release": "3.el8",
+                "version": "8"
+            },
+            "centos-logos": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "1.el8",
+                "version": "85.8"
+            },
+            "centos-stream-release": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653158",
+                "release": "1.el8",
+                "version": "8.6"
+            },
+            "centos-stream-repos": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653158",
+                "release": "3.el8",
+                "version": "8"
+            },
+            "checkpolicy": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "1.el8",
+                "version": "2.9"
+            },
+            "chkconfig": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "1.19.1"
+            },
+            "chrony": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "1.el8",
+                "version": "4.1"
+            },
+            "clevis": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "1.el8",
+                "version": "15"
+            },
+            "clevis-luks": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "1.el8",
+                "version": "15"
+            },
+            "cockpit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "cockpit-bridge": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "cockpit-packagekit": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "cockpit-pcp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634726191",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "cockpit-podman": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "1.module_el8.6.0+944+d413f95e",
+                "version": "35"
+            },
+            "cockpit-storaged": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653311",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "cockpit-system": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653311",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "cockpit-ws": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "1.el8",
+                "version": "251.1"
+            },
+            "conmon": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653287",
+                "release": "1.module_el8.6.0+944+d413f95e",
+                "version": "2.0.30"
+            },
+            "container-selinux": {
+                "arch": "noarch",
+                "epoch": "2",
+                "installdate": "1634653228",
+                "release": "2.module_el8.6.0+944+d413f95e",
+                "version": "2.168.0"
+            },
+            "containernetworking-plugins": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "1.module_el8.6.0+944+d413f95e",
+                "version": "1.0.1"
+            },
+            "containers-common": {
+                "arch": "noarch",
+                "epoch": "2",
+                "installdate": "1634653293",
+                "release": "4.module_el8.6.0+944+d413f95e",
+                "version": "1"
+            },
+            "coreutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653186",
+                "release": "12.el8",
+                "version": "8.30"
+            },
+            "coreutils-common": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653172",
+                "release": "12.el8",
+                "version": "8.30"
+            },
+            "cpio": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "11.el8",
+                "version": "2.12"
+            },
+            "cpp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727862",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "cracklib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653184",
+                "release": "15.el8",
+                "version": "2.9.6"
+            },
+            "cracklib-dicts": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "15.el8",
+                "version": "2.9.6"
+            },
+            "criu": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653293",
+                "release": "3.module_el8.6.0+926+8bef8ae7",
+                "version": "3.15"
+            },
+            "cronie": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653206",
+                "release": "4.el8",
+                "version": "1.5.2"
+            },
+            "cronie-anacron": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653206",
+                "release": "4.el8",
+                "version": "1.5.2"
+            },
+            "crontabs": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653206",
+                "release": "17.20190603git.el8",
+                "version": "1.11"
+            },
+            "crypto-policies": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653184",
+                "release": "1.gitc776d3e.el8",
+                "version": "20210617"
+            },
+            "crypto-policies-scripts": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653184",
+                "release": "1.gitc776d3e.el8",
+                "version": "20210617"
+            },
+            "cryptsetup": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "4.el8",
+                "version": "2.3.3"
+            },
+            "cryptsetup-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653188",
+                "release": "4.el8",
+                "version": "2.3.3"
+            },
+            "cups-libs": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653210",
+                "release": "40.el8",
+                "version": "2.2.6"
+            },
+            "curl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "21.el8",
+                "version": "7.61.1"
+            },
+            "cyrus-sasl-gssapi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "5.el8",
+                "version": "2.1.27"
+            },
+            "cyrus-sasl-lib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653178",
+                "release": "5.el8",
+                "version": "2.1.27"
+            },
+            "cyrus-sasl-plain": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653331",
+                "release": "5.el8",
+                "version": "2.1.27"
+            },
+            "dbus": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653193",
+                "release": "14.el8",
+                "version": "1.12.8"
+            },
+            "dbus-common": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653158",
+                "release": "14.el8",
+                "version": "1.12.8"
+            },
+            "dbus-daemon": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653189",
+                "release": "14.el8",
+                "version": "1.12.8"
+            },
+            "dbus-glib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "2.el8",
+                "version": "0.110"
+            },
+            "dbus-libs": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653186",
+                "release": "14.el8",
+                "version": "1.12.8"
+            },
+            "dbus-tools": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653186",
+                "release": "14.el8",
+                "version": "1.12.8"
+            },
+            "dejavu-fonts-common": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "7.el8",
+                "version": "2.35"
+            },
+            "dejavu-sans-mono-fonts": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "7.el8",
+                "version": "2.35"
+            },
+            "desktop-file-utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "8.el8",
+                "version": "0.23"
+            },
+            "device-mapper": {
+                "arch": "x86_64",
+                "epoch": "8",
+                "installdate": "1634653185",
+                "release": "10.el8",
+                "version": "1.02.177"
+            },
+            "device-mapper-event": {
+                "arch": "x86_64",
+                "epoch": "8",
+                "installdate": "1634653226",
+                "release": "10.el8",
+                "version": "1.02.177"
+            },
+            "device-mapper-event-libs": {
+                "arch": "x86_64",
+                "epoch": "8",
+                "installdate": "1634653196",
+                "release": "10.el8",
+                "version": "1.02.177"
+            },
+            "device-mapper-libs": {
+                "arch": "x86_64",
+                "epoch": "8",
+                "installdate": "1634653187",
+                "release": "10.el8",
+                "version": "1.02.177"
+            },
+            "device-mapper-multipath": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "17.el8",
+                "version": "0.8.4"
+            },
+            "device-mapper-multipath-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "17.el8",
+                "version": "0.8.4"
+            },
+            "device-mapper-persistent-data": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "4.el8",
+                "version": "0.9.0"
+            },
+            "diffutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "6.el8",
+                "version": "3.6"
+            },
+            "dmidecode": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653167",
+                "release": "10.el8",
+                "version": "3.2"
+            },
+            "dnf": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "4.el8",
+                "version": "4.7.0"
+            },
+            "dnf-data": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "4.el8",
+                "version": "4.7.0"
+            },
+            "dnf-plugin-subscription-manager": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "dnf-plugins-core": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "3.el8",
+                "version": "4.0.21"
+            },
+            "dos2unix": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "3.el8",
+                "version": "7.4.0"
+            },
+            "dosfstools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "6.el8",
+                "version": "4.1"
+            },
+            "dracut": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653191",
+                "release": "191.git20210920.el8",
+                "version": "049"
+            },
+            "dracut-config-rescue": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653329",
+                "release": "191.git20210920.el8",
+                "version": "049"
+            },
+            "dracut-network": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "191.git20210920.el8",
+                "version": "049"
+            },
+            "dracut-squash": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "191.git20210920.el8",
+                "version": "049"
+            },
+            "e2fsprogs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "2.el8",
+                "version": "1.45.6"
+            },
+            "e2fsprogs-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "2.el8",
+                "version": "1.45.6"
+            },
+            "ed": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "4.el8",
+                "version": "1.14.2"
+            },
+            "elfutils-debuginfod-client": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "1.el8",
+                "version": "0.185"
+            },
+            "elfutils-default-yama-scope": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653184",
+                "release": "1.el8",
+                "version": "0.185"
+            },
+            "elfutils-libelf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "0.185"
+            },
+            "elfutils-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "1.el8",
+                "version": "0.185"
+            },
+            "emacs-filesystem": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653158",
+                "release": "7.el8",
+                "version": "26.1"
+            },
+            "epel-next-release": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730503",
+                "release": "11.el8",
+                "version": "8"
+            },
+            "epel-release": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730503",
+                "release": "11.el8",
+                "version": "8"
+            },
+            "ethtool": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653166",
+                "release": "7.el8",
+                "version": "5.8"
+            },
+            "expat": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "4.el8",
+                "version": "2.2.5"
+            },
+            "file": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "20.el8",
+                "version": "5.33"
+            },
+            "file-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "20.el8",
+                "version": "5.33"
+            },
+            "filesystem": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653159",
+                "release": "6.el8",
+                "version": "3.8"
+            },
+            "findutils": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653164",
+                "release": "20.el8",
+                "version": "4.6.0"
+            },
+            "firewalld": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "7.el8",
+                "version": "0.9.3"
+            },
+            "firewalld-filesystem": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653158",
+                "release": "7.el8",
+                "version": "0.9.3"
+            },
+            "fontconfig": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653209",
+                "release": "4.el8",
+                "version": "2.13.1"
+            },
+            "fontpackages-filesystem": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653135",
+                "release": "22.el8",
+                "version": "1.44"
+            },
+            "fprintd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "2.el8",
+                "version": "1.90.9"
+            },
+            "fprintd-pam": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "2.el8",
+                "version": "1.90.9"
+            },
+            "freetype": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "4.el8_3.1",
+                "version": "2.9.1"
+            },
+            "fstrm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "2.el8",
+                "version": "0.6.1"
+            },
+            "fuse-common": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653158",
+                "release": "12.el8",
+                "version": "3.2.1"
+            },
+            "fuse-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "12.el8",
+                "version": "2.9.7"
+            },
+            "fuse-overlayfs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "1.module_el8.6.0+926+8bef8ae7",
+                "version": "1.7.1"
+            },
+            "fuse3": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "12.el8",
+                "version": "3.2.1"
+            },
+            "fuse3-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "12.el8",
+                "version": "3.2.1"
+            },
+            "gawk": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "2.el8",
+                "version": "4.2.1"
+            },
+            "gcc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727869",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "gcc-c++": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728012",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "gdbm": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653167",
+                "release": "1.el8",
+                "version": "1.18"
+            },
+            "gdbm-devel": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634727871",
+                "release": "1.el8",
+                "version": "1.18"
+            },
+            "gdbm-libs": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653165",
+                "release": "1.el8",
+                "version": "1.18"
+            },
+            "gdisk": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "6.el8",
+                "version": "1.0.3"
+            },
+            "gdk-pixbuf2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653207",
+                "release": "5.el8",
+                "version": "2.36.12"
+            },
+            "geolite2-city": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653314",
+                "release": "1.el8",
+                "version": "20180605"
+            },
+            "geolite2-country": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653311",
+                "release": "1.el8",
+                "version": "20180605"
+            },
+            "gettext": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653191",
+                "release": "17.el8",
+                "version": "0.19.8.1"
+            },
+            "gettext-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "17.el8",
+                "version": "0.19.8.1"
+            },
+            "glib-networking": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "1.1.el8",
+                "version": "2.56.1"
+            },
+            "glib2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653193",
+                "release": "156.el8",
+                "version": "2.56.4"
+            },
+            "glibc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653161",
+                "release": "164.el8",
+                "version": "2.28"
+            },
+            "glibc-common": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653160",
+                "release": "164.el8",
+                "version": "2.28"
+            },
+            "glibc-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727865",
+                "release": "164.el8",
+                "version": "2.28"
+            },
+            "glibc-headers": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727865",
+                "release": "164.el8",
+                "version": "2.28"
+            },
+            "glibc-langpack-cs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653160",
+                "release": "164.el8",
+                "version": "2.28"
+            },
+            "gmp": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653163",
+                "release": "10.el8",
+                "version": "6.1.2"
+            },
+            "gnupg2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "2.el8",
+                "version": "2.2.20"
+            },
+            "gnupg2-smime": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "2.el8",
+                "version": "2.2.20"
+            },
+            "gnutls": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653193",
+                "release": "4.el8",
+                "version": "3.6.16"
+            },
+            "gobject-introspection": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "1.el8",
+                "version": "1.56.1"
+            },
+            "gpg-pubkey": {
+                "arch": "(none)",
+                "epoch": "0",
+                "installdate": "1634731179",
+                "release": "53a9be98",
+                "version": "de57bfbe",
+                "versions": [
+                    {
+                        "arch": "(none)",
+                        "epoch": "0",
+                        "installdate": "1634727240",
+                        "release": "5ccc5b19",
+                        "version": "8483c65d"
+                    },
+                    {
+                        "arch": "(none)",
+                        "epoch": "0",
+                        "installdate": "1634730530",
+                        "release": "5cf7cefb",
+                        "version": "2f86d6a1"
+                    },
+                    {
+                        "arch": "(none)",
+                        "epoch": "0",
+                        "installdate": "1634731179",
+                        "release": "53a9be98",
+                        "version": "de57bfbe"
+                    }
+                ]
+            },
+            "gpgme": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "9.el8",
+                "version": "1.13.1"
+            },
+            "gpm-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "17.el8",
+                "version": "1.20.7"
+            },
+            "grep": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "6.el8",
+                "version": "3.1"
+            },
+            "groff-base": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "18.el8",
+                "version": "1.22.3"
+            },
+            "grub2-common": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653164",
+                "release": "99.el8_4.1",
+                "version": "2.02"
+            },
+            "grub2-pc": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653322",
+                "release": "99.el8_4.1",
+                "version": "2.02"
+            },
+            "grub2-pc-modules": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653168",
+                "release": "99.el8_4.1",
+                "version": "2.02"
+            },
+            "grub2-tools": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653192",
+                "release": "99.el8_4.1",
+                "version": "2.02"
+            },
+            "grub2-tools-extra": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653291",
+                "release": "99.el8_4.1",
+                "version": "2.02"
+            },
+            "grub2-tools-minimal": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653183",
+                "release": "99.el8_4.1",
+                "version": "2.02"
+            },
+            "grubby": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "42.el8",
+                "version": "8.40"
+            },
+            "gsettings-desktop-schemas": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "6.el8",
+                "version": "3.32.0"
+            },
+            "gzip": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653184",
+                "release": "12.el8",
+                "version": "1.9"
+            },
+            "hardlink": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653177",
+                "release": "6.el8",
+                "version": "1.3"
+            },
+            "hdparm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "4.el8",
+                "version": "9.54"
+            },
+            "hostname": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "7.el8.0.1",
+                "version": "3.20"
+            },
+            "hwdata": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653135",
+                "release": "8.10.el8",
+                "version": "0.314"
+            },
+            "ima-evm-utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "12.el8",
+                "version": "1.3.2"
+            },
+            "info": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "6.el8",
+                "version": "6.5"
+            },
+            "initscripts": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653206",
+                "release": "1.el8",
+                "version": "10.00.15"
+            },
+            "iproute": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "3.el8",
+                "version": "5.12.0"
+            },
+            "iprutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "1.el8",
+                "version": "2.4.19"
+            },
+            "ipset": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "1.el8",
+                "version": "7.1"
+            },
+            "ipset-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "1.el8",
+                "version": "7.1"
+            },
+            "iptables": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653293",
+                "release": "20.el8",
+                "version": "1.8.4"
+            },
+            "iptables-ebtables": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "20.el8",
+                "version": "1.8.4"
+            },
+            "iptables-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "20.el8",
+                "version": "1.8.4"
+            },
+            "iptstate": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653322",
+                "release": "6.el8",
+                "version": "2.2.6"
+            },
+            "iputils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "7.el8",
+                "version": "20180629"
+            },
+            "irqbalance": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653329",
+                "release": "6.el8",
+                "version": "1.4.0"
+            },
+            "iscsi-initiator-utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "4.git095f59c.el8",
+                "version": "6.2.1.4"
+            },
+            "iscsi-initiator-utils-iscsiuio": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "4.git095f59c.el8",
+                "version": "6.2.1.4"
+            },
+            "isl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727866",
+                "release": "6.el8",
+                "version": "0.16.1"
+            },
+            "isns-utils-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "1.el8",
+                "version": "0.99"
+            },
+            "iwl100-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "39.31.5.1"
+            },
+            "iwl1000-firmware": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "39.31.5.1"
+            },
+            "iwl105-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "18.168.6.1"
+            },
+            "iwl135-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "18.168.6.1"
+            },
+            "iwl2000-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "18.168.6.1"
+            },
+            "iwl2030-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "18.168.6.1"
+            },
+            "iwl3160-firmware": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653339",
+                "release": "103.el8.1",
+                "version": "25.30.13.0"
+            },
+            "iwl5000-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "8.83.5.1_1"
+            },
+            "iwl5150-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "8.24.2.2"
+            },
+            "iwl6000-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "9.221.4.1"
+            },
+            "iwl6000g2a-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "18.168.6.1"
+            },
+            "iwl6000g2b-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "18.168.6.1"
+            },
+            "iwl6050-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "41.28.5.1"
+            },
+            "iwl7260-firmware": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653338",
+                "release": "103.el8.1",
+                "version": "25.30.13.0"
+            },
+            "jansson": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "3.el8",
+                "version": "2.11"
+            },
+            "jimtcl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "6.el8",
+                "version": "0.77"
+            },
+            "jose": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "2.el8",
+                "version": "10"
+            },
+            "jq": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "12.el8",
+                "version": "1.5"
+            },
+            "json-c": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "2.el8",
+                "version": "0.13.1"
+            },
+            "json-glib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "1.el8",
+                "version": "1.4.4"
+            },
+            "kbd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653189",
+                "release": "10.el8",
+                "version": "2.0.4"
+            },
+            "kbd-legacy": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653158",
+                "release": "10.el8",
+                "version": "2.0.4"
+            },
+            "kbd-misc": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653158",
+                "release": "10.el8",
+                "version": "2.0.4"
+            },
+            "kernel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "kernel-core": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653199",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "kernel-headers": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727865",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "kernel-modules": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653215",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "kernel-tools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "kernel-tools-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653172",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "kexec-tools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "57.el8",
+                "version": "2.0.20"
+            },
+            "keyutils-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "9.el8",
+                "version": "1.5.10"
+            },
+            "keyutils-libs-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "9.el8",
+                "version": "1.5.10"
+            },
+            "kmod": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653188",
+                "release": "18.el8",
+                "version": "25"
+            },
+            "kmod-kvdo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653226",
+                "release": "79.el8",
+                "version": "6.2.5.72"
+            },
+            "kmod-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653188",
+                "release": "18.el8",
+                "version": "25"
+            },
+            "kpartx": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "17.el8",
+                "version": "0.8.4"
+            },
+            "kpatch": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "1.el8",
+                "version": "0.9.4"
+            },
+            "kpatch-dnf": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "1.el8",
+                "version": "0.4"
+            },
+            "krb5-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "14.el8",
+                "version": "1.18.2"
+            },
+            "krb5-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "14.el8",
+                "version": "1.18.2"
+            },
+            "langpacks-cs": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653334",
+                "release": "12.el8",
+                "version": "1.0"
+            },
+            "ledmon": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653330",
+                "release": "1.el8",
+                "version": "0.95"
+            },
+            "less": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653173",
+                "release": "1.el8",
+                "version": "530"
+            },
+            "libX11": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "5.el8",
+                "version": "1.6.8"
+            },
+            "libX11-common": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "5.el8",
+                "version": "1.6.8"
+            },
+            "libXau": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "3.el8",
+                "version": "1.0.9"
+            },
+            "libXext": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "1.el8",
+                "version": "1.3.4"
+            },
+            "libXrender": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "7.el8",
+                "version": "0.9.10"
+            },
+            "libacl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "2.2.53"
+            },
+            "libaio": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "1.el8",
+                "version": "0.3.112"
+            },
+            "libappstream-glib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "3.el8",
+                "version": "0.7.14"
+            },
+            "libarchive": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "1.el8",
+                "version": "3.3.3"
+            },
+            "libassuan": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "3.el8",
+                "version": "2.5.1"
+            },
+            "libatasmart": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "14.el8",
+                "version": "0.19"
+            },
+            "libattr": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "3.el8",
+                "version": "2.4.48"
+            },
+            "libbasicobjects": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "39.el8",
+                "version": "0.1.1"
+            },
+            "libblkid": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653187",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "libblockdev": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-crypto": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-fs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-loop": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-lvm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653227",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-mdraid": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-part": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-swap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libblockdev-utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "7.el8",
+                "version": "2.24"
+            },
+            "libbpf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "1.el8",
+                "version": "0.4.0"
+            },
+            "libbytesize": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "3.el8",
+                "version": "1.4"
+            },
+            "libcap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "5.el8",
+                "version": "2.26"
+            },
+            "libcap-ng": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "0.7.11"
+            },
+            "libcollection": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "39.el8",
+                "version": "0.7.0"
+            },
+            "libcom_err": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "2.el8",
+                "version": "1.45.6"
+            },
+            "libcom_err-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "2.el8",
+                "version": "1.45.6"
+            },
+            "libcomps": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "2.el8",
+                "version": "0.1.16"
+            },
+            "libconfig": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "9.el8",
+                "version": "1.5"
+            },
+            "libcroco": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "4.el8_2.1",
+                "version": "0.6.12"
+            },
+            "libcurl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "21.el8",
+                "version": "7.61.1"
+            },
+            "libdaemon": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "15.el8",
+                "version": "0.14"
+            },
+            "libdb": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653188",
+                "release": "42.el8_4",
+                "version": "5.3.28"
+            },
+            "libdb-utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "42.el8_4",
+                "version": "5.3.28"
+            },
+            "libdhash": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "39.el8",
+                "version": "0.5.0"
+            },
+            "libdnf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "3.el8",
+                "version": "0.63.0"
+            },
+            "libedit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "23.20170329cvs.el8",
+                "version": "3.1"
+            },
+            "libertas-usb8388-firmware": {
+                "arch": "noarch",
+                "epoch": "2",
+                "installdate": "1634653334",
+                "release": "103.gitd79c2677.el8",
+                "version": "20210702"
+            },
+            "libestr": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "1.el8",
+                "version": "0.1.10"
+            },
+            "libevent": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "5.el8",
+                "version": "2.1.8"
+            },
+            "libfastjson": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "1.el8",
+                "version": "0.99.9"
+            },
+            "libfdisk": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653186",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "libffi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "22.el8",
+                "version": "3.1"
+            },
+            "libffi-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727871",
+                "release": "22.el8",
+                "version": "3.1"
+            },
+            "libfprint": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "1.el8",
+                "version": "1.90.7"
+            },
+            "libgcc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653134",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "libgcrypt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "6.el8",
+                "version": "1.8.5"
+            },
+            "libgomp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "libgpg-error": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "1.el8",
+                "version": "1.31"
+            },
+            "libgudev": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "4.el8",
+                "version": "232"
+            },
+            "libgusb": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653226",
+                "release": "1.el8",
+                "version": "0.3.0"
+            },
+            "libibverbs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "1.el8",
+                "version": "35.0"
+            },
+            "libicu": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653170",
+                "release": "2.el8_1",
+                "version": "60.3"
+            },
+            "libidn2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "1.el8",
+                "version": "2.2.0"
+            },
+            "libini_config": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "39.el8",
+                "version": "1.3.1"
+            },
+            "libipa_hbac": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "libjose": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "2.el8",
+                "version": "10"
+            },
+            "libkadm5": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "14.el8",
+                "version": "1.18.2"
+            },
+            "libkcapi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "2.el8",
+                "version": "1.2.0"
+            },
+            "libkcapi-hmaccalc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "2.el8",
+                "version": "1.2.0"
+            },
+            "libksba": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "7.el8",
+                "version": "1.3.5"
+            },
+            "libldb": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "2.el8",
+                "version": "2.3.0"
+            },
+            "libluksmeta": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "4.el8",
+                "version": "9"
+            },
+            "libmaxminddb": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653314",
+                "release": "10.el8",
+                "version": "1.2.0"
+            },
+            "libmetalink": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "7.el8",
+                "version": "0.1.3"
+            },
+            "libmnl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "6.el8",
+                "version": "1.0.4"
+            },
+            "libmodman": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653171",
+                "release": "17.el8",
+                "version": "2.0.1"
+            },
+            "libmodulemd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "1.el8",
+                "version": "2.13.0"
+            },
+            "libmount": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653186",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "libmpc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727860",
+                "release": "9.1.el8",
+                "version": "1.1.0"
+            },
+            "libndp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "6.el8",
+                "version": "1.7"
+            },
+            "libnet": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "15.el8",
+                "version": "1.1.6"
+            },
+            "libnetfilter_conntrack": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "5.el8",
+                "version": "1.0.6"
+            },
+            "libnfnetlink": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "13.el8",
+                "version": "1.0.1"
+            },
+            "libnfsidmap": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653302",
+                "release": "46.el8",
+                "version": "2.3.3"
+            },
+            "libnftnl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "4.el8",
+                "version": "1.1.5"
+            },
+            "libnghttp2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "3.el8_2.1",
+                "version": "1.33.0"
+            },
+            "libnl3": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "3.5.0"
+            },
+            "libnl3-cli": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "1.el8",
+                "version": "3.5.0"
+            },
+            "libnsl2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "2.20180605git4a062cf.el8",
+                "version": "1.2.0"
+            },
+            "libpath_utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "39.el8",
+                "version": "0.2.1"
+            },
+            "libpcap": {
+                "arch": "x86_64",
+                "epoch": "14",
+                "installdate": "1634653292",
+                "release": "5.el8",
+                "version": "1.9.1"
+            },
+            "libpipeline": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "2.el8",
+                "version": "1.5.0"
+            },
+            "libpkgconf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "1.el8",
+                "version": "1.4.2"
+            },
+            "libpng": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653165",
+                "release": "5.el8",
+                "version": "1.6.34"
+            },
+            "libproxy": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653171",
+                "release": "5.2.el8",
+                "version": "0.4.15"
+            },
+            "libpsl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "6.el8",
+                "version": "0.20.2"
+            },
+            "libpwquality": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653189",
+                "release": "3.el8",
+                "version": "1.4.4"
+            },
+            "libref_array": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "39.el8",
+                "version": "0.1.5"
+            },
+            "librelp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "1.el8",
+                "version": "1.9.0"
+            },
+            "librepo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "2.el8",
+                "version": "1.14.0"
+            },
+            "libreport-filesystem": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "15.el8",
+                "version": "2.9.5"
+            },
+            "libseccomp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "1.el8",
+                "version": "2.5.1"
+            },
+            "libsecret": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "1.el8",
+                "version": "0.18.6"
+            },
+            "libselinux": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653159",
+                "release": "5.el8",
+                "version": "2.9"
+            },
+            "libselinux-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "5.el8",
+                "version": "2.9"
+            },
+            "libselinux-utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "5.el8",
+                "version": "2.9"
+            },
+            "libsemanage": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "6.el8",
+                "version": "2.9"
+            },
+            "libsepol": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "3.el8",
+                "version": "2.9"
+            },
+            "libsepol-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "3.el8",
+                "version": "2.9"
+            },
+            "libsigsegv": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "5.el8",
+                "version": "2.11"
+            },
+            "libslirp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "1.module_el8.6.0+926+8bef8ae7",
+                "version": "4.4.0"
+            },
+            "libsmartcols": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "libsmbclient": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653211",
+                "release": "2.el8",
+                "version": "4.14.5"
+            },
+            "libsodium": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730534",
+                "release": "2.el8",
+                "version": "1.0.18"
+            },
+            "libsolv": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "1.el8",
+                "version": "0.7.19"
+            },
+            "libsoup": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "2.el8",
+                "version": "2.62.3"
+            },
+            "libss": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653172",
+                "release": "2.el8",
+                "version": "1.45.6"
+            },
+            "libssh": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "3.el8",
+                "version": "0.9.4"
+            },
+            "libssh-config": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653157",
+                "release": "3.el8",
+                "version": "0.9.4"
+            },
+            "libsss_autofs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "libsss_certmap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "libsss_idmap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "libsss_nss_idmap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "libsss_sudo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "libstdc++": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "libstdc++-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728010",
+                "release": "3.el8",
+                "version": "8.5.0"
+            },
+            "libstemmer": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "10.585svn.el8",
+                "version": "0"
+            },
+            "libstoragemgmt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "1.el8",
+                "version": "1.9.1"
+            },
+            "libsysfs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "24.el8",
+                "version": "2.1.0"
+            },
+            "libtalloc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "1.el8",
+                "version": "2.3.2"
+            },
+            "libtasn1": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "3.el8",
+                "version": "4.13"
+            },
+            "libtdb": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "1.4.3"
+            },
+            "libteam": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "2.el8",
+                "version": "1.31"
+            },
+            "libtevent": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "0.el8",
+                "version": "0.11.0"
+            },
+            "libtirpc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "5.el8",
+                "version": "1.1.4"
+            },
+            "libtool": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728012",
+                "release": "25.el8",
+                "version": "2.4.6"
+            },
+            "libudisks2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "7.el8",
+                "version": "2.9.0"
+            },
+            "libunistring": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "3.el8",
+                "version": "0.9.9"
+            },
+            "libunwind": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731219",
+                "release": "3.el8",
+                "version": "1.3.1"
+            },
+            "libusbx": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "4.el8",
+                "version": "1.0.23"
+            },
+            "libuser": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "23.el8",
+                "version": "0.62"
+            },
+            "libutempter": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653189",
+                "release": "14.el8",
+                "version": "1.1.6"
+            },
+            "libuuid": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "libuv": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634726138",
+                "release": "1.el8_4",
+                "version": "1.41.1"
+            },
+            "libverto": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "5.el8",
+                "version": "0.3.0"
+            },
+            "libverto-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "5.el8",
+                "version": "0.3.0"
+            },
+            "libwbclient": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "2.el8",
+                "version": "4.14.5"
+            },
+            "libxcb": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "1.el8",
+                "version": "1.13.1"
+            },
+            "libxcrypt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "6.el8",
+                "version": "4.1.1"
+            },
+            "libxcrypt-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727865",
+                "release": "6.el8",
+                "version": "4.1.1"
+            },
+            "libxkbcommon": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653178",
+                "release": "1.el8",
+                "version": "0.9.1"
+            },
+            "libxml2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "11.el8",
+                "version": "2.9.7"
+            },
+            "libxslt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "6.el8",
+                "version": "1.1.32"
+            },
+            "libyaml": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "5.el8",
+                "version": "0.1.7"
+            },
+            "libzstd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8",
+                "version": "1.4.4"
+            },
+            "linux-firmware": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653157",
+                "release": "103.gitd79c2677.el8",
+                "version": "20210702"
+            },
+            "llvm-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634729423",
+                "release": "2.module_el8.6.0+937+1cafe22c",
+                "version": "12.0.1"
+            },
+            "lmdb-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "1.el8",
+                "version": "0.9.24"
+            },
+            "logrotate": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "4.el8",
+                "version": "3.14.0"
+            },
+            "lshw": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "6.el8",
+                "version": "B.02.19.2"
+            },
+            "lsof": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653331",
+                "release": "1.el8",
+                "version": "4.93.2"
+            },
+            "lsscsi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "3.el8",
+                "version": "0.32"
+            },
+            "lua-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "12.el8",
+                "version": "5.3.4"
+            },
+            "luksmeta": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "4.el8",
+                "version": "9"
+            },
+            "lvm2": {
+                "arch": "x86_64",
+                "epoch": "8",
+                "installdate": "1634653227",
+                "release": "10.el8",
+                "version": "2.03.12"
+            },
+            "lvm2-libs": {
+                "arch": "x86_64",
+                "epoch": "8",
+                "installdate": "1634653227",
+                "release": "10.el8",
+                "version": "2.03.12"
+            },
+            "lz4-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "3.el8_4",
+                "version": "1.8.3"
+            },
+            "lzo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "14.el8",
+                "version": "2.08"
+            },
+            "m4": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "7.el8",
+                "version": "1.4.18"
+            },
+            "mailcap": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653334",
+                "release": "3.el8",
+                "version": "2.1.48"
+            },
+            "make": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634728012",
+                "release": "10.el8",
+                "version": "4.2.1"
+            },
+            "man-db": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653331",
+                "release": "18.el8",
+                "version": "2.7.6.1"
+            },
+            "man-pages": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653319",
+                "release": "6.el8",
+                "version": "4.15"
+            },
+            "man-pages-overrides": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "1.el8",
+                "version": "8.5.0.1"
+            },
+            "mcelog": {
+                "arch": "x86_64",
+                "epoch": "3",
+                "installdate": "1634653324",
+                "release": "1.el8",
+                "version": "175"
+            },
+            "mdadm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "rc2.el8",
+                "version": "4.2"
+            },
+            "memstrack": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "1.el8",
+                "version": "0.1.11"
+            },
+            "microcode_ctl": {
+                "arch": "x86_64",
+                "epoch": "4",
+                "installdate": "1634653325",
+                "release": "1.el8",
+                "version": "20210608"
+            },
+            "mlocate": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653328",
+                "release": "20.el8",
+                "version": "0.26"
+            },
+            "mozjs60": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653172",
+                "release": "4.el8",
+                "version": "60.9.0"
+            },
+            "mpfr": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653166",
+                "release": "1.el8",
+                "version": "3.1.6"
+            },
+            "mtr": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653334",
+                "release": "3.el8",
+                "version": "0.92"
+            },
+            "nano": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653332",
+                "release": "1.el8",
+                "version": "2.9.8"
+            },
+            "ncurses": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "9.20180224.el8",
+                "version": "6.1"
+            },
+            "ncurses-base": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "9.20180224.el8",
+                "version": "6.1"
+            },
+            "ncurses-c++-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727862",
+                "release": "9.20180224.el8",
+                "version": "6.1"
+            },
+            "ncurses-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727863",
+                "release": "9.20180224.el8",
+                "version": "6.1"
+            },
+            "ncurses-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653159",
+                "release": "9.20180224.el8",
+                "version": "6.1"
+            },
+            "net-tools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653329",
+                "release": "0.52.20160912git.el8",
+                "version": "2.0"
+            },
+            "nettle": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "7.el8",
+                "version": "3.4.1"
+            },
+            "newt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653178",
+                "release": "11.el8",
+                "version": "0.52.20"
+            },
+            "nftables": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653293",
+                "release": "21.el8",
+                "version": "0.9.3"
+            },
+            "nmap-ncat": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653322",
+                "release": "6.el8",
+                "version": "7.70"
+            },
+            "npth": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "4.el8",
+                "version": "1.5"
+            },
+            "nspr": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "1.el8_4",
+                "version": "4.32.0"
+            },
+            "nss": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "6.el8_4",
+                "version": "3.67.0"
+            },
+            "nss-softokn": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "6.el8_4",
+                "version": "3.67.0"
+            },
+            "nss-softokn-freebl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653168",
+                "release": "6.el8_4",
+                "version": "3.67.0"
+            },
+            "nss-sysinit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "6.el8_4",
+                "version": "3.67.0"
+            },
+            "nss-util": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "6.el8_4",
+                "version": "3.67.0"
+            },
+            "numactl-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "13.el8",
+                "version": "2.0.12"
+            },
+            "nvme-cli": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653329",
+                "release": "3.el8",
+                "version": "1.14"
+            },
+            "oddjob": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653286",
+                "release": "1.el8",
+                "version": "0.34.7"
+            },
+            "oddjob-mkhomedir": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "1.el8",
+                "version": "0.34.7"
+            },
+            "oniguruma": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653176",
+                "release": "2.el8",
+                "version": "6.8.2"
+            },
+            "openldap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "18.el8",
+                "version": "2.4.46"
+            },
+            "openpgm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731219",
+                "release": "21.el8",
+                "version": "5.2.122"
+            },
+            "openssh": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "9.el8",
+                "version": "8.0p1"
+            },
+            "openssh-clients": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "9.el8",
+                "version": "8.0p1"
+            },
+            "openssh-server": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "9.el8",
+                "version": "8.0p1"
+            },
+            "openssl": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653184",
+                "release": "4.el8",
+                "version": "1.1.1k"
+            },
+            "openssl-devel": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634727871",
+                "release": "4.el8",
+                "version": "1.1.1k"
+            },
+            "openssl-libs": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653188",
+                "release": "4.el8",
+                "version": "1.1.1k"
+            },
+            "openssl-pkcs11": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "2.el8",
+                "version": "0.4.10"
+            },
+            "os-prober": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653191",
+                "release": "9.el8",
+                "version": "1.74"
+            },
+            "p11-kit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "1.el8",
+                "version": "0.23.22"
+            },
+            "p11-kit-trust": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "1.el8",
+                "version": "0.23.22"
+            },
+            "pam": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653190",
+                "release": "15.el8",
+                "version": "1.3.1"
+            },
+            "parted": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "39.el8",
+                "version": "3.2"
+            },
+            "passwd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "3.el8",
+                "version": "0.80"
+            },
+            "patch": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728012",
+                "release": "11.el8",
+                "version": "2.7.6"
+            },
+            "pciutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "1.el8",
+                "version": "3.7.0"
+            },
+            "pciutils-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "1.el8",
+                "version": "3.7.0"
+            },
+            "pcp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634726190",
+                "release": "1.el8",
+                "version": "5.3.3"
+            },
+            "pcp-conf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634726187",
+                "release": "1.el8",
+                "version": "5.3.3"
+            },
+            "pcp-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634726187",
+                "release": "1.el8",
+                "version": "5.3.3"
+            },
+            "pcp-selinux": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634726139",
+                "release": "1.el8",
+                "version": "5.3.3"
+            },
+            "pcre": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "6.el8",
+                "version": "8.42"
+            },
+            "pcre2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653159",
+                "release": "2.el8",
+                "version": "10.32"
+            },
+            "pcre2-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727862",
+                "release": "2.el8",
+                "version": "10.32"
+            },
+            "pcre2-utf16": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727862",
+                "release": "2.el8",
+                "version": "10.32"
+            },
+            "pcre2-utf32": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727862",
+                "release": "2.el8",
+                "version": "10.32"
+            },
+            "perl-Carp": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728006",
+                "release": "396.el8",
+                "version": "1.42"
+            },
+            "perl-Data-Dumper": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "399.el8",
+                "version": "2.167"
+            },
+            "perl-Digest": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "395.el8",
+                "version": "1.17"
+            },
+            "perl-Digest-MD5": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "396.el8",
+                "version": "2.55"
+            },
+            "perl-Encode": {
+                "arch": "x86_64",
+                "epoch": "4",
+                "installdate": "1634728006",
+                "release": "3.el8",
+                "version": "2.97"
+            },
+            "perl-Errno": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "420.el8",
+                "version": "1.28"
+            },
+            "perl-Exporter": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728006",
+                "release": "396.el8",
+                "version": "5.72"
+            },
+            "perl-File-Path": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "2.el8",
+                "version": "2.15"
+            },
+            "perl-File-Temp": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "1.el8",
+                "version": "0.230.600"
+            },
+            "perl-Getopt-Long": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634728005",
+                "release": "4.el8",
+                "version": "2.50"
+            },
+            "perl-HTTP-Tiny": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "1.el8",
+                "version": "0.074"
+            },
+            "perl-IO": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "420.el8",
+                "version": "1.38"
+            },
+            "perl-IO-Socket-IP": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "5.el8",
+                "version": "0.39"
+            },
+            "perl-IO-Socket-SSL": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "4.module_el8.4.0+517+be1595ff",
+                "version": "2.066"
+            },
+            "perl-MIME-Base64": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "396.el8",
+                "version": "3.15"
+            },
+            "perl-Mozilla-CA": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "7.module_el8.3.0+416+dee7bcef",
+                "version": "20160104"
+            },
+            "perl-Net-SSLeay": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "1.module_el8.4.0+517+be1595ff",
+                "version": "1.88"
+            },
+            "perl-PathTools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "1.el8",
+                "version": "3.74"
+            },
+            "perl-Pod-Escapes": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634728005",
+                "release": "395.el8",
+                "version": "1.07"
+            },
+            "perl-Pod-Perldoc": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "396.el8",
+                "version": "3.28"
+            },
+            "perl-Pod-Simple": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634728005",
+                "release": "395.el8",
+                "version": "3.35"
+            },
+            "perl-Pod-Usage": {
+                "arch": "noarch",
+                "epoch": "4",
+                "installdate": "1634728005",
+                "release": "395.el8",
+                "version": "1.69"
+            },
+            "perl-Scalar-List-Utils": {
+                "arch": "x86_64",
+                "epoch": "3",
+                "installdate": "1634728006",
+                "release": "2.el8",
+                "version": "1.49"
+            },
+            "perl-Socket": {
+                "arch": "x86_64",
+                "epoch": "4",
+                "installdate": "1634728005",
+                "release": "3.el8",
+                "version": "2.027"
+            },
+            "perl-Storable": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634728005",
+                "release": "3.el8",
+                "version": "3.11"
+            },
+            "perl-Term-ANSIColor": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "396.el8",
+                "version": "4.06"
+            },
+            "perl-Term-Cap": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "395.el8",
+                "version": "1.17"
+            },
+            "perl-Text-ParseWords": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "395.el8",
+                "version": "3.30"
+            },
+            "perl-Text-Tabs+Wrap": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "395.el8",
+                "version": "2013.0523"
+            },
+            "perl-Thread-Queue": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728008",
+                "release": "1.el8",
+                "version": "3.13"
+            },
+            "perl-Time-Local": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634728005",
+                "release": "1.el8",
+                "version": "1.280"
+            },
+            "perl-URI": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "3.el8",
+                "version": "1.73"
+            },
+            "perl-Unicode-Normalize": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "396.el8",
+                "version": "1.25"
+            },
+            "perl-constant": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "396.el8",
+                "version": "1.33"
+            },
+            "perl-interpreter": {
+                "arch": "x86_64",
+                "epoch": "4",
+                "installdate": "1634728008",
+                "release": "420.el8",
+                "version": "5.26.3"
+            },
+            "perl-libnet": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728004",
+                "release": "3.el8",
+                "version": "3.11"
+            },
+            "perl-libs": {
+                "arch": "x86_64",
+                "epoch": "4",
+                "installdate": "1634728006",
+                "release": "420.el8",
+                "version": "5.26.3"
+            },
+            "perl-macros": {
+                "arch": "x86_64",
+                "epoch": "4",
+                "installdate": "1634728007",
+                "release": "420.el8",
+                "version": "5.26.3"
+            },
+            "perl-parent": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634728006",
+                "release": "1.el8",
+                "version": "0.237"
+            },
+            "perl-podlators": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728005",
+                "release": "1.el8",
+                "version": "4.11"
+            },
+            "perl-threads": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634728007",
+                "release": "2.el8",
+                "version": "2.21"
+            },
+            "perl-threads-shared": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728007",
+                "release": "2.el8",
+                "version": "1.58"
+            },
+            "pigz": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653172",
+                "release": "4.el8",
+                "version": "2.4"
+            },
+            "pinentry": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653289",
+                "release": "2.el8",
+                "version": "1.1.0"
+            },
+            "pinfo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653322",
+                "release": "18.el8",
+                "version": "0.6.10"
+            },
+            "pixman": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "1.el8",
+                "version": "0.38.4"
+            },
+            "pkgconf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "1.el8",
+                "version": "1.4.2"
+            },
+            "pkgconf-m4": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "1.el8",
+                "version": "1.4.2"
+            },
+            "pkgconf-pkg-config": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "1.el8",
+                "version": "1.4.2"
+            },
+            "platform-python": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "42.el8",
+                "version": "3.6.8"
+            },
+            "platform-python-pip": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653179",
+                "release": "20.el8",
+                "version": "9.0.3"
+            },
+            "platform-python-setuptools": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653179",
+                "release": "6.el8",
+                "version": "39.2.0"
+            },
+            "plymouth": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "10.20200615git1e36e30.el8",
+                "version": "0.9.4"
+            },
+            "plymouth-core-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "10.20200615git1e36e30.el8",
+                "version": "0.9.4"
+            },
+            "plymouth-scripts": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "10.20200615git1e36e30.el8",
+                "version": "0.9.4"
+            },
+            "podman": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "0.10.module_el8.6.0+944+d413f95e",
+                "version": "4.0.0"
+            },
+            "podman-catatonit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653294",
+                "release": "0.10.module_el8.6.0+944+d413f95e",
+                "version": "4.0.0"
+            },
+            "policycoreutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "16.el8",
+                "version": "2.9"
+            },
+            "policycoreutils-python-utils": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653228",
+                "release": "16.el8",
+                "version": "2.9"
+            },
+            "polkit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "12.el8",
+                "version": "0.115"
+            },
+            "polkit-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "12.el8",
+                "version": "0.115"
+            },
+            "polkit-pkla-compat": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "12.el8",
+                "version": "0.1"
+            },
+            "popt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "1.el8",
+                "version": "1.18"
+            },
+            "prefixdevname": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653331",
+                "release": "6.el8",
+                "version": "0.1.0"
+            },
+            "procps-ng": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "6.el8",
+                "version": "3.3.15"
+            },
+            "protobuf-c": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "6.el8",
+                "version": "1.3.0"
+            },
+            "psacct": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653329",
+                "release": "4.el8",
+                "version": "6.6.3"
+            },
+            "psmisc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "5.el8",
+                "version": "23.1"
+            },
+            "publicsuffix-list-dafsa": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "1.el8",
+                "version": "20180723"
+            },
+            "python3-audit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "0.17.20191104git1c2f876.el8",
+                "version": "3.0"
+            },
+            "python3-babel": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730537",
+                "release": "7.el8",
+                "version": "2.5.1"
+            },
+            "python3-bcrypt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730535",
+                "release": "2.el8.1",
+                "version": "3.1.6"
+            },
+            "python3-bind": {
+                "arch": "noarch",
+                "epoch": "32",
+                "installdate": "1634653306",
+                "release": "6.el8",
+                "version": "9.11.26"
+            },
+            "python3-cairo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653310",
+                "release": "6.el8",
+                "version": "1.16.3"
+            },
+            "python3-cffi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730535",
+                "release": "5.el8",
+                "version": "1.11.5"
+            },
+            "python3-chardet": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "7.el8",
+                "version": "3.0.4"
+            },
+            "python3-cloud-what": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "python3-configobj": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653286",
+                "release": "11.el8",
+                "version": "5.0.6"
+            },
+            "python3-contextvars": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634731219",
+                "release": "1.el8",
+                "version": "2.4"
+            },
+            "python3-cryptography": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730535",
+                "release": "5.el8",
+                "version": "3.2.1"
+            },
+            "python3-dateutil": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653286",
+                "release": "6.el8",
+                "version": "2.6.1"
+            },
+            "python3-dbus": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "15.el8",
+                "version": "1.2.4"
+            },
+            "python3-decorator": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "2.el8",
+                "version": "4.2.1"
+            },
+            "python3-distro": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634731220",
+                "release": "2.module_el8.5.0+761+faacb0fb",
+                "version": "1.4.0"
+            },
+            "python3-dmidecode": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "15.el8",
+                "version": "3.12.2"
+            },
+            "python3-dnf": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "4.el8",
+                "version": "4.7.0"
+            },
+            "python3-dnf-plugins-core": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "3.el8",
+                "version": "4.0.21"
+            },
+            "python3-ethtool": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "3.el8",
+                "version": "0.14"
+            },
+            "python3-firewall": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "7.el8",
+                "version": "0.9.3"
+            },
+            "python3-gobject": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653310",
+                "release": "2.el8",
+                "version": "3.28.3"
+            },
+            "python3-gobject-base": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653200",
+                "release": "2.el8",
+                "version": "3.28.3"
+            },
+            "python3-gpg": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "9.el8",
+                "version": "1.13.1"
+            },
+            "python3-hawkey": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "3.el8",
+                "version": "0.63.0"
+            },
+            "python3-html5lib": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653304",
+                "release": "6.el8",
+                "version": "0.999999999"
+            },
+            "python3-idna": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "5.el8",
+                "version": "2.5"
+            },
+            "python3-immutables": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731219",
+                "release": "2.el8",
+                "version": "0.15"
+            },
+            "python3-iniparse": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "31.el8",
+                "version": "0.4"
+            },
+            "python3-inotify": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "13.el8",
+                "version": "0.9.6"
+            },
+            "python3-jinja2": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730538",
+                "release": "3.el8",
+                "version": "2.10.1"
+            },
+            "python3-jmespath": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730538",
+                "release": "11.el8",
+                "version": "0.9.0"
+            },
+            "python3-libcomps": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "2.el8",
+                "version": "0.1.16"
+            },
+            "python3-libdnf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "3.el8",
+                "version": "0.63.0"
+            },
+            "python3-librepo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "2.el8",
+                "version": "1.14.0"
+            },
+            "python3-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653183",
+                "release": "42.el8",
+                "version": "3.6.8"
+            },
+            "python3-libselinux": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "5.el8",
+                "version": "2.9"
+            },
+            "python3-libsemanage": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653227",
+                "release": "6.el8",
+                "version": "2.9"
+            },
+            "python3-libstoragemgmt": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653287",
+                "release": "1.el8",
+                "version": "1.9.1"
+            },
+            "python3-libxml2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "11.el8",
+                "version": "2.9.7"
+            },
+            "python3-linux-procfs": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653286",
+                "release": "1.el8",
+                "version": "0.6.3"
+            },
+            "python3-lxml": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653305",
+                "release": "3.el8",
+                "version": "4.2.3"
+            },
+            "python3-m2crypto": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731219",
+                "release": "5.el8",
+                "version": "0.35.2"
+            },
+            "python3-markupsafe": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730538",
+                "release": "19.el8",
+                "version": "0.23"
+            },
+            "python3-msgpack": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731219",
+                "release": "1.el8",
+                "version": "0.6.2"
+            },
+            "python3-nftables": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653296",
+                "release": "21.el8",
+                "version": "0.9.3"
+            },
+            "python3-paramiko": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730537",
+                "release": "1.el8",
+                "version": "2.4.3"
+            },
+            "python3-perf": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653306",
+                "release": "338.el8",
+                "version": "4.18.0"
+            },
+            "python3-pexpect": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "3.el8",
+                "version": "4.3.1"
+            },
+            "python3-pip": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634728716",
+                "release": "20.el8",
+                "version": "9.0.3"
+            },
+            "python3-pip-wheel": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "20.el8",
+                "version": "9.0.3"
+            },
+            "python3-ply": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653306",
+                "release": "9.el8",
+                "version": "3.9"
+            },
+            "python3-policycoreutils": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653228",
+                "release": "16.el8",
+                "version": "2.9"
+            },
+            "python3-psutil": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "11.el8",
+                "version": "5.4.3"
+            },
+            "python3-ptyprocess": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "4.el8",
+                "version": "0.5.2"
+            },
+            "python3-pyasn1": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730537",
+                "release": "6.el8",
+                "version": "0.3.7"
+            },
+            "python3-pycparser": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730535",
+                "release": "14.el8",
+                "version": "2.14"
+            },
+            "python3-pycurl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731220",
+                "release": "4.el8",
+                "version": "7.43.0.2"
+            },
+            "python3-pydbus": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "5.el8",
+                "version": "0.6.0"
+            },
+            "python3-pynacl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730535",
+                "release": "5.el8",
+                "version": "1.3.0"
+            },
+            "python3-pysocks": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "3.el8",
+                "version": "1.6.8"
+            },
+            "python3-pytz": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634730535",
+                "release": "9.el8",
+                "version": "2017.2"
+            },
+            "python3-pyudev": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653286",
+                "release": "7.el8",
+                "version": "0.21.0"
+            },
+            "python3-pyyaml": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653306",
+                "release": "12.el8",
+                "version": "3.12"
+            },
+            "python3-requests": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "2.1.el8_1",
+                "version": "2.20.0"
+            },
+            "python3-rpm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "18.el8",
+                "version": "4.14.3"
+            },
+            "python3-setools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653227",
+                "release": "2.el8",
+                "version": "4.3.0"
+            },
+            "python3-setuptools": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653306",
+                "release": "6.el8",
+                "version": "39.2.0"
+            },
+            "python3-setuptools-wheel": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "6.el8",
+                "version": "39.2.0"
+            },
+            "python3-six": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653196",
+                "release": "8.el8",
+                "version": "1.11.0"
+            },
+            "python3-slip": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653286",
+                "release": "11.el8",
+                "version": "0.6.4"
+            },
+            "python3-slip-dbus": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "11.el8",
+                "version": "0.6.4"
+            },
+            "python3-sssdconfig": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653306",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "python3-subscription-manager-rhsm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727411",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "python3-syspurpose": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653306",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "python3-systemd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653297",
+                "release": "8.el8",
+                "version": "234"
+            },
+            "python3-tracer": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "2.el8",
+                "version": "0.7.5"
+            },
+            "python3-unbound": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "17.el8",
+                "version": "1.7.3"
+            },
+            "python3-urllib3": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "5.el8",
+                "version": "1.24.2"
+            },
+            "python3-webencodings": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653304",
+                "release": "6.el8",
+                "version": "0.5.1"
+            },
+            "python3-zmq": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731220",
+                "release": "1.el8",
+                "version": "19.0.0"
+            },
+            "python36": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728716",
+                "release": "38.module_el8.5.0+895+a459eca8",
+                "version": "3.6.8"
+            },
+            "qemu-guest-agent": {
+                "arch": "x86_64",
+                "epoch": "15",
+                "installdate": "1634653324",
+                "release": "52.module_el8.5.0+853+a4d5519d",
+                "version": "4.2.0"
+            },
+            "quota": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653331",
+                "release": "14.el8",
+                "version": "4.04"
+            },
+            "quota-nls": {
+                "arch": "noarch",
+                "epoch": "1",
+                "installdate": "1634653136",
+                "release": "14.el8",
+                "version": "4.04"
+            },
+            "rdma-core": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653292",
+                "release": "1.el8",
+                "version": "35.0"
+            },
+            "readline": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "10.el8",
+                "version": "7.0"
+            },
+            "readline-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727871",
+                "release": "10.el8",
+                "version": "7.0"
+            },
+            "realmd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "23.el8",
+                "version": "0.16.3"
+            },
+            "rhsm-icons": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "rootfiles": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653334",
+                "release": "22.el8",
+                "version": "8.1"
+            },
+            "rpm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653185",
+                "release": "18.el8",
+                "version": "4.14.3"
+            },
+            "rpm-build-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653290",
+                "release": "18.el8",
+                "version": "4.14.3"
+            },
+            "rpm-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653188",
+                "release": "18.el8",
+                "version": "4.14.3"
+            },
+            "rpm-plugin-selinux": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653201",
+                "release": "18.el8",
+                "version": "4.14.3"
+            },
+            "rpm-plugin-systemd-inhibit": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "18.el8",
+                "version": "4.14.3"
+            },
+            "rsync": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "13.el8",
+                "version": "3.1.3"
+            },
+            "rsyslog": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653201",
+                "release": "5.el8",
+                "version": "8.2102.0"
+            },
+            "rsyslog-gnutls": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653324",
+                "release": "5.el8",
+                "version": "8.2102.0"
+            },
+            "rsyslog-gssapi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653324",
+                "release": "5.el8",
+                "version": "8.2102.0"
+            },
+            "rsyslog-relp": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653322",
+                "release": "5.el8",
+                "version": "8.2102.0"
+            },
+            "ruby": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727245",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "2.5.9"
+            },
+            "ruby-irb": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727244",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "2.5.9"
+            },
+            "ruby-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727244",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "2.5.9"
+            },
+            "rubygem-bigdecimal": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727244",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "1.3.4"
+            },
+            "rubygem-did_you_mean": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727244",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "1.2.0"
+            },
+            "rubygem-io-console": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727244",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "0.4.6"
+            },
+            "rubygem-json": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727244",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "2.1.0"
+            },
+            "rubygem-openssl": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727245",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "2.1.2"
+            },
+            "rubygem-psych": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727245",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "3.0.2"
+            },
+            "rubygem-rdoc": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727245",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "6.0.1.1"
+            },
+            "rubygems": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727245",
+                "release": "107.module_el8.5.0+811+d98a1657",
+                "version": "2.7.6.3"
+            },
+            "runc": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653293",
+                "release": "1.module_el8.6.0+926+8bef8ae7",
+                "version": "1.0.2"
+            },
+            "rust": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634729427",
+                "release": "2.module_el8.5.0+910+9ca45234",
+                "version": "1.54.0"
+            },
+            "rust-std-static": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634729420",
+                "release": "2.module_el8.5.0+910+9ca45234",
+                "version": "1.54.0"
+            },
+            "salt": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634731226",
+                "release": "1.el8",
+                "version": "3004"
+            },
+            "salt-master": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634731226",
+                "release": "1.el8",
+                "version": "3004"
+            },
+            "salt-minion": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634735764",
+                "release": "1.el8",
+                "version": "3004"
+            },
+            "samba-client-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653211",
+                "release": "2.el8",
+                "version": "4.14.5"
+            },
+            "samba-common": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653201",
+                "release": "2.el8",
+                "version": "4.14.5"
+            },
+            "samba-common-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653210",
+                "release": "2.el8",
+                "version": "4.14.5"
+            },
+            "sed": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653163",
+                "release": "2.el8",
+                "version": "4.5"
+            },
+            "selinux-policy": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653201",
+                "release": "80.el8",
+                "version": "3.14.3"
+            },
+            "selinux-policy-targeted": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653205",
+                "release": "80.el8",
+                "version": "3.14.3"
+            },
+            "setroubleshoot-plugins": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653310",
+                "release": "1.el8",
+                "version": "3.3.14"
+            },
+            "setroubleshoot-server": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653310",
+                "release": "4.el8",
+                "version": "3.3.24"
+            },
+            "setup": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653159",
+                "release": "6.el8",
+                "version": "2.12.2"
+            },
+            "sg3_utils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653332",
+                "release": "5.el8",
+                "version": "1.44"
+            },
+            "sg3_utils-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "5.el8",
+                "version": "1.44"
+            },
+            "shadow-utils": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653187",
+                "release": "14.el8",
+                "version": "4.6"
+            },
+            "shared-mime-info": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653193",
+                "release": "3.el8",
+                "version": "1.9"
+            },
+            "slang": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653177",
+                "release": "3.el8",
+                "version": "2.3.2"
+            },
+            "slirp4netns": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "1.module_el8.6.0+926+8bef8ae7",
+                "version": "1.1.8"
+            },
+            "smartmontools": {
+                "arch": "x86_64",
+                "epoch": "1",
+                "installdate": "1634653329",
+                "release": "1.el8",
+                "version": "7.1"
+            },
+            "snappy": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653172",
+                "release": "3.el8",
+                "version": "1.1.8"
+            },
+            "sos": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653304",
+                "release": "5.el8",
+                "version": "4.1"
+            },
+            "sqlite": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "15.el8",
+                "version": "3.26.0"
+            },
+            "sqlite-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634728012",
+                "release": "15.el8",
+                "version": "3.26.0"
+            },
+            "sqlite-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "15.el8",
+                "version": "3.26.0"
+            },
+            "squashfs-tools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "20.el8",
+                "version": "4.3"
+            },
+            "sscg": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653296",
+                "release": "14.el8",
+                "version": "2.3.3"
+            },
+            "sshpass": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634730534",
+                "release": "9.el8",
+                "version": "1.06"
+            },
+            "sssd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-ad": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-client": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-common": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653302",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-common-pac": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-ipa": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653315",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-kcm": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-krb5": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-krb5-common": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-ldap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-nfs-idmap": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653302",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "sssd-proxy": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653303",
+                "release": "2.el8",
+                "version": "2.5.2"
+            },
+            "strace": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653331",
+                "release": "3.el8",
+                "version": "5.7"
+            },
+            "subscription-manager": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727412",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "subscription-manager-cockpit": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634727412",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "subscription-manager-rhsm-certificates": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "3.el8",
+                "version": "1.28.21"
+            },
+            "sudo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "7.el8",
+                "version": "1.8.29"
+            },
+            "symlinks": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653334",
+                "release": "19.el8",
+                "version": "1.4"
+            },
+            "systemd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653194",
+                "release": "51.el8",
+                "version": "239"
+            },
+            "systemd-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653186",
+                "release": "51.el8",
+                "version": "239"
+            },
+            "systemd-pam": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653191",
+                "release": "51.el8",
+                "version": "239"
+            },
+            "systemd-udev": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653195",
+                "release": "51.el8",
+                "version": "239"
+            },
+            "tar": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653169",
+                "release": "5.el8",
+                "version": "1.30"
+            },
+            "tcpdump": {
+                "arch": "x86_64",
+                "epoch": "14",
+                "installdate": "1634653322",
+                "release": "2.el8",
+                "version": "4.9.3"
+            },
+            "teamd": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653302",
+                "release": "2.el8",
+                "version": "1.31"
+            },
+            "time": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653333",
+                "release": "3.el8",
+                "version": "1.9"
+            },
+            "timedatex": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653286",
+                "release": "3.el8",
+                "version": "0.5"
+            },
+            "tpm2-tools": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "5.el8",
+                "version": "4.1.1"
+            },
+            "tpm2-tss": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "4.el8",
+                "version": "2.3.2"
+            },
+            "tracer-common": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653309",
+                "release": "2.el8",
+                "version": "0.7.5"
+            },
+            "tree": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653334",
+                "release": "15.el8",
+                "version": "1.7.0"
+            },
+            "trousers": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653195",
+                "release": "1.el8",
+                "version": "0.3.15"
+            },
+            "trousers-lib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653188",
+                "release": "1.el8",
+                "version": "0.3.15"
+            },
+            "tuned": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653319",
+                "release": "1.el8",
+                "version": "2.16.0"
+            },
+            "tzdata": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653136",
+                "release": "1.el8",
+                "version": "2021b"
+            },
+            "udisks2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653299",
+                "release": "7.el8",
+                "version": "2.9.0"
+            },
+            "udisks2-iscsi": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653299",
+                "release": "7.el8",
+                "version": "2.9.0"
+            },
+            "udisks2-lvm2": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653299",
+                "release": "7.el8",
+                "version": "2.9.0"
+            },
+            "unbound-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653212",
+                "release": "17.el8",
+                "version": "1.7.3"
+            },
+            "unzip": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653169",
+                "release": "45.el8",
+                "version": "6.0"
+            },
+            "usb_modeswitch": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653226",
+                "release": "1.el8",
+                "version": "2.5.2"
+            },
+            "usb_modeswitch-data": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653226",
+                "release": "1.el8",
+                "version": "20191128"
+            },
+            "usbutils": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653324",
+                "release": "3.el8",
+                "version": "010"
+            },
+            "usermode": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727410",
+                "release": "2.el8",
+                "version": "1.113"
+            },
+            "userspace-rcu": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653167",
+                "release": "4.el8",
+                "version": "0.10.1"
+            },
+            "util-linux": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653191",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "util-linux-user": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "28.el8",
+                "version": "2.32.1"
+            },
+            "vdo": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "14.el8",
+                "version": "6.2.5.74"
+            },
+            "vim-common": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653309",
+                "release": "16.el8",
+                "version": "8.0.1763"
+            },
+            "vim-enhanced": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653319",
+                "release": "16.el8",
+                "version": "8.0.1763"
+            },
+            "vim-filesystem": {
+                "arch": "noarch",
+                "epoch": "2",
+                "installdate": "1634653306",
+                "release": "16.el8",
+                "version": "8.0.1763"
+            },
+            "vim-minimal": {
+                "arch": "x86_64",
+                "epoch": "2",
+                "installdate": "1634653169",
+                "release": "16.el8",
+                "version": "8.0.1763"
+            },
+            "virt-what": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653291",
+                "release": "12.el8",
+                "version": "1.18"
+            },
+            "volume_key-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653298",
+                "release": "5.el8",
+                "version": "0.3.11"
+            },
+            "wget": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653322",
+                "release": "10.el8",
+                "version": "1.19.5"
+            },
+            "which": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653164",
+                "release": "16.el8",
+                "version": "2.21"
+            },
+            "words": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653334",
+                "release": "28.el8",
+                "version": "3.0"
+            },
+            "xdg-utils": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653288",
+                "release": "5.el8",
+                "version": "1.1.2"
+            },
+            "xfsdump": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653323",
+                "release": "2.el8",
+                "version": "3.1.8"
+            },
+            "xfsprogs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653208",
+                "release": "9.el8",
+                "version": "5.0.0"
+            },
+            "xkeyboard-config": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653178",
+                "release": "1.el8",
+                "version": "2.28"
+            },
+            "xz": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653165",
+                "release": "3.el8",
+                "version": "5.2.4"
+            },
+            "xz-libs": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "3.el8",
+                "version": "5.2.4"
+            },
+            "yum": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634653320",
+                "release": "4.el8",
+                "version": "4.7.0"
+            },
+            "yum-utils": {
+                "arch": "noarch",
+                "epoch": "0",
+                "installdate": "1634731220",
+                "release": "3.el8",
+                "version": "4.0.21"
+            },
+            "zeromq": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634731220",
+                "release": "2.el8",
+                "version": "4.3.4"
+            },
+            "zip": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653332",
+                "release": "23.el8",
+                "version": "3.0"
+            },
+            "zlib": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634653162",
+                "release": "17.el8",
+                "version": "1.2.11"
+            },
+            "zlib-devel": {
+                "arch": "x86_64",
+                "epoch": "0",
+                "installdate": "1634727862",
+                "release": "17.el8",
+                "version": "1.2.11"
+            }
+        },
+        "ohai_platform": "centos",
+        "ohai_platform_family": "rhel",
+        "ohai_platform_version": "8",
+        "ohai_root_group": "root",
+        "ohai_shard_seed": 38085582,
+        "ohai_shells": [
+            "/bin/sh",
+            "/bin/bash",
+            "/usr/bin/sh",
+            "/usr/bin/bash"
+        ],
+        "ohai_sysconf": {
+            "AIO_LISTIO_MAX": null,
+            "AIO_MAX": null,
+            "AIO_PRIO_DELTA_MAX": 20,
+            "ARG_MAX": 2097152,
+            "ATEXIT_MAX": 2147483647,
+            "BC_BASE_MAX": 99,
+            "BC_DIM_MAX": 2048,
+            "BC_SCALE_MAX": 99,
+            "BC_STRING_MAX": 1000,
+            "CHARCLASS_NAME_MAX": 2048,
+            "CHAR_BIT": 8,
+            "CHAR_MAX": 127,
+            "CHAR_MIN": -128,
+            "CHILD_MAX": 3085,
+            "CLK_TCK": 100,
+            "COLL_WEIGHTS_MAX": 255,
+            "CS_PATH": "/usr/bin",
+            "DELAYTIMER_MAX": 2147483647,
+            "EQUIV_CLASS_MAX": null,
+            "EXPR_NEST_MAX": 32,
+            "FILESIZEBITS": 64,
+            "GNU_LIBC_VERSION": "glibc 2.28",
+            "GNU_LIBPTHREAD_VERSION": "NPTL 2.28",
+            "HOST_NAME_MAX": 64,
+            "INT_MAX": 2147483647,
+            "INT_MIN": -2147483648,
+            "IOV_MAX": 1024,
+            "IPV6": 200809,
+            "LEVEL1_DCACHE_ASSOC": 8,
+            "LEVEL1_DCACHE_LINESIZE": 64,
+            "LEVEL1_DCACHE_SIZE": 32768,
+            "LEVEL1_ICACHE_ASSOC": 8,
+            "LEVEL1_ICACHE_LINESIZE": 64,
+            "LEVEL1_ICACHE_SIZE": 32768,
+            "LEVEL2_CACHE_ASSOC": 8,
+            "LEVEL2_CACHE_LINESIZE": 64,
+            "LEVEL2_CACHE_SIZE": 2097152,
+            "LEVEL3_CACHE_ASSOC": 16,
+            "LEVEL3_CACHE_LINESIZE": 64,
+            "LEVEL3_CACHE_SIZE": 16777216,
+            "LEVEL4_CACHE_ASSOC": 0,
+            "LEVEL4_CACHE_LINESIZE": 0,
+            "LEVEL4_CACHE_SIZE": 0,
+            "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+            "LFS64_LDFLAGS": null,
+            "LFS64_LIBS": null,
+            "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+            "LFS_CFLAGS": null,
+            "LFS_LDFLAGS": null,
+            "LFS_LIBS": null,
+            "LFS_LINTFLAGS": null,
+            "LINE_MAX": 2048,
+            "LINK_MAX": 2147483647,
+            "LOGIN_NAME_MAX": 256,
+            "LOGNAME_MAX": 256,
+            "LONG_BIT": 64,
+            "MAX_CANON": 255,
+            "MAX_INPUT": 255,
+            "MB_LEN_MAX": 16,
+            "MQ_OPEN_MAX": null,
+            "MQ_PRIO_MAX": 32768,
+            "NAME_MAX": 255,
+            "NGROUPS_MAX": 65536,
+            "NL_ARGMAX": 4096,
+            "NL_LANGMAX": 2048,
+            "NL_MSGMAX": 2147483647,
+            "NL_NMAX": 2147483647,
+            "NL_SETMAX": 2147483647,
+            "NL_TEXTMAX": 2147483647,
+            "NSS_BUFLEN_GROUP": 1024,
+            "NSS_BUFLEN_PASSWD": 1024,
+            "NZERO": 20,
+            "OPEN_MAX": 1024,
+            "PAGESIZE": 4096,
+            "PAGE_SIZE": 4096,
+            "PASS_MAX": 8192,
+            "PATH": "/usr/bin",
+            "PATH_MAX": 4096,
+            "PIPE_BUF": 4096,
+            "POSIX2_BC_BASE_MAX": 99,
+            "POSIX2_BC_DIM_MAX": 2048,
+            "POSIX2_BC_SCALE_MAX": 99,
+            "POSIX2_BC_STRING_MAX": 1000,
+            "POSIX2_CHAR_TERM": 200809,
+            "POSIX2_COLL_WEIGHTS_MAX": 255,
+            "POSIX2_C_BIND": 200809,
+            "POSIX2_C_DEV": 200809,
+            "POSIX2_C_VERSION": 200809,
+            "POSIX2_EXPR_NEST_MAX": 32,
+            "POSIX2_FORT_DEV": null,
+            "POSIX2_FORT_RUN": null,
+            "POSIX2_LINE_MAX": 2048,
+            "POSIX2_LOCALEDEF": 200809,
+            "POSIX2_PBS": null,
+            "POSIX2_PBS_ACCOUNTING": null,
+            "POSIX2_PBS_LOCATE": null,
+            "POSIX2_PBS_MESSAGE": null,
+            "POSIX2_PBS_TRACK": null,
+            "POSIX2_RE_DUP_MAX": 32767,
+            "POSIX2_SW_DEV": 200809,
+            "POSIX2_SYMLINKS": 1,
+            "POSIX2_UPE": null,
+            "POSIX2_VERSION": 200809,
+            "POSIX_ALLOC_SIZE_MIN": 4096,
+            "POSIX_REC_INCR_XFER_SIZE": null,
+            "POSIX_REC_MAX_XFER_SIZE": null,
+            "POSIX_REC_MIN_XFER_SIZE": 4096,
+            "POSIX_REC_XFER_ALIGN": 4096,
+            "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+            "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+            "POSIX_V6_ILP32_OFF32_LIBS": null,
+            "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+            "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+            "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+            "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+            "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+            "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+            "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+            "POSIX_V6_LP64_OFF64_LIBS": null,
+            "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+            "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+            "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+            "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+            "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+            "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+            "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+            "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+            "POSIX_V7_ILP32_OFF32_LIBS": null,
+            "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+            "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+            "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+            "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+            "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+            "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+            "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+            "POSIX_V7_LP64_OFF64_LIBS": null,
+            "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+            "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+            "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+            "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+            "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+            "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+            "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+            "PTHREAD_KEYS_MAX": 1024,
+            "PTHREAD_STACK_MIN": 16384,
+            "PTHREAD_THREADS_MAX": null,
+            "RAW_SOCKETS": 200809,
+            "RE_DUP_MAX": 32767,
+            "RTSIG_MAX": 32,
+            "SCHAR_MAX": 127,
+            "SCHAR_MIN": -128,
+            "SEM_NSEMS_MAX": null,
+            "SEM_VALUE_MAX": 2147483647,
+            "SHRT_MAX": 32767,
+            "SHRT_MIN": -32768,
+            "SIGQUEUE_MAX": 3085,
+            "SOCK_MAXBUF": null,
+            "SSIZE_MAX": 32767,
+            "STREAM_MAX": 16,
+            "SYMLINK_MAX": null,
+            "SYMLOOP_MAX": null,
+            "TIMER_MAX": null,
+            "TTY_NAME_MAX": 32,
+            "TZNAME_MAX": null,
+            "UCHAR_MAX": 255,
+            "UINT_MAX": 4294967295,
+            "UIO_MAXIOV": 1024,
+            "ULONG_MAX": 18446744073709551615,
+            "USHRT_MAX": 65535,
+            "WORD_BIT": 32,
+            "XBS5_ILP32_OFF32_CFLAGS": null,
+            "XBS5_ILP32_OFF32_LDFLAGS": null,
+            "XBS5_ILP32_OFF32_LIBS": null,
+            "XBS5_ILP32_OFF32_LINTFLAGS": null,
+            "XBS5_ILP32_OFFBIG_CFLAGS": null,
+            "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+            "XBS5_ILP32_OFFBIG_LIBS": null,
+            "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+            "XBS5_LP64_OFF64_CFLAGS": "-m64",
+            "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+            "XBS5_LP64_OFF64_LIBS": null,
+            "XBS5_LP64_OFF64_LINTFLAGS": null,
+            "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+            "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+            "XBS5_LPBIG_OFFBIG_LIBS": null,
+            "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+            "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+            "_AVPHYS_PAGES": 18733,
+            "_NPROCESSORS_CONF": 1,
+            "_NPROCESSORS_ONLN": 1,
+            "_PHYS_PAGES": 207127,
+            "_POSIX2_LINE_MAX": 2048,
+            "_POSIX_ADVISORY_INFO": 200809,
+            "_POSIX_ARG_MAX": 2097152,
+            "_POSIX_ASYNCHRONOUS_IO": 200809,
+            "_POSIX_ASYNC_IO": null,
+            "_POSIX_BARRIERS": 200809,
+            "_POSIX_BASE": null,
+            "_POSIX_CHILD_MAX": 3085,
+            "_POSIX_CHOWN_RESTRICTED": 1,
+            "_POSIX_CLOCK_SELECTION": 200809,
+            "_POSIX_CPUTIME": 200809,
+            "_POSIX_C_LANG_SUPPORT": null,
+            "_POSIX_C_LANG_SUPPORT_R": null,
+            "_POSIX_DEVICE_IO": null,
+            "_POSIX_DEVICE_SPECIFIC": null,
+            "_POSIX_DEVICE_SPECIFIC_R": null,
+            "_POSIX_FD_MGMT": null,
+            "_POSIX_FIFO": null,
+            "_POSIX_FILE_ATTRIBUTES": null,
+            "_POSIX_FILE_LOCKING": null,
+            "_POSIX_FILE_SYSTEM": null,
+            "_POSIX_FSYNC": 200809,
+            "_POSIX_IPV6": 200809,
+            "_POSIX_JOB_CONTROL": 1,
+            "_POSIX_LINK_MAX": 2147483647,
+            "_POSIX_MAPPED_FILES": 200809,
+            "_POSIX_MAX_CANON": 255,
+            "_POSIX_MAX_INPUT": 255,
+            "_POSIX_MEMLOCK": 200809,
+            "_POSIX_MEMLOCK_RANGE": 200809,
+            "_POSIX_MEMORY_PROTECTION": 200809,
+            "_POSIX_MESSAGE_PASSING": 200809,
+            "_POSIX_MONOTONIC_CLOCK": 200809,
+            "_POSIX_MULTI_PROCESS": null,
+            "_POSIX_NAME_MAX": 255,
+            "_POSIX_NETWORKING": null,
+            "_POSIX_NGROUPS_MAX": 65536,
+            "_POSIX_NO_TRUNC": 1,
+            "_POSIX_OPEN_MAX": 1024,
+            "_POSIX_PATH_MAX": 4096,
+            "_POSIX_PII": null,
+            "_POSIX_PII_INTERNET": null,
+            "_POSIX_PII_INTERNET_DGRAM": null,
+            "_POSIX_PII_INTERNET_STREAM": null,
+            "_POSIX_PII_OSI": null,
+            "_POSIX_PII_OSI_CLTS": null,
+            "_POSIX_PII_OSI_COTS": null,
+            "_POSIX_PII_OSI_M": null,
+            "_POSIX_PII_SOCKET": null,
+            "_POSIX_PII_XTI": null,
+            "_POSIX_PIPE": null,
+            "_POSIX_PIPE_BUF": 4096,
+            "_POSIX_POLL": null,
+            "_POSIX_PRIORITIZED_IO": 200809,
+            "_POSIX_PRIORITY_SCHEDULING": 200809,
+            "_POSIX_PRIO_IO": null,
+            "_POSIX_RAW_SOCKETS": 200809,
+            "_POSIX_READER_WRITER_LOCKS": 200809,
+            "_POSIX_REALTIME_SIGNALS": 200809,
+            "_POSIX_REGEXP": 1,
+            "_POSIX_SAVED_IDS": 1,
+            "_POSIX_SELECT": null,
+            "_POSIX_SEMAPHORES": 200809,
+            "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+            "_POSIX_SHELL": 1,
+            "_POSIX_SIGNALS": null,
+            "_POSIX_SINGLE_PROCESS": null,
+            "_POSIX_SPAWN": 200809,
+            "_POSIX_SPIN_LOCKS": 200809,
+            "_POSIX_SPORADIC_SERVER": null,
+            "_POSIX_SSIZE_MAX": 32767,
+            "_POSIX_STREAM_MAX": 16,
+            "_POSIX_SYNCHRONIZED_IO": 200809,
+            "_POSIX_SYNC_IO": null,
+            "_POSIX_SYSTEM_DATABASE": null,
+            "_POSIX_SYSTEM_DATABASE_R": null,
+            "_POSIX_THREADS": 200809,
+            "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+            "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+            "_POSIX_THREAD_CPUTIME": 200809,
+            "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+            "_POSIX_THREAD_PRIO_INHERIT": 200809,
+            "_POSIX_THREAD_PRIO_PROTECT": 200809,
+            "_POSIX_THREAD_PROCESS_SHARED": 200809,
+            "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+            "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+            "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+            "_POSIX_THREAD_SPORADIC_SERVER": null,
+            "_POSIX_TIMEOUTS": 200809,
+            "_POSIX_TIMERS": 200809,
+            "_POSIX_TRACE": null,
+            "_POSIX_TRACE_EVENT_FILTER": null,
+            "_POSIX_TRACE_INHERIT": null,
+            "_POSIX_TRACE_LOG": null,
+            "_POSIX_TYPED_MEMORY_OBJECTS": null,
+            "_POSIX_TZNAME_MAX": null,
+            "_POSIX_USER_GROUPS": null,
+            "_POSIX_USER_GROUPS_R": null,
+            "_POSIX_V6_ILP32_OFF32": null,
+            "_POSIX_V6_ILP32_OFFBIG": null,
+            "_POSIX_V6_LP64_OFF64": 1,
+            "_POSIX_V6_LPBIG_OFFBIG": null,
+            "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+            "_POSIX_V7_ILP32_OFF32": null,
+            "_POSIX_V7_ILP32_OFFBIG": null,
+            "_POSIX_V7_LP64_OFF64": 1,
+            "_POSIX_V7_LPBIG_OFFBIG": null,
+            "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+            "_POSIX_VDISABLE": 0,
+            "_POSIX_VERSION": 200809,
+            "_REGEX_VERSION": null,
+            "_T_IOV_MAX": null,
+            "_XBS5_ILP32_OFF32": null,
+            "_XBS5_ILP32_OFFBIG": null,
+            "_XBS5_LP64_OFF64": 1,
+            "_XBS5_LPBIG_OFFBIG": null,
+            "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+            "_XOPEN_CRYPT": null,
+            "_XOPEN_ENH_I18N": 1,
+            "_XOPEN_LEGACY": 1,
+            "_XOPEN_REALTIME": 1,
+            "_XOPEN_REALTIME_THREADS": 1,
+            "_XOPEN_SHM": 1,
+            "_XOPEN_UNIX": 1,
+            "_XOPEN_VERSION": 700,
+            "_XOPEN_XCU_VERSION": 4,
+            "_XOPEN_XPG2": 1,
+            "_XOPEN_XPG3": 1,
+            "_XOPEN_XPG4": 1
+        },
+        "ohai_systemd_paths": {
+            "search-binaries": "/usr/local/rvm/gems/ruby-2.6.6/bin",
+            "search-binaries-default": "/usr/local/sbin",
+            "search-configuration": "/root/.config",
+            "search-configuration-factory": "/usr/local/share/factory/etc",
+            "search-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+            "search-library-private": "/root/.local/lib",
+            "search-shared": "/root/.local/share",
+            "search-state-factory": "/usr/local/share/factory/var",
+            "system-binaries": "/usr/bin",
+            "system-configuration": "/etc",
+            "system-configuration-factory": "/usr/share/factory/etc",
+            "system-include": "/usr/include",
+            "system-library-arch": "/usr/lib64",
+            "system-library-private": "/usr/lib",
+            "system-runtime": "/run",
+            "system-runtime-logs": "/run/log",
+            "system-shared": "/usr/share",
+            "system-state-cache": "/var/cache",
+            "system-state-factory": "/usr/share/factory/var",
+            "system-state-logs": "/var/log",
+            "system-state-private": "/var/lib",
+            "system-state-spool": "/var/spool",
+            "temporary": "/tmp",
+            "temporary-large": "/var/tmp",
+            "user": "/root",
+            "user-binaries": "/root/.local/bin",
+            "user-configuration": "/root/.config",
+            "user-desktop": "/root/Desktop",
+            "user-documents": "/root",
+            "user-download": "/root",
+            "user-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+            "user-library-private": "/root/.local/lib",
+            "user-music": "/root",
+            "user-pictures": "/root",
+            "user-public": "/root",
+            "user-runtime": "/run/user/0",
+            "user-shared": "/root/.local/share",
+            "user-state-cache": "/root/.cache",
+            "user-templates": "/root",
+            "user-videos": "/root"
+        },
+        "ohai_time": {
+            "timezone": "EDT"
+        },
+        "ohai_uptime": "23 hours 21 minutes 53 seconds",
+        "ohai_uptime_seconds": 84113,
+        "ohai_virtualization": {
+            "role": "guest",
+            "system": "kvm",
+            "systems": {
+                "kvm": "guest"
+            }
+        }
+    },
+    "changed": false
+}

--- a/test/static_fixtures/facts/chef_centos_7.json
+++ b/test/static_fixtures/facts/chef_centos_7.json
@@ -1,0 +1,10990 @@
+{
+    "kernel": {
+      "name": "Linux",
+      "release": "3.10.0-1062.18.1.el7.x86_64",
+      "version": "#1 SMP Tue Mar 17 23:49:17 UTC 2020",
+      "machine": "x86_64",
+      "processor": "x86_64",
+      "os": "GNU/Linux",
+      "modules": {
+        "openvswitch": {
+          "size": "114838",
+          "refcount": "0"
+        },
+        "nf_conntrack_ipv6": {
+          "size": "18935",
+          "refcount": "1"
+        },
+        "nf_nat_ipv6": {
+          "size": "14131",
+          "refcount": "1"
+        },
+        "nf_conntrack_ipv4": {
+          "size": "15053",
+          "refcount": "1"
+        },
+        "nf_defrag_ipv4": {
+          "size": "12729",
+          "refcount": "1"
+        },
+        "nf_nat_ipv4": {
+          "size": "14115",
+          "refcount": "1"
+        },
+        "nf_defrag_ipv6": {
+          "size": "35104",
+          "refcount": "2"
+        },
+        "nf_nat": {
+          "size": "26583",
+          "refcount": "3"
+        },
+        "nf_conntrack": {
+          "size": "139224",
+          "refcount": "6"
+        },
+        "sunrpc": {
+          "size": "354099",
+          "refcount": "1"
+        },
+        "squashfs": {
+          "size": "47827",
+          "refcount": "3"
+        },
+        "loop": {
+          "size": "28072",
+          "refcount": "6"
+        },
+        "iTCO_wdt": {
+          "size": "13523",
+          "refcount": "0",
+          "version": "1.11"
+        },
+        "gpio_ich": {
+          "size": "13476",
+          "refcount": "0"
+        },
+        "iTCO_vendor_support": {
+          "size": "13242",
+          "refcount": "1",
+          "version": "1.04"
+        },
+        "intel_powerclamp": {
+          "size": "14451",
+          "refcount": "0"
+        },
+        "coretemp": {
+          "size": "13444",
+          "refcount": "0"
+        },
+        "kvm_intel": {
+          "size": "188688",
+          "refcount": "0"
+        },
+        "ipmi_ssif": {
+          "size": "29595",
+          "refcount": "0"
+        },
+        "kvm": {
+          "size": "636921",
+          "refcount": "1"
+        },
+        "irqbypass": {
+          "size": "13503",
+          "refcount": "1"
+        },
+        "crc32_pclmul": {
+          "size": "13133",
+          "refcount": "0"
+        },
+        "ghash_clmulni_intel": {
+          "size": "13273",
+          "refcount": "0"
+        },
+        "aesni_intel": {
+          "size": "189456",
+          "refcount": "0"
+        },
+        "lrw": {
+          "size": "13286",
+          "refcount": "1"
+        },
+        "gf128mul": {
+          "size": "15139",
+          "refcount": "1"
+        },
+        "glue_helper": {
+          "size": "13990",
+          "refcount": "1"
+        },
+        "ablk_helper": {
+          "size": "13597",
+          "refcount": "1"
+        },
+        "cryptd": {
+          "size": "21190",
+          "refcount": "3"
+        },
+        "pcspkr": {
+          "size": "12718",
+          "refcount": "0"
+        },
+        "lpc_ich": {
+          "size": "21086",
+          "refcount": "0"
+        },
+        "ipmi_si": {
+          "size": "59965",
+          "refcount": "0"
+        },
+        "sg": {
+          "size": "40719",
+          "refcount": "0",
+          "version": "3.5.36"
+        },
+        "hpilo": {
+          "size": "17541",
+          "refcount": "0",
+          "version": "1.5.0"
+        },
+        "hpwdt": {
+          "size": "14536",
+          "refcount": "0",
+          "version": "2.0.2"
+        },
+        "i7core_edac": {
+          "size": "24182",
+          "refcount": "0"
+        },
+        "ipmi_devintf": {
+          "size": "17459",
+          "refcount": "0"
+        },
+        "ipmi_msghandler": {
+          "size": "56728",
+          "refcount": "3",
+          "version": "39.2"
+        },
+        "pcc_cpufreq": {
+          "size": "14104",
+          "refcount": "0",
+          "version": "1.10.00"
+        },
+        "acpi_power_meter": {
+          "size": "18104",
+          "refcount": "0"
+        },
+        "ip_tables": {
+          "size": "27126",
+          "refcount": "0"
+        },
+        "xfs": {
+          "size": "993020",
+          "refcount": "3"
+        },
+        "libcrc32c": {
+          "size": "12644",
+          "refcount": "4"
+        },
+        "radeon": {
+          "size": "1502567",
+          "refcount": "1"
+        },
+        "sd_mod": {
+          "size": "46281",
+          "refcount": "3"
+        },
+        "crc_t10dif": {
+          "size": "12912",
+          "refcount": "1"
+        },
+        "crct10dif_generic": {
+          "size": "12647",
+          "refcount": "0"
+        },
+        "i2c_algo_bit": {
+          "size": "13413",
+          "refcount": "1"
+        },
+        "drm_kms_helper": {
+          "size": "186531",
+          "refcount": "1"
+        },
+        "syscopyarea": {
+          "size": "12529",
+          "refcount": "1"
+        },
+        "sysfillrect": {
+          "size": "12701",
+          "refcount": "1"
+        },
+        "sysimgblt": {
+          "size": "12640",
+          "refcount": "1"
+        },
+        "fb_sys_fops": {
+          "size": "12703",
+          "refcount": "1"
+        },
+        "ttm": {
+          "size": "96673",
+          "refcount": "1"
+        },
+        "drm": {
+          "size": "456166",
+          "refcount": "4"
+        },
+        "hpsa": {
+          "size": "94845",
+          "refcount": "2",
+          "version": "3.4.20-170-RH1"
+        },
+        "crct10dif_pclmul": {
+          "size": "14307",
+          "refcount": "1"
+        },
+        "crct10dif_common": {
+          "size": "12595",
+          "refcount": "3"
+        },
+        "crc32c_intel": {
+          "size": "22094",
+          "refcount": "1"
+        },
+        "serio_raw": {
+          "size": "13434",
+          "refcount": "0"
+        },
+        "bnx2": {
+          "size": "89308",
+          "refcount": "0",
+          "version": "2.2.6"
+        },
+        "drm_panel_orientation_quirks": {
+          "size": "17180",
+          "refcount": "1"
+        },
+        "scsi_transport_sas": {
+          "size": "41224",
+          "refcount": "1"
+        },
+        "dm_mirror": {
+          "size": "22289",
+          "refcount": "0"
+        },
+        "dm_region_hash": {
+          "size": "20813",
+          "refcount": "1"
+        },
+        "dm_log": {
+          "size": "18411",
+          "refcount": "2"
+        },
+        "dm_mod": {
+          "size": "124501",
+          "refcount": "11"
+        }
+      }
+    },
+    "memory": {
+      "swap": {
+        "cached": "0kB",
+        "total": "24772604kB",
+        "free": "24772604kB"
+      },
+      "hugepages": {
+        "total": "0",
+        "free": "0",
+        "reserved": "0",
+        "surplus": "0"
+      },
+      "directmap": {
+        "4k": "204988kB",
+        "2M": "7124992kB",
+        "1G": "42991616kB"
+      },
+      "total": "49280220kB",
+      "free": "44146616kB",
+      "available": "44482680kB",
+      "buffers": "6232kB",
+      "cached": "697832kB",
+      "active": "4007048kB",
+      "inactive": "486168kB",
+      "dirty": "30456kB",
+      "writeback": "0kB",
+      "anon_pages": "3814980kB",
+      "mapped": "103476kB",
+      "slab": "175700kB",
+      "slab_reclaimable": "65456kB",
+      "slab_unreclaim": "110244kB",
+      "page_tables": "25012kB",
+      "nfs_unstable": "0kB",
+      "bounce": "0kB",
+      "commit_limit": "49412712kB",
+      "committed_as": "15716440kB",
+      "vmalloc_total": "34359738367kB",
+      "vmalloc_used": "198740kB",
+      "vmalloc_chunk": "34333980668kB",
+      "hugepage_size": "2048kB"
+    },
+    "network": {
+      "interfaces": {
+        "lo": {
+          "mtu": "65536",
+          "flags": [
+            "LOOPBACK",
+            "UP",
+            "LOWER_UP"
+          ],
+          "encapsulation": "Loopback",
+          "addresses": {
+            "127.0.0.1": {
+              "family": "inet",
+              "prefixlen": "8",
+              "netmask": "255.0.0.0",
+              "scope": "Node"
+            },
+            "::1": {
+              "family": "inet6",
+              "prefixlen": "128",
+              "scope": "Node",
+              "tags": [
+
+              ]
+            }
+          },
+          "state": "unknown",
+          "routes": [
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            },
+            {
+              "destination": "unreachable",
+              "family": "inet6",
+              "metric": "1024"
+            }
+          ]
+        },
+        "enp3s0f0": {
+          "type": "enp",
+          "number": "3s0f0",
+          "mtu": "1500",
+          "flags": [
+            "BROADCAST",
+            "MULTICAST",
+            "UP",
+            "LOWER_UP"
+          ],
+          "encapsulation": "Ethernet",
+          "addresses": {
+            "6C:3B:E5:B2:BD:64": {
+              "family": "lladdr"
+            },
+            "192.168.88.241": {
+              "family": "inet",
+              "prefixlen": "24",
+              "netmask": "255.255.255.0",
+              "broadcast": "192.168.88.255",
+              "scope": "Global"
+            },
+            "fe80::7543:f88e:2995:aac9": {
+              "family": "inet6",
+              "prefixlen": "64",
+              "scope": "Link",
+              "tags": [
+                "noprefixroute"
+              ]
+            }
+          },
+          "state": "up",
+          "arp": {
+            "192.168.88.248": "04:d3:b0:c3:a1:db",
+            "192.168.88.1": "08:55:31:bc:a1:ad"
+          },
+          "routes": [
+            {
+              "destination": "default",
+              "family": "inet",
+              "via": "192.168.88.1",
+              "metric": "100",
+              "proto": "dhcp"
+            },
+            {
+              "destination": "192.168.88.0/24",
+              "family": "inet",
+              "scope": "link",
+              "metric": "100",
+              "proto": "kernel",
+              "src": "192.168.88.241"
+            },
+            {
+              "destination": "fe80::/64",
+              "family": "inet6",
+              "metric": "100",
+              "proto": "kernel"
+            }
+          ],
+          "link_speed": 1000,
+          "duplex": "Full",
+          "port": "Twisted Pair",
+          "transceiver": "internal",
+          "auto_negotiation": "on",
+          "mdi_x": "off",
+          "ring_params": {
+            "max_rx": 2040,
+            "max_rx_mini": 0,
+            "max_rx_jumbo": 8160,
+            "max_tx": 255,
+            "current_rx": 255,
+            "current_rx_mini": 0,
+            "current_rx_jumbo": 0,
+            "current_tx": 255
+          },
+          "channel_params": {
+            "max_rx": 8,
+            "max_tx": 8,
+            "max_other": 0,
+            "max_combined": 0,
+            "current_rx": 8,
+            "current_tx": 8,
+            "current_other": 0,
+            "current_combined": 0
+          },
+          "coalesce_params": {
+            "adaptive_rx": "off",
+            "adaptive_tx": "off",
+            "stats-block-usecs": 999936,
+            "sample-interval": 0,
+            "pkt-rate-low": 0,
+            "pkt-rate-high": 0,
+            "rx-usecs": 18,
+            "rx-frames": 12,
+            "rx-usecs-irq": 18,
+            "rx-frames-irq": 2,
+            "tx-usecs": 80,
+            "tx-frames": 20,
+            "tx-usecs-irq": 18,
+            "tx-frames-irq": 2,
+            "rx-usecs-low": 0,
+            "rx-frame-low": 0,
+            "tx-usecs-low": 0,
+            "tx-frame-low": 0,
+            "rx-usecs-high": 0,
+            "rx-frame-high": 0,
+            "tx-usecs-high": 0,
+            "tx-frame-high": 0
+          },
+          "offload_params": {
+            "rx-checksumming": "on",
+            "tx-checksumming": "on",
+            "tx-checksum-ipv4": "on",
+            "tx-checksum-ip-generic": "off",
+            "tx-checksum-ipv6": "on",
+            "tx-checksum-fcoe-crc": "off",
+            "tx-checksum-sctp": "off",
+            "scatter-gather": "on",
+            "tx-scatter-gather": "on",
+            "tx-scatter-gather-fraglist": "off",
+            "tcp-segmentation-offload": "on",
+            "tx-tcp-segmentation": "on",
+            "tx-tcp-ecn-segmentation": "on",
+            "tx-tcp6-segmentation": "on",
+            "tx-tcp-mangleid-segmentation": "off",
+            "udp-fragmentation-offload": "off",
+            "generic-segmentation-offload": "on",
+            "generic-receive-offload": "on",
+            "large-receive-offload": "off",
+            "rx-vlan-offload": "on",
+            "tx-vlan-offload": "on",
+            "ntuple-filters": "off",
+            "receive-hashing": "on",
+            "highdma": "on",
+            "rx-vlan-filter": "off",
+            "vlan-challenged": "off",
+            "tx-lockless": "off",
+            "netns-local": "off",
+            "tx-gso-robust": "off",
+            "tx-fcoe-segmentation": "off",
+            "tx-gre-segmentation": "off",
+            "tx-ipip-segmentation": "off",
+            "tx-sit-segmentation": "off",
+            "tx-udp_tnl-segmentation": "off",
+            "fcoe-mtu": "off",
+            "tx-nocache-copy": "off",
+            "loopback": "off",
+            "rx-fcs": "off",
+            "rx-all": "off",
+            "tx-vlan-stag-hw-insert": "off",
+            "rx-vlan-stag-hw-parse": "off",
+            "rx-vlan-stag-filter": "off",
+            "busy-poll": "off",
+            "tx-gre-csum-segmentation": "off",
+            "tx-udp_tnl-csum-segmentation": "off",
+            "tx-gso-partial": "off",
+            "tx-sctp-segmentation": "off",
+            "rx-gro-hw": "off",
+            "l2-fwd-offload": "off",
+            "hw-tc-offload": "off",
+            "rx-udp_tunnel-port-offload": "off"
+          },
+          "driver_info": {
+            "driver": "bnx2",
+            "version": "2.2.6",
+            "firmware-version": "bc 5.2.3 NCSI 2.0.12",
+            "expansion-rom-version": "",
+            "bus-info": "0000:03:00.0",
+            "supports-statistics": "yes",
+            "supports-test": "yes",
+            "supports-eeprom-access": "yes",
+            "supports-register-dump": "yes",
+            "supports-priv-flags": "no"
+          },
+          "pause_params": {
+            "autonegotiate": true,
+            "rx": false,
+            "tx": false
+          }
+        },
+        "enp3s0f1": {
+          "type": "enp",
+          "number": "3s0f1",
+          "mtu": "1500",
+          "flags": [
+            "BROADCAST",
+            "MULTICAST",
+            "UP"
+          ],
+          "encapsulation": "Ethernet",
+          "addresses": {
+            "6C:3B:E5:B2:BD:66": {
+              "family": "lladdr"
+            }
+          },
+          "state": "down",
+          "link_speed": 0,
+          "duplex": "Unknown! (255)",
+          "port": "Twisted Pair",
+          "transceiver": "internal",
+          "auto_negotiation": "on",
+          "mdi_x": "Unknown",
+          "ring_params": {
+            "max_rx": 2040,
+            "max_rx_mini": 0,
+            "max_rx_jumbo": 8160,
+            "max_tx": 255,
+            "current_rx": 255,
+            "current_rx_mini": 0,
+            "current_rx_jumbo": 0,
+            "current_tx": 255
+          },
+          "channel_params": {
+            "max_rx": 8,
+            "max_tx": 8,
+            "max_other": 0,
+            "max_combined": 0,
+            "current_rx": 8,
+            "current_tx": 8,
+            "current_other": 0,
+            "current_combined": 0
+          },
+          "coalesce_params": {
+            "adaptive_rx": "off",
+            "adaptive_tx": "off",
+            "stats-block-usecs": 999936,
+            "sample-interval": 0,
+            "pkt-rate-low": 0,
+            "pkt-rate-high": 0,
+            "rx-usecs": 18,
+            "rx-frames": 12,
+            "rx-usecs-irq": 18,
+            "rx-frames-irq": 2,
+            "tx-usecs": 80,
+            "tx-frames": 20,
+            "tx-usecs-irq": 18,
+            "tx-frames-irq": 2,
+            "rx-usecs-low": 0,
+            "rx-frame-low": 0,
+            "tx-usecs-low": 0,
+            "tx-frame-low": 0,
+            "rx-usecs-high": 0,
+            "rx-frame-high": 0,
+            "tx-usecs-high": 0,
+            "tx-frame-high": 0
+          },
+          "offload_params": {
+            "rx-checksumming": "on",
+            "tx-checksumming": "on",
+            "tx-checksum-ipv4": "on",
+            "tx-checksum-ip-generic": "off",
+            "tx-checksum-ipv6": "on",
+            "tx-checksum-fcoe-crc": "off",
+            "tx-checksum-sctp": "off",
+            "scatter-gather": "on",
+            "tx-scatter-gather": "on",
+            "tx-scatter-gather-fraglist": "off",
+            "tcp-segmentation-offload": "on",
+            "tx-tcp-segmentation": "on",
+            "tx-tcp-ecn-segmentation": "on",
+            "tx-tcp6-segmentation": "on",
+            "tx-tcp-mangleid-segmentation": "off",
+            "udp-fragmentation-offload": "off",
+            "generic-segmentation-offload": "on",
+            "generic-receive-offload": "on",
+            "large-receive-offload": "off",
+            "rx-vlan-offload": "on",
+            "tx-vlan-offload": "on",
+            "ntuple-filters": "off",
+            "receive-hashing": "on",
+            "highdma": "on",
+            "rx-vlan-filter": "off",
+            "vlan-challenged": "off",
+            "tx-lockless": "off",
+            "netns-local": "off",
+            "tx-gso-robust": "off",
+            "tx-fcoe-segmentation": "off",
+            "tx-gre-segmentation": "off",
+            "tx-ipip-segmentation": "off",
+            "tx-sit-segmentation": "off",
+            "tx-udp_tnl-segmentation": "off",
+            "fcoe-mtu": "off",
+            "tx-nocache-copy": "off",
+            "loopback": "off",
+            "rx-fcs": "off",
+            "rx-all": "off",
+            "tx-vlan-stag-hw-insert": "off",
+            "rx-vlan-stag-hw-parse": "off",
+            "rx-vlan-stag-filter": "off",
+            "busy-poll": "off",
+            "tx-gre-csum-segmentation": "off",
+            "tx-udp_tnl-csum-segmentation": "off",
+            "tx-gso-partial": "off",
+            "tx-sctp-segmentation": "off",
+            "rx-gro-hw": "off",
+            "l2-fwd-offload": "off",
+            "hw-tc-offload": "off",
+            "rx-udp_tunnel-port-offload": "off"
+          },
+          "driver_info": {
+            "driver": "bnx2",
+            "version": "2.2.6",
+            "firmware-version": "bc 5.2.3 NCSI 2.0.12",
+            "expansion-rom-version": "",
+            "bus-info": "0000:03:00.1",
+            "supports-statistics": "yes",
+            "supports-test": "yes",
+            "supports-eeprom-access": "yes",
+            "supports-register-dump": "yes",
+            "supports-priv-flags": "no"
+          },
+          "pause_params": {
+            "autonegotiate": true,
+            "rx": false,
+            "tx": false
+          }
+        },
+        "enp4s0f0": {
+          "type": "enp",
+          "number": "4s0f0",
+          "mtu": "1500",
+          "flags": [
+            "BROADCAST",
+            "MULTICAST",
+            "UP"
+          ],
+          "encapsulation": "Ethernet",
+          "addresses": {
+            "6C:3B:E5:B2:BD:24": {
+              "family": "lladdr"
+            }
+          },
+          "state": "down",
+          "link_speed": 0,
+          "duplex": "Unknown! (255)",
+          "port": "Twisted Pair",
+          "transceiver": "internal",
+          "auto_negotiation": "on",
+          "mdi_x": "Unknown",
+          "ring_params": {
+            "max_rx": 2040,
+            "max_rx_mini": 0,
+            "max_rx_jumbo": 8160,
+            "max_tx": 255,
+            "current_rx": 255,
+            "current_rx_mini": 0,
+            "current_rx_jumbo": 0,
+            "current_tx": 255
+          },
+          "channel_params": {
+            "max_rx": 8,
+            "max_tx": 8,
+            "max_other": 0,
+            "max_combined": 0,
+            "current_rx": 8,
+            "current_tx": 8,
+            "current_other": 0,
+            "current_combined": 0
+          },
+          "coalesce_params": {
+            "adaptive_rx": "off",
+            "adaptive_tx": "off",
+            "stats-block-usecs": 999936,
+            "sample-interval": 0,
+            "pkt-rate-low": 0,
+            "pkt-rate-high": 0,
+            "rx-usecs": 18,
+            "rx-frames": 12,
+            "rx-usecs-irq": 18,
+            "rx-frames-irq": 2,
+            "tx-usecs": 80,
+            "tx-frames": 20,
+            "tx-usecs-irq": 18,
+            "tx-frames-irq": 2,
+            "rx-usecs-low": 0,
+            "rx-frame-low": 0,
+            "tx-usecs-low": 0,
+            "tx-frame-low": 0,
+            "rx-usecs-high": 0,
+            "rx-frame-high": 0,
+            "tx-usecs-high": 0,
+            "tx-frame-high": 0
+          },
+          "offload_params": {
+            "rx-checksumming": "on",
+            "tx-checksumming": "on",
+            "tx-checksum-ipv4": "on",
+            "tx-checksum-ip-generic": "off",
+            "tx-checksum-ipv6": "on",
+            "tx-checksum-fcoe-crc": "off",
+            "tx-checksum-sctp": "off",
+            "scatter-gather": "on",
+            "tx-scatter-gather": "on",
+            "tx-scatter-gather-fraglist": "off",
+            "tcp-segmentation-offload": "on",
+            "tx-tcp-segmentation": "on",
+            "tx-tcp-ecn-segmentation": "on",
+            "tx-tcp6-segmentation": "on",
+            "tx-tcp-mangleid-segmentation": "off",
+            "udp-fragmentation-offload": "off",
+            "generic-segmentation-offload": "on",
+            "generic-receive-offload": "on",
+            "large-receive-offload": "off",
+            "rx-vlan-offload": "on",
+            "tx-vlan-offload": "on",
+            "ntuple-filters": "off",
+            "receive-hashing": "on",
+            "highdma": "on",
+            "rx-vlan-filter": "off",
+            "vlan-challenged": "off",
+            "tx-lockless": "off",
+            "netns-local": "off",
+            "tx-gso-robust": "off",
+            "tx-fcoe-segmentation": "off",
+            "tx-gre-segmentation": "off",
+            "tx-ipip-segmentation": "off",
+            "tx-sit-segmentation": "off",
+            "tx-udp_tnl-segmentation": "off",
+            "fcoe-mtu": "off",
+            "tx-nocache-copy": "off",
+            "loopback": "off",
+            "rx-fcs": "off",
+            "rx-all": "off",
+            "tx-vlan-stag-hw-insert": "off",
+            "rx-vlan-stag-hw-parse": "off",
+            "rx-vlan-stag-filter": "off",
+            "busy-poll": "off",
+            "tx-gre-csum-segmentation": "off",
+            "tx-udp_tnl-csum-segmentation": "off",
+            "tx-gso-partial": "off",
+            "tx-sctp-segmentation": "off",
+            "rx-gro-hw": "off",
+            "l2-fwd-offload": "off",
+            "hw-tc-offload": "off",
+            "rx-udp_tunnel-port-offload": "off"
+          },
+          "driver_info": {
+            "driver": "bnx2",
+            "version": "2.2.6",
+            "firmware-version": "bc 5.2.3 NCSI 2.0.12",
+            "expansion-rom-version": "",
+            "bus-info": "0000:04:00.0",
+            "supports-statistics": "yes",
+            "supports-test": "yes",
+            "supports-eeprom-access": "yes",
+            "supports-register-dump": "yes",
+            "supports-priv-flags": "no"
+          },
+          "pause_params": {
+            "autonegotiate": true,
+            "rx": false,
+            "tx": false
+          }
+        },
+        "enp4s0f1": {
+          "type": "enp",
+          "number": "4s0f1",
+          "mtu": "1500",
+          "flags": [
+            "BROADCAST",
+            "MULTICAST",
+            "UP"
+          ],
+          "encapsulation": "Ethernet",
+          "addresses": {
+            "6C:3B:E5:B2:BD:26": {
+              "family": "lladdr"
+            }
+          },
+          "state": "down",
+          "link_speed": 0,
+          "duplex": "Unknown! (255)",
+          "port": "Twisted Pair",
+          "transceiver": "internal",
+          "auto_negotiation": "on",
+          "mdi_x": "Unknown",
+          "ring_params": {
+            "max_rx": 2040,
+            "max_rx_mini": 0,
+            "max_rx_jumbo": 8160,
+            "max_tx": 255,
+            "current_rx": 255,
+            "current_rx_mini": 0,
+            "current_rx_jumbo": 0,
+            "current_tx": 255
+          },
+          "channel_params": {
+            "max_rx": 8,
+            "max_tx": 8,
+            "max_other": 0,
+            "max_combined": 0,
+            "current_rx": 8,
+            "current_tx": 8,
+            "current_other": 0,
+            "current_combined": 0
+          },
+          "coalesce_params": {
+            "adaptive_rx": "off",
+            "adaptive_tx": "off",
+            "stats-block-usecs": 999936,
+            "sample-interval": 0,
+            "pkt-rate-low": 0,
+            "pkt-rate-high": 0,
+            "rx-usecs": 18,
+            "rx-frames": 12,
+            "rx-usecs-irq": 18,
+            "rx-frames-irq": 2,
+            "tx-usecs": 80,
+            "tx-frames": 20,
+            "tx-usecs-irq": 18,
+            "tx-frames-irq": 2,
+            "rx-usecs-low": 0,
+            "rx-frame-low": 0,
+            "tx-usecs-low": 0,
+            "tx-frame-low": 0,
+            "rx-usecs-high": 0,
+            "rx-frame-high": 0,
+            "tx-usecs-high": 0,
+            "tx-frame-high": 0
+          },
+          "offload_params": {
+            "rx-checksumming": "on",
+            "tx-checksumming": "on",
+            "tx-checksum-ipv4": "on",
+            "tx-checksum-ip-generic": "off",
+            "tx-checksum-ipv6": "on",
+            "tx-checksum-fcoe-crc": "off",
+            "tx-checksum-sctp": "off",
+            "scatter-gather": "on",
+            "tx-scatter-gather": "on",
+            "tx-scatter-gather-fraglist": "off",
+            "tcp-segmentation-offload": "on",
+            "tx-tcp-segmentation": "on",
+            "tx-tcp-ecn-segmentation": "on",
+            "tx-tcp6-segmentation": "on",
+            "tx-tcp-mangleid-segmentation": "off",
+            "udp-fragmentation-offload": "off",
+            "generic-segmentation-offload": "on",
+            "generic-receive-offload": "on",
+            "large-receive-offload": "off",
+            "rx-vlan-offload": "on",
+            "tx-vlan-offload": "on",
+            "ntuple-filters": "off",
+            "receive-hashing": "on",
+            "highdma": "on",
+            "rx-vlan-filter": "off",
+            "vlan-challenged": "off",
+            "tx-lockless": "off",
+            "netns-local": "off",
+            "tx-gso-robust": "off",
+            "tx-fcoe-segmentation": "off",
+            "tx-gre-segmentation": "off",
+            "tx-ipip-segmentation": "off",
+            "tx-sit-segmentation": "off",
+            "tx-udp_tnl-segmentation": "off",
+            "fcoe-mtu": "off",
+            "tx-nocache-copy": "off",
+            "loopback": "off",
+            "rx-fcs": "off",
+            "rx-all": "off",
+            "tx-vlan-stag-hw-insert": "off",
+            "rx-vlan-stag-hw-parse": "off",
+            "rx-vlan-stag-filter": "off",
+            "busy-poll": "off",
+            "tx-gre-csum-segmentation": "off",
+            "tx-udp_tnl-csum-segmentation": "off",
+            "tx-gso-partial": "off",
+            "tx-sctp-segmentation": "off",
+            "rx-gro-hw": "off",
+            "l2-fwd-offload": "off",
+            "hw-tc-offload": "off",
+            "rx-udp_tunnel-port-offload": "off"
+          },
+          "driver_info": {
+            "driver": "bnx2",
+            "version": "2.2.6",
+            "firmware-version": "bc 5.2.3 NCSI 2.0.12",
+            "expansion-rom-version": "",
+            "bus-info": "0000:04:00.1",
+            "supports-statistics": "yes",
+            "supports-test": "yes",
+            "supports-eeprom-access": "yes",
+            "supports-register-dump": "yes",
+            "supports-priv-flags": "no"
+          },
+          "pause_params": {
+            "autonegotiate": true,
+            "rx": false,
+            "tx": false
+          }
+        }
+      },
+      "default_interface": "enp3s0f0",
+      "default_gateway": "192.168.88.1"
+    },
+    "counters": {
+      "network": {
+        "interfaces": {
+          "lo": {
+            "tx": {
+              "queuelen": "1000",
+              "bytes": "7046285",
+              "packets": "10738",
+              "errors": "0",
+              "drop": "0",
+              "carrier": "0",
+              "collisions": "0"
+            },
+            "rx": {
+              "bytes": "7046285",
+              "packets": "10738",
+              "errors": "0",
+              "drop": "0",
+              "overrun": "0"
+            }
+          },
+          "enp3s0f0": {
+            "tx": {
+              "queuelen": "1000",
+              "bytes": "3337586",
+              "packets": "18185",
+              "errors": "0",
+              "drop": "0",
+              "carrier": "0",
+              "collisions": "0"
+            },
+            "rx": {
+              "bytes": "28284466",
+              "packets": "22595",
+              "errors": "0",
+              "drop": "0",
+              "overrun": "0"
+            }
+          },
+          "enp3s0f1": {
+            "tx": {
+              "queuelen": "1000",
+              "bytes": "0",
+              "packets": "0",
+              "errors": "0",
+              "drop": "0",
+              "carrier": "0",
+              "collisions": "0"
+            },
+            "rx": {
+              "bytes": "0",
+              "packets": "0",
+              "errors": "0",
+              "drop": "0",
+              "overrun": "0"
+            }
+          },
+          "enp4s0f0": {
+            "tx": {
+              "queuelen": "1000",
+              "bytes": "0",
+              "packets": "0",
+              "errors": "0",
+              "drop": "0",
+              "carrier": "0",
+              "collisions": "0"
+            },
+            "rx": {
+              "bytes": "0",
+              "packets": "0",
+              "errors": "0",
+              "drop": "0",
+              "overrun": "0"
+            }
+          },
+          "enp4s0f1": {
+            "tx": {
+              "queuelen": "1000",
+              "bytes": "0",
+              "packets": "0",
+              "errors": "0",
+              "drop": "0",
+              "carrier": "0",
+              "collisions": "0"
+            },
+            "rx": {
+              "bytes": "0",
+              "packets": "0",
+              "errors": "0",
+              "drop": "0",
+              "overrun": "0"
+            }
+          }
+        }
+      }
+    },
+    "IPAddress": "192.168.88.0/24",
+    "ipaddress": "192.168.88.241",
+    "macaddress": "6C:3B:E5:B2:BD:64",
+    "ip6address": "fe80::7543:f88e:2995:aac9",
+    "lsb": {
+
+    },
+    "os": "linux",
+    "os_version": "3.10.0-1062.18.1.el7.x86_64",
+    "platform": "centos",
+    "platform_version": "7.7.1908",
+    "platform_family": "rhel",
+    "uptime_seconds": 577,
+    "uptime": "9 minutes 37 seconds",
+    "idletime_seconds": 13610,
+    "idletime": "3 hours 46 minutes 50 seconds",
+    "dmi": {
+      "dmidecode_version": "3.2",
+      "smbios_version": "2.7",
+      "structures": {
+        "count": "127",
+        "size": "3808"
+      },
+      "bios": {
+        "all_records": [
+          {
+            "record_id": "0x0000",
+            "size": "0",
+            "application_identifier": "BIOS Information",
+            "Vendor": "HP",
+            "Version": "P68",
+            "Release Date": "08/16/2015",
+            "Address": "0xF0000",
+            "Runtime Size": "64 kB",
+            "ROM Size": "8192 kB",
+            "Characteristics": {
+              "Targeted content distribution is supported": null
+            },
+            "Firmware Revision": "1.88"
+          }
+        ],
+        "vendor": "HP",
+        "version": "P68",
+        "release_date": "08/16/2015",
+        "address": "0xF0000",
+        "runtime_size": "64 kB",
+        "rom_size": "8192 kB",
+        "firmware_revision": "1.88"
+      },
+      "system": {
+        "all_records": [
+          {
+            "record_id": "0x0100",
+            "size": "1",
+            "application_identifier": "System Information",
+            "Manufacturer": "HP",
+            "Product Name": "ProLiant DL360 G7",
+            "Version": "Not Specified",
+            "Serial Number": "MY_SERIAL      ",
+            "UUID": "32305751-4139-5355-4533-303958383241",
+            "Wake-up Type": "Power Switch",
+            "SKU Number": "QW029A          ",
+            "Family": "ProLiant"
+          }
+        ],
+        "manufacturer": "HP",
+        "product_name": "ProLiant DL360 G7",
+        "version": "Not Specified",
+        "serial_number": "MY_SERIAL",
+        "uuid": "32305751-4139-5355-4533-303958383241",
+        "wake_up_type": "Power Switch",
+        "sku_number": "QW029A",
+        "family": "ProLiant"
+      },
+      "chassis": {
+        "all_records": [
+          {
+            "record_id": "0x0300",
+            "size": "3",
+            "application_identifier": "Chassis Information",
+            "Manufacturer": "HP",
+            "Type": "Rack Mount Chassis",
+            "Lock": "Not Present",
+            "Version": "Not Specified",
+            "Serial Number": "MY_SERIAL      ",
+            "Asset Tag": "                                ",
+            "Boot-up State": "Safe",
+            "Power Supply State": "Safe",
+            "Thermal State": "Safe",
+            "Security Status": "Unknown",
+            "OEM Information": "0x00000000",
+            "Height": "1 U",
+            "Number Of Power Cords": "2",
+            "Contained Elements": "0"
+          }
+        ],
+        "manufacturer": "HP",
+        "type": "Rack Mount Chassis",
+        "lock": "Not Present",
+        "version": "Not Specified",
+        "serial_number": "MY_SERIAL",
+        "asset_tag": "",
+        "boot_up_state": "Safe",
+        "power_supply_state": "Safe",
+        "thermal_state": "Safe",
+        "security_status": "Unknown",
+        "oem_information": "0x00000000",
+        "height": "1 U",
+        "number_of_power_cords": "2",
+        "contained_elements": "0"
+      },
+      "processor": {
+        "all_records": [
+          {
+            "record_id": "0x0400",
+            "size": "4",
+            "application_identifier": "Processor Information",
+            "Socket Designation": "Proc 1",
+            "Type": "Central Processor",
+            "Family": "Xeon",
+            "Manufacturer": "Intel",
+            "ID": "C2 06 02 00 FF FB EB BF",
+            "Signature": "Type 0, Family 6, Model 44, Stepping 2",
+            "Flags": {
+              "PBE (Pending break enabled)": null
+            },
+            "Version": "Intel(R) Xeon(R) CPU L5640 @ 2.27GHz            ",
+            "Voltage": "1.4 V",
+            "External Clock": "133 MHz",
+            "Max Speed": "4800 MHz",
+            "Current Speed": "2267 MHz",
+            "Status": "Populated, Enabled",
+            "Upgrade": "Socket LGA1366",
+            "L1 Cache Handle": "0x0710",
+            "L2 Cache Handle": "0x0720",
+            "L3 Cache Handle": "0x0730",
+            "Serial Number": "Not Specified",
+            "Asset Tag": "Not Specified",
+            "Part Number": "Not Specified",
+            "Core Count": "6",
+            "Core Enabled": "6",
+            "Thread Count": "12",
+            "Characteristics": {
+              "64-bit capable": null
+            }
+          },
+          {
+            "record_id": "0x0406",
+            "size": "4",
+            "application_identifier": "Processor Information",
+            "Socket Designation": "Proc 2",
+            "Type": "Central Processor",
+            "Family": "Xeon",
+            "Manufacturer": "Intel",
+            "ID": "C2 06 02 00 FF FB EB BF",
+            "Signature": "Type 0, Family 6, Model 44, Stepping 2",
+            "Flags": {
+              "PBE (Pending break enabled)": null
+            },
+            "Version": "Intel(R) Xeon(R) CPU L5640 @ 2.27GHz            ",
+            "Voltage": "1.4 V",
+            "External Clock": "133 MHz",
+            "Max Speed": "4800 MHz",
+            "Current Speed": "2267 MHz",
+            "Status": "Populated, Idle",
+            "Upgrade": "Socket LGA1366",
+            "L1 Cache Handle": "0x0716",
+            "L2 Cache Handle": "0x0726",
+            "L3 Cache Handle": "0x0736",
+            "Serial Number": "Not Specified",
+            "Asset Tag": "Not Specified",
+            "Part Number": "Not Specified",
+            "Core Count": "6",
+            "Core Enabled": "6",
+            "Thread Count": "12",
+            "Characteristics": {
+              "64-bit capable": null
+            }
+          }
+        ],
+        "type": "Central Processor",
+        "family": "Xeon",
+        "manufacturer": "Intel",
+        "id": "C2 06 02 00 FF FB EB BF",
+        "signature": "Type 0, Family 6, Model 44, Stepping 2",
+        "version": "Intel(R) Xeon(R) CPU L5640 @ 2.27GHz",
+        "voltage": "1.4 V",
+        "external_clock": "133 MHz",
+        "max_speed": "4800 MHz",
+        "current_speed": "2267 MHz",
+        "upgrade": "Socket LGA1366",
+        "serial_number": "Not Specified",
+        "asset_tag": "Not Specified",
+        "part_number": "Not Specified",
+        "core_count": "6",
+        "core_enabled": "6",
+        "thread_count": "12"
+      },
+      "oem_strings": {
+        "all_records": [
+          {
+            "record_id": "0x0B00",
+            "size": "11",
+            "application_identifier": "OEM Strings",
+            "String 1": "PSF:                                                                 ",
+            "String 2": "Product ID: QW029A          "
+          }
+        ],
+        "string_1": "PSF:",
+        "string_2": "Product ID: QW029A"
+      }
+    },
+    "cpu": {
+      "numa_node_cpus": {
+        "0": [
+          0,
+          2,
+          4,
+          6,
+          8,
+          10,
+          12,
+          14,
+          16,
+          18,
+          20,
+          22
+        ],
+        "1": [
+          1,
+          3,
+          5,
+          7,
+          9,
+          11,
+          13,
+          15,
+          17,
+          19,
+          21,
+          23
+        ]
+      },
+      "vulnerability": {
+
+      },
+      "architecture": "x86_64",
+      "cpu_opmodes": [
+        "32-bit",
+        "64-bit"
+      ],
+      "byte_order": "little endian",
+      "cpus": 24,
+      "cpus_online": 24,
+      "threads_per_core": 2,
+      "cores_per_socket": 6,
+      "sockets": 2,
+      "numa_nodes": 2,
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+      "stepping": "2",
+      "mhz": "1600.000",
+      "mhz_max": "2266.0000",
+      "mhz_min": "1600.0000",
+      "bogomips": "4533.91",
+      "virtualization": "VT-x",
+      "l1d_cache": "32K",
+      "l1i_cache": "32K",
+      "l2_cache": "256K",
+      "l3_cache": "12288K",
+      "flags": [
+        "acpi",
+        "aes",
+        "aperfmperf",
+        "apic",
+        "arat",
+        "arch_perfmon",
+        "bts",
+        "clflush",
+        "cmov",
+        "constant_tsc",
+        "cx16",
+        "cx8",
+        "dca",
+        "de",
+        "ds_cpl",
+        "dtes64",
+        "dtherm",
+        "dts",
+        "eagerfpu",
+        "epb",
+        "ept",
+        "est",
+        "flexpriority",
+        "flush_l1d",
+        "fpu",
+        "fxsr",
+        "ht",
+        "ibpb",
+        "ibrs",
+        "ida",
+        "intel_stibp",
+        "lahf_lm",
+        "lm",
+        "mca",
+        "mce",
+        "mmx",
+        "monitor",
+        "msr",
+        "mtrr",
+        "nonstop_tsc",
+        "nopl",
+        "nx",
+        "pae",
+        "pat",
+        "pbe",
+        "pcid",
+        "pclmulqdq",
+        "pdcm",
+        "pdpe1gb",
+        "pebs",
+        "pge",
+        "pni",
+        "popcnt",
+        "pse",
+        "pse36",
+        "rdtscp",
+        "rep_good",
+        "sep",
+        "smx",
+        "spec_ctrl",
+        "ss",
+        "ssbd",
+        "sse",
+        "sse2",
+        "sse4_1",
+        "sse4_2",
+        "ssse3",
+        "stibp",
+        "syscall",
+        "tm",
+        "tm2",
+        "tpr_shadow",
+        "tsc",
+        "vme",
+        "vmx",
+        "vnmi",
+        "vpid",
+        "xtopology",
+        "xtpr"
+      ],
+      "0": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "0",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "1": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "1",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "2": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "2",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "3": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "3",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "4": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "4",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "5": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "5",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "6": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "6",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "7": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "7",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "8": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "8",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "9": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "9",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "10": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "10",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "11": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "11",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "12": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "0",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "13": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "1",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "14": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "2",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "15": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "3",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "16": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "4",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "17": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "5",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "18": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "6",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "19": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "7",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "20": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "8",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "21": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "9",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "22": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "0",
+        "core_id": "10",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "23": {
+        "vendor_id": "GenuineIntel",
+        "family": "6",
+        "model": "44",
+        "model_name": "Intel(R) Xeon(R) CPU           L5640  @ 2.27GHz",
+        "stepping": "2",
+        "mhz": "1600.000",
+        "bogomips": "4533.91",
+        "cache_size": "12288 KB",
+        "physical_id": "1",
+        "core_id": "11",
+        "cores": "6",
+        "flags": [
+          "acpi",
+          "aes",
+          "aperfmperf",
+          "apic",
+          "arat",
+          "arch_perfmon",
+          "bts",
+          "clflush",
+          "cmov",
+          "constant_tsc",
+          "cx16",
+          "cx8",
+          "dca",
+          "de",
+          "ds_cpl",
+          "dtes64",
+          "dtherm",
+          "dts",
+          "eagerfpu",
+          "epb",
+          "ept",
+          "est",
+          "flexpriority",
+          "flush_l1d",
+          "fpu",
+          "fxsr",
+          "ht",
+          "ibpb",
+          "ibrs",
+          "ida",
+          "intel_stibp",
+          "lahf_lm",
+          "lm",
+          "mca",
+          "mce",
+          "mmx",
+          "monitor",
+          "msr",
+          "mtrr",
+          "nonstop_tsc",
+          "nopl",
+          "nx",
+          "pae",
+          "pat",
+          "pbe",
+          "pcid",
+          "pclmulqdq",
+          "pdcm",
+          "pdpe1gb",
+          "pebs",
+          "pge",
+          "pni",
+          "popcnt",
+          "pse",
+          "pse36",
+          "rdtscp",
+          "rep_good",
+          "sep",
+          "smx",
+          "spec_ctrl",
+          "ss",
+          "ssbd",
+          "sse",
+          "sse2",
+          "sse4_1",
+          "sse4_2",
+          "ssse3",
+          "stibp",
+          "syscall",
+          "tm",
+          "tm2",
+          "tpr_shadow",
+          "tsc",
+          "vme",
+          "vmx",
+          "vnmi",
+          "vpid",
+          "xtopology",
+          "xtpr"
+        ]
+      },
+      "total": 24,
+      "real": 2,
+      "cores": 12
+    },
+    "virtualization": {
+      "systems": {
+        "docker": "host",
+        "podman": "host",
+        "kvm": "host"
+      },
+      "system": "kvm",
+      "role": "host"
+    },
+    "languages": {
+      "c": {
+        "glibc": {
+          "version": "2.17",
+          "description": "ldd (GNU libc) 2.17"
+        }
+      },
+      "java": {
+        "version": "1.8.0_242",
+        "runtime": {
+          "name": "OpenJDK Runtime Environment",
+          "build": "1.8.0_242-b08"
+        },
+        "hotspot": {
+          "name": "OpenJDK 64-Bit Server VM",
+          "build": "25.242-b08, mixed mode"
+        }
+      },
+      "lua": {
+        "version": "5.1.4"
+      },
+      "perl": {
+        "version": "5.16.3",
+        "archname": "x86_64-linux-thread-multi"
+      },
+      "python": {
+        "version": "3.7.7",
+        "builddate": "May 7 2020, 21:25:33"
+      },
+      "ruby": {
+        "platform": "x86_64-linux",
+        "version": "3.0.1",
+        "release_date": "2021-04-05",
+        "target": "x86_64-pc-linux-gnu",
+        "target_cpu": "x86_64",
+        "target_vendor": "pc",
+        "target_os": "linux",
+        "host": "x86_64-pc-linux-gnu",
+        "host_cpu": "x86_64",
+        "host_os": "linux",
+        "host_vendor": "pc",
+        "bin_dir": "/opt/chef/embedded/bin",
+        "ruby_bin": "/opt/chef/embedded/bin/ruby",
+        "gem_bin": "/opt/chef/embedded/bin/gem",
+        "gems_dir": "/opt/chef/embedded/lib/ruby/gems/3.0.0"
+      }
+    },
+    "chef_packages": {
+      "chef": {
+        "version": "17.2.29",
+        "chef_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/chef-17.2.29/lib",
+        "chef_effortless": null
+      },
+      "ohai": {
+        "version": "17.1.0",
+        "ohai_root": "/opt/chef/embedded/lib/ruby/gems/3.0.0/gems/ohai-17.1.0/lib/ohai"
+      }
+    },
+    "hostname": "dl-360",
+    "machinename": "dl-360.cluster.com",
+    "fqdn": "dl-360.cluster.com",
+    "domain": "cluster.com",
+    "cloud": null,
+    "command": {
+      "ps": "ps -ef"
+    },
+    "docker": {
+      "version_string": null,
+      "runtimes": null,
+      "root_dir": null,
+      "containers": {
+        "total": null,
+        "running": null,
+        "paused": null,
+        "stopped": null
+      },
+      "plugins": null,
+      "networking": {
+        "ipv4_forwarding": null,
+        "bridge_nf_iptables": null,
+        "bridge_nf_ipv6_iptables": null
+      },
+      "swarm": null
+    },
+    "filesystem": {
+      "by_device": {
+        "devtmpfs": {
+          "kb_size": "24626976",
+          "kb_used": "0",
+          "kb_available": "24626976",
+          "percent_used": "0%",
+          "total_inodes": "6156744",
+          "inodes_used": "521",
+          "inodes_available": "6156223",
+          "inodes_percent_used": "1%",
+          "fs_type": "devtmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "seclabel",
+            "size=24626976k",
+            "nr_inodes=6156744",
+            "mode=755"
+          ],
+          "mounts": [
+            "/dev"
+          ]
+        },
+        "tmpfs": {
+          "kb_size": "4928024",
+          "kb_used": "0",
+          "kb_available": "4928024",
+          "percent_used": "0%",
+          "total_inodes": "6160027",
+          "inodes_used": "3",
+          "inodes_available": "6160024",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "relatime",
+            "seclabel",
+            "size=4928024k",
+            "mode=700"
+          ],
+          "mounts": [
+            "/dev/shm",
+            "/run",
+            "/sys/fs/cgroup",
+            "/run/user/0"
+          ]
+        },
+        "/dev/mapper/centos-root": {
+          "kb_size": "52403200",
+          "kb_used": "49733876",
+          "kb_available": "2669324",
+          "percent_used": "95%",
+          "total_inodes": "5478040",
+          "inodes_used": "139272",
+          "inodes_available": "5338768",
+          "inodes_percent_used": "3%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "b09ba28d-d357-42d6-be64-5e8844961756",
+          "mounts": [
+            "/"
+          ]
+        },
+        "/dev/loop1": {
+          "kb_size": "25344",
+          "kb_used": "25344",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "total_inodes": "509",
+          "inodes_used": "509",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs",
+          "mounts": [
+            "/var/lib/snapd/snap/snapd/6434"
+          ]
+        },
+        "/dev/loop2": {
+          "kb_size": "56064",
+          "kb_used": "56064",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "total_inodes": "10095",
+          "inodes_used": "10095",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs",
+          "mounts": [
+            "/var/lib/snapd/snap/core18/1668"
+          ]
+        },
+        "/dev/loop0": {
+          "kb_size": "56320",
+          "kb_used": "56320",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "total_inodes": "10765",
+          "inodes_used": "10765",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs",
+          "mounts": [
+            "/var/lib/snapd/snap/core18/1705"
+          ]
+        },
+        "/dev/mapper/centos-home": {
+          "kb_size": "898031184",
+          "kb_used": "497259728",
+          "kb_available": "400771456",
+          "percent_used": "56%",
+          "total_inodes": "449234944",
+          "inodes_used": "111949",
+          "inodes_available": "449122995",
+          "inodes_percent_used": "1%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "34f9239e-ce2f-4452-aeea-6d2661561583",
+          "mounts": [
+            "/home"
+          ]
+        },
+        "/dev/sda1": {
+          "kb_size": "1038336",
+          "kb_used": "207172",
+          "kb_available": "831164",
+          "percent_used": "20%",
+          "total_inodes": "524288",
+          "inodes_used": "334",
+          "inodes_available": "523954",
+          "inodes_percent_used": "1%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "6671b904-23ed-4574-ba30-0bc84efc6a83",
+          "mounts": [
+            "/boot"
+          ]
+        },
+        "sysfs": {
+          "fs_type": "sysfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel"
+          ],
+          "mounts": [
+            "/sys"
+          ]
+        },
+        "proc": {
+          "fs_type": "proc",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ],
+          "mounts": [
+            "/proc"
+          ]
+        },
+        "securityfs": {
+          "fs_type": "securityfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ],
+          "mounts": [
+            "/sys/kernel/security"
+          ]
+        },
+        "devpts": {
+          "fs_type": "devpts",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "gid=5",
+            "mode=620",
+            "ptmxmode=000"
+          ],
+          "mounts": [
+            "/dev/pts"
+          ]
+        },
+        "cgroup": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "memory"
+          ],
+          "mounts": [
+            "/sys/fs/cgroup/systemd",
+            "/sys/fs/cgroup/pids",
+            "/sys/fs/cgroup/net_cls,net_prio",
+            "/sys/fs/cgroup/hugetlb",
+            "/sys/fs/cgroup/cpu,cpuacct",
+            "/sys/fs/cgroup/perf_event",
+            "/sys/fs/cgroup/freezer",
+            "/sys/fs/cgroup/cpuset",
+            "/sys/fs/cgroup/blkio",
+            "/sys/fs/cgroup/devices",
+            "/sys/fs/cgroup/memory"
+          ]
+        },
+        "pstore": {
+          "fs_type": "pstore",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ],
+          "mounts": [
+            "/sys/fs/pstore"
+          ]
+        },
+        "configfs": {
+          "fs_type": "configfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "mounts": [
+            "/sys/kernel/config"
+          ]
+        },
+        "selinuxfs": {
+          "fs_type": "selinuxfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "mounts": [
+            "/sys/fs/selinux"
+          ]
+        },
+        "systemd-1": {
+          "fs_type": "autofs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "fd=22",
+            "pgrp=1",
+            "timeout=0",
+            "minproto=5",
+            "maxproto=5",
+            "direct",
+            "pipe_ino=10448"
+          ],
+          "mounts": [
+            "/proc/sys/fs/binfmt_misc"
+          ]
+        },
+        "debugfs": {
+          "fs_type": "debugfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "mounts": [
+            "/sys/kernel/debug"
+          ]
+        },
+        "hugetlbfs": {
+          "fs_type": "hugetlbfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel"
+          ],
+          "mounts": [
+            "/dev/hugepages"
+          ]
+        },
+        "mqueue": {
+          "fs_type": "mqueue",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel"
+          ],
+          "mounts": [
+            "/dev/mqueue"
+          ]
+        },
+        "/var/lib/snapd/snaps/snapd_6434.snap": {
+          "fs_type": "squashfs",
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ],
+          "mounts": [
+            "/var/lib/snapd/snap/snapd/6434"
+          ]
+        },
+        "/var/lib/snapd/snaps/core18_1668.snap": {
+          "fs_type": "squashfs",
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ],
+          "mounts": [
+            "/var/lib/snapd/snap/core18/1668"
+          ]
+        },
+        "/var/lib/snapd/snaps/core18_1705.snap": {
+          "fs_type": "squashfs",
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ],
+          "mounts": [
+            "/var/lib/snapd/snap/core18/1705"
+          ]
+        },
+        "sunrpc": {
+          "fs_type": "rpc_pipefs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "mounts": [
+            "/var/lib/nfs/rpc_pipefs"
+          ]
+        },
+        "/dev/sda": {
+          "mounts": [
+
+          ]
+        },
+        "/dev/sda2": {
+          "fs_type": "LVM2_member",
+          "uuid": "BFRkob-eoD8-VaGI-VFc2-fnVE-Diut-Gin4SQ",
+          "mounts": [
+
+          ]
+        },
+        "/dev/mapper/centos-swap": {
+          "fs_type": "swap",
+          "uuid": "b5bf9bd8-f784-469a-855b-5eb33d672903",
+          "mounts": [
+
+          ]
+        },
+        "rootfs": {
+          "fs_type": "rootfs",
+          "mount_options": [
+            "rw"
+          ],
+          "mounts": [
+            "/"
+          ]
+        }
+      },
+      "by_mountpoint": {
+        "/dev": {
+          "kb_size": "24626976",
+          "kb_used": "0",
+          "kb_available": "24626976",
+          "percent_used": "0%",
+          "total_inodes": "6156744",
+          "inodes_used": "521",
+          "inodes_available": "6156223",
+          "inodes_percent_used": "1%",
+          "fs_type": "devtmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "seclabel",
+            "size=24626976k",
+            "nr_inodes=6156744",
+            "mode=755"
+          ],
+          "devices": [
+            "devtmpfs"
+          ]
+        },
+        "/dev/shm": {
+          "kb_size": "24640108",
+          "kb_used": "12",
+          "kb_available": "24640096",
+          "percent_used": "1%",
+          "total_inodes": "6160027",
+          "inodes_used": "2",
+          "inodes_available": "6160025",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "seclabel"
+          ],
+          "devices": [
+            "tmpfs"
+          ]
+        },
+        "/run": {
+          "kb_size": "24640108",
+          "kb_used": "9560",
+          "kb_available": "24630548",
+          "percent_used": "1%",
+          "total_inodes": "6160027",
+          "inodes_used": "698",
+          "inodes_available": "6159329",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "seclabel",
+            "mode=755"
+          ],
+          "devices": [
+            "tmpfs"
+          ]
+        },
+        "/sys/fs/cgroup": {
+          "kb_size": "24640108",
+          "kb_used": "0",
+          "kb_available": "24640108",
+          "percent_used": "0%",
+          "total_inodes": "6160027",
+          "inodes_used": "16",
+          "inodes_available": "6160011",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "ro",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "seclabel",
+            "mode=755"
+          ],
+          "devices": [
+            "tmpfs"
+          ]
+        },
+        "/": {
+          "kb_size": "52403200",
+          "kb_used": "49733876",
+          "kb_available": "2669324",
+          "percent_used": "95%",
+          "total_inodes": "5478040",
+          "inodes_used": "139272",
+          "inodes_available": "5338768",
+          "inodes_percent_used": "3%",
+          "fs_type": "rootfs",
+          "mount_options": [
+            "rw"
+          ],
+          "uuid": "b09ba28d-d357-42d6-be64-5e8844961756",
+          "devices": [
+            "/dev/mapper/centos-root",
+            "rootfs"
+          ]
+        },
+        "/var/lib/snapd/snap/snapd/6434": {
+          "kb_size": "25344",
+          "kb_used": "25344",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "total_inodes": "509",
+          "inodes_used": "509",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs",
+          "devices": [
+            "/dev/loop1",
+            "/var/lib/snapd/snaps/snapd_6434.snap"
+          ],
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ]
+        },
+        "/var/lib/snapd/snap/core18/1668": {
+          "kb_size": "56064",
+          "kb_used": "56064",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "total_inodes": "10095",
+          "inodes_used": "10095",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs",
+          "devices": [
+            "/dev/loop2",
+            "/var/lib/snapd/snaps/core18_1668.snap"
+          ],
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ]
+        },
+        "/var/lib/snapd/snap/core18/1705": {
+          "kb_size": "56320",
+          "kb_used": "56320",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "total_inodes": "10765",
+          "inodes_used": "10765",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs",
+          "devices": [
+            "/dev/loop0",
+            "/var/lib/snapd/snaps/core18_1705.snap"
+          ],
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ]
+        },
+        "/home": {
+          "kb_size": "898031184",
+          "kb_used": "497259728",
+          "kb_available": "400771456",
+          "percent_used": "56%",
+          "total_inodes": "449234944",
+          "inodes_used": "111949",
+          "inodes_available": "449122995",
+          "inodes_percent_used": "1%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "34f9239e-ce2f-4452-aeea-6d2661561583",
+          "devices": [
+            "/dev/mapper/centos-home"
+          ]
+        },
+        "/boot": {
+          "kb_size": "1038336",
+          "kb_used": "207172",
+          "kb_available": "831164",
+          "percent_used": "20%",
+          "total_inodes": "524288",
+          "inodes_used": "334",
+          "inodes_available": "523954",
+          "inodes_percent_used": "1%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "6671b904-23ed-4574-ba30-0bc84efc6a83",
+          "devices": [
+            "/dev/sda1"
+          ]
+        },
+        "/run/user/0": {
+          "kb_size": "4928024",
+          "kb_used": "0",
+          "kb_available": "4928024",
+          "percent_used": "0%",
+          "total_inodes": "6160027",
+          "inodes_used": "3",
+          "inodes_available": "6160024",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "relatime",
+            "seclabel",
+            "size=4928024k",
+            "mode=700"
+          ],
+          "devices": [
+            "tmpfs"
+          ]
+        },
+        "/sys": {
+          "fs_type": "sysfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel"
+          ],
+          "devices": [
+            "sysfs"
+          ]
+        },
+        "/proc": {
+          "fs_type": "proc",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ],
+          "devices": [
+            "proc"
+          ]
+        },
+        "/sys/kernel/security": {
+          "fs_type": "securityfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ],
+          "devices": [
+            "securityfs"
+          ]
+        },
+        "/dev/pts": {
+          "fs_type": "devpts",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "gid=5",
+            "mode=620",
+            "ptmxmode=000"
+          ],
+          "devices": [
+            "devpts"
+          ]
+        },
+        "/sys/fs/cgroup/systemd": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "xattr",
+            "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+            "name=systemd"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/pstore": {
+          "fs_type": "pstore",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ],
+          "devices": [
+            "pstore"
+          ]
+        },
+        "/sys/fs/cgroup/pids": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "pids"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/net_cls,net_prio": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "net_prio",
+            "net_cls"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/hugetlb": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "hugetlb"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/cpu,cpuacct": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "cpuacct",
+            "cpu"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/perf_event": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "perf_event"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/freezer": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "freezer"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/cpuset": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "cpuset"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/blkio": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "blkio"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/devices": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "devices"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/fs/cgroup/memory": {
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "memory"
+          ],
+          "devices": [
+            "cgroup"
+          ]
+        },
+        "/sys/kernel/config": {
+          "fs_type": "configfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "devices": [
+            "configfs"
+          ]
+        },
+        "/sys/fs/selinux": {
+          "fs_type": "selinuxfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "devices": [
+            "selinuxfs"
+          ]
+        },
+        "/proc/sys/fs/binfmt_misc": {
+          "fs_type": "autofs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "fd=22",
+            "pgrp=1",
+            "timeout=0",
+            "minproto=5",
+            "maxproto=5",
+            "direct",
+            "pipe_ino=10448"
+          ],
+          "devices": [
+            "systemd-1"
+          ]
+        },
+        "/sys/kernel/debug": {
+          "fs_type": "debugfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "devices": [
+            "debugfs"
+          ]
+        },
+        "/dev/hugepages": {
+          "fs_type": "hugetlbfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel"
+          ],
+          "devices": [
+            "hugetlbfs"
+          ]
+        },
+        "/dev/mqueue": {
+          "fs_type": "mqueue",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel"
+          ],
+          "devices": [
+            "mqueue"
+          ]
+        },
+        "/var/lib/nfs/rpc_pipefs": {
+          "fs_type": "rpc_pipefs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ],
+          "devices": [
+            "sunrpc"
+          ]
+        }
+      },
+      "by_pair": {
+        "devtmpfs,/dev": {
+          "device": "devtmpfs",
+          "kb_size": "24626976",
+          "kb_used": "0",
+          "kb_available": "24626976",
+          "percent_used": "0%",
+          "mount": "/dev",
+          "total_inodes": "6156744",
+          "inodes_used": "521",
+          "inodes_available": "6156223",
+          "inodes_percent_used": "1%",
+          "fs_type": "devtmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "seclabel",
+            "size=24626976k",
+            "nr_inodes=6156744",
+            "mode=755"
+          ]
+        },
+        "tmpfs,/dev/shm": {
+          "device": "tmpfs",
+          "kb_size": "24640108",
+          "kb_used": "12",
+          "kb_available": "24640096",
+          "percent_used": "1%",
+          "mount": "/dev/shm",
+          "total_inodes": "6160027",
+          "inodes_used": "2",
+          "inodes_available": "6160025",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "seclabel"
+          ]
+        },
+        "tmpfs,/run": {
+          "device": "tmpfs",
+          "kb_size": "24640108",
+          "kb_used": "9560",
+          "kb_available": "24630548",
+          "percent_used": "1%",
+          "mount": "/run",
+          "total_inodes": "6160027",
+          "inodes_used": "698",
+          "inodes_available": "6159329",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "seclabel",
+            "mode=755"
+          ]
+        },
+        "tmpfs,/sys/fs/cgroup": {
+          "device": "tmpfs",
+          "kb_size": "24640108",
+          "kb_used": "0",
+          "kb_available": "24640108",
+          "percent_used": "0%",
+          "mount": "/sys/fs/cgroup",
+          "total_inodes": "6160027",
+          "inodes_used": "16",
+          "inodes_available": "6160011",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "ro",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "seclabel",
+            "mode=755"
+          ]
+        },
+        "/dev/mapper/centos-root,/": {
+          "device": "/dev/mapper/centos-root",
+          "kb_size": "52403200",
+          "kb_used": "49733876",
+          "kb_available": "2669324",
+          "percent_used": "95%",
+          "mount": "/",
+          "total_inodes": "5478040",
+          "inodes_used": "139272",
+          "inodes_available": "5338768",
+          "inodes_percent_used": "3%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "b09ba28d-d357-42d6-be64-5e8844961756"
+        },
+        "/dev/loop1,/var/lib/snapd/snap/snapd/6434": {
+          "device": "/dev/loop1",
+          "kb_size": "25344",
+          "kb_used": "25344",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "mount": "/var/lib/snapd/snap/snapd/6434",
+          "total_inodes": "509",
+          "inodes_used": "509",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs"
+        },
+        "/dev/loop2,/var/lib/snapd/snap/core18/1668": {
+          "device": "/dev/loop2",
+          "kb_size": "56064",
+          "kb_used": "56064",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "mount": "/var/lib/snapd/snap/core18/1668",
+          "total_inodes": "10095",
+          "inodes_used": "10095",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs"
+        },
+        "/dev/loop0,/var/lib/snapd/snap/core18/1705": {
+          "device": "/dev/loop0",
+          "kb_size": "56320",
+          "kb_used": "56320",
+          "kb_available": "0",
+          "percent_used": "100%",
+          "mount": "/var/lib/snapd/snap/core18/1705",
+          "total_inodes": "10765",
+          "inodes_used": "10765",
+          "inodes_available": "0",
+          "inodes_percent_used": "100%",
+          "fs_type": "squashfs"
+        },
+        "/dev/mapper/centos-home,/home": {
+          "device": "/dev/mapper/centos-home",
+          "kb_size": "898031184",
+          "kb_used": "497259728",
+          "kb_available": "400771456",
+          "percent_used": "56%",
+          "mount": "/home",
+          "total_inodes": "449234944",
+          "inodes_used": "111949",
+          "inodes_available": "449122995",
+          "inodes_percent_used": "1%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "34f9239e-ce2f-4452-aeea-6d2661561583"
+        },
+        "/dev/sda1,/boot": {
+          "device": "/dev/sda1",
+          "kb_size": "1038336",
+          "kb_used": "207172",
+          "kb_available": "831164",
+          "percent_used": "20%",
+          "mount": "/boot",
+          "total_inodes": "524288",
+          "inodes_used": "334",
+          "inodes_available": "523954",
+          "inodes_percent_used": "1%",
+          "fs_type": "xfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel",
+            "attr2",
+            "inode64",
+            "noquota"
+          ],
+          "uuid": "6671b904-23ed-4574-ba30-0bc84efc6a83"
+        },
+        "tmpfs,/run/user/0": {
+          "device": "tmpfs",
+          "kb_size": "4928024",
+          "kb_used": "0",
+          "kb_available": "4928024",
+          "percent_used": "0%",
+          "mount": "/run/user/0",
+          "total_inodes": "6160027",
+          "inodes_used": "3",
+          "inodes_available": "6160024",
+          "inodes_percent_used": "1%",
+          "fs_type": "tmpfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "relatime",
+            "seclabel",
+            "size=4928024k",
+            "mode=700"
+          ]
+        },
+        "sysfs,/sys": {
+          "device": "sysfs",
+          "mount": "/sys",
+          "fs_type": "sysfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel"
+          ]
+        },
+        "proc,/proc": {
+          "device": "proc",
+          "mount": "/proc",
+          "fs_type": "proc",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "securityfs,/sys/kernel/security": {
+          "device": "securityfs",
+          "mount": "/sys/kernel/security",
+          "fs_type": "securityfs",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "devpts,/dev/pts": {
+          "device": "devpts",
+          "mount": "/dev/pts",
+          "fs_type": "devpts",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "gid=5",
+            "mode=620",
+            "ptmxmode=000"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/systemd": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/systemd",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "xattr",
+            "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+            "name=systemd"
+          ]
+        },
+        "pstore,/sys/fs/pstore": {
+          "device": "pstore",
+          "mount": "/sys/fs/pstore",
+          "fs_type": "pstore",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/pids": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/pids",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "pids"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/net_cls,net_prio",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "net_prio",
+            "net_cls"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/hugetlb": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/hugetlb",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "hugetlb"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/cpu,cpuacct",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "cpuacct",
+            "cpu"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/perf_event": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/perf_event",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "perf_event"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/freezer": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/freezer",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "freezer"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/cpuset": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/cpuset",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "cpuset"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/blkio": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/blkio",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "blkio"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/devices": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/devices",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "devices"
+          ]
+        },
+        "cgroup,/sys/fs/cgroup/memory": {
+          "device": "cgroup",
+          "mount": "/sys/fs/cgroup/memory",
+          "fs_type": "cgroup",
+          "mount_options": [
+            "rw",
+            "nosuid",
+            "nodev",
+            "noexec",
+            "relatime",
+            "seclabel",
+            "memory"
+          ]
+        },
+        "configfs,/sys/kernel/config": {
+          "device": "configfs",
+          "mount": "/sys/kernel/config",
+          "fs_type": "configfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "selinuxfs,/sys/fs/selinux": {
+          "device": "selinuxfs",
+          "mount": "/sys/fs/selinux",
+          "fs_type": "selinuxfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "systemd-1,/proc/sys/fs/binfmt_misc": {
+          "device": "systemd-1",
+          "mount": "/proc/sys/fs/binfmt_misc",
+          "fs_type": "autofs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "fd=22",
+            "pgrp=1",
+            "timeout=0",
+            "minproto=5",
+            "maxproto=5",
+            "direct",
+            "pipe_ino=10448"
+          ]
+        },
+        "debugfs,/sys/kernel/debug": {
+          "device": "debugfs",
+          "mount": "/sys/kernel/debug",
+          "fs_type": "debugfs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "hugetlbfs,/dev/hugepages": {
+          "device": "hugetlbfs",
+          "mount": "/dev/hugepages",
+          "fs_type": "hugetlbfs",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel"
+          ]
+        },
+        "mqueue,/dev/mqueue": {
+          "device": "mqueue",
+          "mount": "/dev/mqueue",
+          "fs_type": "mqueue",
+          "mount_options": [
+            "rw",
+            "relatime",
+            "seclabel"
+          ]
+        },
+        "/var/lib/snapd/snaps/snapd_6434.snap,/var/lib/snapd/snap/snapd/6434": {
+          "device": "/var/lib/snapd/snaps/snapd_6434.snap",
+          "mount": "/var/lib/snapd/snap/snapd/6434",
+          "fs_type": "squashfs",
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ]
+        },
+        "/var/lib/snapd/snaps/core18_1668.snap,/var/lib/snapd/snap/core18/1668": {
+          "device": "/var/lib/snapd/snaps/core18_1668.snap",
+          "mount": "/var/lib/snapd/snap/core18/1668",
+          "fs_type": "squashfs",
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ]
+        },
+        "/var/lib/snapd/snaps/core18_1705.snap,/var/lib/snapd/snap/core18/1705": {
+          "device": "/var/lib/snapd/snaps/core18_1705.snap",
+          "mount": "/var/lib/snapd/snap/core18/1705",
+          "fs_type": "squashfs",
+          "mount_options": [
+            "ro",
+            "nodev",
+            "relatime",
+            "context=system_u:object_r:snappy_snap_t:s0"
+          ]
+        },
+        "sunrpc,/var/lib/nfs/rpc_pipefs": {
+          "device": "sunrpc",
+          "mount": "/var/lib/nfs/rpc_pipefs",
+          "fs_type": "rpc_pipefs",
+          "mount_options": [
+            "rw",
+            "relatime"
+          ]
+        },
+        "/dev/sda,": {
+          "device": "/dev/sda"
+        },
+        "/dev/sda2,": {
+          "device": "/dev/sda2",
+          "fs_type": "LVM2_member",
+          "uuid": "BFRkob-eoD8-VaGI-VFc2-fnVE-Diut-Gin4SQ"
+        },
+        "/dev/mapper/centos-swap,": {
+          "device": "/dev/mapper/centos-swap",
+          "fs_type": "swap",
+          "uuid": "b5bf9bd8-f784-469a-855b-5eb33d672903"
+        },
+        "rootfs,/": {
+          "device": "rootfs",
+          "mount": "/",
+          "fs_type": "rootfs",
+          "mount_options": [
+            "rw"
+          ]
+        }
+      }
+    },
+    "fips": {
+      "kernel": {
+        "enabled": true
+      }
+    },
+    "init_package": "systemd",
+    "keys": {
+      "ssh": {
+        "host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABAQC16jY4eJB2lpT4YMGBtObqYks68KPw51jRUSTflxvdHV8Ta3co3XhTtow8p/8zwlCza+e40bpNsEAkXD697jHE0k+kD6CTfZSEQsxRkk/vj+AAMbM4Yj+NQwUIMC1PmNTGW8ELRMmnNrtaAqOYq4P7gggmE2AfuZjq5TWwl4Y19YOBEr0rm7K3o7LCHu+abmUFofKrm8Xq2W+Ks5q3O4zUd3SbAoaxzZ6fO385wmusae6sfOAZ0wce83WOQ1Bn6+VGK1JiqI2SOfml93MM9aic37H4LuQxYY9Y53pNcIDz+4hDtHlQ2IikcnfsCTQYSMeIlDsnohHuJF4CqgAuvnsn",
+        "host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBJV9afQxJeuNb+o12dZ5pVtgGWUukGBYFKSFpV+sakM0wX/ku2X8Wpw5SiJQc9SxgC86zHxfKktoVNSFaORT1cI=",
+        "host_ecdsa_type": "ecdsa-sha2-nistp256",
+        "host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIKrInpXRwf05O+UbA9shX+0iLqvN/rGu2rfPGqBRPtwJ"
+      }
+    },
+    "block_device": {
+      "dm-0": {
+        "size": "104857600",
+        "removable": "0",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      },
+      "dm-1": {
+        "size": "49545216",
+        "removable": "0",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      },
+      "dm-2": {
+        "size": "1796939776",
+        "removable": "0",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      },
+      "loop0": {
+        "size": "112528",
+        "removable": "0",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      },
+      "loop1": {
+        "size": "50616",
+        "removable": "0",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      },
+      "loop2": {
+        "size": "111904",
+        "removable": "0",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      },
+      "sda": {
+        "size": "1953459632",
+        "removable": "0",
+        "model": "LOGICAL VOLUME",
+        "rev": "6.64",
+        "state": "running",
+        "timeout": "30",
+        "vendor": "HP",
+        "queue_depth": "1013",
+        "rotational": "1",
+        "physical_block_size": "512",
+        "logical_block_size": "512"
+      }
+    },
+    "hostnamectl": {
+      "static_hostname": "dl-360.cluster.com",
+      "pretty_hostname": "DL 360",
+      "icon_name": "computer",
+      "machine_id": "ea42471ed4794b3bb31624268587d481",
+      "boot_id": "df510ab39e3b4d0eba7b6a9edc83a0fa",
+      "operating_system": "CentOS Linux 7 (Core)",
+      "cpe_os_name": "cpe:/o:centos:centos:7",
+      "kernel": "Linux 3.10.0-1062.18.1.el7.x86_64",
+      "architecture": "x86-64"
+    },
+    "machine_id": "ea42471ed4794b3bb31624268587d481",
+    "os_release": {
+      "name": "CentOS Linux",
+      "version": "7 (Core)",
+      "id": "centos",
+      "id_like": [
+        "rhel",
+        "fedora"
+      ],
+      "version_id": "7",
+      "pretty_name": "CentOS Linux 7 (Core)",
+      "ansi_color": "0;31",
+      "cpe_name": "cpe:/o:centos:centos:7",
+      "home_url": "https://www.centos.org/",
+      "bug_report_url": "https://bugs.centos.org/",
+      "centos_mantisbt_project": "CentOS-7",
+      "centos_mantisbt_project_version": "7",
+      "redhat_support_product": "centos",
+      "redhat_support_product_version": "7"
+    },
+    "systemd_paths": {
+      "temporary": "/tmp",
+      "temporary-large": "/var/tmp",
+      "system-binaries": "/usr/bin",
+      "system-include": "/usr/include",
+      "system-library-private": "/usr/lib",
+      "system-library-arch": "/usr/lib64",
+      "system-shared": "/usr/share",
+      "system-configuration-factory": "/usr/share/factory/etc",
+      "system-state-factory": "/usr/share/factory/var",
+      "system-configuration": "/etc",
+      "system-runtime": "/run",
+      "system-runtime-logs": "/run/log",
+      "system-state-private": "/var/lib",
+      "system-state-logs": "/var/log",
+      "system-state-cache": "/var/cache",
+      "system-state-spool": "/var/spool",
+      "user-binaries": "/root/.local/bin",
+      "user-library-private": "/root/.local/lib",
+      "user-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+      "user-shared": "/root/.local/share",
+      "user-configuration": "/root/.config",
+      "user-runtime": "/run/user/0",
+      "user-state-cache": "/root/.cache",
+      "user": "/root",
+      "user-documents": "/root",
+      "user-music": "/root",
+      "user-pictures": "/root",
+      "user-videos": "/root",
+      "user-download": "/root",
+      "user-public": "/root",
+      "user-templates": "/root",
+      "user-desktop": "/root/Desktop",
+      "search-binaries": "/opt/chef/embedded/bin",
+      "search-library-private": "/root/.local/lib",
+      "search-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+      "search-shared": "/root/.local/share",
+      "search-configuration-factory": "/usr/local/share/factory/etc",
+      "search-state-factory": "/usr/local/share/factory/var",
+      "search-configuration": "/root/.config"
+    },
+    "ohai_time": 1625212876.6805751,
+    "packages": {
+      "python-dmidecode": {
+        "epoch": "0",
+        "version": "3.12.2",
+        "release": "4.el7",
+        "installdate": "1588520992",
+        "arch": "x86_64"
+      },
+      "hicolor-icon-theme": {
+        "epoch": "0",
+        "version": "0.12",
+        "release": "7.el7",
+        "installdate": "1584625485",
+        "arch": "noarch"
+      },
+      "openssh-clients": {
+        "epoch": "0",
+        "version": "7.4p1",
+        "release": "21.el7",
+        "installdate": "1584455092",
+        "arch": "x86_64"
+      },
+      "setup": {
+        "epoch": "0",
+        "version": "2.8.71",
+        "release": "10.el7",
+        "installdate": "1584454882",
+        "arch": "noarch"
+      },
+      "nftables": {
+        "epoch": "1",
+        "version": "0.8",
+        "release": "14.el7",
+        "installdate": "1588520996",
+        "arch": "x86_64"
+      },
+      "python-pycparser": {
+        "epoch": "0",
+        "version": "2.14",
+        "release": "1.el7",
+        "installdate": "1584625486",
+        "arch": "noarch"
+      },
+      "postfix": {
+        "epoch": "2",
+        "version": "2.10.1",
+        "release": "7.el7",
+        "installdate": "1584455099",
+        "arch": "x86_64"
+      },
+      "kbd-misc": {
+        "epoch": "0",
+        "version": "1.15.5",
+        "release": "15.el7",
+        "installdate": "1584454885",
+        "arch": "noarch"
+      },
+      "libnl": {
+        "epoch": "0",
+        "version": "1.1.4",
+        "release": "3.el7",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "geoipupdate": {
+        "epoch": "0",
+        "version": "2.5.0",
+        "release": "1.el7",
+        "installdate": "1584625486",
+        "arch": "x86_64"
+      },
+      "aic94xx-firmware": {
+        "epoch": "0",
+        "version": "30",
+        "release": "6.el7",
+        "installdate": "1584455141",
+        "arch": "noarch"
+      },
+      "subscription-manager-rhsm-certificates": {
+        "epoch": "0",
+        "version": "1.24.26",
+        "release": "1.el7.centos",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "bind-utils": {
+        "epoch": "32",
+        "version": "9.11.4",
+        "release": "9.P2.el7",
+        "installdate": "1584625487",
+        "arch": "x86_64"
+      },
+      "irqbalance": {
+        "epoch": "3",
+        "version": "1.0.7",
+        "release": "12.el7",
+        "installdate": "1584455147",
+        "arch": "x86_64"
+      },
+      "podman": {
+        "epoch": "0",
+        "version": "1.6.4",
+        "release": "16.el7_8",
+        "installdate": "1588521005",
+        "arch": "x86_64"
+      },
+      "python2-asn1crypto": {
+        "epoch": "0",
+        "version": "0.24.0",
+        "release": "7.el7",
+        "installdate": "1584625487",
+        "arch": "noarch"
+      },
+      "libsepol": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "10.el7",
+        "installdate": "1584454910",
+        "arch": "x86_64"
+      },
+      "gd": {
+        "epoch": "0",
+        "version": "2.0.35",
+        "release": "26.el7",
+        "installdate": "1594661051",
+        "arch": "x86_64"
+      },
+      "cockpit-dashboard": {
+        "epoch": "0",
+        "version": "195.1",
+        "release": "1.el7.centos.0.1",
+        "installdate": "1584625488",
+        "arch": "x86_64"
+      },
+      "e2fsprogs": {
+        "epoch": "0",
+        "version": "1.42.9",
+        "release": "16.el7",
+        "installdate": "1584455151",
+        "arch": "x86_64"
+      },
+      "info": {
+        "epoch": "0",
+        "version": "5.1",
+        "release": "5.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "chef": {
+        "epoch": "0",
+        "version": "17.2.29",
+        "release": "1.el7",
+        "installdate": "1625212845",
+        "arch": "x86_64"
+      },
+      "ovirt-host-deploy-common": {
+        "epoch": "0",
+        "version": "1.8.5",
+        "release": "1.el7",
+        "installdate": "1584625490",
+        "arch": "noarch"
+      },
+      "iwl100-firmware": {
+        "epoch": "0",
+        "version": "39.31.5.1",
+        "release": "72.el7",
+        "installdate": "1584455152",
+        "arch": "noarch"
+      },
+      "sed": {
+        "epoch": "0",
+        "version": "4.2.2",
+        "release": "5.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "ovirt-web-ui": {
+        "epoch": "0",
+        "version": "1.6.0",
+        "release": "1.el7",
+        "installdate": "1584625492",
+        "arch": "noarch"
+      },
+      "iwl5150-firmware": {
+        "epoch": "0",
+        "version": "8.24.2.2",
+        "release": "72.el7",
+        "installdate": "1584455163",
+        "arch": "noarch"
+      },
+      "libdb": {
+        "epoch": "0",
+        "version": "5.3.21",
+        "release": "25.el7",
+        "installdate": "1584454912",
+        "arch": "x86_64"
+      },
+      "cups-libs": {
+        "epoch": "1",
+        "version": "1.6.3",
+        "release": "40.el7",
+        "installdate": "1584625493",
+        "arch": "x86_64"
+      },
+      "iwl6000g2b-firmware": {
+        "epoch": "0",
+        "version": "17.168.5.2",
+        "release": "72.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "elfutils-libelf": {
+        "epoch": "0",
+        "version": "0.176",
+        "release": "2.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "python-daemon": {
+        "epoch": "0",
+        "version": "1.6",
+        "release": "4.el7",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "iwl5000-firmware": {
+        "epoch": "0",
+        "version": "8.83.5.1_1",
+        "release": "72.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "libattr": {
+        "epoch": "0",
+        "version": "2.4.46",
+        "release": "13.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "python-backports-ssl_match_hostname": {
+        "epoch": "0",
+        "version": "3.5.0.1",
+        "release": "1.el7",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "iwl1000-firmware": {
+        "epoch": "1",
+        "version": "39.31.5.1",
+        "release": "72.el7",
+        "installdate": "1584455165",
+        "arch": "noarch"
+      },
+      "libgcrypt": {
+        "epoch": "0",
+        "version": "1.5.3",
+        "release": "14.el7",
+        "installdate": "1584454914",
+        "arch": "x86_64"
+      },
+      "novnc": {
+        "epoch": "0",
+        "version": "0.5.1",
+        "release": "2.el7",
+        "installdate": "1584625494",
+        "arch": "noarch"
+      },
+      "json-glib": {
+        "epoch": "0",
+        "version": "1.4.2",
+        "release": "2.el7",
+        "installdate": "1584455916",
+        "arch": "x86_64"
+      },
+      "lua": {
+        "epoch": "0",
+        "version": "5.1.4",
+        "release": "15.el7",
+        "installdate": "1584454915",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-wildfly-overlay": {
+        "epoch": "0",
+        "version": "17.0.1",
+        "release": "1.el7",
+        "installdate": "1584625518",
+        "arch": "noarch"
+      },
+      "gsettings-desktop-schemas": {
+        "epoch": "0",
+        "version": "3.28.0",
+        "release": "2.el7",
+        "installdate": "1584455917",
+        "arch": "x86_64"
+      },
+      "libnl3": {
+        "epoch": "0",
+        "version": "3.2.28",
+        "release": "4.el7",
+        "installdate": "1584454916",
+        "arch": "x86_64"
+      },
+      "libxml2-python": {
+        "epoch": "0",
+        "version": "2.9.1",
+        "release": "6.el7_2.3",
+        "installdate": "1584625518",
+        "arch": "x86_64"
+      },
+      "cockpit-bridge": {
+        "epoch": "0",
+        "version": "195.1",
+        "release": "1.el7.centos.0.1",
+        "installdate": "1584455918",
+        "arch": "x86_64"
+      },
+      "libmnl": {
+        "epoch": "0",
+        "version": "1.0.3",
+        "release": "7.el7",
+        "installdate": "1584454917",
+        "arch": "x86_64"
+      },
+      "postgresql-jdbc": {
+        "epoch": "0",
+        "version": "9.2.1002",
+        "release": "6.el7_5",
+        "installdate": "1584625525",
+        "arch": "noarch"
+      },
+      "libassuan": {
+        "epoch": "0",
+        "version": "2.1.0",
+        "release": "3.el7",
+        "installdate": "1584454917",
+        "arch": "x86_64"
+      },
+      "pytz": {
+        "epoch": "0",
+        "version": "2016.10",
+        "release": "2.el7",
+        "installdate": "1584625525",
+        "arch": "noarch"
+      },
+      "libcgroup": {
+        "epoch": "0",
+        "version": "0.41",
+        "release": "21.el7",
+        "installdate": "1584610681",
+        "arch": "x86_64"
+      },
+      "xz": {
+        "epoch": "0",
+        "version": "5.2.2",
+        "release": "1.el7",
+        "installdate": "1584454918",
+        "arch": "x86_64"
+      },
+      "python2-traceback2": {
+        "epoch": "0",
+        "version": "1.4.0",
+        "release": "14.el7",
+        "installdate": "1584625527",
+        "arch": "noarch"
+      },
+      "snap-confine": {
+        "epoch": "0",
+        "version": "2.43.3",
+        "release": "1.el7",
+        "installdate": "1584610682",
+        "arch": "x86_64"
+      },
+      "libedit": {
+        "epoch": "0",
+        "version": "3.0",
+        "release": "12.20121213cvs.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "libibverbs": {
+        "epoch": "0",
+        "version": "22.1",
+        "release": "3.el7",
+        "installdate": "1584625527",
+        "arch": "x86_64"
+      },
+      "selinux-policy": {
+        "epoch": "0",
+        "version": "3.13.1",
+        "release": "252.el7_7.6",
+        "installdate": "1584610682",
+        "arch": "noarch"
+      },
+      "tcp_wrappers-libs": {
+        "epoch": "0",
+        "version": "7.6",
+        "release": "77.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "libX11": {
+        "epoch": "0",
+        "version": "1.6.7",
+        "release": "2.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "fuse": {
+        "epoch": "0",
+        "version": "2.9.2",
+        "release": "11.el7",
+        "installdate": "1584610726",
+        "arch": "x86_64"
+      },
+      "jansson": {
+        "epoch": "0",
+        "version": "2.10",
+        "release": "1.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "libXi": {
+        "epoch": "0",
+        "version": "1.7.9",
+        "release": "1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "snapd": {
+        "epoch": "0",
+        "version": "2.43.3",
+        "release": "1.el7",
+        "installdate": "1584610729",
+        "arch": "x86_64"
+      },
+      "keyutils-libs": {
+        "epoch": "0",
+        "version": "1.5.8",
+        "release": "3.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "gtk-update-icon-cache": {
+        "epoch": "0",
+        "version": "3.22.30",
+        "release": "3.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libuuid": {
+        "epoch": "0",
+        "version": "2.23.2",
+        "release": "61.el7_7.1",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "libXft": {
+        "epoch": "0",
+        "version": "2.3.2",
+        "release": "2.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libsmartcols": {
+        "epoch": "0",
+        "version": "2.23.2",
+        "release": "61.el7_7.1",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "ipset-libs": {
+        "epoch": "0",
+        "version": "7.1",
+        "release": "1.el7",
+        "installdate": "1584454921",
+        "arch": "x86_64"
+      },
+      "libglvnd-glx": {
+        "epoch": "1",
+        "version": "1.0.1",
+        "release": "0.8.git5baa1e5.el7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "python-firewall": {
+        "epoch": "0",
+        "version": "0.6.3",
+        "release": "2.el7_7.4",
+        "installdate": "1584624361",
+        "arch": "noarch"
+      },
+      "tar": {
+        "epoch": "2",
+        "version": "1.26",
+        "release": "35.el7",
+        "installdate": "1584454922",
+        "arch": "x86_64"
+      },
+      "quota-nls": {
+        "epoch": "1",
+        "version": "4.01",
+        "release": "19.el7",
+        "installdate": "1584625529",
+        "arch": "noarch"
+      },
+      "krb5-libs": {
+        "epoch": "0",
+        "version": "1.15.1",
+        "release": "37.el7_7.2",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "ovn": {
+        "epoch": "0",
+        "version": "2.11.1",
+        "release": "5.el7",
+        "installdate": "1584625531",
+        "arch": "x86_64"
+      },
+      "nss-sysinit": {
+        "epoch": "0",
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "libselinux-utils": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "14.1.el7",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "git": {
+        "epoch": "0",
+        "version": "1.8.3.1",
+        "release": "21.el7_7",
+        "installdate": "1584625533",
+        "arch": "x86_64"
+      },
+      "device-mapper-libs": {
+        "epoch": "7",
+        "version": "1.02.158",
+        "release": "2.el7_7.2",
+        "installdate": "1584624366",
+        "arch": "x86_64"
+      },
+      "snappy": {
+        "epoch": "0",
+        "version": "1.1.0",
+        "release": "3.el7",
+        "installdate": "1584454995",
+        "arch": "x86_64"
+      },
+      "python2-ovsdbapp": {
+        "epoch": "0",
+        "version": "0.12.2",
+        "release": "1.el7",
+        "installdate": "1584625534",
+        "arch": "noarch"
+      },
+      "NetworkManager-libnm": {
+        "epoch": "1",
+        "version": "1.18.0",
+        "release": "5.el7_7.2",
+        "installdate": "1584624367",
+        "arch": "x86_64"
+      },
+      "quota": {
+        "epoch": "1",
+        "version": "4.01",
+        "release": "19.el7",
+        "installdate": "1584625534",
+        "arch": "x86_64"
+      },
+      "lvm2": {
+        "epoch": "7",
+        "version": "2.02.185",
+        "release": "2.el7_7.2",
+        "installdate": "1584624368",
+        "arch": "x86_64"
+      },
+      "p11-kit-trust": {
+        "epoch": "0",
+        "version": "0.23.5",
+        "release": "3.el7",
+        "installdate": "1584454996",
+        "arch": "x86_64"
+      },
+      "libiscsi": {
+        "epoch": "0",
+        "version": "1.9.0",
+        "release": "7.el7",
+        "installdate": "1584625535",
+        "arch": "x86_64"
+      },
+      "tuned": {
+        "epoch": "0",
+        "version": "2.11.0",
+        "release": "5.el7_7.1",
+        "installdate": "1584624369",
+        "arch": "noarch"
+      },
+      "openssl-libs": {
+        "epoch": "1",
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "installdate": "1584455002",
+        "arch": "x86_64"
+      },
+      "libnfsidmap": {
+        "epoch": "0",
+        "version": "0.25",
+        "release": "19.el7",
+        "installdate": "1584625535",
+        "arch": "x86_64"
+      },
+      "firewalld": {
+        "epoch": "0",
+        "version": "0.6.3",
+        "release": "2.el7_7.4",
+        "installdate": "1584624374",
+        "arch": "noarch"
+      },
+      "shadow-utils": {
+        "epoch": "2",
+        "version": "4.6",
+        "release": "5.el7",
+        "installdate": "1584455011",
+        "arch": "x86_64"
+      },
+      "gtk2": {
+        "epoch": "0",
+        "version": "2.24.31",
+        "release": "1.el7",
+        "installdate": "1584625537",
+        "arch": "x86_64"
+      },
+      "kernel-tools": {
+        "epoch": "0",
+        "version": "3.10.0",
+        "release": "1062.18.1.el7",
+        "installdate": "1584624385",
+        "arch": "x86_64"
+      },
+      "xalan-j2": {
+        "epoch": "0",
+        "version": "2.7.1",
+        "release": "23.el7",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "iprutils": {
+        "epoch": "0",
+        "version": "2.4.17.1",
+        "release": "3.el7_7",
+        "installdate": "1584624386",
+        "arch": "x86_64"
+      },
+      "cracklib-dicts": {
+        "epoch": "0",
+        "version": "2.9.0",
+        "release": "11.el7",
+        "installdate": "1584455017",
+        "arch": "x86_64"
+      },
+      "isorelax": {
+        "epoch": "1",
+        "version": "0",
+        "release": "0.15.release20050331.el7",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "ca-certificates": {
+        "epoch": "0",
+        "version": "2019.2.32",
+        "release": "76.el7_7",
+        "installdate": "1584624386",
+        "arch": "noarch"
+      },
+      "gettext-libs": {
+        "epoch": "0",
+        "version": "0.19.8.1",
+        "release": "2.el7",
+        "installdate": "1584455018",
+        "arch": "x86_64"
+      },
+      "javassist": {
+        "epoch": "0",
+        "version": "3.16.1",
+        "release": "10.el7",
+        "installdate": "1584625538",
+        "arch": "noarch"
+      },
+      "gpg-pubkey": {
+        "epoch": "0",
+        "version": "ba07f4fb",
+        "release": "5ac168db",
+        "installdate": "1588520701",
+        "arch": "(none)",
+        "versions": [
+          {
+            "epoch": "0",
+            "version": "e451e5b5",
+            "release": "54c22d60",
+            "installdate": "1584624802",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "621e9f35",
+            "release": "58adea78",
+            "installdate": "1588520453",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "f4a80eb5",
+            "release": "53a7ff4b",
+            "installdate": "1584455908",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "352c64e5",
+            "release": "52ae6884",
+            "installdate": "1584610629",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "61e8806c",
+            "release": "5581df56",
+            "installdate": "1584624802",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "51bc2a13",
+            "release": "58ab4a7a",
+            "installdate": "1584624802",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "3e1ba8d5",
+            "release": "558ab6a8",
+            "installdate": "1588520701",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "fe590cb7",
+            "release": "5337fb76",
+            "installdate": "1584624802",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "f2ee9d55",
+            "release": "560cfc0a",
+            "installdate": "1584624802",
+            "arch": "(none)"
+          },
+          {
+            "epoch": "0",
+            "version": "ba07f4fb",
+            "release": "5ac168db",
+            "installdate": "1588520701",
+            "arch": "(none)"
+          }
+        ]
+      },
+      "gobject-introspection": {
+        "epoch": "0",
+        "version": "1.56.1",
+        "release": "1.el7",
+        "installdate": "1584455019",
+        "arch": "x86_64"
+      },
+      "javamail": {
+        "epoch": "0",
+        "version": "1.4.6",
+        "release": "8.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "libjpeg-turbo": {
+        "epoch": "0",
+        "version": "1.2.90",
+        "release": "8.el7",
+        "installdate": "1584625425",
+        "arch": "x86_64"
+      },
+      "libselinux-python": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "14.1.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "avalon-framework": {
+        "epoch": "0",
+        "version": "4.3",
+        "release": "10.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "m2crypto": {
+        "epoch": "0",
+        "version": "0.21.1",
+        "release": "17.el7",
+        "installdate": "1584625427",
+        "arch": "x86_64"
+      },
+      "pyxattr": {
+        "epoch": "0",
+        "version": "0.5.1",
+        "release": "5.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "otopi-java": {
+        "epoch": "0",
+        "version": "1.8.4",
+        "release": "1.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "libxslt": {
+        "epoch": "0",
+        "version": "1.1.28",
+        "release": "5.el7",
+        "installdate": "1584625427",
+        "arch": "x86_64"
+      },
+      "python-linux-procfs": {
+        "epoch": "0",
+        "version": "0.4.11",
+        "release": "4.el7",
+        "installdate": "1584455020",
+        "arch": "noarch"
+      },
+      "joda-time": {
+        "epoch": "0",
+        "version": "2.2",
+        "release": "3.tzdata2013c.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "unbound-libs": {
+        "epoch": "0",
+        "version": "1.6.6",
+        "release": "1.el7",
+        "installdate": "1584625427",
+        "arch": "x86_64"
+      },
+      "fipscheck-lib": {
+        "epoch": "0",
+        "version": "1.4.1",
+        "release": "6.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "httpcomponents-client": {
+        "epoch": "0",
+        "version": "4.2.5",
+        "release": "5.el7_0",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "python-enum34": {
+        "epoch": "0",
+        "version": "1.0.4",
+        "release": "1.el7",
+        "installdate": "1584625428",
+        "arch": "noarch"
+      },
+      "logrotate": {
+        "epoch": "0",
+        "version": "3.8.6",
+        "release": "17.el7",
+        "installdate": "1584455022",
+        "arch": "x86_64"
+      },
+      "qdox": {
+        "epoch": "0",
+        "version": "1.12.1",
+        "release": "10.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "rpcbind": {
+        "epoch": "0",
+        "version": "0.2.0",
+        "release": "48.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "xmlrpc-common": {
+        "epoch": "1",
+        "version": "3.1.3",
+        "release": "9.el7_5",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "yajl": {
+        "epoch": "0",
+        "version": "2.0.4",
+        "release": "4.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "rpm": {
+        "epoch": "0",
+        "version": "4.11.3",
+        "release": "40.el7",
+        "installdate": "1584455024",
+        "arch": "x86_64"
+      },
+      "rxjava": {
+        "epoch": "0",
+        "version": "1.0.13",
+        "release": "2.el7",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "libcollection": {
+        "epoch": "0",
+        "version": "0.7.0",
+        "release": "32.el7",
+        "installdate": "1584625429",
+        "arch": "x86_64"
+      },
+      "python-urlgrabber": {
+        "epoch": "0",
+        "version": "3.10",
+        "release": "9.el7",
+        "installdate": "1584455025",
+        "arch": "noarch"
+      },
+      "jaxen": {
+        "epoch": "0",
+        "version": "1.1.3",
+        "release": "11.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "scl-utils": {
+        "epoch": "0",
+        "version": "20130529",
+        "release": "19.el7",
+        "installdate": "1584625446",
+        "arch": "x86_64"
+      },
+      "ebay-cors-filter": {
+        "epoch": "0",
+        "version": "1.0.1",
+        "release": "3.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "rh-postgresql10-postgresql-server": {
+        "epoch": "0",
+        "version": "10.6",
+        "release": "1.el7",
+        "installdate": "1584625455",
+        "arch": "x86_64"
+      },
+      "qrencode-libs": {
+        "epoch": "0",
+        "version": "3.4.1",
+        "release": "3.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "xz-java": {
+        "epoch": "0",
+        "version": "1.3",
+        "release": "3.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "librados2": {
+        "epoch": "1",
+        "version": "10.2.5",
+        "release": "4.el7",
+        "installdate": "1584625464",
+        "arch": "x86_64"
+      },
+      "hardlink": {
+        "epoch": "1",
+        "version": "1.0",
+        "release": "19.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "java-1.8.0-openjdk-devel": {
+        "epoch": "1",
+        "version": "1.8.0.242.b08",
+        "release": "0.el7_7",
+        "installdate": "1584625543",
+        "arch": "x86_64"
+      },
+      "bind-license": {
+        "epoch": "32",
+        "version": "9.11.4",
+        "release": "9.P2.el7",
+        "installdate": "1584625465",
+        "arch": "noarch"
+      },
+      "rpm-build-libs": {
+        "epoch": "0",
+        "version": "4.11.3",
+        "release": "40.el7",
+        "installdate": "1584455050",
+        "arch": "x86_64"
+      },
+      "archaius-core": {
+        "epoch": "0",
+        "version": "0.4.1",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "lapack": {
+        "epoch": "0",
+        "version": "3.4.2",
+        "release": "8.el7",
+        "installdate": "1584625469",
+        "arch": "x86_64"
+      },
+      "yum-plugin-fastestmirror": {
+        "epoch": "0",
+        "version": "1.1.31",
+        "release": "52.el7",
+        "installdate": "1584455051",
+        "arch": "noarch"
+      },
+      "resteasy-base-jaxrs": {
+        "epoch": "0",
+        "version": "3.0.6",
+        "release": "4.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "ovirt-vmconsole-proxy": {
+        "epoch": "0",
+        "version": "1.0.7",
+        "release": "2.el7",
+        "installdate": "1584625470",
+        "arch": "noarch"
+      },
+      "kpartx": {
+        "epoch": "0",
+        "version": "0.4.9",
+        "release": "127.el7",
+        "installdate": "1584455052",
+        "arch": "x86_64"
+      },
+      "openstack-java-cinder-model": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "collectd-disk": {
+        "epoch": "0",
+        "version": "5.10.0",
+        "release": "2.el7",
+        "installdate": "1584625475",
+        "arch": "x86_64"
+      },
+      "cryptsetup-libs": {
+        "epoch": "0",
+        "version": "2.0.3",
+        "release": "5.el7",
+        "installdate": "1584455054",
+        "arch": "x86_64"
+      },
+      "openstack-java-glance-client": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "fontconfig": {
+        "epoch": "0",
+        "version": "2.13.0",
+        "release": "4.3.el7",
+        "installdate": "1584625475",
+        "arch": "x86_64"
+      },
+      "openstack-java-resteasy-connector": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "mod_ssl": {
+        "epoch": "1",
+        "version": "2.4.6",
+        "release": "90.el7.centos",
+        "installdate": "1584625478",
+        "arch": "x86_64"
+      },
+      "elfutils-default-yama-scope": {
+        "epoch": "0",
+        "version": "0.176",
+        "release": "2.el7",
+        "installdate": "1584455062",
+        "arch": "noarch"
+      },
+      "libini_config": {
+        "epoch": "0",
+        "version": "1.3.1",
+        "release": "32.el7",
+        "installdate": "1584625544",
+        "arch": "x86_64"
+      },
+      "javapackages-tools": {
+        "epoch": "0",
+        "version": "3.4.1",
+        "release": "11.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "initscripts": {
+        "epoch": "0",
+        "version": "9.49.47",
+        "release": "1.el7",
+        "installdate": "1584455063",
+        "arch": "x86_64"
+      },
+      "ovirt-imageio-proxy-setup": {
+        "epoch": "0",
+        "version": "1.5.3",
+        "release": "0.el7",
+        "installdate": "1584625546",
+        "arch": "noarch"
+      },
+      "ovirt-engine-extensions-api-impl": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "policycoreutils": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "33.el7",
+        "installdate": "1584455063",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-tools-backup": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625547",
+        "arch": "noarch"
+      },
+      "glusterfs-client-xlators": {
+        "epoch": "0",
+        "version": "6.8",
+        "release": "1.el7",
+        "installdate": "1584625479",
+        "arch": "x86_64"
+      },
+      "cronie-anacron": {
+        "epoch": "0",
+        "version": "1.4.11",
+        "release": "23.el7",
+        "installdate": "1584455067",
+        "arch": "x86_64"
+      },
+      "yum-plugin-versionlock": {
+        "epoch": "0",
+        "version": "1.1.31",
+        "release": "52.el7",
+        "installdate": "1584625547",
+        "arch": "noarch"
+      },
+      "perl-parent": {
+        "epoch": "1",
+        "version": "0.225",
+        "release": "244.el7",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "ovirt-ansible-image-template": {
+        "epoch": "0",
+        "version": "1.1.12",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Pod-Escapes": {
+        "epoch": "1",
+        "version": "1.04",
+        "release": "294.el7_6",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "dhclient": {
+        "epoch": "12",
+        "version": "4.2.5",
+        "release": "77.el7.centos",
+        "installdate": "1584455070",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-metrics": {
+        "epoch": "0",
+        "version": "1.3.7",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-libs": {
+        "epoch": "4",
+        "version": "5.16.3",
+        "release": "294.el7_6",
+        "installdate": "1584625480",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-infra": {
+        "epoch": "0",
+        "version": "1.1.13",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Exporter": {
+        "epoch": "0",
+        "version": "5.68",
+        "release": "3.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "libpciaccess": {
+        "epoch": "0",
+        "version": "0.14",
+        "release": "1.el7",
+        "installdate": "1584455074",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-roles": {
+        "epoch": "0",
+        "version": "1.1.7",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-threads-shared": {
+        "epoch": "0",
+        "version": "1.43",
+        "release": "6.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "alsa-firmware": {
+        "epoch": "0",
+        "version": "1.0.28",
+        "release": "2.el7",
+        "installdate": "1584455080",
+        "arch": "noarch"
+      },
+      "ovirt-engine-ui-extensions": {
+        "epoch": "0",
+        "version": "1.0.10",
+        "release": "1.el7",
+        "installdate": "1584625571",
+        "arch": "noarch"
+      },
+      "perl-File-Temp": {
+        "epoch": "0",
+        "version": "0.23.01",
+        "release": "3.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "dbus-python": {
+        "epoch": "0",
+        "version": "1.1.1",
+        "release": "9.el7",
+        "installdate": "1584455080",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-tools": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625591",
+        "arch": "noarch"
+      },
+      "perl-Pod-Simple": {
+        "epoch": "1",
+        "version": "3.28",
+        "release": "4.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "plymouth-core-libs": {
+        "epoch": "0",
+        "version": "0.8.9",
+        "release": "0.32.20140113.el7.centos",
+        "installdate": "1584455081",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-setup-plugin-ovirt-engine": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584627318",
+        "arch": "noarch"
+      },
+      "perl-TermReadKey": {
+        "epoch": "0",
+        "version": "2.30",
+        "release": "20.el7",
+        "installdate": "1584625484",
+        "arch": "x86_64"
+      },
+      "libestr": {
+        "epoch": "0",
+        "version": "0.1.9",
+        "release": "2.el7",
+        "installdate": "1584455081",
+        "arch": "x86_64"
+      },
+      "xorg-x11-font-utils": {
+        "epoch": "1",
+        "version": "7.5",
+        "release": "21.el7",
+        "installdate": "1584625484",
+        "arch": "x86_64"
+      },
+      "kubectl": {
+        "epoch": "0",
+        "version": "1.18.2",
+        "release": "0",
+        "installdate": "1588520704",
+        "arch": "x86_64"
+      },
+      "python-pwquality": {
+        "epoch": "0",
+        "version": "1.2.3",
+        "release": "5.el7",
+        "installdate": "1584625485",
+        "arch": "x86_64"
+      },
+      "grub2": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584455089",
+        "arch": "x86_64"
+      },
+      "libgcc": {
+        "epoch": "0",
+        "version": "4.8.5",
+        "release": "39.el7",
+        "installdate": "1584454882",
+        "arch": "x86_64"
+      },
+      "openssh-server": {
+        "epoch": "0",
+        "version": "7.4p1",
+        "release": "21.el7",
+        "installdate": "1584455092",
+        "arch": "x86_64"
+      },
+      "grub2-common": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584454882",
+        "arch": "noarch"
+      },
+      "filesystem": {
+        "epoch": "0",
+        "version": "3.2",
+        "release": "25.el7",
+        "installdate": "1584454883",
+        "arch": "x86_64"
+      },
+      "authconfig": {
+        "epoch": "0",
+        "version": "6.2.8",
+        "release": "30.el7",
+        "installdate": "1584455093",
+        "arch": "x86_64"
+      },
+      "grub2-pc-modules": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584454883",
+        "arch": "noarch"
+      },
+      "audit": {
+        "epoch": "0",
+        "version": "2.8.5",
+        "release": "4.el7",
+        "installdate": "1584455102",
+        "arch": "x86_64"
+      },
+      "ncurses-base": {
+        "epoch": "0",
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "installdate": "1584454886",
+        "arch": "noarch"
+      },
+      "kbd": {
+        "epoch": "0",
+        "version": "1.15.5",
+        "release": "15.el7",
+        "installdate": "1584455141",
+        "arch": "x86_64"
+      },
+      "biosdevname": {
+        "epoch": "0",
+        "version": "0.7.3",
+        "release": "2.el7",
+        "installdate": "1584455141",
+        "arch": "x86_64"
+      },
+      "glibc-common": {
+        "epoch": "0",
+        "version": "2.17",
+        "release": "292.el7",
+        "installdate": "1584454902",
+        "arch": "x86_64"
+      },
+      "chrony": {
+        "epoch": "0",
+        "version": "3.4",
+        "release": "1.el7",
+        "installdate": "1584455147",
+        "arch": "x86_64"
+      },
+      "nspr": {
+        "epoch": "0",
+        "version": "4.21.0",
+        "release": "1.el7",
+        "installdate": "1584454909",
+        "arch": "x86_64"
+      },
+      "dracut-config-rescue": {
+        "epoch": "0",
+        "version": "033",
+        "release": "564.el7",
+        "installdate": "1584455147",
+        "arch": "x86_64"
+      },
+      "libstdc++": {
+        "epoch": "0",
+        "version": "4.8.5",
+        "release": "39.el7",
+        "installdate": "1584454909",
+        "arch": "x86_64"
+      },
+      "man-db": {
+        "epoch": "0",
+        "version": "2.6.3",
+        "release": "11.el7",
+        "installdate": "1584455149",
+        "arch": "x86_64"
+      },
+      "bash": {
+        "epoch": "0",
+        "version": "4.2.46",
+        "release": "33.el7",
+        "installdate": "1584454910",
+        "arch": "x86_64"
+      },
+      "passwd": {
+        "epoch": "0",
+        "version": "0.79",
+        "release": "5.el7",
+        "installdate": "1584455149",
+        "arch": "x86_64"
+      },
+      "pcre": {
+        "epoch": "0",
+        "version": "8.32",
+        "release": "17.el7",
+        "installdate": "1584454910",
+        "arch": "x86_64"
+      },
+      "xfsprogs": {
+        "epoch": "0",
+        "version": "4.5.0",
+        "release": "20.el7",
+        "installdate": "1584455150",
+        "arch": "x86_64"
+      },
+      "zlib": {
+        "epoch": "0",
+        "version": "1.2.7",
+        "release": "18.el7",
+        "installdate": "1584454910",
+        "arch": "x86_64"
+      },
+      "btrfs-progs": {
+        "epoch": "0",
+        "version": "4.9.1",
+        "release": "1.el7",
+        "installdate": "1584455152",
+        "arch": "x86_64"
+      },
+      "xz-libs": {
+        "epoch": "0",
+        "version": "5.2.2",
+        "release": "1.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "libsysfs": {
+        "epoch": "0",
+        "version": "2.1.0",
+        "release": "16.el7",
+        "installdate": "1584455152",
+        "arch": "x86_64"
+      },
+      "rootfiles": {
+        "epoch": "0",
+        "version": "8.1",
+        "release": "11.el7",
+        "installdate": "1584455152",
+        "arch": "noarch"
+      },
+      "bzip2-libs": {
+        "epoch": "0",
+        "version": "1.0.6",
+        "release": "13.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "iwl7260-firmware": {
+        "epoch": "0",
+        "version": "22.0.7.0",
+        "release": "72.el7",
+        "installdate": "1584455163",
+        "arch": "noarch"
+      },
+      "chkconfig": {
+        "epoch": "0",
+        "version": "1.7.4",
+        "release": "1.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "iwl105-firmware": {
+        "epoch": "0",
+        "version": "18.168.6.1",
+        "release": "72.el7",
+        "installdate": "1584455163",
+        "arch": "noarch"
+      },
+      "readline": {
+        "epoch": "0",
+        "version": "6.2",
+        "release": "11.el7",
+        "installdate": "1584454912",
+        "arch": "x86_64"
+      },
+      "iwl4965-firmware": {
+        "epoch": "0",
+        "version": "228.61.2.24",
+        "release": "72.el7",
+        "installdate": "1584455163",
+        "arch": "noarch"
+      },
+      "gawk": {
+        "epoch": "0",
+        "version": "4.0.2",
+        "release": "4.el7_3.1",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "iwl6050-firmware": {
+        "epoch": "0",
+        "version": "41.28.5.1",
+        "release": "72.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "libffi": {
+        "epoch": "0",
+        "version": "3.0.13",
+        "release": "18.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "iwl6000-firmware": {
+        "epoch": "0",
+        "version": "9.221.4.1",
+        "release": "72.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "audit-libs": {
+        "epoch": "0",
+        "version": "2.8.5",
+        "release": "4.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "iwl3945-firmware": {
+        "epoch": "0",
+        "version": "15.32.2.9",
+        "release": "72.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "libacl": {
+        "epoch": "0",
+        "version": "2.2.51",
+        "release": "14.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "iwl2000-firmware": {
+        "epoch": "0",
+        "version": "18.168.6.1",
+        "release": "72.el7",
+        "installdate": "1584455165",
+        "arch": "noarch"
+      },
+      "libgpg-error": {
+        "epoch": "0",
+        "version": "1.12",
+        "release": "3.el7",
+        "installdate": "1584454914",
+        "arch": "x86_64"
+      },
+      "iwl3160-firmware": {
+        "epoch": "0",
+        "version": "22.0.7.0",
+        "release": "72.el7",
+        "installdate": "1584455166",
+        "arch": "noarch"
+      },
+      "libxml2": {
+        "epoch": "0",
+        "version": "2.9.1",
+        "release": "6.el7_2.3",
+        "installdate": "1584454915",
+        "arch": "x86_64"
+      },
+      "expat": {
+        "epoch": "0",
+        "version": "2.1.0",
+        "release": "10.el7_3",
+        "installdate": "1584454915",
+        "arch": "x86_64"
+      },
+      "nettle": {
+        "epoch": "0",
+        "version": "2.7.1",
+        "release": "8.el7",
+        "installdate": "1584455917",
+        "arch": "x86_64"
+      },
+      "which": {
+        "epoch": "0",
+        "version": "2.20",
+        "release": "7.el7",
+        "installdate": "1584454915",
+        "arch": "x86_64"
+      },
+      "libproxy": {
+        "epoch": "0",
+        "version": "0.4.11",
+        "release": "11.el7",
+        "installdate": "1584455917",
+        "arch": "x86_64"
+      },
+      "diffutils": {
+        "epoch": "0",
+        "version": "3.3",
+        "release": "5.el7",
+        "installdate": "1584454916",
+        "arch": "x86_64"
+      },
+      "trousers": {
+        "epoch": "0",
+        "version": "0.3.14",
+        "release": "2.el7",
+        "installdate": "1584455918",
+        "arch": "x86_64"
+      },
+      "glib-networking": {
+        "epoch": "0",
+        "version": "2.56.1",
+        "release": "1.el7",
+        "installdate": "1584455918",
+        "arch": "x86_64"
+      },
+      "file": {
+        "epoch": "0",
+        "version": "5.11",
+        "release": "35.el7",
+        "installdate": "1584454917",
+        "arch": "x86_64"
+      },
+      "cockpit-system": {
+        "epoch": "0",
+        "version": "195.1",
+        "release": "1.el7.centos.0.1",
+        "installdate": "1584455919",
+        "arch": "noarch"
+      },
+      "libaio": {
+        "epoch": "0",
+        "version": "0.3.109",
+        "release": "13.el7",
+        "installdate": "1584454917",
+        "arch": "x86_64"
+      },
+      "cockpit": {
+        "epoch": "0",
+        "version": "195.1",
+        "release": "1.el7.centos.0.1",
+        "installdate": "1584455921",
+        "arch": "x86_64"
+      },
+      "libnl3-cli": {
+        "epoch": "0",
+        "version": "3.2.28",
+        "release": "4.el7",
+        "installdate": "1584454917",
+        "arch": "x86_64"
+      },
+      "p11-kit": {
+        "epoch": "0",
+        "version": "0.23.5",
+        "release": "3.el7",
+        "installdate": "1584454917",
+        "arch": "x86_64"
+      },
+      "audit-libs-python": {
+        "epoch": "0",
+        "version": "2.8.5",
+        "release": "4.el7",
+        "installdate": "1584610681",
+        "arch": "x86_64"
+      },
+      "e2fsprogs-libs": {
+        "epoch": "0",
+        "version": "1.42.9",
+        "release": "16.el7",
+        "installdate": "1584454918",
+        "arch": "x86_64"
+      },
+      "fuse-libs": {
+        "epoch": "0",
+        "version": "2.9.2",
+        "release": "11.el7",
+        "installdate": "1584610681",
+        "arch": "x86_64"
+      },
+      "libunistring": {
+        "epoch": "0",
+        "version": "0.9.3",
+        "release": "9.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "checkpolicy": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "8.el7",
+        "installdate": "1584610681",
+        "arch": "x86_64"
+      },
+      "libgomp": {
+        "epoch": "0",
+        "version": "4.8.5",
+        "release": "39.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "python-IPy": {
+        "epoch": "0",
+        "version": "0.75",
+        "release": "6.el7",
+        "installdate": "1584610682",
+        "arch": "noarch"
+      },
+      "sysvinit-tools": {
+        "epoch": "0",
+        "version": "2.88",
+        "release": "14.dsf.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "policycoreutils-python": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "33.el7",
+        "installdate": "1584610682",
+        "arch": "x86_64"
+      },
+      "libnfnetlink": {
+        "epoch": "0",
+        "version": "1.0.1",
+        "release": "4.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "selinux-policy-targeted": {
+        "epoch": "0",
+        "version": "3.13.1",
+        "release": "252.el7_7.6",
+        "installdate": "1584610695",
+        "arch": "noarch"
+      },
+      "lzo": {
+        "epoch": "0",
+        "version": "2.06",
+        "release": "8.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "squashfs-tools": {
+        "epoch": "0",
+        "version": "4.3",
+        "release": "0.21.gitaae0aff4.el7",
+        "installdate": "1584610726",
+        "arch": "x86_64"
+      },
+      "newt": {
+        "epoch": "0",
+        "version": "0.52.15",
+        "release": "4.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "bash-completion": {
+        "epoch": "1",
+        "version": "2.1",
+        "release": "6.el7",
+        "installdate": "1584610726",
+        "arch": "noarch"
+      },
+      "gdbm": {
+        "epoch": "0",
+        "version": "1.10",
+        "release": "8.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "squashfuse": {
+        "epoch": "0",
+        "version": "0.1.102",
+        "release": "1.el7",
+        "installdate": "1584610726",
+        "arch": "x86_64"
+      },
+      "ethtool": {
+        "epoch": "2",
+        "version": "4.8",
+        "release": "10.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "ovirt-release43": {
+        "epoch": "0",
+        "version": "4.3.9",
+        "release": "1.el7",
+        "installdate": "1584624189",
+        "arch": "noarch"
+      },
+      "pciutils-libs": {
+        "epoch": "0",
+        "version": "3.5.1",
+        "release": "3.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "nss-util": {
+        "epoch": "0",
+        "version": "3.44.0",
+        "release": "4.el7_7",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "iptables": {
+        "epoch": "0",
+        "version": "1.4.21",
+        "release": "33.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "libblkid": {
+        "epoch": "0",
+        "version": "2.23.2",
+        "release": "61.el7_7.1",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "less": {
+        "epoch": "0",
+        "version": "458",
+        "release": "9.el7",
+        "installdate": "1584454921",
+        "arch": "x86_64"
+      },
+      "nss-softokn-freebl": {
+        "epoch": "0",
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "device-mapper-persistent-data": {
+        "epoch": "0",
+        "version": "0.8.5",
+        "release": "1.el7",
+        "installdate": "1584454921",
+        "arch": "x86_64"
+      },
+      "util-linux": {
+        "epoch": "0",
+        "version": "2.23.2",
+        "release": "61.el7_7.1",
+        "installdate": "1584624360",
+        "arch": "x86_64"
+      },
+      "ipset": {
+        "epoch": "0",
+        "version": "7.1",
+        "release": "1.el7",
+        "installdate": "1584454921",
+        "arch": "x86_64"
+      },
+      "firewalld-filesystem": {
+        "epoch": "0",
+        "version": "0.6.3",
+        "release": "2.el7_7.4",
+        "installdate": "1584624361",
+        "arch": "noarch"
+      },
+      "vim-minimal": {
+        "epoch": "2",
+        "version": "7.4.629",
+        "release": "6.el7",
+        "installdate": "1584454922",
+        "arch": "x86_64"
+      },
+      "kernel-tools-libs": {
+        "epoch": "0",
+        "version": "3.10.0",
+        "release": "1062.18.1.el7",
+        "installdate": "1584624361",
+        "arch": "x86_64"
+      },
+      "libdb-utils": {
+        "epoch": "0",
+        "version": "5.3.21",
+        "release": "25.el7",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "kmod": {
+        "epoch": "0",
+        "version": "20",
+        "release": "25.el7_7.1",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "libss": {
+        "epoch": "0",
+        "version": "1.42.9",
+        "release": "16.el7",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "python-perf": {
+        "epoch": "0",
+        "version": "3.10.0",
+        "release": "1062.18.1.el7",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "make": {
+        "epoch": "1",
+        "version": "3.82",
+        "release": "24.el7",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "nss-softokn": {
+        "epoch": "0",
+        "version": "3.44.0",
+        "release": "8.el7_7",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "freetype": {
+        "epoch": "0",
+        "version": "2.8",
+        "release": "14.el7",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "nss": {
+        "epoch": "0",
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "linux-firmware": {
+        "epoch": "0",
+        "version": "20190429",
+        "release": "72.gitddde598.el7",
+        "installdate": "1584454994",
+        "arch": "noarch"
+      },
+      "systemd": {
+        "epoch": "0",
+        "version": "219",
+        "release": "67.el7_7.4",
+        "installdate": "1584624365",
+        "arch": "x86_64"
+      },
+      "mozjs17": {
+        "epoch": "0",
+        "version": "17.0.0",
+        "release": "20.el7",
+        "installdate": "1584454995",
+        "arch": "x86_64"
+      },
+      "device-mapper": {
+        "epoch": "7",
+        "version": "1.02.158",
+        "release": "2.el7_7.2",
+        "installdate": "1584624366",
+        "arch": "x86_64"
+      },
+      "gmp": {
+        "epoch": "1",
+        "version": "6.0.0",
+        "release": "15.el7",
+        "installdate": "1584454995",
+        "arch": "x86_64"
+      },
+      "polkit": {
+        "epoch": "0",
+        "version": "0.112",
+        "release": "22.el7_7.1",
+        "installdate": "1584624366",
+        "arch": "x86_64"
+      },
+      "libsemanage": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "14.el7",
+        "installdate": "1584454995",
+        "arch": "x86_64"
+      },
+      "NetworkManager": {
+        "epoch": "1",
+        "version": "1.18.0",
+        "release": "5.el7_7.2",
+        "installdate": "1584624368",
+        "arch": "x86_64"
+      },
+      "libndp": {
+        "epoch": "0",
+        "version": "1.2",
+        "release": "9.el7",
+        "installdate": "1584454996",
+        "arch": "x86_64"
+      },
+      "lvm2-libs": {
+        "epoch": "7",
+        "version": "2.02.185",
+        "release": "2.el7_7.2",
+        "installdate": "1584624368",
+        "arch": "x86_64"
+      },
+      "libtasn1": {
+        "epoch": "0",
+        "version": "4.10",
+        "release": "1.el7",
+        "installdate": "1584454996",
+        "arch": "x86_64"
+      },
+      "NetworkManager-tui": {
+        "epoch": "1",
+        "version": "1.18.0",
+        "release": "5.el7_7.2",
+        "installdate": "1584624369",
+        "arch": "x86_64"
+      },
+      "NetworkManager-wifi": {
+        "epoch": "1",
+        "version": "1.18.0",
+        "release": "5.el7_7.2",
+        "installdate": "1584624369",
+        "arch": "x86_64"
+      },
+      "systemd-sysv": {
+        "epoch": "0",
+        "version": "219",
+        "release": "67.el7_7.4",
+        "installdate": "1584624369",
+        "arch": "x86_64"
+      },
+      "microcode_ctl": {
+        "epoch": "2",
+        "version": "2.1",
+        "release": "53.7.el7_7",
+        "installdate": "1584624370",
+        "arch": "x86_64"
+      },
+      "python": {
+        "epoch": "0",
+        "version": "2.7.5",
+        "release": "86.el7",
+        "installdate": "1584455008",
+        "arch": "x86_64"
+      },
+      "curl": {
+        "epoch": "0",
+        "version": "7.29.0",
+        "release": "54.el7_7.2",
+        "installdate": "1584624374",
+        "arch": "x86_64"
+      },
+      "gzip": {
+        "epoch": "0",
+        "version": "1.5",
+        "release": "10.el7",
+        "installdate": "1584455011",
+        "arch": "x86_64"
+      },
+      "kernel": {
+        "epoch": "0",
+        "version": "3.10.0",
+        "release": "1062.el7",
+        "installdate": "1584455141",
+        "arch": "x86_64",
+        "versions": [
+          {
+            "epoch": "0",
+            "version": "3.10.0",
+            "release": "1062.18.1.el7",
+            "installdate": "1584624380",
+            "arch": "x86_64"
+          },
+          {
+            "epoch": "0",
+            "version": "3.10.0",
+            "release": "1062.el7",
+            "installdate": "1584455141",
+            "arch": "x86_64"
+          }
+        ]
+      },
+      "python-decorator": {
+        "epoch": "0",
+        "version": "3.4.0",
+        "release": "3.el7",
+        "installdate": "1584455011",
+        "arch": "noarch"
+      },
+      "procps-ng": {
+        "epoch": "0",
+        "version": "3.3.10",
+        "release": "26.el7_7.1",
+        "installdate": "1584624385",
+        "arch": "x86_64"
+      },
+      "glib2": {
+        "epoch": "0",
+        "version": "2.56.1",
+        "release": "5.el7",
+        "installdate": "1584455014",
+        "arch": "x86_64"
+      },
+      "hostname": {
+        "epoch": "0",
+        "version": "3.13",
+        "release": "3.el7_7.1",
+        "installdate": "1584624385",
+        "arch": "x86_64"
+      },
+      "libcroco": {
+        "epoch": "0",
+        "version": "0.6.12",
+        "release": "4.el7",
+        "installdate": "1584455014",
+        "arch": "x86_64"
+      },
+      "numactl-libs": {
+        "epoch": "0",
+        "version": "2.0.12",
+        "release": "3.el7_7.1",
+        "installdate": "1584624386",
+        "arch": "x86_64"
+      },
+      "libpwquality": {
+        "epoch": "0",
+        "version": "1.2.3",
+        "release": "5.el7",
+        "installdate": "1584455017",
+        "arch": "x86_64"
+      },
+      "epel-release": {
+        "epoch": "0",
+        "version": "7",
+        "release": "12",
+        "installdate": "1584624386",
+        "arch": "noarch"
+      },
+      "cyrus-sasl-lib": {
+        "epoch": "0",
+        "version": "2.1.26",
+        "release": "23.el7",
+        "installdate": "1584455018",
+        "arch": "x86_64"
+      },
+      "gettext": {
+        "epoch": "0",
+        "version": "0.19.8.1",
+        "release": "2.el7",
+        "installdate": "1584455019",
+        "arch": "x86_64"
+      },
+      "pkgconfig": {
+        "epoch": "1",
+        "version": "0.27.1",
+        "release": "4.el7",
+        "installdate": "1584455019",
+        "arch": "x86_64"
+      },
+      "python-gobject-base": {
+        "epoch": "0",
+        "version": "3.22.0",
+        "release": "1.el7_4.1",
+        "installdate": "1584455019",
+        "arch": "x86_64"
+      },
+      "python2-six": {
+        "epoch": "0",
+        "version": "1.10.0",
+        "release": "9.el7",
+        "installdate": "1584625425",
+        "arch": "noarch"
+      },
+      "python2-netaddr": {
+        "epoch": "0",
+        "version": "0.7.19",
+        "release": "5.el7",
+        "installdate": "1584625426",
+        "arch": "noarch"
+      },
+      "python-slip": {
+        "epoch": "0",
+        "version": "0.4.0",
+        "release": "4.el7",
+        "installdate": "1584455020",
+        "arch": "noarch"
+      },
+      "glusterfs-libs": {
+        "epoch": "0",
+        "version": "6.8",
+        "release": "1.el7",
+        "installdate": "1584625426",
+        "arch": "x86_64"
+      },
+      "pyliblzma": {
+        "epoch": "0",
+        "version": "0.5.3",
+        "release": "11.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "boost-system": {
+        "epoch": "0",
+        "version": "1.53.0",
+        "release": "27.el7",
+        "installdate": "1584625427",
+        "arch": "x86_64"
+      },
+      "newt-python": {
+        "epoch": "0",
+        "version": "0.52.15",
+        "release": "4.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "python2-jmespath": {
+        "epoch": "0",
+        "version": "0.9.0",
+        "release": "5.el7",
+        "installdate": "1584625427",
+        "arch": "noarch"
+      },
+      "python-configobj": {
+        "epoch": "0",
+        "version": "4.7.2",
+        "release": "7.el7",
+        "installdate": "1584455020",
+        "arch": "noarch"
+      },
+      "python2-idna": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "1.el7",
+        "installdate": "1584625427",
+        "arch": "noarch"
+      },
+      "grubby": {
+        "epoch": "0",
+        "version": "8.28",
+        "release": "26.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "libevent": {
+        "epoch": "0",
+        "version": "2.0.21",
+        "release": "4.el7",
+        "installdate": "1584625427",
+        "arch": "x86_64"
+      },
+      "fipscheck": {
+        "epoch": "0",
+        "version": "1.4.1",
+        "release": "6.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "apr": {
+        "epoch": "0",
+        "version": "1.4.8",
+        "release": "5.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "bind-export-libs": {
+        "epoch": "32",
+        "version": "9.11.4",
+        "release": "9.P2.el7",
+        "installdate": "1584455021",
+        "arch": "x86_64"
+      },
+      "boost-thread": {
+        "epoch": "0",
+        "version": "1.53.0",
+        "release": "27.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "mariadb-libs": {
+        "epoch": "1",
+        "version": "5.5.64",
+        "release": "1.el7",
+        "installdate": "1584455022",
+        "arch": "x86_64"
+      },
+      "postgresql-libs": {
+        "epoch": "0",
+        "version": "9.2.24",
+        "release": "2.el7_7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "nss-pem": {
+        "epoch": "0",
+        "version": "1.0.3",
+        "release": "7.el7",
+        "installdate": "1584455022",
+        "arch": "x86_64"
+      },
+      "libtirpc": {
+        "epoch": "0",
+        "version": "0.2.4",
+        "release": "0.16.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "libxshmfence": {
+        "epoch": "0",
+        "version": "1.2",
+        "release": "1.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "mailcap": {
+        "epoch": "0",
+        "version": "2.1.41",
+        "release": "2.el7",
+        "installdate": "1584625428",
+        "arch": "noarch"
+      },
+      "rpm-libs": {
+        "epoch": "0",
+        "version": "4.11.3",
+        "release": "40.el7",
+        "installdate": "1584455023",
+        "arch": "x86_64"
+      },
+      "collectd": {
+        "epoch": "0",
+        "version": "5.10.0",
+        "release": "2.el7",
+        "installdate": "1584625429",
+        "arch": "x86_64"
+      },
+      "openldap": {
+        "epoch": "0",
+        "version": "2.4.44",
+        "release": "21.el7_6",
+        "installdate": "1584455024",
+        "arch": "x86_64"
+      },
+      "libwayland-server": {
+        "epoch": "0",
+        "version": "1.15.0",
+        "release": "1.el7",
+        "installdate": "1584625429",
+        "arch": "x86_64"
+      },
+      "python-pycurl": {
+        "epoch": "0",
+        "version": "7.19.0",
+        "release": "19.el7",
+        "installdate": "1584455025",
+        "arch": "x86_64"
+      },
+      "libglvnd": {
+        "epoch": "1",
+        "version": "1.0.1",
+        "release": "0.8.git5baa1e5.el7",
+        "installdate": "1584625429",
+        "arch": "x86_64"
+      },
+      "boost-iostreams": {
+        "epoch": "0",
+        "version": "1.53.0",
+        "release": "27.el7",
+        "installdate": "1584625446",
+        "arch": "x86_64"
+      },
+      "alsa-lib": {
+        "epoch": "0",
+        "version": "1.1.8",
+        "release": "1.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "rh-postgresql10-runtime": {
+        "epoch": "0",
+        "version": "3.1",
+        "release": "1.el7",
+        "installdate": "1584625446",
+        "arch": "x86_64"
+      },
+      "dmidecode": {
+        "epoch": "1",
+        "version": "3.2",
+        "release": "3.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "rh-postgresql10-postgresql": {
+        "epoch": "0",
+        "version": "10.6",
+        "release": "1.el7",
+        "installdate": "1584625453",
+        "arch": "x86_64"
+      },
+      "libdaemon": {
+        "epoch": "0",
+        "version": "0.14",
+        "release": "7.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "libICE": {
+        "epoch": "0",
+        "version": "1.0.9",
+        "release": "9.el7",
+        "installdate": "1584625464",
+        "arch": "x86_64"
+      },
+      "libfastjson": {
+        "epoch": "0",
+        "version": "0.99.4",
+        "release": "3.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "libpipeline": {
+        "epoch": "0",
+        "version": "1.2.3",
+        "release": "3.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "gnupg2": {
+        "epoch": "0",
+        "version": "2.0.22",
+        "release": "5.el7_5",
+        "installdate": "1584455050",
+        "arch": "x86_64"
+      },
+      "rpm-python": {
+        "epoch": "0",
+        "version": "4.11.3",
+        "release": "40.el7",
+        "installdate": "1584455051",
+        "arch": "x86_64"
+      },
+      "pygpgme": {
+        "epoch": "0",
+        "version": "0.3",
+        "release": "9.el7",
+        "installdate": "1584455051",
+        "arch": "x86_64"
+      },
+      "yum": {
+        "epoch": "0",
+        "version": "3.4.3",
+        "release": "163.el7.centos",
+        "installdate": "1584455052",
+        "arch": "noarch"
+      },
+      "dracut": {
+        "epoch": "0",
+        "version": "033",
+        "release": "564.el7",
+        "installdate": "1584455054",
+        "arch": "x86_64"
+      },
+      "elfutils-libs": {
+        "epoch": "0",
+        "version": "0.176",
+        "release": "2.el7",
+        "installdate": "1584455054",
+        "arch": "x86_64"
+      },
+      "dbus-libs": {
+        "epoch": "1",
+        "version": "1.10.24",
+        "release": "13.el7_6",
+        "installdate": "1584455055",
+        "arch": "x86_64"
+      },
+      "dbus": {
+        "epoch": "1",
+        "version": "1.10.24",
+        "release": "13.el7_6",
+        "installdate": "1584455062",
+        "arch": "x86_64"
+      },
+      "iputils": {
+        "epoch": "0",
+        "version": "20160308",
+        "release": "10.el7",
+        "installdate": "1584455062",
+        "arch": "x86_64"
+      },
+      "grub2-tools-minimal": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584455063",
+        "arch": "x86_64"
+      },
+      "wpa_supplicant": {
+        "epoch": "1",
+        "version": "2.6",
+        "release": "12.el7",
+        "installdate": "1584455065",
+        "arch": "x86_64"
+      },
+      "grub2-tools": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584455067",
+        "arch": "x86_64"
+      },
+      "cronie": {
+        "epoch": "0",
+        "version": "1.4.11",
+        "release": "23.el7",
+        "installdate": "1584455067",
+        "arch": "x86_64"
+      },
+      "dhcp-libs": {
+        "epoch": "12",
+        "version": "4.2.5",
+        "release": "77.el7.centos",
+        "installdate": "1584455067",
+        "arch": "x86_64"
+      },
+      "dhcp-common": {
+        "epoch": "12",
+        "version": "4.2.5",
+        "release": "77.el7.centos",
+        "installdate": "1584455070",
+        "arch": "x86_64"
+      },
+      "dracut-network": {
+        "epoch": "0",
+        "version": "033",
+        "release": "564.el7",
+        "installdate": "1584455070",
+        "arch": "x86_64"
+      },
+      "grub2-pc": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584455071",
+        "arch": "x86_64"
+      },
+      "hwdata": {
+        "epoch": "0",
+        "version": "0.252",
+        "release": "9.3.el7",
+        "installdate": "1584455074",
+        "arch": "x86_64"
+      },
+      "libdrm": {
+        "epoch": "0",
+        "version": "2.4.97",
+        "release": "2.el7",
+        "installdate": "1584455078",
+        "arch": "x86_64"
+      },
+      "fxload": {
+        "epoch": "0",
+        "version": "2002_04_11",
+        "release": "16.el7",
+        "installdate": "1584455078",
+        "arch": "x86_64"
+      },
+      "alsa-tools-firmware": {
+        "epoch": "0",
+        "version": "1.1.0",
+        "release": "1.el7",
+        "installdate": "1584455080",
+        "arch": "x86_64"
+      },
+      "dbus-glib": {
+        "epoch": "0",
+        "version": "0.100",
+        "release": "7.el7",
+        "installdate": "1584455080",
+        "arch": "x86_64"
+      },
+      "python-slip-dbus": {
+        "epoch": "0",
+        "version": "0.4.0",
+        "release": "4.el7",
+        "installdate": "1584455080",
+        "arch": "noarch"
+      },
+      "python-pyudev": {
+        "epoch": "0",
+        "version": "0.15",
+        "release": "9.el7",
+        "installdate": "1584455080",
+        "arch": "noarch"
+      },
+      "plymouth-scripts": {
+        "epoch": "0",
+        "version": "0.8.9",
+        "release": "0.32.20140113.el7.centos",
+        "installdate": "1584455081",
+        "arch": "x86_64"
+      },
+      "virt-what": {
+        "epoch": "0",
+        "version": "1.18",
+        "release": "4.el7",
+        "installdate": "1584455081",
+        "arch": "x86_64"
+      },
+      "python-syspurpose": {
+        "epoch": "0",
+        "version": "1.24.26",
+        "release": "1.el7.centos",
+        "installdate": "1588520992",
+        "arch": "x86_64"
+      },
+      "rh-postgresql10-postgresql-contrib": {
+        "epoch": "0",
+        "version": "10.6",
+        "release": "1.el7",
+        "installdate": "1584625485",
+        "arch": "x86_64"
+      },
+      "containernetworking-plugins": {
+        "epoch": "0",
+        "version": "0.8.1",
+        "release": "4.el7.centos",
+        "installdate": "1588520996",
+        "arch": "x86_64"
+      },
+      "graphite2": {
+        "epoch": "0",
+        "version": "1.3.10",
+        "release": "1.el7_3",
+        "installdate": "1584625485",
+        "arch": "x86_64"
+      },
+      "libnftnl": {
+        "epoch": "0",
+        "version": "1.0.8",
+        "release": "3.el7",
+        "installdate": "1588520996",
+        "arch": "x86_64"
+      },
+      "python-ply": {
+        "epoch": "0",
+        "version": "3.4",
+        "release": "11.el7",
+        "installdate": "1584625486",
+        "arch": "noarch"
+      },
+      "conmon": {
+        "epoch": "2",
+        "version": "2.0.8",
+        "release": "1.el7",
+        "installdate": "1588520997",
+        "arch": "x86_64"
+      },
+      "python2-cffi": {
+        "epoch": "0",
+        "version": "1.11.2",
+        "release": "1.el7",
+        "installdate": "1584625486",
+        "arch": "x86_64"
+      },
+      "python-inotify": {
+        "epoch": "0",
+        "version": "0.9.4",
+        "release": "4.el7",
+        "installdate": "1588521001",
+        "arch": "noarch"
+      },
+      "atk": {
+        "epoch": "0",
+        "version": "2.28.1",
+        "release": "1.el7",
+        "installdate": "1584625486",
+        "arch": "x86_64"
+      },
+      "python-ethtool": {
+        "epoch": "0",
+        "version": "0.8",
+        "release": "8.el7",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "GeoIP": {
+        "epoch": "0",
+        "version": "1.5.0",
+        "release": "14.el7",
+        "installdate": "1584625486",
+        "arch": "x86_64"
+      },
+      "fuse-overlayfs": {
+        "epoch": "0",
+        "version": "0.7.2",
+        "release": "6.el7_8",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "bind-libs": {
+        "epoch": "32",
+        "version": "9.11.4",
+        "release": "9.P2.el7",
+        "installdate": "1584625487",
+        "arch": "x86_64"
+      },
+      "subscription-manager-rhsm": {
+        "epoch": "0",
+        "version": "1.24.26",
+        "release": "1.el7.centos",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "python2-mimeparse": {
+        "epoch": "0",
+        "version": "1.6.0",
+        "release": "5.el7",
+        "installdate": "1584625487",
+        "arch": "noarch"
+      },
+      "containers-common": {
+        "epoch": "1",
+        "version": "0.1.40",
+        "release": "7.el7_8",
+        "installdate": "1588521002",
+        "arch": "x86_64"
+      },
+      "lksctp-tools": {
+        "epoch": "0",
+        "version": "1.0.17",
+        "release": "2.el7",
+        "installdate": "1584625487",
+        "arch": "x86_64"
+      },
+      "docker-ce-cli": {
+        "epoch": "1",
+        "version": "19.03.8",
+        "release": "3.el7",
+        "installdate": "1588521385",
+        "arch": "x86_64"
+      },
+      "python2-cryptography": {
+        "epoch": "0",
+        "version": "2.1.4",
+        "release": "2.el7",
+        "installdate": "1584625487",
+        "arch": "x86_64"
+      },
+      "libXpm": {
+        "epoch": "0",
+        "version": "3.5.12",
+        "release": "1.el7",
+        "installdate": "1594661051",
+        "arch": "x86_64"
+      },
+      "libssh": {
+        "epoch": "0",
+        "version": "0.7.1",
+        "release": "7.el7",
+        "installdate": "1584625488",
+        "arch": "x86_64"
+      },
+      "gnuplot-common": {
+        "epoch": "0",
+        "version": "4.6.2",
+        "release": "3.el7",
+        "installdate": "1594661051",
+        "arch": "x86_64"
+      },
+      "ovirt-cockpit-sso": {
+        "epoch": "0",
+        "version": "0.1.1",
+        "release": "1.el7",
+        "installdate": "1584625488",
+        "arch": "noarch"
+      },
+      "wget": {
+        "epoch": "0",
+        "version": "1.14",
+        "release": "18.el7_6.1",
+        "installdate": "1618037215",
+        "arch": "x86_64"
+      },
+      "python-paramiko": {
+        "epoch": "0",
+        "version": "2.1.1",
+        "release": "9.el7",
+        "installdate": "1584625490",
+        "arch": "noarch"
+      },
+      "python2-ovirt-host-deploy": {
+        "epoch": "0",
+        "version": "1.8.5",
+        "release": "1.el7",
+        "installdate": "1584625490",
+        "arch": "noarch"
+      },
+      "systemd-python": {
+        "epoch": "0",
+        "version": "219",
+        "release": "67.el7_7.4",
+        "installdate": "1584625491",
+        "arch": "x86_64"
+      },
+      "tzdata-java": {
+        "epoch": "0",
+        "version": "2019c",
+        "release": "1.el7",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "avahi-libs": {
+        "epoch": "0",
+        "version": "0.6.31",
+        "release": "19.el7",
+        "installdate": "1584625493",
+        "arch": "x86_64"
+      },
+      "libwayland-client": {
+        "epoch": "0",
+        "version": "1.15.0",
+        "release": "1.el7",
+        "installdate": "1584625493",
+        "arch": "x86_64"
+      },
+      "python-lockfile": {
+        "epoch": "1",
+        "version": "0.9.1",
+        "release": "4.el7.centos",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "python2-ovirt-engine-lib": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "python-backports": {
+        "epoch": "0",
+        "version": "1.0",
+        "release": "8.el7",
+        "installdate": "1584625493",
+        "arch": "x86_64"
+      },
+      "python-setuptools": {
+        "epoch": "0",
+        "version": "0.9.8",
+        "release": "7.el7",
+        "installdate": "1584625494",
+        "arch": "noarch"
+      },
+      "python-websockify": {
+        "epoch": "0",
+        "version": "0.8.0",
+        "release": "3.el7",
+        "installdate": "1584625494",
+        "arch": "noarch"
+      },
+      "python-nose": {
+        "epoch": "0",
+        "version": "1.3.7",
+        "release": "7.el7",
+        "installdate": "1584625494",
+        "arch": "noarch"
+      },
+      "ovirt-engine-wildfly": {
+        "epoch": "0",
+        "version": "17.0.1",
+        "release": "1.el7",
+        "installdate": "1584625518",
+        "arch": "x86_64"
+      },
+      "python2-pysocks": {
+        "epoch": "0",
+        "version": "1.6.8",
+        "release": "6.el7",
+        "installdate": "1584625518",
+        "arch": "noarch"
+      },
+      "python2-requests": {
+        "epoch": "0",
+        "version": "2.19.1",
+        "release": "4.el7",
+        "installdate": "1584625518",
+        "arch": "noarch"
+      },
+      "ovirt-engine-setup-base": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625519",
+        "arch": "noarch"
+      },
+      "java-1.8.0-openjdk-headless": {
+        "epoch": "1",
+        "version": "1.8.0.242.b08",
+        "release": "0.el7_7",
+        "installdate": "1584625524",
+        "arch": "x86_64"
+      },
+      "ttmkfdir": {
+        "epoch": "0",
+        "version": "3.0.9",
+        "release": "42.el7",
+        "installdate": "1584625525",
+        "arch": "x86_64"
+      },
+      "rsyslog-elasticsearch": {
+        "epoch": "0",
+        "version": "8.24.0",
+        "release": "41.el7_7.4",
+        "installdate": "1584625525",
+        "arch": "x86_64"
+      },
+      "python2-babel": {
+        "epoch": "0",
+        "version": "2.3.4",
+        "release": "1.el7",
+        "installdate": "1584625527",
+        "arch": "noarch"
+      },
+      "python-linecache2": {
+        "epoch": "0",
+        "version": "1.0.0",
+        "release": "1.el7",
+        "installdate": "1584625527",
+        "arch": "noarch"
+      },
+      "python-unittest2": {
+        "epoch": "0",
+        "version": "1.1.0",
+        "release": "4.el7",
+        "installdate": "1584625527",
+        "arch": "noarch"
+      },
+      "rdma-core": {
+        "epoch": "0",
+        "version": "22.1",
+        "release": "3.el7",
+        "installdate": "1584625527",
+        "arch": "x86_64"
+      },
+      "gperftools-libs": {
+        "epoch": "0",
+        "version": "2.6.1",
+        "release": "1.el7",
+        "installdate": "1584625527",
+        "arch": "x86_64"
+      },
+      "libxcb": {
+        "epoch": "0",
+        "version": "1.13",
+        "release": "1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXext": {
+        "epoch": "0",
+        "version": "1.3.3",
+        "release": "3.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXfixes": {
+        "epoch": "0",
+        "version": "5.0.3",
+        "release": "1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXdamage": {
+        "epoch": "0",
+        "version": "1.1.4",
+        "release": "4.1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXcomposite": {
+        "epoch": "0",
+        "version": "0.4.4",
+        "release": "4.1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXtst": {
+        "epoch": "0",
+        "version": "1.2.3",
+        "release": "1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXrandr": {
+        "epoch": "0",
+        "version": "1.5.1",
+        "release": "2.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libXinerama": {
+        "epoch": "0",
+        "version": "1.1.3",
+        "release": "2.1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "mesa-libGL": {
+        "epoch": "0",
+        "version": "18.3.4",
+        "release": "6.el7_7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "mesa-libEGL": {
+        "epoch": "0",
+        "version": "18.3.4",
+        "release": "6.el7_7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "giflib": {
+        "epoch": "0",
+        "version": "4.1.6",
+        "release": "9.el7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "dpdk": {
+        "epoch": "0",
+        "version": "18.11.2",
+        "release": "1.el7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "python-openvswitch": {
+        "epoch": "1",
+        "version": "2.11.0",
+        "release": "4.el7",
+        "installdate": "1584625530",
+        "arch": "x86_64"
+      },
+      "ovn-central": {
+        "epoch": "0",
+        "version": "2.11.1",
+        "release": "5.el7",
+        "installdate": "1584625531",
+        "arch": "x86_64"
+      },
+      "perl-Git": {
+        "epoch": "0",
+        "version": "1.8.3.1",
+        "release": "21.el7_7",
+        "installdate": "1584625531",
+        "arch": "noarch"
+      },
+      "python2-pbr": {
+        "epoch": "0",
+        "version": "4.2.0",
+        "release": "3.el7",
+        "installdate": "1584625533",
+        "arch": "noarch"
+      },
+      "python2-fixtures": {
+        "epoch": "0",
+        "version": "3.0.0",
+        "release": "7.el7",
+        "installdate": "1584625534",
+        "arch": "noarch"
+      },
+      "ovirt-provider-ovn": {
+        "epoch": "0",
+        "version": "1.2.29",
+        "release": "1.el7",
+        "installdate": "1584625534",
+        "arch": "noarch"
+      },
+      "tcp_wrappers": {
+        "epoch": "0",
+        "version": "7.6",
+        "release": "77.el7",
+        "installdate": "1584625534",
+        "arch": "x86_64"
+      },
+      "rsyslog-mmjsonparse": {
+        "epoch": "0",
+        "version": "8.24.0",
+        "release": "41.el7_7.4",
+        "installdate": "1584625534",
+        "arch": "x86_64"
+      },
+      "PyYAML": {
+        "epoch": "0",
+        "version": "3.10",
+        "release": "11.el7",
+        "installdate": "1584625535",
+        "arch": "x86_64"
+      },
+      "qemu-img-ev": {
+        "epoch": "10",
+        "version": "2.12.0",
+        "release": "33.1.el7_7.4",
+        "installdate": "1584625535",
+        "arch": "x86_64"
+      },
+      "python2-passlib": {
+        "epoch": "0",
+        "version": "1.7.1",
+        "release": "1.el7",
+        "installdate": "1584625535",
+        "arch": "noarch"
+      },
+      "pixman": {
+        "epoch": "0",
+        "version": "0.34.0",
+        "release": "1.el7",
+        "installdate": "1584625535",
+        "arch": "x86_64"
+      },
+      "pango": {
+        "epoch": "0",
+        "version": "1.42.4",
+        "release": "4.el7_7",
+        "installdate": "1584625536",
+        "arch": "x86_64"
+      },
+      "java-1.8.0-openjdk": {
+        "epoch": "1",
+        "version": "1.8.0.242.b08",
+        "release": "0.el7_7",
+        "installdate": "1584625537",
+        "arch": "x86_64"
+      },
+      "xml-commons-resolver": {
+        "epoch": "0",
+        "version": "1.2",
+        "release": "15.el7",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "xerces-j2": {
+        "epoch": "0",
+        "version": "2.11.0",
+        "release": "17.el7_0",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "apache-commons-codec": {
+        "epoch": "0",
+        "version": "1.8",
+        "release": "7.el7",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "apache-commons-lang": {
+        "epoch": "0",
+        "version": "2.6",
+        "release": "15.el7",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "tzdata": {
+        "epoch": "0",
+        "version": "2019c",
+        "release": "1.el7",
+        "installdate": "1584624389",
+        "arch": "noarch"
+      },
+      "objectweb-asm": {
+        "epoch": "0",
+        "version": "3.3.1",
+        "release": "9.el7",
+        "installdate": "1584625538",
+        "arch": "noarch"
+      },
+      "geronimo-jms": {
+        "epoch": "0",
+        "version": "1.1.1",
+        "release": "19.el7",
+        "installdate": "1584625538",
+        "arch": "noarch"
+      },
+      "msv-msv": {
+        "epoch": "1",
+        "version": "2013.5.1",
+        "release": "7.el7",
+        "installdate": "1584625538",
+        "arch": "noarch"
+      },
+      "log4j": {
+        "epoch": "0",
+        "version": "1.2.17",
+        "release": "16.el7_4",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "apache-commons-logging": {
+        "epoch": "0",
+        "version": "1.1.2",
+        "release": "7.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "jakarta-commons-httpclient": {
+        "epoch": "1",
+        "version": "3.1",
+        "release": "16.el7_0",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "apache-commons-digester": {
+        "epoch": "0",
+        "version": "1.8.1",
+        "release": "19.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "ovirt-host-deploy-java": {
+        "epoch": "0",
+        "version": "1.8.5",
+        "release": "1.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "joda-convert": {
+        "epoch": "0",
+        "version": "1.3",
+        "release": "5.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "jzlib": {
+        "epoch": "0",
+        "version": "1.1.1",
+        "release": "6.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "httpcomponents-core": {
+        "epoch": "0",
+        "version": "4.2.4",
+        "release": "6.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "apache-commons-io": {
+        "epoch": "1",
+        "version": "2.4",
+        "release": "12.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "easymock2": {
+        "epoch": "0",
+        "version": "2.5.2",
+        "release": "12.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "hamcrest": {
+        "epoch": "0",
+        "version": "1.3",
+        "release": "6.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "ws-commons-util": {
+        "epoch": "0",
+        "version": "1.0.1",
+        "release": "29.el7",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "xmlrpc-client": {
+        "epoch": "1",
+        "version": "3.1.3",
+        "release": "9.el7_5",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "jctools": {
+        "epoch": "0",
+        "version": "1.1",
+        "release": "0.3.alpha.el7",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "hsqldb": {
+        "epoch": "1",
+        "version": "1.8.1.3",
+        "release": "14.el7",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "jdom": {
+        "epoch": "0",
+        "version": "1.1.3",
+        "release": "6.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "dom4j": {
+        "epoch": "0",
+        "version": "1.6.1",
+        "release": "20.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "resteasy-base-jaxrs-api": {
+        "epoch": "0",
+        "version": "3.0.6",
+        "release": "4.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "cal10n": {
+        "epoch": "0",
+        "version": "0.7.7",
+        "release": "4.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "apache-commons-net": {
+        "epoch": "0",
+        "version": "3.2",
+        "release": "8.el7.centos",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "boost-random": {
+        "epoch": "0",
+        "version": "1.53.0",
+        "release": "27.el7",
+        "installdate": "1584625464",
+        "arch": "x86_64"
+      },
+      "apache-commons-compress": {
+        "epoch": "0",
+        "version": "1.5",
+        "release": "4.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "libquadmath": {
+        "epoch": "0",
+        "version": "4.8.5",
+        "release": "39.el7",
+        "installdate": "1584625465",
+        "arch": "x86_64"
+      },
+      "jackson-core": {
+        "epoch": "0",
+        "version": "2.6.3",
+        "release": "1.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "libref_array": {
+        "epoch": "0",
+        "version": "0.1.5",
+        "release": "32.el7",
+        "installdate": "1584625465",
+        "arch": "x86_64"
+      },
+      "ant": {
+        "epoch": "0",
+        "version": "1.9.4",
+        "release": "2.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "libbasicobjects": {
+        "epoch": "0",
+        "version": "0.1.1",
+        "release": "32.el7",
+        "installdate": "1584625465",
+        "arch": "x86_64"
+      },
+      "apache-commons-configuration": {
+        "epoch": "0",
+        "version": "1.9",
+        "release": "8.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "blas": {
+        "epoch": "0",
+        "version": "3.4.2",
+        "release": "8.el7",
+        "installdate": "1584625466",
+        "arch": "x86_64"
+      },
+      "hystrix-core": {
+        "epoch": "0",
+        "version": "1.4.21",
+        "release": "6.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "librbd1": {
+        "epoch": "1",
+        "version": "10.2.5",
+        "release": "4.el7",
+        "installdate": "1584625470",
+        "arch": "x86_64"
+      },
+      "jboss-annotations-1.1-api": {
+        "epoch": "0",
+        "version": "1.0.1",
+        "release": "0.6.20120212git76e1a2.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "libSM": {
+        "epoch": "0",
+        "version": "1.2.2",
+        "release": "2.el7",
+        "installdate": "1584625470",
+        "arch": "x86_64"
+      },
+      "jsr-311": {
+        "epoch": "0",
+        "version": "1.1.1",
+        "release": "6.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "mesa-libgbm": {
+        "epoch": "0",
+        "version": "18.3.4",
+        "release": "6.el7_7",
+        "installdate": "1584625475",
+        "arch": "x86_64"
+      },
+      "openstack-java-client": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "collectd-postgresql": {
+        "epoch": "0",
+        "version": "5.10.0",
+        "release": "2.el7",
+        "installdate": "1584625475",
+        "arch": "x86_64"
+      },
+      "openstack-java-quantum-model": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "collectd-write_syslog": {
+        "epoch": "0",
+        "version": "5.10.0",
+        "release": "2.el7",
+        "installdate": "1584625475",
+        "arch": "x86_64"
+      },
+      "openstack-java-glance-model": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "dejavu-sans-fonts": {
+        "epoch": "0",
+        "version": "2.33",
+        "release": "6.el7",
+        "installdate": "1584625475",
+        "arch": "noarch"
+      },
+      "openstack-java-keystone-client": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "python-ovirt-engine-sdk4": {
+        "epoch": "0",
+        "version": "4.3.2",
+        "release": "2.el7",
+        "installdate": "1584625477",
+        "arch": "x86_64"
+      },
+      "openstack-java-cinder-client": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "httpd": {
+        "epoch": "0",
+        "version": "2.4.6",
+        "release": "90.el7.centos",
+        "installdate": "1584625478",
+        "arch": "x86_64"
+      },
+      "vdsm-jsonrpc-java": {
+        "epoch": "0",
+        "version": "1.4.18",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "libverto-libevent": {
+        "epoch": "0",
+        "version": "0.2.5",
+        "release": "4.el7",
+        "installdate": "1584625478",
+        "arch": "x86_64"
+      },
+      "libpath_utils": {
+        "epoch": "0",
+        "version": "0.2.1",
+        "release": "32.el7",
+        "installdate": "1584625544",
+        "arch": "x86_64"
+      },
+      "python-javapackages": {
+        "epoch": "0",
+        "version": "3.4.1",
+        "release": "11.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "gssproxy": {
+        "epoch": "0",
+        "version": "0.7.0",
+        "release": "26.el7",
+        "installdate": "1584625545",
+        "arch": "x86_64"
+      },
+      "relaxngDatatype": {
+        "epoch": "0",
+        "version": "1.0",
+        "release": "11.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "ovirt-engine-setup-plugin-ovirt-engine-common": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625546",
+        "arch": "noarch"
+      },
+      "bea-stax-api": {
+        "epoch": "0",
+        "version": "1.2.0",
+        "release": "9.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "ovirt-engine-dwh-setup": {
+        "epoch": "0",
+        "version": "4.3.8",
+        "release": "1.el7",
+        "installdate": "1584625546",
+        "arch": "noarch"
+      },
+      "ovirt-engine-extension-aaa-jdbc": {
+        "epoch": "0",
+        "version": "1.1.10",
+        "release": "1.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "ovirt-imageio-proxy": {
+        "epoch": "0",
+        "version": "1.5.3",
+        "release": "0.el7",
+        "installdate": "1584625546",
+        "arch": "noarch"
+      },
+      "bea-stax": {
+        "epoch": "0",
+        "version": "1.2.0",
+        "release": "9.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "ovirt-engine-setup-plugin-websocket-proxy": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625547",
+        "arch": "noarch"
+      },
+      "glusterfs": {
+        "epoch": "0",
+        "version": "6.8",
+        "release": "1.el7",
+        "installdate": "1584625479",
+        "arch": "x86_64"
+      },
+      "ovirt-iso-uploader": {
+        "epoch": "0",
+        "version": "4.3.2",
+        "release": "1.el7",
+        "installdate": "1584625547",
+        "arch": "noarch"
+      },
+      "jasper-libs": {
+        "epoch": "0",
+        "version": "1.900.1",
+        "release": "33.el7",
+        "installdate": "1584625480",
+        "arch": "x86_64"
+      },
+      "python-markupsafe": {
+        "epoch": "0",
+        "version": "0.11",
+        "release": "10.el7",
+        "installdate": "1584625547",
+        "arch": "x86_64"
+      },
+      "perl-HTTP-Tiny": {
+        "epoch": "0",
+        "version": "0.033",
+        "release": "3.el7",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "ansible": {
+        "epoch": "0",
+        "version": "2.9.6",
+        "release": "1.el7",
+        "installdate": "1584625568",
+        "arch": "noarch"
+      },
+      "perl-Pod-Perldoc": {
+        "epoch": "0",
+        "version": "3.20",
+        "release": "4.el7",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "ovirt-ansible-engine-setup": {
+        "epoch": "0",
+        "version": "1.1.9",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Text-ParseWords": {
+        "epoch": "0",
+        "version": "3.29",
+        "release": "4.el7",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "ovirt-ansible-cluster-upgrade": {
+        "epoch": "0",
+        "version": "1.1.14",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Pod-Usage": {
+        "epoch": "0",
+        "version": "1.63",
+        "release": "3.el7",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "ovirt-ansible-hosted-engine-setup": {
+        "epoch": "0",
+        "version": "1.0.32",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-threads": {
+        "epoch": "0",
+        "version": "1.87",
+        "release": "4.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-repositories": {
+        "epoch": "0",
+        "version": "1.1.5",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Filter": {
+        "epoch": "0",
+        "version": "1.49",
+        "release": "3.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-manageiq": {
+        "epoch": "0",
+        "version": "1.1.14",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Time-HiRes": {
+        "epoch": "4",
+        "version": "1.9725",
+        "release": "3.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-disaster-recovery": {
+        "epoch": "0",
+        "version": "1.2.0",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-constant": {
+        "epoch": "0",
+        "version": "1.27",
+        "release": "2.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "ovirt-engine-vmconsole-proxy-helper": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Scalar-List-Utils": {
+        "epoch": "0",
+        "version": "1.27",
+        "release": "248.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-setup-plugin-cinderlib": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625570",
+        "arch": "noarch"
+      },
+      "perl-Carp": {
+        "epoch": "0",
+        "version": "1.26",
+        "release": "244.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "ovirt-engine-webadmin-portal": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625589",
+        "arch": "noarch"
+      },
+      "perl-File-Path": {
+        "epoch": "0",
+        "version": "2.09",
+        "release": "2.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "ovirt-engine-restapi": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625590",
+        "arch": "noarch"
+      },
+      "perl-macros": {
+        "epoch": "4",
+        "version": "5.16.3",
+        "release": "294.el7_6",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-backend": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625593",
+        "arch": "noarch"
+      },
+      "perl-Getopt-Long": {
+        "epoch": "0",
+        "version": "2.40",
+        "release": "3.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "ovirt-engine": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584627317",
+        "arch": "noarch"
+      },
+      "perl-Error": {
+        "epoch": "1",
+        "version": "0.17020",
+        "release": "2.el7",
+        "installdate": "1584625484",
+        "arch": "noarch"
+      },
+      "ovirt-engine-setup": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584627318",
+        "arch": "noarch"
+      },
+      "jbigkit-libs": {
+        "epoch": "0",
+        "version": "2.0",
+        "release": "11.el7",
+        "installdate": "1584625484",
+        "arch": "x86_64"
+      },
+      "yum-utils": {
+        "epoch": "0",
+        "version": "1.1.31",
+        "release": "53.el7",
+        "installdate": "1588520431",
+        "arch": "noarch"
+      },
+      "libfontenc": {
+        "epoch": "0",
+        "version": "1.1.3",
+        "release": "3.el7",
+        "installdate": "1584625484",
+        "arch": "x86_64"
+      },
+      "container-selinux": {
+        "epoch": "2",
+        "version": "2.119.1",
+        "release": "1.c57a6f9.el7",
+        "installdate": "1588520592",
+        "arch": "noarch"
+      },
+      "otopi-common": {
+        "epoch": "0",
+        "version": "1.8.4",
+        "release": "1.el7",
+        "installdate": "1584625484",
+        "arch": "noarch"
+      },
+      "libthai": {
+        "epoch": "0",
+        "version": "0.1.14",
+        "release": "9.el7",
+        "installdate": "1584625485",
+        "arch": "x86_64"
+      },
+      "slirp4netns": {
+        "epoch": "0",
+        "version": "0.4.3",
+        "release": "4.el7_8",
+        "installdate": "1588520992",
+        "arch": "x86_64"
+      },
+      "uuid": {
+        "epoch": "0",
+        "version": "1.6.2",
+        "release": "26.el7",
+        "installdate": "1584625485",
+        "arch": "x86_64"
+      },
+      "kexec-tools": {
+        "epoch": "0",
+        "version": "2.0.15",
+        "release": "33.el7",
+        "installdate": "1584455092",
+        "arch": "x86_64"
+      },
+      "centos-release": {
+        "epoch": "0",
+        "version": "7",
+        "release": "7.1908.0.el7.centos",
+        "installdate": "1584454882",
+        "arch": "x86_64"
+      },
+      "usermode": {
+        "epoch": "0",
+        "version": "1.111",
+        "release": "6.el7",
+        "installdate": "1588520996",
+        "arch": "x86_64"
+      },
+      "harfbuzz": {
+        "epoch": "0",
+        "version": "1.7.5",
+        "release": "2.el7",
+        "installdate": "1584625486",
+        "arch": "x86_64"
+      },
+      "basesystem": {
+        "epoch": "0",
+        "version": "10.0",
+        "release": "7.el7.centos",
+        "installdate": "1584454883",
+        "arch": "noarch"
+      },
+      "containerd.io": {
+        "epoch": "0",
+        "version": "1.2.13",
+        "release": "3.1.el7",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "bzip2": {
+        "epoch": "0",
+        "version": "1.0.6",
+        "release": "13.el7",
+        "installdate": "1584625486",
+        "arch": "x86_64"
+      },
+      "kbd-legacy": {
+        "epoch": "0",
+        "version": "1.15.5",
+        "release": "15.el7",
+        "installdate": "1584454886",
+        "arch": "noarch"
+      },
+      "fuse3-libs": {
+        "epoch": "0",
+        "version": "3.6.1",
+        "release": "4.el7",
+        "installdate": "1588521001",
+        "arch": "x86_64"
+      },
+      "bind-libs-lite": {
+        "epoch": "32",
+        "version": "9.11.4",
+        "release": "9.P2.el7",
+        "installdate": "1584625487",
+        "arch": "x86_64"
+      },
+      "glibc": {
+        "epoch": "0",
+        "version": "2.17",
+        "release": "292.el7",
+        "installdate": "1584454905",
+        "arch": "x86_64"
+      },
+      "subscription-manager": {
+        "epoch": "0",
+        "version": "1.24.26",
+        "release": "1.el7.centos",
+        "installdate": "1588521002",
+        "arch": "x86_64"
+      },
+      "pcsc-lite-libs": {
+        "epoch": "0",
+        "version": "1.8.8",
+        "release": "8.el7",
+        "installdate": "1584625487",
+        "arch": "x86_64"
+      },
+      "parted": {
+        "epoch": "0",
+        "version": "3.1",
+        "release": "31.el7",
+        "installdate": "1584455148",
+        "arch": "x86_64"
+      },
+      "ncurses-libs": {
+        "epoch": "0",
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "installdate": "1584454909",
+        "arch": "x86_64"
+      },
+      "docker-ce": {
+        "epoch": "3",
+        "version": "19.03.8",
+        "release": "3.el7",
+        "installdate": "1588521389",
+        "arch": "x86_64"
+      },
+      "python2-pyOpenSSL": {
+        "epoch": "0",
+        "version": "17.3.0",
+        "release": "3.el7",
+        "installdate": "1584625488",
+        "arch": "noarch"
+      },
+      "libselinux": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "14.1.el7",
+        "installdate": "1584454910",
+        "arch": "x86_64"
+      },
+      "gnuplot": {
+        "epoch": "0",
+        "version": "4.6.2",
+        "release": "3.el7",
+        "installdate": "1594661052",
+        "arch": "x86_64"
+      },
+      "python2-pyasn1": {
+        "epoch": "0",
+        "version": "0.1.9",
+        "release": "7.el7",
+        "installdate": "1584625490",
+        "arch": "noarch"
+      },
+      "libcom_err": {
+        "epoch": "0",
+        "version": "1.42.9",
+        "release": "16.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "libX11-common": {
+        "epoch": "0",
+        "version": "1.6.7",
+        "release": "2.el7",
+        "installdate": "1584625490",
+        "arch": "noarch"
+      },
+      "iwl7265-firmware": {
+        "epoch": "0",
+        "version": "22.0.7.0",
+        "release": "72.el7",
+        "installdate": "1584455160",
+        "arch": "noarch"
+      },
+      "popt": {
+        "epoch": "0",
+        "version": "1.13",
+        "release": "16.el7",
+        "installdate": "1584454911",
+        "arch": "x86_64"
+      },
+      "fribidi": {
+        "epoch": "0",
+        "version": "1.0.2",
+        "release": "1.el7_7.1",
+        "installdate": "1584625493",
+        "arch": "x86_64"
+      },
+      "iwl135-firmware": {
+        "epoch": "0",
+        "version": "18.168.6.1",
+        "release": "72.el7",
+        "installdate": "1584455163",
+        "arch": "noarch"
+      },
+      "grep": {
+        "epoch": "0",
+        "version": "2.20",
+        "release": "3.el7",
+        "installdate": "1584454912",
+        "arch": "x86_64"
+      },
+      "python2-chardet": {
+        "epoch": "0",
+        "version": "3.0.4",
+        "release": "7.el7",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "ivtv-firmware": {
+        "epoch": "2",
+        "version": "20080701",
+        "release": "26.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "libcap-ng": {
+        "epoch": "0",
+        "version": "0.7.5",
+        "release": "4.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "python2-extras": {
+        "epoch": "0",
+        "version": "1.0.0",
+        "release": "2.el7",
+        "installdate": "1584625493",
+        "arch": "noarch"
+      },
+      "iwl2030-firmware": {
+        "epoch": "0",
+        "version": "18.168.6.1",
+        "release": "72.el7",
+        "installdate": "1584455164",
+        "arch": "noarch"
+      },
+      "libcap": {
+        "epoch": "0",
+        "version": "2.22",
+        "release": "10.el7",
+        "installdate": "1584454913",
+        "arch": "x86_64"
+      },
+      "python2-ovirt-setup-lib": {
+        "epoch": "0",
+        "version": "1.2.0",
+        "release": "1.el7",
+        "installdate": "1584625494",
+        "arch": "noarch"
+      },
+      "iwl6000g2a-firmware": {
+        "epoch": "0",
+        "version": "17.168.5.3",
+        "release": "72.el7",
+        "installdate": "1584455166",
+        "arch": "noarch"
+      },
+      "cpio": {
+        "epoch": "0",
+        "version": "2.11",
+        "release": "27.el7",
+        "installdate": "1584454915",
+        "arch": "x86_64"
+      },
+      "numpy": {
+        "epoch": "1",
+        "version": "1.7.1",
+        "release": "13.el7",
+        "installdate": "1584625496",
+        "arch": "x86_64"
+      },
+      "libmodman": {
+        "epoch": "0",
+        "version": "2.0.1",
+        "release": "8.el7",
+        "installdate": "1584455917",
+        "arch": "x86_64"
+      },
+      "findutils": {
+        "epoch": "1",
+        "version": "4.5.11",
+        "release": "6.el7",
+        "installdate": "1584454915",
+        "arch": "x86_64"
+      },
+      "python2-urllib3": {
+        "epoch": "0",
+        "version": "1.21.1",
+        "release": "1.el7",
+        "installdate": "1584625518",
+        "arch": "noarch"
+      },
+      "gnutls": {
+        "epoch": "0",
+        "version": "3.3.29",
+        "release": "9.el7_6",
+        "installdate": "1584455918",
+        "arch": "x86_64"
+      },
+      "file-libs": {
+        "epoch": "0",
+        "version": "5.11",
+        "release": "35.el7",
+        "installdate": "1584454916",
+        "arch": "x86_64"
+      },
+      "copy-jdk-configs": {
+        "epoch": "0",
+        "version": "3.3",
+        "release": "10.el7_5",
+        "installdate": "1584625519",
+        "arch": "noarch"
+      },
+      "cockpit-ws": {
+        "epoch": "0",
+        "version": "195.1",
+        "release": "1.el7.centos.0.1",
+        "installdate": "1584455919",
+        "arch": "x86_64"
+      },
+      "xorg-x11-fonts-Type1": {
+        "epoch": "0",
+        "version": "7.5",
+        "release": "9.el7",
+        "installdate": "1584625525",
+        "arch": "noarch"
+      },
+      "setools-libs": {
+        "epoch": "0",
+        "version": "3.3.8",
+        "release": "4.el7",
+        "installdate": "1584610681",
+        "arch": "x86_64"
+      },
+      "groff-base": {
+        "epoch": "0",
+        "version": "1.22.2",
+        "release": "8.el7",
+        "installdate": "1584454918",
+        "arch": "x86_64"
+      },
+      "sshpass": {
+        "epoch": "0",
+        "version": "1.06",
+        "release": "2.el7",
+        "installdate": "1584625527",
+        "arch": "x86_64"
+      },
+      "libzstd": {
+        "epoch": "0",
+        "version": "1.4.4",
+        "release": "1.el7",
+        "installdate": "1584610681",
+        "arch": "x86_64"
+      },
+      "libidn": {
+        "epoch": "0",
+        "version": "1.28",
+        "release": "4.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "pciutils": {
+        "epoch": "0",
+        "version": "3.5.1",
+        "release": "3.el7",
+        "installdate": "1584625527",
+        "arch": "x86_64"
+      },
+      "libsemanage-python": {
+        "epoch": "0",
+        "version": "2.5",
+        "release": "14.el7",
+        "installdate": "1584610682",
+        "arch": "x86_64"
+      },
+      "lz4": {
+        "epoch": "0",
+        "version": "1.7.5",
+        "release": "3.el7",
+        "installdate": "1584454919",
+        "arch": "x86_64"
+      },
+      "libXau": {
+        "epoch": "0",
+        "version": "1.0.8",
+        "release": "2.1.el7",
+        "installdate": "1584625527",
+        "arch": "x86_64"
+      },
+      "snapd-selinux": {
+        "epoch": "0",
+        "version": "2.43.3",
+        "release": "1.el7",
+        "installdate": "1584610710",
+        "arch": "noarch"
+      },
+      "slang": {
+        "epoch": "0",
+        "version": "2.2.4",
+        "release": "11.el7",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "libXrender": {
+        "epoch": "0",
+        "version": "0.9.10",
+        "release": "1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "squashfuse-libs": {
+        "epoch": "0",
+        "version": "0.1.102",
+        "release": "1.el7",
+        "installdate": "1584610726",
+        "arch": "x86_64"
+      },
+      "gdk-pixbuf2": {
+        "epoch": "0",
+        "version": "2.36.12",
+        "release": "3.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "systemd-libs": {
+        "epoch": "0",
+        "version": "219",
+        "release": "67.el7_7.4",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "libnetfilter_conntrack": {
+        "epoch": "0",
+        "version": "1.0.6",
+        "release": "1.el7_3",
+        "installdate": "1584454920",
+        "arch": "x86_64"
+      },
+      "libXcursor": {
+        "epoch": "0",
+        "version": "1.1.15",
+        "release": "1.el7",
+        "installdate": "1584625528",
+        "arch": "x86_64"
+      },
+      "libmount": {
+        "epoch": "0",
+        "version": "2.23.2",
+        "release": "61.el7_7.1",
+        "installdate": "1584624359",
+        "arch": "x86_64"
+      },
+      "libteam": {
+        "epoch": "0",
+        "version": "1.27",
+        "release": "9.el7",
+        "installdate": "1584454921",
+        "arch": "x86_64"
+      },
+      "libXxf86vm": {
+        "epoch": "0",
+        "version": "1.1.4",
+        "release": "1.el7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "kmod-libs": {
+        "epoch": "0",
+        "version": "20",
+        "release": "25.el7_7.1",
+        "installdate": "1584624360",
+        "arch": "x86_64"
+      },
+      "acl": {
+        "epoch": "0",
+        "version": "2.2.51",
+        "release": "14.el7",
+        "installdate": "1584454921",
+        "arch": "x86_64"
+      },
+      "libglvnd-egl": {
+        "epoch": "1",
+        "version": "1.0.1",
+        "release": "0.8.git5baa1e5.el7",
+        "installdate": "1584625529",
+        "arch": "x86_64"
+      },
+      "binutils": {
+        "epoch": "0",
+        "version": "2.27",
+        "release": "41.base.el7_7.3",
+        "installdate": "1584624362",
+        "arch": "x86_64"
+      },
+      "pinentry": {
+        "epoch": "0",
+        "version": "0.8.1",
+        "release": "17.el7",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "openvswitch": {
+        "epoch": "1",
+        "version": "2.11.0",
+        "release": "4.el7",
+        "installdate": "1584625530",
+        "arch": "x86_64"
+      },
+      "sqlite": {
+        "epoch": "0",
+        "version": "3.7.17",
+        "release": "8.el7_7.1",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "libpng": {
+        "epoch": "2",
+        "version": "1.5.13",
+        "release": "7.el7_2",
+        "installdate": "1584454923",
+        "arch": "x86_64"
+      },
+      "rsync": {
+        "epoch": "0",
+        "version": "3.1.2",
+        "release": "6.el7_6.1",
+        "installdate": "1584625531",
+        "arch": "x86_64"
+      },
+      "libcurl": {
+        "epoch": "0",
+        "version": "7.29.0",
+        "release": "54.el7_7.2",
+        "installdate": "1584624363",
+        "arch": "x86_64"
+      },
+      "ncurses": {
+        "epoch": "0",
+        "version": "5.9",
+        "release": "14.20130511.el7_4",
+        "installdate": "1584454994",
+        "arch": "x86_64"
+      },
+      "python-testtools": {
+        "epoch": "0",
+        "version": "1.8.0",
+        "release": "2.el7",
+        "installdate": "1584625534",
+        "arch": "noarch"
+      },
+      "device-mapper-event-libs": {
+        "epoch": "7",
+        "version": "1.02.158",
+        "release": "2.el7_7.2",
+        "installdate": "1584624366",
+        "arch": "x86_64"
+      },
+      "ustr": {
+        "epoch": "0",
+        "version": "1.0.4",
+        "release": "16.el7",
+        "installdate": "1584454995",
+        "arch": "x86_64"
+      },
+      "keyutils": {
+        "epoch": "0",
+        "version": "1.5.8",
+        "release": "3.el7",
+        "installdate": "1584625534",
+        "arch": "x86_64"
+      },
+      "device-mapper-event": {
+        "epoch": "7",
+        "version": "1.02.158",
+        "release": "2.el7_7.2",
+        "installdate": "1584624368",
+        "arch": "x86_64"
+      },
+      "libverto": {
+        "epoch": "0",
+        "version": "0.2.5",
+        "release": "4.el7",
+        "installdate": "1584454996",
+        "arch": "x86_64"
+      },
+      "libyaml": {
+        "epoch": "0",
+        "version": "0.1.4",
+        "release": "11.el7_0",
+        "installdate": "1584625534",
+        "arch": "x86_64"
+      },
+      "NetworkManager-team": {
+        "epoch": "1",
+        "version": "1.18.0",
+        "release": "5.el7_7.2",
+        "installdate": "1584624369",
+        "arch": "x86_64"
+      },
+      "coreutils": {
+        "epoch": "0",
+        "version": "8.22",
+        "release": "24.el7",
+        "installdate": "1584455001",
+        "arch": "x86_64"
+      },
+      "ovirt-imageio-common": {
+        "epoch": "0",
+        "version": "1.5.3",
+        "release": "0.el7",
+        "installdate": "1584625535",
+        "arch": "x86_64"
+      },
+      "rsyslog": {
+        "epoch": "0",
+        "version": "8.24.0",
+        "release": "41.el7_7.4",
+        "installdate": "1584624369",
+        "arch": "x86_64"
+      },
+      "python-libs": {
+        "epoch": "0",
+        "version": "2.7.5",
+        "release": "86.el7",
+        "installdate": "1584455008",
+        "arch": "x86_64"
+      },
+      "cairo": {
+        "epoch": "0",
+        "version": "1.15.12",
+        "release": "4.el7",
+        "installdate": "1584625536",
+        "arch": "x86_64"
+      },
+      "nss-tools": {
+        "epoch": "0",
+        "version": "3.44.0",
+        "release": "7.el7_7",
+        "installdate": "1584624374",
+        "arch": "x86_64"
+      },
+      "cracklib": {
+        "epoch": "0",
+        "version": "2.9.0",
+        "release": "11.el7",
+        "installdate": "1584455011",
+        "arch": "x86_64"
+      },
+      "xml-commons-apis": {
+        "epoch": "0",
+        "version": "1.4.01",
+        "release": "16.el7",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "sudo": {
+        "epoch": "0",
+        "version": "1.8.23",
+        "release": "4.el7_7.2",
+        "installdate": "1584624385",
+        "arch": "x86_64"
+      },
+      "shared-mime-info": {
+        "epoch": "0",
+        "version": "1.8",
+        "release": "4.el7",
+        "installdate": "1584455014",
+        "arch": "x86_64"
+      },
+      "apache-commons-collections": {
+        "epoch": "0",
+        "version": "3.2.1",
+        "release": "22.el7_2",
+        "installdate": "1584625537",
+        "arch": "noarch"
+      },
+      "iproute": {
+        "epoch": "0",
+        "version": "4.11.0",
+        "release": "25.el7_7.2",
+        "installdate": "1584624386",
+        "arch": "x86_64"
+      },
+      "pam": {
+        "epoch": "0",
+        "version": "1.1.8",
+        "release": "22.el7",
+        "installdate": "1584455018",
+        "arch": "x86_64"
+      },
+      "msv-xsdlib": {
+        "epoch": "1",
+        "version": "2013.5.1",
+        "release": "7.el7",
+        "installdate": "1584625538",
+        "arch": "noarch"
+      },
+      "yum-metadata-parser": {
+        "epoch": "0",
+        "version": "1.1.4",
+        "release": "10.el7",
+        "installdate": "1584455019",
+        "arch": "x86_64"
+      },
+      "scannotation": {
+        "epoch": "0",
+        "version": "1.0.3",
+        "release": "0.7.r12.el7",
+        "installdate": "1584625538",
+        "arch": "noarch"
+      },
+      "libutempter": {
+        "epoch": "0",
+        "version": "1.1.6",
+        "release": "4.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "avalon-logkit": {
+        "epoch": "0",
+        "version": "2.1",
+        "release": "14.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "python-dateutil": {
+        "epoch": "1",
+        "version": "2.4.2",
+        "release": "1.el7",
+        "installdate": "1584625426",
+        "arch": "noarch"
+      },
+      "python-iniparse": {
+        "epoch": "0",
+        "version": "0.4",
+        "release": "9.el7",
+        "installdate": "1584455020",
+        "arch": "noarch"
+      },
+      "apache-commons-beanutils": {
+        "epoch": "0",
+        "version": "1.8.3",
+        "release": "15.el7_7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "mesa-libglapi": {
+        "epoch": "0",
+        "version": "18.3.4",
+        "release": "6.el7_7",
+        "installdate": "1584625427",
+        "arch": "x86_64"
+      },
+      "python-schedutils": {
+        "epoch": "0",
+        "version": "0.4",
+        "release": "6.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "apache-commons-jexl": {
+        "epoch": "0",
+        "version": "2.1.1",
+        "release": "9.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "python-ipaddress": {
+        "epoch": "0",
+        "version": "1.0.16",
+        "release": "2.el7",
+        "installdate": "1584625427",
+        "arch": "noarch"
+      },
+      "libssh2": {
+        "epoch": "0",
+        "version": "1.8.0",
+        "release": "3.el7",
+        "installdate": "1584455020",
+        "arch": "x86_64"
+      },
+      "jsch": {
+        "epoch": "0",
+        "version": "0.1.50",
+        "release": "5.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "apr-util": {
+        "epoch": "0",
+        "version": "1.5.2",
+        "release": "6.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "openssl": {
+        "epoch": "1",
+        "version": "1.0.2k",
+        "release": "19.el7",
+        "installdate": "1584455021",
+        "arch": "x86_64"
+      },
+      "antlr-tool": {
+        "epoch": "0",
+        "version": "2.7.7",
+        "release": "30.el7",
+        "installdate": "1584625539",
+        "arch": "noarch"
+      },
+      "python-psycopg2": {
+        "epoch": "0",
+        "version": "2.5.1",
+        "release": "4.el7",
+        "installdate": "1584625428",
+        "arch": "x86_64"
+      },
+      "junit": {
+        "epoch": "0",
+        "version": "4.11",
+        "release": "8.el7",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "fontpackages-filesystem": {
+        "epoch": "0",
+        "version": "1.44",
+        "release": "8.el7",
+        "installdate": "1584625428",
+        "arch": "noarch"
+      },
+      "xpp3": {
+        "epoch": "0",
+        "version": "1.1.3.8",
+        "release": "11.el7",
+        "installdate": "1584625540",
+        "arch": "noarch"
+      },
+      "python-webob": {
+        "epoch": "0",
+        "version": "1.2.3",
+        "release": "7.el7",
+        "installdate": "1584625429",
+        "arch": "noarch"
+      },
+      "libuser": {
+        "epoch": "0",
+        "version": "0.60",
+        "release": "9.el7",
+        "installdate": "1584455024",
+        "arch": "x86_64"
+      },
+      "ws-jaxme": {
+        "epoch": "0",
+        "version": "0.5.2",
+        "release": "10.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "ovirt-vmconsole": {
+        "epoch": "0",
+        "version": "1.0.7",
+        "release": "2.el7",
+        "installdate": "1584625429",
+        "arch": "noarch"
+      },
+      "centos-logos": {
+        "epoch": "0",
+        "version": "70.0.6",
+        "release": "3.el7.centos",
+        "installdate": "1584455048",
+        "arch": "noarch"
+      },
+      "apache-commons-jxpath": {
+        "epoch": "0",
+        "version": "1.3",
+        "release": "20.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "rh-postgresql10-postgresql-libs": {
+        "epoch": "0",
+        "version": "10.6",
+        "release": "1.el7",
+        "installdate": "1584625453",
+        "arch": "x86_64"
+      },
+      "libseccomp": {
+        "epoch": "0",
+        "version": "2.3.1",
+        "release": "3.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "slf4j": {
+        "epoch": "0",
+        "version": "1.7.4",
+        "release": "4.el7_4",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "liblognorm": {
+        "epoch": "0",
+        "version": "2.0.2",
+        "release": "3.el7",
+        "installdate": "1584625464",
+        "arch": "x86_64"
+      },
+      "lsscsi": {
+        "epoch": "0",
+        "version": "0.27",
+        "release": "6.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "aopalliance": {
+        "epoch": "0",
+        "version": "1.0",
+        "release": "8.el7",
+        "installdate": "1584625541",
+        "arch": "noarch"
+      },
+      "libgfortran": {
+        "epoch": "0",
+        "version": "4.8.5",
+        "release": "39.el7",
+        "installdate": "1584625465",
+        "arch": "x86_64"
+      },
+      "pth": {
+        "epoch": "0",
+        "version": "2.0.7",
+        "release": "23.el7",
+        "installdate": "1584455049",
+        "arch": "x86_64"
+      },
+      "apache-commons-vfs": {
+        "epoch": "0",
+        "version": "2.0",
+        "release": "11.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "atlas": {
+        "epoch": "0",
+        "version": "3.10.1",
+        "release": "12.el7",
+        "installdate": "1584625466",
+        "arch": "x86_64"
+      },
+      "gpgme": {
+        "epoch": "0",
+        "version": "1.3.2",
+        "release": "5.el7",
+        "installdate": "1584455051",
+        "arch": "x86_64"
+      },
+      "hystrix-metrics-event-stream": {
+        "epoch": "0",
+        "version": "1.4.21",
+        "release": "6.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "rsyslog-mmnormalize": {
+        "epoch": "0",
+        "version": "8.24.0",
+        "release": "41.el7_7.4",
+        "installdate": "1584625470",
+        "arch": "x86_64"
+      },
+      "json-c": {
+        "epoch": "0",
+        "version": "0.11",
+        "release": "4.el7_0",
+        "installdate": "1584455052",
+        "arch": "x86_64"
+      },
+      "jackson": {
+        "epoch": "0",
+        "version": "1.9.4",
+        "release": "7.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "collectd-write_http": {
+        "epoch": "0",
+        "version": "5.10.0",
+        "release": "2.el7",
+        "installdate": "1584625475",
+        "arch": "x86_64"
+      },
+      "openstack-java-keystone-model": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "dejavu-fonts-common": {
+        "epoch": "0",
+        "version": "2.33",
+        "release": "6.el7",
+        "installdate": "1584625475",
+        "arch": "noarch"
+      },
+      "openstack-java-quantum-client": {
+        "epoch": "0",
+        "version": "3.2.7",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "httpd-tools": {
+        "epoch": "0",
+        "version": "2.4.6",
+        "release": "90.el7.centos",
+        "installdate": "1584625477",
+        "arch": "x86_64"
+      },
+      "python-httplib2": {
+        "epoch": "0",
+        "version": "0.9.2",
+        "release": "1.el7",
+        "installdate": "1584625544",
+        "arch": "noarch"
+      },
+      "python-lxml": {
+        "epoch": "0",
+        "version": "3.2.1",
+        "release": "4.el7",
+        "installdate": "1584625479",
+        "arch": "x86_64"
+      },
+      "polkit-pkla-compat": {
+        "epoch": "0",
+        "version": "0.1",
+        "release": "4.el7",
+        "installdate": "1584455062",
+        "arch": "x86_64"
+      },
+      "nfs-utils": {
+        "epoch": "1",
+        "version": "1.3.0",
+        "release": "0.65.el7",
+        "installdate": "1584625545",
+        "arch": "x86_64"
+      },
+      "tomcat-servlet-3.0-api": {
+        "epoch": "0",
+        "version": "7.0.76",
+        "release": "11.el7_7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "ovirt-engine-dwh": {
+        "epoch": "0",
+        "version": "4.3.8",
+        "release": "1.el7",
+        "installdate": "1584625546",
+        "arch": "noarch"
+      },
+      "stax2-api": {
+        "epoch": "0",
+        "version": "3.1.1",
+        "release": "10.el7",
+        "installdate": "1584625479",
+        "arch": "noarch"
+      },
+      "os-prober": {
+        "epoch": "0",
+        "version": "1.58",
+        "release": "9.el7",
+        "installdate": "1584455065",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-websocket-proxy": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625547",
+        "arch": "noarch"
+      },
+      "glusterfs-api": {
+        "epoch": "0",
+        "version": "6.8",
+        "release": "1.el7",
+        "installdate": "1584625480",
+        "arch": "x86_64"
+      },
+      "crontabs": {
+        "epoch": "0",
+        "version": "1.11",
+        "release": "6.20121102git.el7",
+        "installdate": "1584455067",
+        "arch": "noarch"
+      },
+      "python-jinja2": {
+        "epoch": "0",
+        "version": "2.7.2",
+        "release": "4.el7",
+        "installdate": "1584625547",
+        "arch": "noarch"
+      },
+      "perl-podlators": {
+        "epoch": "0",
+        "version": "2.5.1",
+        "release": "3.el7",
+        "installdate": "1584625480",
+        "arch": "noarch"
+      },
+      "openssh": {
+        "epoch": "0",
+        "version": "7.4p1",
+        "release": "21.el7",
+        "installdate": "1584455070",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-vm-infra": {
+        "epoch": "0",
+        "version": "1.1.22",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Encode": {
+        "epoch": "0",
+        "version": "2.51",
+        "release": "7.el7",
+        "installdate": "1584625480",
+        "arch": "x86_64"
+      },
+      "grub2-tools-extra": {
+        "epoch": "1",
+        "version": "2.02",
+        "release": "0.80.el7.centos",
+        "installdate": "1584455071",
+        "arch": "x86_64"
+      },
+      "ovirt-ansible-shutdown-env": {
+        "epoch": "0",
+        "version": "1.0.3",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Storable": {
+        "epoch": "0",
+        "version": "2.45",
+        "release": "3.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "v2v-conversion-host-ansible": {
+        "epoch": "0",
+        "version": "1.16.0",
+        "release": "1.el7",
+        "installdate": "1584625569",
+        "arch": "noarch"
+      },
+      "perl-Time-Local": {
+        "epoch": "0",
+        "version": "1.2300",
+        "release": "2.el7",
+        "installdate": "1584625481",
+        "arch": "noarch"
+      },
+      "ebtables": {
+        "epoch": "0",
+        "version": "2.0.10",
+        "release": "16.el7",
+        "installdate": "1584455078",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-setup-plugin-vmconsole-proxy-helper": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584625570",
+        "arch": "noarch"
+      },
+      "perl-Socket": {
+        "epoch": "0",
+        "version": "2.010",
+        "release": "4.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "teamd": {
+        "epoch": "0",
+        "version": "1.27",
+        "release": "9.el7",
+        "installdate": "1584455080",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-api-explorer": {
+        "epoch": "0",
+        "version": "0.0.5",
+        "release": "1.el7",
+        "installdate": "1584625589",
+        "arch": "noarch"
+      },
+      "perl-PathTools": {
+        "epoch": "0",
+        "version": "3.40",
+        "release": "5.el7",
+        "installdate": "1584625481",
+        "arch": "x86_64"
+      },
+      "ovirt-engine-dbscripts": {
+        "epoch": "0",
+        "version": "4.3.9.3",
+        "release": "1.el7",
+        "installdate": "1584626966",
+        "arch": "noarch"
+      },
+      "perl": {
+        "epoch": "4",
+        "version": "5.16.3",
+        "release": "294.el7_6",
+        "installdate": "1584625484",
+        "arch": "x86_64"
+      },
+      "plymouth": {
+        "epoch": "0",
+        "version": "0.8.9",
+        "release": "0.32.20140113.el7.centos",
+        "installdate": "1584455081",
+        "arch": "x86_64"
+      },
+      "python-kitchen": {
+        "epoch": "0",
+        "version": "1.1.1",
+        "release": "5.el7",
+        "installdate": "1588520431",
+        "arch": "noarch"
+      },
+      "libtiff": {
+        "epoch": "0",
+        "version": "4.0.3",
+        "release": "32.el7",
+        "installdate": "1584625484",
+        "arch": "x86_64"
+      },
+      "python2-otopi": {
+        "epoch": "0",
+        "version": "1.8.4",
+        "release": "1.el7",
+        "installdate": "1584625485",
+        "arch": "noarch"
+      }
+    },
+    "root_group": "root",
+    "shard_seed": 146224395,
+    "shells": [
+      "/bin/sh",
+      "/bin/bash",
+      "/usr/bin/sh",
+      "/usr/bin/bash"
+    ],
+    "sysconf": {
+      "LINK_MAX": 2147483647,
+      "_POSIX_LINK_MAX": 2147483647,
+      "MAX_CANON": 255,
+      "_POSIX_MAX_CANON": 255,
+      "MAX_INPUT": 255,
+      "_POSIX_MAX_INPUT": 255,
+      "NAME_MAX": 255,
+      "_POSIX_NAME_MAX": 255,
+      "PATH_MAX": 4096,
+      "_POSIX_PATH_MAX": 4096,
+      "PIPE_BUF": 4096,
+      "_POSIX_PIPE_BUF": 4096,
+      "SOCK_MAXBUF": null,
+      "_POSIX_ASYNC_IO": null,
+      "_POSIX_CHOWN_RESTRICTED": 1,
+      "_POSIX_NO_TRUNC": 1,
+      "_POSIX_PRIO_IO": null,
+      "_POSIX_SYNC_IO": null,
+      "_POSIX_VDISABLE": 0,
+      "ARG_MAX": 2097152,
+      "ATEXIT_MAX": 2147483647,
+      "CHAR_BIT": 8,
+      "CHAR_MAX": 127,
+      "CHAR_MIN": -128,
+      "CHILD_MAX": 192398,
+      "CLK_TCK": 100,
+      "INT_MAX": 2147483647,
+      "INT_MIN": -2147483648,
+      "IOV_MAX": 1024,
+      "LOGNAME_MAX": 256,
+      "LONG_BIT": 64,
+      "MB_LEN_MAX": 16,
+      "NGROUPS_MAX": 65536,
+      "NL_ARGMAX": 4096,
+      "NL_LANGMAX": 2048,
+      "NL_MSGMAX": 2147483647,
+      "NL_NMAX": 2147483647,
+      "NL_SETMAX": 2147483647,
+      "NL_TEXTMAX": 2147483647,
+      "NSS_BUFLEN_GROUP": 1024,
+      "NSS_BUFLEN_PASSWD": 1024,
+      "NZERO": 20,
+      "OPEN_MAX": 1024,
+      "PAGESIZE": 4096,
+      "PAGE_SIZE": 4096,
+      "PASS_MAX": 8192,
+      "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+      "PTHREAD_KEYS_MAX": 1024,
+      "PTHREAD_STACK_MIN": 16384,
+      "PTHREAD_THREADS_MAX": null,
+      "SCHAR_MAX": 127,
+      "SCHAR_MIN": -128,
+      "SHRT_MAX": 32767,
+      "SHRT_MIN": -32768,
+      "SSIZE_MAX": 32767,
+      "TTY_NAME_MAX": 32,
+      "TZNAME_MAX": 6,
+      "UCHAR_MAX": 255,
+      "UINT_MAX": 4294967295,
+      "UIO_MAXIOV": 1024,
+      "ULONG_MAX": 18446744073709551615,
+      "USHRT_MAX": 65535,
+      "WORD_BIT": 32,
+      "_AVPHYS_PAGES": 11033070,
+      "_NPROCESSORS_CONF": 24,
+      "_NPROCESSORS_ONLN": 24,
+      "_PHYS_PAGES": 12320055,
+      "_POSIX_ARG_MAX": 2097152,
+      "_POSIX_ASYNCHRONOUS_IO": 200809,
+      "_POSIX_CHILD_MAX": 192398,
+      "_POSIX_FSYNC": 200809,
+      "_POSIX_JOB_CONTROL": 1,
+      "_POSIX_MAPPED_FILES": 200809,
+      "_POSIX_MEMLOCK": 200809,
+      "_POSIX_MEMLOCK_RANGE": 200809,
+      "_POSIX_MEMORY_PROTECTION": 200809,
+      "_POSIX_MESSAGE_PASSING": 200809,
+      "_POSIX_NGROUPS_MAX": 65536,
+      "_POSIX_OPEN_MAX": 1024,
+      "_POSIX_PII": null,
+      "_POSIX_PII_INTERNET": null,
+      "_POSIX_PII_INTERNET_DGRAM": null,
+      "_POSIX_PII_INTERNET_STREAM": null,
+      "_POSIX_PII_OSI": null,
+      "_POSIX_PII_OSI_CLTS": null,
+      "_POSIX_PII_OSI_COTS": null,
+      "_POSIX_PII_OSI_M": null,
+      "_POSIX_PII_SOCKET": null,
+      "_POSIX_PII_XTI": null,
+      "_POSIX_POLL": null,
+      "_POSIX_PRIORITIZED_IO": 200809,
+      "_POSIX_PRIORITY_SCHEDULING": 200809,
+      "_POSIX_REALTIME_SIGNALS": 200809,
+      "_POSIX_SAVED_IDS": 1,
+      "_POSIX_SELECT": null,
+      "_POSIX_SEMAPHORES": 200809,
+      "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+      "_POSIX_SSIZE_MAX": 32767,
+      "_POSIX_STREAM_MAX": 16,
+      "_POSIX_SYNCHRONIZED_IO": 200809,
+      "_POSIX_THREADS": 200809,
+      "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+      "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+      "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+      "_POSIX_THREAD_PRIO_INHERIT": 200809,
+      "_POSIX_THREAD_PRIO_PROTECT": 200809,
+      "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+      "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+      "_POSIX_THREAD_PROCESS_SHARED": 200809,
+      "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+      "_POSIX_TIMERS": 200809,
+      "TIMER_MAX": null,
+      "_POSIX_TZNAME_MAX": 6,
+      "_POSIX_VERSION": 200809,
+      "_T_IOV_MAX": null,
+      "_XOPEN_CRYPT": 1,
+      "_XOPEN_ENH_I18N": 1,
+      "_XOPEN_LEGACY": 1,
+      "_XOPEN_REALTIME": 1,
+      "_XOPEN_REALTIME_THREADS": 1,
+      "_XOPEN_SHM": 1,
+      "_XOPEN_UNIX": 1,
+      "_XOPEN_VERSION": 700,
+      "_XOPEN_XCU_VERSION": 4,
+      "_XOPEN_XPG2": 1,
+      "_XOPEN_XPG3": 1,
+      "_XOPEN_XPG4": 1,
+      "BC_BASE_MAX": 99,
+      "BC_DIM_MAX": 2048,
+      "BC_SCALE_MAX": 99,
+      "BC_STRING_MAX": 1000,
+      "CHARCLASS_NAME_MAX": 2048,
+      "COLL_WEIGHTS_MAX": 255,
+      "EQUIV_CLASS_MAX": null,
+      "EXPR_NEST_MAX": 32,
+      "LINE_MAX": 2048,
+      "POSIX2_BC_BASE_MAX": 99,
+      "POSIX2_BC_DIM_MAX": 2048,
+      "POSIX2_BC_SCALE_MAX": 99,
+      "POSIX2_BC_STRING_MAX": 1000,
+      "POSIX2_CHAR_TERM": 200809,
+      "POSIX2_COLL_WEIGHTS_MAX": 255,
+      "POSIX2_C_BIND": 200809,
+      "POSIX2_C_DEV": 200809,
+      "POSIX2_C_VERSION": null,
+      "POSIX2_EXPR_NEST_MAX": 32,
+      "POSIX2_FORT_DEV": null,
+      "POSIX2_FORT_RUN": null,
+      "_POSIX2_LINE_MAX": 2048,
+      "POSIX2_LINE_MAX": 2048,
+      "POSIX2_LOCALEDEF": 200809,
+      "POSIX2_RE_DUP_MAX": 32767,
+      "POSIX2_SW_DEV": 200809,
+      "POSIX2_UPE": null,
+      "POSIX2_VERSION": 200809,
+      "RE_DUP_MAX": 32767,
+      "PATH": "/usr/bin",
+      "CS_PATH": "/usr/bin",
+      "LFS_CFLAGS": null,
+      "LFS_LDFLAGS": null,
+      "LFS_LIBS": null,
+      "LFS_LINTFLAGS": null,
+      "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+      "LFS64_LDFLAGS": null,
+      "LFS64_LIBS": null,
+      "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+      "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+      "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+      "_XBS5_ILP32_OFF32": null,
+      "XBS5_ILP32_OFF32_CFLAGS": null,
+      "XBS5_ILP32_OFF32_LDFLAGS": null,
+      "XBS5_ILP32_OFF32_LIBS": null,
+      "XBS5_ILP32_OFF32_LINTFLAGS": null,
+      "_XBS5_ILP32_OFFBIG": null,
+      "XBS5_ILP32_OFFBIG_CFLAGS": null,
+      "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+      "XBS5_ILP32_OFFBIG_LIBS": null,
+      "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+      "_XBS5_LP64_OFF64": 1,
+      "XBS5_LP64_OFF64_CFLAGS": "-m64",
+      "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+      "XBS5_LP64_OFF64_LIBS": null,
+      "XBS5_LP64_OFF64_LINTFLAGS": null,
+      "_XBS5_LPBIG_OFFBIG": null,
+      "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+      "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+      "XBS5_LPBIG_OFFBIG_LIBS": null,
+      "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+      "_POSIX_V6_ILP32_OFF32": null,
+      "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+      "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+      "POSIX_V6_ILP32_OFF32_LIBS": null,
+      "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+      "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+      "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+      "_POSIX_V6_ILP32_OFFBIG": null,
+      "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+      "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+      "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+      "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+      "_POSIX_V6_LP64_OFF64": 1,
+      "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+      "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+      "POSIX_V6_LP64_OFF64_LIBS": null,
+      "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+      "_POSIX_V6_LPBIG_OFFBIG": null,
+      "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+      "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+      "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+      "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+      "_POSIX_V7_ILP32_OFF32": null,
+      "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+      "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+      "POSIX_V7_ILP32_OFF32_LIBS": null,
+      "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+      "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+      "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+      "_POSIX_V7_ILP32_OFFBIG": null,
+      "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+      "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+      "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+      "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+      "_POSIX_V7_LP64_OFF64": 1,
+      "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+      "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+      "POSIX_V7_LP64_OFF64_LIBS": null,
+      "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+      "_POSIX_V7_LPBIG_OFFBIG": null,
+      "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+      "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+      "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+      "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+      "_POSIX_ADVISORY_INFO": 200809,
+      "_POSIX_BARRIERS": 200809,
+      "_POSIX_BASE": null,
+      "_POSIX_C_LANG_SUPPORT": null,
+      "_POSIX_C_LANG_SUPPORT_R": null,
+      "_POSIX_CLOCK_SELECTION": 200809,
+      "_POSIX_CPUTIME": 200809,
+      "_POSIX_THREAD_CPUTIME": 200809,
+      "_POSIX_DEVICE_SPECIFIC": null,
+      "_POSIX_DEVICE_SPECIFIC_R": null,
+      "_POSIX_FD_MGMT": null,
+      "_POSIX_FIFO": null,
+      "_POSIX_PIPE": null,
+      "_POSIX_FILE_ATTRIBUTES": null,
+      "_POSIX_FILE_LOCKING": null,
+      "_POSIX_FILE_SYSTEM": null,
+      "_POSIX_MONOTONIC_CLOCK": 200809,
+      "_POSIX_MULTI_PROCESS": null,
+      "_POSIX_SINGLE_PROCESS": null,
+      "_POSIX_NETWORKING": null,
+      "_POSIX_READER_WRITER_LOCKS": 200809,
+      "_POSIX_SPIN_LOCKS": 200809,
+      "_POSIX_REGEXP": 1,
+      "_REGEX_VERSION": null,
+      "_POSIX_SHELL": 1,
+      "_POSIX_SIGNALS": null,
+      "_POSIX_SPAWN": 200809,
+      "_POSIX_SPORADIC_SERVER": null,
+      "_POSIX_THREAD_SPORADIC_SERVER": null,
+      "_POSIX_SYSTEM_DATABASE": null,
+      "_POSIX_SYSTEM_DATABASE_R": null,
+      "_POSIX_TIMEOUTS": 200809,
+      "_POSIX_TYPED_MEMORY_OBJECTS": null,
+      "_POSIX_USER_GROUPS": null,
+      "_POSIX_USER_GROUPS_R": null,
+      "POSIX2_PBS": null,
+      "POSIX2_PBS_ACCOUNTING": null,
+      "POSIX2_PBS_LOCATE": null,
+      "POSIX2_PBS_TRACK": null,
+      "POSIX2_PBS_MESSAGE": null,
+      "SYMLOOP_MAX": null,
+      "STREAM_MAX": 16,
+      "AIO_LISTIO_MAX": null,
+      "AIO_MAX": null,
+      "AIO_PRIO_DELTA_MAX": 20,
+      "DELAYTIMER_MAX": 2147483647,
+      "HOST_NAME_MAX": 64,
+      "LOGIN_NAME_MAX": 256,
+      "MQ_OPEN_MAX": null,
+      "MQ_PRIO_MAX": 32768,
+      "_POSIX_DEVICE_IO": null,
+      "_POSIX_TRACE": null,
+      "_POSIX_TRACE_EVENT_FILTER": null,
+      "_POSIX_TRACE_INHERIT": null,
+      "_POSIX_TRACE_LOG": null,
+      "RTSIG_MAX": 32,
+      "SEM_NSEMS_MAX": null,
+      "SEM_VALUE_MAX": 2147483647,
+      "SIGQUEUE_MAX": 192398,
+      "FILESIZEBITS": 64,
+      "POSIX_ALLOC_SIZE_MIN": 4096,
+      "POSIX_REC_INCR_XFER_SIZE": null,
+      "POSIX_REC_MAX_XFER_SIZE": null,
+      "POSIX_REC_MIN_XFER_SIZE": 4096,
+      "POSIX_REC_XFER_ALIGN": 4096,
+      "SYMLINK_MAX": null,
+      "GNU_LIBC_VERSION": "glibc 2.17",
+      "GNU_LIBPTHREAD_VERSION": "NPTL 2.17",
+      "POSIX2_SYMLINKS": 1,
+      "LEVEL1_ICACHE_SIZE": 32768,
+      "LEVEL1_ICACHE_ASSOC": 4,
+      "LEVEL1_ICACHE_LINESIZE": 64,
+      "LEVEL1_DCACHE_SIZE": 32768,
+      "LEVEL1_DCACHE_ASSOC": 8,
+      "LEVEL1_DCACHE_LINESIZE": 64,
+      "LEVEL2_CACHE_SIZE": 262144,
+      "LEVEL2_CACHE_ASSOC": 8,
+      "LEVEL2_CACHE_LINESIZE": 64,
+      "LEVEL3_CACHE_SIZE": 12582912,
+      "LEVEL3_CACHE_ASSOC": 16,
+      "LEVEL3_CACHE_LINESIZE": 64,
+      "LEVEL4_CACHE_SIZE": 0,
+      "LEVEL4_CACHE_ASSOC": 0,
+      "LEVEL4_CACHE_LINESIZE": 0,
+      "IPV6": 200809,
+      "RAW_SOCKETS": 200809
+    },
+    "time": {
+      "timezone": "EDT"
+    }
+  }

--- a/test/static_fixtures/facts/chef_centos_8.json
+++ b/test/static_fixtures/facts/chef_centos_8.json
@@ -1,0 +1,10445 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "4.18.0-305.19.1.el8_4.x86_64",
+    "version": "#1 SMP Wed Sep 15 15:39:39 UTC 2021",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "nft_reject_inet": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "nf_reject_ipv4": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nf_reject_ipv6": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nft_reject": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "nft_ct": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "nft_chain_nat": {
+        "size": "16384",
+        "refcount": "8"
+      },
+      "nf_nat": {
+        "size": "45056",
+        "refcount": "1"
+      },
+      "nf_conntrack": {
+        "size": "172032",
+        "refcount": "2"
+      },
+      "nf_defrag_ipv6": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "nf_defrag_ipv4": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip_set": {
+        "size": "49152",
+        "refcount": "0"
+      },
+      "nf_tables": {
+        "size": "172032",
+        "refcount": "4"
+      },
+      "nfnetlink": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "snd_hda_codec_generic": {
+        "size": "90112",
+        "refcount": "1"
+      },
+      "ledtrig_audio": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_hda_intel": {
+        "size": "49152",
+        "refcount": "0"
+      },
+      "snd_intel_dspcfg": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "soundwire_intel": {
+        "size": "40960",
+        "refcount": "1"
+      },
+      "soundwire_generic_allocation": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_soc_core": {
+        "size": "282624",
+        "refcount": "1"
+      },
+      "snd_compress": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "soundwire_cadence": {
+        "size": "32768",
+        "refcount": "1"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "soundwire_bus": {
+        "size": "86016",
+        "refcount": "3"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "snd_hda_codec": {
+        "size": "151552",
+        "refcount": "2"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "snd_hda_core": {
+        "size": "94208",
+        "refcount": "3"
+      },
+      "snd_hwdep": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_pcm": {
+        "size": "114688",
+        "refcount": "6"
+      },
+      "snd_timer": {
+        "size": "40960",
+        "refcount": "1"
+      },
+      "snd": {
+        "size": "94208",
+        "refcount": "8"
+      },
+      "pcspkr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "virtio_balloon": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "soundcore": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "i2c_piix4": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "xfs": {
+        "size": "1515520",
+        "refcount": "2"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "4"
+      },
+      "sr_mod": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "cdrom": {
+        "size": "65536",
+        "refcount": "1"
+      },
+      "sd_mod": {
+        "size": "53248",
+        "refcount": "3"
+      },
+      "t10_pi": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sg": {
+        "size": "40960",
+        "refcount": "0",
+        "version": "3.5.36"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0",
+        "version": "0.2.15"
+      },
+      "qxl": {
+        "size": "73728",
+        "refcount": "0"
+      },
+      "drm_ttm_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ttm": {
+        "size": "114688",
+        "refcount": "2"
+      },
+      "drm_kms_helper": {
+        "size": "233472",
+        "refcount": "3"
+      },
+      "syscopyarea": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "8139too": {
+        "size": "40960",
+        "refcount": "0",
+        "version": "0.9.28"
+      },
+      "ata_piix": {
+        "size": "36864",
+        "refcount": "2",
+        "version": "2.13"
+      },
+      "sysfillrect": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysimgblt": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "fb_sys_fops": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "drm": {
+        "size": "569344",
+        "refcount": "5"
+      },
+      "libata": {
+        "size": "270336",
+        "refcount": "2",
+        "version": "3.00"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "virtio_console": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "8139cp": {
+        "size": "36864",
+        "refcount": "0",
+        "version": "1.3"
+      },
+      "mii": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "dm_mirror": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "dm_region_hash": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "dm_log": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "dm_mod": {
+        "size": "151552",
+        "refcount": "8"
+      },
+      "fuse": {
+        "size": "151552",
+        "refcount": "1"
+      }
+    }
+  },
+  "memory": {
+    "swap": {
+      "cached": "280280kB",
+      "total": "4194300kB",
+      "free": "2984768kB"
+    },
+    "hugepages": {
+      "total": "0",
+      "free": "0",
+      "reserved": "0",
+      "surplus": "0"
+    },
+    "directmap": {
+      "4k": "282496kB",
+      "2M": "10203136kB",
+      "1G": "2097152kB"
+    },
+    "total": "10018628kB",
+    "free": "445748kB",
+    "available": "1161784kB",
+    "buffers": "3172kB",
+    "cached": "947816kB",
+    "active": "1816824kB",
+    "inactive": "7303812kB",
+    "dirty": "204kB",
+    "writeback": "0kB",
+    "anon_pages": "7898568kB",
+    "mapped": "157020kB",
+    "slab": "253004kB",
+    "slab_reclaimable": "134880kB",
+    "slab_unreclaim": "118124kB",
+    "page_tables": "77044kB",
+    "nfs_unstable": "0kB",
+    "bounce": "0kB",
+    "commit_limit": "9203612kB",
+    "committed_as": "13120452kB",
+    "vmalloc_total": "34359738367kB",
+    "vmalloc_used": "0kB",
+    "vmalloc_chunk": "0kB",
+    "hugepage_size": "2048kB",
+    "hugetlb": "0kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ]
+          }
+        },
+        "state": "unknown",
+        "routes": [
+          {
+            "destination": "::1",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ]
+      },
+      "ens3": {
+        "type": "ens",
+        "number": "3",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "52:54:00:2A:FA:7A": {
+            "family": "lladdr"
+          },
+          "192.168.88.15": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "192.168.88.255",
+            "scope": "Global"
+          },
+          "fe80::5054:ff:fe2a:fa7a": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+              "noprefixroute"
+            ]
+          }
+        },
+        "state": "up",
+        "arp": {
+          "192.168.88.248": "04:d3:b0:c3:a1:db",
+          "192.168.88.30": "e4:5f:01:2a:62:53",
+          "192.168.88.1": "08:55:31:bc:a1:ad"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "192.168.88.1",
+            "metric": "100",
+            "proto": "dhcp"
+          },
+          {
+            "destination": "192.168.88.0/24",
+            "family": "inet",
+            "scope": "link",
+            "metric": "100",
+            "proto": "kernel",
+            "src": "192.168.88.15"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "100",
+            "proto": "kernel"
+          }
+        ],
+        "link_speed": 100,
+        "duplex": "Full",
+        "auto_negotiation": "on",
+        "port": "MII",
+        "transceiver": "internal",
+        "ring_params": {
+          "max_rx": 64,
+          "max_rx_mini": 0,
+          "max_rx_jumbo": 0,
+          "max_tx": 64,
+          "current_rx": 64,
+          "current_rx_mini": 0,
+          "current_rx_jumbo": 0,
+          "current_tx": 64
+        }
+      }
+    },
+    "default_interface": "ens3",
+    "default_gateway": "192.168.88.1"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1000",
+            "bytes": "1062942167",
+            "packets": "6486111",
+            "errors": "0",
+            "drop": "0",
+            "carrier": "0",
+            "collisions": "0"
+          },
+          "rx": {
+            "bytes": "1062942167",
+            "packets": "6486111",
+            "errors": "0",
+            "drop": "0",
+            "overrun": "0"
+          }
+        },
+        "ens3": {
+          "tx": {
+            "queuelen": "1000",
+            "bytes": "301954062",
+            "packets": "844611",
+            "errors": "0",
+            "drop": "0",
+            "carrier": "0",
+            "collisions": "4321866"
+          },
+          "rx": {
+            "bytes": "802284466",
+            "packets": "1214923",
+            "errors": "0",
+            "drop": "0",
+            "overrun": "0"
+          }
+        }
+      }
+    }
+  },
+  "ipaddress": "192.168.88.15",
+  "macaddress": "52:54:00:2A:FA:7A",
+  "ip6address": "fe80::5054:ff:fe2a:fa7a",
+  "lsb": {
+
+  },
+  "os": "linux",
+  "os_version": "4.18.0-305.19.1.el8_4.x86_64",
+  "platform": "centos",
+  "platform_version": "8.4.2105",
+  "platform_family": "rhel",
+  "uptime_seconds": 178001,
+  "uptime": "2 days 01 hours 26 minutes 41 seconds",
+  "idletime_seconds": 1054639,
+  "idletime": "12 days 04 hours 57 minutes 19 seconds",
+  "dmi": {
+    "dmidecode_version": "3.2",
+    "smbios_version": "2.8",
+    "structures": {
+      "count": "10",
+      "size": "483"
+    },
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "SeaBIOS",
+          "Version": "1.11.0-2.el7",
+          "Release Date": "04/01/2014",
+          "Address": "0xE8000",
+          "Runtime Size": "96 kB",
+          "ROM Size": "64 kB",
+          "Characteristics": {
+            "BIOS characteristics not supported": null,
+            "Targeted content distribution is supported": null
+          },
+          "BIOS Revision": "0.0"
+        }
+      ],
+      "vendor": "SeaBIOS",
+      "version": "1.11.0-2.el7",
+      "release_date": "04/01/2014",
+      "address": "0xE8000",
+      "runtime_size": "96 kB",
+      "rom_size": "64 kB",
+      "bios_revision": "0.0"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0100",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "Red Hat",
+          "Product Name": "KVM",
+          "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+          "Serial Number": "Not Specified",
+          "UUID": "5d33f1d4-5b77-4d26-b22a-76ffcc26d275",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Red Hat Enterprise Linux"
+        }
+      ],
+      "manufacturer": "Red Hat",
+      "product_name": "KVM",
+      "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+      "serial_number": "Not Specified",
+      "uuid": "5d33f1d4-5b77-4d26-b22a-76ffcc26d275",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Red Hat Enterprise Linux"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0300",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Red Hat",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "Unknown",
+          "OEM Information": "0x00000000",
+          "Height": "Unspecified",
+          "Number Of Power Cords": "Unspecified",
+          "Contained Elements": "0"
+        }
+      ],
+      "manufacturer": "Red Hat",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "Unknown",
+      "oem_information": "0x00000000",
+      "height": "Unspecified",
+      "number_of_power_cords": "Unspecified",
+      "contained_elements": "0"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "record_id": "0x0400",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 0",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "Red Hat",
+          "ID": "C1 06 02 00 FF FB 8B 0F",
+          "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2000 MHz",
+          "Current Speed": "2000 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Part Number": "Not Specified",
+          "Core Count": "3",
+          "Core Enabled": "3",
+          "Thread Count": "2",
+          "Characteristics": "None"
+        }
+      ],
+      "socket_designation": "CPU 0",
+      "type": "Central Processor",
+      "family": "Other",
+      "manufacturer": "Red Hat",
+      "id": "C1 06 02 00 FF FB 8B 0F",
+      "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+      "voltage": "Unknown",
+      "external_clock": "Unknown",
+      "max_speed": "2000 MHz",
+      "current_speed": "2000 MHz",
+      "status": "Populated, Enabled",
+      "upgrade": "Other",
+      "l1_cache_handle": "Not Provided",
+      "l2_cache_handle": "Not Provided",
+      "l3_cache_handle": "Not Provided",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "part_number": "Not Specified",
+      "core_count": "3",
+      "core_enabled": "3",
+      "thread_count": "2",
+      "characteristics": "None"
+    }
+  },
+  "virtualization": {
+    "systems": {
+      "kvm": "guest"
+    },
+    "system": "kvm",
+    "role": "guest"
+  },
+  "languages": {
+    "c": {
+      "glibc": {
+        "version": "2.28.",
+        "description": "GNU C Library (GNU libc) stable release version 2.28."
+      }
+    },
+    "java": {
+      "version": "1.8.0_312",
+      "runtime": {
+        "name": "OpenJDK Runtime Environment",
+        "build": "1.8.0_312-b07"
+      },
+      "hotspot": {
+        "name": "OpenJDK 64-Bit Server VM",
+        "build": "25.312-b07, mixed mode"
+      }
+    },
+    "lua": {
+      "version": "5.3.4"
+    },
+    "nodejs": {
+      "version": "10.24.0"
+    },
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "2.7.4",
+      "release_date": "2021-07-07",
+      "target": "x86_64-redhat-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "redhat",
+      "target_os": "linux",
+      "host": "x86_64-redhat-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux",
+      "host_vendor": "redhat",
+      "bin_dir": "/usr/bin",
+      "ruby_bin": "/usr/bin/ruby",
+      "gems_dir": "/usr/share/gems",
+      "gem_bin": "/usr/bin/gem"
+    }
+  },
+  "chef_packages": {
+    "chef": {
+      "version": "15.14.0",
+      "chef_root": "/opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/chef-15.14.0/lib"
+    },
+    "ohai": {
+      "version": "15.12.0",
+      "ohai_root": "/opt/chefdk/embedded/lib/ruby/gems/2.6.0/gems/ohai-15.12.0/lib/ohai"
+    }
+  },
+  "cloud": null,
+  "command": {
+    "ps": "ps -ef"
+  },
+  "cpu": {
+    "0": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "0",
+      "cores": "3",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "1": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "0",
+      "cores": "3",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "2": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "1",
+      "cores": "3",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "3": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "1",
+      "cores": "3",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "4": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "2",
+      "cores": "3",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "5": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "2",
+      "cores": "3",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "total": 6,
+    "real": 1,
+    "cores": 3
+  },
+  "time": {
+    "timezone": "EDT"
+  },
+  "filesystem": {
+    "by_device": {
+      "devtmpfs": {
+        "kb_size": "4989300",
+        "kb_used": "0",
+        "kb_available": "4989300",
+        "percent_used": "0%",
+        "total_inodes": "1247325",
+        "inodes_used": "394",
+        "inodes_available": "1246931",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4989300k",
+          "nr_inodes=1247325",
+          "mode=755"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "tmpfs": {
+        "kb_size": "1001860",
+        "kb_used": "0",
+        "kb_available": "1001860",
+        "percent_used": "0%",
+        "total_inodes": "1252328",
+        "inodes_used": "62",
+        "inodes_available": "1252266",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=1001860k",
+          "mode=700"
+        ],
+        "mounts": [
+          "/dev/shm",
+          "/run",
+          "/sys/fs/cgroup",
+          "/run/user/0"
+        ]
+      },
+      "/dev/mapper/cl_foreman-root": {
+        "kb_size": "36678148",
+        "kb_used": "5390132",
+        "kb_available": "31288016",
+        "percent_used": "15%",
+        "total_inodes": "18348032",
+        "inodes_used": "219595",
+        "inodes_available": "18128437",
+        "inodes_percent_used": "2%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "d227e051-0a78-4598-a07c-6b1cda2b3cec",
+        "mounts": [
+          "/"
+        ]
+      },
+      "/dev/sda1": {
+        "kb_size": "1038336",
+        "kb_used": "206292",
+        "kb_available": "832044",
+        "percent_used": "20%",
+        "total_inodes": "524288",
+        "inodes_used": "309",
+        "inodes_available": "523979",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "cda15c21-642c-46e7-87d9-3506279a8bcb",
+        "mounts": [
+          "/boot"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "cgroup": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup/systemd",
+          "/sys/fs/cgroup/net_cls,net_prio",
+          "/sys/fs/cgroup/cpuset",
+          "/sys/fs/cgroup/freezer",
+          "/sys/fs/cgroup/devices",
+          "/sys/fs/cgroup/pids",
+          "/sys/fs/cgroup/memory",
+          "/sys/fs/cgroup/perf_event",
+          "/sys/fs/cgroup/cpu,cpuacct",
+          "/sys/fs/cgroup/hugetlb",
+          "/sys/fs/cgroup/rdma",
+          "/sys/fs/cgroup/blkio"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "none": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "selinuxfs": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/selinux"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=40",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=21910"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "/dev/sda": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/sda2": {
+        "fs_type": "LVM2_member",
+        "uuid": "qE9NTM-TAa1-9mSq-bfz1-gnvb-KeDV-fs1qQ9",
+        "mounts": [
+
+        ]
+      },
+      "/dev/sr0": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/mapper/cl_foreman-swap": {
+        "fs_type": "swap",
+        "uuid": "88a8f999-83e4-4bd7-8307-34c312e19c3b",
+        "mounts": [
+
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/dev": {
+        "kb_size": "4989300",
+        "kb_used": "0",
+        "kb_available": "4989300",
+        "percent_used": "0%",
+        "total_inodes": "1247325",
+        "inodes_used": "394",
+        "inodes_available": "1246931",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4989300k",
+          "nr_inodes=1247325",
+          "mode=755"
+        ],
+        "devices": [
+          "devtmpfs"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "5009312",
+        "kb_used": "64",
+        "kb_available": "5009248",
+        "percent_used": "1%",
+        "total_inodes": "1252328",
+        "inodes_used": "2",
+        "inodes_available": "1252326",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run": {
+        "kb_size": "5009312",
+        "kb_used": "17068",
+        "kb_available": "4992244",
+        "percent_used": "1%",
+        "total_inodes": "1252328",
+        "inodes_used": "688",
+        "inodes_available": "1251640",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "mode=755"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "kb_size": "5009312",
+        "kb_used": "0",
+        "kb_available": "5009312",
+        "percent_used": "0%",
+        "total_inodes": "1252328",
+        "inodes_used": "17",
+        "inodes_available": "1252311",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "seclabel",
+          "mode=755"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "36678148",
+        "kb_used": "5390132",
+        "kb_available": "31288016",
+        "percent_used": "15%",
+        "total_inodes": "18348032",
+        "inodes_used": "219595",
+        "inodes_available": "18128437",
+        "inodes_percent_used": "2%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "d227e051-0a78-4598-a07c-6b1cda2b3cec",
+        "devices": [
+          "/dev/mapper/cl_foreman-root"
+        ]
+      },
+      "/boot": {
+        "kb_size": "1038336",
+        "kb_used": "206292",
+        "kb_available": "832044",
+        "percent_used": "20%",
+        "total_inodes": "524288",
+        "inodes_used": "309",
+        "inodes_available": "523979",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "cda15c21-642c-46e7-87d9-3506279a8bcb",
+        "devices": [
+          "/dev/sda1"
+        ]
+      },
+      "/run/user/0": {
+        "kb_size": "1001860",
+        "kb_used": "0",
+        "kb_available": "1001860",
+        "percent_used": "0%",
+        "total_inodes": "1252328",
+        "inodes_used": "62",
+        "inodes_available": "1252266",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=1001860k",
+          "mode=700"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/fs/cgroup/systemd": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "xattr",
+          "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+          "name=systemd"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/sys/fs/cgroup/net_cls,net_prio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "net_cls",
+          "net_prio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/cpuset": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpuset"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/freezer": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "freezer"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/devices": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/pids": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "pids"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/memory": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "memory"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/perf_event": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "perf_event"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/cpu,cpuacct": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpu",
+          "cpuacct"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/hugetlb": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/rdma": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/blkio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/sys/fs/selinux": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "selinuxfs"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=40",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=21910"
+        ],
+        "devices": [
+          "systemd-1"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "fusectl"
+        ]
+      }
+    },
+    "by_pair": {
+      "devtmpfs,/dev": {
+        "device": "devtmpfs",
+        "kb_size": "4989300",
+        "kb_used": "0",
+        "kb_available": "4989300",
+        "percent_used": "0%",
+        "mount": "/dev",
+        "total_inodes": "1247325",
+        "inodes_used": "394",
+        "inodes_available": "1246931",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=4989300k",
+          "nr_inodes=1247325",
+          "mode=755"
+        ]
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "5009312",
+        "kb_used": "64",
+        "kb_available": "5009248",
+        "percent_used": "1%",
+        "mount": "/dev/shm",
+        "total_inodes": "1252328",
+        "inodes_used": "2",
+        "inodes_available": "1252326",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel"
+        ]
+      },
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "5009312",
+        "kb_used": "17068",
+        "kb_available": "4992244",
+        "percent_used": "1%",
+        "mount": "/run",
+        "total_inodes": "1252328",
+        "inodes_used": "688",
+        "inodes_available": "1251640",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "mode=755"
+        ]
+      },
+      "tmpfs,/sys/fs/cgroup": {
+        "device": "tmpfs",
+        "kb_size": "5009312",
+        "kb_used": "0",
+        "kb_available": "5009312",
+        "percent_used": "0%",
+        "mount": "/sys/fs/cgroup",
+        "total_inodes": "1252328",
+        "inodes_used": "17",
+        "inodes_available": "1252311",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "seclabel",
+          "mode=755"
+        ]
+      },
+      "/dev/mapper/cl_foreman-root,/": {
+        "device": "/dev/mapper/cl_foreman-root",
+        "kb_size": "36678148",
+        "kb_used": "5390132",
+        "kb_available": "31288016",
+        "percent_used": "15%",
+        "mount": "/",
+        "total_inodes": "18348032",
+        "inodes_used": "219595",
+        "inodes_available": "18128437",
+        "inodes_percent_used": "2%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "d227e051-0a78-4598-a07c-6b1cda2b3cec"
+      },
+      "/dev/sda1,/boot": {
+        "device": "/dev/sda1",
+        "kb_size": "1038336",
+        "kb_used": "206292",
+        "kb_available": "832044",
+        "percent_used": "20%",
+        "mount": "/boot",
+        "total_inodes": "524288",
+        "inodes_used": "309",
+        "inodes_available": "523979",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "cda15c21-642c-46e7-87d9-3506279a8bcb"
+      },
+      "tmpfs,/run/user/0": {
+        "device": "tmpfs",
+        "kb_size": "1001860",
+        "kb_used": "0",
+        "kb_available": "1001860",
+        "percent_used": "0%",
+        "mount": "/run/user/0",
+        "total_inodes": "1252328",
+        "inodes_used": "62",
+        "inodes_available": "1252266",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=1001860k",
+          "mode=700"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/systemd": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/systemd",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "xattr",
+          "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+          "name=systemd"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/net_cls,net_prio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "net_cls",
+          "net_prio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpuset": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/cpuset",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpuset"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/freezer": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/freezer",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "freezer"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/devices": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/devices",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/pids": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/pids",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "pids"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/memory": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/memory",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "memory"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/perf_event": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/perf_event",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "perf_event"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/cpu,cpuacct",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpu",
+          "cpuacct"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/hugetlb": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/hugetlb",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/rdma": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/rdma",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/blkio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/blkio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ]
+      },
+      "none,/sys/kernel/tracing": {
+        "device": "none",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "selinuxfs,/sys/fs/selinux": {
+        "device": "selinuxfs",
+        "mount": "/sys/fs/selinux",
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=40",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=21910"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ]
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "/dev/sda,": {
+        "device": "/dev/sda"
+      },
+      "/dev/sda2,": {
+        "device": "/dev/sda2",
+        "fs_type": "LVM2_member",
+        "uuid": "qE9NTM-TAa1-9mSq-bfz1-gnvb-KeDV-fs1qQ9"
+      },
+      "/dev/sr0,": {
+        "device": "/dev/sr0"
+      },
+      "/dev/mapper/cl_foreman-swap,": {
+        "device": "/dev/mapper/cl_foreman-swap",
+        "fs_type": "swap",
+        "uuid": "88a8f999-83e4-4bd7-8307-34c312e19c3b"
+      }
+    }
+  },
+  "hostname": "foreman",
+  "machinename": "foreman.cluster.local",
+  "fqdn": "foreman.cluster.local",
+  "domain": "cluster.local",
+  "init_package": "systemd",
+  "keys": {
+    "ssh": {
+      "host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC5FSCrvEZC+ilJZkP9f02AV7TMyfLr6rWSzkfPkKLpkDKcvDl4uM8B8DzzAexoLo08JXIcsgDEJTky/OC8S0cMsN4udgCC4bY5cJyX1Bm1+99N/6uMXXMxiYkRWTVt5ysJQ6fRmGefo6RIy0v+AjTLk7MIwwzpESY2D7JKzN8dGnhfJit3+DFZigLfvGaNFkSF3JiPPNLQXH53SbEUJUdxPsZ+lnmx7daRoZrqsnBGCfmBsbUKbWMFeRknPrAEFF91AE2S5h1J0KbiKTSWlmyKSssGh3DMXOG/YZ3oKY+6DgodGLJymlBxo7wwKydGy2w4Wi0jhGErYRLoJ5/4gkYLG14yFIJqLCDGJmyULl7L04xv7+3we7qJnv/3RPJVHYHQUUK6uhZ4GItuFjNTFxOu+oZFIzhrWoFFFU9iJtBRYHMvYoi4zws0ieDrtRjDEJprLH3UwwSBoVuCaO4dwHblud7eNKvg/ncHkukWWkHzryrlYoWj9rS7XmBgFDLn38k=",
+      "host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBKo3INMUZ/UbvGA4tQzaEAFZjrUwtKHCz4gHk3RjdNVcG1HvvRo9HkLrO9bCt1jorz38JDX5iifPcfYnU/c7tSY=",
+      "host_ecdsa_type": "ecdsa-sha2-nistp256",
+      "host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAIABUOP592JUbSLVfWz3W5VQ90gk0hmnPz9pGwVp2LfcX"
+    }
+  },
+  "block_device": {
+    "dm-1": {
+      "size": "8388608",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "sr0": {
+      "size": "2097151",
+      "removable": "1",
+      "model": "QEMU DVD-ROM",
+      "rev": "2.5+",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "QEMU",
+      "queue_depth": "1",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "dm-0": {
+      "size": "73392128",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "sda": {
+      "size": "83886080",
+      "removable": "0",
+      "model": "QEMU HARDDISK",
+      "rev": "2.5+",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "ATA",
+      "queue_depth": "1",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": false
+    }
+  },
+  "hostnamectl": {
+    "static_hostname": "foreman.cluster.local",
+    "icon_name": "computer-vm",
+    "chassis": "vm",
+    "machine_id": "5d33f1d45b774d26b22a76ffcc26d275",
+    "boot_id": "c5c662f68faf4310a6003d256e6dc552",
+    "virtualization": "kvm",
+    "operating_system": "CentOS Linux 8",
+    "cpe_os_name": "cpe",
+    "kernel": "Linux 4.18.0-305.19.1.el8_4.x86_64",
+    "architecture": "x86-64"
+  },
+  "machine_id": "5d33f1d45b774d26b22a76ffcc26d275",
+  "systemd_paths": {
+    "temporary": "/tmp",
+    "temporary-large": "/var/tmp",
+    "system-binaries": "/usr/bin",
+    "system-include": "/usr/include",
+    "system-library-private": "/usr/lib",
+    "system-library-arch": "/usr/lib64",
+    "system-shared": "/usr/share",
+    "system-configuration-factory": "/usr/share/factory/etc",
+    "system-state-factory": "/usr/share/factory/var",
+    "system-configuration": "/etc",
+    "system-runtime": "/run",
+    "system-runtime-logs": "/run/log",
+    "system-state-private": "/var/lib",
+    "system-state-logs": "/var/log",
+    "system-state-cache": "/var/cache",
+    "system-state-spool": "/var/spool",
+    "user-binaries": "/root/.local/bin",
+    "user-library-private": "/root/.local/lib",
+    "user-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+    "user-shared": "/root/.local/share",
+    "user-configuration": "/root/.config",
+    "user-runtime": "/run/user/0",
+    "user-state-cache": "/root/.cache",
+    "user": "/root",
+    "user-documents": "/root",
+    "user-music": "/root",
+    "user-pictures": "/root",
+    "user-videos": "/root",
+    "user-download": "/root",
+    "user-public": "/root",
+    "user-templates": "/root",
+    "user-desktop": "/root/Desktop",
+    "search-binaries": "/usr/local/sbin",
+    "search-binaries-default": "/usr/local/sbin",
+    "search-library-private": "/root/.local/lib",
+    "search-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+    "search-shared": "/root/.local/share",
+    "search-configuration-factory": "/usr/local/share/factory/etc",
+    "search-state-factory": "/usr/local/share/factory/var",
+    "search-configuration": "/root/.config"
+  },
+  "ohai_time": 1636124469.243534,
+  "packages": {
+    "python3-django-guardian": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "1.el8",
+      "installdate": "1636006059",
+      "arch": "noarch"
+    },
+    "device-mapper-libs": {
+      "epoch": "8",
+      "version": "1.02.175",
+      "release": "5.el8",
+      "installdate": "1635944560",
+      "arch": "x86_64"
+    },
+    "python3-pyjwkest": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "2.el8",
+      "installdate": "1636006587",
+      "arch": "noarch"
+    },
+    "vim-enhanced": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "15.el8",
+      "installdate": "1635944678",
+      "arch": "x86_64"
+    },
+    "python3-pip-wheel": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "19.el8",
+      "installdate": "1635944506",
+      "arch": "noarch"
+    },
+    "python3-pycparser": {
+      "epoch": "0",
+      "version": "2.20",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "noarch"
+    },
+    "trousers-lib": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1635944562",
+      "arch": "x86_64"
+    },
+    "python3-django-readonly-field": {
+      "epoch": "0",
+      "version": "1.0.5",
+      "release": "1.el8",
+      "installdate": "1636006597",
+      "arch": "noarch"
+    },
+    "grub2-pc": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1635944679",
+      "arch": "x86_64"
+    },
+    "publicsuffix-list-dafsa": {
+      "epoch": "0",
+      "version": "20180723",
+      "release": "1.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "python3-markuppy": {
+      "epoch": "0",
+      "version": "1.14",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "dracut": {
+      "epoch": "0",
+      "version": "049",
+      "release": "135.git20210121.el8",
+      "installdate": "1635944564",
+      "arch": "x86_64"
+    },
+    "python3-tenacity": {
+      "epoch": "0",
+      "version": "7.0.0",
+      "release": "1.el8",
+      "installdate": "1636006610",
+      "arch": "noarch"
+    },
+    "xfsdump": {
+      "epoch": "0",
+      "version": "3.1.8",
+      "release": "2.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "firewalld-filesystem": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "7.el8_4",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "python3-diff-match-patch": {
+      "epoch": "0",
+      "version": "20200713",
+      "release": "1.el8",
+      "installdate": "1636006062",
+      "arch": "noarch"
+    },
+    "systemd": {
+      "epoch": "0",
+      "version": "239",
+      "release": "45.el8_4.3",
+      "installdate": "1635944567",
+      "arch": "x86_64"
+    },
+    "python3-markdown": {
+      "epoch": "0",
+      "version": "3.3.4",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "iptstate": {
+      "epoch": "0",
+      "version": "2.2.6",
+      "release": "6.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "filesystem": {
+      "epoch": "0",
+      "version": "3.8",
+      "release": "3.el8",
+      "installdate": "1635944531",
+      "arch": "x86_64"
+    },
+    "python3-chardet": {
+      "epoch": "0",
+      "version": "3.0.4",
+      "release": "7.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "python3-libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "python3-bleach-allowlist": {
+      "epoch": "0",
+      "version": "1.0.3",
+      "release": "1.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "net-tools": {
+      "epoch": "0",
+      "version": "2.0",
+      "release": "0.52.20160912git.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "bash": {
+      "epoch": "0",
+      "version": "4.4.20",
+      "release": "1.el8_4",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "rubygem-i18n": {
+      "epoch": "0",
+      "version": "1.8.2",
+      "release": "2.el8",
+      "installdate": "1636006338",
+      "arch": "noarch"
+    },
+    "gobject-introspection": {
+      "epoch": "0",
+      "version": "1.56.1",
+      "release": "1.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "python3-pulp-ansible": {
+      "epoch": "1",
+      "version": "0.9.0",
+      "release": "2.el8",
+      "installdate": "1636006634",
+      "arch": "noarch"
+    },
+    "ledmon": {
+      "epoch": "0",
+      "version": "0.95",
+      "release": "1.el8",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "libcap": {
+      "epoch": "0",
+      "version": "2.26",
+      "release": "4.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "rubygem-net-ssh": {
+      "epoch": "0",
+      "version": "4.2.0",
+      "release": "3.el8",
+      "installdate": "1636006346",
+      "arch": "noarch"
+    },
+    "rsyslog": {
+      "epoch": "0",
+      "version": "8.1911.0",
+      "release": "7.el8_4.2",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "redis": {
+      "epoch": "0",
+      "version": "5.0.3",
+      "release": "5.module_el8.4.0+955+7126e393",
+      "installdate": "1636007584",
+      "arch": "x86_64"
+    },
+    "bash-completion": {
+      "epoch": "1",
+      "version": "2.7",
+      "release": "5.el8",
+      "installdate": "1635944690",
+      "arch": "noarch"
+    },
+    "elfutils-libelf": {
+      "epoch": "0",
+      "version": "0.182",
+      "release": "3.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-ruby2ruby": {
+      "epoch": "0",
+      "version": "2.4.2",
+      "release": "4.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "cronie-anacron": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "4.el8",
+      "installdate": "1635944579",
+      "arch": "x86_64"
+    },
+    "bc": {
+      "epoch": "0",
+      "version": "1.07.1",
+      "release": "5.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "libbasicobjects": {
+      "epoch": "0",
+      "version": "0.1.1",
+      "release": "39.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-unf_ext": {
+      "epoch": "0",
+      "version": "0.0.7.2",
+      "release": "4.el8",
+      "installdate": "1636006348",
+      "arch": "x86_64"
+    },
+    "gdk-pixbuf2": {
+      "epoch": "0",
+      "version": "2.36.12",
+      "release": "5.el8",
+      "installdate": "1635944581",
+      "arch": "x86_64"
+    },
+    "mtr": {
+      "epoch": "2",
+      "version": "0.92",
+      "release": "3.el8",
+      "installdate": "1635944692",
+      "arch": "x86_64"
+    },
+    "nspr": {
+      "epoch": "0",
+      "version": "4.32.0",
+      "release": "1.el8_4",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-sequel": {
+      "epoch": "0",
+      "version": "5.42.0",
+      "release": "2.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "tpm2-tss": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "3.el8",
+      "installdate": "1635944583",
+      "arch": "x86_64"
+    },
+    "iwl7260-firmware": {
+      "epoch": "1",
+      "version": "25.30.13.0",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "libnl3": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-oauth": {
+      "epoch": "0",
+      "version": "0.5.4",
+      "release": "5.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "18.el8",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "iwl2030-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "6.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-mail": {
+      "epoch": "0",
+      "version": "2.7.1",
+      "release": "2.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "tpm2-tools": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "2.el8",
+      "installdate": "1635944586",
+      "arch": "x86_64"
+    },
+    "foreman-release": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1635946873",
+      "arch": "noarch"
+    },
+    "p11-kit": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-facter": {
+      "epoch": "0",
+      "version": "4.0.51",
+      "release": "2.el8",
+      "installdate": "1636006353",
+      "arch": "x86_64"
+    },
+    "libblockdev-fs": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "python3-libcomps": {
+      "epoch": "0",
+      "version": "0.1.15",
+      "release": "1.el8",
+      "installdate": "1635946986",
+      "arch": "x86_64"
+    },
+    "file": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "16.el8_3.1",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-daemons": {
+      "epoch": "0",
+      "version": "1.2.3",
+      "release": "7.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "iptables-ebtables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "17.el8",
+      "installdate": "1635944599",
+      "arch": "x86_64"
+    },
+    "ruby-libs": {
+      "epoch": "0",
+      "version": "2.7.4",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947072",
+      "arch": "x86_64"
+    },
+    "libpsl": {
+      "epoch": "0",
+      "version": "0.20.2",
+      "release": "6.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-algebrick": {
+      "epoch": "0",
+      "version": "0.7.3",
+      "release": "8.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "python3-libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "6.el8",
+      "installdate": "1635944600",
+      "arch": "x86_64"
+    },
+    "rubygem-psych": {
+      "epoch": "0",
+      "version": "3.1.0",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947073",
+      "arch": "x86_64"
+    },
+    "diffutils": {
+      "epoch": "0",
+      "version": "3.6",
+      "release": "6.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-actionpack": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006356",
+      "arch": "noarch"
+    },
+    "python3-dateutil": {
+      "epoch": "1",
+      "version": "2.6.1",
+      "release": "6.el8",
+      "installdate": "1635944653",
+      "arch": "noarch"
+    },
+    "rubygem-kafo_wizards": {
+      "epoch": "0",
+      "version": "0.0.2",
+      "release": "2.el8",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "libnetfilter_conntrack": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "5.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-deep_cloneable": {
+      "epoch": "0",
+      "version": "3.0.0",
+      "release": "4.el8",
+      "installdate": "1636006357",
+      "arch": "noarch"
+    },
+    "librelp": {
+      "epoch": "0",
+      "version": "1.2.16",
+      "release": "1.el8",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "rubygem-logging": {
+      "epoch": "0",
+      "version": "2.3.0",
+      "release": "2.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "userspace-rcu": {
+      "epoch": "0",
+      "version": "0.10.1",
+      "release": "4.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-actioncable": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "dbus-glib": {
+      "epoch": "0",
+      "version": "0.110",
+      "release": "2.el8",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "zstd": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1635947221",
+      "arch": "x86_64"
+    },
+    "nss-softokn-freebl": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1635944539",
+      "arch": "x86_64"
+    },
+    "rubygem-rails": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "libappstream-glib": {
+      "epoch": "0",
+      "version": "0.7.14",
+      "release": "3.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "gc": {
+      "epoch": "0",
+      "version": "7.6.4",
+      "release": "3.el8",
+      "installdate": "1635947222",
+      "arch": "x86_64"
+    },
+    "attr": {
+      "epoch": "0",
+      "version": "2.4.48",
+      "release": "3.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "rubygem-parallel": {
+      "epoch": "0",
+      "version": "1.19.1",
+      "release": "2.el8",
+      "installdate": "1636006387",
+      "arch": "noarch"
+    },
+    "libdnf": {
+      "epoch": "0",
+      "version": "0.55.0",
+      "release": "7.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "rpm-build": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635947224",
+      "arch": "x86_64"
+    },
+    "libmodman": {
+      "epoch": "0",
+      "version": "2.0.1",
+      "release": "17.el8",
+      "installdate": "1635944542",
+      "arch": "x86_64"
+    },
+    "rubygem-connection_pool": {
+      "epoch": "0",
+      "version": "2.2.2",
+      "release": "3.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "python3-rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "libXcomposite": {
+      "epoch": "0",
+      "version": "0.4.4",
+      "release": "14.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "less": {
+      "epoch": "0",
+      "version": "530",
+      "release": "1.el8",
+      "installdate": "1635944544",
+      "arch": "x86_64"
+    },
+    "httpd-tools": {
+      "epoch": "0",
+      "version": "2.4.37",
+      "release": "39.module_el8.4.0+950+0577e6ac.1",
+      "installdate": "1636006398",
+      "arch": "x86_64"
+    },
+    "luksmeta": {
+      "epoch": "0",
+      "version": "9",
+      "release": "4.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "libXrandr": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "1.el8",
+      "installdate": "1636005940",
+      "arch": "x86_64"
+    },
+    "criu": {
+      "epoch": "0",
+      "version": "3.15",
+      "release": "1.module_el8.4.0+641+6116a774",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "rubygem-angular-rails-templates": {
+      "epoch": "1",
+      "version": "1.1.0",
+      "release": "2.el8",
+      "installdate": "1636006426",
+      "arch": "noarch"
+    },
+    "device-mapper-multipath-libs": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "10.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "libwayland-cursor": {
+      "epoch": "0",
+      "version": "1.17.0",
+      "release": "1.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "fuse-libs": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "12.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "rubygem-qpid_proton": {
+      "epoch": "0",
+      "version": "0.32.0",
+      "release": "3.el8",
+      "installdate": "1636006427",
+      "arch": "x86_64"
+    },
+    "dhcp-libs": {
+      "epoch": "12",
+      "version": "4.3.6",
+      "release": "44.0.1.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "java-1.8.0-openjdk-headless": {
+      "epoch": "1",
+      "version": "1.8.0.312.b07",
+      "release": "1.el8_4",
+      "installdate": "1636005947",
+      "arch": "x86_64"
+    },
+    "libnghttp2": {
+      "epoch": "0",
+      "version": "1.33.0",
+      "release": "3.el8_2.1",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-pulp_ansible_client": {
+      "epoch": "0",
+      "version": "0.8.0",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "volume_key-libs": {
+      "epoch": "0",
+      "version": "0.3.11",
+      "release": "5.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "pki-servlet-4.0-api": {
+      "epoch": "1",
+      "version": "9.0.30",
+      "release": "1.module_el8.4.0+595+e59c9af2",
+      "installdate": "1636005949",
+      "arch": "noarch"
+    },
+    "libsss_nss_idmap": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-rainbow": {
+      "epoch": "0",
+      "version": "2.2.2",
+      "release": "1.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "teamd": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1635944664",
+      "arch": "x86_64"
+    },
+    "libXft": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "1.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "slang": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "3.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-foreman_maintain": {
+      "epoch": "1",
+      "version": "0.8.10",
+      "release": "1.el8",
+      "installdate": "1636006453",
+      "arch": "noarch"
+    },
+    "sssd-ldap": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "pango": {
+      "epoch": "0",
+      "version": "1.42.4",
+      "release": "6.el8",
+      "installdate": "1636005958",
+      "arch": "x86_64"
+    },
+    "python3-libs": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "38.el8_4",
+      "installdate": "1635944555",
+      "arch": "x86_64"
+    },
+    "libkadm5": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "8.3.el8_4",
+      "installdate": "1636006464",
+      "arch": "x86_64"
+    },
+    "adwaita-cursor-theme": {
+      "epoch": "0",
+      "version": "3.28.0",
+      "release": "2.el8",
+      "installdate": "1636005963",
+      "arch": "noarch"
+    },
+    "platform-python": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "38.el8_4",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "rubygem-rubyipmi": {
+      "epoch": "0",
+      "version": "0.10.0",
+      "release": "7.el8",
+      "installdate": "1636006467",
+      "arch": "noarch"
+    },
+    "python3-ply": {
+      "epoch": "0",
+      "version": "3.9",
+      "release": "9.el8",
+      "installdate": "1635944668",
+      "arch": "noarch"
+    },
+    "python3-idna": {
+      "epoch": "0",
+      "version": "2.10",
+      "release": "1.el8",
+      "installdate": "1636006047",
+      "arch": "noarch"
+    },
+    "openssl": {
+      "epoch": "1",
+      "version": "1.1.1g",
+      "release": "15.el8_3",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "katello-default-ca": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006515",
+      "arch": "noarch"
+    },
+    "python3-sssdconfig": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944669",
+      "arch": "noarch"
+    },
+    "python3-aioredis": {
+      "epoch": "0",
+      "version": "2.0.0",
+      "release": "1.el8",
+      "installdate": "1636006048",
+      "arch": "noarch"
+    },
+    "krb5-libs": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "8.3.el8_4",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "foreman.cluster.local-puppet-client": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006561",
+      "arch": "noarch"
+    },
+    "vim-common": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "15.el8",
+      "installdate": "1635944672",
+      "arch": "x86_64"
+    },
+    "python3-xlrd": {
+      "epoch": "0",
+      "version": "2.0.1",
+      "release": "1.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "foreman-cli": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006566",
+      "arch": "noarch"
+    },
+    "libXrender": {
+      "epoch": "0",
+      "version": "0.9.10",
+      "release": "7.el8",
+      "installdate": "1635944672",
+      "arch": "x86_64"
+    },
+    "python3-drf-nested-routers": {
+      "epoch": "0",
+      "version": "0.93.3",
+      "release": "1.el8",
+      "installdate": "1636006058",
+      "arch": "noarch"
+    },
+    "systemd-libs": {
+      "epoch": "0",
+      "version": "239",
+      "release": "45.el8_4.3",
+      "installdate": "1635944559",
+      "arch": "x86_64"
+    },
+    "setroubleshoot-server": {
+      "epoch": "0",
+      "version": "3.3.24",
+      "release": "3.el8",
+      "installdate": "1635944673",
+      "arch": "x86_64"
+    },
+    "fontpackages-filesystem": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "22.el8",
+      "installdate": "1635944504",
+      "arch": "noarch"
+    },
+    "python3-pyparsing": {
+      "epoch": "0",
+      "version": "2.4.7",
+      "release": "1.el8",
+      "installdate": "1636006059",
+      "arch": "noarch"
+    },
+    "drpm": {
+      "epoch": "0",
+      "version": "0.4.1",
+      "release": "3.el8",
+      "installdate": "1636006596",
+      "arch": "x86_64"
+    },
+    "rpm-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635944561",
+      "arch": "x86_64"
+    },
+    "dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.18",
+      "release": "4.el8",
+      "installdate": "1635944679",
+      "arch": "noarch"
+    },
+    "geolite2-city": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "python3-django-prometheus": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "noarch"
+    },
+    "python3-debian": {
+      "epoch": "0",
+      "version": "0.1.40",
+      "release": "1.el8",
+      "installdate": "1636006601",
+      "arch": "noarch"
+    },
+    "pam": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "14.el8",
+      "installdate": "1635944563",
+      "arch": "x86_64"
+    },
+    "wget": {
+      "epoch": "0",
+      "version": "1.19.5",
+      "release": "10.el8",
+      "installdate": "1635944681",
+      "arch": "x86_64"
+    },
+    "linux-firmware": {
+      "epoch": "0",
+      "version": "20201218",
+      "release": "102.git05789708.el8",
+      "installdate": "1635944529",
+      "arch": "noarch"
+    },
+    "python3-et-xmlfile": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "python3-pygments": {
+      "epoch": "0",
+      "version": "2.8.1",
+      "release": "1.el8",
+      "installdate": "1636006611",
+      "arch": "noarch"
+    },
+    "shared-mime-info": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1635944566",
+      "arch": "x86_64"
+    },
+    "passwd": {
+      "epoch": "0",
+      "version": "0.80",
+      "release": "3.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "dbus-common": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "12.el8_4.2",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "python3-backoff": {
+      "epoch": "0",
+      "version": "1.10.0",
+      "release": "3.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "python3-colorama": {
+      "epoch": "0",
+      "version": "0.4.4",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "qemu-guest-agent": {
+      "epoch": "15",
+      "version": "4.2.0",
+      "release": "48.module_el8.4.0+885+5e18b468.3",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1635944531",
+      "arch": "x86_64"
+    },
+    "pulpcore-selinux": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "2.el8",
+      "installdate": "1636006065",
+      "arch": "x86_64"
+    },
+    "python3-jmespath": {
+      "epoch": "0",
+      "version": "0.9.0",
+      "release": "11.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "libusbx": {
+      "epoch": "0",
+      "version": "1.0.23",
+      "release": "4.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "irqbalance": {
+      "epoch": "2",
+      "version": "1.4.0",
+      "release": "6.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "libcom_err": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "1.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "rubygem-ruby_parser": {
+      "epoch": "0",
+      "version": "3.10.1",
+      "release": "4.el8",
+      "installdate": "1636006346",
+      "arch": "noarch"
+    },
+    "rubygem-hammer_cli_katello": {
+      "epoch": "0",
+      "version": "1.1.1",
+      "release": "0.1.pre.master.20210804141838gitece0b63.el8",
+      "installdate": "1636006669",
+      "arch": "noarch"
+    },
+    "parted": {
+      "epoch": "0",
+      "version": "3.2",
+      "release": "38.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "strace": {
+      "epoch": "0",
+      "version": "5.7",
+      "release": "2.1.el8_4",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "bzip2-libs": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-rake": {
+      "epoch": "0",
+      "version": "13.0.1",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1636006347",
+      "arch": "noarch"
+    },
+    "chefdk": {
+      "epoch": "0",
+      "version": "4.13.3",
+      "release": "1.el7",
+      "installdate": "1636124394",
+      "arch": "x86_64"
+    },
+    "selinux-policy-targeted": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "67.el8_4.2",
+      "installdate": "1635944579",
+      "arch": "noarch"
+    },
+    "biosdevname": {
+      "epoch": "0",
+      "version": "0.7.3",
+      "release": "2.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "expat": {
+      "epoch": "0",
+      "version": "2.2.5",
+      "release": "4.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-zeitwerk": {
+      "epoch": "0",
+      "version": "2.2.2",
+      "release": "2.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "python3-libstoragemgmt": {
+      "epoch": "0",
+      "version": "1.8.7",
+      "release": "1.el8",
+      "installdate": "1635944580",
+      "arch": "noarch"
+    },
+    "iprutils": {
+      "epoch": "0",
+      "version": "2.4.19",
+      "release": "1.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "libcollection": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "39.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-tzinfo": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "2.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "bind-libs-lite": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "installdate": "1635944582",
+      "arch": "x86_64"
+    },
+    "langpacks-en": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "12.el8",
+      "installdate": "1635944692",
+      "arch": "noarch"
+    },
+    "keyutils-libs": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "6.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-css_parser": {
+      "epoch": "0",
+      "version": "1.4.7",
+      "release": "5.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "cyrus-sasl-gssapi": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "iwl6000g2a-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "libassuan": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "3.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-nokogiri": {
+      "epoch": "0",
+      "version": "1.11.3",
+      "release": "2.el8",
+      "installdate": "1636006350",
+      "arch": "x86_64"
+    },
+    "samba-common-libs": {
+      "epoch": "0",
+      "version": "4.13.3",
+      "release": "4.el8_4",
+      "installdate": "1635944585",
+      "arch": "x86_64"
+    },
+    "iwl105-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "libidn2": {
+      "epoch": "0",
+      "version": "2.2.0",
+      "release": "1.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-marcel": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "1.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "bind-libs": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "centos-release-configmanagement": {
+      "epoch": "0",
+      "version": "1",
+      "release": "1.el8",
+      "installdate": "1635946906",
+      "arch": "noarch"
+    },
+    "libmaxminddb": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "10.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-fog-core": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "4.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "PackageKit-glib": {
+      "epoch": "0",
+      "version": "1.1.12",
+      "release": "6.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "python3-lxml": {
+      "epoch": "0",
+      "version": "4.6.3",
+      "release": "1.el8",
+      "installdate": "1635946986",
+      "arch": "x86_64"
+    },
+    "pixman": {
+      "epoch": "0",
+      "version": "0.38.4",
+      "release": "1.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-bcrypt": {
+      "epoch": "0",
+      "version": "3.1.12",
+      "release": "4.el8",
+      "installdate": "1636006354",
+      "arch": "x86_64"
+    },
+    "lvm2-libs": {
+      "epoch": "8",
+      "version": "2.03.11",
+      "release": "5.el8",
+      "installdate": "1635944600",
+      "arch": "x86_64"
+    },
+    "rubygem-bundler": {
+      "epoch": "0",
+      "version": "2.2.24",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947073",
+      "arch": "noarch"
+    },
+    "libnftnl": {
+      "epoch": "0",
+      "version": "1.1.5",
+      "release": "4.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-activesupport": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006355",
+      "arch": "noarch"
+    },
+    "python3-slip": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "11.el8",
+      "installdate": "1635944653",
+      "arch": "noarch"
+    },
+    "ruby": {
+      "epoch": "0",
+      "version": "2.7.4",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947074",
+      "arch": "x86_64"
+    },
+    "libselinux-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-activerecord-session_store": {
+      "epoch": "0",
+      "version": "2.0.0",
+      "release": "1.el8",
+      "installdate": "1636006357",
+      "arch": "noarch"
+    },
+    "authselect-libs": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "2.el8",
+      "installdate": "1635944653",
+      "arch": "x86_64"
+    },
+    "rubygem-hashie": {
+      "epoch": "0",
+      "version": "3.6.0",
+      "release": "3.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "libyaml": {
+      "epoch": "0",
+      "version": "0.1.7",
+      "release": "5.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-rails-i18n": {
+      "epoch": "0",
+      "version": "6.0.0",
+      "release": "3.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "slirp4netns": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "1.module_el8.4.0+641+6116a774",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "foreman-installer": {
+      "epoch": "1",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1635947090",
+      "arch": "noarch"
+    },
+    "libteam": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-actionmailbox": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "glib-networking": {
+      "epoch": "0",
+      "version": "2.56.1",
+      "release": "1.1.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "perl-srpm-macros": {
+      "epoch": "0",
+      "version": "1",
+      "release": "25.el8",
+      "installdate": "1635947221",
+      "arch": "noarch"
+    },
+    "ipset": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1635944539",
+      "arch": "x86_64"
+    },
+    "foreman": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006370",
+      "arch": "noarch"
+    },
+    "gnupg2": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "go-srpm-macros": {
+      "epoch": "0",
+      "version": "2",
+      "release": "17.el8",
+      "installdate": "1635947224",
+      "arch": "noarch"
+    },
+    "sqlite": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "13.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "rubygem-sd_notify": {
+      "epoch": "0",
+      "version": "0.1.0",
+      "release": "2.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "podman": {
+      "epoch": "0",
+      "version": "3.2.3",
+      "release": "0.11.module_el8.4.0+942+d25aada8",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "foreman-selinux": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636005879",
+      "arch": "noarch"
+    },
+    "snappy": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "3.el8",
+      "installdate": "1635944543",
+      "arch": "x86_64"
+    },
+    "apr-util-bdb": {
+      "epoch": "0",
+      "version": "1.6.1",
+      "release": "6.el8",
+      "installdate": "1636006398",
+      "arch": "x86_64"
+    },
+    "sudo": {
+      "epoch": "0",
+      "version": "1.8.29",
+      "release": "7.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "libXcursor": {
+      "epoch": "0",
+      "version": "1.1.15",
+      "release": "3.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "libXau": {
+      "epoch": "0",
+      "version": "1.0.9",
+      "release": "3.el8",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "postgresql": {
+      "epoch": "0",
+      "version": "12.7",
+      "release": "1.module_el8.4.0+828+b906d54a",
+      "installdate": "1636006408",
+      "arch": "x86_64"
+    },
+    "isns-utils-libs": {
+      "epoch": "0",
+      "version": "0.99",
+      "release": "1.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "hicolor-icon-theme": {
+      "epoch": "0",
+      "version": "0.17",
+      "release": "2.el8",
+      "installdate": "1636005940",
+      "arch": "noarch"
+    },
+    "jq": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "12.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "rubygem-fx": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "2.el8",
+      "installdate": "1636006427",
+      "arch": "noarch"
+    },
+    "plymouth-scripts": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "9.20200615git1e36e30.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "jasper-libs": {
+      "epoch": "0",
+      "version": "2.0.14",
+      "release": "4.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "hardlink": {
+      "epoch": "1",
+      "version": "1.3",
+      "release": "6.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "rubygem-sinatra": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "2.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "nss-sysinit": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "slf4j-jdk14": {
+      "epoch": "0",
+      "version": "1.7.25",
+      "release": "4.module_el8.4.0+595+e59c9af2",
+      "installdate": "1636005948",
+      "arch": "noarch"
+    },
+    "pkgconf": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-pulp_python_client": {
+      "epoch": "0",
+      "version": "3.4.0",
+      "release": "1.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "binutils": {
+      "epoch": "0",
+      "version": "2.30",
+      "release": "93.el8",
+      "installdate": "1635944663",
+      "arch": "x86_64"
+    },
+    "xorg-x11-font-utils": {
+      "epoch": "1",
+      "version": "7.5",
+      "release": "40.el8",
+      "installdate": "1636005949",
+      "arch": "x86_64"
+    },
+    "libverto": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-foreman_remote_execution": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "1.fm3_0.el8",
+      "installdate": "1636006439",
+      "arch": "noarch"
+    },
+    "sssd-krb5-common": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "gdk-pixbuf2-modules": {
+      "epoch": "0",
+      "version": "2.36.12",
+      "release": "5.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "libxkbcommon": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1635944550",
+      "arch": "x86_64"
+    },
+    "rubygem-rsec": {
+      "epoch": "0",
+      "version": "0.4.3",
+      "release": "5.el8",
+      "installdate": "1636006464",
+      "arch": "noarch"
+    },
+    "sos": {
+      "epoch": "0",
+      "version": "4.0",
+      "release": "12.el8_4",
+      "installdate": "1635944667",
+      "arch": "noarch"
+    },
+    "java-1.8.0-openjdk-devel": {
+      "epoch": "1",
+      "version": "1.8.0.312.b07",
+      "release": "1.el8_4",
+      "installdate": "1636005961",
+      "arch": "x86_64"
+    },
+    "libibverbs": {
+      "epoch": "0",
+      "version": "32.0",
+      "release": "4.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "rubygem-ruby-libvirt": {
+      "epoch": "0",
+      "version": "0.7.1",
+      "release": "2.el8",
+      "installdate": "1636006467",
+      "arch": "x86_64"
+    },
+    "kpatch-dnf": {
+      "epoch": "0",
+      "version": "0.2",
+      "release": "3.el8",
+      "installdate": "1635944668",
+      "arch": "noarch"
+    },
+    "java-11-openjdk": {
+      "epoch": "1",
+      "version": "11.0.13.0.8",
+      "release": "1.el8_4",
+      "installdate": "1636005972",
+      "arch": "x86_64"
+    },
+    "libkcapi-hmaccalc": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "python3-iniparse": {
+      "epoch": "0",
+      "version": "0.4",
+      "release": "31.el8",
+      "installdate": "1636006486",
+      "arch": "noarch"
+    },
+    "python3-redis": {
+      "epoch": "0",
+      "version": "3.5.3",
+      "release": "1.el8",
+      "installdate": "1636006047",
+      "arch": "noarch"
+    },
+    "elfutils-default-yama-scope": {
+      "epoch": "0",
+      "version": "0.182",
+      "release": "3.el8",
+      "installdate": "1635944557",
+      "arch": "noarch"
+    },
+    "pulp-client": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006546",
+      "arch": "noarch"
+    },
+    "fprintd-pam": {
+      "epoch": "0",
+      "version": "1.90.9",
+      "release": "2.el8",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "python3-dynaconf": {
+      "epoch": "0",
+      "version": "3.1.5",
+      "release": "1.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "kpartx": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "10.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "rubygem-amazing_print": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "2.el8",
+      "installdate": "1636006565",
+      "arch": "noarch"
+    },
+    "libX11-common": {
+      "epoch": "0",
+      "version": "1.6.8",
+      "release": "4.el8",
+      "installdate": "1635944672",
+      "arch": "noarch"
+    },
+    "python3-uritemplate": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "2.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "libfdisk": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-url-normalize": {
+      "epoch": "0",
+      "version": "1.4.3",
+      "release": "2.el8",
+      "installdate": "1636006585",
+      "arch": "noarch"
+    },
+    "setroubleshoot-plugins": {
+      "epoch": "0",
+      "version": "3.3.13",
+      "release": "1.el8",
+      "installdate": "1635944673",
+      "arch": "noarch"
+    },
+    "libblkid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944559",
+      "arch": "x86_64"
+    },
+    "hwdata": {
+      "epoch": "0",
+      "version": "0.314",
+      "release": "8.8.el8",
+      "installdate": "1635944504",
+      "arch": "noarch"
+    },
+    "python3-django-lifecycle": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1636006059",
+      "arch": "noarch"
+    },
+    "cockpit": {
+      "epoch": "0",
+      "version": "238.2",
+      "release": "1.el8",
+      "installdate": "1635944674",
+      "arch": "x86_64"
+    },
+    "openssl-libs": {
+      "epoch": "1",
+      "version": "1.1.1g",
+      "release": "15.el8_3",
+      "installdate": "1635944561",
+      "arch": "x86_64"
+    },
+    "tzdata": {
+      "epoch": "0",
+      "version": "2021e",
+      "release": "1.el8",
+      "installdate": "1635944505",
+      "arch": "noarch"
+    },
+    "python3-drf-access-policy": {
+      "epoch": "0",
+      "version": "0.9.0",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "noarch"
+    },
+    "vdo": {
+      "epoch": "0",
+      "version": "6.2.4.14",
+      "release": "14.el8",
+      "installdate": "1635944679",
+      "arch": "x86_64"
+    },
+    "kmod": {
+      "epoch": "0",
+      "version": "25",
+      "release": "17.el8",
+      "installdate": "1635944561",
+      "arch": "x86_64"
+    },
+    "geolite2-country": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1635944506",
+      "arch": "noarch"
+    },
+    "sssd-kcm": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944679",
+      "arch": "x86_64"
+    },
+    "libutempter": {
+      "epoch": "0",
+      "version": "1.1.6",
+      "release": "14.el8",
+      "installdate": "1635944562",
+      "arch": "x86_64"
+    },
+    "dejavu-sans-mono-fonts": {
+      "epoch": "0",
+      "version": "2.35",
+      "release": "7.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "buildah": {
+      "epoch": "0",
+      "version": "1.21.4",
+      "release": "2.module_el8.4.0+942+d25aada8",
+      "installdate": "1635944681",
+      "arch": "x86_64"
+    },
+    "util-linux": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944564",
+      "arch": "x86_64"
+    },
+    "ncurses-base": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "7.20180224.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "rsyslog-relp": {
+      "epoch": "0",
+      "version": "8.1911.0",
+      "release": "7.el8_4.2",
+      "installdate": "1635944681",
+      "arch": "x86_64"
+    },
+    "gettext": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1635944564",
+      "arch": "x86_64"
+    },
+    "kbd-legacy": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "openssh-server": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "6.el8_4.2",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "gnutls": {
+      "epoch": "0",
+      "version": "3.6.14",
+      "release": "8.el8_3",
+      "installdate": "1635944566",
+      "arch": "x86_64"
+    },
+    "dhcp-common": {
+      "epoch": "12",
+      "version": "4.3.6",
+      "release": "44.0.1.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "rsyslog-gnutls": {
+      "epoch": "0",
+      "version": "8.1911.0",
+      "release": "7.el8_4.2",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "trousers": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "centos-linux-repos": {
+      "epoch": "0",
+      "version": "8",
+      "release": "3.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "bolt": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "polkit": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "11.el8_4.1",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "pcre2": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1635944531",
+      "arch": "x86_64"
+    },
+    "microcode_ctl": {
+      "epoch": "4",
+      "version": "20210216",
+      "release": "1.20210608.1.el8_4",
+      "installdate": "1635944683",
+      "arch": "x86_64"
+    },
+    "policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "14.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "glibc-common": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "151.el8",
+      "installdate": "1635944532",
+      "arch": "x86_64"
+    },
+    "smartmontools": {
+      "epoch": "1",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "iptables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "17.el8",
+      "installdate": "1635944570",
+      "arch": "x86_64"
+    },
+    "zlib": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "17.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "nmap-ncat": {
+      "epoch": "2",
+      "version": "7.70",
+      "release": "5.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "json-glib": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "libuuid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "man-db": {
+      "epoch": "0",
+      "version": "2.7.6.1",
+      "release": "17.el8",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "libblockdev-utils": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "libxml2": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "9.el8_4.2",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-plain": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1635944690",
+      "arch": "x86_64"
+    },
+    "python3-decorator": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "2.el8",
+      "installdate": "1635944575",
+      "arch": "noarch"
+    },
+    "libxcrypt": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "4.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "sg3_utils": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "crontabs": {
+      "epoch": "0",
+      "version": "1.11",
+      "release": "17.20190603git.el8",
+      "installdate": "1635944579",
+      "arch": "noarch"
+    },
+    "libtevent": {
+      "epoch": "0",
+      "version": "0.10.2",
+      "release": "2.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "lshw": {
+      "epoch": "0",
+      "version": "B.02.19.2",
+      "release": "5.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "iputils": {
+      "epoch": "0",
+      "version": "20180629",
+      "release": "7.el8",
+      "installdate": "1635944580",
+      "arch": "x86_64"
+    },
+    "grep": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "6.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "time": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "NetworkManager-libnm": {
+      "epoch": "1",
+      "version": "1.30.0",
+      "release": "10.el8_4",
+      "installdate": "1635944581",
+      "arch": "x86_64"
+    },
+    "audit-libs": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "libsysfs": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "24.el8",
+      "installdate": "1635944692",
+      "arch": "x86_64"
+    },
+    "openssh": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "6.el8_4.2",
+      "installdate": "1635944582",
+      "arch": "x86_64"
+    },
+    "libzstd": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "tree": {
+      "epoch": "0",
+      "version": "1.7.0",
+      "release": "15.el8",
+      "installdate": "1635944692",
+      "arch": "x86_64"
+    },
+    "libjose": {
+      "epoch": "0",
+      "version": "10",
+      "release": "2.el8",
+      "installdate": "1635944582",
+      "arch": "x86_64"
+    },
+    "json-c": {
+      "epoch": "0",
+      "version": "0.13.1",
+      "release": "0.4.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "mailcap": {
+      "epoch": "0",
+      "version": "2.1.48",
+      "release": "3.el8",
+      "installdate": "1635944692",
+      "arch": "noarch"
+    },
+    "xfsprogs": {
+      "epoch": "0",
+      "version": "5.0.0",
+      "release": "8.el8",
+      "installdate": "1635944583",
+      "arch": "x86_64"
+    },
+    "sed": {
+      "epoch": "0",
+      "version": "4.5",
+      "release": "2.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "iwl6000g2b-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "python3-audit": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "nss-util": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "iwl5000-firmware": {
+      "epoch": "0",
+      "version": "8.83.5.1_1",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "adcli": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "9.el8",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "libsss_idmap": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "iwl135-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "samba-client-libs": {
+      "epoch": "0",
+      "version": "4.13.3",
+      "release": "4.el8_4",
+      "installdate": "1635944586",
+      "arch": "x86_64"
+    },
+    "libunistring": {
+      "epoch": "0",
+      "version": "0.9.9",
+      "release": "3.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "alsa-sof-firmware": {
+      "epoch": "0",
+      "version": "1.6.1",
+      "release": "2.el8",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "python3-unbound": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "15.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "libaio": {
+      "epoch": "0",
+      "version": "0.3.112",
+      "release": "1.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "gpg-pubkey": {
+      "epoch": "0",
+      "version": "6e8b7e8a",
+      "release": "5ab2cdb0",
+      "installdate": "1636006045",
+      "arch": "(none)",
+      "versions": [
+        {
+          "epoch": "0",
+          "version": "8483c65d",
+          "release": "5ccc5b19",
+          "installdate": "1635946904",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "6d05e64c",
+          "release": "60d9d236",
+          "installdate": "1635946983",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "ef8d349f",
+          "release": "57b6233e",
+          "installdate": "1635947002",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "9b776908",
+          "release": "6108060f",
+          "installdate": "1635947002",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "9e61ef26",
+          "release": "5cabbf8a",
+          "installdate": "1635947002",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "6e8b7e8a",
+          "release": "5ab2cdb0",
+          "installdate": "1636006045",
+          "arch": "(none)"
+        }
+      ]
+    },
+    "audit": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "freetype": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el8_3.1",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "libblockdev-part": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "lz4-libs": {
+      "epoch": "0",
+      "version": "1.8.3",
+      "release": "3.el8_4",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "python3-pyyaml": {
+      "epoch": "0",
+      "version": "5.4.1",
+      "release": "1.el8",
+      "installdate": "1635946986",
+      "arch": "x86_64"
+    },
+    "kernel-modules": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944590",
+      "arch": "x86_64"
+    },
+    "fstrm": {
+      "epoch": "0",
+      "version": "0.6.0",
+      "release": "3.el8.1",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "usb_modeswitch": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "1.el8",
+      "installdate": "1635944599",
+      "arch": "x86_64"
+    },
+    "p11-kit-trust": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-bigdecimal": {
+      "epoch": "0",
+      "version": "2.0.0",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947072",
+      "arch": "x86_64"
+    },
+    "lvm2": {
+      "epoch": "8",
+      "version": "2.03.11",
+      "release": "5.el8",
+      "installdate": "1635944600",
+      "arch": "x86_64"
+    },
+    "ethtool": {
+      "epoch": "2",
+      "version": "5.8",
+      "release": "5.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-json": {
+      "epoch": "0",
+      "version": "2.3.0",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947073",
+      "arch": "x86_64"
+    },
+    "python3-policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "14.el8",
+      "installdate": "1635944601",
+      "arch": "noarch"
+    },
+    "libksba": {
+      "epoch": "0",
+      "version": "1.3.5",
+      "release": "7.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygems": {
+      "epoch": "0",
+      "version": "3.1.6",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "timedatex": {
+      "epoch": "0",
+      "version": "0.5",
+      "release": "3.el8",
+      "installdate": "1635944653",
+      "arch": "x86_64"
+    },
+    "e2fsprogs-libs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "1.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "python-rpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "python3-pyudev": {
+      "epoch": "0",
+      "version": "0.21.0",
+      "release": "7.el8",
+      "installdate": "1635944653",
+      "arch": "noarch"
+    },
+    "libedit": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "23.20170329cvs.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-clamp": {
+      "epoch": "0",
+      "version": "1.1.2",
+      "release": "7.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "mdadm": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "16.el8_4",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "libini_config": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "39.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-little-plugger": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "3.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "desktop-file-utils": {
+      "epoch": "0",
+      "version": "0.23",
+      "release": "8.el8",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "psmisc": {
+      "epoch": "0",
+      "version": "23.1",
+      "release": "5.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "puppet-agent": {
+      "epoch": "0",
+      "version": "6.25.0",
+      "release": "1.el8",
+      "installdate": "1635947087",
+      "arch": "x86_64"
+    },
+    "containers-common": {
+      "epoch": "1",
+      "version": "1.3.1",
+      "release": "5.module_el8.4.0+886+c9a8d9ad",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "libbytesize": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "3.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "libbabeltrace": {
+      "epoch": "0",
+      "version": "1.5.4",
+      "release": "3.el8",
+      "installdate": "1635947221",
+      "arch": "x86_64"
+    },
+    "python3-slip-dbus": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "11.el8",
+      "installdate": "1635944654",
+      "arch": "noarch"
+    },
+    "grub2-pc-modules": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1635944539",
+      "arch": "noarch"
+    },
+    "qt5-srpm-macros": {
+      "epoch": "0",
+      "version": "5.12.5",
+      "release": "3.el8",
+      "installdate": "1635947221",
+      "arch": "noarch"
+    },
+    "cockpit-bridge": {
+      "epoch": "0",
+      "version": "238.2",
+      "release": "1.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "ipset-libs": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1635944539",
+      "arch": "x86_64"
+    },
+    "libipt": {
+      "epoch": "0",
+      "version": "1.6.1",
+      "release": "8.el8",
+      "installdate": "1635947222",
+      "arch": "x86_64"
+    },
+    "libsecret": {
+      "epoch": "0",
+      "version": "0.18.6",
+      "release": "1.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "tar": {
+      "epoch": "2",
+      "version": "1.30",
+      "release": "5.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "gdb-headless": {
+      "epoch": "0",
+      "version": "8.2",
+      "release": "15.el8",
+      "installdate": "1635947224",
+      "arch": "x86_64"
+    },
+    "gpgme": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "7.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "libmetalink": {
+      "epoch": "0",
+      "version": "0.1.3",
+      "release": "7.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "dwz": {
+      "epoch": "0",
+      "version": "0.12",
+      "release": "9.el8",
+      "installdate": "1635947224",
+      "arch": "x86_64"
+    },
+    "python3-libdnf": {
+      "epoch": "0",
+      "version": "0.55.0",
+      "release": "7.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "libconfig": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "9.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "foreman-installer-katello": {
+      "epoch": "1",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1635947225",
+      "arch": "noarch"
+    },
+    "python3-gpg": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "7.el8",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "mozjs60": {
+      "epoch": "0",
+      "version": "60.9.0",
+      "release": "4.el8",
+      "installdate": "1635944543",
+      "arch": "x86_64"
+    },
+    "libXi": {
+      "epoch": "0",
+      "version": "1.7.10",
+      "release": "1.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "dracut-squash": {
+      "epoch": "0",
+      "version": "049",
+      "release": "135.git20210121.el8",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "pigz": {
+      "epoch": "0",
+      "version": "2.4",
+      "release": "4.el8",
+      "installdate": "1635944544",
+      "arch": "x86_64"
+    },
+    "atk": {
+      "epoch": "0",
+      "version": "2.28.1",
+      "release": "1.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "cryptsetup": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "4.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "gpm-libs": {
+      "epoch": "0",
+      "version": "1.20.7",
+      "release": "17.el8",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "tzdata-java": {
+      "epoch": "0",
+      "version": "2021e",
+      "release": "1.el8",
+      "installdate": "1636005940",
+      "arch": "noarch"
+    },
+    "rpm-plugin-systemd-inhibit": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "libfastjson": {
+      "epoch": "0",
+      "version": "0.99.8",
+      "release": "2.el8",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "lcms2": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "2.el8",
+      "installdate": "1636005940",
+      "arch": "x86_64"
+    },
+    "iscsi-initiator-utils-iscsiuio": {
+      "epoch": "0",
+      "version": "6.2.1.2",
+      "release": "1.gita8fcb37.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "oniguruma": {
+      "epoch": "0",
+      "version": "6.8.2",
+      "release": "2.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "alsa-lib": {
+      "epoch": "0",
+      "version": "1.2.4",
+      "release": "5.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "e2fsprogs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "1.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "checkpolicy": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "1.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "at-spi2-atk": {
+      "epoch": "0",
+      "version": "2.26.2",
+      "release": "1.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "plymouth": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "9.20200615git1e36e30.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "fuse3-libs": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "12.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "lua": {
+      "epoch": "0",
+      "version": "5.3.4",
+      "release": "11.el8",
+      "installdate": "1636005942",
+      "arch": "x86_64"
+    },
+    "dracut-network": {
+      "epoch": "0",
+      "version": "049",
+      "release": "135.git20210121.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "libdaemon": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "15.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "slf4j": {
+      "epoch": "0",
+      "version": "1.7.25",
+      "release": "4.module_el8.4.0+595+e59c9af2",
+      "installdate": "1636005948",
+      "arch": "noarch"
+    },
+    "libfprint": {
+      "epoch": "0",
+      "version": "1.90.7",
+      "release": "1.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "libpkgconf": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "glassfish-jaxb-api": {
+      "epoch": "0",
+      "version": "2.2.12",
+      "release": "8.module_el8.4.0+595+e59c9af2",
+      "installdate": "1636005949",
+      "arch": "noarch"
+    },
+    "udisks2": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "6.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "gawk": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "2.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "libfontenc": {
+      "epoch": "0",
+      "version": "1.1.3",
+      "release": "8.el8",
+      "installdate": "1636005949",
+      "arch": "x86_64"
+    },
+    "centos-logos": {
+      "epoch": "0",
+      "version": "85.8",
+      "release": "1.el8",
+      "installdate": "1635944664",
+      "arch": "x86_64"
+    },
+    "libstemmer": {
+      "epoch": "0",
+      "version": "0",
+      "release": "10.585svn.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "libdatrie": {
+      "epoch": "0",
+      "version": "0.2.9",
+      "release": "7.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "libnfsidmap": {
+      "epoch": "1",
+      "version": "2.3.3",
+      "release": "41.el8_4.2",
+      "installdate": "1635944664",
+      "arch": "x86_64"
+    },
+    "ncurses": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "7.20180224.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "libtiff": {
+      "epoch": "0",
+      "version": "4.0.9",
+      "release": "18.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "sssd-common-pac": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "xkeyboard-config": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "1.el8",
+      "installdate": "1635944550",
+      "arch": "noarch"
+    },
+    "java-11-openjdk-headless": {
+      "epoch": "1",
+      "version": "11.0.13.0.8",
+      "release": "1.el8_4",
+      "installdate": "1636005957",
+      "arch": "x86_64"
+    },
+    "python3-psutil": {
+      "epoch": "0",
+      "version": "5.4.3",
+      "release": "10.el8",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "platform-python-pip": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "19.el8",
+      "installdate": "1635944551",
+      "arch": "noarch"
+    },
+    "java-1.8.0-openjdk": {
+      "epoch": "1",
+      "version": "1.8.0.312.b07",
+      "release": "1.el8_4",
+      "installdate": "1636005959",
+      "arch": "x86_64"
+    },
+    "python3-webencodings": {
+      "epoch": "0",
+      "version": "0.5.1",
+      "release": "6.el8",
+      "installdate": "1635944667",
+      "arch": "noarch"
+    },
+    "rdma-core": {
+      "epoch": "0",
+      "version": "32.0",
+      "release": "4.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "tomcatjss": {
+      "epoch": "0",
+      "version": "7.6.1",
+      "release": "1.module_el8.4.0+627+e8937f0b",
+      "installdate": "1636005963",
+      "arch": "noarch"
+    },
+    "libssh": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "2.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "gtk3": {
+      "epoch": "0",
+      "version": "3.22.30",
+      "release": "6.el8",
+      "installdate": "1636005972",
+      "arch": "x86_64"
+    },
+    "python3-dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.18",
+      "release": "4.el8",
+      "installdate": "1635944668",
+      "arch": "noarch"
+    },
+    "libkcapi": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "katello-selinux": {
+      "epoch": "0",
+      "version": "4.0.2",
+      "release": "1.el8",
+      "installdate": "1636006007",
+      "arch": "noarch"
+    },
+    "bind-utils": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "installdate": "1635944668",
+      "arch": "x86_64"
+    },
+    "curl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "18.el8_4.1",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "python3-typing-extensions": {
+      "epoch": "0",
+      "version": "3.7.4.3",
+      "release": "1.el8",
+      "installdate": "1636006047",
+      "arch": "noarch"
+    },
+    "python3-schedutils": {
+      "epoch": "0",
+      "version": "0.6",
+      "release": "6.el8",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "crypto-policies": {
+      "epoch": "0",
+      "version": "20210209",
+      "release": "1.gitbfb6bed.el8_3",
+      "installdate": "1635944557",
+      "arch": "noarch"
+    },
+    "python3-attrs": {
+      "epoch": "0",
+      "version": "21.2.0",
+      "release": "1.el8",
+      "installdate": "1636006048",
+      "arch": "noarch"
+    },
+    "realmd": {
+      "epoch": "0",
+      "version": "0.16.3",
+      "release": "22.el8",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "cracklib-dicts": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1635944557",
+      "arch": "x86_64"
+    },
+    "python3-yarl": {
+      "epoch": "0",
+      "version": "1.6.3",
+      "release": "1.el8",
+      "installdate": "1636006048",
+      "arch": "x86_64"
+    },
+    "python3-syspurpose": {
+      "epoch": "0",
+      "version": "1.28.13",
+      "release": "4.el8_4",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "libnsl2": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.20180605git4a062cf.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-importlib-metadata": {
+      "epoch": "0",
+      "version": "1.7.0",
+      "release": "1.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "python3-tracer": {
+      "epoch": "0",
+      "version": "0.7.5",
+      "release": "2.el8",
+      "installdate": "1635944672",
+      "arch": "noarch"
+    },
+    "elfutils-libs": {
+      "epoch": "0",
+      "version": "0.182",
+      "release": "3.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-urlman": {
+      "epoch": "0",
+      "version": "1.4.0",
+      "release": "1.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "libX11": {
+      "epoch": "0",
+      "version": "1.6.8",
+      "release": "4.el8",
+      "installdate": "1635944672",
+      "arch": "x86_64"
+    },
+    "libcroco": {
+      "epoch": "0",
+      "version": "0.6.12",
+      "release": "4.el8_2.1",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-django": {
+      "epoch": "0",
+      "version": "2.2.24",
+      "release": "1.el8",
+      "installdate": "1636006057",
+      "arch": "noarch"
+    },
+    "cairo-gobject": {
+      "epoch": "0",
+      "version": "1.15.12",
+      "release": "3.el8",
+      "installdate": "1635944672",
+      "arch": "x86_64"
+    },
+    "dbus-tools": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "12.el8_4.2",
+      "installdate": "1635944559",
+      "arch": "x86_64"
+    },
+    "python3-certifi": {
+      "epoch": "0",
+      "version": "2020.6.20",
+      "release": "1.el8",
+      "installdate": "1636006587",
+      "arch": "noarch"
+    },
+    "python3-pulp-file": {
+      "epoch": "0",
+      "version": "1.8.2",
+      "release": "2.el8",
+      "installdate": "1636006592",
+      "arch": "noarch"
+    },
+    "python3-solv": {
+      "epoch": "0",
+      "version": "0.7.20",
+      "release": "1.el8",
+      "installdate": "1636006596",
+      "arch": "x86_64"
+    },
+    "python3-pycares": {
+      "epoch": "0",
+      "version": "4.0.0",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "x86_64"
+    },
+    "python3-pulp-rpm": {
+      "epoch": "0",
+      "version": "3.14.6",
+      "release": "2.el8",
+      "installdate": "1636006597",
+      "arch": "noarch"
+    },
+    "python3-markupsafe": {
+      "epoch": "0",
+      "version": "1.1.1",
+      "release": "2.el8",
+      "installdate": "1636006061",
+      "arch": "x86_64"
+    },
+    "python3-semantic-version": {
+      "epoch": "0",
+      "version": "2.8.5",
+      "release": "1.el8",
+      "installdate": "1636006610",
+      "arch": "noarch"
+    },
+    "python3-drf-spectacular": {
+      "epoch": "0",
+      "version": "0.17.3",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "python3-ruamel-yaml": {
+      "epoch": "0",
+      "version": "0.16.10",
+      "release": "1.el8",
+      "installdate": "1636006610",
+      "arch": "noarch"
+    },
+    "python3-openpyxl": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "1.el8",
+      "installdate": "1636006062",
+      "arch": "noarch"
+    },
+    "python3-mccabe": {
+      "epoch": "0",
+      "version": "0.6.1",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "python3-odfpy": {
+      "epoch": "0",
+      "version": "1.4.1",
+      "release": "2.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "python3-commonmark": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "python3-asyncio-throttle": {
+      "epoch": "0",
+      "version": "1.0.2",
+      "release": "1.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "python3-bracex": {
+      "epoch": "0",
+      "version": "2.1.1",
+      "release": "1.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "libpq": {
+      "epoch": "0",
+      "version": "13.3",
+      "release": "1.el8_4",
+      "installdate": "1636006064",
+      "arch": "x86_64"
+    },
+    "sshpass": {
+      "epoch": "0",
+      "version": "1.06",
+      "release": "8.el8",
+      "installdate": "1636006613",
+      "arch": "x86_64"
+    },
+    "rubygem-rack": {
+      "epoch": "0",
+      "version": "2.2.3",
+      "release": "2.el8",
+      "installdate": "1636006338",
+      "arch": "noarch"
+    },
+    "ansible-lint": {
+      "epoch": "0",
+      "version": "5.0.8",
+      "release": "1.el8",
+      "installdate": "1636006633",
+      "arch": "noarch"
+    },
+    "npm": {
+      "epoch": "1",
+      "version": "6.14.11",
+      "release": "1.10.24.0.1.module_el8.3.0+717+fa496f1d",
+      "installdate": "1636006344",
+      "arch": "x86_64"
+    },
+    "rubygem-hammer_cli_foreman_tasks": {
+      "epoch": "0",
+      "version": "0.0.16",
+      "release": "1.fm3_0.el8",
+      "installdate": "1636006668",
+      "arch": "noarch"
+    },
+    "rubygem-sprockets": {
+      "epoch": "0",
+      "version": "4.0.2",
+      "release": "2.el8",
+      "installdate": "1636006346",
+      "arch": "noarch"
+    },
+    "rubygem-foreman_puppet": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "1.fm3_0.el8",
+      "installdate": "1636006683",
+      "arch": "noarch"
+    },
+    "rubygem-graphql": {
+      "epoch": "0",
+      "version": "1.8.14",
+      "release": "3.el8",
+      "installdate": "1636006347",
+      "arch": "noarch"
+    },
+    "chef": {
+      "epoch": "0",
+      "version": "17.7.29",
+      "release": "1.el8",
+      "installdate": "1636117713",
+      "arch": "x86_64"
+    },
+    "rubygem-gettext_i18n_rails": {
+      "epoch": "0",
+      "version": "1.8.0",
+      "release": "3.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-concurrent-ruby-edge": {
+      "epoch": "1",
+      "version": "0.6.0",
+      "release": "3.fm2_5.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-websocket-extensions": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "2.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-domain_name": {
+      "epoch": "0",
+      "version": "0.5.20160310",
+      "release": "5.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-statsd-instrument": {
+      "epoch": "0",
+      "version": "2.1.4",
+      "release": "4.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "rubygem-rack-cors": {
+      "epoch": "0",
+      "version": "1.0.2",
+      "release": "3.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "rubygem-promise.rb": {
+      "epoch": "0",
+      "version": "0.7.4",
+      "release": "3.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "rubygem-netrc": {
+      "epoch": "0",
+      "version": "0.11.0",
+      "release": "6.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "rubygem-roadie": {
+      "epoch": "0",
+      "version": "3.4.0",
+      "release": "4.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "rubygem-mime-types": {
+      "epoch": "0",
+      "version": "3.3.1",
+      "release": "2.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "rubygem-jwt": {
+      "epoch": "0",
+      "version": "2.2.2",
+      "release": "2.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "rubygem-ffi": {
+      "epoch": "0",
+      "version": "1.12.2",
+      "release": "2.el8",
+      "installdate": "1636006353",
+      "arch": "x86_64"
+    },
+    "rubygem-erubi": {
+      "epoch": "0",
+      "version": "1.9.0",
+      "release": "2.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "rubygem-loofah": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "2.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "rubygem-apipie-params": {
+      "epoch": "0",
+      "version": "0.0.5",
+      "release": "5.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "foreman-debug": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "rubygem-rails-dom-testing": {
+      "epoch": "0",
+      "version": "2.0.3",
+      "release": "7.el8",
+      "installdate": "1636006355",
+      "arch": "noarch"
+    },
+    "rubygem-sprockets-rails": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "7.el8",
+      "installdate": "1636006356",
+      "arch": "noarch"
+    },
+    "rubygem-ancestry": {
+      "epoch": "0",
+      "version": "3.0.7",
+      "release": "2.el8",
+      "installdate": "1636006357",
+      "arch": "noarch"
+    },
+    "rubygem-scoped_search": {
+      "epoch": "0",
+      "version": "4.1.9",
+      "release": "2.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "rubygem-responders": {
+      "epoch": "0",
+      "version": "3.0.0",
+      "release": "4.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "rubygem-globalid": {
+      "epoch": "0",
+      "version": "0.4.2",
+      "release": "2.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "rubygem-actiontext": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "rubygem-webpack-rails": {
+      "epoch": "0",
+      "version": "0.9.8",
+      "release": "6.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "foreman-postgresql": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006382",
+      "arch": "noarch"
+    },
+    "rubygem-colorize": {
+      "epoch": "0",
+      "version": "0.8.1",
+      "release": "2.el8",
+      "installdate": "1636006387",
+      "arch": "noarch"
+    },
+    "rubygem-redis": {
+      "epoch": "0",
+      "version": "4.1.2",
+      "release": "3.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "rubygem-gitlab-sidekiq-fetcher": {
+      "epoch": "0",
+      "version": "0.6.0",
+      "release": "2.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "apr-util-openssl": {
+      "epoch": "0",
+      "version": "1.6.1",
+      "release": "6.el8",
+      "installdate": "1636006398",
+      "arch": "x86_64"
+    },
+    "httpd-filesystem": {
+      "epoch": "0",
+      "version": "2.4.37",
+      "release": "39.module_el8.4.0+950+0577e6ac.1",
+      "installdate": "1636006399",
+      "arch": "noarch"
+    },
+    "postgresql-server": {
+      "epoch": "0",
+      "version": "12.7",
+      "release": "1.module_el8.4.0+828+b906d54a",
+      "installdate": "1636006416",
+      "arch": "x86_64"
+    },
+    "rubygem-runcible": {
+      "epoch": "0",
+      "version": "2.13.1",
+      "release": "2.el8",
+      "installdate": "1636006426",
+      "arch": "noarch"
+    },
+    "rubygem-activerecord-import": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "1.el8",
+      "installdate": "1636006427",
+      "arch": "noarch"
+    },
+    "katello-common": {
+      "epoch": "0",
+      "version": "4.2.0.1",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "rubygem-multipart-post": {
+      "epoch": "0",
+      "version": "2.0.0",
+      "release": "3.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "rubygem-pulp_container_client": {
+      "epoch": "0",
+      "version": "2.7.0",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "rubygem-pulp_rpm_client": {
+      "epoch": "0",
+      "version": "3.13.3",
+      "release": "1.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "rubygem-deface": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "3.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "rubygem-katello": {
+      "epoch": "0",
+      "version": "4.2.0.1",
+      "release": "1.el8",
+      "installdate": "1636006452",
+      "arch": "noarch"
+    },
+    "postgresql-evr": {
+      "epoch": "0",
+      "version": "0.0.2",
+      "release": "1.el8",
+      "installdate": "1636006458",
+      "arch": "x86_64"
+    },
+    "rubygem-rb-inotify": {
+      "epoch": "0",
+      "version": "0.9.7",
+      "release": "6.el8",
+      "installdate": "1636006464",
+      "arch": "noarch"
+    },
+    "cyrus-sasl": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1636006465",
+      "arch": "x86_64"
+    },
+    "rubygem-xmlrpc": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1636006467",
+      "arch": "noarch"
+    },
+    "puppet-agent-oauth": {
+      "epoch": "0",
+      "version": "0.5.5",
+      "release": "1.el8",
+      "installdate": "1636006473",
+      "arch": "noarch"
+    },
+    "python3-subscription-manager-rhsm": {
+      "epoch": "0",
+      "version": "1.28.13",
+      "release": "4.el8_4",
+      "installdate": "1636006487",
+      "arch": "x86_64"
+    },
+    "foreman.cluster.local-foreman-client": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006525",
+      "arch": "noarch"
+    },
+    "foreman.cluster.local-foreman-proxy": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006549",
+      "arch": "noarch"
+    },
+    "rubygem-unicode-display_width": {
+      "epoch": "0",
+      "version": "1.7.0",
+      "release": "2.el8",
+      "installdate": "1636006565",
+      "arch": "noarch"
+    },
+    "rubygem-hammer_cli": {
+      "epoch": "0",
+      "version": "3.0.0",
+      "release": "1.el8",
+      "installdate": "1636006566",
+      "arch": "noarch"
+    },
+    "python3-pyOpenSSL": {
+      "epoch": "0",
+      "version": "19.1.0",
+      "release": "1.el8",
+      "installdate": "1636006584",
+      "arch": "noarch"
+    },
+    "python3-pycryptodomex": {
+      "epoch": "0",
+      "version": "3.10.1",
+      "release": "1.el8",
+      "installdate": "1636006586",
+      "arch": "x86_64"
+    },
+    "python3-django-filter": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "1.el8",
+      "installdate": "1636006058",
+      "arch": "noarch"
+    },
+    "libgcc": {
+      "epoch": "0",
+      "version": "8.4.1",
+      "release": "1.el8",
+      "installdate": "1635944504",
+      "arch": "x86_64"
+    },
+    "shadow-utils": {
+      "epoch": "2",
+      "version": "4.6",
+      "release": "12.el8",
+      "installdate": "1635944560",
+      "arch": "x86_64"
+    },
+    "cockpit-storaged": {
+      "epoch": "0",
+      "version": "238.2",
+      "release": "1.el8",
+      "installdate": "1635944674",
+      "arch": "noarch"
+    },
+    "python3-pyrsistent": {
+      "epoch": "0",
+      "version": "0.17.3",
+      "release": "1.el8",
+      "installdate": "1636006059",
+      "arch": "x86_64"
+    },
+    "abattis-cantarell-fonts": {
+      "epoch": "0",
+      "version": "0.0.25",
+      "release": "6.el8",
+      "installdate": "1635944504",
+      "arch": "noarch"
+    },
+    "kmod-libs": {
+      "epoch": "0",
+      "version": "25",
+      "release": "17.el8",
+      "installdate": "1635944561",
+      "arch": "x86_64"
+    },
+    "tuned": {
+      "epoch": "0",
+      "version": "2.15.0",
+      "release": "2.el8_4.1",
+      "installdate": "1635944678",
+      "arch": "noarch"
+    },
+    "python3-pygtrie": {
+      "epoch": "0",
+      "version": "2.4.2",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "noarch"
+    },
+    "libreport-filesystem": {
+      "epoch": "0",
+      "version": "2.9.5",
+      "release": "15.el8",
+      "installdate": "1635944506",
+      "arch": "x86_64"
+    },
+    "cryptsetup-libs": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "4.el8",
+      "installdate": "1635944562",
+      "arch": "x86_64"
+    },
+    "yum": {
+      "epoch": "0",
+      "version": "4.4.2",
+      "release": "11.el8",
+      "installdate": "1635944679",
+      "arch": "noarch"
+    },
+    "dejavu-fonts-common": {
+      "epoch": "0",
+      "version": "2.35",
+      "release": "7.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "kbd": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1635944562",
+      "arch": "x86_64"
+    },
+    "cockpit-podman": {
+      "epoch": "0",
+      "version": "32",
+      "release": "2.module_el8.4.0+886+c9a8d9ad",
+      "installdate": "1635944679",
+      "arch": "noarch"
+    },
+    "pkgconf-m4": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "systemd-pam": {
+      "epoch": "0",
+      "version": "239",
+      "release": "45.el8_4.3",
+      "installdate": "1635944564",
+      "arch": "x86_64"
+    },
+    "pinfo": {
+      "epoch": "0",
+      "version": "0.6.10",
+      "release": "18.el8",
+      "installdate": "1635944681",
+      "arch": "x86_64"
+    },
+    "kbd-misc": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "grub2-tools": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1635944565",
+      "arch": "x86_64"
+    },
+    "openssh-clients": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "6.el8_4.2",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "emacs-filesystem": {
+      "epoch": "1",
+      "version": "26.1",
+      "release": "5.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "dbus": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "12.el8_4.2",
+      "installdate": "1635944566",
+      "arch": "x86_64"
+    },
+    "NetworkManager-tui": {
+      "epoch": "1",
+      "version": "1.30.0",
+      "release": "10.el8_4",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "centos-linux-release": {
+      "epoch": "0",
+      "version": "8.4",
+      "release": "1.2105.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "polkit-libs": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "11.el8_4.1",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "usbutils": {
+      "epoch": "0",
+      "version": "010",
+      "release": "3.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "basesystem": {
+      "epoch": "0",
+      "version": "11",
+      "release": "5.el8",
+      "installdate": "1635944531",
+      "arch": "noarch"
+    },
+    "polkit-pkla-compat": {
+      "epoch": "0",
+      "version": "0.1",
+      "release": "12.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "mcelog": {
+      "epoch": "3",
+      "version": "173",
+      "release": "0.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "glibc-langpack-en": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "151.el8",
+      "installdate": "1635944531",
+      "arch": "x86_64"
+    },
+    "libsss_certmap": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "psacct": {
+      "epoch": "0",
+      "version": "6.6.3",
+      "release": "4.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "libsepol": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "2.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "kernel-core": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944573",
+      "arch": "x86_64"
+    },
+    "nvme-cli": {
+      "epoch": "0",
+      "version": "1.12",
+      "release": "4.el8_4",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "info": {
+      "epoch": "0",
+      "version": "6.5",
+      "release": "6.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "libgudev": {
+      "epoch": "0",
+      "version": "232",
+      "release": "4.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "prefixdevname": {
+      "epoch": "0",
+      "version": "0.1.0",
+      "release": "6.el8",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "libstdc++": {
+      "epoch": "0",
+      "version": "8.4.1",
+      "release": "1.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "logrotate": {
+      "epoch": "0",
+      "version": "3.14.0",
+      "release": "4.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "quota": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "12.el8",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "libtalloc": {
+      "epoch": "0",
+      "version": "2.3.1",
+      "release": "2.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-selinux": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635944575",
+      "arch": "x86_64"
+    },
+    "zip": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "23.el8",
+      "installdate": "1635944690",
+      "arch": "x86_64"
+    },
+    "sqlite-libs": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "13.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "cronie": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "4.el8",
+      "installdate": "1635944579",
+      "arch": "x86_64"
+    },
+    "rsync": {
+      "epoch": "0",
+      "version": "3.1.3",
+      "release": "12.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "pcre": {
+      "epoch": "0",
+      "version": "8.42",
+      "release": "4.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "libstoragemgmt": {
+      "epoch": "0",
+      "version": "1.8.7",
+      "release": "1.el8",
+      "installdate": "1635944580",
+      "arch": "x86_64"
+    },
+    "ed": {
+      "epoch": "0",
+      "version": "1.14.2",
+      "release": "4.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "libcap-ng": {
+      "epoch": "0",
+      "version": "0.7.9",
+      "release": "5.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "NetworkManager": {
+      "epoch": "1",
+      "version": "1.30.0",
+      "release": "10.el8_4",
+      "installdate": "1635944581",
+      "arch": "x86_64"
+    },
+    "dos2unix": {
+      "epoch": "0",
+      "version": "7.4.0",
+      "release": "3.el8",
+      "installdate": "1635944692",
+      "arch": "x86_64"
+    },
+    "libref_array": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "39.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "fuse-overlayfs": {
+      "epoch": "0",
+      "version": "1.6",
+      "release": "1.module_el8.4.0+886+c9a8d9ad",
+      "installdate": "1635944582",
+      "arch": "x86_64"
+    },
+    "symlinks": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "19.el8",
+      "installdate": "1635944692",
+      "arch": "x86_64"
+    },
+    "gmp": {
+      "epoch": "1",
+      "version": "6.1.2",
+      "release": "10.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "libevent": {
+      "epoch": "0",
+      "version": "2.1.8",
+      "release": "5.el8",
+      "installdate": "1635944583",
+      "arch": "x86_64"
+    },
+    "rootfiles": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "22.el8",
+      "installdate": "1635944692",
+      "arch": "noarch"
+    },
+    "libacl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "fontconfig": {
+      "epoch": "0",
+      "version": "2.13.1",
+      "release": "3.el8",
+      "installdate": "1635944583",
+      "arch": "x86_64"
+    },
+    "iwl6050-firmware": {
+      "epoch": "0",
+      "version": "41.28.5.1",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "lua-libs": {
+      "epoch": "0",
+      "version": "5.3.4",
+      "release": "11.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "python3-libxml2": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "9.el8_4.2",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "iwl5150-firmware": {
+      "epoch": "0",
+      "version": "8.24.2.2",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "libseccomp": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "1.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "cups-libs": {
+      "epoch": "1",
+      "version": "2.2.6",
+      "release": "38.el8",
+      "installdate": "1635944585",
+      "arch": "x86_64"
+    },
+    "iwl2000-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "findutils": {
+      "epoch": "1",
+      "version": "4.6.0",
+      "release": "20.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "libsmbclient": {
+      "epoch": "0",
+      "version": "4.13.3",
+      "release": "4.el8_4",
+      "installdate": "1635944586",
+      "arch": "x86_64"
+    },
+    "iwl100-firmware": {
+      "epoch": "0",
+      "version": "39.31.5.1",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "grub2-common": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1635944536",
+      "arch": "noarch"
+    },
+    "jose": {
+      "epoch": "0",
+      "version": "10",
+      "release": "2.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "katello-repos": {
+      "epoch": "0",
+      "version": "4.2.0.1",
+      "release": "1.el8",
+      "installdate": "1635946890",
+      "arch": "noarch"
+    },
+    "libpng": {
+      "epoch": "2",
+      "version": "1.6.34",
+      "release": "5.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "libblockdev": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "puppet6-release": {
+      "epoch": "0",
+      "version": "6.0.0",
+      "release": "14.el8",
+      "installdate": "1635946915",
+      "arch": "noarch"
+    },
+    "libsmartcols": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "libblockdev-swap": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "python3-six": {
+      "epoch": "0",
+      "version": "1.15.0",
+      "release": "1.el8",
+      "installdate": "1635946986",
+      "arch": "noarch"
+    },
+    "nettle": {
+      "epoch": "0",
+      "version": "3.4.1",
+      "release": "4.el8_3",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "kmod-kvdo": {
+      "epoch": "0",
+      "version": "6.2.4.26",
+      "release": "77.el8",
+      "installdate": "1635944599",
+      "arch": "x86_64"
+    },
+    "libtasn1": {
+      "epoch": "0",
+      "version": "4.13",
+      "release": "3.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "usb_modeswitch-data": {
+      "epoch": "0",
+      "version": "20191128",
+      "release": "1.el8",
+      "installdate": "1635944600",
+      "arch": "noarch"
+    },
+    "ruby-default-gems": {
+      "epoch": "0",
+      "version": "2.7.4",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947072",
+      "arch": "noarch"
+    },
+    "libnl3-cli": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "libblockdev-lvm": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944600",
+      "arch": "x86_64"
+    },
+    "rubygem-irb": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947073",
+      "arch": "noarch"
+    },
+    "xz": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "policycoreutils-python-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "14.el8",
+      "installdate": "1635944601",
+      "arch": "noarch"
+    },
+    "rubygem-rdoc": {
+      "epoch": "0",
+      "version": "6.2.1.1",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "libgomp": {
+      "epoch": "0",
+      "version": "8.4.1",
+      "release": "1.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "python3-configobj": {
+      "epoch": "0",
+      "version": "5.0.6",
+      "release": "11.el8",
+      "installdate": "1635944653",
+      "arch": "noarch"
+    },
+    "python-srpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "dmidecode": {
+      "epoch": "1",
+      "version": "3.2",
+      "release": "8.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "oddjob": {
+      "epoch": "0",
+      "version": "0.34.7",
+      "release": "1.el8",
+      "installdate": "1635944653",
+      "arch": "x86_64"
+    },
+    "rubygem-ansi": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "3.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "libpath_utils": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "39.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "libblockdev-mdraid": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "rubygem-kafo_parsers": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "1.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "numactl-libs": {
+      "epoch": "0",
+      "version": "2.0.12",
+      "release": "11.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "xdg-utils": {
+      "epoch": "0",
+      "version": "1.1.2",
+      "release": "5.el8",
+      "installdate": "1635944654",
+      "arch": "noarch"
+    },
+    "rubygem-kafo": {
+      "epoch": "0",
+      "version": "6.4.0",
+      "release": "1.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "squashfs-tools": {
+      "epoch": "0",
+      "version": "4.3",
+      "release": "20.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "libudisks2": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "6.el8",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "libtool-ltdl": {
+      "epoch": "0",
+      "version": "2.4.6",
+      "release": "25.el8",
+      "installdate": "1635947221",
+      "arch": "x86_64"
+    },
+    "ipcalc": {
+      "epoch": "0",
+      "version": "0.2.4",
+      "release": "4.el8",
+      "installdate": "1635944539",
+      "arch": "x86_64"
+    },
+    "python3-firewall": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "7.el8_4",
+      "installdate": "1635944654",
+      "arch": "noarch"
+    },
+    "rust-srpm-macros": {
+      "epoch": "0",
+      "version": "5",
+      "release": "2.el8",
+      "installdate": "1635947221",
+      "arch": "noarch"
+    },
+    "nss-softokn": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1635944539",
+      "arch": "x86_64"
+    },
+    "libsoup": {
+      "epoch": "0",
+      "version": "2.62.3",
+      "release": "2.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "ocaml-srpm-macros": {
+      "epoch": "0",
+      "version": "5",
+      "release": "4.el8",
+      "installdate": "1635947222",
+      "arch": "noarch"
+    },
+    "acl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "pinentry": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "2.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "guile": {
+      "epoch": "5",
+      "version": "2.0.14",
+      "release": "7.el8",
+      "installdate": "1635947223",
+      "arch": "x86_64"
+    },
+    "librepo": {
+      "epoch": "0",
+      "version": "1.12.0",
+      "release": "3.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "efi-srpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "3.el8",
+      "installdate": "1635947224",
+      "arch": "noarch"
+    },
+    "unzip": {
+      "epoch": "0",
+      "version": "6.0",
+      "release": "45.el8_4",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "python3-hawkey": {
+      "epoch": "0",
+      "version": "0.55.0",
+      "release": "7.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "katello-certs-tools": {
+      "epoch": "0",
+      "version": "2.8.0",
+      "release": "1.el8",
+      "installdate": "1635947224",
+      "arch": "noarch"
+    },
+    "libproxy": {
+      "epoch": "0",
+      "version": "0.4.15",
+      "release": "5.2.el8",
+      "installdate": "1635944542",
+      "arch": "x86_64"
+    },
+    "rpm-build-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "14.el8_4",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "libjpeg-turbo": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "10.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "libss": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "1.el8",
+      "installdate": "1635944544",
+      "arch": "x86_64"
+    },
+    "virt-what": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "9.el8_4",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "libXtst": {
+      "epoch": "0",
+      "version": "1.2.3",
+      "release": "7.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "containernetworking-plugins": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.module_el8.4.0+781+acf4c33b",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "libluksmeta": {
+      "epoch": "0",
+      "version": "9",
+      "release": "4.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "lksctp-tools": {
+      "epoch": "0",
+      "version": "1.0.18",
+      "release": "3.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "libestr": {
+      "epoch": "0",
+      "version": "0.1.10",
+      "release": "1.el8",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "sscg": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "14.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "libXinerama": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "1.el8",
+      "installdate": "1636005940",
+      "arch": "x86_64"
+    },
+    "runc": {
+      "epoch": "0",
+      "version": "1.0.0",
+      "release": "74.rc95.module_el8.4.0+886+c9a8d9ad",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "iscsi-initiator-utils": {
+      "epoch": "0",
+      "version": "6.2.1.2",
+      "release": "1.gita8fcb37.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "giflib": {
+      "epoch": "0",
+      "version": "5.1.4",
+      "release": "3.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "c-ares": {
+      "epoch": "0",
+      "version": "1.13.0",
+      "release": "5.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "libatasmart": {
+      "epoch": "0",
+      "version": "0.19",
+      "release": "14.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "at-spi2-core": {
+      "epoch": "0",
+      "version": "2.28.0",
+      "release": "1.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "fuse3": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "12.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "python3-systemd": {
+      "epoch": "0",
+      "version": "234",
+      "release": "8.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "rest": {
+      "epoch": "0",
+      "version": "0.8.1",
+      "release": "2.el8",
+      "installdate": "1636005942",
+      "arch": "x86_64"
+    },
+    "jimtcl": {
+      "epoch": "0",
+      "version": "0.77",
+      "release": "6.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "kexec-tools": {
+      "epoch": "0",
+      "version": "2.0.20",
+      "release": "46.el8_4.2",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "javapackages-tools": {
+      "epoch": "0",
+      "version": "5.3.0",
+      "release": "1.module_el8.0.0+11+5b8c10bd",
+      "installdate": "1636005948",
+      "arch": "noarch"
+    },
+    "libpipeline": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "2.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "fprintd": {
+      "epoch": "0",
+      "version": "1.90.9",
+      "release": "2.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "ant-lib": {
+      "epoch": "0",
+      "version": "1.10.5",
+      "release": "1.module_el8.0.0+47+197dca37",
+      "installdate": "1636005949",
+      "arch": "noarch"
+    },
+    "libsigsegv": {
+      "epoch": "0",
+      "version": "2.11",
+      "release": "5.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "udisks2-iscsi": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "6.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "libwayland-egl": {
+      "epoch": "0",
+      "version": "1.17.0",
+      "release": "1.el8",
+      "installdate": "1636005949",
+      "arch": "x86_64"
+    },
+    "libsss_sudo": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "cockpit-ws": {
+      "epoch": "0",
+      "version": "238.2",
+      "release": "1.el8",
+      "installdate": "1635944664",
+      "arch": "x86_64"
+    },
+    "libepoxy": {
+      "epoch": "0",
+      "version": "1.5.3",
+      "release": "1.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "memstrack": {
+      "epoch": "0",
+      "version": "0.1.11",
+      "release": "1.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "sssd-nfs-idmap": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944664",
+      "arch": "x86_64"
+    },
+    "jbigkit-libs": {
+      "epoch": "0",
+      "version": "2.1",
+      "release": "14.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "newt": {
+      "epoch": "0",
+      "version": "0.52.20",
+      "release": "11.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "sssd-krb5": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "harfbuzz": {
+      "epoch": "0",
+      "version": "1.7.5",
+      "release": "3.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-lib": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1635944550",
+      "arch": "x86_64"
+    },
+    "python3-ptyprocess": {
+      "epoch": "0",
+      "version": "0.5.2",
+      "release": "4.el8",
+      "installdate": "1635944665",
+      "arch": "noarch"
+    },
+    "gtk2": {
+      "epoch": "0",
+      "version": "2.24.32",
+      "release": "5.el8",
+      "installdate": "1636005959",
+      "arch": "x86_64"
+    },
+    "grub2-tools-minimal": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "python3-html5lib": {
+      "epoch": "1",
+      "version": "0.999999999",
+      "release": "6.el8",
+      "installdate": "1635944667",
+      "arch": "noarch"
+    },
+    "pki-servlet-engine": {
+      "epoch": "1",
+      "version": "9.0.30",
+      "release": "1.module_el8.4.0+595+e59c9af2",
+      "installdate": "1636005963",
+      "arch": "noarch"
+    },
+    "iptables-libs": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "17.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "python3-dnf": {
+      "epoch": "0",
+      "version": "4.4.2",
+      "release": "11.el8",
+      "installdate": "1635944668",
+      "arch": "noarch"
+    },
+    "adwaita-icon-theme": {
+      "epoch": "0",
+      "version": "3.28.0",
+      "release": "2.el8",
+      "installdate": "1636005971",
+      "arch": "noarch"
+    },
+    "grubby": {
+      "epoch": "0",
+      "version": "8.40",
+      "release": "41.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "python3-perf": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944668",
+      "arch": "x86_64"
+    },
+    "candlepin-selinux": {
+      "epoch": "0",
+      "version": "4.1.7",
+      "release": "1.el8",
+      "installdate": "1636005975",
+      "arch": "noarch"
+    },
+    "libdb-utils": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "sssd-ad": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944668",
+      "arch": "x86_64"
+    },
+    "python3-typing": {
+      "epoch": "0",
+      "version": "3.7.4.3",
+      "release": "1.el8",
+      "installdate": "1636006047",
+      "arch": "noarch"
+    },
+    "crypto-policies-scripts": {
+      "epoch": "0",
+      "version": "20210209",
+      "release": "1.gitbfb6bed.el8_3",
+      "installdate": "1635944557",
+      "arch": "noarch"
+    },
+    "python3-setuptools": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1635944669",
+      "arch": "noarch"
+    },
+    "python3-click": {
+      "epoch": "0",
+      "version": "7.1.2",
+      "release": "1.el8",
+      "installdate": "1636006048",
+      "arch": "noarch"
+    },
+    "cracklib": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1635944557",
+      "arch": "x86_64"
+    },
+    "authselect": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "2.el8",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "python3-rq": {
+      "epoch": "0",
+      "version": "1.8.1",
+      "release": "1.el8",
+      "installdate": "1636006048",
+      "arch": "noarch"
+    },
+    "libtirpc": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "4.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "vim-filesystem": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "15.el8",
+      "installdate": "1635944669",
+      "arch": "noarch"
+    },
+    "python3-zipp": {
+      "epoch": "0",
+      "version": "3.4.0",
+      "release": "2.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "elfutils-debuginfod-client": {
+      "epoch": "0",
+      "version": "0.182",
+      "release": "3.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "cockpit-packagekit": {
+      "epoch": "0",
+      "version": "238.2",
+      "release": "1.el8",
+      "installdate": "1635944672",
+      "arch": "noarch"
+    },
+    "python3-whitenoise": {
+      "epoch": "0",
+      "version": "5.2.0",
+      "release": "1.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "gettext-libs": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "libXext": {
+      "epoch": "0",
+      "version": "1.3.4",
+      "release": "1.el8",
+      "installdate": "1635944672",
+      "arch": "x86_64"
+    },
+    "python3-pytz": {
+      "epoch": "0",
+      "version": "2021.1",
+      "release": "1.el8",
+      "installdate": "1636006050",
+      "arch": "noarch"
+    },
+    "dbus-libs": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "12.el8_4.2",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-cairo": {
+      "epoch": "0",
+      "version": "1.16.3",
+      "release": "6.el8",
+      "installdate": "1635944673",
+      "arch": "x86_64"
+    },
+    "python3-ecdsa": {
+      "epoch": "0",
+      "version": "0.13.3",
+      "release": "2.el8",
+      "installdate": "1636006587",
+      "arch": "noarch"
+    },
+    "python3-pulp-container": {
+      "epoch": "0",
+      "version": "2.8.1",
+      "release": "0.2.el8",
+      "installdate": "1636006588",
+      "arch": "noarch"
+    },
+    "python3-createrepo_c": {
+      "epoch": "0",
+      "version": "0.17.6",
+      "release": "1.el8",
+      "installdate": "1636006596",
+      "arch": "x86_64"
+    },
+    "python3-aiodns": {
+      "epoch": "0",
+      "version": "3.0.0",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "noarch"
+    },
+    "python3-aiohttp-xmlrpc": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "1.el8",
+      "installdate": "1636006597",
+      "arch": "noarch"
+    },
+    "python3-jinja2": {
+      "epoch": "0",
+      "version": "2.11.3",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "python3-packaging": {
+      "epoch": "0",
+      "version": "21.0",
+      "release": "1.el8",
+      "installdate": "1636006610",
+      "arch": "noarch"
+    },
+    "python3-gunicorn": {
+      "epoch": "0",
+      "version": "20.1.0",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "python3-ruamel-yaml-clib": {
+      "epoch": "0",
+      "version": "0.2.0",
+      "release": "2.el8",
+      "installdate": "1636006610",
+      "arch": "x86_64"
+    },
+    "python3-djangorestframework-queryfields": {
+      "epoch": "0",
+      "version": "1.0.0",
+      "release": "3.el8",
+      "installdate": "1636006062",
+      "arch": "noarch"
+    },
+    "python3-pycodestyle": {
+      "epoch": "0",
+      "version": "2.7.0",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "python3-tablib": {
+      "epoch": "0",
+      "version": "3.0.0",
+      "release": "1.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "python3-dataclasses": {
+      "epoch": "0",
+      "version": "0.8",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "python3-aiofiles": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "1.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "python3-enrich": {
+      "epoch": "0",
+      "version": "1.2.6",
+      "release": "1.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "python3-psycopg2": {
+      "epoch": "0",
+      "version": "2.8.6",
+      "release": "1.el8",
+      "installdate": "1636006064",
+      "arch": "x86_64"
+    },
+    "python3-async-lru": {
+      "epoch": "0",
+      "version": "1.0.2",
+      "release": "1.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "rubygem-concurrent-ruby": {
+      "epoch": "1",
+      "version": "1.1.6",
+      "release": "3.el8",
+      "installdate": "1636006338",
+      "arch": "noarch"
+    },
+    "ansible-test": {
+      "epoch": "0",
+      "version": "2.9.27",
+      "release": "1.el8",
+      "installdate": "1636006633",
+      "arch": "noarch"
+    },
+    "nodejs": {
+      "epoch": "1",
+      "version": "10.24.0",
+      "release": "1.module_el8.3.0+717+fa496f1d",
+      "installdate": "1636006346",
+      "arch": "x86_64"
+    },
+    "python3-pulp-certguard": {
+      "epoch": "0",
+      "version": "1.4.0",
+      "release": "3.el8",
+      "installdate": "1636006639",
+      "arch": "noarch"
+    },
+    "rubygem-thor": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "3.el8",
+      "installdate": "1636006346",
+      "arch": "noarch"
+    },
+    "rubygem-hammer_cli_foreman_remote_execution": {
+      "epoch": "0",
+      "version": "0.2.2",
+      "release": "1.fm3_0.el8",
+      "installdate": "1636006676",
+      "arch": "noarch"
+    },
+    "rubygem-fast_gettext": {
+      "epoch": "0",
+      "version": "1.4.1",
+      "release": "5.el8",
+      "installdate": "1636006347",
+      "arch": "noarch"
+    },
+    "rubygem-smart_proxy_pulp": {
+      "epoch": "0",
+      "version": "3.1.0",
+      "release": "1.fm2_6.el8",
+      "installdate": "1636007685",
+      "arch": "noarch"
+    },
+    "rubygem-net-scp": {
+      "epoch": "0",
+      "version": "1.2.1",
+      "release": "5.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-rack-jsonp": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "10.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-websocket-driver": {
+      "epoch": "0",
+      "version": "0.7.1",
+      "release": "2.el8",
+      "installdate": "1636006348",
+      "arch": "x86_64"
+    },
+    "rubygem-http-cookie": {
+      "epoch": "0",
+      "version": "1.0.2",
+      "release": "5.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "rubygem-sshkey": {
+      "epoch": "0",
+      "version": "1.9.0",
+      "release": "5.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "rubygem-public_suffix": {
+      "epoch": "0",
+      "version": "3.0.3",
+      "release": "3.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "rubygem-graphql-batch": {
+      "epoch": "0",
+      "version": "0.3.10",
+      "release": "3.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "rubygem-net-ping": {
+      "epoch": "0",
+      "version": "2.0.1",
+      "release": "5.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "rubygem-mini_mime": {
+      "epoch": "0",
+      "version": "1.0.2",
+      "release": "2.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "rubygem-rest-client": {
+      "epoch": "0",
+      "version": "2.0.2",
+      "release": "4.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "rubygem-hocon": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "2.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "rubygem-get_process_mem": {
+      "epoch": "0",
+      "version": "0.2.7",
+      "release": "2.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "rubygem-deacon": {
+      "epoch": "0",
+      "version": "1.0.0",
+      "release": "5.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "rubygem-rails-html-sanitizer": {
+      "epoch": "0",
+      "version": "1.3.0",
+      "release": "2.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "rubygem-apipie-dsl": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "1.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "rubygem-pg": {
+      "epoch": "0",
+      "version": "1.2.3",
+      "release": "1.module_el8.3.0+429+625e5e4e",
+      "installdate": "1636006354",
+      "arch": "x86_64"
+    },
+    "rubygem-actionview": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006355",
+      "arch": "noarch"
+    },
+    "rubygem-activemodel": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006357",
+      "arch": "noarch"
+    },
+    "rubygem-audited": {
+      "epoch": "0",
+      "version": "4.9.0",
+      "release": "4.el8",
+      "installdate": "1636006357",
+      "arch": "noarch"
+    },
+    "rubygem-validates_lengths_from_database": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "8.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "rubygem-roadie-rails": {
+      "epoch": "0",
+      "version": "2.1.1",
+      "release": "3.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "rubygem-activejob": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "rubygem-actionmailer": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "rubygem-ldap_fluff": {
+      "epoch": "0",
+      "version": "0.6.0",
+      "release": "1.el8",
+      "installdate": "1636006360",
+      "arch": "noarch"
+    },
+    "rubygem-puma": {
+      "epoch": "0",
+      "version": "5.3.2",
+      "release": "1.el8",
+      "installdate": "1636006387",
+      "arch": "x86_64"
+    },
+    "rubygem-puma-status": {
+      "epoch": "0",
+      "version": "1.3",
+      "release": "1.el8",
+      "installdate": "1636006387",
+      "arch": "noarch"
+    },
+    "rubygem-rack-protection": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "2.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "foreman-dynflow-sidekiq": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "apr-util": {
+      "epoch": "0",
+      "version": "1.6.1",
+      "release": "6.el8",
+      "installdate": "1636006398",
+      "arch": "x86_64"
+    },
+    "mod_http2": {
+      "epoch": "0",
+      "version": "1.15.7",
+      "release": "3.module_el8.4.0+778+c970deab",
+      "installdate": "1636006399",
+      "arch": "x86_64"
+    },
+    "rubygem-tilt": {
+      "epoch": "0",
+      "version": "2.0.8",
+      "release": "5.el8",
+      "installdate": "1636006426",
+      "arch": "noarch"
+    },
+    "rubygem-robotex": {
+      "epoch": "0",
+      "version": "1.0.0",
+      "release": "22.el8",
+      "installdate": "1636006426",
+      "arch": "noarch"
+    },
+    "qpid-proton-c": {
+      "epoch": "0",
+      "version": "0.32.0",
+      "release": "3.el8",
+      "installdate": "1636006427",
+      "arch": "x86_64"
+    },
+    "rubygem-ruby2_keywords": {
+      "epoch": "0",
+      "version": "0.0.4",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "rubygem-faraday": {
+      "epoch": "0",
+      "version": "0.17.3",
+      "release": "2.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "rubygem-pulp_deb_client": {
+      "epoch": "0",
+      "version": "2.13.0",
+      "release": "1.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "rubygem-pulpcore_client": {
+      "epoch": "1",
+      "version": "3.14.1",
+      "release": "1.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "rubygem-parse-cron": {
+      "epoch": "0",
+      "version": "0.1.4",
+      "release": "5.fm2_5.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "yum-utils": {
+      "epoch": "0",
+      "version": "4.0.18",
+      "release": "4.el8",
+      "installdate": "1636006452",
+      "arch": "noarch"
+    },
+    "rubygem-server_sent_events": {
+      "epoch": "0",
+      "version": "0.1.2",
+      "release": "2.el8",
+      "installdate": "1636006464",
+      "arch": "noarch"
+    },
+    "rubygem-gssapi": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "8.el8",
+      "installdate": "1636006464",
+      "arch": "noarch"
+    },
+    "yajl": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "10.el8",
+      "installdate": "1636006465",
+      "arch": "x86_64"
+    },
+    "ipmitool": {
+      "epoch": "0",
+      "version": "1.8.18",
+      "release": "17.el8",
+      "installdate": "1636006467",
+      "arch": "x86_64"
+    },
+    "katello-client-bootstrap": {
+      "epoch": "0",
+      "version": "1.7.7",
+      "release": "1.el8",
+      "installdate": "1636006481",
+      "arch": "noarch"
+    },
+    "puppetserver": {
+      "epoch": "0",
+      "version": "6.17.0",
+      "release": "1.el8",
+      "installdate": "1636006501",
+      "arch": "noarch"
+    },
+    "localhost-tomcat": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006529",
+      "arch": "noarch"
+    },
+    "foreman.cluster.local-foreman-proxy-client": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006556",
+      "arch": "noarch"
+    },
+    "rubygem-unicode": {
+      "epoch": "0",
+      "version": "0.4.4.4",
+      "release": "4.el8",
+      "installdate": "1636006565",
+      "arch": "x86_64"
+    },
+    "rubygem-hammer_cli_foreman": {
+      "epoch": "0",
+      "version": "3.0.0",
+      "release": "1.el8",
+      "installdate": "1636006566",
+      "arch": "noarch"
+    },
+    "python3-pyjwt": {
+      "epoch": "0",
+      "version": "1.7.1",
+      "release": "3.el8",
+      "installdate": "1636006585",
+      "arch": "noarch"
+    },
+    "python3-django-currentuser": {
+      "epoch": "0",
+      "version": "0.5.3",
+      "release": "1.el8",
+      "installdate": "1636006058",
+      "arch": "noarch"
+    },
+    "python3-future": {
+      "epoch": "0",
+      "version": "0.18.2",
+      "release": "3.el8",
+      "installdate": "1636006587",
+      "arch": "noarch"
+    },
+    "cockpit-system": {
+      "epoch": "0",
+      "version": "238.2",
+      "release": "1.el8",
+      "installdate": "1635944674",
+      "arch": "noarch"
+    },
+    "bind-license": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "installdate": "1635944504",
+      "arch": "noarch"
+    },
+    "python3-jsonschema": {
+      "epoch": "0",
+      "version": "3.2.0",
+      "release": "4.el8",
+      "installdate": "1636006059",
+      "arch": "noarch"
+    },
+    "libdb": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1635944561",
+      "arch": "x86_64"
+    },
+    "createrepo_c-libs": {
+      "epoch": "0",
+      "version": "0.17.6",
+      "release": "1.el8",
+      "installdate": "1636006596",
+      "arch": "x86_64"
+    },
+    "kpatch": {
+      "epoch": "0",
+      "version": "0.9.2",
+      "release": "3.el8",
+      "installdate": "1635944679",
+      "arch": "noarch"
+    },
+    "dnf-data": {
+      "epoch": "0",
+      "version": "4.4.2",
+      "release": "11.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "python3-prometheus-client": {
+      "epoch": "0",
+      "version": "0.8.0",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "noarch"
+    },
+    "libpwquality": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "3.el8",
+      "installdate": "1635944562",
+      "arch": "x86_64"
+    },
+    "python3-pulp-deb": {
+      "epoch": "0",
+      "version": "2.14.1",
+      "release": "2.el8",
+      "installdate": "1636006601",
+      "arch": "noarch"
+    },
+    "firewalld": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "7.el8_4",
+      "installdate": "1635944681",
+      "arch": "noarch"
+    },
+    "libssh-config": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "2.el8",
+      "installdate": "1635944529",
+      "arch": "noarch"
+    },
+    "python3-gnupg": {
+      "epoch": "0",
+      "version": "0.4.7",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "glib2": {
+      "epoch": "0",
+      "version": "2.56.4",
+      "release": "10.el8_4.1",
+      "installdate": "1635944566",
+      "arch": "x86_64"
+    },
+    "python3-pyflakes": {
+      "epoch": "0",
+      "version": "2.3.1",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "util-linux-user": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "centos-gpg-keys": {
+      "epoch": "1",
+      "version": "8",
+      "release": "3.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "python3-django-import-export": {
+      "epoch": "0",
+      "version": "2.5.0",
+      "release": "1.el8",
+      "installdate": "1636006063",
+      "arch": "noarch"
+    },
+    "libldb": {
+      "epoch": "0",
+      "version": "2.2.0",
+      "release": "2.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "python3-rich": {
+      "epoch": "0",
+      "version": "10.0.1",
+      "release": "1.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "at": {
+      "epoch": "0",
+      "version": "3.1.20",
+      "release": "11.el8",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "ncurses-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "7.20180224.el8",
+      "installdate": "1635944531",
+      "arch": "x86_64"
+    },
+    "python3-pulpcore": {
+      "epoch": "0",
+      "version": "3.14.8",
+      "release": "2.el8",
+      "installdate": "1636006065",
+      "arch": "noarch"
+    },
+    "device-mapper-event-libs": {
+      "epoch": "8",
+      "version": "1.02.175",
+      "release": "5.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "ansible": {
+      "epoch": "0",
+      "version": "2.9.27",
+      "release": "1.el8",
+      "installdate": "1636006632",
+      "arch": "noarch"
+    },
+    "dracut-config-rescue": {
+      "epoch": "0",
+      "version": "049",
+      "release": "135.git20210121.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "popt": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "rubygem-sexp_processor": {
+      "epoch": "0",
+      "version": "4.10.0",
+      "release": "7.el8",
+      "installdate": "1636006346",
+      "arch": "noarch"
+    },
+    "rubygem-hammer_cli_foreman_puppet": {
+      "epoch": "0",
+      "version": "0.0.3",
+      "release": "1.fm3_0.el8",
+      "installdate": "1636006672",
+      "arch": "noarch"
+    },
+    "lsof": {
+      "epoch": "0",
+      "version": "4.93.2",
+      "release": "1.el8",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "libgpg-error": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "1.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-builder": {
+      "epoch": "0",
+      "version": "3.2.4",
+      "release": "2.el8",
+      "installdate": "1636006347",
+      "arch": "noarch"
+    },
+    "selinux-policy": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "67.el8_4.2",
+      "installdate": "1635944575",
+      "arch": "noarch"
+    },
+    "nano": {
+      "epoch": "0",
+      "version": "2.9.8",
+      "release": "1.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "libtdb": {
+      "epoch": "0",
+      "version": "1.4.3",
+      "release": "1.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-rack-test": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "5.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "python3-libstoragemgmt-clibs": {
+      "epoch": "0",
+      "version": "1.8.7",
+      "release": "1.el8",
+      "installdate": "1635944580",
+      "arch": "x86_64"
+    },
+    "hostname": {
+      "epoch": "0",
+      "version": "3.20",
+      "release": "6.el8",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "libdhash": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "39.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-thread_safe": {
+      "epoch": "0",
+      "version": "0.3.6",
+      "release": "6.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "iproute": {
+      "epoch": "0",
+      "version": "5.9.0",
+      "release": "4.el8",
+      "installdate": "1635944582",
+      "arch": "x86_64"
+    },
+    "words": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "28.el8",
+      "installdate": "1635944692",
+      "arch": "noarch"
+    },
+    "libattr": {
+      "epoch": "0",
+      "version": "2.4.48",
+      "release": "3.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-addressable": {
+      "epoch": "0",
+      "version": "2.8.0",
+      "release": "1.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "avahi-libs": {
+      "epoch": "0",
+      "version": "0.7",
+      "release": "20.el8",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "iwl6000-firmware": {
+      "epoch": "0",
+      "version": "9.221.4.1",
+      "release": "102.el8.1",
+      "installdate": "1635944696",
+      "arch": "noarch"
+    },
+    "libgcrypt": {
+      "epoch": "0",
+      "version": "1.8.5",
+      "release": "4.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-mini_portile2": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "1.el8",
+      "installdate": "1636006350",
+      "arch": "noarch"
+    },
+    "libwbclient": {
+      "epoch": "0",
+      "version": "4.13.3",
+      "release": "4.el8_4",
+      "installdate": "1635944585",
+      "arch": "x86_64"
+    },
+    "iwl1000-firmware": {
+      "epoch": "1",
+      "version": "39.31.5.1",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "file-libs": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "16.el8_3.1",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-method_source": {
+      "epoch": "0",
+      "version": "0.9.2",
+      "release": "3.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "clevis": {
+      "epoch": "0",
+      "version": "15",
+      "release": "1.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "centos-release-ansible-29": {
+      "epoch": "0",
+      "version": "1",
+      "release": "2.el8",
+      "installdate": "1635946906",
+      "arch": "noarch"
+    },
+    "protobuf-c": {
+      "epoch": "0",
+      "version": "1.3.0",
+      "release": "6.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-excon": {
+      "epoch": "0",
+      "version": "0.76.0",
+      "release": "2.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "python3-pydbus": {
+      "epoch": "0",
+      "version": "0.6.0",
+      "release": "5.el8",
+      "installdate": "1635944587",
+      "arch": "noarch"
+    },
+    "libsolv": {
+      "epoch": "0",
+      "version": "0.7.20",
+      "release": "1.el8",
+      "installdate": "1635946987",
+      "arch": "x86_64"
+    },
+    "gdbm-libs": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-bundler_ext": {
+      "epoch": "0",
+      "version": "0.4.1",
+      "release": "6.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "device-mapper-event": {
+      "epoch": "8",
+      "version": "1.02.175",
+      "release": "5.el8",
+      "installdate": "1635944600",
+      "arch": "x86_64"
+    },
+    "rubygem-io-console": {
+      "epoch": "0",
+      "version": "0.5.6",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947073",
+      "arch": "x86_64"
+    },
+    "mpfr": {
+      "epoch": "0",
+      "version": "3.1.6",
+      "release": "1.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-minitest": {
+      "epoch": "0",
+      "version": "5.13.0",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "container-selinux": {
+      "epoch": "2",
+      "version": "2.167.0",
+      "release": "1.module_el8.4.0+942+d25aada8",
+      "installdate": "1635944601",
+      "arch": "noarch"
+    },
+    "rubygem-highline": {
+      "epoch": "0",
+      "version": "2.0.3",
+      "release": "2.el8",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "cpio": {
+      "epoch": "0",
+      "version": "2.12",
+      "release": "10.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-activerecord": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006357",
+      "arch": "noarch"
+    },
+    "oddjob-mkhomedir": {
+      "epoch": "0",
+      "version": "0.34.7",
+      "release": "1.el8",
+      "installdate": "1635944653",
+      "arch": "x86_64"
+    },
+    "rubygem-powerbar": {
+      "epoch": "0",
+      "version": "2.0.1",
+      "release": "3.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "lzo": {
+      "epoch": "0",
+      "version": "2.08",
+      "release": "14.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-will_paginate": {
+      "epoch": "0",
+      "version": "3.1.7",
+      "release": "4.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "libslirp": {
+      "epoch": "0",
+      "version": "4.3.1",
+      "release": "1.module_el8.4.0+575+63b40ad7",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "patch": {
+      "epoch": "0",
+      "version": "2.7.6",
+      "release": "11.el8",
+      "installdate": "1635947221",
+      "arch": "x86_64"
+    },
+    "gdbm": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-activestorage": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "gsettings-desktop-schemas": {
+      "epoch": "0",
+      "version": "3.32.0",
+      "release": "5.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "openblas-srpm-macros": {
+      "epoch": "0",
+      "version": "2",
+      "release": "2.el8",
+      "installdate": "1635947221",
+      "arch": "noarch"
+    },
+    "groff-base": {
+      "epoch": "0",
+      "version": "1.22.3",
+      "release": "18.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "rubygem-rabl": {
+      "epoch": "0",
+      "version": "0.14.3",
+      "release": "2.el8",
+      "installdate": "1636006360",
+      "arch": "noarch"
+    },
+    "gnupg2-smime": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "ghc-srpm-macros": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "7.el8",
+      "installdate": "1635947224",
+      "arch": "noarch"
+    },
+    "bzip2": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "foreman-service": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006387",
+      "arch": "noarch"
+    },
+    "podman-catatonit": {
+      "epoch": "0",
+      "version": "3.2.3",
+      "release": "0.11.module_el8.4.0+942+d25aada8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "javapackages-filesystem": {
+      "epoch": "0",
+      "version": "5.3.0",
+      "release": "1.module_el8.0.0+11+5b8c10bd",
+      "installdate": "1636005939",
+      "arch": "noarch"
+    },
+    "coreutils-common": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "8.el8",
+      "installdate": "1635944544",
+      "arch": "x86_64"
+    },
+    "apr": {
+      "epoch": "0",
+      "version": "1.6.3",
+      "release": "11.el8",
+      "installdate": "1636006398",
+      "arch": "x86_64"
+    },
+    "sssd-client": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "libXdamage": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "14.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "libxcb": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "1.el8",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "httpd": {
+      "epoch": "0",
+      "version": "2.4.37",
+      "release": "39.module_el8.4.0+950+0577e6ac.1",
+      "installdate": "1636006400",
+      "arch": "x86_64"
+    },
+    "bind-export-libs": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "gtk-update-icon-cache": {
+      "epoch": "0",
+      "version": "3.22.30",
+      "release": "6.el8",
+      "installdate": "1636005940",
+      "arch": "x86_64"
+    },
+    "brotli": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "3.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "rubygem-anemone": {
+      "epoch": "0",
+      "version": "0.7.2",
+      "release": "23.el8",
+      "installdate": "1636006427",
+      "arch": "noarch"
+    },
+    "plymouth-core-libs": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "9.20200615git1e36e30.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "ttmkfdir": {
+      "epoch": "0",
+      "version": "3.0.9",
+      "release": "54.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "hdparm": {
+      "epoch": "0",
+      "version": "9.54",
+      "release": "3.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "rubygem-mustermann": {
+      "epoch": "0",
+      "version": "1.1.1",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "nss": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "apache-commons-lang3": {
+      "epoch": "0",
+      "version": "3.7",
+      "release": "3.module_el8.0.0+39+6a9b6e22",
+      "installdate": "1636005948",
+      "arch": "noarch"
+    },
+    "pkgconf-pkg-config": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-pulp_file_client": {
+      "epoch": "0",
+      "version": "1.8.1",
+      "release": "1.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "udisks2-lvm2": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "6.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "xorg-x11-fonts-Type1": {
+      "epoch": "0",
+      "version": "7.5",
+      "release": "19.el8",
+      "installdate": "1636005949",
+      "arch": "noarch"
+    },
+    "lmdb-libs": {
+      "epoch": "0",
+      "version": "0.9.24",
+      "release": "1.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-foreman-tasks": {
+      "epoch": "0",
+      "version": "5.1.1",
+      "release": "1.fm3_0.el8",
+      "installdate": "1636006432",
+      "arch": "noarch"
+    },
+    "sssd-common": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "graphite2": {
+      "epoch": "0",
+      "version": "1.3.10",
+      "release": "10.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "pciutils": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el8",
+      "installdate": "1635944550",
+      "arch": "x86_64"
+    },
+    "rubygem-redfish_client": {
+      "epoch": "0",
+      "version": "0.5.2",
+      "release": "2.el8",
+      "installdate": "1636006464",
+      "arch": "noarch"
+    },
+    "python3-pexpect": {
+      "epoch": "0",
+      "version": "4.3.1",
+      "release": "3.el8",
+      "installdate": "1635944666",
+      "arch": "noarch"
+    },
+    "ant": {
+      "epoch": "0",
+      "version": "1.10.5",
+      "release": "1.module_el8.0.0+47+197dca37",
+      "installdate": "1636005961",
+      "arch": "noarch"
+    },
+    "libpcap": {
+      "epoch": "14",
+      "version": "1.9.1",
+      "release": "5.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "libvirt-libs": {
+      "epoch": "0",
+      "version": "6.0.0",
+      "release": "35.1.module_el8.4.0+885+5e18b468",
+      "installdate": "1636006466",
+      "arch": "x86_64"
+    },
+    "dnf": {
+      "epoch": "0",
+      "version": "4.4.2",
+      "release": "11.el8",
+      "installdate": "1635944668",
+      "arch": "noarch"
+    },
+    "candlepin": {
+      "epoch": "0",
+      "version": "4.1.7",
+      "release": "1.el8",
+      "installdate": "1636005975",
+      "arch": "noarch"
+    },
+    "libarchive": {
+      "epoch": "0",
+      "version": "3.3.3",
+      "release": "1.el8",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "subscription-manager-rhsm-certificates": {
+      "epoch": "0",
+      "version": "1.28.13",
+      "release": "4.el8_4",
+      "installdate": "1636006486",
+      "arch": "x86_64"
+    },
+    "sssd-ipa": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944668",
+      "arch": "x86_64"
+    },
+    "python3-multidict": {
+      "epoch": "0",
+      "version": "5.1.0",
+      "release": "1.el8",
+      "installdate": "1636006048",
+      "arch": "x86_64"
+    },
+    "gzip": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "12.el8",
+      "installdate": "1635944557",
+      "arch": "x86_64"
+    },
+    "foreman.cluster.local-apache": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006537",
+      "arch": "noarch"
+    },
+    "authselect-compat": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "2.el8",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "python3-idna-ssl": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "3.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "device-mapper": {
+      "epoch": "8",
+      "version": "1.02.175",
+      "release": "5.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "rubygem-locale": {
+      "epoch": "0",
+      "version": "2.0.9",
+      "release": "15.el8",
+      "installdate": "1636006565",
+      "arch": "noarch"
+    },
+    "man-pages-overrides": {
+      "epoch": "0",
+      "version": "8.3.0.2",
+      "release": "2.el8",
+      "installdate": "1635944672",
+      "arch": "noarch"
+    },
+    "python3-sqlparse": {
+      "epoch": "0",
+      "version": "0.4.1",
+      "release": "1.el8",
+      "installdate": "1636006050",
+      "arch": "noarch"
+    },
+    "libmount": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "27.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-urllib3": {
+      "epoch": "0",
+      "version": "1.26.6",
+      "release": "1.el8",
+      "installdate": "1636006585",
+      "arch": "noarch"
+    },
+    "python3-gobject": {
+      "epoch": "0",
+      "version": "3.28.3",
+      "release": "2.el8",
+      "installdate": "1635944673",
+      "arch": "x86_64"
+    },
+    "python3-django-guid": {
+      "epoch": "0",
+      "version": "2.2.1",
+      "release": "1.el8",
+      "installdate": "1636006059",
+      "arch": "noarch"
+    },
+    "python3-requests": {
+      "epoch": "0",
+      "version": "2.25.1",
+      "release": "1.el8",
+      "installdate": "1636006587",
+      "arch": "noarch"
+    },
+    "ca-certificates": {
+      "epoch": "0",
+      "version": "2021.2.50",
+      "release": "80.0.el8_4",
+      "installdate": "1635944560",
+      "arch": "noarch"
+    },
+    "man-pages": {
+      "epoch": "0",
+      "version": "4.15",
+      "release": "6.el8",
+      "installdate": "1635944678",
+      "arch": "x86_64"
+    },
+    "python3-setuptools-wheel": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1635944505",
+      "arch": "noarch"
+    },
+    "python3-cffi": {
+      "epoch": "0",
+      "version": "1.14.5",
+      "release": "1.el8",
+      "installdate": "1636006060",
+      "arch": "x86_64"
+    },
+    "python3-productmd": {
+      "epoch": "0",
+      "version": "1.33",
+      "release": "1.el8",
+      "installdate": "1636006596",
+      "arch": "noarch"
+    },
+    "dbus-daemon": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "12.el8_4.2",
+      "installdate": "1635944562",
+      "arch": "x86_64"
+    },
+    "chrony": {
+      "epoch": "0",
+      "version": "3.5",
+      "release": "2.el8",
+      "installdate": "1635944679",
+      "arch": "x86_64"
+    },
+    "quota-nls": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "12.el8",
+      "installdate": "1635944509",
+      "arch": "noarch"
+    },
+    "python3-inflection": {
+      "epoch": "0",
+      "version": "0.5.1",
+      "release": "1.el8",
+      "installdate": "1636006061",
+      "arch": "noarch"
+    },
+    "python3-bleach": {
+      "epoch": "0",
+      "version": "3.3.0",
+      "release": "1.el8",
+      "installdate": "1636006610",
+      "arch": "noarch"
+    },
+    "os-prober": {
+      "epoch": "0",
+      "version": "1.74",
+      "release": "6.el8",
+      "installdate": "1635944564",
+      "arch": "x86_64"
+    },
+    "kernel": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944681",
+      "arch": "x86_64"
+    },
+    "fuse-common": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "12.el8",
+      "installdate": "1635944530",
+      "arch": "x86_64"
+    },
+    "python3-defusedxml": {
+      "epoch": "0",
+      "version": "0.7.1",
+      "release": "1.el8",
+      "installdate": "1636006062",
+      "arch": "noarch"
+    },
+    "python3-flake8": {
+      "epoch": "0",
+      "version": "3.9.2",
+      "release": "1.el8",
+      "installdate": "1636006612",
+      "arch": "noarch"
+    },
+    "systemd-udev": {
+      "epoch": "0",
+      "version": "239",
+      "release": "45.el8_4.3",
+      "installdate": "1635944568",
+      "arch": "x86_64"
+    },
+    "rsyslog-gssapi": {
+      "epoch": "0",
+      "version": "8.1911.0",
+      "release": "7.el8_4.2",
+      "installdate": "1635944682",
+      "arch": "x86_64"
+    },
+    "setup": {
+      "epoch": "0",
+      "version": "2.12.2",
+      "release": "6.el8",
+      "installdate": "1635944530",
+      "arch": "noarch"
+    },
+    "python3-aiohttp": {
+      "epoch": "0",
+      "version": "3.7.4",
+      "release": "1.el8",
+      "installdate": "1636006064",
+      "arch": "x86_64"
+    },
+    "python3-wcmatch": {
+      "epoch": "0",
+      "version": "8.2",
+      "release": "1.el8",
+      "installdate": "1636006613",
+      "arch": "noarch"
+    },
+    "libmodulemd": {
+      "epoch": "0",
+      "version": "2.9.4",
+      "release": "2.el8",
+      "installdate": "1635944569",
+      "arch": "x86_64"
+    },
+    "mlocate": {
+      "epoch": "0",
+      "version": "0.26",
+      "release": "20.el8",
+      "installdate": "1635944688",
+      "arch": "x86_64"
+    },
+    "glibc": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "151.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "nodejs-full-i18n": {
+      "epoch": "1",
+      "version": "10.24.0",
+      "release": "1.module_el8.3.0+717+fa496f1d",
+      "installdate": "1636006339",
+      "arch": "x86_64"
+    },
+    "python3-galaxy-importer": {
+      "epoch": "0",
+      "version": "0.3.2",
+      "release": "1.el8",
+      "installdate": "1636006633",
+      "arch": "noarch"
+    },
+    "python3-gobject-base": {
+      "epoch": "0",
+      "version": "3.28.3",
+      "release": "2.el8",
+      "installdate": "1635944574",
+      "arch": "x86_64"
+    },
+    "tcpdump": {
+      "epoch": "14",
+      "version": "4.9.3",
+      "release": "1.el8",
+      "installdate": "1635944689",
+      "arch": "x86_64"
+    },
+    "xz-libs": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1635944533",
+      "arch": "x86_64"
+    },
+    "rubygem-net-ldap": {
+      "epoch": "0",
+      "version": "0.17.0",
+      "release": "2.el8",
+      "installdate": "1636006347",
+      "arch": "noarch"
+    },
+    "mod_ssl": {
+      "epoch": "1",
+      "version": "2.4.37",
+      "release": "39.module_el8.4.0+950+0577e6ac.1",
+      "installdate": "1636006688",
+      "arch": "x86_64"
+    },
+    "samba-common": {
+      "epoch": "0",
+      "version": "4.13.3",
+      "release": "4.el8_4",
+      "installdate": "1635944575",
+      "arch": "noarch"
+    },
+    "blktrace": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "10.el8",
+      "installdate": "1635944690",
+      "arch": "x86_64"
+    },
+    "readline": {
+      "epoch": "0",
+      "version": "7.0",
+      "release": "10.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-safemode": {
+      "epoch": "0",
+      "version": "1.3.6",
+      "release": "2.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "initscripts": {
+      "epoch": "0",
+      "version": "10.00.15",
+      "release": "1.el8",
+      "installdate": "1635944580",
+      "arch": "x86_64"
+    },
+    "bpftool": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944691",
+      "arch": "x86_64"
+    },
+    "chkconfig": {
+      "epoch": "0",
+      "version": "1.13",
+      "release": "2.el8",
+      "installdate": "1635944534",
+      "arch": "x86_64"
+    },
+    "rubygem-unf": {
+      "epoch": "0",
+      "version": "0.1.3",
+      "release": "9.el8",
+      "installdate": "1636006348",
+      "arch": "noarch"
+    },
+    "libuser": {
+      "epoch": "0",
+      "version": "0.62",
+      "release": "23.el8",
+      "installdate": "1635944582",
+      "arch": "x86_64"
+    },
+    "lsscsi": {
+      "epoch": "0",
+      "version": "0.32",
+      "release": "2.el8",
+      "installdate": "1635944692",
+      "arch": "x86_64"
+    },
+    "jansson": {
+      "epoch": "0",
+      "version": "2.11",
+      "release": "3.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-secure_headers": {
+      "epoch": "0",
+      "version": "6.3.0",
+      "release": "3.el8",
+      "installdate": "1636006349",
+      "arch": "noarch"
+    },
+    "ima-evm-utils": {
+      "epoch": "0",
+      "version": "1.3.2",
+      "release": "12.el8",
+      "installdate": "1635944583",
+      "arch": "x86_64"
+    },
+    "libertas-usb8388-firmware": {
+      "epoch": "2",
+      "version": "20201218",
+      "release": "102.git05789708.el8",
+      "installdate": "1635944692",
+      "arch": "noarch"
+    },
+    "libmnl": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "6.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-nio4r": {
+      "epoch": "0",
+      "version": "2.5.4",
+      "release": "2.el8",
+      "installdate": "1636006350",
+      "arch": "x86_64"
+    },
+    "python3-nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "18.el8",
+      "installdate": "1635944584",
+      "arch": "x86_64"
+    },
+    "iwl3160-firmware": {
+      "epoch": "1",
+      "version": "25.30.13.0",
+      "release": "102.el8.1",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "which": {
+      "epoch": "0",
+      "version": "2.21",
+      "release": "12.el8",
+      "installdate": "1635944535",
+      "arch": "x86_64"
+    },
+    "rubygem-mime-types-data": {
+      "epoch": "0",
+      "version": "3.2018.0812",
+      "release": "5.el8",
+      "installdate": "1636006351",
+      "arch": "noarch"
+    },
+    "unbound-libs": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "15.el8",
+      "installdate": "1635944586",
+      "arch": "x86_64"
+    },
+    "NetworkManager-config-server": {
+      "epoch": "1",
+      "version": "1.30.0",
+      "release": "10.el8_4",
+      "installdate": "1635944697",
+      "arch": "noarch"
+    },
+    "libffi": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "22.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-formatador": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "13.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "libblockdev-loop": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944587",
+      "arch": "x86_64"
+    },
+    "libcomps": {
+      "epoch": "0",
+      "version": "0.1.15",
+      "release": "1.el8",
+      "installdate": "1635946986",
+      "arch": "x86_64"
+    },
+    "pciutils-libs": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el8",
+      "installdate": "1635944536",
+      "arch": "x86_64"
+    },
+    "rubygem-crass": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "2.el8",
+      "installdate": "1636006353",
+      "arch": "noarch"
+    },
+    "libgusb": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "1.el8",
+      "installdate": "1635944599",
+      "arch": "x86_64"
+    },
+    "device-mapper-persistent-data": {
+      "epoch": "0",
+      "version": "0.8.5",
+      "release": "4.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-dynflow": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "1.fm2_6.el8",
+      "installdate": "1636006354",
+      "arch": "noarch"
+    },
+    "python3-setools": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "2.el8",
+      "installdate": "1635944601",
+      "arch": "x86_64"
+    },
+    "rubygem-openssl": {
+      "epoch": "0",
+      "version": "2.1.2",
+      "release": "137.module_el8.4.0+875+807aec38",
+      "installdate": "1635947073",
+      "arch": "x86_64"
+    },
+    "gdisk": {
+      "epoch": "0",
+      "version": "1.0.3",
+      "release": "6.el8",
+      "installdate": "1635944537",
+      "arch": "x86_64"
+    },
+    "rubygem-railties": {
+      "epoch": "0",
+      "version": "6.0.3.7",
+      "release": "1.el8",
+      "installdate": "1636006356",
+      "arch": "noarch"
+    },
+    "python3-linux-procfs": {
+      "epoch": "0",
+      "version": "0.6.3",
+      "release": "1.el8",
+      "installdate": "1635944653",
+      "arch": "noarch"
+    },
+    "python3-rpm-macros": {
+      "epoch": "0",
+      "version": "3",
+      "release": "41.el8",
+      "installdate": "1635947074",
+      "arch": "noarch"
+    },
+    "libnfnetlink": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "13.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-friendly_id": {
+      "epoch": "0",
+      "version": "5.3.0",
+      "release": "2.el8",
+      "installdate": "1636006358",
+      "arch": "noarch"
+    },
+    "conmon": {
+      "epoch": "2",
+      "version": "2.0.29",
+      "release": "1.module_el8.4.0+886+c9a8d9ad",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "rubygem-multi_json": {
+      "epoch": "0",
+      "version": "1.14.1",
+      "release": "3.el8",
+      "installdate": "1635947075",
+      "arch": "noarch"
+    },
+    "sg3_utils-libs": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1635944538",
+      "arch": "x86_64"
+    },
+    "rubygem-record_tag_helper": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "4.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "python3-dbus": {
+      "epoch": "0",
+      "version": "1.2.4",
+      "release": "15.el8",
+      "installdate": "1635944654",
+      "arch": "x86_64"
+    },
+    "elfutils": {
+      "epoch": "0",
+      "version": "0.182",
+      "release": "3.el8",
+      "installdate": "1635947221",
+      "arch": "x86_64"
+    },
+    "libxslt": {
+      "epoch": "0",
+      "version": "1.1.32",
+      "release": "6.el8",
+      "installdate": "1635944539",
+      "arch": "x86_64"
+    },
+    "rubygem-apipie-rails": {
+      "epoch": "0",
+      "version": "0.5.17",
+      "release": "4.el8",
+      "installdate": "1636006359",
+      "arch": "noarch"
+    },
+    "libipa_hbac": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944655",
+      "arch": "x86_64"
+    },
+    "libatomic_ops": {
+      "epoch": "0",
+      "version": "7.6.2",
+      "release": "3.el8",
+      "installdate": "1635947222",
+      "arch": "x86_64"
+    },
+    "vim-minimal": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "15.el8",
+      "installdate": "1635944540",
+      "arch": "x86_64"
+    },
+    "rubygem-net_http_unix": {
+      "epoch": "0",
+      "version": "0.2.2",
+      "release": "2.el8",
+      "installdate": "1636006387",
+      "arch": "noarch"
+    },
+    "PackageKit": {
+      "epoch": "0",
+      "version": "1.1.12",
+      "release": "6.el8",
+      "installdate": "1635944656",
+      "arch": "x86_64"
+    },
+    "redhat-rpm-config": {
+      "epoch": "0",
+      "version": "125",
+      "release": "1.el8",
+      "installdate": "1635947224",
+      "arch": "noarch"
+    },
+    "libicu": {
+      "epoch": "0",
+      "version": "60.3",
+      "release": "2.el8_1",
+      "installdate": "1635944542",
+      "arch": "x86_64"
+    },
+    "rubygem-sidekiq": {
+      "epoch": "0",
+      "version": "5.2.7",
+      "release": "4.el8",
+      "installdate": "1636006392",
+      "arch": "noarch"
+    },
+    "grub2-tools-extra": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1635944659",
+      "arch": "x86_64"
+    },
+    "libXfixes": {
+      "epoch": "0",
+      "version": "5.0.3",
+      "release": "7.el8",
+      "installdate": "1636005939",
+      "arch": "x86_64"
+    },
+    "kernel-tools-libs": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944544",
+      "arch": "x86_64"
+    },
+    "centos-logos-httpd": {
+      "epoch": "0",
+      "version": "85.8",
+      "release": "1.el8",
+      "installdate": "1636006398",
+      "arch": "noarch"
+    },
+    "clevis-luks": {
+      "epoch": "0",
+      "version": "15",
+      "release": "1.el8",
+      "installdate": "1635944660",
+      "arch": "x86_64"
+    },
+    "libwayland-client": {
+      "epoch": "0",
+      "version": "1.17.0",
+      "release": "1.el8",
+      "installdate": "1636005940",
+      "arch": "x86_64"
+    },
+    "libnet": {
+      "epoch": "0",
+      "version": "1.1.6",
+      "release": "15.el8",
+      "installdate": "1635944547",
+      "arch": "x86_64"
+    },
+    "rubygem-stomp": {
+      "epoch": "0",
+      "version": "1.4.9",
+      "release": "2.el8",
+      "installdate": "1636006426",
+      "arch": "noarch"
+    },
+    "device-mapper-multipath": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "10.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "colord-libs": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1636005941",
+      "arch": "x86_64"
+    },
+    "dosfstools": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "6.el8",
+      "installdate": "1635944548",
+      "arch": "x86_64"
+    },
+    "katello-debug": {
+      "epoch": "0",
+      "version": "4.2.0.1",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "dhcp-client": {
+      "epoch": "12",
+      "version": "4.3.6",
+      "release": "44.0.1.el8",
+      "installdate": "1635944661",
+      "arch": "x86_64"
+    },
+    "copy-jdk-configs": {
+      "epoch": "0",
+      "version": "3.7",
+      "release": "4.el8",
+      "installdate": "1636005942",
+      "arch": "noarch"
+    },
+    "libndp": {
+      "epoch": "0",
+      "version": "1.7",
+      "release": "5.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-pulp_certguard_client": {
+      "epoch": "0",
+      "version": "1.4.0",
+      "release": "1.el8",
+      "installdate": "1636006428",
+      "arch": "noarch"
+    },
+    "libblockdev-crypto": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "5.el8",
+      "installdate": "1635944662",
+      "arch": "x86_64"
+    },
+    "jss": {
+      "epoch": "0",
+      "version": "4.8.1",
+      "release": "2.module_el8.4.0+796+2f72979f",
+      "installdate": "1636005949",
+      "arch": "x86_64"
+    },
+    "libsss_autofs": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "rubygem-polyglot": {
+      "epoch": "0",
+      "version": "0.3.5",
+      "release": "3.el8",
+      "installdate": "1636006429",
+      "arch": "noarch"
+    },
+    "NetworkManager-team": {
+      "epoch": "1",
+      "version": "1.30.0",
+      "release": "10.el8_4",
+      "installdate": "1635944664",
+      "arch": "x86_64"
+    },
+    "libthai": {
+      "epoch": "0",
+      "version": "0.1.27",
+      "release": "2.el8",
+      "installdate": "1636005950",
+      "arch": "x86_64"
+    },
+    "npth": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "4.el8",
+      "installdate": "1635944549",
+      "arch": "x86_64"
+    },
+    "katello": {
+      "epoch": "0",
+      "version": "4.2.0.1",
+      "release": "1.el8",
+      "installdate": "1636006453",
+      "arch": "noarch"
+    },
+    "sssd-proxy": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944665",
+      "arch": "x86_64"
+    },
+    "fribidi": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "8.el8",
+      "installdate": "1636005958",
+      "arch": "x86_64"
+    },
+    "platform-python-setuptools": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1635944551",
+      "arch": "noarch"
+    },
+    "rubygem-rkerberos": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "20.el8",
+      "installdate": "1636006464",
+      "arch": "x86_64"
+    },
+    "kernel-tools": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "305.19.1.el8_4",
+      "installdate": "1635944667",
+      "arch": "x86_64"
+    },
+    "dconf": {
+      "epoch": "0",
+      "version": "0.28.0",
+      "release": "4.el8",
+      "installdate": "1636005963",
+      "arch": "x86_64"
+    },
+    "openldap": {
+      "epoch": "0",
+      "version": "2.4.46",
+      "release": "17.el8_4",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "foreman-proxy": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "1.el8",
+      "installdate": "1636006468",
+      "arch": "noarch"
+    },
+    "python3-bind": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "4.el8_4",
+      "installdate": "1635944668",
+      "arch": "noarch"
+    },
+    "libcurl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "18.el8_4.1",
+      "installdate": "1635944556",
+      "arch": "x86_64"
+    },
+    "katello-server-ca": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "1",
+      "installdate": "1636006517",
+      "arch": "noarch"
+    },
+    "sssd": {
+      "epoch": "0",
+      "version": "2.4.0",
+      "release": "9.el8_4.2",
+      "installdate": "1635944669",
+      "arch": "x86_64"
+    },
+    "python3-async-timeout": {
+      "epoch": "0",
+      "version": "3.0.1",
+      "release": "2.el8",
+      "installdate": "1636006048",
+      "arch": "noarch"
+    },
+    "procps-ng": {
+      "epoch": "0",
+      "version": "3.3.15",
+      "release": "6.el8",
+      "installdate": "1635944557",
+      "arch": "x86_64"
+    },
+    "rubygem-apipie-bindings": {
+      "epoch": "0",
+      "version": "0.4.0",
+      "release": "2.el8",
+      "installdate": "1636006565",
+      "arch": "noarch"
+    },
+    "tracer-common": {
+      "epoch": "0",
+      "version": "0.7.5",
+      "release": "2.el8",
+      "installdate": "1635944672",
+      "arch": "noarch"
+    },
+    "python3-xlwt": {
+      "epoch": "0",
+      "version": "1.3.0",
+      "release": "1.el8",
+      "installdate": "1636006049",
+      "arch": "noarch"
+    },
+    "openssl-pkcs11": {
+      "epoch": "0",
+      "version": "0.4.10",
+      "release": "2.el8",
+      "installdate": "1635944558",
+      "arch": "x86_64"
+    },
+    "python3-cryptography": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "4.el8",
+      "installdate": "1636006584",
+      "arch": "x86_64"
+    },
+    "cairo": {
+      "epoch": "0",
+      "version": "1.15.12",
+      "release": "3.el8",
+      "installdate": "1635944672",
+      "arch": "x86_64"
+    },
+    "python3-djangorestframework": {
+      "epoch": "0",
+      "version": "3.12.4",
+      "release": "1.el8",
+      "installdate": "1636006058",
+      "arch": "noarch"
+    },
+    "coreutils": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "8.el8",
+      "installdate": "1635944559",
+      "arch": "x86_64"
+    }
+  },
+  "root_group": "root",
+  "shard_seed": 80786970,
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/sh",
+    "/usr/bin/bash"
+  ],
+  "sysconf": {
+    "LINK_MAX": 2147483647,
+    "_POSIX_LINK_MAX": 2147483647,
+    "MAX_CANON": 255,
+    "_POSIX_MAX_CANON": 255,
+    "MAX_INPUT": 255,
+    "_POSIX_MAX_INPUT": 255,
+    "NAME_MAX": 255,
+    "_POSIX_NAME_MAX": 255,
+    "PATH_MAX": 4096,
+    "_POSIX_PATH_MAX": 4096,
+    "PIPE_BUF": 4096,
+    "_POSIX_PIPE_BUF": 4096,
+    "SOCK_MAXBUF": null,
+    "_POSIX_ASYNC_IO": null,
+    "_POSIX_CHOWN_RESTRICTED": 1,
+    "_POSIX_NO_TRUNC": 1,
+    "_POSIX_PRIO_IO": null,
+    "_POSIX_SYNC_IO": null,
+    "_POSIX_VDISABLE": 0,
+    "ARG_MAX": 2097152,
+    "ATEXIT_MAX": 2147483647,
+    "CHAR_BIT": 8,
+    "CHAR_MAX": 127,
+    "CHAR_MIN": -128,
+    "CHILD_MAX": 38978,
+    "CLK_TCK": 100,
+    "INT_MAX": 2147483647,
+    "INT_MIN": -2147483648,
+    "IOV_MAX": 1024,
+    "LOGNAME_MAX": 256,
+    "LONG_BIT": 64,
+    "MB_LEN_MAX": 16,
+    "NGROUPS_MAX": 65536,
+    "NL_ARGMAX": 4096,
+    "NL_LANGMAX": 2048,
+    "NL_MSGMAX": 2147483647,
+    "NL_NMAX": 2147483647,
+    "NL_SETMAX": 2147483647,
+    "NL_TEXTMAX": 2147483647,
+    "NSS_BUFLEN_GROUP": 1024,
+    "NSS_BUFLEN_PASSWD": 1024,
+    "NZERO": 20,
+    "OPEN_MAX": 1024,
+    "PAGESIZE": 4096,
+    "PAGE_SIZE": 4096,
+    "PASS_MAX": 8192,
+    "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+    "PTHREAD_KEYS_MAX": 1024,
+    "PTHREAD_STACK_MIN": 16384,
+    "PTHREAD_THREADS_MAX": null,
+    "SCHAR_MAX": 127,
+    "SCHAR_MIN": -128,
+    "SHRT_MAX": 32767,
+    "SHRT_MIN": -32768,
+    "SSIZE_MAX": 32767,
+    "TTY_NAME_MAX": 32,
+    "TZNAME_MAX": null,
+    "UCHAR_MAX": 255,
+    "UINT_MAX": 4294967295,
+    "UIO_MAXIOV": 1024,
+    "ULONG_MAX": 18446744073709551615,
+    "USHRT_MAX": 65535,
+    "WORD_BIT": 32,
+    "_AVPHYS_PAGES": 108304,
+    "_NPROCESSORS_CONF": 6,
+    "_NPROCESSORS_ONLN": 6,
+    "_PHYS_PAGES": 2504657,
+    "_POSIX_ARG_MAX": 2097152,
+    "_POSIX_ASYNCHRONOUS_IO": 200809,
+    "_POSIX_CHILD_MAX": 38978,
+    "_POSIX_FSYNC": 200809,
+    "_POSIX_JOB_CONTROL": 1,
+    "_POSIX_MAPPED_FILES": 200809,
+    "_POSIX_MEMLOCK": 200809,
+    "_POSIX_MEMLOCK_RANGE": 200809,
+    "_POSIX_MEMORY_PROTECTION": 200809,
+    "_POSIX_MESSAGE_PASSING": 200809,
+    "_POSIX_NGROUPS_MAX": 65536,
+    "_POSIX_OPEN_MAX": 1024,
+    "_POSIX_PII": null,
+    "_POSIX_PII_INTERNET": null,
+    "_POSIX_PII_INTERNET_DGRAM": null,
+    "_POSIX_PII_INTERNET_STREAM": null,
+    "_POSIX_PII_OSI": null,
+    "_POSIX_PII_OSI_CLTS": null,
+    "_POSIX_PII_OSI_COTS": null,
+    "_POSIX_PII_OSI_M": null,
+    "_POSIX_PII_SOCKET": null,
+    "_POSIX_PII_XTI": null,
+    "_POSIX_POLL": null,
+    "_POSIX_PRIORITIZED_IO": 200809,
+    "_POSIX_PRIORITY_SCHEDULING": 200809,
+    "_POSIX_REALTIME_SIGNALS": 200809,
+    "_POSIX_SAVED_IDS": 1,
+    "_POSIX_SELECT": null,
+    "_POSIX_SEMAPHORES": 200809,
+    "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+    "_POSIX_SSIZE_MAX": 32767,
+    "_POSIX_STREAM_MAX": 16,
+    "_POSIX_SYNCHRONIZED_IO": 200809,
+    "_POSIX_THREADS": 200809,
+    "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+    "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+    "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+    "_POSIX_THREAD_PRIO_INHERIT": 200809,
+    "_POSIX_THREAD_PRIO_PROTECT": 200809,
+    "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+    "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+    "_POSIX_THREAD_PROCESS_SHARED": 200809,
+    "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+    "_POSIX_TIMERS": 200809,
+    "TIMER_MAX": null,
+    "_POSIX_TZNAME_MAX": null,
+    "_POSIX_VERSION": 200809,
+    "_T_IOV_MAX": null,
+    "_XOPEN_CRYPT": null,
+    "_XOPEN_ENH_I18N": 1,
+    "_XOPEN_LEGACY": 1,
+    "_XOPEN_REALTIME": 1,
+    "_XOPEN_REALTIME_THREADS": 1,
+    "_XOPEN_SHM": 1,
+    "_XOPEN_UNIX": 1,
+    "_XOPEN_VERSION": 700,
+    "_XOPEN_XCU_VERSION": 4,
+    "_XOPEN_XPG2": 1,
+    "_XOPEN_XPG3": 1,
+    "_XOPEN_XPG4": 1,
+    "BC_BASE_MAX": 99,
+    "BC_DIM_MAX": 2048,
+    "BC_SCALE_MAX": 99,
+    "BC_STRING_MAX": 1000,
+    "CHARCLASS_NAME_MAX": 2048,
+    "COLL_WEIGHTS_MAX": 255,
+    "EQUIV_CLASS_MAX": null,
+    "EXPR_NEST_MAX": 32,
+    "LINE_MAX": 2048,
+    "POSIX2_BC_BASE_MAX": 99,
+    "POSIX2_BC_DIM_MAX": 2048,
+    "POSIX2_BC_SCALE_MAX": 99,
+    "POSIX2_BC_STRING_MAX": 1000,
+    "POSIX2_CHAR_TERM": 200809,
+    "POSIX2_COLL_WEIGHTS_MAX": 255,
+    "POSIX2_C_BIND": 200809,
+    "POSIX2_C_DEV": 200809,
+    "POSIX2_C_VERSION": 200809,
+    "POSIX2_EXPR_NEST_MAX": 32,
+    "POSIX2_FORT_DEV": null,
+    "POSIX2_FORT_RUN": null,
+    "_POSIX2_LINE_MAX": 2048,
+    "POSIX2_LINE_MAX": 2048,
+    "POSIX2_LOCALEDEF": 200809,
+    "POSIX2_RE_DUP_MAX": 32767,
+    "POSIX2_SW_DEV": 200809,
+    "POSIX2_UPE": null,
+    "POSIX2_VERSION": 200809,
+    "RE_DUP_MAX": 32767,
+    "PATH": "/usr/bin",
+    "CS_PATH": "/usr/bin",
+    "LFS_CFLAGS": null,
+    "LFS_LDFLAGS": null,
+    "LFS_LIBS": null,
+    "LFS_LINTFLAGS": null,
+    "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+    "LFS64_LDFLAGS": null,
+    "LFS64_LIBS": null,
+    "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+    "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+    "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+    "_XBS5_ILP32_OFF32": null,
+    "XBS5_ILP32_OFF32_CFLAGS": null,
+    "XBS5_ILP32_OFF32_LDFLAGS": null,
+    "XBS5_ILP32_OFF32_LIBS": null,
+    "XBS5_ILP32_OFF32_LINTFLAGS": null,
+    "_XBS5_ILP32_OFFBIG": null,
+    "XBS5_ILP32_OFFBIG_CFLAGS": null,
+    "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+    "XBS5_ILP32_OFFBIG_LIBS": null,
+    "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+    "_XBS5_LP64_OFF64": 1,
+    "XBS5_LP64_OFF64_CFLAGS": "-m64",
+    "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+    "XBS5_LP64_OFF64_LIBS": null,
+    "XBS5_LP64_OFF64_LINTFLAGS": null,
+    "_XBS5_LPBIG_OFFBIG": null,
+    "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+    "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+    "XBS5_LPBIG_OFFBIG_LIBS": null,
+    "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V6_ILP32_OFF32": null,
+    "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+    "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+    "POSIX_V6_ILP32_OFF32_LIBS": null,
+    "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+    "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+    "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+    "_POSIX_V6_ILP32_OFFBIG": null,
+    "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+    "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+    "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+    "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V6_LP64_OFF64": 1,
+    "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+    "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+    "POSIX_V6_LP64_OFF64_LIBS": null,
+    "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+    "_POSIX_V6_LPBIG_OFFBIG": null,
+    "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+    "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+    "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+    "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V7_ILP32_OFF32": null,
+    "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+    "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+    "POSIX_V7_ILP32_OFF32_LIBS": null,
+    "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+    "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+    "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+    "_POSIX_V7_ILP32_OFFBIG": null,
+    "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+    "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+    "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+    "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V7_LP64_OFF64": 1,
+    "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+    "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+    "POSIX_V7_LP64_OFF64_LIBS": null,
+    "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+    "_POSIX_V7_LPBIG_OFFBIG": null,
+    "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+    "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+    "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+    "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+    "_POSIX_ADVISORY_INFO": 200809,
+    "_POSIX_BARRIERS": 200809,
+    "_POSIX_BASE": null,
+    "_POSIX_C_LANG_SUPPORT": null,
+    "_POSIX_C_LANG_SUPPORT_R": null,
+    "_POSIX_CLOCK_SELECTION": 200809,
+    "_POSIX_CPUTIME": 200809,
+    "_POSIX_THREAD_CPUTIME": 200809,
+    "_POSIX_DEVICE_SPECIFIC": null,
+    "_POSIX_DEVICE_SPECIFIC_R": null,
+    "_POSIX_FD_MGMT": null,
+    "_POSIX_FIFO": null,
+    "_POSIX_PIPE": null,
+    "_POSIX_FILE_ATTRIBUTES": null,
+    "_POSIX_FILE_LOCKING": null,
+    "_POSIX_FILE_SYSTEM": null,
+    "_POSIX_MONOTONIC_CLOCK": 200809,
+    "_POSIX_MULTI_PROCESS": null,
+    "_POSIX_SINGLE_PROCESS": null,
+    "_POSIX_NETWORKING": null,
+    "_POSIX_READER_WRITER_LOCKS": 200809,
+    "_POSIX_SPIN_LOCKS": 200809,
+    "_POSIX_REGEXP": 1,
+    "_REGEX_VERSION": null,
+    "_POSIX_SHELL": 1,
+    "_POSIX_SIGNALS": null,
+    "_POSIX_SPAWN": 200809,
+    "_POSIX_SPORADIC_SERVER": null,
+    "_POSIX_THREAD_SPORADIC_SERVER": null,
+    "_POSIX_SYSTEM_DATABASE": null,
+    "_POSIX_SYSTEM_DATABASE_R": null,
+    "_POSIX_TIMEOUTS": 200809,
+    "_POSIX_TYPED_MEMORY_OBJECTS": null,
+    "_POSIX_USER_GROUPS": null,
+    "_POSIX_USER_GROUPS_R": null,
+    "POSIX2_PBS": null,
+    "POSIX2_PBS_ACCOUNTING": null,
+    "POSIX2_PBS_LOCATE": null,
+    "POSIX2_PBS_TRACK": null,
+    "POSIX2_PBS_MESSAGE": null,
+    "SYMLOOP_MAX": null,
+    "STREAM_MAX": 16,
+    "AIO_LISTIO_MAX": null,
+    "AIO_MAX": null,
+    "AIO_PRIO_DELTA_MAX": 20,
+    "DELAYTIMER_MAX": 2147483647,
+    "HOST_NAME_MAX": 64,
+    "LOGIN_NAME_MAX": 256,
+    "MQ_OPEN_MAX": null,
+    "MQ_PRIO_MAX": 32768,
+    "_POSIX_DEVICE_IO": null,
+    "_POSIX_TRACE": null,
+    "_POSIX_TRACE_EVENT_FILTER": null,
+    "_POSIX_TRACE_INHERIT": null,
+    "_POSIX_TRACE_LOG": null,
+    "RTSIG_MAX": 32,
+    "SEM_NSEMS_MAX": null,
+    "SEM_VALUE_MAX": 2147483647,
+    "SIGQUEUE_MAX": 38978,
+    "FILESIZEBITS": 64,
+    "POSIX_ALLOC_SIZE_MIN": 4096,
+    "POSIX_REC_INCR_XFER_SIZE": null,
+    "POSIX_REC_MAX_XFER_SIZE": null,
+    "POSIX_REC_MIN_XFER_SIZE": 4096,
+    "POSIX_REC_XFER_ALIGN": 4096,
+    "SYMLINK_MAX": null,
+    "GNU_LIBC_VERSION": "glibc 2.28",
+    "GNU_LIBPTHREAD_VERSION": "NPTL 2.28",
+    "POSIX2_SYMLINKS": 1,
+    "LEVEL1_ICACHE_SIZE": 32768,
+    "LEVEL1_ICACHE_ASSOC": 8,
+    "LEVEL1_ICACHE_LINESIZE": 64,
+    "LEVEL1_DCACHE_SIZE": 32768,
+    "LEVEL1_DCACHE_ASSOC": 8,
+    "LEVEL1_DCACHE_LINESIZE": 64,
+    "LEVEL2_CACHE_SIZE": 2097152,
+    "LEVEL2_CACHE_ASSOC": 8,
+    "LEVEL2_CACHE_LINESIZE": 64,
+    "LEVEL3_CACHE_SIZE": 16777216,
+    "LEVEL3_CACHE_ASSOC": 16,
+    "LEVEL3_CACHE_LINESIZE": 64,
+    "LEVEL4_CACHE_SIZE": 0,
+    "LEVEL4_CACHE_ASSOC": 0,
+    "LEVEL4_CACHE_LINESIZE": 0,
+    "IPV6": 200809,
+    "RAW_SOCKETS": 200809,
+    "_POSIX_IPV6": 200809,
+    "_POSIX_RAW_SOCKETS": 200809
+  }
+}

--- a/test/static_fixtures/facts/chef_centos_stream.json
+++ b/test/static_fixtures/facts/chef_centos_stream.json
@@ -1,0 +1,7875 @@
+{
+  "kernel": {
+    "name": "Linux",
+    "release": "4.18.0-338.el8.x86_64",
+    "version": "#1 SMP Fri Aug 27 17:32:14 UTC 2021",
+    "machine": "x86_64",
+    "processor": "x86_64",
+    "os": "GNU/Linux",
+    "modules": {
+      "nft_chain_nat": {
+        "size": "16384",
+        "refcount": "8"
+      },
+      "nf_nat": {
+        "size": "45056",
+        "refcount": "1"
+      },
+      "nf_conntrack": {
+        "size": "172032",
+        "refcount": "1"
+      },
+      "nf_defrag_ipv6": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "nf_defrag_ipv4": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ip_set": {
+        "size": "49152",
+        "refcount": "0"
+      },
+      "nf_tables": {
+        "size": "172032",
+        "refcount": "1"
+      },
+      "nfnetlink": {
+        "size": "16384",
+        "refcount": "2"
+      },
+      "snd_hda_codec_generic": {
+        "size": "86016",
+        "refcount": "1"
+      },
+      "ledtrig_audio": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_hda_intel": {
+        "size": "49152",
+        "refcount": "0"
+      },
+      "snd_intel_dspcfg": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "snd_intel_sdw_acpi": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "snd_hda_codec": {
+        "size": "151552",
+        "refcount": "2"
+      },
+      "crct10dif_pclmul": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "crc32_pclmul": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "snd_hda_core": {
+        "size": "102400",
+        "refcount": "3"
+      },
+      "snd_hwdep": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ghash_clmulni_intel": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "snd_pcm": {
+        "size": "118784",
+        "refcount": "3"
+      },
+      "snd_timer": {
+        "size": "36864",
+        "refcount": "1"
+      },
+      "joydev": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "snd": {
+        "size": "94208",
+        "refcount": "6"
+      },
+      "virtio_balloon": {
+        "size": "20480",
+        "refcount": "0"
+      },
+      "pcspkr": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "soundcore": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "i2c_piix4": {
+        "size": "24576",
+        "refcount": "0"
+      },
+      "xfs": {
+        "size": "1544192",
+        "refcount": "2"
+      },
+      "libcrc32c": {
+        "size": "16384",
+        "refcount": "4"
+      },
+      "sr_mod": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "cdrom": {
+        "size": "65536",
+        "refcount": "1"
+      },
+      "qxl": {
+        "size": "69632",
+        "refcount": "0"
+      },
+      "sg": {
+        "size": "40960",
+        "refcount": "0",
+        "version": "3.5.36"
+      },
+      "drm_ttm_helper": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "ttm": {
+        "size": "77824",
+        "refcount": "2"
+      },
+      "ata_generic": {
+        "size": "16384",
+        "refcount": "0",
+        "version": "0.2.15"
+      },
+      "drm_kms_helper": {
+        "size": "253952",
+        "refcount": "3"
+      },
+      "syscopyarea": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysfillrect": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "sysimgblt": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "fb_sys_fops": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "drm": {
+        "size": "573440",
+        "refcount": "5"
+      },
+      "ata_piix": {
+        "size": "36864",
+        "refcount": "0",
+        "version": "2.13"
+      },
+      "libata": {
+        "size": "270336",
+        "refcount": "2",
+        "version": "3.00"
+      },
+      "crc32c_intel": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "virtio_net": {
+        "size": "53248",
+        "refcount": "0"
+      },
+      "virtio_console": {
+        "size": "36864",
+        "refcount": "0"
+      },
+      "serio_raw": {
+        "size": "16384",
+        "refcount": "0"
+      },
+      "virtio_blk": {
+        "size": "20480",
+        "refcount": "3"
+      },
+      "net_failover": {
+        "size": "24576",
+        "refcount": "1"
+      },
+      "failover": {
+        "size": "16384",
+        "refcount": "1"
+      },
+      "dm_mirror": {
+        "size": "28672",
+        "refcount": "0"
+      },
+      "dm_region_hash": {
+        "size": "20480",
+        "refcount": "1"
+      },
+      "dm_log": {
+        "size": "20480",
+        "refcount": "2"
+      },
+      "dm_mod": {
+        "size": "151552",
+        "refcount": "9"
+      },
+      "fuse": {
+        "size": "155648",
+        "refcount": "1"
+      }
+    }
+  },
+  "memory": {
+    "swap": {
+      "cached": "28820kB",
+      "total": "1048572kB",
+      "free": "288152kB"
+    },
+    "hugepages": {
+      "total": "0",
+      "free": "0",
+      "reserved": "0",
+      "surplus": "0"
+    },
+    "directmap": {
+      "4k": "159588kB",
+      "2M": "888832kB",
+      "1G": "0kB"
+    },
+    "total": "828508kB",
+    "free": "65072kB",
+    "available": "258188kB",
+    "buffers": "3164kB",
+    "cached": "290712kB",
+    "active": "318644kB",
+    "inactive": "310228kB",
+    "dirty": "0kB",
+    "writeback": "0kB",
+    "anon_pages": "308188kB",
+    "mapped": "32540kB",
+    "slab": "73376kB",
+    "slab_reclaimable": "27648kB",
+    "slab_unreclaim": "45728kB",
+    "page_tables": "24900kB",
+    "nfs_unstable": "0kB",
+    "bounce": "0kB",
+    "commit_limit": "1462824kB",
+    "committed_as": "2208568kB",
+    "vmalloc_total": "34359738367kB",
+    "vmalloc_used": "0kB",
+    "vmalloc_chunk": "0kB",
+    "hugepage_size": "2048kB",
+    "hugetlb": "0kB"
+  },
+  "network": {
+    "interfaces": {
+      "lo": {
+        "mtu": "65536",
+        "flags": [
+          "LOOPBACK",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Loopback",
+        "addresses": {
+          "127.0.0.1": {
+            "family": "inet",
+            "prefixlen": "8",
+            "netmask": "255.0.0.0",
+            "scope": "Node"
+          },
+          "::1": {
+            "family": "inet6",
+            "prefixlen": "128",
+            "scope": "Node",
+            "tags": [
+
+            ]
+          }
+        },
+        "state": "unknown",
+        "routes": [
+          {
+            "destination": "::1",
+            "family": "inet6",
+            "metric": "256",
+            "proto": "kernel"
+          }
+        ]
+      },
+      "ens3": {
+        "type": "ens",
+        "number": "3",
+        "mtu": "1500",
+        "flags": [
+          "BROADCAST",
+          "MULTICAST",
+          "UP",
+          "LOWER_UP"
+        ],
+        "encapsulation": "Ethernet",
+        "addresses": {
+          "52:54:00:E3:8D:8B": {
+            "family": "lladdr"
+          },
+          "192.168.88.20": {
+            "family": "inet",
+            "prefixlen": "24",
+            "netmask": "255.255.255.0",
+            "broadcast": "192.168.88.255",
+            "scope": "Global"
+          },
+          "fe80::5054:ff:fee3:8d8b": {
+            "family": "inet6",
+            "prefixlen": "64",
+            "scope": "Link",
+            "tags": [
+              "noprefixroute"
+            ]
+          }
+        },
+        "state": "up",
+        "arp": {
+          "192.168.88.248": "04:d3:b0:c3:a1:db",
+          "192.168.88.1": "08:55:31:bc:a1:ad",
+          "192.168.88.251": "18:1d:ea:94:6b:dc",
+          "192.168.88.30": "e4:5f:01:2a:62:53"
+        },
+        "routes": [
+          {
+            "destination": "default",
+            "family": "inet",
+            "via": "192.168.88.1",
+            "metric": "100",
+            "proto": "dhcp"
+          },
+          {
+            "destination": "192.168.88.0/24",
+            "family": "inet",
+            "scope": "link",
+            "metric": "100",
+            "proto": "kernel",
+            "src": "192.168.88.20"
+          },
+          {
+            "destination": "fe80::/64",
+            "family": "inet6",
+            "metric": "100",
+            "proto": "kernel"
+          }
+        ],
+        "link_speed": 0,
+        "duplex": "Unknown! (255)",
+        "auto_negotiation": "off",
+        "port": "Other",
+        "transceiver": "internal",
+        "ring_params": {
+          "max_rx": 256,
+          "max_rx_mini": 0,
+          "max_rx_jumbo": 0,
+          "max_tx": 256,
+          "current_rx": 256,
+          "current_rx_mini": 0,
+          "current_rx_jumbo": 0,
+          "current_tx": 256
+        },
+        "channel_params": {
+          "max_rx": 0,
+          "max_tx": 0,
+          "max_other": 0,
+          "max_combined": 1,
+          "current_rx": 0,
+          "current_tx": 0,
+          "current_other": 0,
+          "current_combined": 1
+        },
+        "coalesce_params": {
+
+        },
+        "driver_info": {
+          "driver": "virtio_net",
+          "version": "1.0.0",
+          "firmware-version": "",
+          "expansion-rom-version": "",
+          "bus-info": "0000:00:03.0",
+          "supports-statistics": "yes",
+          "supports-test": "no",
+          "supports-eeprom-access": "no",
+          "supports-register-dump": "no",
+          "supports-priv-flags": "no"
+        },
+        "pause_params": {
+
+        }
+      }
+    },
+    "default_interface": "ens3",
+    "default_gateway": "192.168.88.1"
+  },
+  "counters": {
+    "network": {
+      "interfaces": {
+        "lo": {
+          "tx": {
+            "queuelen": "1000",
+            "bytes": "8335269",
+            "packets": "2431",
+            "errors": "0",
+            "drop": "0",
+            "carrier": "0",
+            "collisions": "0"
+          },
+          "rx": {
+            "bytes": "8335269",
+            "packets": "2431",
+            "errors": "0",
+            "drop": "0",
+            "overrun": "0"
+          }
+        },
+        "ens3": {
+          "tx": {
+            "queuelen": "1000",
+            "bytes": "44454199",
+            "packets": "171568",
+            "errors": "0",
+            "drop": "0",
+            "carrier": "0",
+            "collisions": "0"
+          },
+          "rx": {
+            "bytes": "473477134",
+            "packets": "434247",
+            "errors": "0",
+            "drop": "44906",
+            "overrun": "0"
+          }
+        }
+      }
+    }
+  },
+  "IPAddress": "192.168.88.0/24",
+  "ipaddress": "192.168.88.20",
+  "macaddress": "52:54:00:E3:8D:8B",
+  "ip6address": "fe80::5054:ff:fee3:8d8b",
+  "lsb": {
+
+  },
+  "os": "linux",
+  "os_version": "4.18.0-338.el8.x86_64",
+  "platform": "centos",
+  "platform_version": "8",
+  "platform_family": "rhel",
+  "uptime_seconds": 84185,
+  "uptime": "23 hours 23 minutes 05 seconds",
+  "idletime_seconds": 82439,
+  "idletime": "22 hours 53 minutes 59 seconds",
+  "dmi": {
+    "dmidecode_version": "3.2",
+    "smbios_version": "2.8",
+    "structures": {
+      "count": "9",
+      "size": "450"
+    },
+    "bios": {
+      "all_records": [
+        {
+          "record_id": "0x0000",
+          "size": "0",
+          "application_identifier": "BIOS Information",
+          "Vendor": "SeaBIOS",
+          "Version": "1.11.0-2.el7",
+          "Release Date": "04/01/2014",
+          "Address": "0xE8000",
+          "Runtime Size": "96 kB",
+          "ROM Size": "64 kB",
+          "Characteristics": {
+            "Targeted content distribution is supported": null
+          },
+          "BIOS Revision": "0.0"
+        }
+      ],
+      "vendor": "SeaBIOS",
+      "version": "1.11.0-2.el7",
+      "release_date": "04/01/2014",
+      "address": "0xE8000",
+      "runtime_size": "96 kB",
+      "rom_size": "64 kB",
+      "bios_revision": "0.0"
+    },
+    "system": {
+      "all_records": [
+        {
+          "record_id": "0x0100",
+          "size": "1",
+          "application_identifier": "System Information",
+          "Manufacturer": "Red Hat",
+          "Product Name": "KVM",
+          "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+          "Serial Number": "Not Specified",
+          "UUID": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+          "Wake-up Type": "Power Switch",
+          "SKU Number": "Not Specified",
+          "Family": "Red Hat Enterprise Linux"
+        }
+      ],
+      "manufacturer": "Red Hat",
+      "product_name": "KVM",
+      "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+      "serial_number": "Not Specified",
+      "uuid": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+      "wake_up_type": "Power Switch",
+      "sku_number": "Not Specified",
+      "family": "Red Hat Enterprise Linux"
+    },
+    "chassis": {
+      "all_records": [
+        {
+          "record_id": "0x0300",
+          "size": "3",
+          "application_identifier": "Chassis Information",
+          "Manufacturer": "Red Hat",
+          "Type": "Other",
+          "Lock": "Not Present",
+          "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Boot-up State": "Safe",
+          "Power Supply State": "Safe",
+          "Thermal State": "Safe",
+          "Security Status": "Unknown",
+          "OEM Information": "0x00000000",
+          "Height": "Unspecified",
+          "Number Of Power Cords": "Unspecified",
+          "Contained Elements": "0"
+        }
+      ],
+      "manufacturer": "Red Hat",
+      "type": "Other",
+      "lock": "Not Present",
+      "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "boot_up_state": "Safe",
+      "power_supply_state": "Safe",
+      "thermal_state": "Safe",
+      "security_status": "Unknown",
+      "oem_information": "0x00000000",
+      "height": "Unspecified",
+      "number_of_power_cords": "Unspecified",
+      "contained_elements": "0"
+    },
+    "processor": {
+      "all_records": [
+        {
+          "record_id": "0x0400",
+          "size": "4",
+          "application_identifier": "Processor Information",
+          "Socket Designation": "CPU 0",
+          "Type": "Central Processor",
+          "Family": "Other",
+          "Manufacturer": "Red Hat",
+          "ID": "C1 06 02 00 FF FB 8B 0F",
+          "Version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+          "Voltage": "Unknown",
+          "External Clock": "Unknown",
+          "Max Speed": "2000 MHz",
+          "Current Speed": "2000 MHz",
+          "Status": "Populated, Enabled",
+          "Upgrade": "Other",
+          "L1 Cache Handle": "Not Provided",
+          "L2 Cache Handle": "Not Provided",
+          "L3 Cache Handle": "Not Provided",
+          "Serial Number": "Not Specified",
+          "Asset Tag": "Not Specified",
+          "Part Number": "Not Specified",
+          "Core Count": "1",
+          "Core Enabled": "1",
+          "Thread Count": "1",
+          "Characteristics": "None"
+        }
+      ],
+      "socket_designation": "CPU 0",
+      "type": "Central Processor",
+      "family": "Other",
+      "manufacturer": "Red Hat",
+      "id": "C1 06 02 00 FF FB 8B 0F",
+      "version": "RHEL 7.6.0 PC (i440FX + PIIX, 1996)",
+      "voltage": "Unknown",
+      "external_clock": "Unknown",
+      "max_speed": "2000 MHz",
+      "current_speed": "2000 MHz",
+      "status": "Populated, Enabled",
+      "upgrade": "Other",
+      "l1_cache_handle": "Not Provided",
+      "l2_cache_handle": "Not Provided",
+      "l3_cache_handle": "Not Provided",
+      "serial_number": "Not Specified",
+      "asset_tag": "Not Specified",
+      "part_number": "Not Specified",
+      "core_count": "1",
+      "core_enabled": "1",
+      "thread_count": "1",
+      "characteristics": "None"
+    }
+  },
+  "virtualization": {
+    "systems": {
+      "kvm": "guest"
+    },
+    "system": "kvm",
+    "role": "guest"
+  },
+  "languages": {
+    "c": {
+      "gcc": {
+        "target": "x86_64-redhat-linux",
+        "configured_with": "../configure --enable-bootstrap --enable-languages=c,c++,fortran,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl --disable-libmpx --enable-offload-targets=nvptx-none --without-cuda-driver --enable-gnu-indirect-function --enable-cet --with-tune=generic --with-arch_32=x86-64 --build=x86_64-redhat-linux",
+        "thread_model": "posix",
+        "description": "gcc version 8.5.0 20210514 (Red Hat 8.5.0-3) (GCC) ",
+        "version": "8.5.0"
+      },
+      "glibc": {
+        "version": "2.28.",
+        "description": "GNU C Library (GNU libc) stable release version 2.28."
+      }
+    },
+    "perl": {
+      "version": "5.26.3",
+      "archname": "x86_64-linux-thread-multi"
+    },
+    "ruby": {
+      "platform": "x86_64-linux",
+      "version": "2.6.6",
+      "release_date": "2020-03-31",
+      "target": "x86_64-pc-linux-gnu",
+      "target_cpu": "x86_64",
+      "target_vendor": "pc",
+      "target_os": "linux",
+      "host": "x86_64-pc-linux-gnu",
+      "host_cpu": "x86_64",
+      "host_os": "linux-gnu",
+      "host_vendor": "pc",
+      "bin_dir": "/usr/local/rvm/rubies/ruby-2.6.6/bin",
+      "ruby_bin": "/usr/local/rvm/rubies/ruby-2.6.6/bin/ruby",
+      "gem_bin": "/usr/local/rvm/rubies/ruby-2.6.6/bin/gem",
+      "gems_dir": "/usr/local/rvm/gems/ruby-2.6.6"
+    },
+    "rust": {
+      "version": "1.54.0"
+    }
+  },
+  "chef_packages": {
+    "ohai": {
+      "version": "16.13.0",
+      "ohai_root": "/usr/local/rvm/gems/ruby-2.6.6/gems/ohai-16.13.0/lib/ohai"
+    }
+  },
+  "hostname": "stream",
+  "machinename": "stream.dl360.cluster.com",
+  "fqdn": "stream.dl360.cluster.com",
+  "domain": "dl360.cluster.com",
+  "cloud": null,
+  "command": {
+    "ps": "ps -ef"
+  },
+  "cpu": {
+    "0": {
+      "vendor_id": "GenuineIntel",
+      "family": "6",
+      "model": "44",
+      "model_name": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+      "stepping": "1",
+      "mhz": "2266.746",
+      "cache_size": "16384 KB",
+      "physical_id": "0",
+      "core_id": "0",
+      "cores": "1",
+      "flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+      ]
+    },
+    "total": 1,
+    "real": 1,
+    "cores": 1
+  },
+  "filesystem": {
+    "by_device": {
+      "devtmpfs": {
+        "kb_size": "395016",
+        "kb_used": "0",
+        "kb_available": "395016",
+        "percent_used": "0%",
+        "total_inodes": "98754",
+        "inodes_used": "370",
+        "inodes_available": "98384",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=395016k",
+          "nr_inodes=98754",
+          "mode=755"
+        ],
+        "mounts": [
+          "/dev"
+        ]
+      },
+      "tmpfs": {
+        "kb_size": "82848",
+        "kb_used": "0",
+        "kb_available": "82848",
+        "percent_used": "0%",
+        "total_inodes": "103563",
+        "inodes_used": "28",
+        "inodes_available": "103535",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=82848k",
+          "mode=700"
+        ],
+        "mounts": [
+          "/dev/shm",
+          "/run",
+          "/sys/fs/cgroup",
+          "/run/user/0"
+        ]
+      },
+      "/dev/mapper/cs_stream-root": {
+        "kb_size": "8374272",
+        "kb_used": "3579628",
+        "kb_available": "4794644",
+        "percent_used": "43%",
+        "total_inodes": "4192256",
+        "inodes_used": "102909",
+        "inodes_available": "4089347",
+        "inodes_percent_used": "3%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "50d1cc90-1804-4026-b473-58da96d64156",
+        "mounts": [
+          "/"
+        ]
+      },
+      "/dev/vda1": {
+        "kb_size": "1038336",
+        "kb_used": "221668",
+        "kb_available": "816668",
+        "percent_used": "22%",
+        "total_inodes": "524288",
+        "inodes_used": "309",
+        "inodes_available": "523979",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee",
+        "mounts": [
+          "/boot"
+        ]
+      },
+      "sysfs": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys"
+        ]
+      },
+      "proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/proc"
+        ]
+      },
+      "securityfs": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/security"
+        ]
+      },
+      "devpts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "mounts": [
+          "/dev/pts"
+        ]
+      },
+      "cgroup": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ],
+        "mounts": [
+          "/sys/fs/cgroup/systemd",
+          "/sys/fs/cgroup/devices",
+          "/sys/fs/cgroup/cpuset",
+          "/sys/fs/cgroup/blkio",
+          "/sys/fs/cgroup/hugetlb",
+          "/sys/fs/cgroup/memory",
+          "/sys/fs/cgroup/perf_event",
+          "/sys/fs/cgroup/cpu,cpuacct",
+          "/sys/fs/cgroup/freezer",
+          "/sys/fs/cgroup/pids",
+          "/sys/fs/cgroup/net_cls,net_prio",
+          "/sys/fs/cgroup/rdma"
+        ]
+      },
+      "pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/fs/pstore"
+        ]
+      },
+      "bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "mounts": [
+          "/sys/fs/bpf"
+        ]
+      },
+      "none": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/tracing"
+        ]
+      },
+      "configfs": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/kernel/config"
+        ]
+      },
+      "selinuxfs": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/selinux"
+        ]
+      },
+      "hugetlbfs": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "mounts": [
+          "/dev/hugepages"
+        ]
+      },
+      "debugfs": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/debug"
+        ]
+      },
+      "systemd-1": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=34",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18891"
+        ],
+        "mounts": [
+          "/proc/sys/fs/binfmt_misc"
+        ]
+      },
+      "mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/dev/mqueue"
+        ]
+      },
+      "fusectl": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "mounts": [
+          "/sys/fs/fuse/connections"
+        ]
+      },
+      "tracefs": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "mounts": [
+          "/sys/kernel/debug/tracing"
+        ]
+      },
+      "/dev/sr0": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/vda": {
+        "mounts": [
+
+        ]
+      },
+      "/dev/vda2": {
+        "fs_type": "LVM2_member",
+        "uuid": "iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL",
+        "mounts": [
+
+        ]
+      },
+      "/dev/mapper/cs_stream-swap": {
+        "fs_type": "swap",
+        "uuid": "0d782303-3cd7-451a-b5fd-083ba57fb696",
+        "mounts": [
+
+        ]
+      }
+    },
+    "by_mountpoint": {
+      "/dev": {
+        "kb_size": "395016",
+        "kb_used": "0",
+        "kb_available": "395016",
+        "percent_used": "0%",
+        "total_inodes": "98754",
+        "inodes_used": "370",
+        "inodes_available": "98384",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=395016k",
+          "nr_inodes=98754",
+          "mode=755"
+        ],
+        "devices": [
+          "devtmpfs"
+        ]
+      },
+      "/dev/shm": {
+        "kb_size": "414252",
+        "kb_used": "360",
+        "kb_available": "413892",
+        "percent_used": "1%",
+        "total_inodes": "103563",
+        "inodes_used": "91",
+        "inodes_available": "103472",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/run": {
+        "kb_size": "414252",
+        "kb_used": "10980",
+        "kb_available": "403272",
+        "percent_used": "3%",
+        "total_inodes": "103563",
+        "inodes_used": "622",
+        "inodes_available": "102941",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "mode=755"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys/fs/cgroup": {
+        "kb_size": "414252",
+        "kb_used": "0",
+        "kb_available": "414252",
+        "percent_used": "0%",
+        "total_inodes": "103563",
+        "inodes_used": "17",
+        "inodes_available": "103546",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "seclabel",
+          "mode=755"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/": {
+        "kb_size": "8374272",
+        "kb_used": "3579628",
+        "kb_available": "4794644",
+        "percent_used": "43%",
+        "total_inodes": "4192256",
+        "inodes_used": "102909",
+        "inodes_available": "4089347",
+        "inodes_percent_used": "3%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "50d1cc90-1804-4026-b473-58da96d64156",
+        "devices": [
+          "/dev/mapper/cs_stream-root"
+        ]
+      },
+      "/boot": {
+        "kb_size": "1038336",
+        "kb_used": "221668",
+        "kb_available": "816668",
+        "percent_used": "22%",
+        "total_inodes": "524288",
+        "inodes_used": "309",
+        "inodes_available": "523979",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee",
+        "devices": [
+          "/dev/vda1"
+        ]
+      },
+      "/run/user/0": {
+        "kb_size": "82848",
+        "kb_used": "0",
+        "kb_available": "82848",
+        "percent_used": "0%",
+        "total_inodes": "103563",
+        "inodes_used": "28",
+        "inodes_available": "103535",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=82848k",
+          "mode=700"
+        ],
+        "devices": [
+          "tmpfs"
+        ]
+      },
+      "/sys": {
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "sysfs"
+        ]
+      },
+      "/proc": {
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "proc"
+        ]
+      },
+      "/sys/kernel/security": {
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ],
+        "devices": [
+          "securityfs"
+        ]
+      },
+      "/dev/pts": {
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ],
+        "devices": [
+          "devpts"
+        ]
+      },
+      "/sys/fs/cgroup/systemd": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "xattr",
+          "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+          "name=systemd"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/pstore": {
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "pstore"
+        ]
+      },
+      "/sys/fs/bpf": {
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ],
+        "devices": [
+          "bpf"
+        ]
+      },
+      "/sys/fs/cgroup/devices": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/cpuset": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpuset"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/blkio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/hugetlb": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/memory": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "memory"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/perf_event": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "perf_event"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/cpu,cpuacct": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpu",
+          "cpuacct"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/freezer": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "freezer"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/pids": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "pids"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/net_cls,net_prio": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "net_cls",
+          "net_prio"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/fs/cgroup/rdma": {
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ],
+        "devices": [
+          "cgroup"
+        ]
+      },
+      "/sys/kernel/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "none"
+        ]
+      },
+      "/sys/kernel/config": {
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "configfs"
+        ]
+      },
+      "/sys/fs/selinux": {
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "selinuxfs"
+        ]
+      },
+      "/dev/hugepages": {
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ],
+        "devices": [
+          "hugetlbfs"
+        ]
+      },
+      "/sys/kernel/debug": {
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "debugfs"
+        ]
+      },
+      "/proc/sys/fs/binfmt_misc": {
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=34",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18891"
+        ],
+        "devices": [
+          "systemd-1"
+        ]
+      },
+      "/dev/mqueue": {
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "mqueue"
+        ]
+      },
+      "/sys/fs/fuse/connections": {
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ],
+        "devices": [
+          "fusectl"
+        ]
+      },
+      "/sys/kernel/debug/tracing": {
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ],
+        "devices": [
+          "tracefs"
+        ]
+      }
+    },
+    "by_pair": {
+      "devtmpfs,/dev": {
+        "device": "devtmpfs",
+        "kb_size": "395016",
+        "kb_used": "0",
+        "kb_available": "395016",
+        "percent_used": "0%",
+        "mount": "/dev",
+        "total_inodes": "98754",
+        "inodes_used": "370",
+        "inodes_available": "98384",
+        "inodes_percent_used": "1%",
+        "fs_type": "devtmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "seclabel",
+          "size=395016k",
+          "nr_inodes=98754",
+          "mode=755"
+        ]
+      },
+      "tmpfs,/dev/shm": {
+        "device": "tmpfs",
+        "kb_size": "414252",
+        "kb_used": "360",
+        "kb_available": "413892",
+        "percent_used": "1%",
+        "mount": "/dev/shm",
+        "total_inodes": "103563",
+        "inodes_used": "91",
+        "inodes_available": "103472",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel"
+        ]
+      },
+      "tmpfs,/run": {
+        "device": "tmpfs",
+        "kb_size": "414252",
+        "kb_used": "10980",
+        "kb_available": "403272",
+        "percent_used": "3%",
+        "mount": "/run",
+        "total_inodes": "103563",
+        "inodes_used": "622",
+        "inodes_available": "102941",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "seclabel",
+          "mode=755"
+        ]
+      },
+      "tmpfs,/sys/fs/cgroup": {
+        "device": "tmpfs",
+        "kb_size": "414252",
+        "kb_used": "0",
+        "kb_available": "414252",
+        "percent_used": "0%",
+        "mount": "/sys/fs/cgroup",
+        "total_inodes": "103563",
+        "inodes_used": "17",
+        "inodes_available": "103546",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "ro",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "seclabel",
+          "mode=755"
+        ]
+      },
+      "/dev/mapper/cs_stream-root,/": {
+        "device": "/dev/mapper/cs_stream-root",
+        "kb_size": "8374272",
+        "kb_used": "3579628",
+        "kb_available": "4794644",
+        "percent_used": "43%",
+        "mount": "/",
+        "total_inodes": "4192256",
+        "inodes_used": "102909",
+        "inodes_available": "4089347",
+        "inodes_percent_used": "3%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "50d1cc90-1804-4026-b473-58da96d64156"
+      },
+      "/dev/vda1,/boot": {
+        "device": "/dev/vda1",
+        "kb_size": "1038336",
+        "kb_used": "221668",
+        "kb_available": "816668",
+        "percent_used": "22%",
+        "mount": "/boot",
+        "total_inodes": "524288",
+        "inodes_used": "309",
+        "inodes_available": "523979",
+        "inodes_percent_used": "1%",
+        "fs_type": "xfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "attr2",
+          "inode64",
+          "logbufs=8",
+          "logbsize=32k",
+          "noquota"
+        ],
+        "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+      },
+      "tmpfs,/run/user/0": {
+        "device": "tmpfs",
+        "kb_size": "82848",
+        "kb_used": "0",
+        "kb_available": "82848",
+        "percent_used": "0%",
+        "mount": "/run/user/0",
+        "total_inodes": "103563",
+        "inodes_used": "28",
+        "inodes_available": "103535",
+        "inodes_percent_used": "1%",
+        "fs_type": "tmpfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "relatime",
+          "seclabel",
+          "size=82848k",
+          "mode=700"
+        ]
+      },
+      "sysfs,/sys": {
+        "device": "sysfs",
+        "mount": "/sys",
+        "fs_type": "sysfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "proc,/proc": {
+        "device": "proc",
+        "mount": "/proc",
+        "fs_type": "proc",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "securityfs,/sys/kernel/security": {
+        "device": "securityfs",
+        "mount": "/sys/kernel/security",
+        "fs_type": "securityfs",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime"
+        ]
+      },
+      "devpts,/dev/pts": {
+        "device": "devpts",
+        "mount": "/dev/pts",
+        "fs_type": "devpts",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "gid=5",
+          "mode=620",
+          "ptmxmode=000"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/systemd": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/systemd",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "xattr",
+          "release_agent=/usr/lib/systemd/systemd-cgroups-agent",
+          "name=systemd"
+        ]
+      },
+      "pstore,/sys/fs/pstore": {
+        "device": "pstore",
+        "mount": "/sys/fs/pstore",
+        "fs_type": "pstore",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "bpf,/sys/fs/bpf": {
+        "device": "bpf",
+        "mount": "/sys/fs/bpf",
+        "fs_type": "bpf",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "mode=700"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/devices": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/devices",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "devices"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpuset": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/cpuset",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpuset"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/blkio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/blkio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "blkio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/hugetlb": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/hugetlb",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "hugetlb"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/memory": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/memory",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "memory"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/perf_event": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/perf_event",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "perf_event"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/cpu,cpuacct": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/cpu,cpuacct",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "cpu",
+          "cpuacct"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/freezer": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/freezer",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "freezer"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/pids": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/pids",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "pids"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/net_cls,net_prio": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/net_cls,net_prio",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "net_cls",
+          "net_prio"
+        ]
+      },
+      "cgroup,/sys/fs/cgroup/rdma": {
+        "device": "cgroup",
+        "mount": "/sys/fs/cgroup/rdma",
+        "fs_type": "cgroup",
+        "mount_options": [
+          "rw",
+          "nosuid",
+          "nodev",
+          "noexec",
+          "relatime",
+          "seclabel",
+          "rdma"
+        ]
+      },
+      "none,/sys/kernel/tracing": {
+        "device": "none",
+        "mount": "/sys/kernel/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "configfs,/sys/kernel/config": {
+        "device": "configfs",
+        "mount": "/sys/kernel/config",
+        "fs_type": "configfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "selinuxfs,/sys/fs/selinux": {
+        "device": "selinuxfs",
+        "mount": "/sys/fs/selinux",
+        "fs_type": "selinuxfs",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "hugetlbfs,/dev/hugepages": {
+        "device": "hugetlbfs",
+        "mount": "/dev/hugepages",
+        "fs_type": "hugetlbfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel",
+          "pagesize=2M"
+        ]
+      },
+      "debugfs,/sys/kernel/debug": {
+        "device": "debugfs",
+        "mount": "/sys/kernel/debug",
+        "fs_type": "debugfs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "systemd-1,/proc/sys/fs/binfmt_misc": {
+        "device": "systemd-1",
+        "mount": "/proc/sys/fs/binfmt_misc",
+        "fs_type": "autofs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "fd=34",
+          "pgrp=1",
+          "timeout=0",
+          "minproto=5",
+          "maxproto=5",
+          "direct",
+          "pipe_ino=18891"
+        ]
+      },
+      "mqueue,/dev/mqueue": {
+        "device": "mqueue",
+        "mount": "/dev/mqueue",
+        "fs_type": "mqueue",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "fusectl,/sys/fs/fuse/connections": {
+        "device": "fusectl",
+        "mount": "/sys/fs/fuse/connections",
+        "fs_type": "fusectl",
+        "mount_options": [
+          "rw",
+          "relatime"
+        ]
+      },
+      "tracefs,/sys/kernel/debug/tracing": {
+        "device": "tracefs",
+        "mount": "/sys/kernel/debug/tracing",
+        "fs_type": "tracefs",
+        "mount_options": [
+          "rw",
+          "relatime",
+          "seclabel"
+        ]
+      },
+      "/dev/sr0,": {
+        "device": "/dev/sr0"
+      },
+      "/dev/vda,": {
+        "device": "/dev/vda"
+      },
+      "/dev/vda2,": {
+        "device": "/dev/vda2",
+        "fs_type": "LVM2_member",
+        "uuid": "iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL"
+      },
+      "/dev/mapper/cs_stream-swap,": {
+        "device": "/dev/mapper/cs_stream-swap",
+        "fs_type": "swap",
+        "uuid": "0d782303-3cd7-451a-b5fd-083ba57fb696"
+      }
+    }
+  },
+  "fips": {
+    "kernel": {
+      "enabled": true
+    }
+  },
+  "init_package": "systemd",
+  "keys": {
+    "ssh": {
+      "host_rsa_public": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDId3dwByYgssoJLLqDZNkweT+TscVl2htpObYaWqIBfTH6rur0rXvOrRclEn+ZbZhvnAoUwNHUvIK6LZDL1Ji+mnAC8//P09HMMflHDDhrpZXEEfyN5yqG6Pc2CAPFlaiBatlThVZmo3RiHAQAZ2daBAZs9w6wgb2ImS+Lor5kyyFzVfEba7moDTBo09C7eG2k0O2dm70c9j3ArBs++LQc7BGSfL+GODADHXraJ8SFWkiXxKXMd7rLgOhEXEtnP9IksZBqeS/R1v7Vg8eErHhxUYRQDAPtJ4uaQCCGOIeUqcgzimY5hpi8kiyd7VK5P96MaRsr4Dv5X7MzwhUF+1vM8mkl2FX+zXfOA9m+KwA+EgmYCRsLqLugRTDEQBd/MzYz7uzUo+4nWZYUe4+N+1V9Dm6BbayPh+RT9dN1y1Luvm3nXpdPlj+6Wmo1LywNWwRWIXEj/zhVKK165Jh/5EOju0yO07IB9N0g1IzZSvHb6BGkw7OhwTKIoQ7D/O8buEs=",
+      "host_ecdsa_public": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLdk3JuvO4JtWAGg9jIqEDpeYc8ofaX5N6XwN0qyIW3iF12S9eNv6TZKTVLfZk7kF3n5MXTIkjJkfh+C2U9f4ic=",
+      "host_ecdsa_type": "ecdsa-sha2-nistp256",
+      "host_ed25519_public": "AAAAC3NzaC1lZDI1NTE5AAAAICNdD7XD7S1/I6b1nve57M+9r53NRt4fFYP3F1XSfiUN"
+    }
+  },
+  "block_device": {
+    "dm-0": {
+      "size": "16769024",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "dm-1": {
+      "size": "2097152",
+      "removable": "0",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "sr0": {
+      "size": "2097151",
+      "removable": "1",
+      "model": "QEMU DVD-ROM",
+      "rev": "2.5+",
+      "state": "running",
+      "timeout": "30",
+      "vendor": "QEMU",
+      "queue_depth": "1",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    },
+    "vda": {
+      "size": "20971520",
+      "removable": "0",
+      "vendor": "0x1af4",
+      "rotational": "1",
+      "physical_block_size": "512",
+      "logical_block_size": "512"
+    }
+  },
+  "hostnamectl": {
+    "static_hostname": "stream.dl360.cluster.com",
+    "icon_name": "computer-vm",
+    "chassis": "vm",
+    "machine_id": "b9ea0f0a5ce445dc9a0e4979ea4911c1",
+    "boot_id": "0f8f6635fc0d4b7e85eb17ec27b341df",
+    "virtualization": "kvm",
+    "operating_system": "CentOS Stream 8",
+    "cpe_os_name": "cpe:/o:centos:centos:8",
+    "kernel": "Linux 4.18.0-338.el8.x86_64",
+    "architecture": "x86-64"
+  },
+  "machine_id": "b9ea0f0a5ce445dc9a0e4979ea4911c1",
+  "os_release": {
+    "name": "CentOS Stream",
+    "version": "8",
+    "id": "centos",
+    "id_like": [
+      "rhel",
+      "fedora"
+    ],
+    "version_id": "8",
+    "platform_id": "platform:el8",
+    "pretty_name": "CentOS Stream 8",
+    "ansi_color": "0;31",
+    "cpe_name": "cpe:/o:centos:centos:8",
+    "home_url": "https://centos.org/",
+    "bug_report_url": "https://bugzilla.redhat.com/",
+    "redhat_support_product": "Red Hat Enterprise Linux 8",
+    "redhat_support_product_version": "CentOS Stream"
+  },
+  "systemd_paths": {
+    "temporary": "/tmp",
+    "temporary-large": "/var/tmp",
+    "system-binaries": "/usr/bin",
+    "system-include": "/usr/include",
+    "system-library-private": "/usr/lib",
+    "system-library-arch": "/usr/lib64",
+    "system-shared": "/usr/share",
+    "system-configuration-factory": "/usr/share/factory/etc",
+    "system-state-factory": "/usr/share/factory/var",
+    "system-configuration": "/etc",
+    "system-runtime": "/run",
+    "system-runtime-logs": "/run/log",
+    "system-state-private": "/var/lib",
+    "system-state-logs": "/var/log",
+    "system-state-cache": "/var/cache",
+    "system-state-spool": "/var/spool",
+    "user-binaries": "/root/.local/bin",
+    "user-library-private": "/root/.local/lib",
+    "user-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+    "user-shared": "/root/.local/share",
+    "user-configuration": "/root/.config",
+    "user-runtime": "/run/user/0",
+    "user-state-cache": "/root/.cache",
+    "user": "/root",
+    "user-documents": "/root",
+    "user-music": "/root",
+    "user-pictures": "/root",
+    "user-videos": "/root",
+    "user-download": "/root",
+    "user-public": "/root",
+    "user-templates": "/root",
+    "user-desktop": "/root/Desktop",
+    "search-binaries": "/usr/local/rvm/gems/ruby-2.6.6/bin",
+    "search-binaries-default": "/usr/local/sbin",
+    "search-library-private": "/root/.local/lib",
+    "search-library-arch": "/root/.local/lib/x86_64-linux-gnu",
+    "search-shared": "/root/.local/share",
+    "search-configuration-factory": "/usr/local/share/factory/etc",
+    "search-state-factory": "/usr/local/share/factory/var",
+    "search-configuration": "/root/.config"
+  },
+  "ohai_time": 1634737983.1405475,
+  "packages": {
+    "vdo": {
+      "epoch": "0",
+      "version": "6.2.5.74",
+      "release": "14.el8",
+      "installdate": "1634653320",
+      "arch": "x86_64"
+    },
+    "kbd": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1634653189",
+      "arch": "x86_64"
+    },
+    "bind-license": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "6.el8",
+      "installdate": "1634653135",
+      "arch": "noarch"
+    },
+    "sssd-kcm": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653320",
+      "arch": "x86_64"
+    },
+    "systemd-pam": {
+      "epoch": "0",
+      "version": "239",
+      "release": "51.el8",
+      "installdate": "1634653191",
+      "arch": "x86_64"
+    },
+    "python3-pip-wheel": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "20.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "iptstate": {
+      "epoch": "0",
+      "version": "2.2.6",
+      "release": "6.el8",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "grub2-tools": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1634653192",
+      "arch": "x86_64"
+    },
+    "dejavu-sans-mono-fonts": {
+      "epoch": "0",
+      "version": "2.35",
+      "release": "7.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "wget": {
+      "epoch": "0",
+      "version": "1.19.5",
+      "release": "10.el8",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "dbus": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "14.el8",
+      "installdate": "1634653193",
+      "arch": "x86_64"
+    },
+    "ncurses-base": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "kernel": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "polkit-libs": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "12.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "kbd-legacy": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "passwd": {
+      "epoch": "0",
+      "version": "0.80",
+      "release": "3.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "python3-six": {
+      "epoch": "0",
+      "version": "1.11.0",
+      "release": "8.el8",
+      "installdate": "1634653196",
+      "arch": "noarch"
+    },
+    "dbus-common": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "14.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "rsyslog-gssapi": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "5.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "libsss_certmap": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "setup": {
+      "epoch": "0",
+      "version": "2.12.2",
+      "release": "6.el8",
+      "installdate": "1634653159",
+      "arch": "noarch"
+    },
+    "at": {
+      "epoch": "0",
+      "version": "3.1.20",
+      "release": "11.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "gobject-introspection": {
+      "epoch": "0",
+      "version": "1.56.1",
+      "release": "1.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1634653159",
+      "arch": "x86_64"
+    },
+    "net-tools": {
+      "epoch": "0",
+      "version": "2.0",
+      "release": "0.52.20160912git.el8",
+      "installdate": "1634653329",
+      "arch": "x86_64"
+    },
+    "libsolv": {
+      "epoch": "0",
+      "version": "0.7.19",
+      "release": "1.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "glibc": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "164.el8",
+      "installdate": "1634653161",
+      "arch": "x86_64"
+    },
+    "dracut-config-rescue": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1634653329",
+      "arch": "x86_64"
+    },
+    "rsyslog": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "5.el8",
+      "installdate": "1634653201",
+      "arch": "x86_64"
+    },
+    "libcom_err": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "man-db": {
+      "epoch": "0",
+      "version": "2.7.6.1",
+      "release": "18.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "selinux-policy-targeted": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "80.el8",
+      "installdate": "1634653205",
+      "arch": "noarch"
+    },
+    "libstdc++": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-plain": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "initscripts": {
+      "epoch": "0",
+      "version": "10.00.15",
+      "release": "1.el8",
+      "installdate": "1634653206",
+      "arch": "x86_64"
+    },
+    "sqlite-libs": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "15.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "sg3_utils": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1634653332",
+      "arch": "x86_64"
+    },
+    "libuser": {
+      "epoch": "0",
+      "version": "0.62",
+      "release": "23.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "readline": {
+      "epoch": "0",
+      "version": "7.0",
+      "release": "10.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "bpftool": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "libevent": {
+      "epoch": "0",
+      "version": "2.1.8",
+      "release": "5.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "expat": {
+      "epoch": "0",
+      "version": "2.2.5",
+      "release": "4.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "time": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "fontconfig": {
+      "epoch": "0",
+      "version": "2.13.1",
+      "release": "4.el8",
+      "installdate": "1634653209",
+      "arch": "x86_64"
+    },
+    "libcollection": {
+      "epoch": "0",
+      "version": "0.7.0",
+      "release": "39.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "libsysfs": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "24.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "python3-decorator": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "2.el8",
+      "installdate": "1634653210",
+      "arch": "noarch"
+    },
+    "jansson": {
+      "epoch": "0",
+      "version": "2.11",
+      "release": "3.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "tree": {
+      "epoch": "0",
+      "version": "1.7.0",
+      "release": "15.el8",
+      "installdate": "1634653334",
+      "arch": "x86_64"
+    },
+    "libwbclient": {
+      "epoch": "0",
+      "version": "4.14.5",
+      "release": "2.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "gmp": {
+      "epoch": "1",
+      "version": "6.1.2",
+      "release": "10.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "mailcap": {
+      "epoch": "0",
+      "version": "2.1.48",
+      "release": "3.el8",
+      "installdate": "1634653334",
+      "arch": "noarch"
+    },
+    "tpm2-tools": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "5.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libacl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "iwl6000g2b-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "clevis": {
+      "epoch": "0",
+      "version": "15",
+      "release": "1.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "lua-libs": {
+      "epoch": "0",
+      "version": "5.3.4",
+      "release": "12.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "iwl5000-firmware": {
+      "epoch": "0",
+      "version": "8.83.5.1_1",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "libblockdev-loop": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libseccomp": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "1.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "iwl135-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "PackageKit-glib": {
+      "epoch": "0",
+      "version": "1.1.12",
+      "release": "6.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "findutils": {
+      "epoch": "1",
+      "version": "4.6.0",
+      "release": "20.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "alsa-sof-firmware": {
+      "epoch": "0",
+      "version": "1.8",
+      "release": "1.el8",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "usb_modeswitch": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "1.el8",
+      "installdate": "1634653226",
+      "arch": "x86_64"
+    },
+    "grub2-common": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1634653164",
+      "arch": "noarch"
+    },
+    "pcp-conf": {
+      "epoch": "0",
+      "version": "5.3.3",
+      "release": "1.el8",
+      "installdate": "1634726187",
+      "arch": "x86_64"
+    },
+    "lvm2": {
+      "epoch": "8",
+      "version": "2.03.12",
+      "release": "10.el8",
+      "installdate": "1634653227",
+      "arch": "x86_64"
+    },
+    "libpng": {
+      "epoch": "2",
+      "version": "1.6.34",
+      "release": "5.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "gpg-pubkey": {
+      "epoch": "0",
+      "version": "de57bfbe",
+      "release": "53a9be98",
+      "installdate": "1634731179",
+      "arch": "(none)",
+      "versions": [
+        {
+          "epoch": "0",
+          "version": "8483c65d",
+          "release": "5ccc5b19",
+          "installdate": "1634727240",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "2f86d6a1",
+          "release": "5cf7cefb",
+          "installdate": "1634730530",
+          "arch": "(none)"
+        },
+        {
+          "epoch": "0",
+          "version": "de57bfbe",
+          "release": "53a9be98",
+          "installdate": "1634731179",
+          "arch": "(none)"
+        }
+      ]
+    },
+    "python3-policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "16.el8",
+      "installdate": "1634653228",
+      "arch": "noarch"
+    },
+    "lz4-libs": {
+      "epoch": "0",
+      "version": "1.8.3",
+      "release": "3.el8_4",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "rubygem-did_you_mean": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727244",
+      "arch": "noarch"
+    },
+    "python3-configobj": {
+      "epoch": "0",
+      "version": "5.0.6",
+      "release": "11.el8",
+      "installdate": "1634653286",
+      "arch": "noarch"
+    },
+    "fstrm": {
+      "epoch": "0",
+      "version": "0.6.1",
+      "release": "2.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "rubygem-psych": {
+      "epoch": "0",
+      "version": "3.0.2",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727245",
+      "arch": "x86_64"
+    },
+    "timedatex": {
+      "epoch": "0",
+      "version": "0.5",
+      "release": "3.el8",
+      "installdate": "1634653286",
+      "arch": "x86_64"
+    },
+    "p11-kit-trust": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "python3-iniparse": {
+      "epoch": "0",
+      "version": "0.4",
+      "release": "31.el8",
+      "installdate": "1634727410",
+      "arch": "noarch"
+    },
+    "iputils": {
+      "epoch": "0",
+      "version": "20180629",
+      "release": "7.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "device-mapper-persistent-data": {
+      "epoch": "0",
+      "version": "0.9.0",
+      "release": "4.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "rhsm-icons": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727410",
+      "arch": "noarch"
+    },
+    "libblockdev-mdraid": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "libnftnl": {
+      "epoch": "0",
+      "version": "1.1.5",
+      "release": "4.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "dnf-plugin-subscription-manager": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727411",
+      "arch": "x86_64"
+    },
+    "xdg-utils": {
+      "epoch": "0",
+      "version": "1.1.2",
+      "release": "5.el8",
+      "installdate": "1634653288",
+      "arch": "noarch"
+    },
+    "diffutils": {
+      "epoch": "0",
+      "version": "3.6",
+      "release": "6.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "python3-chardet": {
+      "epoch": "0",
+      "version": "3.0.4",
+      "release": "7.el8",
+      "installdate": "1634727411",
+      "arch": "noarch"
+    },
+    "dbus-glib": {
+      "epoch": "0",
+      "version": "0.110",
+      "release": "2.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "cpio": {
+      "epoch": "0",
+      "version": "2.12",
+      "release": "11.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "subscription-manager": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727412",
+      "arch": "x86_64"
+    },
+    "glib-networking": {
+      "epoch": "0",
+      "version": "2.56.1",
+      "release": "1.1.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "libnetfilter_conntrack": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "5.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "zlib-devel": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "17.el8",
+      "installdate": "1634727862",
+      "arch": "x86_64"
+    },
+    "libipa_hbac": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "lzo": {
+      "epoch": "0",
+      "version": "2.08",
+      "release": "14.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "ncurses-c++-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1634727862",
+      "arch": "x86_64"
+    },
+    "gnupg2": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "userspace-rcu": {
+      "epoch": "0",
+      "version": "0.10.1",
+      "release": "4.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libselinux-devel": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "PackageKit": {
+      "epoch": "0",
+      "version": "1.1.12",
+      "release": "6.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "gdbm": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "krb5-devel": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "14.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "rpm-build-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "18.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "nss-softokn": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "glibc-devel": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "164.el8",
+      "installdate": "1634727865",
+      "arch": "x86_64"
+    },
+    "virt-what": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "12.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "acl": {
+      "epoch": "0",
+      "version": "2.2.53",
+      "release": "1.el8",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "readline-devel": {
+      "epoch": "0",
+      "version": "7.0",
+      "release": "10.el8",
+      "installdate": "1634727871",
+      "arch": "x86_64"
+    },
+    "libluksmeta": {
+      "epoch": "0",
+      "version": "9",
+      "release": "4.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "libcomps": {
+      "epoch": "0",
+      "version": "0.1.16",
+      "release": "2.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "perl-Digest": {
+      "epoch": "0",
+      "version": "1.17",
+      "release": "395.el8",
+      "installdate": "1634728004",
+      "arch": "noarch"
+    },
+    "iproute": {
+      "epoch": "0",
+      "version": "5.12.0",
+      "release": "3.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "bzip2": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "perl-Net-SSLeay": {
+      "epoch": "0",
+      "version": "1.88",
+      "release": "1.module_el8.4.0+517+be1595ff",
+      "installdate": "1634728004",
+      "arch": "x86_64"
+    },
+    "rdma-core": {
+      "epoch": "0",
+      "version": "35.0",
+      "release": "1.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "libmodman": {
+      "epoch": "0",
+      "version": "2.0.1",
+      "release": "17.el8",
+      "installdate": "1634653171",
+      "arch": "x86_64"
+    },
+    "perl-IO-Socket-IP": {
+      "epoch": "0",
+      "version": "0.39",
+      "release": "5.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "iptables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "20.el8",
+      "installdate": "1634653293",
+      "arch": "x86_64"
+    },
+    "coreutils-common": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "12.el8",
+      "installdate": "1634653172",
+      "arch": "x86_64"
+    },
+    "perl-Term-Cap": {
+      "epoch": "0",
+      "version": "1.17",
+      "release": "395.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "containers-common": {
+      "epoch": "2",
+      "version": "1",
+      "release": "4.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653293",
+      "arch": "noarch"
+    },
+    "less": {
+      "epoch": "0",
+      "version": "530",
+      "release": "1.el8",
+      "installdate": "1634653173",
+      "arch": "x86_64"
+    },
+    "perl-podlators": {
+      "epoch": "0",
+      "version": "4.11",
+      "release": "1.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "python3-firewall": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "7.el8",
+      "installdate": "1634653296",
+      "arch": "noarch"
+    },
+    "libxcb": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "1.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-MIME-Base64": {
+      "epoch": "0",
+      "version": "3.15",
+      "release": "396.el8",
+      "installdate": "1634728005",
+      "arch": "x86_64"
+    },
+    "iscsi-initiator-utils-iscsiuio": {
+      "epoch": "0",
+      "version": "6.2.1.4",
+      "release": "4.git095f59c.el8",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "oniguruma": {
+      "epoch": "0",
+      "version": "6.8.2",
+      "release": "2.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-Socket": {
+      "epoch": "4",
+      "version": "2.027",
+      "release": "3.el8",
+      "installdate": "1634728005",
+      "arch": "x86_64"
+    },
+    "device-mapper-multipath": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "17.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "checkpolicy": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "1.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-libs": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "420.el8",
+      "installdate": "1634728006",
+      "arch": "x86_64"
+    },
+    "plymouth": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "10.20200615git1e36e30.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "fuse3-libs": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "12.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "perl-Text-Tabs+Wrap": {
+      "epoch": "0",
+      "version": "2013.0523",
+      "release": "395.el8",
+      "installdate": "1634728007",
+      "arch": "noarch"
+    },
+    "nss": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "libdaemon": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "15.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "perl-PathTools": {
+      "epoch": "0",
+      "version": "3.74",
+      "release": "1.el8",
+      "installdate": "1634728007",
+      "arch": "x86_64"
+    },
+    "volume_key-libs": {
+      "epoch": "0",
+      "version": "0.3.11",
+      "release": "5.el8",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "libpkgconf": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "perl-interpreter": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "420.el8",
+      "installdate": "1634728008",
+      "arch": "x86_64"
+    },
+    "udisks2-lvm2": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "7.el8",
+      "installdate": "1634653299",
+      "arch": "x86_64"
+    },
+    "gawk": {
+      "epoch": "0",
+      "version": "4.2.1",
+      "release": "2.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libstdc++-devel": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634728010",
+      "arch": "x86_64"
+    },
+    "libnfsidmap": {
+      "epoch": "1",
+      "version": "2.3.3",
+      "release": "46.el8",
+      "installdate": "1634653302",
+      "arch": "x86_64"
+    },
+    "libstemmer": {
+      "epoch": "0",
+      "version": "0",
+      "release": "10.585svn.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "sqlite-devel": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "15.el8",
+      "installdate": "1634728012",
+      "arch": "x86_64"
+    },
+    "sssd-common-pac": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653303",
+      "arch": "x86_64"
+    },
+    "ncurses": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "python3-pip": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "20.el8",
+      "installdate": "1634728716",
+      "arch": "noarch"
+    },
+    "python3-psutil": {
+      "epoch": "0",
+      "version": "5.4.3",
+      "release": "11.el8",
+      "installdate": "1634653303",
+      "arch": "x86_64"
+    },
+    "xkeyboard-config": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "1.el8",
+      "installdate": "1634653178",
+      "arch": "noarch"
+    },
+    "cargo": {
+      "epoch": "0",
+      "version": "1.54.0",
+      "release": "2.module_el8.5.0+910+9ca45234",
+      "installdate": "1634729578",
+      "arch": "x86_64"
+    },
+    "python3-webencodings": {
+      "epoch": "0",
+      "version": "0.5.1",
+      "release": "6.el8",
+      "installdate": "1634653304",
+      "arch": "noarch"
+    },
+    "platform-python-setuptools": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1634653179",
+      "arch": "noarch"
+    },
+    "sshpass": {
+      "epoch": "0",
+      "version": "1.06",
+      "release": "9.el8",
+      "installdate": "1634730534",
+      "arch": "x86_64"
+    },
+    "python3-libcomps": {
+      "epoch": "0",
+      "version": "0.1.16",
+      "release": "2.el8",
+      "installdate": "1634653305",
+      "arch": "x86_64"
+    },
+    "openldap": {
+      "epoch": "0",
+      "version": "2.4.46",
+      "release": "18.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "python3-cryptography": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "5.el8",
+      "installdate": "1634730535",
+      "arch": "x86_64"
+    },
+    "python3-dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "3.el8",
+      "installdate": "1634653305",
+      "arch": "noarch"
+    },
+    "libkcapi-hmaccalc": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "python3-babel": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "7.el8",
+      "installdate": "1634730537",
+      "arch": "noarch"
+    },
+    "python3-pyyaml": {
+      "epoch": "0",
+      "version": "3.12",
+      "release": "12.el8",
+      "installdate": "1634653306",
+      "arch": "x86_64"
+    },
+    "libcurl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "21.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "python3-jinja2": {
+      "epoch": "0",
+      "version": "2.10.1",
+      "release": "3.el8",
+      "installdate": "1634730538",
+      "arch": "noarch"
+    },
+    "vim-filesystem": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "16.el8",
+      "installdate": "1634653306",
+      "arch": "noarch"
+    },
+    "elfutils-default-yama-scope": {
+      "epoch": "0",
+      "version": "0.185",
+      "release": "1.el8",
+      "installdate": "1634653184",
+      "arch": "noarch"
+    },
+    "python3-msgpack": {
+      "epoch": "0",
+      "version": "0.6.2",
+      "release": "1.el8",
+      "installdate": "1634731219",
+      "arch": "x86_64"
+    },
+    "cockpit-packagekit": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634653309",
+      "arch": "noarch"
+    },
+    "procps-ng": {
+      "epoch": "0",
+      "version": "3.3.15",
+      "release": "6.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "openpgm": {
+      "epoch": "0",
+      "version": "5.2.122",
+      "release": "21.el8",
+      "installdate": "1634731219",
+      "arch": "x86_64"
+    },
+    "libXext": {
+      "epoch": "0",
+      "version": "1.3.4",
+      "release": "1.el8",
+      "installdate": "1634653309",
+      "arch": "x86_64"
+    },
+    "kpartx": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "17.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "yum-utils": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "3.el8",
+      "installdate": "1634731220",
+      "arch": "noarch"
+    },
+    "python3-cairo": {
+      "epoch": "0",
+      "version": "1.16.3",
+      "release": "6.el8",
+      "installdate": "1634653310",
+      "arch": "x86_64"
+    },
+    "openssl-pkcs11": {
+      "epoch": "0",
+      "version": "0.4.10",
+      "release": "2.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "salt-master": {
+      "epoch": "0",
+      "version": "3004",
+      "release": "1.el8",
+      "installdate": "1634731226",
+      "arch": "noarch"
+    },
+    "cockpit-system": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634653311",
+      "arch": "noarch"
+    },
+    "libfdisk": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653186",
+      "arch": "x86_64"
+    },
+    "libmaxminddb": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "10.el8",
+      "installdate": "1634653314",
+      "arch": "x86_64"
+    },
+    "coreutils": {
+      "epoch": "0",
+      "version": "8.30",
+      "release": "12.el8",
+      "installdate": "1634653186",
+      "arch": "x86_64"
+    },
+    "sssd-ad": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "libblkid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653187",
+      "arch": "x86_64"
+    },
+    "authselect": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "libdb": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    },
+    "man-pages": {
+      "epoch": "0",
+      "version": "4.15",
+      "release": "6.el8",
+      "installdate": "1634653319",
+      "arch": "x86_64"
+    },
+    "trousers-lib": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    },
+    "libgcc": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634653134",
+      "arch": "x86_64"
+    },
+    "libutempter": {
+      "epoch": "0",
+      "version": "1.1.6",
+      "release": "14.el8",
+      "installdate": "1634653189",
+      "arch": "x86_64"
+    },
+    "fontpackages-filesystem": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "22.el8",
+      "installdate": "1634653135",
+      "arch": "noarch"
+    },
+    "libpwquality": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "3.el8",
+      "installdate": "1634653189",
+      "arch": "x86_64"
+    },
+    "abattis-cantarell-fonts": {
+      "epoch": "0",
+      "version": "0.0.25",
+      "release": "6.el8",
+      "installdate": "1634653135",
+      "arch": "noarch"
+    },
+    "util-linux": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653191",
+      "arch": "x86_64"
+    },
+    "python3-setuptools-wheel": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "dracut": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1634653191",
+      "arch": "x86_64"
+    },
+    "libreport-filesystem": {
+      "epoch": "0",
+      "version": "2.9.5",
+      "release": "15.el8",
+      "installdate": "1634653136",
+      "arch": "x86_64"
+    },
+    "gettext": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1634653191",
+      "arch": "x86_64"
+    },
+    "dejavu-fonts-common": {
+      "epoch": "0",
+      "version": "2.35",
+      "release": "7.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "glib2": {
+      "epoch": "0",
+      "version": "2.56.4",
+      "release": "156.el8",
+      "installdate": "1634653193",
+      "arch": "x86_64"
+    },
+    "quota-nls": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "14.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "gnutls": {
+      "epoch": "0",
+      "version": "3.6.16",
+      "release": "4.el8",
+      "installdate": "1634653193",
+      "arch": "x86_64"
+    },
+    "pkgconf-m4": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "systemd": {
+      "epoch": "0",
+      "version": "239",
+      "release": "51.el8",
+      "installdate": "1634653194",
+      "arch": "x86_64"
+    },
+    "linux-firmware": {
+      "epoch": "0",
+      "version": "20210702",
+      "release": "103.gitd79c2677.el8",
+      "installdate": "1634653157",
+      "arch": "noarch"
+    },
+    "trousers": {
+      "epoch": "0",
+      "version": "0.3.15",
+      "release": "1.el8",
+      "installdate": "1634653195",
+      "arch": "x86_64"
+    },
+    "kbd-misc": {
+      "epoch": "0",
+      "version": "2.0.4",
+      "release": "10.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "libldb": {
+      "epoch": "0",
+      "version": "2.3.0",
+      "release": "2.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "fuse-common": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "12.el8",
+      "installdate": "1634653158",
+      "arch": "x86_64"
+    },
+    "polkit-pkla-compat": {
+      "epoch": "0",
+      "version": "0.1",
+      "release": "12.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "emacs-filesystem": {
+      "epoch": "1",
+      "version": "26.1",
+      "release": "7.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "python3-libselinux": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "centos-gpg-keys": {
+      "epoch": "1",
+      "version": "8",
+      "release": "3.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "policycoreutils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "16.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "centos-stream-repos": {
+      "epoch": "0",
+      "version": "8",
+      "release": "3.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "device-mapper-event-libs": {
+      "epoch": "8",
+      "version": "1.02.177",
+      "release": "10.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "filesystem": {
+      "epoch": "0",
+      "version": "3.8",
+      "release": "6.el8",
+      "installdate": "1634653159",
+      "arch": "x86_64"
+    },
+    "kernel-core": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653199",
+      "arch": "x86_64"
+    },
+    "pcre2": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1634653159",
+      "arch": "x86_64"
+    },
+    "python3-gobject-base": {
+      "epoch": "0",
+      "version": "3.28.3",
+      "release": "2.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "ncurses-libs": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1634653159",
+      "arch": "x86_64"
+    },
+    "libgudev": {
+      "epoch": "0",
+      "version": "232",
+      "release": "4.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "glibc-common": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "164.el8",
+      "installdate": "1634653160",
+      "arch": "x86_64"
+    },
+    "parted": {
+      "epoch": "0",
+      "version": "3.2",
+      "release": "39.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "bash": {
+      "epoch": "0",
+      "version": "4.4.20",
+      "release": "3.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "logrotate": {
+      "epoch": "0",
+      "version": "3.14.0",
+      "release": "4.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "zlib": {
+      "epoch": "0",
+      "version": "1.2.11",
+      "release": "17.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "samba-common": {
+      "epoch": "0",
+      "version": "4.14.5",
+      "release": "2.el8",
+      "installdate": "1634653201",
+      "arch": "noarch"
+    },
+    "popt": {
+      "epoch": "0",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "selinux-policy": {
+      "epoch": "0",
+      "version": "3.14.3",
+      "release": "80.el8",
+      "installdate": "1634653201",
+      "arch": "noarch"
+    },
+    "xz-libs": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "crontabs": {
+      "epoch": "0",
+      "version": "1.11",
+      "release": "17.20190603git.el8",
+      "installdate": "1634653206",
+      "arch": "noarch"
+    },
+    "libxml2": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "11.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "cronie-anacron": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "4.el8",
+      "installdate": "1634653206",
+      "arch": "x86_64"
+    },
+    "libuuid": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "NetworkManager-libnm": {
+      "epoch": "1",
+      "version": "1.34.0",
+      "release": "0.2.el8",
+      "installdate": "1634653206",
+      "arch": "x86_64"
+    },
+    "bzip2-libs": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "26.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "gdk-pixbuf2": {
+      "epoch": "0",
+      "version": "2.36.12",
+      "release": "5.el8",
+      "installdate": "1634653207",
+      "arch": "x86_64"
+    },
+    "libtalloc": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "1.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "openssh": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "9.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "libxcrypt": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "6.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "libjose": {
+      "epoch": "0",
+      "version": "10",
+      "release": "2.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "libtevent": {
+      "epoch": "0",
+      "version": "0.11.0",
+      "release": "0.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "tpm2-tss": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "4.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "libtdb": {
+      "epoch": "0",
+      "version": "1.4.3",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "xfsprogs": {
+      "epoch": "0",
+      "version": "5.0.0",
+      "release": "9.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "libbasicobjects": {
+      "epoch": "0",
+      "version": "0.1.1",
+      "release": "39.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "avahi-libs": {
+      "epoch": "0",
+      "version": "0.7",
+      "release": "20.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "libdhash": {
+      "epoch": "0",
+      "version": "0.5.0",
+      "release": "39.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "python3-audit": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "libzstd": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "python3-libxml2": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "11.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "libcap-ng": {
+      "epoch": "0",
+      "version": "0.7.11",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "cups-libs": {
+      "epoch": "1",
+      "version": "2.2.6",
+      "release": "40.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "nspr": {
+      "epoch": "0",
+      "version": "4.32.0",
+      "release": "1.el8_4",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "samba-common-libs": {
+      "epoch": "0",
+      "version": "4.14.5",
+      "release": "2.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "json-c": {
+      "epoch": "0",
+      "version": "0.13.1",
+      "release": "2.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "libsmbclient": {
+      "epoch": "0",
+      "version": "4.14.5",
+      "release": "2.el8",
+      "installdate": "1634653211",
+      "arch": "x86_64"
+    },
+    "libattr": {
+      "epoch": "0",
+      "version": "2.4.48",
+      "release": "3.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "unbound-libs": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "17.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "sed": {
+      "epoch": "0",
+      "version": "4.5",
+      "release": "2.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "jose": {
+      "epoch": "0",
+      "version": "10",
+      "release": "2.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libnl3": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "audit": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "nss-util": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "libblockdev-fs": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libgcrypt": {
+      "epoch": "0",
+      "version": "1.8.5",
+      "release": "6.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "libblockdev-part": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libsss_idmap": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "python3-pydbus": {
+      "epoch": "0",
+      "version": "0.6.0",
+      "release": "5.el8",
+      "installdate": "1634653212",
+      "arch": "noarch"
+    },
+    "libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "6.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "kernel-modules": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653215",
+      "arch": "x86_64"
+    },
+    "libunistring": {
+      "epoch": "0",
+      "version": "0.9.9",
+      "release": "3.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "libgusb": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "1.el8",
+      "installdate": "1634653226",
+      "arch": "x86_64"
+    },
+    "file-libs": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "20.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "usb_modeswitch-data": {
+      "epoch": "0",
+      "version": "20191128",
+      "release": "1.el8",
+      "installdate": "1634653226",
+      "arch": "noarch"
+    },
+    "libaio": {
+      "epoch": "0",
+      "version": "0.3.112",
+      "release": "1.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "lvm2-libs": {
+      "epoch": "8",
+      "version": "2.03.12",
+      "release": "10.el8",
+      "installdate": "1634653227",
+      "arch": "x86_64"
+    },
+    "p11-kit": {
+      "epoch": "0",
+      "version": "0.23.22",
+      "release": "1.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "libblockdev-lvm": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653227",
+      "arch": "x86_64"
+    },
+    "freetype": {
+      "epoch": "0",
+      "version": "2.9.1",
+      "release": "4.el8_3.1",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "python3-setools": {
+      "epoch": "0",
+      "version": "4.3.0",
+      "release": "2.el8",
+      "installdate": "1634653227",
+      "arch": "x86_64"
+    },
+    "libsmartcols": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "policycoreutils-python-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "16.el8",
+      "installdate": "1634653228",
+      "arch": "noarch"
+    },
+    "pciutils-libs": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "python3-slip": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "11.el8",
+      "installdate": "1634653286",
+      "arch": "noarch"
+    },
+    "nettle": {
+      "epoch": "0",
+      "version": "3.4.1",
+      "release": "7.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "python3-dateutil": {
+      "epoch": "1",
+      "version": "2.6.1",
+      "release": "6.el8",
+      "installdate": "1634653286",
+      "arch": "noarch"
+    },
+    "pixman": {
+      "epoch": "0",
+      "version": "0.38.4",
+      "release": "1.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "python3-pyudev": {
+      "epoch": "0",
+      "version": "0.21.0",
+      "release": "7.el8",
+      "installdate": "1634653286",
+      "arch": "noarch"
+    },
+    "libtasn1": {
+      "epoch": "0",
+      "version": "4.13",
+      "release": "3.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "oddjob": {
+      "epoch": "0",
+      "version": "0.34.7",
+      "release": "1.el8",
+      "installdate": "1634653286",
+      "arch": "x86_64"
+    },
+    "pcre": {
+      "epoch": "0",
+      "version": "8.42",
+      "release": "6.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "authselect-libs": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "xz": {
+      "epoch": "0",
+      "version": "5.2.4",
+      "release": "3.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "libstoragemgmt": {
+      "epoch": "0",
+      "version": "1.9.1",
+      "release": "1.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "libpsl": {
+      "epoch": "0",
+      "version": "0.20.2",
+      "release": "6.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "mdadm": {
+      "epoch": "0",
+      "version": "4.2",
+      "release": "rc2.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "ethtool": {
+      "epoch": "2",
+      "version": "5.8",
+      "release": "7.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "librelp": {
+      "epoch": "0",
+      "version": "1.9.0",
+      "release": "1.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "mpfr": {
+      "epoch": "0",
+      "version": "3.1.6",
+      "release": "1.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "desktop-file-utils": {
+      "epoch": "0",
+      "version": "0.23",
+      "release": "8.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "gdisk": {
+      "epoch": "0",
+      "version": "1.0.3",
+      "release": "6.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "libslirp": {
+      "epoch": "0",
+      "version": "4.4.0",
+      "release": "1.module_el8.6.0+926+8bef8ae7",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "libgomp": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "libudisks2": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "7.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "libselinux-utils": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "5.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "python3-dbus": {
+      "epoch": "0",
+      "version": "1.2.4",
+      "release": "15.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "dmidecode": {
+      "epoch": "1",
+      "version": "3.2",
+      "release": "10.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "gsettings-desktop-schemas": {
+      "epoch": "0",
+      "version": "3.32.0",
+      "release": "6.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "libnfnetlink": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "13.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "cockpit-bridge": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "libpath_utils": {
+      "epoch": "0",
+      "version": "0.2.1",
+      "release": "39.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libappstream-glib": {
+      "epoch": "0",
+      "version": "0.7.14",
+      "release": "3.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "libyaml": {
+      "epoch": "0",
+      "version": "0.1.7",
+      "release": "5.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libsecret": {
+      "epoch": "0",
+      "version": "0.18.6",
+      "release": "1.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "numactl-libs": {
+      "epoch": "0",
+      "version": "2.0.12",
+      "release": "13.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "sg3_utils-libs": {
+      "epoch": "0",
+      "version": "1.44",
+      "release": "5.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "squashfs-tools": {
+      "epoch": "0",
+      "version": "4.3",
+      "release": "20.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libteam": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "grub2-pc-modules": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1634653168",
+      "arch": "noarch"
+    },
+    "nss-softokn-freebl": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "ipset-libs": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "groff-base": {
+      "epoch": "0",
+      "version": "1.22.3",
+      "release": "18.el8",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "tar": {
+      "epoch": "2",
+      "version": "1.30",
+      "release": "5.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "attr": {
+      "epoch": "0",
+      "version": "2.4.48",
+      "release": "3.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "libmetalink": {
+      "epoch": "0",
+      "version": "0.1.3",
+      "release": "7.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "sqlite": {
+      "epoch": "0",
+      "version": "3.26.0",
+      "release": "15.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "unzip": {
+      "epoch": "0",
+      "version": "6.0",
+      "release": "45.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "libicu": {
+      "epoch": "0",
+      "version": "60.3",
+      "release": "2.el8_1",
+      "installdate": "1634653170",
+      "arch": "x86_64"
+    },
+    "libproxy": {
+      "epoch": "0",
+      "version": "0.4.15",
+      "release": "5.2.el8",
+      "installdate": "1634653171",
+      "arch": "x86_64"
+    },
+    "snappy": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "3.el8",
+      "installdate": "1634653172",
+      "arch": "x86_64"
+    },
+    "libss": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1634653172",
+      "arch": "x86_64"
+    },
+    "kernel-tools-libs": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653172",
+      "arch": "x86_64"
+    },
+    "containernetworking-plugins": {
+      "epoch": "0",
+      "version": "1.0.1",
+      "release": "1.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "libXau": {
+      "epoch": "0",
+      "version": "1.0.9",
+      "release": "3.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "libestr": {
+      "epoch": "0",
+      "version": "0.1.10",
+      "release": "1.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "libnet": {
+      "epoch": "0",
+      "version": "1.1.6",
+      "release": "15.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "jq": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "12.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "c-ares": {
+      "epoch": "0",
+      "version": "1.13.0",
+      "release": "5.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "dosfstools": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "6.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "fuse3": {
+      "epoch": "0",
+      "version": "3.2.1",
+      "release": "12.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "hardlink": {
+      "epoch": "1",
+      "version": "1.3",
+      "release": "6.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "jimtcl": {
+      "epoch": "0",
+      "version": "0.77",
+      "release": "6.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libndp": {
+      "epoch": "0",
+      "version": "1.7",
+      "release": "6.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libpipeline": {
+      "epoch": "0",
+      "version": "1.5.0",
+      "release": "2.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "pkgconf": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libsigsegv": {
+      "epoch": "0",
+      "version": "2.11",
+      "release": "5.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libsss_autofs": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libsss_sudo": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libverto": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "memstrack": {
+      "epoch": "0",
+      "version": "0.1.11",
+      "release": "1.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "npth": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "4.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "newt": {
+      "epoch": "0",
+      "version": "0.52.20",
+      "release": "11.el8",
+      "installdate": "1634653178",
+      "arch": "x86_64"
+    },
+    "libxkbcommon": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1634653178",
+      "arch": "x86_64"
+    },
+    "platform-python-pip": {
+      "epoch": "0",
+      "version": "9.0.3",
+      "release": "20.el8",
+      "installdate": "1634653179",
+      "arch": "noarch"
+    },
+    "python3-libs": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "42.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "libssh": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "3.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "platform-python": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "42.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "libkcapi": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "libarchive": {
+      "epoch": "0",
+      "version": "3.3.3",
+      "release": "1.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "curl": {
+      "epoch": "0",
+      "version": "7.61.1",
+      "release": "21.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "openssl": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "4.el8",
+      "installdate": "1634653184",
+      "arch": "x86_64"
+    },
+    "crypto-policies": {
+      "epoch": "0",
+      "version": "20210617",
+      "release": "1.gitc776d3e.el8",
+      "installdate": "1634653184",
+      "arch": "noarch"
+    },
+    "gzip": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "12.el8",
+      "installdate": "1634653184",
+      "arch": "x86_64"
+    },
+    "cracklib-dicts": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "krb5-libs": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "14.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "libnsl2": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "2.20180605git4a062cf.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "device-mapper": {
+      "epoch": "8",
+      "version": "1.02.177",
+      "release": "10.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "elfutils-libs": {
+      "epoch": "0",
+      "version": "0.185",
+      "release": "1.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "18.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "libcroco": {
+      "epoch": "0",
+      "version": "0.6.12",
+      "release": "4.el8_2.1",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "libmount": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653186",
+      "arch": "x86_64"
+    },
+    "dbus-tools": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "14.el8",
+      "installdate": "1634653186",
+      "arch": "x86_64"
+    },
+    "systemd-libs": {
+      "epoch": "0",
+      "version": "239",
+      "release": "51.el8",
+      "installdate": "1634653186",
+      "arch": "x86_64"
+    },
+    "device-mapper-libs": {
+      "epoch": "8",
+      "version": "1.02.177",
+      "release": "10.el8",
+      "installdate": "1634653187",
+      "arch": "x86_64"
+    },
+    "ca-certificates": {
+      "epoch": "0",
+      "version": "2021.2.50",
+      "release": "82.el8",
+      "installdate": "1634653187",
+      "arch": "noarch"
+    },
+    "kmod-libs": {
+      "epoch": "0",
+      "version": "25",
+      "release": "18.el8",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    },
+    "rpm-libs": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "18.el8",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    },
+    "cryptsetup-libs": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "4.el8",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    },
+    "tuned": {
+      "epoch": "0",
+      "version": "2.16.0",
+      "release": "1.el8",
+      "installdate": "1634653319",
+      "arch": "noarch"
+    },
+    "dnf-plugins-core": {
+      "epoch": "0",
+      "version": "4.0.21",
+      "release": "3.el8",
+      "installdate": "1634653320",
+      "arch": "noarch"
+    },
+    "yum": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "4.el8",
+      "installdate": "1634653320",
+      "arch": "noarch"
+    },
+    "firewalld": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "7.el8",
+      "installdate": "1634653320",
+      "arch": "noarch"
+    },
+    "buildah": {
+      "epoch": "0",
+      "version": "1.24.0",
+      "release": "0.7.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "nmap-ncat": {
+      "epoch": "2",
+      "version": "7.70",
+      "release": "6.el8",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "grub2-pc": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "pinfo": {
+      "epoch": "0",
+      "version": "0.6.10",
+      "release": "18.el8",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "chrony": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "1.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "xfsdump": {
+      "epoch": "0",
+      "version": "3.1.8",
+      "release": "2.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "openssh-server": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "9.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "util-linux-user": {
+      "epoch": "0",
+      "version": "2.32.1",
+      "release": "28.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "rsyslog-gnutls": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "5.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "usbutils": {
+      "epoch": "0",
+      "version": "010",
+      "release": "3.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "qemu-guest-agent": {
+      "epoch": "15",
+      "version": "4.2.0",
+      "release": "52.module_el8.5.0+853+a4d5519d",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "mcelog": {
+      "epoch": "3",
+      "version": "175",
+      "release": "1.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "mlocate": {
+      "epoch": "0",
+      "version": "0.26",
+      "release": "20.el8",
+      "installdate": "1634653328",
+      "arch": "x86_64"
+    },
+    "psacct": {
+      "epoch": "0",
+      "version": "6.6.3",
+      "release": "4.el8",
+      "installdate": "1634653329",
+      "arch": "x86_64"
+    },
+    "irqbalance": {
+      "epoch": "2",
+      "version": "1.4.0",
+      "release": "6.el8",
+      "installdate": "1634653329",
+      "arch": "x86_64"
+    },
+    "nvme-cli": {
+      "epoch": "0",
+      "version": "1.14",
+      "release": "3.el8",
+      "installdate": "1634653329",
+      "arch": "x86_64"
+    },
+    "prefixdevname": {
+      "epoch": "0",
+      "version": "0.1.0",
+      "release": "6.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "strace": {
+      "epoch": "0",
+      "version": "5.7",
+      "release": "3.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "quota": {
+      "epoch": "1",
+      "version": "4.04",
+      "release": "14.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "blktrace": {
+      "epoch": "0",
+      "version": "1.2.0",
+      "release": "10.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "zip": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "23.el8",
+      "installdate": "1634653332",
+      "arch": "x86_64"
+    },
+    "biosdevname": {
+      "epoch": "0",
+      "version": "0.7.3",
+      "release": "2.el8",
+      "installdate": "1634653332",
+      "arch": "x86_64"
+    },
+    "rsync": {
+      "epoch": "0",
+      "version": "3.1.3",
+      "release": "13.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "bc": {
+      "epoch": "0",
+      "version": "1.07.1",
+      "release": "5.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "ed": {
+      "epoch": "0",
+      "version": "1.14.2",
+      "release": "4.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "iprutils": {
+      "epoch": "0",
+      "version": "2.4.19",
+      "release": "1.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "dos2unix": {
+      "epoch": "0",
+      "version": "7.4.0",
+      "release": "3.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "lsscsi": {
+      "epoch": "0",
+      "version": "0.32",
+      "release": "3.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "symlinks": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "19.el8",
+      "installdate": "1634653334",
+      "arch": "x86_64"
+    },
+    "langpacks-cs": {
+      "epoch": "0",
+      "version": "1.0",
+      "release": "12.el8",
+      "installdate": "1634653334",
+      "arch": "noarch"
+    },
+    "rootfiles": {
+      "epoch": "0",
+      "version": "8.1",
+      "release": "22.el8",
+      "installdate": "1634653334",
+      "arch": "noarch"
+    },
+    "libertas-usb8388-firmware": {
+      "epoch": "2",
+      "version": "20210702",
+      "release": "103.gitd79c2677.el8",
+      "installdate": "1634653334",
+      "arch": "noarch"
+    },
+    "iwl6050-firmware": {
+      "epoch": "0",
+      "version": "41.28.5.1",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "iwl6000g2a-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "iwl5150-firmware": {
+      "epoch": "0",
+      "version": "8.24.2.2",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "iwl3160-firmware": {
+      "epoch": "1",
+      "version": "25.30.13.0",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "iwl2000-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "iwl105-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "iwl100-firmware": {
+      "epoch": "0",
+      "version": "39.31.5.1",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "NetworkManager-config-server": {
+      "epoch": "1",
+      "version": "1.34.0",
+      "release": "0.2.el8",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "pcp-selinux": {
+      "epoch": "0",
+      "version": "5.3.3",
+      "release": "1.el8",
+      "installdate": "1634726139",
+      "arch": "x86_64"
+    },
+    "pcp-libs": {
+      "epoch": "0",
+      "version": "5.3.3",
+      "release": "1.el8",
+      "installdate": "1634726187",
+      "arch": "x86_64"
+    },
+    "cockpit-pcp": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634726191",
+      "arch": "x86_64"
+    },
+    "ruby-libs": {
+      "epoch": "0",
+      "version": "2.5.9",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727244",
+      "arch": "x86_64"
+    },
+    "rubygem-bigdecimal": {
+      "epoch": "0",
+      "version": "1.3.4",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727244",
+      "arch": "x86_64"
+    },
+    "rubygem-io-console": {
+      "epoch": "0",
+      "version": "0.4.6",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727244",
+      "arch": "x86_64"
+    },
+    "rubygem-openssl": {
+      "epoch": "0",
+      "version": "2.1.2",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727245",
+      "arch": "x86_64"
+    },
+    "rubygem-rdoc": {
+      "epoch": "0",
+      "version": "6.0.1.1",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727245",
+      "arch": "noarch"
+    },
+    "ruby": {
+      "epoch": "0",
+      "version": "2.5.9",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727245",
+      "arch": "x86_64"
+    },
+    "python3-dmidecode": {
+      "epoch": "0",
+      "version": "3.12.2",
+      "release": "15.el8",
+      "installdate": "1634727410",
+      "arch": "x86_64"
+    },
+    "subscription-manager-rhsm-certificates": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727410",
+      "arch": "x86_64"
+    },
+    "python3-pysocks": {
+      "epoch": "0",
+      "version": "1.6.8",
+      "release": "3.el8",
+      "installdate": "1634727410",
+      "arch": "noarch"
+    },
+    "python3-librepo": {
+      "epoch": "0",
+      "version": "1.14.0",
+      "release": "2.el8",
+      "installdate": "1634727410",
+      "arch": "x86_64"
+    },
+    "python3-inotify": {
+      "epoch": "0",
+      "version": "0.9.6",
+      "release": "13.el8",
+      "installdate": "1634727411",
+      "arch": "noarch"
+    },
+    "python3-ethtool": {
+      "epoch": "0",
+      "version": "0.14",
+      "release": "3.el8",
+      "installdate": "1634727411",
+      "arch": "x86_64"
+    },
+    "python3-requests": {
+      "epoch": "0",
+      "version": "2.20.0",
+      "release": "2.1.el8_1",
+      "installdate": "1634727411",
+      "arch": "noarch"
+    },
+    "python3-subscription-manager-rhsm": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727411",
+      "arch": "x86_64"
+    },
+    "subscription-manager-cockpit": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727412",
+      "arch": "noarch"
+    },
+    "cpp": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634727862",
+      "arch": "x86_64"
+    },
+    "pcre2-utf32": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1634727862",
+      "arch": "x86_64"
+    },
+    "pcre2-devel": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1634727862",
+      "arch": "x86_64"
+    },
+    "gnupg2-smime": {
+      "epoch": "0",
+      "version": "2.2.20",
+      "release": "2.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "ncurses-devel": {
+      "epoch": "0",
+      "version": "6.1",
+      "release": "9.20180224.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "gpgme": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "9.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "libsepol-devel": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "3.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "libdnf": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "3.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "libkadm5": {
+      "epoch": "0",
+      "version": "1.18.2",
+      "release": "14.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "python3-libdnf": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "3.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "keyutils-libs-devel": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "9.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "python3-gpg": {
+      "epoch": "0",
+      "version": "1.13.1",
+      "release": "9.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "kernel-headers": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634727865",
+      "arch": "x86_64"
+    },
+    "python3-rpm": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "18.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "libxcrypt-devel": {
+      "epoch": "0",
+      "version": "4.1.1",
+      "release": "6.el8",
+      "installdate": "1634727865",
+      "arch": "x86_64"
+    },
+    "dracut-squash": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "isl": {
+      "epoch": "0",
+      "version": "0.16.1",
+      "release": "6.el8",
+      "installdate": "1634727866",
+      "arch": "x86_64"
+    },
+    "sssd-client": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "openssl-devel": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "4.el8",
+      "installdate": "1634727871",
+      "arch": "x86_64"
+    },
+    "cryptsetup": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "4.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "libffi-devel": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "22.el8",
+      "installdate": "1634727871",
+      "arch": "x86_64"
+    },
+    "luksmeta": {
+      "epoch": "0",
+      "version": "9",
+      "release": "4.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "m4": {
+      "epoch": "0",
+      "version": "1.4.18",
+      "release": "7.el8",
+      "installdate": "1634728004",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-systemd-inhibit": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "18.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "perl-Digest-MD5": {
+      "epoch": "0",
+      "version": "2.55",
+      "release": "396.el8",
+      "installdate": "1634728004",
+      "arch": "x86_64"
+    },
+    "dracut-network": {
+      "epoch": "0",
+      "version": "049",
+      "release": "191.git20210920.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "perl-libnet": {
+      "epoch": "0",
+      "version": "3.11",
+      "release": "3.el8",
+      "installdate": "1634728004",
+      "arch": "noarch"
+    },
+    "pciutils": {
+      "epoch": "0",
+      "version": "3.7.0",
+      "release": "1.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "perl-URI": {
+      "epoch": "0",
+      "version": "1.73",
+      "release": "3.el8",
+      "installdate": "1634728004",
+      "arch": "noarch"
+    },
+    "libibverbs": {
+      "epoch": "0",
+      "version": "35.0",
+      "release": "1.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "perl-Mozilla-CA": {
+      "epoch": "0",
+      "version": "20160104",
+      "release": "7.module_el8.3.0+416+dee7bcef",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "iptables-libs": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "20.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "perl-Time-Local": {
+      "epoch": "1",
+      "version": "1.280",
+      "release": "1.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "21.el8",
+      "installdate": "1634653293",
+      "arch": "x86_64"
+    },
+    "perl-Term-ANSIColor": {
+      "epoch": "0",
+      "version": "4.06",
+      "release": "396.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "runc": {
+      "epoch": "0",
+      "version": "1.0.2",
+      "release": "1.module_el8.6.0+926+8bef8ae7",
+      "installdate": "1634653293",
+      "arch": "x86_64"
+    },
+    "perl-File-Temp": {
+      "epoch": "0",
+      "version": "0.230.600",
+      "release": "1.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "podman-catatonit": {
+      "epoch": "0",
+      "version": "4.0.0",
+      "release": "0.10.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653294",
+      "arch": "x86_64"
+    },
+    "perl-HTTP-Tiny": {
+      "epoch": "0",
+      "version": "0.074",
+      "release": "1.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "python3-nftables": {
+      "epoch": "1",
+      "version": "0.9.3",
+      "release": "21.el8",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Perldoc": {
+      "epoch": "0",
+      "version": "3.28",
+      "release": "396.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "iptables-ebtables": {
+      "epoch": "0",
+      "version": "1.8.4",
+      "release": "20.el8",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Usage": {
+      "epoch": "4",
+      "version": "1.69",
+      "release": "395.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "isns-utils-libs": {
+      "epoch": "0",
+      "version": "0.99",
+      "release": "1.el8",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "perl-Storable": {
+      "epoch": "1",
+      "version": "3.11",
+      "release": "3.el8",
+      "installdate": "1634728005",
+      "arch": "x86_64"
+    },
+    "iscsi-initiator-utils": {
+      "epoch": "0",
+      "version": "6.2.1.4",
+      "release": "4.git095f59c.el8",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "perl-Errno": {
+      "epoch": "0",
+      "version": "1.28",
+      "release": "420.el8",
+      "installdate": "1634728005",
+      "arch": "x86_64"
+    },
+    "device-mapper-multipath-libs": {
+      "epoch": "0",
+      "version": "0.8.4",
+      "release": "17.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "perl-Encode": {
+      "epoch": "4",
+      "version": "2.97",
+      "release": "3.el8",
+      "installdate": "1634728006",
+      "arch": "x86_64"
+    },
+    "libatasmart": {
+      "epoch": "0",
+      "version": "0.19",
+      "release": "14.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "perl-Exporter": {
+      "epoch": "0",
+      "version": "5.72",
+      "release": "396.el8",
+      "installdate": "1634728006",
+      "arch": "noarch"
+    },
+    "plymouth-scripts": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "10.20200615git1e36e30.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "perl-Scalar-List-Utils": {
+      "epoch": "3",
+      "version": "1.49",
+      "release": "2.el8",
+      "installdate": "1634728006",
+      "arch": "x86_64"
+    },
+    "python3-systemd": {
+      "epoch": "0",
+      "version": "234",
+      "release": "8.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "perl-macros": {
+      "epoch": "4",
+      "version": "5.26.3",
+      "release": "420.el8",
+      "installdate": "1634728007",
+      "arch": "x86_64"
+    },
+    "cockpit-ws": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "perl-Unicode-Normalize": {
+      "epoch": "0",
+      "version": "1.25",
+      "release": "396.el8",
+      "installdate": "1634728007",
+      "arch": "x86_64"
+    },
+    "nss-sysinit": {
+      "epoch": "0",
+      "version": "3.67.0",
+      "release": "6.el8_4",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "perl-IO": {
+      "epoch": "0",
+      "version": "1.38",
+      "release": "420.el8",
+      "installdate": "1634728007",
+      "arch": "x86_64"
+    },
+    "fprintd": {
+      "epoch": "0",
+      "version": "1.90.9",
+      "release": "2.el8",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "perl-constant": {
+      "epoch": "0",
+      "version": "1.33",
+      "release": "396.el8",
+      "installdate": "1634728007",
+      "arch": "noarch"
+    },
+    "libblockdev-crypto": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "perl-threads-shared": {
+      "epoch": "0",
+      "version": "1.58",
+      "release": "2.el8",
+      "installdate": "1634728007",
+      "arch": "x86_64"
+    },
+    "udisks2-iscsi": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "7.el8",
+      "installdate": "1634653299",
+      "arch": "x86_64"
+    },
+    "autoconf": {
+      "epoch": "0",
+      "version": "2.69",
+      "release": "29.el8",
+      "installdate": "1634728008",
+      "arch": "noarch"
+    },
+    "binutils": {
+      "epoch": "0",
+      "version": "2.30",
+      "release": "108.el8",
+      "installdate": "1634653302",
+      "arch": "x86_64"
+    },
+    "automake": {
+      "epoch": "0",
+      "version": "1.16.1",
+      "release": "7.el8",
+      "installdate": "1634728009",
+      "arch": "noarch"
+    },
+    "NetworkManager-team": {
+      "epoch": "1",
+      "version": "1.34.0",
+      "release": "0.2.el8",
+      "installdate": "1634653302",
+      "arch": "x86_64"
+    },
+    "gcc-c++": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634728012",
+      "arch": "x86_64"
+    },
+    "sssd-nfs-idmap": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653302",
+      "arch": "x86_64"
+    },
+    "bison": {
+      "epoch": "0",
+      "version": "3.0.4",
+      "release": "10.el8",
+      "installdate": "1634728012",
+      "arch": "x86_64"
+    },
+    "sssd-krb5-common": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653303",
+      "arch": "x86_64"
+    },
+    "patch": {
+      "epoch": "0",
+      "version": "2.7.6",
+      "release": "11.el8",
+      "installdate": "1634728012",
+      "arch": "x86_64"
+    },
+    "sssd-krb5": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653303",
+      "arch": "x86_64"
+    },
+    "python36": {
+      "epoch": "0",
+      "version": "3.6.8",
+      "release": "38.module_el8.5.0+895+a459eca8",
+      "installdate": "1634728716",
+      "arch": "x86_64"
+    },
+    "sssd-proxy": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653303",
+      "arch": "x86_64"
+    },
+    "rust-std-static": {
+      "epoch": "0",
+      "version": "1.54.0",
+      "release": "2.module_el8.5.0+910+9ca45234",
+      "installdate": "1634729420",
+      "arch": "x86_64"
+    },
+    "python3-ptyprocess": {
+      "epoch": "0",
+      "version": "0.5.2",
+      "release": "4.el8",
+      "installdate": "1634653303",
+      "arch": "noarch"
+    },
+    "rust": {
+      "epoch": "0",
+      "version": "1.54.0",
+      "release": "2.module_el8.5.0+910+9ca45234",
+      "installdate": "1634729427",
+      "arch": "x86_64"
+    },
+    "sos": {
+      "epoch": "0",
+      "version": "4.1",
+      "release": "5.el8",
+      "installdate": "1634653304",
+      "arch": "noarch"
+    },
+    "epel-release": {
+      "epoch": "0",
+      "version": "8",
+      "release": "11.el8",
+      "installdate": "1634730503",
+      "arch": "noarch"
+    },
+    "python3-html5lib": {
+      "epoch": "1",
+      "version": "0.999999999",
+      "release": "6.el8",
+      "installdate": "1634653304",
+      "arch": "noarch"
+    },
+    "kernel-tools": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653305",
+      "arch": "x86_64"
+    },
+    "libsodium": {
+      "epoch": "0",
+      "version": "1.0.18",
+      "release": "2.el8",
+      "installdate": "1634730534",
+      "arch": "x86_64"
+    },
+    "python3-dnf": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "4.el8",
+      "installdate": "1634653305",
+      "arch": "noarch"
+    },
+    "python3-cffi": {
+      "epoch": "0",
+      "version": "1.11.5",
+      "release": "5.el8",
+      "installdate": "1634730535",
+      "arch": "x86_64"
+    },
+    "kpatch-dnf": {
+      "epoch": "0",
+      "version": "0.4",
+      "release": "1.el8",
+      "installdate": "1634653305",
+      "arch": "noarch"
+    },
+    "python3-bcrypt": {
+      "epoch": "0",
+      "version": "3.1.6",
+      "release": "2.el8.1",
+      "installdate": "1634730535",
+      "arch": "x86_64"
+    },
+    "python3-perf": {
+      "epoch": "0",
+      "version": "4.18.0",
+      "release": "338.el8",
+      "installdate": "1634653306",
+      "arch": "x86_64"
+    },
+    "python3-pytz": {
+      "epoch": "0",
+      "version": "2017.2",
+      "release": "9.el8",
+      "installdate": "1634730535",
+      "arch": "noarch"
+    },
+    "python3-bind": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "6.el8",
+      "installdate": "1634653306",
+      "arch": "noarch"
+    },
+    "python3-pyasn1": {
+      "epoch": "0",
+      "version": "0.3.7",
+      "release": "6.el8",
+      "installdate": "1634730537",
+      "arch": "noarch"
+    },
+    "python3-setuptools": {
+      "epoch": "0",
+      "version": "39.2.0",
+      "release": "6.el8",
+      "installdate": "1634653306",
+      "arch": "noarch"
+    },
+    "python3-markupsafe": {
+      "epoch": "0",
+      "version": "0.23",
+      "release": "19.el8",
+      "installdate": "1634730538",
+      "arch": "x86_64"
+    },
+    "python3-syspurpose": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634653306",
+      "arch": "x86_64"
+    },
+    "python3-jmespath": {
+      "epoch": "0",
+      "version": "0.9.0",
+      "release": "11.el8",
+      "installdate": "1634730538",
+      "arch": "noarch"
+    },
+    "vim-common": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "16.el8",
+      "installdate": "1634653309",
+      "arch": "x86_64"
+    },
+    "python3-tracer": {
+      "epoch": "0",
+      "version": "0.7.5",
+      "release": "2.el8",
+      "installdate": "1634653309",
+      "arch": "noarch"
+    },
+    "python3-m2crypto": {
+      "epoch": "0",
+      "version": "0.35.2",
+      "release": "5.el8",
+      "installdate": "1634731219",
+      "arch": "x86_64"
+    },
+    "man-pages-overrides": {
+      "epoch": "0",
+      "version": "8.5.0.1",
+      "release": "1.el8",
+      "installdate": "1634653309",
+      "arch": "noarch"
+    },
+    "python3-contextvars": {
+      "epoch": "0",
+      "version": "2.4",
+      "release": "1.el8",
+      "installdate": "1634731219",
+      "arch": "noarch"
+    },
+    "libX11": {
+      "epoch": "0",
+      "version": "1.6.8",
+      "release": "5.el8",
+      "installdate": "1634653309",
+      "arch": "x86_64"
+    },
+    "libunwind": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "3.el8",
+      "installdate": "1634731219",
+      "arch": "x86_64"
+    },
+    "libXrender": {
+      "epoch": "0",
+      "version": "0.9.10",
+      "release": "7.el8",
+      "installdate": "1634653309",
+      "arch": "x86_64"
+    },
+    "python3-zmq": {
+      "epoch": "0",
+      "version": "19.0.0",
+      "release": "1.el8",
+      "installdate": "1634731220",
+      "arch": "x86_64"
+    },
+    "cairo-gobject": {
+      "epoch": "0",
+      "version": "1.15.12",
+      "release": "3.el8",
+      "installdate": "1634653310",
+      "arch": "x86_64"
+    },
+    "python3-pycurl": {
+      "epoch": "0",
+      "version": "7.43.0.2",
+      "release": "4.el8",
+      "installdate": "1634731220",
+      "arch": "x86_64"
+    },
+    "python3-gobject": {
+      "epoch": "0",
+      "version": "3.28.3",
+      "release": "2.el8",
+      "installdate": "1634653310",
+      "arch": "x86_64"
+    },
+    "salt": {
+      "epoch": "0",
+      "version": "3004",
+      "release": "1.el8",
+      "installdate": "1634731226",
+      "arch": "noarch"
+    },
+    "setroubleshoot-server": {
+      "epoch": "0",
+      "version": "3.3.24",
+      "release": "4.el8",
+      "installdate": "1634653310",
+      "arch": "x86_64"
+    },
+    "salt-minion": {
+      "epoch": "0",
+      "version": "3004",
+      "release": "1.el8",
+      "installdate": "1634735764",
+      "arch": "noarch"
+    },
+    "cockpit-storaged": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634653311",
+      "arch": "noarch"
+    },
+    "geolite2-city": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1634653314",
+      "arch": "noarch"
+    },
+    "bind-libs-lite": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "6.el8",
+      "installdate": "1634653314",
+      "arch": "x86_64"
+    },
+    "bind-utils": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "6.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "sssd-ipa": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "realmd": {
+      "epoch": "0",
+      "version": "0.16.3",
+      "release": "23.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "authselect-compat": {
+      "epoch": "0",
+      "version": "1.2.2",
+      "release": "3.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "cockpit": {
+      "epoch": "0",
+      "version": "251.1",
+      "release": "1.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "vim-enhanced": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "16.el8",
+      "installdate": "1634653319",
+      "arch": "x86_64"
+    },
+    "dbus-daemon": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "14.el8",
+      "installdate": "1634653189",
+      "arch": "x86_64"
+    },
+    "hwdata": {
+      "epoch": "0",
+      "version": "0.314",
+      "release": "8.10.el8",
+      "installdate": "1634653135",
+      "arch": "noarch"
+    },
+    "kpatch": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "1.el8",
+      "installdate": "1634653320",
+      "arch": "noarch"
+    },
+    "pam": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "15.el8",
+      "installdate": "1634653190",
+      "arch": "x86_64"
+    },
+    "tzdata": {
+      "epoch": "0",
+      "version": "2021b",
+      "release": "1.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "cockpit-podman": {
+      "epoch": "0",
+      "version": "35",
+      "release": "1.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653320",
+      "arch": "noarch"
+    },
+    "os-prober": {
+      "epoch": "0",
+      "version": "1.74",
+      "release": "9.el8",
+      "installdate": "1634653191",
+      "arch": "x86_64"
+    },
+    "dnf-data": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "4.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "tcpdump": {
+      "epoch": "14",
+      "version": "4.9.3",
+      "release": "2.el8",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "shared-mime-info": {
+      "epoch": "0",
+      "version": "1.9",
+      "release": "3.el8",
+      "installdate": "1634653193",
+      "arch": "x86_64"
+    },
+    "publicsuffix-list-dafsa": {
+      "epoch": "0",
+      "version": "20180723",
+      "release": "1.el8",
+      "installdate": "1634653136",
+      "arch": "noarch"
+    },
+    "rsyslog-relp": {
+      "epoch": "0",
+      "version": "8.2102.0",
+      "release": "5.el8",
+      "installdate": "1634653322",
+      "arch": "x86_64"
+    },
+    "systemd-udev": {
+      "epoch": "0",
+      "version": "239",
+      "release": "51.el8",
+      "installdate": "1634653195",
+      "arch": "x86_64"
+    },
+    "libssh-config": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "3.el8",
+      "installdate": "1634653157",
+      "arch": "noarch"
+    },
+    "openssh-clients": {
+      "epoch": "0",
+      "version": "8.0p1",
+      "release": "9.el8",
+      "installdate": "1634653323",
+      "arch": "x86_64"
+    },
+    "polkit": {
+      "epoch": "0",
+      "version": "0.115",
+      "release": "12.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "firewalld-filesystem": {
+      "epoch": "0",
+      "version": "0.9.3",
+      "release": "7.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "NetworkManager-tui": {
+      "epoch": "1",
+      "version": "1.34.0",
+      "release": "0.2.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "libmodulemd": {
+      "epoch": "0",
+      "version": "2.13.0",
+      "release": "1.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "centos-stream-release": {
+      "epoch": "0",
+      "version": "8.6",
+      "release": "1.el8",
+      "installdate": "1634653158",
+      "arch": "noarch"
+    },
+    "bolt": {
+      "epoch": "0",
+      "version": "0.9.1",
+      "release": "1.el8",
+      "installdate": "1634653324",
+      "arch": "x86_64"
+    },
+    "libusbx": {
+      "epoch": "0",
+      "version": "1.0.23",
+      "release": "4.el8",
+      "installdate": "1634653196",
+      "arch": "x86_64"
+    },
+    "basesystem": {
+      "epoch": "0",
+      "version": "11",
+      "release": "5.el8",
+      "installdate": "1634653159",
+      "arch": "noarch"
+    },
+    "microcode_ctl": {
+      "epoch": "4",
+      "version": "20210608",
+      "release": "1.el8",
+      "installdate": "1634653325",
+      "arch": "x86_64"
+    },
+    "json-glib": {
+      "epoch": "0",
+      "version": "1.4.4",
+      "release": "1.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "glibc-langpack-cs": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "164.el8",
+      "installdate": "1634653160",
+      "arch": "x86_64"
+    },
+    "smartmontools": {
+      "epoch": "1",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1634653329",
+      "arch": "x86_64"
+    },
+    "libblockdev-utils": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653200",
+      "arch": "x86_64"
+    },
+    "libsepol": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "3.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "ledmon": {
+      "epoch": "0",
+      "version": "0.95",
+      "release": "1.el8",
+      "installdate": "1634653330",
+      "arch": "x86_64"
+    },
+    "rpm-plugin-selinux": {
+      "epoch": "0",
+      "version": "4.14.3",
+      "release": "18.el8",
+      "installdate": "1634653201",
+      "arch": "x86_64"
+    },
+    "info": {
+      "epoch": "0",
+      "version": "6.5",
+      "release": "6.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "lsof": {
+      "epoch": "0",
+      "version": "4.93.2",
+      "release": "1.el8",
+      "installdate": "1634653331",
+      "arch": "x86_64"
+    },
+    "cronie": {
+      "epoch": "0",
+      "version": "1.5.2",
+      "release": "4.el8",
+      "installdate": "1634653206",
+      "arch": "x86_64"
+    },
+    "libcap": {
+      "epoch": "0",
+      "version": "2.26",
+      "release": "5.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "bash-completion": {
+      "epoch": "1",
+      "version": "2.7",
+      "release": "5.el8",
+      "installdate": "1634653332",
+      "arch": "noarch"
+    },
+    "NetworkManager": {
+      "epoch": "1",
+      "version": "1.34.0",
+      "release": "0.2.el8",
+      "installdate": "1634653207",
+      "arch": "x86_64"
+    },
+    "libgpg-error": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "1.el8",
+      "installdate": "1634653162",
+      "arch": "x86_64"
+    },
+    "nano": {
+      "epoch": "0",
+      "version": "2.9.8",
+      "release": "1.el8",
+      "installdate": "1634653332",
+      "arch": "x86_64"
+    },
+    "fuse-overlayfs": {
+      "epoch": "0",
+      "version": "1.7.1",
+      "release": "1.module_el8.6.0+926+8bef8ae7",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "elfutils-libelf": {
+      "epoch": "0",
+      "version": "0.185",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "lshw": {
+      "epoch": "0",
+      "version": "B.02.19.2",
+      "release": "6.el8",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "ima-evm-utils": {
+      "epoch": "0",
+      "version": "1.3.2",
+      "release": "12.el8",
+      "installdate": "1634653208",
+      "arch": "x86_64"
+    },
+    "chkconfig": {
+      "epoch": "0",
+      "version": "1.19.1",
+      "release": "1.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "hostname": {
+      "epoch": "0",
+      "version": "3.20",
+      "release": "7.el8.0.1",
+      "installdate": "1634653333",
+      "arch": "x86_64"
+    },
+    "cyrus-sasl-gssapi": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "libref_array": {
+      "epoch": "0",
+      "version": "0.1.5",
+      "release": "39.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "mtr": {
+      "epoch": "2",
+      "version": "0.92",
+      "release": "3.el8",
+      "installdate": "1634653334",
+      "arch": "x86_64"
+    },
+    "adcli": {
+      "epoch": "0",
+      "version": "0.8.2",
+      "release": "12.el8",
+      "installdate": "1634653210",
+      "arch": "x86_64"
+    },
+    "audit-libs": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "0.17.20191104git1c2f876.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "words": {
+      "epoch": "0",
+      "version": "3.0",
+      "release": "28.el8",
+      "installdate": "1634653334",
+      "arch": "noarch"
+    },
+    "samba-client-libs": {
+      "epoch": "0",
+      "version": "4.14.5",
+      "release": "2.el8",
+      "installdate": "1634653211",
+      "arch": "x86_64"
+    },
+    "keyutils-libs": {
+      "epoch": "0",
+      "version": "1.5.10",
+      "release": "9.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "iwl7260-firmware": {
+      "epoch": "1",
+      "version": "25.30.13.0",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "python3-unbound": {
+      "epoch": "0",
+      "version": "1.7.3",
+      "release": "17.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libmnl": {
+      "epoch": "0",
+      "version": "1.0.4",
+      "release": "6.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "iwl6000-firmware": {
+      "epoch": "0",
+      "version": "9.221.4.1",
+      "release": "103.el8.1",
+      "installdate": "1634653338",
+      "arch": "noarch"
+    },
+    "libblockdev": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "libassuan": {
+      "epoch": "0",
+      "version": "2.5.1",
+      "release": "3.el8",
+      "installdate": "1634653163",
+      "arch": "x86_64"
+    },
+    "iwl2030-firmware": {
+      "epoch": "0",
+      "version": "18.168.6.1",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "libblockdev-swap": {
+      "epoch": "0",
+      "version": "2.24",
+      "release": "7.el8",
+      "installdate": "1634653212",
+      "arch": "x86_64"
+    },
+    "which": {
+      "epoch": "0",
+      "version": "2.21",
+      "release": "16.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "iwl1000-firmware": {
+      "epoch": "1",
+      "version": "39.31.5.1",
+      "release": "103.el8.1",
+      "installdate": "1634653339",
+      "arch": "noarch"
+    },
+    "kmod-kvdo": {
+      "epoch": "0",
+      "version": "6.2.5.72",
+      "release": "79.el8",
+      "installdate": "1634653226",
+      "arch": "x86_64"
+    },
+    "libidn2": {
+      "epoch": "0",
+      "version": "2.2.0",
+      "release": "1.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "libuv": {
+      "epoch": "1",
+      "version": "1.41.1",
+      "release": "1.el8_4",
+      "installdate": "1634726138",
+      "arch": "x86_64"
+    },
+    "device-mapper-event": {
+      "epoch": "8",
+      "version": "1.02.177",
+      "release": "10.el8",
+      "installdate": "1634653226",
+      "arch": "x86_64"
+    },
+    "libffi": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "22.el8",
+      "installdate": "1634653164",
+      "arch": "x86_64"
+    },
+    "pcp": {
+      "epoch": "0",
+      "version": "5.3.3",
+      "release": "1.el8",
+      "installdate": "1634726190",
+      "arch": "x86_64"
+    },
+    "python3-libsemanage": {
+      "epoch": "0",
+      "version": "2.9",
+      "release": "6.el8",
+      "installdate": "1634653227",
+      "arch": "x86_64"
+    },
+    "protobuf-c": {
+      "epoch": "0",
+      "version": "1.3.0",
+      "release": "6.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "ruby-irb": {
+      "epoch": "0",
+      "version": "2.5.9",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727244",
+      "arch": "noarch"
+    },
+    "container-selinux": {
+      "epoch": "2",
+      "version": "2.168.0",
+      "release": "2.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653228",
+      "arch": "noarch"
+    },
+    "file": {
+      "epoch": "0",
+      "version": "5.33",
+      "release": "20.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "rubygem-json": {
+      "epoch": "0",
+      "version": "2.1.0",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727244",
+      "arch": "x86_64"
+    },
+    "python3-linux-procfs": {
+      "epoch": "0",
+      "version": "0.6.3",
+      "release": "1.el8",
+      "installdate": "1634653286",
+      "arch": "noarch"
+    },
+    "gdbm-libs": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "rubygems": {
+      "epoch": "0",
+      "version": "2.7.6.3",
+      "release": "107.module_el8.5.0+811+d98a1657",
+      "installdate": "1634727245",
+      "arch": "noarch"
+    },
+    "oddjob-mkhomedir": {
+      "epoch": "0",
+      "version": "0.34.7",
+      "release": "1.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "grep": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "6.el8",
+      "installdate": "1634653165",
+      "arch": "x86_64"
+    },
+    "usermode": {
+      "epoch": "0",
+      "version": "1.113",
+      "release": "2.el8",
+      "installdate": "1634727410",
+      "arch": "x86_64"
+    },
+    "python3-libstoragemgmt": {
+      "epoch": "0",
+      "version": "1.9.1",
+      "release": "1.el8",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "libnl3-cli": {
+      "epoch": "0",
+      "version": "3.5.0",
+      "release": "1.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "python3-urllib3": {
+      "epoch": "0",
+      "version": "1.24.2",
+      "release": "5.el8",
+      "installdate": "1634727410",
+      "arch": "noarch"
+    },
+    "conmon": {
+      "epoch": "2",
+      "version": "2.0.30",
+      "release": "1.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653287",
+      "arch": "x86_64"
+    },
+    "libksba": {
+      "epoch": "0",
+      "version": "1.3.5",
+      "release": "7.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "python3-idna": {
+      "epoch": "0",
+      "version": "2.5",
+      "release": "5.el8",
+      "installdate": "1634727411",
+      "arch": "noarch"
+    },
+    "slirp4netns": {
+      "epoch": "0",
+      "version": "1.1.8",
+      "release": "1.module_el8.6.0+926+8bef8ae7",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "e2fsprogs-libs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1634653166",
+      "arch": "x86_64"
+    },
+    "python3-cloud-what": {
+      "epoch": "0",
+      "version": "1.28.21",
+      "release": "3.el8",
+      "installdate": "1634727411",
+      "arch": "x86_64"
+    },
+    "python3-slip-dbus": {
+      "epoch": "0",
+      "version": "0.6.4",
+      "release": "11.el8",
+      "installdate": "1634653288",
+      "arch": "noarch"
+    },
+    "libedit": {
+      "epoch": "0",
+      "version": "3.1",
+      "release": "23.20170329cvs.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libmpc": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "9.1.el8",
+      "installdate": "1634727860",
+      "arch": "x86_64"
+    },
+    "libsoup": {
+      "epoch": "0",
+      "version": "2.62.3",
+      "release": "2.el8",
+      "installdate": "1634653288",
+      "arch": "x86_64"
+    },
+    "libini_config": {
+      "epoch": "0",
+      "version": "1.3.1",
+      "release": "39.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "pcre2-utf16": {
+      "epoch": "0",
+      "version": "10.32",
+      "release": "2.el8",
+      "installdate": "1634727862",
+      "arch": "x86_64"
+    },
+    "pinentry": {
+      "epoch": "0",
+      "version": "1.1.0",
+      "release": "2.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "psmisc": {
+      "epoch": "0",
+      "version": "23.1",
+      "release": "5.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libverto-devel": {
+      "epoch": "0",
+      "version": "0.3.0",
+      "release": "5.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "librepo": {
+      "epoch": "0",
+      "version": "1.14.0",
+      "release": "2.el8",
+      "installdate": "1634653289",
+      "arch": "x86_64"
+    },
+    "libbytesize": {
+      "epoch": "0",
+      "version": "1.4",
+      "release": "3.el8",
+      "installdate": "1634653167",
+      "arch": "x86_64"
+    },
+    "libcom_err-devel": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1634727863",
+      "arch": "x86_64"
+    },
+    "python3-hawkey": {
+      "epoch": "0",
+      "version": "0.63.0",
+      "release": "3.el8",
+      "installdate": "1634653290",
+      "arch": "x86_64"
+    },
+    "libxslt": {
+      "epoch": "0",
+      "version": "1.1.32",
+      "release": "6.el8",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "glibc-headers": {
+      "epoch": "0",
+      "version": "2.28",
+      "release": "164.el8",
+      "installdate": "1634727865",
+      "arch": "x86_64"
+    },
+    "grub2-tools-extra": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "ipset": {
+      "epoch": "0",
+      "version": "7.1",
+      "release": "1.el8",
+      "installdate": "1634653168",
+      "arch": "x86_64"
+    },
+    "gcc": {
+      "epoch": "0",
+      "version": "8.5.0",
+      "release": "3.el8",
+      "installdate": "1634727869",
+      "arch": "x86_64"
+    },
+    "sudo": {
+      "epoch": "0",
+      "version": "1.8.29",
+      "release": "7.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "vim-minimal": {
+      "epoch": "2",
+      "version": "8.0.1763",
+      "release": "16.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "gdbm-devel": {
+      "epoch": "1",
+      "version": "1.18",
+      "release": "1.el8",
+      "installdate": "1634727871",
+      "arch": "x86_64"
+    },
+    "clevis-luks": {
+      "epoch": "0",
+      "version": "15",
+      "release": "1.el8",
+      "installdate": "1634653291",
+      "arch": "x86_64"
+    },
+    "libbpf": {
+      "epoch": "0",
+      "version": "0.4.0",
+      "release": "1.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "perl-Data-Dumper": {
+      "epoch": "0",
+      "version": "2.167",
+      "release": "399.el8",
+      "installdate": "1634728004",
+      "arch": "x86_64"
+    },
+    "kexec-tools": {
+      "epoch": "0",
+      "version": "2.0.20",
+      "release": "57.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "libconfig": {
+      "epoch": "0",
+      "version": "1.5",
+      "release": "9.el8",
+      "installdate": "1634653169",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Escapes": {
+      "epoch": "1",
+      "version": "1.07",
+      "release": "395.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "libpcap": {
+      "epoch": "14",
+      "version": "1.9.1",
+      "release": "5.el8",
+      "installdate": "1634653292",
+      "arch": "x86_64"
+    },
+    "mozjs60": {
+      "epoch": "0",
+      "version": "60.9.0",
+      "release": "4.el8",
+      "installdate": "1634653172",
+      "arch": "x86_64"
+    },
+    "perl-IO-Socket-SSL": {
+      "epoch": "0",
+      "version": "2.066",
+      "release": "4.module_el8.4.0+517+be1595ff",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "criu": {
+      "epoch": "0",
+      "version": "3.15",
+      "release": "3.module_el8.6.0+926+8bef8ae7",
+      "installdate": "1634653293",
+      "arch": "x86_64"
+    },
+    "pigz": {
+      "epoch": "0",
+      "version": "2.4",
+      "release": "4.el8",
+      "installdate": "1634653172",
+      "arch": "x86_64"
+    },
+    "perl-Pod-Simple": {
+      "epoch": "1",
+      "version": "3.35",
+      "release": "395.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "podman": {
+      "epoch": "0",
+      "version": "4.0.0",
+      "release": "0.10.module_el8.6.0+944+d413f95e",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "gpm-libs": {
+      "epoch": "0",
+      "version": "1.20.7",
+      "release": "17.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-Text-ParseWords": {
+      "epoch": "0",
+      "version": "3.30",
+      "release": "395.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "sscg": {
+      "epoch": "0",
+      "version": "2.3.3",
+      "release": "14.el8",
+      "installdate": "1634653296",
+      "arch": "x86_64"
+    },
+    "libfastjson": {
+      "epoch": "0",
+      "version": "0.99.9",
+      "release": "1.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-Getopt-Long": {
+      "epoch": "1",
+      "version": "2.50",
+      "release": "4.el8",
+      "installdate": "1634728005",
+      "arch": "noarch"
+    },
+    "e2fsprogs": {
+      "epoch": "0",
+      "version": "1.45.6",
+      "release": "2.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "brotli": {
+      "epoch": "0",
+      "version": "1.0.6",
+      "release": "3.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-Carp": {
+      "epoch": "0",
+      "version": "1.42",
+      "release": "396.el8",
+      "installdate": "1634728006",
+      "arch": "noarch"
+    },
+    "plymouth-core-libs": {
+      "epoch": "0",
+      "version": "0.9.4",
+      "release": "10.20200615git1e36e30.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "fuse-libs": {
+      "epoch": "0",
+      "version": "2.9.7",
+      "release": "12.el8",
+      "installdate": "1634653176",
+      "arch": "x86_64"
+    },
+    "perl-parent": {
+      "epoch": "1",
+      "version": "0.237",
+      "release": "1.el8",
+      "installdate": "1634728006",
+      "arch": "noarch"
+    },
+    "centos-logos": {
+      "epoch": "0",
+      "version": "85.8",
+      "release": "1.el8",
+      "installdate": "1634653297",
+      "arch": "x86_64"
+    },
+    "hdparm": {
+      "epoch": "0",
+      "version": "9.54",
+      "release": "4.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "perl-File-Path": {
+      "epoch": "0",
+      "version": "2.15",
+      "release": "2.el8",
+      "installdate": "1634728007",
+      "arch": "noarch"
+    },
+    "libfprint": {
+      "epoch": "0",
+      "version": "1.90.7",
+      "release": "1.el8",
+      "installdate": "1634653298",
+      "arch": "x86_64"
+    },
+    "libnghttp2": {
+      "epoch": "0",
+      "version": "1.33.0",
+      "release": "3.el8_2.1",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "perl-threads": {
+      "epoch": "1",
+      "version": "2.21",
+      "release": "2.el8",
+      "installdate": "1634728007",
+      "arch": "x86_64"
+    },
+    "udisks2": {
+      "epoch": "0",
+      "version": "2.9.0",
+      "release": "7.el8",
+      "installdate": "1634653299",
+      "arch": "x86_64"
+    },
+    "pkgconf-pkg-config": {
+      "epoch": "0",
+      "version": "1.4.2",
+      "release": "1.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "perl-Thread-Queue": {
+      "epoch": "0",
+      "version": "3.13",
+      "release": "1.el8",
+      "installdate": "1634728008",
+      "arch": "noarch"
+    },
+    "teamd": {
+      "epoch": "0",
+      "version": "1.31",
+      "release": "2.el8",
+      "installdate": "1634653302",
+      "arch": "x86_64"
+    },
+    "libsss_nss_idmap": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "libtool": {
+      "epoch": "0",
+      "version": "2.4.6",
+      "release": "25.el8",
+      "installdate": "1634728012",
+      "arch": "x86_64"
+    },
+    "sssd-common": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653302",
+      "arch": "x86_64"
+    },
+    "lmdb-libs": {
+      "epoch": "0",
+      "version": "0.9.24",
+      "release": "1.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "make": {
+      "epoch": "1",
+      "version": "4.2.1",
+      "release": "10.el8",
+      "installdate": "1634728012",
+      "arch": "x86_64"
+    },
+    "sssd-ldap": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653303",
+      "arch": "x86_64"
+    },
+    "slang": {
+      "epoch": "0",
+      "version": "2.3.2",
+      "release": "3.el8",
+      "installdate": "1634653177",
+      "arch": "x86_64"
+    },
+    "llvm-libs": {
+      "epoch": "0",
+      "version": "12.0.1",
+      "release": "2.module_el8.6.0+937+1cafe22c",
+      "installdate": "1634729423",
+      "arch": "x86_64"
+    },
+    "python3-pexpect": {
+      "epoch": "0",
+      "version": "4.3.1",
+      "release": "3.el8",
+      "installdate": "1634653303",
+      "arch": "noarch"
+    },
+    "cyrus-sasl-lib": {
+      "epoch": "0",
+      "version": "2.1.27",
+      "release": "5.el8",
+      "installdate": "1634653178",
+      "arch": "x86_64"
+    },
+    "epel-next-release": {
+      "epoch": "0",
+      "version": "8",
+      "release": "11.el8",
+      "installdate": "1634730503",
+      "arch": "noarch"
+    },
+    "python3-lxml": {
+      "epoch": "0",
+      "version": "4.2.3",
+      "release": "3.el8",
+      "installdate": "1634653305",
+      "arch": "x86_64"
+    },
+    "grub2-tools-minimal": {
+      "epoch": "1",
+      "version": "2.02",
+      "release": "99.el8_4.1",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "python3-pycparser": {
+      "epoch": "0",
+      "version": "2.14",
+      "release": "14.el8",
+      "installdate": "1634730535",
+      "arch": "noarch"
+    },
+    "dnf": {
+      "epoch": "0",
+      "version": "4.7.0",
+      "release": "4.el8",
+      "installdate": "1634653305",
+      "arch": "noarch"
+    },
+    "grubby": {
+      "epoch": "0",
+      "version": "8.40",
+      "release": "42.el8",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "python3-pynacl": {
+      "epoch": "0",
+      "version": "1.3.0",
+      "release": "5.el8",
+      "installdate": "1634730535",
+      "arch": "x86_64"
+    },
+    "python3-ply": {
+      "epoch": "0",
+      "version": "3.9",
+      "release": "9.el8",
+      "installdate": "1634653306",
+      "arch": "noarch"
+    },
+    "libdb-utils": {
+      "epoch": "0",
+      "version": "5.3.28",
+      "release": "42.el8_4",
+      "installdate": "1634653183",
+      "arch": "x86_64"
+    },
+    "python3-paramiko": {
+      "epoch": "0",
+      "version": "2.4.3",
+      "release": "1.el8",
+      "installdate": "1634730537",
+      "arch": "noarch"
+    },
+    "python3-sssdconfig": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653306",
+      "arch": "noarch"
+    },
+    "crypto-policies-scripts": {
+      "epoch": "0",
+      "version": "20210617",
+      "release": "1.gitc776d3e.el8",
+      "installdate": "1634653184",
+      "arch": "noarch"
+    },
+    "ansible": {
+      "epoch": "0",
+      "version": "2.9.25",
+      "release": "1.el8",
+      "installdate": "1634730553",
+      "arch": "noarch"
+    },
+    "tracer-common": {
+      "epoch": "0",
+      "version": "0.7.5",
+      "release": "2.el8",
+      "installdate": "1634653309",
+      "arch": "noarch"
+    },
+    "cracklib": {
+      "epoch": "0",
+      "version": "2.9.6",
+      "release": "15.el8",
+      "installdate": "1634653184",
+      "arch": "x86_64"
+    },
+    "python3-immutables": {
+      "epoch": "0",
+      "version": "0.15",
+      "release": "2.el8",
+      "installdate": "1634731219",
+      "arch": "x86_64"
+    },
+    "libX11-common": {
+      "epoch": "0",
+      "version": "1.6.8",
+      "release": "5.el8",
+      "installdate": "1634653309",
+      "arch": "noarch"
+    },
+    "libtirpc": {
+      "epoch": "0",
+      "version": "1.1.4",
+      "release": "5.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "zeromq": {
+      "epoch": "0",
+      "version": "4.3.4",
+      "release": "2.el8",
+      "installdate": "1634731220",
+      "arch": "x86_64"
+    },
+    "cairo": {
+      "epoch": "0",
+      "version": "1.15.12",
+      "release": "3.el8",
+      "installdate": "1634653310",
+      "arch": "x86_64"
+    },
+    "elfutils-debuginfod-client": {
+      "epoch": "0",
+      "version": "0.185",
+      "release": "1.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "python3-distro": {
+      "epoch": "0",
+      "version": "1.4.0",
+      "release": "2.module_el8.5.0+761+faacb0fb",
+      "installdate": "1634731220",
+      "arch": "noarch"
+    },
+    "setroubleshoot-plugins": {
+      "epoch": "0",
+      "version": "3.3.14",
+      "release": "1.el8",
+      "installdate": "1634653310",
+      "arch": "noarch"
+    },
+    "gettext-libs": {
+      "epoch": "0",
+      "version": "0.19.8.1",
+      "release": "17.el8",
+      "installdate": "1634653185",
+      "arch": "x86_64"
+    },
+    "geolite2-country": {
+      "epoch": "0",
+      "version": "20180605",
+      "release": "1.el8",
+      "installdate": "1634653311",
+      "arch": "noarch"
+    },
+    "dbus-libs": {
+      "epoch": "1",
+      "version": "1.12.8",
+      "release": "14.el8",
+      "installdate": "1634653186",
+      "arch": "x86_64"
+    },
+    "bind-libs": {
+      "epoch": "32",
+      "version": "9.11.26",
+      "release": "6.el8",
+      "installdate": "1634653314",
+      "arch": "x86_64"
+    },
+    "shadow-utils": {
+      "epoch": "2",
+      "version": "4.6",
+      "release": "14.el8",
+      "installdate": "1634653187",
+      "arch": "x86_64"
+    },
+    "sssd": {
+      "epoch": "0",
+      "version": "2.5.2",
+      "release": "2.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "openssl-libs": {
+      "epoch": "1",
+      "version": "1.1.1k",
+      "release": "4.el8",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    },
+    "fprintd-pam": {
+      "epoch": "0",
+      "version": "1.90.9",
+      "release": "2.el8",
+      "installdate": "1634653315",
+      "arch": "x86_64"
+    },
+    "kmod": {
+      "epoch": "0",
+      "version": "25",
+      "release": "18.el8",
+      "installdate": "1634653188",
+      "arch": "x86_64"
+    }
+  },
+  "root_group": "root",
+  "shard_seed": 38085582,
+  "shells": [
+    "/bin/sh",
+    "/bin/bash",
+    "/usr/bin/sh",
+    "/usr/bin/bash"
+  ],
+  "sysconf": {
+    "LINK_MAX": 2147483647,
+    "_POSIX_LINK_MAX": 2147483647,
+    "MAX_CANON": 255,
+    "_POSIX_MAX_CANON": 255,
+    "MAX_INPUT": 255,
+    "_POSIX_MAX_INPUT": 255,
+    "NAME_MAX": 255,
+    "_POSIX_NAME_MAX": 255,
+    "PATH_MAX": 4096,
+    "_POSIX_PATH_MAX": 4096,
+    "PIPE_BUF": 4096,
+    "_POSIX_PIPE_BUF": 4096,
+    "SOCK_MAXBUF": null,
+    "_POSIX_ASYNC_IO": null,
+    "_POSIX_CHOWN_RESTRICTED": 1,
+    "_POSIX_NO_TRUNC": 1,
+    "_POSIX_PRIO_IO": null,
+    "_POSIX_SYNC_IO": null,
+    "_POSIX_VDISABLE": 0,
+    "ARG_MAX": 2097152,
+    "ATEXIT_MAX": 2147483647,
+    "CHAR_BIT": 8,
+    "CHAR_MAX": 127,
+    "CHAR_MIN": -128,
+    "CHILD_MAX": 3085,
+    "CLK_TCK": 100,
+    "INT_MAX": 2147483647,
+    "INT_MIN": -2147483648,
+    "IOV_MAX": 1024,
+    "LOGNAME_MAX": 256,
+    "LONG_BIT": 64,
+    "MB_LEN_MAX": 16,
+    "NGROUPS_MAX": 65536,
+    "NL_ARGMAX": 4096,
+    "NL_LANGMAX": 2048,
+    "NL_MSGMAX": 2147483647,
+    "NL_NMAX": 2147483647,
+    "NL_SETMAX": 2147483647,
+    "NL_TEXTMAX": 2147483647,
+    "NSS_BUFLEN_GROUP": 1024,
+    "NSS_BUFLEN_PASSWD": 1024,
+    "NZERO": 20,
+    "OPEN_MAX": 1024,
+    "PAGESIZE": 4096,
+    "PAGE_SIZE": 4096,
+    "PASS_MAX": 8192,
+    "PTHREAD_DESTRUCTOR_ITERATIONS": 4,
+    "PTHREAD_KEYS_MAX": 1024,
+    "PTHREAD_STACK_MIN": 16384,
+    "PTHREAD_THREADS_MAX": null,
+    "SCHAR_MAX": 127,
+    "SCHAR_MIN": -128,
+    "SHRT_MAX": 32767,
+    "SHRT_MIN": -32768,
+    "SSIZE_MAX": 32767,
+    "TTY_NAME_MAX": 32,
+    "TZNAME_MAX": null,
+    "UCHAR_MAX": 255,
+    "UINT_MAX": 4294967295,
+    "UIO_MAXIOV": 1024,
+    "ULONG_MAX": 18446744073709551615,
+    "USHRT_MAX": 65535,
+    "WORD_BIT": 32,
+    "_AVPHYS_PAGES": 20611,
+    "_NPROCESSORS_CONF": 1,
+    "_NPROCESSORS_ONLN": 1,
+    "_PHYS_PAGES": 207127,
+    "_POSIX_ARG_MAX": 2097152,
+    "_POSIX_ASYNCHRONOUS_IO": 200809,
+    "_POSIX_CHILD_MAX": 3085,
+    "_POSIX_FSYNC": 200809,
+    "_POSIX_JOB_CONTROL": 1,
+    "_POSIX_MAPPED_FILES": 200809,
+    "_POSIX_MEMLOCK": 200809,
+    "_POSIX_MEMLOCK_RANGE": 200809,
+    "_POSIX_MEMORY_PROTECTION": 200809,
+    "_POSIX_MESSAGE_PASSING": 200809,
+    "_POSIX_NGROUPS_MAX": 65536,
+    "_POSIX_OPEN_MAX": 1024,
+    "_POSIX_PII": null,
+    "_POSIX_PII_INTERNET": null,
+    "_POSIX_PII_INTERNET_DGRAM": null,
+    "_POSIX_PII_INTERNET_STREAM": null,
+    "_POSIX_PII_OSI": null,
+    "_POSIX_PII_OSI_CLTS": null,
+    "_POSIX_PII_OSI_COTS": null,
+    "_POSIX_PII_OSI_M": null,
+    "_POSIX_PII_SOCKET": null,
+    "_POSIX_PII_XTI": null,
+    "_POSIX_POLL": null,
+    "_POSIX_PRIORITIZED_IO": 200809,
+    "_POSIX_PRIORITY_SCHEDULING": 200809,
+    "_POSIX_REALTIME_SIGNALS": 200809,
+    "_POSIX_SAVED_IDS": 1,
+    "_POSIX_SELECT": null,
+    "_POSIX_SEMAPHORES": 200809,
+    "_POSIX_SHARED_MEMORY_OBJECTS": 200809,
+    "_POSIX_SSIZE_MAX": 32767,
+    "_POSIX_STREAM_MAX": 16,
+    "_POSIX_SYNCHRONIZED_IO": 200809,
+    "_POSIX_THREADS": 200809,
+    "_POSIX_THREAD_ATTR_STACKADDR": 200809,
+    "_POSIX_THREAD_ATTR_STACKSIZE": 200809,
+    "_POSIX_THREAD_PRIORITY_SCHEDULING": 200809,
+    "_POSIX_THREAD_PRIO_INHERIT": 200809,
+    "_POSIX_THREAD_PRIO_PROTECT": 200809,
+    "_POSIX_THREAD_ROBUST_PRIO_INHERIT": null,
+    "_POSIX_THREAD_ROBUST_PRIO_PROTECT": null,
+    "_POSIX_THREAD_PROCESS_SHARED": 200809,
+    "_POSIX_THREAD_SAFE_FUNCTIONS": 200809,
+    "_POSIX_TIMERS": 200809,
+    "TIMER_MAX": null,
+    "_POSIX_TZNAME_MAX": null,
+    "_POSIX_VERSION": 200809,
+    "_T_IOV_MAX": null,
+    "_XOPEN_CRYPT": null,
+    "_XOPEN_ENH_I18N": 1,
+    "_XOPEN_LEGACY": 1,
+    "_XOPEN_REALTIME": 1,
+    "_XOPEN_REALTIME_THREADS": 1,
+    "_XOPEN_SHM": 1,
+    "_XOPEN_UNIX": 1,
+    "_XOPEN_VERSION": 700,
+    "_XOPEN_XCU_VERSION": 4,
+    "_XOPEN_XPG2": 1,
+    "_XOPEN_XPG3": 1,
+    "_XOPEN_XPG4": 1,
+    "BC_BASE_MAX": 99,
+    "BC_DIM_MAX": 2048,
+    "BC_SCALE_MAX": 99,
+    "BC_STRING_MAX": 1000,
+    "CHARCLASS_NAME_MAX": 2048,
+    "COLL_WEIGHTS_MAX": 255,
+    "EQUIV_CLASS_MAX": null,
+    "EXPR_NEST_MAX": 32,
+    "LINE_MAX": 2048,
+    "POSIX2_BC_BASE_MAX": 99,
+    "POSIX2_BC_DIM_MAX": 2048,
+    "POSIX2_BC_SCALE_MAX": 99,
+    "POSIX2_BC_STRING_MAX": 1000,
+    "POSIX2_CHAR_TERM": 200809,
+    "POSIX2_COLL_WEIGHTS_MAX": 255,
+    "POSIX2_C_BIND": 200809,
+    "POSIX2_C_DEV": 200809,
+    "POSIX2_C_VERSION": 200809,
+    "POSIX2_EXPR_NEST_MAX": 32,
+    "POSIX2_FORT_DEV": null,
+    "POSIX2_FORT_RUN": null,
+    "_POSIX2_LINE_MAX": 2048,
+    "POSIX2_LINE_MAX": 2048,
+    "POSIX2_LOCALEDEF": 200809,
+    "POSIX2_RE_DUP_MAX": 32767,
+    "POSIX2_SW_DEV": 200809,
+    "POSIX2_UPE": null,
+    "POSIX2_VERSION": 200809,
+    "RE_DUP_MAX": 32767,
+    "PATH": "/usr/bin",
+    "CS_PATH": "/usr/bin",
+    "LFS_CFLAGS": null,
+    "LFS_LDFLAGS": null,
+    "LFS_LIBS": null,
+    "LFS_LINTFLAGS": null,
+    "LFS64_CFLAGS": "-D_LARGEFILE64_SOURCE",
+    "LFS64_LDFLAGS": null,
+    "LFS64_LIBS": null,
+    "LFS64_LINTFLAGS": "-D_LARGEFILE64_SOURCE",
+    "_XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+    "XBS5_WIDTH_RESTRICTED_ENVS": "XBS5_LP64_OFF64",
+    "_XBS5_ILP32_OFF32": null,
+    "XBS5_ILP32_OFF32_CFLAGS": null,
+    "XBS5_ILP32_OFF32_LDFLAGS": null,
+    "XBS5_ILP32_OFF32_LIBS": null,
+    "XBS5_ILP32_OFF32_LINTFLAGS": null,
+    "_XBS5_ILP32_OFFBIG": null,
+    "XBS5_ILP32_OFFBIG_CFLAGS": null,
+    "XBS5_ILP32_OFFBIG_LDFLAGS": null,
+    "XBS5_ILP32_OFFBIG_LIBS": null,
+    "XBS5_ILP32_OFFBIG_LINTFLAGS": null,
+    "_XBS5_LP64_OFF64": 1,
+    "XBS5_LP64_OFF64_CFLAGS": "-m64",
+    "XBS5_LP64_OFF64_LDFLAGS": "-m64",
+    "XBS5_LP64_OFF64_LIBS": null,
+    "XBS5_LP64_OFF64_LINTFLAGS": null,
+    "_XBS5_LPBIG_OFFBIG": null,
+    "XBS5_LPBIG_OFFBIG_CFLAGS": null,
+    "XBS5_LPBIG_OFFBIG_LDFLAGS": null,
+    "XBS5_LPBIG_OFFBIG_LIBS": null,
+    "XBS5_LPBIG_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V6_ILP32_OFF32": null,
+    "POSIX_V6_ILP32_OFF32_CFLAGS": null,
+    "POSIX_V6_ILP32_OFF32_LDFLAGS": null,
+    "POSIX_V6_ILP32_OFF32_LIBS": null,
+    "POSIX_V6_ILP32_OFF32_LINTFLAGS": null,
+    "_POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+    "POSIX_V6_WIDTH_RESTRICTED_ENVS": "POSIX_V6_LP64_OFF64",
+    "_POSIX_V6_ILP32_OFFBIG": null,
+    "POSIX_V6_ILP32_OFFBIG_CFLAGS": null,
+    "POSIX_V6_ILP32_OFFBIG_LDFLAGS": null,
+    "POSIX_V6_ILP32_OFFBIG_LIBS": null,
+    "POSIX_V6_ILP32_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V6_LP64_OFF64": 1,
+    "POSIX_V6_LP64_OFF64_CFLAGS": "-m64",
+    "POSIX_V6_LP64_OFF64_LDFLAGS": "-m64",
+    "POSIX_V6_LP64_OFF64_LIBS": null,
+    "POSIX_V6_LP64_OFF64_LINTFLAGS": null,
+    "_POSIX_V6_LPBIG_OFFBIG": null,
+    "POSIX_V6_LPBIG_OFFBIG_CFLAGS": null,
+    "POSIX_V6_LPBIG_OFFBIG_LDFLAGS": null,
+    "POSIX_V6_LPBIG_OFFBIG_LIBS": null,
+    "POSIX_V6_LPBIG_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V7_ILP32_OFF32": null,
+    "POSIX_V7_ILP32_OFF32_CFLAGS": null,
+    "POSIX_V7_ILP32_OFF32_LDFLAGS": null,
+    "POSIX_V7_ILP32_OFF32_LIBS": null,
+    "POSIX_V7_ILP32_OFF32_LINTFLAGS": null,
+    "_POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+    "POSIX_V7_WIDTH_RESTRICTED_ENVS": "POSIX_V7_LP64_OFF64",
+    "_POSIX_V7_ILP32_OFFBIG": null,
+    "POSIX_V7_ILP32_OFFBIG_CFLAGS": null,
+    "POSIX_V7_ILP32_OFFBIG_LDFLAGS": null,
+    "POSIX_V7_ILP32_OFFBIG_LIBS": null,
+    "POSIX_V7_ILP32_OFFBIG_LINTFLAGS": null,
+    "_POSIX_V7_LP64_OFF64": 1,
+    "POSIX_V7_LP64_OFF64_CFLAGS": "-m64",
+    "POSIX_V7_LP64_OFF64_LDFLAGS": "-m64",
+    "POSIX_V7_LP64_OFF64_LIBS": null,
+    "POSIX_V7_LP64_OFF64_LINTFLAGS": null,
+    "_POSIX_V7_LPBIG_OFFBIG": null,
+    "POSIX_V7_LPBIG_OFFBIG_CFLAGS": null,
+    "POSIX_V7_LPBIG_OFFBIG_LDFLAGS": null,
+    "POSIX_V7_LPBIG_OFFBIG_LIBS": null,
+    "POSIX_V7_LPBIG_OFFBIG_LINTFLAGS": null,
+    "_POSIX_ADVISORY_INFO": 200809,
+    "_POSIX_BARRIERS": 200809,
+    "_POSIX_BASE": null,
+    "_POSIX_C_LANG_SUPPORT": null,
+    "_POSIX_C_LANG_SUPPORT_R": null,
+    "_POSIX_CLOCK_SELECTION": 200809,
+    "_POSIX_CPUTIME": 200809,
+    "_POSIX_THREAD_CPUTIME": 200809,
+    "_POSIX_DEVICE_SPECIFIC": null,
+    "_POSIX_DEVICE_SPECIFIC_R": null,
+    "_POSIX_FD_MGMT": null,
+    "_POSIX_FIFO": null,
+    "_POSIX_PIPE": null,
+    "_POSIX_FILE_ATTRIBUTES": null,
+    "_POSIX_FILE_LOCKING": null,
+    "_POSIX_FILE_SYSTEM": null,
+    "_POSIX_MONOTONIC_CLOCK": 200809,
+    "_POSIX_MULTI_PROCESS": null,
+    "_POSIX_SINGLE_PROCESS": null,
+    "_POSIX_NETWORKING": null,
+    "_POSIX_READER_WRITER_LOCKS": 200809,
+    "_POSIX_SPIN_LOCKS": 200809,
+    "_POSIX_REGEXP": 1,
+    "_REGEX_VERSION": null,
+    "_POSIX_SHELL": 1,
+    "_POSIX_SIGNALS": null,
+    "_POSIX_SPAWN": 200809,
+    "_POSIX_SPORADIC_SERVER": null,
+    "_POSIX_THREAD_SPORADIC_SERVER": null,
+    "_POSIX_SYSTEM_DATABASE": null,
+    "_POSIX_SYSTEM_DATABASE_R": null,
+    "_POSIX_TIMEOUTS": 200809,
+    "_POSIX_TYPED_MEMORY_OBJECTS": null,
+    "_POSIX_USER_GROUPS": null,
+    "_POSIX_USER_GROUPS_R": null,
+    "POSIX2_PBS": null,
+    "POSIX2_PBS_ACCOUNTING": null,
+    "POSIX2_PBS_LOCATE": null,
+    "POSIX2_PBS_TRACK": null,
+    "POSIX2_PBS_MESSAGE": null,
+    "SYMLOOP_MAX": null,
+    "STREAM_MAX": 16,
+    "AIO_LISTIO_MAX": null,
+    "AIO_MAX": null,
+    "AIO_PRIO_DELTA_MAX": 20,
+    "DELAYTIMER_MAX": 2147483647,
+    "HOST_NAME_MAX": 64,
+    "LOGIN_NAME_MAX": 256,
+    "MQ_OPEN_MAX": null,
+    "MQ_PRIO_MAX": 32768,
+    "_POSIX_DEVICE_IO": null,
+    "_POSIX_TRACE": null,
+    "_POSIX_TRACE_EVENT_FILTER": null,
+    "_POSIX_TRACE_INHERIT": null,
+    "_POSIX_TRACE_LOG": null,
+    "RTSIG_MAX": 32,
+    "SEM_NSEMS_MAX": null,
+    "SEM_VALUE_MAX": 2147483647,
+    "SIGQUEUE_MAX": 3085,
+    "FILESIZEBITS": 64,
+    "POSIX_ALLOC_SIZE_MIN": 4096,
+    "POSIX_REC_INCR_XFER_SIZE": null,
+    "POSIX_REC_MAX_XFER_SIZE": null,
+    "POSIX_REC_MIN_XFER_SIZE": 4096,
+    "POSIX_REC_XFER_ALIGN": 4096,
+    "SYMLINK_MAX": null,
+    "GNU_LIBC_VERSION": "glibc 2.28",
+    "GNU_LIBPTHREAD_VERSION": "NPTL 2.28",
+    "POSIX2_SYMLINKS": 1,
+    "LEVEL1_ICACHE_SIZE": 32768,
+    "LEVEL1_ICACHE_ASSOC": 8,
+    "LEVEL1_ICACHE_LINESIZE": 64,
+    "LEVEL1_DCACHE_SIZE": 32768,
+    "LEVEL1_DCACHE_ASSOC": 8,
+    "LEVEL1_DCACHE_LINESIZE": 64,
+    "LEVEL2_CACHE_SIZE": 2097152,
+    "LEVEL2_CACHE_ASSOC": 8,
+    "LEVEL2_CACHE_LINESIZE": 64,
+    "LEVEL3_CACHE_SIZE": 16777216,
+    "LEVEL3_CACHE_ASSOC": 16,
+    "LEVEL3_CACHE_LINESIZE": 64,
+    "LEVEL4_CACHE_SIZE": 0,
+    "LEVEL4_CACHE_ASSOC": 0,
+    "LEVEL4_CACHE_LINESIZE": 0,
+    "IPV6": 200809,
+    "RAW_SOCKETS": 200809,
+    "_POSIX_IPV6": 200809,
+    "_POSIX_RAW_SOCKETS": 200809
+  },
+  "time": {
+    "timezone": "EDT"
+  }
+}

--- a/test/static_fixtures/facts/puppet_centos_8_facter_2.5.json
+++ b/test/static_fixtures/facts/puppet_centos_8_facter_2.5.json
@@ -1,0 +1,118 @@
+{
+  "architecture": "x86_64",
+  "kernel": "Linux",
+  "blockdevice_vda_size": 7516192768,
+  "blockdevice_vda_vendor": "0x1af4",
+  "blockdevices": "vda",
+  "virtual": "kvm",
+  "is_virtual": true,
+  "hardwaremodel": "x86_64",
+  "operatingsystem": "CentOS",
+  "os": {
+    "name": "CentOS",
+    "family": "RedHat",
+    "release": {
+      "major": "8",
+      "minor": "3",
+      "full": "8.3.2011"
+    }
+  },
+  "facterversion": "2.5.7",
+  "filesystems": "ext2,ext3,ext4,xfs",
+  "fqdn": "stream",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hostname": "stream",
+  "id": "root",
+  "interfaces": "",
+  "ipaddress": "192.168.122.29",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-193.6.3.el8_2.x86_64",
+  "kernelversion": "4.18.0",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "1.14.0-1.fc33",
+  "bios_release_date": "04/01/2014",
+  "manufacturer": "QEMU",
+  "productname": "Standard PC (Q35 + ICH9, 2009)",
+  "serialnumber": "Not Specified",
+  "uuid": "1ddbeb7e-aea3-4ae3-8a57-61867d346372",
+  "type": "Other",
+  "memorysize": "1.78 GB",
+  "memoryfree": "1.44 GB",
+  "swapsize": "615.00 MB",
+  "swapfree": "609.23 MB",
+  "swapsize_mb": "615.00",
+  "swapfree_mb": "609.23",
+  "memorysize_mb": "1826.77",
+  "memoryfree_mb": "1477.75",
+  "operatingsystemmajrelease": "8",
+  "operatingsystemrelease": "8.3.2011",
+  "osfamily": "RedHat",
+  "partitions": {
+    "vda4": {
+      "uuid": "4fd120e4-1f6d-46b3-a404-5569ef6af1f9",
+      "size": "11316608",
+      "mount": "/",
+      "label": "primary",
+      "filesystem": "xfs"
+    },
+    "vda2": {
+      "uuid": "0b3df967-65cc-4a48-8b98-f7f0badc0d91",
+      "size": "2097152",
+      "mount": "/boot",
+      "label": "primary",
+      "filesystem": "ext4"
+    },
+    "vda3": {
+      "uuid": "40f14688-2619-4046-a9eb-b7333fff1b84",
+      "size": "1259520",
+      "label": "primary",
+      "filesystem": "swap"
+    },
+    "vda1": {
+      "size": "2048",
+      "label": "primary"
+    }
+  },
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin",
+  "physicalprocessorcount": 2,
+  "processors": {
+    "models": [
+      "Intel Core Processor (Skylake, IBRS)",
+      "Intel Core Processor (Skylake, IBRS)"
+    ],
+    "count": 2,
+    "physicalcount": 2
+  },
+  "processor0": "Intel Core Processor (Skylake, IBRS)",
+  "processor1": "Intel Core Processor (Skylake, IBRS)",
+  "processorcount": 2,
+  "ps": "ps -ef",
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
+  "rubyversion": "2.7.1",
+  "selinux": true,
+  "selinux_enforced": true,
+  "selinux_policyversion": "31",
+  "selinux_current_mode": "enforcing",
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDSOlxRR5iy0VM5BVl2JiFvUvv5UMAUMPkNxKuo89U/jG1X3N9pqxSpgwy4VnzAJTMXTUObCnSTueiVjj0HHz6UMuRxIe4MYb2XFNrdQUV3BPKvbP3NG02bBGRhH35mr0g9Yd9Rc1Ayf5gTlfGkbOh4JbjPygQ9ub/5gUnEbFOS4x39U3wnZV4z/1s0RwWtzdLe8kj36/gvoYaBdrsDNtFQjEGWSHhjiwXf0wOvOVt+OKY77Z1+pM6CcqQVR75VcT52P/y5UEIREo7CP0eHxjD5JAcm7fWJrxeHFH3Cv1dh9I/J9b5k3WGFciqsv5zebx4MMq64poKbmyFyR+R1ixKM9laoaUiTC5N3ajM54kSb5wREIiMMFpPo7ArfXnIbjOsHidnmXvMfOwTLwwymBoKsWNR2LIf3u/mBOdBC2PtrYz9nL6pi5Lb2OOpa0S+LQFxWulFPWvTN83Mqlcr8qScJqPfgwlM6pIco6blJwe078N5ldXdeaj54I0RQ4XYChhE=",
+  "sshfp_rsa": "SSHFP 1 1 0f2ab3941f9c7a54211076bc27dee370e10698b0\nSSHFP 1 2 c45674d9bc1091ac4cc9150fd517b0b895650fa590e41e288cc07f2699dfb9e1",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEBFrxBiebSB+0M1LGyX3H3ZHd676wnGGfYjexjSvopznvfkb0PdNSLUvHpc1gU/yPBx7HP/pdGvdDWnwvoNkLY=",
+  "sshfp_ecdsa": "SSHFP 3 1 1896eda9c97def529c64f97ebcdb5aee32e25285\nSSHFP 3 2 6932a390ad20961350b2ab36861b18ec2ce2644d433bc54f432600421f58bcd1",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIFu6kGHnNmCA56gkfRAyAxZZEdwF5mCD6aRb0PznE++s",
+  "sshfp_ed25519": "SSHFP 4 1 43113e7fca870374e8a5f9981e4bf6f97a7bc59a\nSSHFP 4 2 d17bfb375bc87e76dcc937708974cd3f7a361843625f67c485426ad4c9bf441f",
+  "system_uptime": {
+    "seconds": 1311,
+    "hours": 0,
+    "days": 0,
+    "uptime": "0:21 hours"
+  },
+  "timezone": "EDT",
+  "uniqueid": "a8c01d7a",
+  "uptime": "0:21 hours",
+  "uptime_days": 0,
+  "uptime_hours": 0,
+  "uptime_seconds": 1311
+}

--- a/test/static_fixtures/facts/puppet_centos_8_facter_4.1.json
+++ b/test/static_fixtures/facts/puppet_centos_8_facter_4.1.json
@@ -1,0 +1,246 @@
+{
+  "disks": {
+    "vda": {
+      "size": "7.00 GiB",
+      "size_bytes": 7516192768,
+      "type": "hdd",
+      "vendor": "0x1af4"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "04/01/2014",
+      "vendor": "SeaBIOS",
+      "version": "1.14.0-1.fc33"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "QEMU",
+    "product": {
+      "name": "Standard PC (Q35 + ICH9, 2009)",
+      "uuid": "1ddbeb7e-aea3-4ae3-8a57-61867d346372"
+    }
+  },
+  "facterversion": "4.1.0",
+  "filesystems": "ext2,ext3,ext4,xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "kvm": {
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-193.6.3.el8_2.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.31,
+    "1m": 0.2,
+    "5m": 0.36
+  },
+  "memory": {
+    "swap": {
+      "available": "609.23 MiB",
+      "available_bytes": 638828544,
+      "capacity": "0.94%",
+      "total": "615.00 MiB",
+      "total_bytes": 644870144,
+      "used": "5.76 MiB",
+      "used_bytes": 6041600
+    },
+    "system": {
+      "available": "1.33 GiB",
+      "available_bytes": 1428824064,
+      "capacity": "25.41%",
+      "total": "1.78 GiB",
+      "total_bytes": 1915502592,
+      "used": "464.13 MiB",
+      "used_bytes": 486678528
+    }
+  },
+  "networking": {
+    "fqdn": "stream",
+    "hostname": "stream",
+    "interfaces": {
+      "enp1s0": {
+        "bindings": [
+          {
+            "address": "192.168.122.29",
+            "netmask": "255.255.255.0",
+            "network": "192.168.122.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::5054:ff:fe85:821",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link"
+          }
+        ],
+        "ip": "192.168.122.29",
+        "ip6": "fe80::5054:ff:fe85:821",
+        "mac": "52:54:00:85:08:21",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "192.168.122.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host"
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "192.168.122.29",
+    "ip6": "fe80::5054:ff:fe85:821",
+    "mac": "52:54:00:85:08:21",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "192.168.122.0",
+    "network6": "fe80::",
+    "primary": "enp1s0",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "description": "CentOS Linux release 8.3.2011",
+      "id": "CentOS",
+      "release": {
+        "full": "8.3.2011",
+        "major": "8",
+        "minor": "3"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "CentOS",
+    "release": {
+      "full": "8.3.2011",
+      "major": "8",
+      "minor": "3"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "31"
+    }
+  },
+  "partitions": {
+    "/dev/vda1": {
+      "partlabel": "primary",
+      "partuuid": "d4ceee7d-f2a8-41cc-9a1f-941b15f6d988",
+      "size": "1.00 MiB",
+      "size_bytes": 1048576
+    },
+    "/dev/vda2": {
+      "filesystem": "ext4",
+      "partlabel": "primary",
+      "partuuid": "268627c0-d337-45e0-8b78-3b4516743e37",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "0b3df967-65cc-4a48-8b98-f7f0badc0d91"
+    },
+    "/dev/vda3": {
+      "filesystem": "swap",
+      "partlabel": "primary",
+      "partuuid": "c30f23cb-3504-4020-81b6-1da9d9413a5b",
+      "size": "615.00 MiB",
+      "size_bytes": 644874240,
+      "uuid": "40f14688-2619-4046-a9eb-b7333fff1b84"
+    },
+    "/dev/vda4": {
+      "filesystem": "xfs",
+      "partlabel": "primary",
+      "partuuid": "81a2926c-2b51-4bc8-8ba9-f0af2a91fe85",
+      "size": "5.40 GiB",
+      "size_bytes": 5794103296,
+      "uuid": "4fd120e4-1f6d-46b3-a404-5569ef6af1f9"
+    }
+  },
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin",
+  "processors": {
+    "count": 2,
+    "isa": "x86_64",
+    "models": [
+      "Intel Core Processor (Skylake, IBRS)",
+      "Intel Core Processor (Skylake, IBRS)"
+    ],
+    "physicalcount": 2,
+    "speed": "3.00 GHz"
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/usr/local/share/ruby/site_ruby",
+    "version": "2.7.1"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 1896eda9c97def529c64f97ebcdb5aee32e25285",
+        "sha256": "SSHFP 3 2 6932a390ad20961350b2ab36861b18ec2ce2644d433bc54f432600421f58bcd1"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEBFrxBiebSB+0M1LGyX3H3ZHd676wnGGfYjexjSvopznvfkb0PdNSLUvHpc1gU/yPBx7HP/pdGvdDWnwvoNkLY=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 43113e7fca870374e8a5f9981e4bf6f97a7bc59a",
+        "sha256": "SSHFP 4 2 d17bfb375bc87e76dcc937708974cd3f7a361843625f67c485426ad4c9bf441f"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAIFu6kGHnNmCA56gkfRAyAxZZEdwF5mCD6aRb0PznE++s",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 0f2ab3941f9c7a54211076bc27dee370e10698b0",
+        "sha256": "SSHFP 1 2 c45674d9bc1091ac4cc9150fd517b0b895650fa590e41e288cc07f2699dfb9e1"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDSOlxRR5iy0VM5BVl2JiFvUvv5UMAUMPkNxKuo89U/jG1X3N9pqxSpgwy4VnzAJTMXTUObCnSTueiVjj0HHz6UMuRxIe4MYb2XFNrdQUV3BPKvbP3NG02bBGRhH35mr0g9Yd9Rc1Ayf5gTlfGkbOh4JbjPygQ9ub/5gUnEbFOS4x39U3wnZV4z/1s0RwWtzdLe8kj36/gvoYaBdrsDNtFQjEGWSHhjiwXf0wOvOVt+OKY77Z1+pM6CcqQVR75VcT52P/y5UEIREo7CP0eHxjD5JAcm7fWJrxeHFH3Cv1dh9I/J9b5k3WGFciqsv5zebx4MMq64poKbmyFyR+R1ixKM9laoaUiTC5N3ajM54kSb5wREIiMMFpPo7ArfXnIbjOsHidnmXvMfOwTLwwymBoKsWNR2LIf3u/mBOdBC2PtrYz9nL6pi5Lb2OOpa0S+LQFxWulFPWvTN83Mqlcr8qScJqPfgwlM6pIco6blJwe078N5ldXdeaj54I0RQ4XYChhE=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 0,
+    "hours": 0,
+    "seconds": 679,
+    "uptime": "0:11 hours"
+  },
+  "timezone": "EDT",
+  "virtual": "kvm"
+}

--- a/test/static_fixtures/facts/puppet_centos_stream.json
+++ b/test/static_fixtures/facts/puppet_centos_stream.json
@@ -1,0 +1,255 @@
+{
+  "disks": {
+    "sr0": {
+      "model": "QEMU DVD-ROM",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741312,
+      "type": "hdd",
+      "vendor": "QEMU"
+    },
+    "vda": {
+      "size": "10.00 GiB",
+      "size_bytes": 10737418240,
+      "type": "hdd",
+      "vendor": "0x1af4"
+    }
+  },
+  "dmi": {
+    "bios": {
+      "release_date": "04/01/2014",
+      "vendor": "SeaBIOS",
+      "version": "1.11.0-2.el7"
+    },
+    "chassis": {
+      "type": "Other"
+    },
+    "manufacturer": "Red Hat",
+    "product": {
+      "name": "KVM",
+      "uuid": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1"
+    }
+  },
+  "facterversion": "4.2.5",
+  "filesystems": "xfs",
+  "fips_enabled": false,
+  "hypervisors": {
+    "kvm": {
+    }
+  },
+  "identity": {
+    "gid": 0,
+    "group": "root",
+    "privileged": true,
+    "uid": 0,
+    "user": "root"
+  },
+  "is_virtual": true,
+  "kernel": "Linux",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-338.el8.x86_64",
+  "kernelversion": "4.18.0",
+  "load_averages": {
+    "15m": 0.04,
+    "1m": 0.35,
+    "5m": 0.12
+  },
+  "memory": {
+    "swap": {
+      "available": "365.77 MiB",
+      "available_bytes": 383541248,
+      "capacity": "64.28%",
+      "total": "1.00 GiB",
+      "total_bytes": 1073737728,
+      "used": "658.22 MiB",
+      "used_bytes": 690196480
+    },
+    "system": {
+      "available": "269.00 MiB",
+      "available_bytes": 282066944,
+      "capacity": "66.75%",
+      "total": "809.09 MiB",
+      "total_bytes": 848392192,
+      "used": "540.09 MiB",
+      "used_bytes": 566325248
+    }
+  },
+  "networking": {
+    "domain": "dl360.cluster.com",
+    "fqdn": "stream.dl360.cluster.com",
+    "hostname": "stream",
+    "interfaces": {
+      "ens3": {
+        "bindings": [
+          {
+            "address": "192.168.88.20",
+            "netmask": "255.255.255.0",
+            "network": "192.168.88.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "fe80::5054:ff:fee3:8d8b",
+            "netmask": "ffff:ffff:ffff:ffff::",
+            "network": "fe80::",
+            "scope6": "link",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "192.168.88.20",
+        "ip6": "fe80::5054:ff:fee3:8d8b",
+        "mac": "52:54:00:e3:8d:8b",
+        "mtu": 1500,
+        "netmask": "255.255.255.0",
+        "netmask6": "ffff:ffff:ffff:ffff::",
+        "network": "192.168.88.0",
+        "network6": "fe80::",
+        "scope6": "link"
+      },
+      "lo": {
+        "bindings": [
+          {
+            "address": "127.0.0.1",
+            "netmask": "255.0.0.0",
+            "network": "127.0.0.0"
+          }
+        ],
+        "bindings6": [
+          {
+            "address": "::1",
+            "netmask": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "network": "::1",
+            "scope6": "host",
+            "flags": [
+              "permanent"
+            ]
+          }
+        ],
+        "ip": "127.0.0.1",
+        "ip6": "::1",
+        "mtu": 65536,
+        "netmask": "255.0.0.0",
+        "netmask6": "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+        "network": "127.0.0.0",
+        "network6": "::1",
+        "scope6": "host"
+      }
+    },
+    "ip": "192.168.88.20",
+    "ip6": "fe80::5054:ff:fee3:8d8b",
+    "mac": "52:54:00:e3:8d:8b",
+    "mtu": 1500,
+    "netmask": "255.255.255.0",
+    "netmask6": "ffff:ffff:ffff:ffff::",
+    "network": "192.168.88.0",
+    "network6": "fe80::",
+    "primary": "ens3",
+    "scope6": "link"
+  },
+  "os": {
+    "architecture": "x86_64",
+    "distro": {
+      "description": "CentOS Stream release 8",
+      "id": "CentOSStream",
+      "release": {
+        "full": "8",
+        "major": "8"
+      }
+    },
+    "family": "RedHat",
+    "hardware": "x86_64",
+    "name": "CentOS",
+    "release": {
+      "full": "8",
+      "major": "8"
+    },
+    "selinux": {
+      "config_mode": "enforcing",
+      "config_policy": "targeted",
+      "current_mode": "enforcing",
+      "enabled": true,
+      "enforced": true,
+      "policy_version": "33"
+    }
+  },
+  "partitions": {
+    "/dev/mapper/cs_stream-root": {
+      "filesystem": "xfs",
+      "size": "8.00 GiB",
+      "size_bytes": 8585740288,
+      "uuid": "50d1cc90-1804-4026-b473-58da96d64156"
+    },
+    "/dev/mapper/cs_stream-swap": {
+      "filesystem": "swap",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "0d782303-3cd7-451a-b5fd-083ba57fb696"
+    },
+    "/dev/vda1": {
+      "filesystem": "xfs",
+      "partuuid": "d7c9ab65-01",
+      "size": "1.00 GiB",
+      "size_bytes": 1073741824,
+      "uuid": "9900694f-e73a-4e83-83e9-042cce34a5ee"
+    },
+    "/dev/vda2": {
+      "filesystem": "LVM2_member",
+      "partuuid": "d7c9ab65-02",
+      "size": "9.00 GiB",
+      "size_bytes": 9662627840,
+      "uuid": "iG7brm-YhtC-3kJT-BcpM-xbcC-aqbj-UewxvL"
+    }
+  },
+  "path": "/usr/local/rvm/gems/ruby-2.6.6/bin:/usr/local/rvm/gems/ruby-2.6.6@global/bin:/usr/local/rvm/rubies/ruby-2.6.6/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/local/rvm/bin:/root/bin",
+  "processors": {
+    "cores": 1,
+    "count": 1,
+    "isa": "x86_64",
+    "models": [
+      "Westmere E56xx/L56xx/X56xx (IBRS update)"
+    ],
+    "physicalcount": 1,
+    "speed": "2.27 GHz",
+    "threads": 1
+  },
+  "ruby": {
+    "platform": "x86_64-linux",
+    "sitedir": "/usr/local/rvm/rubies/ruby-2.6.6/lib/ruby/site_ruby/2.6.0",
+    "version": "2.6.6"
+  },
+  "ssh": {
+    "ecdsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 3 1 d9413db6fc7ce6057a7d57b4d2226498978d32cc",
+        "sha256": "SSHFP 3 2 ed6abdf69798184794ffdcb0af778ab09d4cc1fa04a3840c01ae320eb752205b"
+      },
+      "key": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBLdk3JuvO4JtWAGg9jIqEDpeYc8ofaX5N6XwN0qyIW3iF12S9eNv6TZKTVLfZk7kF3n5MXTIkjJkfh+C2U9f4ic=",
+      "type": "ecdsa-sha2-nistp256"
+    },
+    "ed25519": {
+      "fingerprints": {
+        "sha1": "SSHFP 4 1 7eb4b26f1c0f3ba859277cc08d2a93fa1711504c",
+        "sha256": "SSHFP 4 2 3da2e178f69ccfbaae32a0e5bea93fc9ef1ddb418a6d7dedc8ebf27ff0ce8f17"
+      },
+      "key": "AAAAC3NzaC1lZDI1NTE5AAAAICNdD7XD7S1/I6b1nve57M+9r53NRt4fFYP3F1XSfiUN",
+      "type": "ssh-ed25519"
+    },
+    "rsa": {
+      "fingerprints": {
+        "sha1": "SSHFP 1 1 f1321c1ba331e0457d303c2fd4a5f8b50a84bc6c",
+        "sha256": "SSHFP 1 2 ef5855802fbe846d1334c562ceffadee8675d64797215e0003516dc68e61b87f"
+      },
+      "key": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDId3dwByYgssoJLLqDZNkweT+TscVl2htpObYaWqIBfTH6rur0rXvOrRclEn+ZbZhvnAoUwNHUvIK6LZDL1Ji+mnAC8//P09HMMflHDDhrpZXEEfyN5yqG6Pc2CAPFlaiBatlThVZmo3RiHAQAZ2daBAZs9w6wgb2ImS+Lor5kyyFzVfEba7moDTBo09C7eG2k0O2dm70c9j3ArBs++LQc7BGSfL+GODADHXraJ8SFWkiXxKXMd7rLgOhEXEtnP9IksZBqeS/R1v7Vg8eErHhxUYRQDAPtJ4uaQCCGOIeUqcgzimY5hpi8kiyd7VK5P96MaRsr4Dv5X7MzwhUF+1vM8mkl2FX+zXfOA9m+KwA+EgmYCRsLqLugRTDEQBd/MzYz7uzUo+4nWZYUe4+N+1V9Dm6BbayPh+RT9dN1y1Luvm3nXpdPlj+6Wmo1LywNWwRWIXEj/zhVKK165Jh/5EOju0yO07IB9N0g1IzZSvHb6BGkw7OhwTKIoQ7D/O8buEs=",
+      "type": "ssh-rsa"
+    }
+  },
+  "system_uptime": {
+    "days": 1,
+    "hours": 39,
+    "seconds": 142509,
+    "uptime": "1 day"
+  },
+  "timezone": "EDT",
+  "virtual": "kvm"
+}

--- a/test/static_fixtures/facts/puppet_centos_stream_facter_2.5.json
+++ b/test/static_fixtures/facts/puppet_centos_stream_facter_2.5.json
@@ -1,0 +1,117 @@
+{
+  "architecture": "x86_64",
+  "kernel": "Linux",
+  "blockdevice_vda_size": 7516192768,
+  "blockdevice_vda_vendor": "0x1af4",
+  "blockdevices": "vda",
+  "virtual": "kvm",
+  "is_virtual": true,
+  "hardwaremodel": "x86_64",
+  "operatingsystem": "CentOS",
+  "os": {
+    "name": "CentOS",
+    "family": "RedHat",
+    "release": {
+      "major": "8",
+      "full": "8"
+    }
+  },
+  "facterversion": "2.5.7",
+  "filesystems": "ext2,ext3,ext4,xfs",
+  "fqdn": "stream",
+  "gid": "root",
+  "hardwareisa": "x86_64",
+  "hostname": "stream",
+  "id": "root",
+  "interfaces": "",
+  "ipaddress": "192.168.122.29",
+  "kernelmajversion": "4.18",
+  "kernelrelease": "4.18.0-193.6.3.el8_2.x86_64",
+  "kernelversion": "4.18.0",
+  "bios_vendor": "SeaBIOS",
+  "bios_version": "1.14.0-1.fc33",
+  "bios_release_date": "04/01/2014",
+  "manufacturer": "QEMU",
+  "productname": "Standard PC (Q35 + ICH9, 2009)",
+  "serialnumber": "Not Specified",
+  "uuid": "1ddbeb7e-aea3-4ae3-8a57-61867d346372",
+  "type": "Other",
+  "memorysize": "1.78 GB",
+  "memoryfree": "1.40 GB",
+  "swapsize": "615.00 MB",
+  "swapfree": "602.25 MB",
+  "swapsize_mb": "615.00",
+  "swapfree_mb": "602.25",
+  "memorysize_mb": "1826.77",
+  "memoryfree_mb": "1435.07",
+  "operatingsystemmajrelease": "8",
+  "operatingsystemrelease": "8",
+  "osfamily": "RedHat",
+  "partitions": {
+    "vda4": {
+      "uuid": "4fd120e4-1f6d-46b3-a404-5569ef6af1f9",
+      "size": "11316608",
+      "mount": "/",
+      "label": "primary",
+      "filesystem": "xfs"
+    },
+    "vda2": {
+      "uuid": "0b3df967-65cc-4a48-8b98-f7f0badc0d91",
+      "size": "2097152",
+      "mount": "/boot",
+      "label": "primary",
+      "filesystem": "ext4"
+    },
+    "vda3": {
+      "uuid": "40f14688-2619-4046-a9eb-b7333fff1b84",
+      "size": "1259520",
+      "label": "primary",
+      "filesystem": "swap"
+    },
+    "vda1": {
+      "size": "2048",
+      "label": "primary"
+    }
+  },
+  "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin",
+  "physicalprocessorcount": 2,
+  "processors": {
+    "models": [
+      "Intel Core Processor (Skylake, IBRS)",
+      "Intel Core Processor (Skylake, IBRS)"
+    ],
+    "count": 2,
+    "physicalcount": 2
+  },
+  "processor0": "Intel Core Processor (Skylake, IBRS)",
+  "processor1": "Intel Core Processor (Skylake, IBRS)",
+  "processorcount": 2,
+  "ps": "ps -ef",
+  "rubyplatform": "x86_64-linux",
+  "rubysitedir": "/usr/local/share/ruby/site_ruby",
+  "rubyversion": "2.7.1",
+  "selinux": true,
+  "selinux_enforced": true,
+  "selinux_policyversion": "31",
+  "selinux_current_mode": "enforcing",
+  "selinux_config_mode": "enforcing",
+  "selinux_config_policy": "targeted",
+  "sshrsakey": "AAAAB3NzaC1yc2EAAAADAQABAAABgQDSOlxRR5iy0VM5BVl2JiFvUvv5UMAUMPkNxKuo89U/jG1X3N9pqxSpgwy4VnzAJTMXTUObCnSTueiVjj0HHz6UMuRxIe4MYb2XFNrdQUV3BPKvbP3NG02bBGRhH35mr0g9Yd9Rc1Ayf5gTlfGkbOh4JbjPygQ9ub/5gUnEbFOS4x39U3wnZV4z/1s0RwWtzdLe8kj36/gvoYaBdrsDNtFQjEGWSHhjiwXf0wOvOVt+OKY77Z1+pM6CcqQVR75VcT52P/y5UEIREo7CP0eHxjD5JAcm7fWJrxeHFH3Cv1dh9I/J9b5k3WGFciqsv5zebx4MMq64poKbmyFyR+R1ixKM9laoaUiTC5N3ajM54kSb5wREIiMMFpPo7ArfXnIbjOsHidnmXvMfOwTLwwymBoKsWNR2LIf3u/mBOdBC2PtrYz9nL6pi5Lb2OOpa0S+LQFxWulFPWvTN83Mqlcr8qScJqPfgwlM6pIco6blJwe078N5ldXdeaj54I0RQ4XYChhE=",
+  "sshfp_rsa": "SSHFP 1 1 0f2ab3941f9c7a54211076bc27dee370e10698b0\nSSHFP 1 2 c45674d9bc1091ac4cc9150fd517b0b895650fa590e41e288cc07f2699dfb9e1",
+  "sshecdsakey": "AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEBFrxBiebSB+0M1LGyX3H3ZHd676wnGGfYjexjSvopznvfkb0PdNSLUvHpc1gU/yPBx7HP/pdGvdDWnwvoNkLY=",
+  "sshfp_ecdsa": "SSHFP 3 1 1896eda9c97def529c64f97ebcdb5aee32e25285\nSSHFP 3 2 6932a390ad20961350b2ab36861b18ec2ce2644d433bc54f432600421f58bcd1",
+  "sshed25519key": "AAAAC3NzaC1lZDI1NTE5AAAAIFu6kGHnNmCA56gkfRAyAxZZEdwF5mCD6aRb0PznE++s",
+  "sshfp_ed25519": "SSHFP 4 1 43113e7fca870374e8a5f9981e4bf6f97a7bc59a\nSSHFP 4 2 d17bfb375bc87e76dcc937708974cd3f7a361843625f67c485426ad4c9bf441f",
+  "system_uptime": {
+    "seconds": 4782,
+    "hours": 1,
+    "days": 0,
+    "uptime": "1:19 hours"
+  },
+  "timezone": "EDT",
+  "uniqueid": "a8c01d7a",
+  "uptime": "1:19 hours",
+  "uptime_days": 0,
+  "uptime_hours": 1,
+  "uptime_seconds": 4782
+}

--- a/test/static_fixtures/facts/salt_centos_8.json
+++ b/test/static_fixtures/facts/salt_centos_8.json
@@ -1,0 +1,280 @@
+{
+    "cwd": "/root",
+    "ip_gw": true,
+    "ip4_gw": "192.168.88.1",
+    "ip6_gw": false,
+    "dns": {
+        "nameservers": [
+            "192.168.88.30",
+            "192.168.88.1"
+        ],
+        "ip4_nameservers": [
+            "192.168.88.30",
+            "192.168.88.1"
+        ],
+        "ip6_nameservers": [],
+        "sortlist": [],
+        "domain": "",
+        "search": [
+            "cluster.local"
+        ],
+        "options": []
+    },
+    "fqdns": [
+        "foreman.cluster.local"
+    ],
+    "machine_id": "5d33f1d45b774d26b22a76ffcc26d275",
+    "master": "192.168.88.15",
+    "server_id": 359285562,
+    "localhost": "foreman.cluster.local",
+    "fqdn": "foreman.cluster.local",
+    "host": "foreman",
+    "domain": "cluster.local",
+    "hwaddr_interfaces": {
+        "lo": "00:00:00:00:00:00",
+        "ens3": "52:54:00:2a:fa:7a"
+    },
+    "id": "foreman.cluster.local",
+    "ip4_interfaces": {
+        "lo": [
+            "127.0.0.1"
+        ],
+        "ens3": [
+            "192.168.88.15"
+        ]
+    },
+    "ip6_interfaces": {
+        "lo": [
+            "::1"
+        ],
+        "ens3": [
+            "fe80::5054:ff:fe2a:fa7a"
+        ]
+    },
+    "ipv4": [
+        "127.0.0.1",
+        "192.168.88.15"
+    ],
+    "ipv6": [
+        "::1",
+        "fe80::5054:ff:fe2a:fa7a"
+    ],
+    "fqdn_ip4": [
+        "192.168.88.15"
+    ],
+    "fqdn_ip6": [
+        "fe80::5054:ff:fe2a:fa7a"
+    ],
+    "ip_interfaces": {
+        "lo": [
+            "127.0.0.1",
+            "::1"
+        ],
+        "ens3": [
+            "192.168.88.15",
+            "fe80::5054:ff:fe2a:fa7a"
+        ]
+    },
+    "kernelparams": [
+        [
+            "BOOT_IMAGE",
+            "(hd0,msdos1)/vmlinuz-4.18.0-305.19.1.el8_4.x86_64"
+        ],
+        [
+            "root",
+            "/dev/mapper/cl_foreman-root"
+        ],
+        [
+            "ro",
+            null
+        ],
+        [
+            "crashkernel",
+            "auto"
+        ],
+        [
+            "resume",
+            "/dev/mapper/cl_foreman-swap"
+        ],
+        [
+            "rd.lvm.lv",
+            "cl_foreman/root"
+        ],
+        [
+            "rd.lvm.lv",
+            "cl_foreman/swap"
+        ],
+        [
+            "rhgb",
+            null
+        ],
+        [
+            "quiet",
+            null
+        ]
+    ],
+    "locale_info": {
+        "defaultlanguage": "en_US",
+        "defaultencoding": "UTF-8",
+        "detectedencoding": "UTF-8",
+        "timezone": "EDT"
+    },
+    "num_gpus": 1,
+    "gpus": [
+        {
+            "vendor": "unknown",
+            "model": "QXL paravirtual graphic card"
+        }
+    ],
+    "kernel": "Linux",
+    "nodename": "foreman.cluster.local",
+    "kernelrelease": "4.18.0-305.19.1.el8_4.x86_64",
+    "kernelversion": "#1 SMP Wed Sep 15 15:39:39 UTC 2021",
+    "cpuarch": "x86_64",
+    "selinux": {
+        "enabled": true,
+        "enforced": "Enforcing"
+    },
+    "systemd": {
+        "version": "239",
+        "features": "+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=legacy"
+    },
+    "init": "systemd",
+    "lsb_distrib_id": "CentOS Linux",
+    "lsb_distrib_codename": "CentOS Linux 8",
+    "osfullname": "CentOS Linux",
+    "osrelease": "8.4.2105",
+    "oscodename": "CentOS Linux 8",
+    "os": "CentOS",
+    "num_cpus": 6,
+    "cpu_model": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+    "cpu_flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "ht",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+    ],
+    "os_family": "RedHat",
+    "osarch": "x86_64",
+    "mem_total": 9783,
+    "swap_total": 4095,
+    "biosversion": "1.11.0-2.el7",
+    "productname": "KVM",
+    "manufacturer": "Red Hat",
+    "biosreleasedate": "04/01/2014",
+    "uuid": "5d33f1d4-5b77-4d26-b22a-76ffcc26d275",
+    "serialnumber": "",
+    "virtual": "kvm",
+    "ps": "ps -efHww",
+    "osrelease_info": [
+        8,
+        4,
+        2105
+    ],
+    "osmajorrelease": 8,
+    "osfinger": "CentOS Linux-8",
+    "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/opt/puppetlabs/bin:/root/bin",
+    "systempath": [
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/opt/puppetlabs/bin",
+        "/root/bin"
+    ],
+    "pythonexecutable": "/usr/bin/python3.6",
+    "pythonpath": [
+        "/usr/bin",
+        "/usr/lib64/python36.zip",
+        "/usr/lib64/python3.6",
+        "/usr/lib64/python3.6/lib-dynload",
+        "/usr/lib64/python3.6/site-packages",
+        "/usr/lib/python3.6/site-packages"
+    ],
+    "pythonversion": [
+        3,
+        6,
+        8,
+        "final",
+        0
+    ],
+    "saltpath": "/usr/lib/python3.6/site-packages/salt",
+    "saltversion": "3004",
+    "saltversioninfo": [
+        3004
+    ],
+    "zmqversion": "4.3.4",
+    "disks": [
+        "sr0",
+        "sda"
+    ],
+    "ssds": [],
+    "shell": "/bin/bash",
+    "transactional": false,
+    "efi": false,
+    "efi-secure-boot": false,
+    "lvm": {
+        "cl_foreman": [
+            "root",
+            "swap"
+        ]
+    },
+    "mdadm": [],
+    "username": "root",
+    "groupname": "root",
+    "pid": 191775,
+    "gid": 0,
+    "uid": 0,
+    "zfs_support": false,
+    "zfs_feature_flags": false
+}

--- a/test/static_fixtures/facts/salt_centos_stream.json
+++ b/test/static_fixtures/facts/salt_centos_stream.json
@@ -1,0 +1,283 @@
+{
+    "cwd": "/root",
+    "ip_gw": true,
+    "ip4_gw": "192.168.88.1",
+    "ip6_gw": false,
+    "dns": {
+        "nameservers": [
+            "192.168.88.30",
+            "192.168.88.1"
+        ],
+        "ip4_nameservers": [
+            "192.168.88.30",
+            "192.168.88.1"
+        ],
+        "ip6_nameservers": [],
+        "sortlist": [],
+        "domain": "",
+        "search": [
+            "dl360.cluster.com"
+        ],
+        "options": []
+    },
+    "fqdns": [
+        "stream.dl360.cluster.com"
+    ],
+    "machine_id": "b9ea0f0a5ce445dc9a0e4979ea4911c1",
+    "master": "localhost",
+    "server_id": 1758077233,
+    "localhost": "stream.dl360.cluster.com",
+    "fqdn": "stream.dl360.cluster.com",
+    "host": "stream",
+    "domain": "dl360.cluster.com",
+    "hwaddr_interfaces": {
+        "lo": "00:00:00:00:00:00",
+        "ens3": "52:54:00:e3:8d:8b"
+    },
+    "id": "stream.dl360.cluster.com",
+    "ip4_interfaces": {
+        "lo": [
+            "127.0.0.1"
+        ],
+        "ens3": [
+            "192.168.88.20"
+        ]
+    },
+    "ip6_interfaces": {
+        "lo": [
+            "::1"
+        ],
+        "ens3": [
+            "fe80::5054:ff:fee3:8d8b"
+        ]
+    },
+    "ipv4": [
+        "127.0.0.1",
+        "192.168.88.20"
+    ],
+    "ipv6": [
+        "::1",
+        "fe80::5054:ff:fee3:8d8b"
+    ],
+    "fqdn_ip4": [
+        "192.168.88.20"
+    ],
+    "fqdn_ip6": [
+        "fe80::5054:ff:fee3:8d8b"
+    ],
+    "ip_interfaces": {
+        "lo": [
+            "127.0.0.1",
+            "::1"
+        ],
+        "ens3": [
+            "192.168.88.20",
+            "fe80::5054:ff:fee3:8d8b"
+        ]
+    },
+    "kernelparams": [
+        [
+            "BOOT_IMAGE",
+            "(hd0,msdos1)/vmlinuz-4.18.0-338.el8.x86_64"
+        ],
+        [
+            "root",
+            "/dev/mapper/cs_stream-root"
+        ],
+        [
+            "ro",
+            null
+        ],
+        [
+            "crashkernel",
+            "auto"
+        ],
+        [
+            "resume",
+            "/dev/mapper/cs_stream-swap"
+        ],
+        [
+            "rd.lvm.lv",
+            "cs_stream/root"
+        ],
+        [
+            "rd.lvm.lv",
+            "cs_stream/swap"
+        ],
+        [
+            "rhgb",
+            null
+        ],
+        [
+            "quiet",
+            null
+        ]
+    ],
+    "locale_info": {
+        "defaultlanguage": "en_US",
+        "defaultencoding": "UTF-8",
+        "detectedencoding": "UTF-8",
+        "timezone": "EDT"
+    },
+    "num_gpus": 1,
+    "gpus": [
+        {
+            "vendor": "unknown",
+            "model": "QXL paravirtual graphic card"
+        }
+    ],
+    "kernel": "Linux",
+    "nodename": "stream.dl360.cluster.com",
+    "kernelrelease": "4.18.0-338.el8.x86_64",
+    "kernelversion": "#1 SMP Fri Aug 27 17:32:14 UTC 2021",
+    "cpuarch": "x86_64",
+    "selinux": {
+        "enabled": true,
+        "enforced": "Enforcing"
+    },
+    "systemd": {
+        "version": "239",
+        "features": "+PAM +AUDIT +SELINUX +IMA -APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD +IDN2 -IDN +PCRE2 default-hierarchy=legacy"
+    },
+    "init": "systemd",
+    "lsb_distrib_id": "CentOS Stream",
+    "lsb_distrib_release": "8",
+    "lsb_distrib_codename": "CentOS Stream 8",
+    "osfullname": "CentOS Stream",
+    "osrelease": "8",
+    "oscodename": "CentOS Stream 8",
+    "os": "CentOS Stream",
+    "num_cpus": 1,
+    "cpu_model": "Westmere E56xx/L56xx/X56xx (IBRS update)",
+    "cpu_flags": [
+        "fpu",
+        "vme",
+        "de",
+        "pse",
+        "tsc",
+        "msr",
+        "pae",
+        "mce",
+        "cx8",
+        "apic",
+        "sep",
+        "mtrr",
+        "pge",
+        "mca",
+        "cmov",
+        "pat",
+        "pse36",
+        "clflush",
+        "mmx",
+        "fxsr",
+        "sse",
+        "sse2",
+        "syscall",
+        "nx",
+        "pdpe1gb",
+        "rdtscp",
+        "lm",
+        "constant_tsc",
+        "rep_good",
+        "nopl",
+        "xtopology",
+        "cpuid",
+        "tsc_known_freq",
+        "pni",
+        "pclmulqdq",
+        "ssse3",
+        "cx16",
+        "pcid",
+        "sse4_1",
+        "sse4_2",
+        "x2apic",
+        "popcnt",
+        "tsc_deadline_timer",
+        "aes",
+        "hypervisor",
+        "lahf_lm",
+        "pti",
+        "ssbd",
+        "ibrs",
+        "ibpb",
+        "stibp",
+        "tsc_adjust",
+        "arat"
+    ],
+    "os_family": "RedHat",
+    "osarch": "x86_64",
+    "mem_total": 809,
+    "swap_total": 1023,
+    "biosversion": "1.11.0-2.el7",
+    "productname": "KVM",
+    "manufacturer": "Red Hat",
+    "biosreleasedate": "04/01/2014",
+    "uuid": "b9ea0f0a-5ce4-45dc-9a0e-4979ea4911c1",
+    "serialnumber": "",
+    "virtual": "kvm",
+    "ps": "ps -efHww",
+    "osrelease_info": [
+        8
+    ],
+    "osmajorrelease": 8,
+    "osfinger": "CentOS Stream-8",
+    "path": "/usr/local/rvm/gems/ruby-2.6.6/bin:/usr/local/rvm/gems/ruby-2.6.6@global/bin:/usr/local/rvm/rubies/ruby-2.6.6/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/local/rvm/bin:/root/bin",
+    "systempath": [
+        "/usr/local/rvm/gems/ruby-2.6.6/bin",
+        "/usr/local/rvm/gems/ruby-2.6.6@global/bin",
+        "/usr/local/rvm/rubies/ruby-2.6.6/bin",
+        "/usr/local/sbin",
+        "/usr/local/bin",
+        "/usr/sbin",
+        "/usr/bin",
+        "/usr/local/rvm/bin",
+        "/root/bin"
+    ],
+    "pythonexecutable": "/usr/bin/python3.6",
+    "pythonpath": [
+        "/usr/bin",
+        "/usr/lib64/python36.zip",
+        "/usr/lib64/python3.6",
+        "/usr/lib64/python3.6/lib-dynload",
+        "/usr/local/lib64/python3.6/site-packages",
+        "/usr/local/lib/python3.6/site-packages",
+        "/usr/lib64/python3.6/site-packages",
+        "/usr/lib/python3.6/site-packages"
+    ],
+    "pythonversion": [
+        3,
+        6,
+        8,
+        "final",
+        0
+    ],
+    "saltpath": "/usr/lib/python3.6/site-packages/salt",
+    "saltversion": "3004",
+    "saltversioninfo": [
+        3004
+    ],
+    "zmqversion": "4.3.4",
+    "disks": [
+        "sr0",
+        "vda"
+    ],
+    "ssds": [],
+    "shell": "/bin/bash",
+    "transactional": false,
+    "efi": false,
+    "efi-secure-boot": false,
+    "lvm": {
+        "cs_stream": [
+            "root",
+            "swap"
+        ]
+    },
+    "mdadm": [],
+    "username": "root",
+    "groupname": "root",
+    "pid": 80057,
+    "gid": 0,
+    "uid": 0,
+    "zfs_support": false,
+    "zfs_feature_flags": false
+}

--- a/test/unit/foreman_ansible/fact_parser_test.rb
+++ b/test/unit/foreman_ansible/fact_parser_test.rb
@@ -279,4 +279,29 @@ module ForemanAnsible
       end
     end
   end
+
+  class CentOSStreamFactParserTest < ActiveSupport::TestCase
+    context 'CentOS Stream' do
+      setup do
+        facts_stream = HashWithIndifferentAccess.new(read_json_fixture('facts/ansible_centos_stream.json'))
+        facts_8_normal = HashWithIndifferentAccess.new(read_json_fixture('facts/ansible_centos_8.json'))
+        @fact_parser_stream = AnsibleFactParser.new(facts_stream)
+        @fact_parser_8_normal = AnsibleFactParser.new(facts_8_normal)
+      end
+
+      test 'should identify CentOS Stream' do
+        os = @fact_parser_stream.operatingsystem
+        assert_equal 'CentOS_Stream', os.name
+        assert_equal '8', os.major
+        assert_empty os.minor
+      end
+
+      test 'should identify CentOS 8' do
+        os = @fact_parser_8_normal.operatingsystem
+        assert_equal 'CentOS', os.name
+        assert_equal '8', os.major
+        assert_equal '4', os.minor
+      end
+    end
+  end
 end

--- a/test/unit/foreman_chef/fact_parser_test.rb
+++ b/test/unit/foreman_chef/fact_parser_test.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module ForemanChef
+  class FactParserTest < ActiveSupport::TestCase
+    test 'should detect CentOS Stream' do
+      parser = ForemanChef::FactParser.new(stream_facts)
+      os = parser.operatingsystem
+
+      assert os.present?
+      assert_equal 'CentOS_Stream', os.name
+      assert_equal '8', os.major
+      assert_empty os.minor
+    end
+
+    test 'should detect CentOS 7' do
+      parser = ForemanChef::FactParser.new(centos_7_facts)
+      os = parser.operatingsystem
+
+      assert os.present?
+      assert_equal 'centos', os.name
+      assert_equal '7', os.major
+      assert_equal '7', os.minor
+    end
+
+    test 'should detect CentOS 8 non stream version' do
+      parser = ForemanChef::FactParser.new(centos_8_facts)
+      os = parser.operatingsystem
+
+      assert os.present?
+      assert_equal 'centos', os.name
+      assert_equal '8', os.major
+      assert_equal '4', os.minor
+    end
+
+    def stream_facts
+      HashWithIndifferentAccess.new(read_json_fixture('facts/chef_centos_stream.json'))
+    end
+
+    def centos_8_facts
+      HashWithIndifferentAccess.new(read_json_fixture('facts/chef_centos_8.json'))
+    end
+
+    def centos_7_facts
+      HashWithIndifferentAccess.new(read_json_fixture('facts/chef_centos_7.json'))
+    end
+  end
+end

--- a/test/unit/foreman_salt/salt_fact_parser_test.rb
+++ b/test/unit/foreman_salt/salt_fact_parser_test.rb
@@ -4,7 +4,7 @@ module ForemanSalt
   class SaltFactsParserTest < ActiveSupport::TestCase
     def setup
       grains = JSON.parse(File.read(File.join(Rails.root, 'test', 'static_fixtures', 'facts', 'grains_centos.json')))
-      @facts_parser = FactParser.new grains["facts"]
+      @facts_parser = ForemanSalt::FactParser.new grains["facts"]
       User.current = users :admin
     end
 
@@ -21,6 +21,28 @@ module ForemanSalt
       assert_equal '6', os.major
       assert_equal '5', os.minor
       assert_equal 'CentOS 6.5', os.title
+    end
+
+    test "should identify CentOS Stream correctly" do
+      facts = HashWithIndifferentAccess.new(read_json_fixture("facts/salt_centos_stream.json"))
+      parser = ForemanSalt::FactParser.new(facts)
+      os = parser.operatingsystem
+
+      assert os.present?
+      assert_equal 'CentOS_Stream', os.name
+      assert_equal '8', os.major
+      assert_empty os.minor
+    end
+
+    test "should identify CentOS 8 correctly" do
+      facts = HashWithIndifferentAccess.new(read_json_fixture("facts/salt_centos_8.json"))
+      parser = ForemanSalt::FactParser.new(facts)
+      os = parser.operatingsystem
+
+      assert os.present?
+      assert_equal 'CentOS', os.name
+      assert_equal '8', os.major
+      assert_equal '4.2105', os.minor
     end
 
     test "should set domain correctly" do

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -172,6 +172,24 @@ module Katello
       assert_equal parser.operatingsystem.minor, '2'
     end
 
+    def test_operatingsystem_centos_stream
+      @facts['distribution.name'] = 'CentOS Stream'
+      @facts['distribution.version'] = '8'
+      @facts['distribution.id'] = '8'
+
+      assert_equal parser.operatingsystem.name, 'CentOS_Stream'
+      assert_equal parser.operatingsystem.major, '8'
+      assert_equal parser.operatingsystem.minor, ''
+    end
+
+    def test_operatingsystem_centos_8
+      @facts['distribution.name'] = 'CentOS Linux'
+      @facts['distribution.version'] = '8'
+
+      assert_equal parser.operatingsystem.name, 'CentOS'
+      assert_equal parser.operatingsystem.major, '8'
+    end
+
     def test_uname_architecture
       @facts['uname.machine'] = 'i686'
 

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -192,6 +192,38 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
       assert_equal '9', os.minor
       assert_os_idempotent
     end
+
+    test "should correctly identify CentOS Stream" do
+      parser = PuppetFactParser.new(centos_stream_facts)
+      os = parser.operatingsystem
+      assert_equal 'CentOS_Stream', os.name
+      assert_equal '8', os.major
+      assert_empty os.minor
+    end
+
+    test "should correctly identify CentOS Stream by facter 2.5" do
+      parser = PuppetFactParser.new(centos_stream_facts_facter_2)
+      os = parser.operatingsystem
+      assert_equal 'CentOS_Stream', os.name
+      assert_equal '8', os.major
+      assert_empty os.minor
+    end
+
+    test "should correctly identify CentOS 8 by facter 2.5" do
+      parser = PuppetFactParser.new(centos_8_facts_facter_2)
+      os = parser.operatingsystem
+      assert_equal 'CentOS', os.name
+      assert_equal '8', os.major
+      assert_equal '3.2011', os.minor
+    end
+
+    test "should correctly identify CentOS 8 by facter 4.1" do
+      parser = PuppetFactParser.new(centos_8_facts_facter_4)
+      os = parser.operatingsystem
+      assert_equal 'CentOS', os.name
+      assert_equal '8', os.major
+      assert_equal '3.2011', os.minor
+    end
   end
 
   describe "#facterversion" do
@@ -443,6 +475,22 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
   def facts
     #  return the equivalent of Facter.to_hash
     @json ||= read_json_fixture('facts/facts.json')['facts']
+  end
+
+  def centos_stream_facts
+    read_json_fixture('facts/puppet_centos_stream.json')
+  end
+
+  def centos_stream_facts_facter_2
+    read_json_fixture('facts/puppet_centos_stream_facter_2.5.json')
+  end
+
+  def centos_8_facts_facter_2
+    read_json_fixture('facts/puppet_centos_8_facter_2.5.json')
+  end
+
+  def centos_8_facts_facter_4
+    read_json_fixture('facts/puppet_centos_8_facter_4.1.json')
   end
 
   def debian_facts


### PR DESCRIPTION
The facts from Stream has not yet supported in Foreman. This PR adds correct recognition for all parsers.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
