### PR TITLE
Fixes #33970 - Append custom kernel options for kickstart

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -138,7 +138,7 @@ description: |
   end
 
   if host_param('append_kernel_options')
-    options.push("#{host_param('append_kernel_options')}")
+    options.push(host_param('append_kernel_options'))
   end
 -%>
 <%# do not add newline after the next line %>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -136,6 +136,10 @@ description: |
   elsif nic_delay
     options.push("nicdelay=#{nic_delay} linksleep=#{nic_delay}")
   end
+
+  if host_param('append_kernel_options')
+    options.push("#{host_param('append_kernel_options')}")
+  end
 -%>
 <%# do not add newline after the next line %>
 <%= options.join(' ') -%>


### PR DESCRIPTION
For unattended provisioning append parameterized custom kernel options for kickstart_kernel_options.erb snippet

My use case in question is for adding serial console options to the kernel options to be able to have console access during kickstart / discovery / etc., but any desired kernel options could also be added.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
