### PR TITLE
Fixes #33894 - Decode string when setting active tab on host details page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -66,6 +66,8 @@ const HostDetails = ({
     registerCoreTabs();
   }, []);
 
+  const activeTab = decodeURI(hash.slice(2).split('/')[0]);
+
   return (
     <>
       <PageSection
@@ -161,7 +163,7 @@ const HostDetails = ({
               style={{
                 width: window.innerWidth - (isNavCollapsed ? 95 : 220),
               }}
-              activeKey={hash.slice(2).split('/')[0]}
+              activeKey={activeTab}
             >
               {tabs.map(tab => (
                 <Tab key={tab} eventKey={tab} title={tab} />


### PR DESCRIPTION
If the name of a tab (including tabs added by plugins) contains a space, the `activeKey` prop of the `<Tabs>` component was being set to the URI-escaped string, e.g. `Repository%20Sets`. The result is that the tab does not show as active.

This uses `decodeURI` to make sure that the string and tab name will match.

