### PR TITLE
Fixes #33929 - improve subnet network exception

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -200,6 +200,8 @@ class Subnet < ApplicationRecord
 
   def ipaddr
     IPAddr.new("#{network}/#{mask}", family)
+  rescue IPAddr::InvalidAddressError => exception
+    raise ::Foreman::WrappedException.new exception, N_("Invalid address for subnet '#{network}/#{mask}'")
   end
 
   def cidr


### PR DESCRIPTION
We recently added a better subnet address validation, but there was no migration to ensure all addresses are correct and it would need to be interactive perhaps which is a no go. This at least improves the exception a bit.

Previously it was:

```
Backtrace for 'Unable to detect subnet' error (IPAddr::InvalidAddressError): invalid address
/opt/rh/rh-ruby25/root/usr/share/ruby/ipaddr.rb:649:in `in6_addr'
/opt/rh/rh-ruby25/root/usr/share/ruby/ipaddr.rb:586:in `initialize'
/opt/rh/rh-ruby25/root/usr/share/ruby/ipaddr.rb:502:in `new'
/opt/rh/rh-ruby25/root/usr/share/ruby/ipaddr.rb:502:in `mask!'
/opt/rh/rh-ruby25/root/usr/share/ruby/ipaddr.rb:593:in `initialize'
/usr/share/foreman/app/models/subnet.rb:161:in `new'
/usr/share/foreman/app/models/subnet.rb:161:in `ipaddr'
/usr/share/foreman/app/models/subnet.rb:157:in `contains?'
/usr/share/foreman/app/models/subnet.rb:373:in `block in subnet_for'
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->