### PR TITLE
Fixes #33842 - Make ordering by id possible for more models

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -15,6 +15,7 @@ class Architecture < ApplicationRecord
   validates :name, :presence => true, :uniqueness => true, :no_whitespace => true
 
   scoped_search :on => :name, :complete_value => :true
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
   def bootfilename_efi
     case name

--- a/app/models/auth_source.rb
+++ b/app/models/auth_source.rb
@@ -34,6 +34,7 @@ class AuthSource < ApplicationRecord
   scoped_search :relation => :organizations, :on => :id, :rename => :organization_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
   scoped_search :on => :name, :complete_value => :true
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
   # audited gem uses class variable for audied_options so once child class define auditing of these associations
   # other auth sources definitions start failing, since organization_ids_changed? method is undefined there

--- a/app/models/bookmark.rb
+++ b/app/models/bookmark.rb
@@ -18,6 +18,7 @@ class Bookmark < ApplicationRecord
 
   scoped_search :on => :controller, :complete_value => true
   scoped_search :on => :name, :complete_value => true
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
   scope :my_bookmarks, lambda {
     where(public: true).or(where(owner: User.current))

--- a/app/models/compute_attribute.rb
+++ b/app/models/compute_attribute.rb
@@ -12,6 +12,7 @@ class ComputeAttribute < ApplicationRecord
 
   delegate :provider_friendly_name, :to => :compute_resource
   scoped_search :on => [:name], :complete_value => true
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 
   scoped_search :relation => :compute_resource, :on => :name, :rename => :compute_resource, :complete_value => true
   scoped_search :relation => :compute_profile, :on => :name, :rename => :compute_profile, :complete_value => true

--- a/app/models/compute_profile.rb
+++ b/app/models/compute_profile.rb
@@ -18,6 +18,7 @@ class ComputeProfile < ApplicationRecord
   validates :name, :presence => true, :uniqueness => true
 
   scoped_search :on => :name, :complete_value => true
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   default_scope -> { order('compute_profiles.name') }
 
   scope :visibles, -> { where(:id => ComputeAttribute.select(:compute_profile_id)) }

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -40,7 +40,7 @@ class Domain < ApplicationRecord
   validates :fullname, :uniqueness => true, :allow_blank => true, :allow_nil => true
 
   scoped_search :on => [:name, :fullname], :complete_value => true
-
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   # with proc support, default_scope can no longer be chained
   # include all default scoping here
   default_scope lambda {

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -40,6 +40,7 @@ class Filter < ApplicationRecord
   scope :unlimited, -> { where(:search => nil, :taxonomy_search => nil) }
   scope :limited, -> { where("search IS NOT NULL OR taxonomy_search IS NOT NULL") }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :search, :complete_value => true
   scoped_search :on => :override, :complete_value => { :true => true, :false => false }
   scoped_search :on => :limited, :complete_value => { :true => true, :false => false }, :ext_method => :search_by_limited, :only_explicit => true

--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -28,6 +28,7 @@ class HttpProxy < ApplicationRecord
     end
   }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name
   scoped_search :on => :url
 

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -13,6 +13,7 @@ class Image < ApplicationRecord
   validates :uuid, :presence => true, :uniqueness => {:scope => :compute_resource_id}
   validate :uuid_exists?
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => [:name, :username], :complete_value => true
   scoped_search :relation => :compute_resource, :on => :name, :complete_value => :true, :rename => "compute_resource"
   scoped_search :relation => :architecture, :on => :id, :rename => "architecture", :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -7,6 +7,7 @@ class MailNotification < ApplicationRecord
   has_many :user_mail_notifications, :dependent => :destroy
   has_many :users, :through => :user_mail_notifications
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :description, :complete_value => true
   scoped_search :relation => :users, :on => :login, :complete_value => true, :rename => :user

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -33,6 +33,7 @@ class Medium < ApplicationRecord
       order("media.name")
     end
   }
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => :true, :default_order => true
   scoped_search :on => :path, :complete_value => :true
   scoped_search :on => :os_family, :rename => "family", :complete_value => :true

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -16,6 +16,7 @@ class Model < ApplicationRecord
 
   default_scope -> { order('models.name') }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => :true, :default_order => true
   scoped_search :on => :info
   scoped_search :on => :vendor_class, :complete_value => :true

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -66,6 +66,7 @@ module Nic
 
     belongs_to_host :inverse_of => :interfaces, :class_name => "Host::Base"
 
+    scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     scoped_search :on => :mac, :complete_value => true, :only_explicit => true
     scoped_search :on => :ip, :complete_value => true, :only_explicit => true
     scoped_search :on => :name, :complete_value => true, :only_explicit => true

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -46,6 +46,7 @@ class Operatingsystem < ApplicationRecord
 
   default_scope -> { order(:title) }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name,        :complete_value => :true
   scoped_search :on => :major,       :complete_value => :true
   scoped_search :on => :minor,       :complete_value => :true

--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -14,6 +14,7 @@ class Parameter < ApplicationRecord
   validate :validate_and_cast_value
   serialize :value
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :type, :complete_value => true
   scoped_search :on => :value, :complete_value => true

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -7,6 +7,7 @@ class Permission < ApplicationRecord
 
   has_many :roles, :through => :filters
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :resource_type
 

--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -6,6 +6,7 @@ class PersonalAccessToken < ApplicationRecord
 
   belongs_to :user
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name
   scoped_search :on => :user_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -37,6 +37,7 @@ class ProvisioningTemplate < Template
   # tested with scoped_search 3.2.0
   include Taxonomix
   include TemplateTax
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name,    :complete_value => true, :default_order => true
   scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}

--- a/app/models/ptable.rb
+++ b/app/models/ptable.rb
@@ -36,6 +36,7 @@ class Ptable < Template
   # tested with scoped_search 3.2.0
   include Taxonomix
   include TemplateTax
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name,    :complete_value => true, :default_order => true
   scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -21,6 +21,7 @@ class Realm < ApplicationRecord
   has_many_hosts
   has_many :hostgroups
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :realm_type, :complete_value => true, :rename => :type
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -41,6 +41,7 @@ class Report < ApplicationRecord
       scoped_search :on => :reported_at, :complete_value => true, :default_order => :desc, :rename => :reported, :only_explicit => true, :aliases => [:last_report]
       scoped_search :on => :host_id, :complete_value => false, :only_explicit => true
       scoped_search :on => :origin
+      scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
     end
     super
   end

--- a/app/models/report_template.rb
+++ b/app/models/report_template.rb
@@ -18,6 +18,7 @@ class ReportTemplate < Template
   validates :name, :uniqueness => true
 
   include Taxonomix
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name,    :complete_value => true, :default_order => true
   scoped_search :on => :locked,  :complete_value => {:true => true, :false => false}
   scoped_search :on => :snippet, :complete_value => {:true => true, :false => false}

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -73,6 +73,7 @@ class Role < ApplicationRecord
   validates :name, :presence => true, :uniqueness => true
   validates :builtin, :inclusion => { :in => 0..2 }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :builtin, :complete_value => { :true => true, :false => false }
   scoped_search :on => :description, :complete_value => false

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -64,6 +64,7 @@ class Setting < ApplicationRecord
 
   scope :order_by, ->(attr) { except(:order).order(attr) }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search on: :name, complete_value: :true, operators: ['=']
   scoped_search on: :description, complete_value: :true, operators: ['~']
 

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -28,6 +28,7 @@ class SmartProxy < ApplicationRecord
   # There should be no problem with associating features before the proxy is saved as the whole operation is in a transaction
   before_save :sanitize_url, :associate_features
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => :true
   scoped_search :on => :url, :complete_value => :true
   scoped_search :relation => :features, :on => :name, :rename => :feature, :complete_value => :true

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -9,6 +9,7 @@ class SshKey < ApplicationRecord
   before_validation :generate_fingerprint
   before_validation :calculate_length
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name
   scoped_search :on => :user_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
 

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -114,6 +114,7 @@ class Subnet < ApplicationRecord
     end
   }
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => [:name, :network, :mask, :gateway, :dns_primary, :dns_secondary,
                         :vlanid, :mtu, :nic_delay, :ipam, :boot_mode, :type], :complete_value => true
 

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -19,6 +19,7 @@ class TemplateInput < ApplicationRecord
 
   belongs_to :template
   before_destroy :prevent_delete_if_template_is_locked
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => true
   scoped_search :on => :input_type, :complete_value => true
 

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -5,6 +5,7 @@ class TemplateKind < ApplicationRecord
   has_many :provisioning_templates, :inverse_of => :template_kind
   has_many :os_default_templates
   validates :name, :presence => true, :uniqueness => true
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name
 
   PXE = ["PXEGrub2", "PXELinux", "PXEGrub", "iPXE"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -118,6 +118,7 @@ class User < ApplicationRecord
   after_create :welcome_mail
   after_create :set_default_widgets
 
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :login, :complete_value => :true
   scoped_search :on => :firstname, :complete_value => :true
   scoped_search :on => :lastname, :complete_value => :true

--- a/app/models/usergroup.rb
+++ b/app/models/usergroup.rb
@@ -35,6 +35,7 @@ class Usergroup < ApplicationRecord
   default_scope -> { order('usergroups.name') }
   scope :visible, -> {}
   scope :except_current, ->(current) { where.not(:id => current.id) }
+  scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => :true
   scoped_search :relation => :roles, :on => :name, :rename => :role, :complete_value => true
   scoped_search :relation => :roles, :on => :id, :rename => :role_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER


### PR DESCRIPTION
Not sure if I added for all models, but mainly for those which have scoped search by name. I'm adding this due to an old BZ [1]. The BZ is more about wrong description of --order option in hammer, but since the description comes from the API docs I've decided to look whether we even have possibility to order users by id, which we don't.

[1] - https://bugzilla.redhat.com/show_bug.cgi?id=1881668