### PR TITLE
Fixes #33882 - refresh host's global status after clearing a sub status

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -328,6 +328,7 @@ class HostsController < ApplicationController
   def forget_status
     status = @host.host_statuses.find(params[:status])
     status.delete
+    @host.refresh_global_status!
     respond_to do |format|
       format.html do
         redirect_to host_path(@host)

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1049,6 +1049,15 @@ class HostsControllerTest < ActionController::TestCase
     refute host.host_statuses.include?(status)
   end
 
+  test "#forget_status refresh the global state" do
+    host = FactoryBot.create(:host, :managed)
+    failed_status = ::HostStatus::BuildStatus.create!(host_id: host.id)
+    failed_status.stubs(:to_global).returns(2)
+    failed_status.stubs(:relevant?).returns(true)
+    post :forget_status, params: {:id => host.id, :status => failed_status.id}, session: set_session_user
+    assert_equal 0, host.global_status
+  end
+
   test "#disassociate shows error when used on non-CR host" do
     host = FactoryBot.create(:host)
     @request.env["HTTP_REFERER"] = hosts_path

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusActions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusActions.js
@@ -1,6 +1,16 @@
 import { APIActions } from '../../../redux/API';
-import { HOST_STATUSES_KEY } from './Constants';
+import { HOST_STATUSES_KEY, CLEAR_STATUS_KEY } from './Constants';
 import { foremanUrl } from '../../../common/helpers';
+
+const getStatuses = hostName => dispatch => {
+  const url = foremanUrl(`/hosts/${hostName}/statuses`);
+  dispatch(
+    APIActions.get({
+      url,
+      key: HOST_STATUSES_KEY,
+    })
+  );
+};
 
 export const forgetStatus = (hostName, { label, id }) => dispatch => {
   const successToast = () => `Status ${label} has been removed`;
@@ -9,13 +19,10 @@ export const forgetStatus = (hostName, { label, id }) => dispatch => {
   dispatch(
     APIActions.post({
       url: foremanUrl(url),
-      key: HOST_STATUSES_KEY,
+      key: CLEAR_STATUS_KEY,
       successToast,
       errorToast,
-      updateData: prevState => ({
-        ...prevState,
-        statuses: prevState.statuses.filter(status => status.id !== id),
-      }),
+      handleSuccess: () => dispatch(getStatuses(hostName)),
     })
   );
 };


### PR DESCRIPTION
After clearing a status, the global should be refreshed as well, so the consistency keeps.