### PR TITLE
Fixes #33811 - Fixing inheriting of root password for Hosts

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -659,12 +659,12 @@ autopart"', desc: 'to render the content of host partition table'
   def root_pass
     return self[:root_pass] if self[:root_pass].present?
     return hostgroup.try(:root_pass) if hostgroup.try(:root_pass).present?
-    Setting[:root_pass]
+    crypt_pass(Setting[:root_pass], :root)
   end
 
   def root_pass_source
-    return N_("host") if self[:root_pass].present?
-    return N_("hostgroup") if hostgroup.try(:root_pass).present?
+    return N_("host") if root_pass_present?
+    return N_("hostgroup") if hostgroup.try(:root_pass_present?)
     return N_("global setting") if Setting[:root_pass].present?
     nil
   end
@@ -1008,5 +1008,9 @@ autopart"', desc: 'to render the content of host partition table'
 
   def compute_resource_in_taxonomy
     validate_association_taxonomy(:compute_resource)
+  end
+
+  def root_pass_present?
+    self[:root_pass].present?
   end
 end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -197,7 +197,7 @@ class Hostgroup < ApplicationRecord
     return self[:root_pass] if self[:root_pass].present?
     npw = nested_root_pw
     return npw if npw.present?
-    Setting[:root_pass]
+    crypt_pass(Setting[:root_pass], :root)
   end
 
   def explicit_pxe_loader
@@ -249,6 +249,11 @@ class Hostgroup < ApplicationRecord
 
   def render_template(template:, **params)
     template.render(host: self, **params)
+  end
+
+  def root_pass_present?
+    return true if self[:root_pass].present?
+    nested_root_pw
   end
 
   protected

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -707,7 +707,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       facts['foreman_hostgroup'] = hostgroup.title
       post :facts, params: { :name => hostname, :facts => facts }
       assert_response :success
-      assert_equal hostgroup.root_pass, Host.find_by(:name => hostname).root_pass
+      host_pass = as_admin { Host.find_by(:name => hostname).root_pass }
+      assert_equal hostgroup.root_pass, host_pass
     end
 
     test 'when ":restrict_registered_smart_proxies" is false, HTTP requests should be able to import facts' do

--- a/test/models/hostgroup_test.rb
+++ b/test/models/hostgroup_test.rb
@@ -223,6 +223,8 @@ class HostgroupTest < ActiveSupport::TestCase
 
   test "root_pass inherited from settings if blank" do
     Setting[:root_pass] = '12345678'
+    PasswordCrypt.expects(:crypt_gnu_compatible?).at_least_once.returns(true)
+    PasswordCrypt.expects(:passw_crypt).with(Setting[:root_pass]).at_least_once.returns(Setting[:root_pass])
     hostgroup = FactoryBot.build(:hostgroup, :root_pass => '')
     assert_equal '12345678', hostgroup.root_pass
     hostgroup.save!
@@ -231,6 +233,8 @@ class HostgroupTest < ActiveSupport::TestCase
 
   test "root_pass inherited from settings if group and parent are blank" do
     Setting[:root_pass] = '12345678'
+    PasswordCrypt.expects(:crypt_gnu_compatible?).at_least_once.returns(true)
+    PasswordCrypt.expects(:passw_crypt).with(Setting[:root_pass]).at_least_once.returns(Setting[:root_pass])
     parent = FactoryBot.create(:hostgroup, :root_pass => '')
     hostgroup = FactoryBot.build(:hostgroup, :parent => parent, :root_pass => '')
     assert_equal '12345678', hostgroup.root_pass

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -184,6 +184,7 @@ class HostTemplateTest < ActiveSupport::TestCase
     test 'grub_pass helper returns the grub password if enabled' do
       @scope.instance_variable_set('@host', host)
       FactoryBot.create(:parameter, name: 'encrypt_grub', value: 'true')
+      assert host.save
       assert_equal "--iscrypted --password=#{host.grub_pass}", @scope.grub_pass
     end
 


### PR DESCRIPTION
Hosts need passwords, especially the root one for the provisioning. With the bigger amounts of hosts, hostgroups are used for handle and easily modify these attributes for hosts. Root password has special place in this chain but it isn't to great as it looks. When you're change the hostgroup for host, the root password became intanct. It makes sence for host that has own password defined but not for host that use hostgroup's password. So this PR tries to fix it.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
