### PR TITLE
Fixes #33787 - Drop Accept Header handling for API version

### DIFF
--- a/app/services/api_constraints.rb
+++ b/app/services/api_constraints.rb
@@ -5,12 +5,10 @@ class ApiConstraints
   end
 
   def matches?(req)
-    route_match       = req.fullpath.match(%r{/api/v(\d+)}) if req.fullpath
-    header_match      = req.accept.match(%r{version=(\d+)}) if req.accept
+    route_match = req.fullpath.match(%r{/api/v(\d+)}) if req.fullpath
 
     return (@version.to_s == route_match[1]) if route_match
-    return (@version.to_s == header_match[1]) if header_match
-    # if version is not specified in route or header, then it returns true only if :default => true in routes file v1.rb or v2.rb
+    # if version is not specified in route, then it returns true only if :default => true in routes
     @default
   end
 end

--- a/test/integration/catch_json_parse_errors_test.rb
+++ b/test/integration/catch_json_parse_errors_test.rb
@@ -29,7 +29,7 @@ class CatchJsonParseErrorsTest < IntegrationTestWithJavascript
 
   def default_headers
     {
-      'Accept'       => 'application/json,version=2',
+      'Accept'       => 'application/json',
       'Content-Type' => 'application/json',
     }
   end


### PR DESCRIPTION
The API controller has been abusing the Accept header to define which
version of the API should be used. This is not compliant with the HTTP
spec[1] which specifies that this header should be used to indicate
acceptable media types by the client.
Any clients currently passing the header should not be affected as the
default version of the API is v2. There are no plans currently to create
API v3, and even if it will eventually be developed, users will be able
to use the route to indicate which version they wish to use.

[1] https://httpwg.org/specs/rfc7231.html#header.accept


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
