### PR TITLE
Fixes #33935 - Cache setting categories

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -75,7 +75,7 @@ class SettingPresenter
   end
 
   def category_name
-    category.to_s.gsub(/Setting::/, '')
+    category.delete_prefix('Setting::')
   end
 
   def select_values

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -89,10 +89,12 @@ class SettingRegistry
 
   # Returns all the categories used for settings
   def categories
-    sticked_general = { 'general' => nil }
-    sticked_general.merge!(Hash[@settings.map { |_name, definition| [definition.category_name, definition.category_label] }])
-    sticked_general.delete('general') if sticked_general['general'].nil?
-    sticked_general
+    return @categories unless @categories.nil?
+    @categories = @settings.values.uniq(&:category).each_with_object({'general' => nil}) do |definition, memo|
+      memo[definition.category_name] = definition.category_label
+    end
+    @categories.delete('general') if @categories['general'].nil?
+    @categories
   end
 
   def category_settings(category)
@@ -117,6 +119,7 @@ class SettingRegistry
 
   def load_definitions
     @settings = {}
+    @categories = nil
 
     Setting.descendants.each do |cat_cls|
       if cat_cls.default_settings.empty?


### PR DESCRIPTION
Every call to `@settings.category` in the index page recalculates all
the category names and labels by iterating over all settings. Since the
categories can't change in runtime, we can calculate it once and store
the list on the settings registry. We can also get the label once per
category instead of repeating it again for every setting. On my
instance, this led to a reduction of about 50k allocations and 20ms.

There are definitly more areas for improvements. Most of the remaining
allocations come from the `grouped_settings` helper, and specifically
inside the `setting.select_values` calculation.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
