### PR TITLE
Fixes #33862 - add empty state for new host page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -547,5 +547,6 @@ Foreman::Application.routes.draw do
   constraints(id: /[^\/]+/) do
     match 'new/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
   end
+  get 'page-not-found' => 'react#index'
   get 'links/:type(/:section)' => 'links#show', :as => 'external_link', :constraints => { section: %r{.*} }
 end

--- a/webpack/assets/javascripts/react_app/components/HostDetails/EmptyState/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/EmptyState/index.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Redirect } from 'react-router-dom';
+import { translate as __, sprintf } from '../../../common/I18n';
+import { foremanUrl } from '../../../common/helpers';
+
+const RedirectToEmptyHostPage = ({ hostname }) => (
+  <Redirect
+    to={{
+      pathname: '/page-not-found',
+      state: {
+        refresh: true,
+        header: __('No host found'),
+        body: sprintf(
+          __(
+            `The host %s does not exist or there are access permissions needed. Please contact your administrator if this issue continues.`
+          ),
+          hostname
+        ),
+        action: {
+          title: __('All hosts'),
+          url: foremanUrl('/hosts'),
+        },
+        secondayActions: [
+          {
+            title: __('Create a host'),
+            url: foremanUrl('/hosts/new'),
+          },
+        ],
+      },
+    }}
+  />
+);
+
+RedirectToEmptyHostPage.propTypes = {
+  hostname: PropTypes.string.isRequired,
+};
+
+export default RedirectToEmptyHostPage;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/consts.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/consts.js
@@ -1,4 +1,4 @@
 export const DEFAULT_TAB = 'Overview';
 export const HOST_DETAILS_KEY = 'HOST_DETAILS';
 export const HOST_DETAILS_API_OPTIONS = { key: HOST_DETAILS_KEY };
-export const TABS_SLOT_ID = 'host-details-page-tabs'
+export const TABS_SLOT_ID = 'host-details-page-tabs';

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -40,6 +40,7 @@ import './HostDetails.scss';
 import { useAPI } from '../../common/hooks/API/APIHooks';
 import TabRouter from './Tabs/TabRouter';
 import ExperimentalAlert from './ExperimentalAlert';
+import RedirectToEmptyHostPage from './EmptyState';
 
 const HostDetails = ({
   match: {
@@ -79,6 +80,7 @@ const HostDetails = ({
       .split('?')[0] // Remove query params
   );
 
+  if (status === STATUS.ERROR) return <RedirectToEmptyHostPage hostname={id} />;
   return (
     <>
       <PageSection

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
@@ -30,6 +30,11 @@ exports[`Routes rendering routes with children renders routes with chidlren 1`] 
       path="/host_statuses"
       render={[Function]}
     />
+    <Route
+      key="/page-not-found"
+      path="/page-not-found"
+      render={[Function]}
+    />
   </ForemanSwitcher>
   <div
     id="router-child"

--- a/webpack/assets/javascripts/react_app/routes/common/EmptyPage/RedirectedEmptyPage.js
+++ b/webpack/assets/javascripts/react_app/routes/common/EmptyPage/RedirectedEmptyPage.js
@@ -1,0 +1,83 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Button } from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
+import { SearchIcon } from '@patternfly/react-icons';
+import { translate as __ } from '../../../common/I18n';
+import { visit } from '../../../../foreman_navigation';
+import { EmptyStatePattern } from '../../../components/common/EmptyState';
+
+const RedirectedEmptyPage = ({ location: { state = {} } }) => {
+  const {
+    location: { state: defaultState },
+  } = RedirectedEmptyPage.defaultProps;
+  const {
+    header = defaultState.header,
+    body = defaultState.body,
+    action,
+    secondayActions,
+    refresh = defaultState.refresh,
+  } = state;
+  const history = useHistory();
+  const primaryAction = action && (
+    <Button onClick={() => visit(action.url)} variant="primary">
+      {action.title}
+    </Button>
+  );
+  const renderSecondaryActions = () =>
+    secondayActions?.map(({ title, url }) => (
+      <Button key={title} onClick={() => visit(url)} variant="link">
+        {title}
+      </Button>
+    ));
+
+  const refreshButton = refresh && (
+    <Button onClick={() => history.goBack()} variant="link">
+      {__('Return to the last page')}
+    </Button>
+  );
+
+  return (
+    <EmptyStatePattern
+      header={header}
+      variant="xl"
+      icon={<SearchIcon />}
+      action={primaryAction}
+      description={body}
+      secondaryActions={
+        <>
+          {renderSecondaryActions()}
+          {refreshButton}
+        </>
+      }
+    />
+  );
+};
+
+RedirectedEmptyPage.propTypes = {
+  location: PropTypes.shape({
+    state: PropTypes.shape({
+      header: PropTypes.string,
+      refresh: PropTypes.bool,
+      body: PropTypes.string,
+      action: PropTypes.object,
+      secondayActions: PropTypes.array,
+    }),
+  }),
+};
+
+RedirectedEmptyPage.defaultProps = {
+  location: {
+    state: {
+      refresh: true,
+      header: __('Resource not found'),
+      body: __(
+        'Something went wrong and the resource does not exist or there are access permissions needed. Please, contact your administrator if this issue continues'
+      ),
+      action: undefined,
+      secondayActions: [],
+    },
+  },
+};
+
+export default RedirectedEmptyPage;

--- a/webpack/assets/javascripts/react_app/routes/common/EmptyPage/route.js
+++ b/webpack/assets/javascripts/react_app/routes/common/EmptyPage/route.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import RedirectedEmptyPage from './RedirectedEmptyPage';
+
+const EMPTY_PAGE = '/page-not-found';
+export default {
+  path: EMPTY_PAGE,
+  render: props => <RedirectedEmptyPage {...props} />,
+};

--- a/webpack/assets/javascripts/react_app/routes/routes.js
+++ b/webpack/assets/javascripts/react_app/routes/routes.js
@@ -3,6 +3,7 @@ import Models from './Models';
 import HostDetails from './HostDetails';
 import RegistrationCommands from './RegistrationCommands';
 import HostStatuses from './HostStatuses';
+import EmptyPage from './common/EmptyPage/route';
 
 export const routes = [
   Audits,
@@ -10,4 +11,5 @@ export const routes = [
   HostDetails,
   RegistrationCommands,
   HostStatuses,
+  EmptyPage,
 ];


### PR DESCRIPTION
The new host page lacks an empty state, if no host found / no suitable permissions the UI should render an empty state page.