### PR TITLE
Fixes #33955 - Host detail page can't fully see build modal

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -161,6 +161,10 @@ a {
   }
 }
 
+.pf-c-backdrop {
+  z-index: 2000;
+}
+
 .popover {
   max-width: none;
   z-index: 2000;


### PR DESCRIPTION
before
![Screenshot from 2021-11-18 19-44-34](https://user-images.githubusercontent.com/30431079/142491616-35878e31-7cd7-487e-8a73-bb100ad64a2a.png)

after
![Screenshot from 2021-11-18 21-26-39](https://user-images.githubusercontent.com/30431079/142491611-6d5616e9-9a67-4a93-95e0-6b64963c73ac.png)
