### PR TITLE
Fixes #32602 - enables puppet 7 agent support

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -22,6 +22,7 @@ description: |
   - enable-puppetlabs-repo: boolean (default=false)
   - enable-puppetlabs-puppet5-repo: boolean (default=false)
   - enable-puppetlabs-puppet6-repo: boolean (default=false)
+  - enable-puppetoffical-puppet7-repo: boolean (default=false)
 -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -61,17 +62,12 @@ runcmd:
 <%= indent(2) { snippet 'chef_client' } %>
 <% end -%>
 - |
-<%=
-  if puppet_enabled && (host_param_true?('enable-puppetlabs-repo') ||
-    host_param_true?('enable-puppetlabs-puppet6-repo') ||
-    host_param_true?('enable-puppetlabs-puppet5-repo'))
-    indent(2) { snippet 'puppetlabs_repo' }
-  elsif puppet_enabled
-    indent(2) { snippet('puppet_setup', :variables => { :full_puppet_run => true }) }
-  else
-    ''
-  end
--%>
+<% if puppet_enabled %>
+<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<%= indent(2) { snippet 'puppetlabs_repo' } %>
+<% end -%>
+<%= indent(2) { snippet 'puppet_setup' } %>
+<% end -%>
 phone_home:
   url: <%= foreman_url('built') %>
   post: []

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -77,7 +77,7 @@ fi
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -54,7 +54,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -253,10 +253,12 @@ rm /etc/resolv.conf
   <% end -%>
 <% end -%>
 <% if puppet_enabled -%>
-<% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%
   puppet_repo_url_base = 'http://yum.puppet.com'
-  if host_param_true?('enable-puppetlabs-puppet6-repo')
+  if host_param_true?('enable-puppetofficial-puppet7-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet7/sles/#{os_major}/#{@host.architecture}/"
+  elsif host_param_true?('enable-puppetlabs-puppet6-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet6/sles/#{os_major}/#{@host.architecture}/"
   elsif host_param_true?('enable-puppetlabs-puppet5-repo')
     puppet_repo_url = "#{puppet_repo_url_base}/puppet5/sles/#{os_major}/#{@host.architecture}/"

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -305,7 +305,7 @@ fi
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')|| host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')|| host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -12,7 +12,7 @@ description: |
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+  aio_enabled = host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppet7') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -16,7 +16,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+aio_enabled = host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppet7') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
 
 if os_family == 'Freebsd'
   freebsd_package = host_param_true?('enable-puppet6') ? 'puppet6' : 'puppet5'
@@ -48,7 +48,7 @@ else
   yum -t -y install <%= linux_package %>
 fi
 <% elsif os_family == 'Suse' -%>
-<% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetofficial-puppet7-repo') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 rpmkeys --import http://yum.puppet.com/RPM-GPG-KEY-puppetlabs
 rpmkeys --import http://yum.puppet.com/RPM-GPG-KEY-puppet
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -39,6 +39,9 @@ end
 if host_param_true?('enable-puppetlabs-repo')
   repo_name = 'puppet-release'
   repo_subdir = ''
+elsif host_param_true?('enable-puppetofficial-puppet7-repo')
+  repo_name = 'puppet7-release'
+  repo_subdir = 'puppet7/'
 elsif host_param_true?('enable-puppetlabs-puppet6-repo')
   repo_name = 'puppet6-release'
   repo_subdir = 'puppet6/'

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -31,7 +31,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet "blacklist_kernel_modules" %>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetofficials-puppet7-repo') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -63,7 +63,7 @@ fi
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -44,7 +44,7 @@ echo 'Acquire::http::Proxy "<%= proxy_uri %>";' >> /etc/apt/apt.conf
 <% end -%>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-puppetofficial-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -43,15 +43,12 @@ runcmd:
 
 - |
 - |
+
   apt-get update
-  apt-get install -y puppet
+  apt-get install -y puppet-agent
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -61,17 +58,13 @@ runcmd:
   EOF
   
   
-  if [ -f "/etc/default/puppet" ]
-  then
-  /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-  fi
-  /usr/bin/puppet agent --enable
   
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
   systemctl enable puppet
+
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built
   post: []

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -44,18 +44,15 @@ runcmd:
 
 - |
 - |
+
   if [ -f /usr/bin/dnf ]; then
-    dnf -y install puppet
+    dnf -y install puppet-agent
   else
-    yum -t -y install puppet
+    yum -t -y install puppet-agent
   fi
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -72,7 +69,8 @@ runcmd:
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built
   post: []

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -43,15 +43,12 @@ runcmd:
 
 - |
 - |
+
   apt-get update
-  apt-get install -y puppet
+  apt-get install -y puppet-agent
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -61,17 +58,13 @@ runcmd:
   EOF
   
   
-  if [ -f "/etc/default/puppet" ]
-  then
-  /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-  fi
-  /usr/bin/puppet agent --enable
   
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
   systemctl enable puppet
+
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built
   post: []

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -20,10 +20,6 @@ apt-get -y install puppet >/dev/null 2>/dev/null
 
 cat > /etc/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
@@ -25,17 +25,13 @@ pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -52,7 +48,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -43,17 +43,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -70,7 +66,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -10,14 +10,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -27,16 +23,11 @@ certname        = snapshot-ipv4-dhcp-deb10
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -10,14 +10,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -27,16 +23,11 @@ certname        = snapshot-ipv4-dhcp-ubuntu20
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -95,17 +95,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -122,7 +118,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -97,17 +97,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -124,7 +120,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -105,17 +105,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -132,7 +128,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -105,17 +105,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -132,7 +128,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -105,17 +105,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -132,7 +128,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -105,17 +105,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -132,7 +128,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -105,17 +105,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -132,7 +128,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
@@ -1,8 +1,4 @@
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
@@ -1,15 +1,11 @@
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -26,4 +22,4 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -23,18 +23,15 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 
+
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -51,7 +48,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -53,17 +53,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -80,7 +76,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -28,14 +28,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -45,16 +41,11 @@ certname        = snapshot-ipv4-dhcp-deb10
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -28,14 +28,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -45,16 +41,11 @@ certname        = snapshot-ipv4-dhcp-ubuntu20
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -28,17 +28,13 @@ runcmd:
 
 - |
   if [ -f /usr/bin/dnf ]; then
-    dnf -y install puppet
+    dnf -y install puppet-agent
   else
-    yum -t -y install puppet
+    yum -t -y install puppet-agent
   fi
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -55,7 +51,7 @@ runcmd:
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 phone_home:


### PR DESCRIPTION
Update puppet_setup.erb

Fix typos

Update cloud_init_default.erb

Fixing if statement. The way it was it would only add the repo OR do the puppet setup OR do nothing. This way works and is the same as the kickstart default finish template.

Fixes #33034 - add a description to all provisioning templates

This PR udpates all the templates metadata to provide at least minimal
description that is then stored in the DB and shown in the edit form.

Co-authored-by: Timo Goebel <mail@timogoebel.name>
Co-authored-by: Lukas Zapletal <lzap@redhat.com>

Fixes #32602 - enables puppet 7 agent support


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
