### PR TITLE
Fixes #33942 - Allow extra vars for awx/tower on snippet template.

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_script.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_script.erb
@@ -10,5 +10,9 @@ description: |
 #!/bin/sh
 
 echo "Calling Ansible AWX/Tower provisioning callback..."
+<% if host_param('ansible_extra_vars') -%>
+/usr/bin/curl -v -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+<% else -%>
 /usr/bin/curl -v -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') %>" https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+<% end -%>
 echo "DONE"

--- a/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -14,7 +14,11 @@ After=network-online.target
 
 [Service]
 Type=oneshot
+<% if host_param('ansible_extra_vars') -%>
+ExecStart=/usr/bin/curl -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+<% else -%>
 ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" https://<%= host_param('ansible_tower_fqdn') -%>/api/v2/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
+<% end -%>
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]


### PR DESCRIPTION
The chaged templates now supports 'extra_vars' for the awx/tower api callbak via host/hostgroup parameters.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
