### PR TITLE
Require Foreman::Gettext in initializers

### DIFF
--- a/config/initializers/1_fast_gettext.rb
+++ b/config/initializers/1_fast_gettext.rb
@@ -1,6 +1,10 @@
 require 'fast_gettext'
 require 'gettext_i18n_rails'
 
+require "foreman/gettext/all_domains"
+require "foreman/gettext/debug"
+require "foreman/gettext/support"
+
 locale_dir = File.join(Rails.root, 'locale')
 locale_domain = 'foreman'
 

--- a/lib/foreman/gettext/all_domains.rb
+++ b/lib/foreman/gettext/all_domains.rb
@@ -1,20 +1,24 @@
 require 'fast_gettext'
 
 # include this module to translate in all domains by default
-module Foreman::Gettext::AllDomains
-  def _(key)
-    FastGettext::TranslationMultidomain.D_(key)
-  end
+module Foreman
+  module Gettext
+    module AllDomains
+      def _(key)
+        FastGettext::TranslationMultidomain.D_(key)
+      end
 
-  def n_(*keys)
-    FastGettext::TranslationMultidomain.Dn_(*keys)
-  end
+      def n_(*keys)
+        FastGettext::TranslationMultidomain.Dn_(*keys)
+      end
 
-  def s_(key, separator = nil)
-    FastGettext::TranslationMultidomain.Ds_(key, separator)
-  end
+      def s_(key, separator = nil)
+        FastGettext::TranslationMultidomain.Ds_(key, separator)
+      end
 
-  def ns_(*keys)
-    FastGettext::TranslationMultidomain.Dns_(*keys)
+      def ns_(*keys)
+        FastGettext::TranslationMultidomain.Dns_(*keys)
+      end
+    end
   end
 end

--- a/lib/foreman/gettext/debug.rb
+++ b/lib/foreman/gettext/debug.rb
@@ -1,43 +1,47 @@
 require 'fast_gettext'
 
 # include this module to see translations in the UI
-module Foreman::Gettext::Debug
-  DL = "\u00BB".encode("UTF-8") rescue '>'
-  DR = "\u00AB".encode("UTF-8") rescue '<'
+module Foreman
+  module Gettext
+    module Debug
+      DL = "\u00BB".encode("UTF-8") rescue '>'
+      DR = "\u00AB".encode("UTF-8") rescue '<'
 
-  # slightly modified copy of fast_gettext D_* method
-  def _(key)
-    FastGettext.translation_repositories.each_key do |domain|
-      result = FastGettext::TranslationMultidomain.d_(domain, key) { nil }
-      return DL + result.to_s + DR unless result.nil?
-    end
-    DL + key.to_s + DR
-  end
+      # slightly modified copy of fast_gettext D_* method
+      def _(key)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.d_(domain, key) { nil }
+          return DL + result.to_s + DR unless result.nil?
+        end
+        DL + key.to_s + DR
+      end
 
-  # slightly modified copy of fast_gettext D_* method
-  def n_(*keys)
-    FastGettext.translation_repositories.each_key do |domain|
-      result = FastGettext::TranslationMultidomain.dn_(domain, *keys) { nil }
-      return DL + result.to_s + DR unless result.nil?
-    end
-    DL + keys[-3].split(keys[-2] || FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
-  end
+      # slightly modified copy of fast_gettext D_* method
+      def n_(*keys)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.dn_(domain, *keys) { nil }
+          return DL + result.to_s + DR unless result.nil?
+        end
+        DL + keys[-3].split(keys[-2] || FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
+      end
 
-  # slightly modified copy of fast_gettext D_* method
-  def s_(key, separator = nil)
-    FastGettext.translation_repositories.each_key do |domain|
-      result = FastGettext::TranslationMultidomain.ds_(domain, key, separator) { nil }
-      return DL + result.to_s + DR unless result.nil?
-    end
-    DL + key.split(separator || FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
-  end
+      # slightly modified copy of fast_gettext D_* method
+      def s_(key, separator = nil)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.ds_(domain, key, separator) { nil }
+          return DL + result.to_s + DR unless result.nil?
+        end
+        DL + key.split(separator || FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
+      end
 
-  # slightly modified copy of fast_gettext D_* method
-  def ns_(*keys)
-    FastGettext.translation_repositories.each_key do |domain|
-      result = FastGettext::TranslationMultidomain.dns_(domain, *keys) { nil }
-      return DL + result.to_s + DR unless result.nil?
+      # slightly modified copy of fast_gettext D_* method
+      def ns_(*keys)
+        FastGettext.translation_repositories.each_key do |domain|
+          result = FastGettext::TranslationMultidomain.dns_(domain, *keys) { nil }
+          return DL + result.to_s + DR unless result.nil?
+        end
+        DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
+      end
     end
-    DL + keys[-2].split(FastGettext::NAMESPACE_SEPARATOR).last.to_s + DR
   end
 end


### PR DESCRIPTION
Fix deprecation warning the about initialization of auto-loaded constants


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
