### PR TITLE
Fixes #33801 - Replace obsolete URI.escape method

### DIFF
--- a/lib/proxy_api/bmc.rb
+++ b/lib/proxy_api/bmc.rb
@@ -50,7 +50,8 @@ module ProxyAPI
       case args[:action]
       when "on?", "off?", "status"
         args[:action].chop! if args[:action].include?('?')
-        response = parse(get(bmc_url_for_get('power', args[:action]), args))
+        full_path_as_hash = bmc_url_for_get('power', args[:action])
+        response = parse(get(full_path_as_hash[:path], query: full_path_as_hash[:query]))
         response.is_a?(Hash) ? response['result'] : response
       when "on", "off", "cycle", "soft"
         res = parse put(with_provider(args), bmc_url_for('power', args[:action]))
@@ -70,7 +71,8 @@ module ProxyAPI
       # put "/bmc/:host/chassis/identify/:action"
       case args[:action]
       when "status"
-        parse get(bmc_url_for_get('identify', args[:action]), args)
+        full_path_as_hash = bmc_url_for_get('identify', args[:action])
+        parse get(full_path_as_hash[:path], query: full_path_as_hash[:query])
       when "on", "off"
         parse put(with_provider(args), bmc_url_for('identify', args[:action]))
       else
@@ -87,7 +89,8 @@ module ProxyAPI
       # get "/bmc/:host/lan/:action"
       case args[:action]
       when "ip", "netmask", "mac", "gateway"
-        response = parse(get(bmc_url_for_get('lan', args[:action]), args))
+        full_path_as_hash = bmc_url_for_get('lan', args[:action])
+        response = parse(get(full_path_as_hash[:path], query: full_path_as_hash[:query]))
         response.is_a?(Hash) ? response['result'] : response
       else
         raise NoMethodError
@@ -111,9 +114,9 @@ module ProxyAPI
 
     def bmc_url_for_get(controller, action)
       if @provider
-        "#{bmc_url_for(controller, action)}?bmc_provider=#{@provider}"
+        {path: bmc_url_for(controller, action).to_s, query: { bmc_provider: @provider } }
       else
-        bmc_url_for(controller, action)
+        {path: bmc_url_for(controller, action) }
       end
     end
 

--- a/lib/proxy_api/dhcp.rb
+++ b/lib/proxy_api/dhcp.rb
@@ -29,11 +29,11 @@ module ProxyAPI
         params[:to] = subnet.to
       end
       if params.any?
-        params = "?" + params.map { |e| e.join("=") }.join("&")
+        params = params.map { |e| e.join("=") }.join("&")
       else
         params = ""
       end
-      parse get("#{subnet.network}/unused_ip#{params}")
+      parse get("#{subnet.network}/unused_ip", query: params)
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to retrieve unused IP"))
     end

--- a/lib/proxy_api/external_ipam.rb
+++ b/lib/proxy_api/external_ipam.rb
@@ -63,7 +63,7 @@ module ProxyAPI
     #     {"error": "Unable to connect to External IPAM server"}
     def next_ip(subnet, mac, group = "")
       raise "subnet cannot be nil" if subnet.nil?
-      response = parse get("/subnet/#{subnet}/next_ip?mac=#{mac}&group=#{URI.escape(group.to_s)}")
+      response = parse get("/subnet/#{subnet}/next_ip", query: { mac: mac, group: group})
       raise(response['error']) if response['error'].present?
       response['data']
     rescue => e
@@ -95,7 +95,7 @@ module ProxyAPI
     def add_ip_to_subnet(ip, subnet, group = "")
       raise "subnet cannot be nil" if subnet.nil?
       raise "ip cannot be nil" if ip.nil?
-      response = parse post({}, "/subnet/#{subnet}/#{ip}?group=#{URI.escape(group.to_s)}")
+      response = parse post({}, "/subnet/#{subnet}/#{ip}?group=#{CGI.escape(group.to_s)}")
       raise(response['error']) if response.is_a?(Hash) && response['error'].present?
       response
     rescue => e
@@ -145,7 +145,7 @@ module ProxyAPI
     #     {"error": "Unable to connect to External IPAM server"}
     def get_group(group)
       raise "group must be provided" if group.blank?
-      response = parse get("/groups/#{URI.escape(group)}")
+      response = parse get("/groups/#{CGI.escape(group)}")
       raise(response['error']) if response['error'].present?
       response
     rescue => e
@@ -172,7 +172,7 @@ module ProxyAPI
     #     {"error": "Unable to connect to External IPAM"}
     def get_subnets_by_group(group)
       raise "group must be provided" if group.blank?
-      response = parse get("/groups/#{URI.escape(group)}/subnets")
+      response = parse get("/groups/#{CGI.escape(group)}/subnets")
       raise(response['error']) if response.is_a?(Hash) && response['error'].present?
       response
     rescue => e
@@ -196,7 +196,7 @@ module ProxyAPI
     #     {"error": "Unable to connect to External IPAM server"}
     def get_subnet(subnet, group = "")
       raise "subnet cannot be nil" if subnet.nil?
-      response = parse get("/subnet/#{subnet}?group=#{URI.escape(group.to_s)}")
+      response = parse get("/subnet/#{subnet}", query: {group: group})
       raise(response['error']) if response['error'].present?
       response
     rescue => e
@@ -226,7 +226,7 @@ module ProxyAPI
     def ip_exists(ip, subnet, group = "")
       raise "subnet cannot be nil" if subnet.nil?
       raise "ip cannot be nil" if ip.nil?
-      response = parse get("/subnet/#{subnet}/#{ip}?group=#{URI.escape(group.to_s)}")
+      response = parse get("/subnet/#{subnet}/#{ip}", query: {group: group })
       raise(response['error']) if response.is_a?(Hash) && response['error'].present?
       response
     rescue => e
@@ -254,7 +254,7 @@ module ProxyAPI
     def delete_ip_from_subnet(ip, subnet, group = "")
       raise "subnet cannot be nil" if subnet.nil?
       raise "ip cannot be nil" if ip.nil?
-      response = parse delete("/subnet/#{subnet}/#{ip}?group=#{URI.escape(group.to_s)}")
+      response = parse delete("/subnet/#{subnet}/#{ip}?group=#{CGI.escape(group.to_s)}")
       raise(response['error']) if response.is_a?(Hash) && response['error'].present?
       response
     rescue => e

--- a/lib/proxy_api/logs.rb
+++ b/lib/proxy_api/logs.rb
@@ -6,7 +6,7 @@ module ProxyAPI
     end
 
     def all(from = 0)
-      parse(get("?from_timestamp=#{from}"))
+      parse(get("", query: { from_timestamp: from }))
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to fetch logs"))
     end

--- a/test/unit/proxy_api/bmc_test.rb
+++ b/test/unit/proxy_api/bmc_test.rb
@@ -142,27 +142,27 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
 
   test "power function should create correct url for off?" do
     action = "off"
-    expected_path = "/127.0.0.1/chassis/power/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/chassis/power/#{action}"
+    query = { bmc_provider: "a_provider"}
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.power_off?(@options)
   end
   test "power function should create correct url for on?" do
     action = "on"
-    expected_path = "/127.0.0.1/chassis/power/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/chassis/power/#{action}"
+    query = { bmc_provider: "a_provider" }
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.power_on?(@options)
   end
 
   test "power function should create correct url for status" do
     action = "status"
-    expected_path = "/127.0.0.1/chassis/power/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/chassis/power/#{action}"
+    query = { bmc_provider: "a_provider" }
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.power_status(@options)
   end
 
@@ -185,46 +185,46 @@ class ProxyApiBmcTest < ActiveSupport::TestCase
 
   test "identify function should create correct url for status" do
     action = "status"
-    expected_path = "/127.0.0.1/chassis/identify/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/chassis/identify/#{action}"
+    query = { bmc_provider: "a_provider" }
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.identify_status(@options)
   end
 
   test "lan function should create correct url for ip" do
     action = "ip"
-    expected_path = "/127.0.0.1/lan/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/lan/#{action}"
+    query = {bmc_provider: "a_provider" }
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.lan_ip(@options)
   end
 
   test "lan function should create correct url for netmask" do
     action = "netmask"
-    expected_path = "/127.0.0.1/lan/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/lan/#{action}"
+    query = { bmc_provider: "a_provider"}
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.lan_netmask(@options)
   end
 
   test "lan function should create correct url for gateway" do
     action = "gateway"
-    expected_path = "/127.0.0.1/lan/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/lan/#{action}"
+    query = {bmc_provider: "a_provider" }
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.lan_gateway(@options)
   end
 
   test "lan function should create correct url for mac" do
     action = "mac"
-    expected_path = "/127.0.0.1/lan/#{action}?bmc_provider=a_provider"
-    data = @options.merge({:action => action})
+    path = "/127.0.0.1/lan/#{action}"
+    query = { bmc_provider: "a_provider" }
     @testbmc.stubs(:get).returns(fake_rest_client_response(["fakedata"]))
-    @testbmc.expects(:get).with(expected_path, data).at_least_once
+    @testbmc.expects(:get).with(path, query: query).at_least_once
     @testbmc.lan_mac(@options)
   end
 

--- a/test/unit/proxy_api/dhcp_test.rb
+++ b/test/unit/proxy_api/dhcp_test.rb
@@ -71,7 +71,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:network).returns('192.168.0.0')
     subnet_mock.expects(:from).returns(nil)
 
-    proxy_dhcp.expects(:get).with('192.168.0.0/unused_ip').returns(fake_rest_client_response({:ip => '192.168.0.50'}))
+    proxy_dhcp.expects(:get).with('192.168.0.0/unused_ip', {query: ""}).returns(fake_rest_client_response({:ip => '192.168.0.50'}))
     assert_equal({'ip' => '192.168.0.50'}, proxy_dhcp.unused_ip(subnet_mock))
   end
 
@@ -87,12 +87,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:from).at_least_once.returns(from_mock)
     subnet_mock.expects(:to).at_least_once.returns(to_mock)
 
-    proxy_dhcp.expects(:get).with() do |path|
-      # Params built with a hash, so order can change
-      path.include?('192.168.0.0/unused_ip?') &&
-        path.include?('from=192.168.0.50') &&
-        path.include?('to=192.168.0.150')
-    end.returns(fake_rest_client_response({:ip => '192.168.0.50'}))
+    proxy_dhcp.expects(:get).with("192.168.0.0/unused_ip", { query: "from=192.168.0.50&to=192.168.0.150"}).returns(fake_rest_client_response({:ip => '192.168.0.50'}))
     assert_equal({'ip' => '192.168.0.50'}, proxy_dhcp.unused_ip(subnet_mock))
   end
 
@@ -101,7 +96,7 @@ class ProxyApiDhcpTest < ActiveSupport::TestCase
     subnet_mock.expects(:network).returns('192.168.0.0')
     subnet_mock.expects(:from).returns(nil)
 
-    proxy_dhcp.expects(:get).with('192.168.0.0/unused_ip?mac=00:11:22:33:44:55').returns(fake_rest_client_response({:ip => '192.168.0.50'}))
+    proxy_dhcp.expects(:get).with('192.168.0.0/unused_ip', { query: "mac=00:11:22:33:44:55"}).returns(fake_rest_client_response({:ip => '192.168.0.50'}))
     assert_equal({'ip' => '192.168.0.50'}, proxy_dhcp.unused_ip(subnet_mock, '00:11:22:33:44:55'))
   end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
