### PR TITLE
Refs #33805 - clear search on host details tab switch

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/TabRouter/Tabs.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/TabRouter/Tabs.js
@@ -1,11 +1,16 @@
 import React from 'react';
 import { useHistory } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
+import { push } from 'connected-react-router';
 import PropTypes from 'prop-types';
 
 const TabsWithHashHistory = ({ tabs }) => {
   const hashHistory = useHistory();
+  const dispatch = useDispatch();
   const onSelect = (evt, tab) => {
-    hashHistory.push(`/${tab}`);
+    const hash = `/${tab}`;
+    hashHistory.push(hash);
+    dispatch(push({ search: null, hash })); // A tab component may update the url with search params which we need to clear when switching between tabs.
   };
 
   return React.cloneElement(tabs, { onSelect });


### PR DESCRIPTION
A tab component may update the URL with search params which we need to clear when switching between tabs.
The benefit here is that we could reuse existing pages that used to update the URL for table / search params
and it would still work inside a tab, e.g host details tab.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
