### PR TITLE
Fixes #33791 - respect global settings precedence

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -50,6 +50,10 @@ class SettingPresenter
     SETTINGS.key?(name.to_sym)
   end
 
+  def value
+    SETTINGS.fetch(name.to_sym) { super }
+  end
+
   def settings_type
     attribute(:settings_type) || Setting.setting_type_from_value(default)
   end

--- a/test/presenters/setting_presenter_test.rb
+++ b/test/presenters/setting_presenter_test.rb
@@ -1,10 +1,33 @@
 require 'test_helper'
 
 class SettingPresenterTest < ActiveSupport::TestCase
-  def test_should_hide_value_if_encrypted
-    skip 'needs fixing'
-    setting = Setting.create(name: 'encrypted', value: 'clear', encrypted: true)
-    presenter = SettingPresenter.from_setting(setting)
-    assert_equal '*****', presenter.safe_value
+  let(:encrypted) { false }
+  let(:presenter) do
+    SettingPresenter.new({ name: 'presenterfoo',
+                           context: :test,
+                           category: 'Test',
+                           settings_type: 'integer',
+                           default: 2,
+                           full_name: 'test foo',
+                           description: 'test foo',
+                           encrypted: encrypted })
+  end
+
+  describe '#safe_value' do
+    let(:encrypted) { true }
+    it 'should hide value if encrypted' do
+      assert_equal '*****', presenter.safe_value
+    end
+  end
+
+  describe '#value' do
+    context 'with global truth defined in SETTINGS' do
+      setup { SETTINGS.merge!(presenterfoo: 42) }
+      teardown { SETTINGS.delete(:presenterfoo) }
+
+      it 'returns the global' do
+        assert_equal 42, presenter.value
+      end
+    end
   end
 end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -72,6 +72,15 @@ class SettingRegistryTest < ActiveSupport::TestCase
         assert_equal setting_value, registry['foo']
       end
     end
+
+    context 'with SETTINGS value from config file' do
+      setup { SETTINGS.merge!(foo: 42) }
+      teardown { SETTINGS.delete(:foo) }
+
+      it 'returns the global truth' do
+        assert_equal 42, registry['foo']
+      end
+    end
   end
 
   describe '#set_user_value' do


### PR DESCRIPTION
In the new registry we've forgot to force the global values precedence.
This forces the global values to be respected.

Lets fix nightlies