### PR TITLE
Refs #33635 - Make assert_new_button work with PF4 buttons

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -58,7 +58,7 @@ class ActionDispatch::IntegrationTest
 
   def assert_new_button(index_path, new_link_text, new_path)
     visit index_path
-    click_on new_link_text, class: 'btn'
+    click_link(new_link_text)
     assert_current_path new_path
   end
 


### PR DESCRIPTION
PF4 buttons do not have the `btn` class, making the `assert_new_button`
helper fail to properly find them.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
