### PR TITLE
Fixes #33736 - Allow 2 search with bookmark in one page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/Bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/Bookmarks.test.js
@@ -4,6 +4,7 @@ import Bookmarks from '../Bookmarks';
 import { STATUS } from '../../../constants';
 
 const commonFixture = {
+  id: 'architectures',
   controller: 'architectures',
   onBookmarkClick: () => {},
   url: '/api/v2/architectures',

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/__tests__/__snapshots__/Bookmarks.test.js.snap
@@ -13,6 +13,7 @@ exports[`Bookmarks should render bookmarks dropdown when loaded 1`] = `
       ]
     }
     controller="architectures"
+    id=""
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
     title="Create Bookmark"
@@ -110,6 +111,7 @@ exports[`Bookmarks should render bookmarks dropdown when loading 1`] = `
   <SearchModal
     bookmarks={Array []}
     controller="architectures"
+    id=""
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
     title="Create Bookmark"
@@ -212,6 +214,7 @@ exports[`Bookmarks should render when no bookmarks loaded 1`] = `
   <SearchModal
     bookmarks={Array []}
     controller="architectures"
+    id=""
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
     title="Create Bookmark"
@@ -312,6 +315,7 @@ exports[`Bookmarks should show error 1`] = `
   <SearchModal
     bookmarks={Array []}
     controller="architectures"
+    id=""
     onEnter={[Function]}
     setModalClosed={[MockFunction]}
     title="Create Bookmark"

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/index.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/BookmarkForm/index.js
@@ -3,10 +3,10 @@ import BookmarkForm from './BookmarkForm';
 import { submitForm } from '../../../../redux/actions/common/forms';
 import { selectAutocompleteSearchQuery } from '../../../AutoComplete/AutoCompleteSelectors';
 
-const mapStateToProps = (state, { controller }) => ({
+const mapStateToProps = (state, { controller, id = 'searchBar' }) => ({
   initialValues: {
     public: true,
-    query: selectAutocompleteSearchQuery(state, 'searchBar', { controller }),
+    query: selectAutocompleteSearchQuery(state, id, { controller }),
   },
 });
 

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/SearchModal.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/SearchModal.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ForemanModal from '../../ForemanModal';
-import { BOOKMARKS_MODAL } from '../BookmarksConstants';
 import { translate as __ } from '../../../common/I18n';
 import { noop } from '../../../common/helpers';
 import BookmarkForm from './BookmarkForm';
+import { getBookmarksModalId } from '../../PF4/Bookmarks/BookmarksHelpers';
 
 const SearchModal = ({
+  id,
   setModalClosed,
   onEnter,
   title,
@@ -15,12 +16,13 @@ const SearchModal = ({
   bookmarks,
 }) => (
   <ForemanModal
-    id={BOOKMARKS_MODAL}
+    id={getBookmarksModalId(id)}
     title={title}
     enforceFocus
     onEnter={onEnter}
   >
     <BookmarkForm
+      id={id}
       controller={controller}
       url={url}
       setModalClosed={setModalClosed}
@@ -31,6 +33,7 @@ const SearchModal = ({
 );
 
 SearchModal.propTypes = {
+  id: PropTypes.string,
   controller: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   title: PropTypes.string,
@@ -40,6 +43,7 @@ SearchModal.propTypes = {
 };
 
 SearchModal.defaultProps = {
+  id: '',
   title: __('Create Bookmark'),
   onEnter: noop,
   bookmarks: [],

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/__tests__/SearchModal.test.js
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/__tests__/SearchModal.test.js
@@ -3,6 +3,7 @@ import { testComponentSnapshotsWithFixtures } from '@theforeman/test';
 import SearchModal from '../SearchModal';
 
 const props = {
+  id: 'hosts',
   controller: 'hosts',
   url: '/api/bookmarks',
   title: 'Create Bookmark',

--- a/webpack/assets/javascripts/react_app/components/Bookmarks/components/__tests__/__snapshots__/SearchModal.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Bookmarks/components/__tests__/__snapshots__/SearchModal.test.js.snap
@@ -3,13 +3,14 @@
 exports[`SearchModal should show search modal 1`] = `
 <ConnectedForemanModal
   enforceFocus={true}
-  id="bookmarksModal"
+  id="bookmarksModal-hosts"
   onEnter={[MockFunction]}
   title="Create Bookmark"
 >
   <Connect(BookmarkForm)
     bookmarks={Array []}
     controller="hosts"
+    id="hosts"
     onCancel={[MockFunction]}
     setModalClosed={[MockFunction]}
     url="/api/bookmarks"

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
@@ -15,6 +15,7 @@ import { stringifyParams } from '../../../common/urlHelpers';
 import { translate as __ } from '../../../common/I18n';
 
 const Bookmarks = ({
+  id,
   bookmarks,
   status,
   url,
@@ -59,6 +60,7 @@ const Bookmarks = ({
   return (
     <React.Fragment>
       <BookmarkModal
+        id={id}
         controller={controller}
         url={url}
         setModalClosed={setModalClosed}
@@ -84,6 +86,7 @@ const Bookmarks = ({
 };
 
 Bookmarks.propTypes = {
+  id: PropTypes.string.isRequired,
   controller: PropTypes.string.isRequired,
   onBookmarkClick: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarksHelpers.js
@@ -1,0 +1,4 @@
+import { BOOKMARKS_MODAL } from './BookmarksConstants';
+
+export const getBookmarksModalId = id =>
+  id ? `${BOOKMARKS_MODAL}-${id}` : BOOKMARKS_MODAL;

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/Bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/Bookmarks.test.js
@@ -16,6 +16,7 @@ window.open = args => {
 const historyPush = jest.spyOn(history, 'push');
 
 const commonFixture = {
+  id: 'architectures',
   controller: 'architectures',
   onBookmarkClick: () => {},
   url: '/api/v2/architectures',
@@ -124,6 +125,8 @@ describe('Bookmarks', () => {
     expect(helpersNewWindow).toHaveBeenCalledWith('https://test-docs.com');
     expect(screen.queryAllByText('Documentation')).toHaveLength(1);
     expect(screen.queryAllByLabelText('loading bookmarks')).toHaveLength(0);
-    expect(screen.queryAllByText('Failed to load bookmarks: Random test error')).toHaveLength(1);
+    expect(
+      screen.queryAllByText('Failed to load bookmarks: Random test error')
+    ).toHaveLength(1);
   });
 });

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/index.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import PropTypes from 'prop-types';
 import { getBookmarks } from './BookmarksActions';
-import { BOOKMARKS_MODAL, BOOKMARKS } from './BookmarksConstants';
+import { BOOKMARKS } from './BookmarksConstants';
 import { useForemanModal } from '../../ForemanModal/ForemanModalHooks';
 import { selectIsModalOpen } from '../../ForemanModal/ForemanModalSelectors';
 import Bookmarks from './Bookmarks';
 
+import { getBookmarksModalId } from './BookmarksHelpers';
 import reducer from './BookmarksReducer';
 import {
   selectAPIStatus,
@@ -15,6 +16,7 @@ import {
 import { selectBookmarksResults } from './BookmarksSelectors';
 
 const ConnectedBookmarks = ({
+  id,
   controller,
   onBookmarkClick,
   url,
@@ -22,21 +24,21 @@ const ConnectedBookmarks = ({
   documentationUrl,
 }) => {
   const key = `${BOOKMARKS}_${controller.toUpperCase()}`;
+  const modalID = getBookmarksModalId(id);
   const status = useSelector(store => selectAPIStatus(store, key));
   const errors = useSelector(store => selectAPIError(store, key));
   const bookmarks = useSelector(store =>
     selectBookmarksResults(store, key, controller)
   );
-  const isModalOpen = useSelector(store =>
-    selectIsModalOpen(store, BOOKMARKS_MODAL)
-  );
+  const isModalOpen = useSelector(store => selectIsModalOpen(store, modalID));
   const dispatch = useDispatch();
 
   const { setModalOpen, setModalClosed } = useForemanModal({
-    id: BOOKMARKS_MODAL,
+    id: modalID,
   });
   return (
     <Bookmarks
+      id={id}
       bookmarks={bookmarks}
       status={status}
       url={url}
@@ -54,6 +56,7 @@ const ConnectedBookmarks = ({
 };
 
 ConnectedBookmarks.propTypes = {
+  id: PropTypes.string,
   controller: PropTypes.string.isRequired,
   onBookmarkClick: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
@@ -62,6 +65,7 @@ ConnectedBookmarks.propTypes = {
 };
 
 ConnectedBookmarks.defaultProps = {
+  id: 'searchBar',
   canCreate: false,
   documentationUrl: '',
 };

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
@@ -7,6 +7,7 @@ export const SearchBarProps = {
       useKeyShortcuts: true,
     },
     bookmarks: {
+      id: 'searchBar',
       url: '/api/bookmarks',
       canCreate: true,
       documentationUrl: '/doc/url',

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
@@ -33,6 +33,7 @@ exports[`AutoComplete rendering renders AutoComplete 1`] = `
       canCreate={true}
       controller="models"
       documentationUrl="/doc/url"
+      id="searchBar"
       onBookmarkClick={[Function]}
       searchQuery=""
       url="/api/bookmarks"

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -38,7 +38,7 @@ Object {
     },
     "bookmarksPF4": Object {},
     "foremanModals": Object {
-      "bookmarksModal": Object {
+      "bookmarksModal-searchBar": Object {
         "isOpen": false,
         "isSubmitting": false,
       },
@@ -68,7 +68,7 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "id": "bookmarksModal",
+        "id": "bookmarksModal-searchBar",
         "isOpen": false,
         "isSubmitting": false,
       },
@@ -110,7 +110,7 @@ Array [
   Array [
     Object {
       "payload": Object {
-        "id": "bookmarksModal",
+        "id": "bookmarksModal-searchBar",
       },
       "type": "SET_MODAL_OPEN",
     },

--- a/webpack/assets/javascripts/react_app/constants.js
+++ b/webpack/assets/javascripts/react_app/constants.js
@@ -19,6 +19,7 @@ export const getControllerSearchProps = (
     useKeyShortcuts: true,
   },
   bookmarks: {
+    id,
     url: '/api/bookmarks',
     canCreate,
     documentationUrl: getManualURL('4.1.5Searching'),

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -20,6 +20,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -58,6 +59,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
           "bookmarks": Object {
             "canCreate": true,
             "documentationUrl": "/doc/url",
+            "id": "searchBar",
             "url": "/api/bookmarks",
           },
           "controller": "models",
@@ -89,6 +91,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -129,6 +132,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
           "bookmarks": Object {
             "canCreate": true,
             "documentationUrl": "/doc/url",
+            "id": "searchBar",
             "url": "/api/bookmarks",
           },
           "controller": "models",
@@ -160,6 +164,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -200,6 +205,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
           "bookmarks": Object {
             "canCreate": true,
             "documentationUrl": "/doc/url",
+            "id": "searchBar",
             "url": "/api/bookmarks",
           },
           "controller": "models",
@@ -231,6 +237,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -271,6 +278,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
           "bookmarks": Object {
             "canCreate": true,
             "documentationUrl": "/doc/url",
+            "id": "searchBar",
             "url": "/api/bookmarks",
           },
           "controller": "models",

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
@@ -20,6 +20,7 @@ exports[`ModelsPage redering should render when loading 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "models",
@@ -97,6 +98,7 @@ exports[`ModelsPage redering should render with error 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "models",
@@ -179,6 +181,7 @@ exports[`ModelsPage redering should render with models 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "models",
@@ -256,6 +259,7 @@ exports[`ModelsPage redering should render with no data 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
+        "id": "searchBar",
         "url": "/api/bookmarks",
       },
       "controller": "models",

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -65,6 +65,7 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
                 "bookmarks": Object {
                   "canCreate": true,
                   "documentationUrl": "/doc/url",
+                  "id": "searchBar",
                   "url": "/api/bookmarks",
                 },
                 "controller": "models",
@@ -155,6 +156,7 @@ exports[`render pageLayout w/search 1`] = `
                 "bookmarks": Object {
                   "canCreate": true,
                   "documentationUrl": "/doc/url",
+                  "id": "searchBar",
                   "url": "/api/bookmarks",
                 },
                 "controller": "models",
@@ -245,6 +247,7 @@ exports[`render pageLayout w/toolBar 1`] = `
                 "bookmarks": Object {
                   "canCreate": true,
                   "documentationUrl": "/doc/url",
+                  "id": "searchBar",
                   "url": "/api/bookmarks",
                 },
                 "controller": "models",
@@ -317,6 +320,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
                 "bookmarks": Object {
                   "canCreate": true,
                   "documentationUrl": "/doc/url",
+                  "id": "searchBar",
                   "url": "/api/bookmarks",
                 },
                 "controller": "models",
@@ -389,6 +393,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
                 "bookmarks": Object {
                   "canCreate": true,
                   "documentationUrl": "/doc/url",
+                  "id": "searchBar",
                   "url": "/api/bookmarks",
                 },
                 "controller": "models",


### PR DESCRIPTION
The bookmark component uses `selectAutocompleteSearchQuery(state, 'searchBar', { controller }),` so only the search with id = 'searchBar' can be used with the bookmarks.

as I didn't find a page with 2 searches in foreman I tested it in foreman using:
`webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js` 
``` js
toolbarButtons={
        <div>
          <SearchBar
            {...{
              data: {
                controller: 'models',
                autocomplete: {
                  id: 'searchBar1',
                  searchQuery: '',
                  url: 'models/auto_complete_search',
                  useKeyShortcuts: true,
                },
                bookmarks: {
                  id: 'searchBar1',
                  url: '/api/bookmarks',
                  canCreate: true,
                  documentationUrl: '/links/manual/4.1.5Searching',
                },
              },
            }}
          />
          {canCreate && createBtn}
        </div>
      }
```