### PR TITLE
Fixes #33887 - recache after initialization

### DIFF
--- a/config/initializers/fix_cache.rb
+++ b/config/initializers/fix_cache.rb
@@ -1,4 +1,6 @@
 # if fix db cache flag is enabled and we are not running rake task, we want to
 # recreate cache
 
-CacheManager.recache! if !Foreman.in_rake? && Setting['fix_db_cache']
+Rails.application.config.after_initialize do
+  CacheManager.recache! if !Foreman.in_rake? && Setting['fix_db_cache']
+end


### PR DESCRIPTION
We want to postpone Constant loading after_initialization.
This also allows setting to be loaded after initialization takes off the stress for it to be loaded early.