### PR TITLE
Fixes #33732 - Make sure base64 encoding is done when creating a host via API

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -139,6 +139,9 @@ module Api
         else
           @host = Host.new(host_attributes(host_params))
           @host.managed = true if (params[:host] && params[:host][:managed].nil?)
+
+          # Workaround to fix #33732 (do base64 encoding while creating a host via API)
+          @host.root_pass = @host.root_pass
         end
         apply_compute_profile(@host)
         @host.suggest_default_pxe_loader if params[:host] && params[:host][:pxe_loader].nil?


### PR DESCRIPTION
This forces https://github.com/theforeman/foreman/blob/develop/app/models/host/base.rb#L614 that the password should be base64 encoded. 


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
