### PR TITLE
Fix upgrade tests

### DIFF
--- a/db/migrate/20130520161514_add_unique_constraint_to_fact_name.rb
+++ b/db/migrate/20130520161514_add_unique_constraint_to_fact_name.rb
@@ -1,12 +1,7 @@
 class AddUniqueConstraintToFactName < ActiveRecord::Migration[4.2]
   def up
     remove_index(:fact_names, :column => :name) rescue nil
-    options = if ActiveRecord::Base.connection.instance_values["config"][:adapter].grep(/mysql/).any?
-                { :unique => true, :length => 254 }
-              else
-                { :unique => true }
-              end
-    add_index(:fact_names, :name, options)
+    add_index(:fact_names, :name, unique: true)
   end
 
   def down

--- a/db/migrate/20131021152315_change_name_index_on_fact_name.rb
+++ b/db/migrate/20131021152315_change_name_index_on_fact_name.rb
@@ -1,21 +1,11 @@
 class ChangeNameIndexOnFactName < ActiveRecord::Migration[4.2]
   def up
     remove_index :fact_names, :column => :name, :unique => true
-    options = if ActiveRecord::Base.connection.instance_values["config"][:adapter].grep(/mysql/).any?
-                { :unique => true, :length => 254 }
-              else
-                { :unique => true }
-              end
-    add_index :fact_names, [:name, :type], options
+    add_index :fact_names, [:name, :type], unique: true
   end
 
   def down
     remove_index :fact_names, [:name, :type]
-    options = if ActiveRecord::Base.connection.instance_values["config"][:adapter].grep(/mysql/).any?
-                { :unique => true, :length => 254 }
-              else
-                { :unique => true }
-              end
-    add_index :fact_names, :name, options
+    add_index :fact_names, :name, unique: true
   end
 end


### PR DESCRIPTION
With the upgrade tests starting from 1.21 now, looks like some of the checks for db adapters are now failing (specifically, the `.grep` ones). Rather than try to fix each check separately, I'm proposing to pull the whole dropping of mysql back to the stable branch. 1.21 is long out of support and will not see any releases, and no tests are being run on mysql anymore.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
