### PR TITLE
Update RuboCop action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Run rubocop
-        run: bundle exec rubocop -P
+        run: bundle exec rubocop --parallel --format github

--- a/lib/proxy_api.rb
+++ b/lib/proxy_api.rb
@@ -3,4 +3,5 @@ require "json"
 require "uri"
 
 module ProxyAPI
+  #this is invalid according to RuboCop
 end


### PR DESCRIPTION
This uses Ruby 2.7 for RuboCop. That should be slightly faster.

It also switches to the GitHub formatter which adds code annotations.