### PR TITLE
Fixes #33776 - Adding support for IPv6 parsing in RHSM parser

### DIFF
--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -28,6 +28,7 @@ module Katello
         'link' => true,
         'macaddress' => get_rhsm_mac(interface),
         'ipaddress' => get_rhsm_ip(interface),
+        'ipaddress6' => get_rhsm_ipv6(interface),
       }
     end
 
@@ -112,6 +113,11 @@ module Katello
     def get_rhsm_ip(interface)
       ip = facts["net.interface.#{interface}.ipv4_address"]
       Net::Validations.validate_ip(ip) ? ip : nil
+    end
+
+    def get_rhsm_ipv6(interface)
+      ip = facts["net.interface.#{interface}.ipv6_address.link"] || facts["net.interface.#{interface}.ipv6_address.host"]
+      Net::Validations.validate_ip6(ip) ? ip : nil
     end
 
     def get_rhsm_mac(interface)

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -7,6 +7,7 @@ module Katello
         'net.interface.bond0.mac_address' => '52:54:00:6D:40:72',
         'net.interface.eth0.mac_address' => '00:00:00:00:00:12',
         'net.interface.eth0.ipv4_address' => '192.168.0.1',
+        'net.interface.eth0.ipv6_address.link' => '2001:db8::5230:dd:7741:8a',
         'net.interface.eth0.1.mac_address' => '00:00:00:00:00:12',
         'net.interface.eth0.1.ipv4_address' => '192.168.0.2',
         'net.interface.eth1.permanent_mac_address' => '52:54:00:6D:40:72',
@@ -36,6 +37,7 @@ module Katello
         'link' => true,
         'macaddress' => @facts['net.interface.eth0.mac_address'],
         'ipaddress' => @facts['net.interface.eth0.ipv4_address'],
+        'ipaddress6' => @facts['net.interface.eth0.ipv6_address.link'],
       }
       assert_equal expected_eth0, parser.get_facts_for_interface('eth0')
     end
@@ -45,6 +47,7 @@ module Katello
         'link' => true,
         'macaddress' => @facts['net.interface.eth2.permanent_mac_address'],
         'ipaddress' => nil,
+        'ipaddress6' => nil,
       }
       assert_equal expected_eth2, parser.get_facts_for_interface('eth2')
     end


### PR DESCRIPTION
The support for IPv6 parsing from facts by Subscription Manager is missing. This PR adds support for that.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
