### PR TITLE
Fixes #33681 - delete unused react_pagination_props

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -6,13 +6,4 @@ module PaginationHelper
       render('common/pagination', collection: collection, options: options)
     end
   end
-
-  def react_pagination_props(collection = nil, classname = nil)
-    {
-      viewType: 'table',
-      itemCount: collection.total_entries,
-      perPage: Setting[:entries_per_page],
-      classNames: {pagination_classes: classname},
-    }
-  end
 end


### PR DESCRIPTION
Last use was removed here: https://github.com/theforeman/foreman/pull/6733/files
And I didn't find it in any Katello/Foreman repo