### PR TITLE
Fixes #33938 - Implement driverdisk --source=url

### DIFF
--- a/app/views/unattended/partition_tables_templates/kickstart_custom.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_custom.erb
@@ -8,7 +8,10 @@ oses:
 - Fedora
 - RedHat
 - Rocky
-%>
+-%>
+<% if host_param('driverdisk_source') -%>
+driverdisk --source=<%= host_param('driverdisk_source') %>
+<% end -%>
 zerombr
 clearpart --all --initlabel
 <%

--- a/app/views/unattended/partition_tables_templates/kickstart_default.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_default.erb
@@ -8,7 +8,10 @@ oses:
 - Fedora
 - RedHat
 - Rocky
-%>
+-%>
+<% if host_param('driverdisk_source') -%>
+driverdisk --source=<%= host_param('driverdisk_source') %>
+<% end -%>
 <% if host_param('ignoredisk_options') %>
 ignoredisk <%= host_param('ignoredisk_options') %>
 <% end %>

--- a/app/views/unattended/partition_tables_templates/kickstart_default_thin.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_default_thin.erb
@@ -8,7 +8,10 @@ oses:
 - RedHat
 - oVirt
 - RHVH
-%>
+-%>
+<% if host_param('driverdisk_source') -%>
+driverdisk --source=<%= host_param('driverdisk_source') %>
+<% end -%>
 zerombr
 clearpart --all --initlabel
 autopart --type=thinp <%= host_param('autopart_options') %>


### PR DESCRIPTION
With RHEL 8 deprecating a lot of drivers for older hardware, we'll
need to be able to supply driverdisks to our installations for these
to continue operating.

While the driverdisk can take various parameters, I've only
implemented --source=url as it's the only practical one.

https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/considerations_in_adopting_rhel_8/hardware-enablement_considerations-in-adopting-rhel-8#removed-device-drivers_hardware-enablement
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_installation/kickstart-commands-and-options-reference_installing-rhel-as-an-experienced-user#driverdisk_kickstart-commands-for-installation-program-configuration-and-flow-control
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->