### PR TITLE
Fixes #33826 - Better determine if the host has a BMC interface

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -724,7 +724,7 @@ autopart"', desc: 'to render the content of host partition table'
   def bmc_available?
     ipmi = bmc_nic
     return false if ipmi.nil?
-    (ipmi.password.present? && ipmi.username.present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
+    (ipmi.password_unredacted.present? && ipmi.username.present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
   end
   alias_method :bmc_available, :bmc_available?
 

--- a/test/models/nics/bmc_test.rb
+++ b/test/models/nics/bmc_test.rb
@@ -54,7 +54,8 @@ class BMCTest < ActiveSupport::TestCase
   context 'with bmc_credentials_accessible => false' do
     setup do
       Setting[:bmc_credentials_accessible] = false
-      @bmc_nic = FactoryBot.build_stubbed(:nic_bmc, :provider => 'IPMI', :password => 'secret', :subnet => subnets(:one))
+      host = FactoryBot.build(:host, :managed)
+      @bmc_nic = FactoryBot.build_stubbed(:nic_bmc, :host => host, :provider => 'IPMI', :username => "user", :password => 'secret', :subnet => subnets(:one))
     end
 
     test 'BMC password is redacted in ENC output' do
@@ -70,6 +71,11 @@ class BMCTest < ActiveSupport::TestCase
       @bmc_nic.expects(:bmc_proxy).returns(FactoryBot.create(:bmc_smart_proxy))
       ProxyAPI::BMC.expects(:new).with(has_entry(:password => 'secret'))
       @bmc_nic.proxy
+    end
+
+    test 'the host still can find an useful BMC interface' do
+      @bmc_nic.host.expects(:bmc_nic).returns(@bmc_nic)
+      assert_equal true, @bmc_nic.host.bmc_available?
     end
   end
 


### PR DESCRIPTION
Using instead the unredacted password of the BMC interface.

See issue for more details :)
