### PR TITLE
Fixes #33861 - add default type for DB settings

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -195,7 +195,7 @@ class SettingRegistry
   def _load_category_from_db(category_klass)
     category_klass.all.each do |set|
       # set.value can be user value, we have no way of telling the initial value
-      _add(set.name, type: set.settings_type&.to_sym, category: category_klass.name, description: set.description, default: set.default, full_name: set.try(:full_name), context: :deprecated, encrypted: set.try(:encrypted))
+      _add(set.name, type: (set.settings_type || 'string').to_sym, category: category_klass.name, description: set.description, default: set.default, full_name: set.try(:full_name), context: :deprecated, encrypted: set.try(:encrypted))
     end
   end
 end


### PR DESCRIPTION
This is mainly issue in 3.0.
I do not know how many settings have `nil` type, but I'd rather get the fix in 3.0 as quickly as possible

https://community.theforeman.org/t/foreman-upgrade-error-nomethoderror-undefined-method-to-sym-for-nil-nilclass/25449