### PR TITLE
Registration - name & path to host_init_config template

### DIFF
--- a/app/controllers/registration_commands_controller.rb
+++ b/app/controllers/registration_commands_controller.rb
@@ -17,14 +17,15 @@ class RegistrationCommandsController < ApplicationController
 
   def operatingsystem_template
     os = Operatingsystem.authorized(:view_operatingsystems).find(params[:id])
-    template = os.has_default_template?(TemplateKind.find_by(name: 'host_init_config'))
+    template_kind = TemplateKind.find_by(name: 'host_init_config')
+    template = os.os_default_templates
+                 .find_by(template_kind: template_kind)&.provisioning_template
 
-    unless template
+    if template
+      render json: { template: { name: template.name, path: edit_provisioning_template_path(template) } }
+    else
       render json: { template: { name: nil, os_path: edit_operatingsystem_path(os)} }
-      return
     end
-
-    render json: { template: { name: template.name, path: edit_provisioning_template_path(template) } }
   end
 
   def create

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -7,7 +7,12 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
 
       get :operatingsystem_template, params: { id: os.id }, session: set_session_user
       assert_response :success
-      assert_not_nil JSON.parse(@response.body)['template']['name']
+
+      response = JSON.parse(@response.body)['template']
+      template_name = Setting[:default_host_init_config_template]
+
+      assert_includes response['path'], Template.find_by(name: template_name).id.to_s
+      assert response['name'], template_name
     end
 
     test 'without template' do
@@ -15,8 +20,12 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       os.os_default_templates = []
 
       get :operatingsystem_template, params: { id: os.id }, session: set_session_user
+
+      response = JSON.parse(@response.body)['template']
+
       assert_response :success
-      assert_nil JSON.parse(@response.body)['template']['name']
+      assert_includes response['os_path'], os.id.to_s
+      assert_nil response['name']
     end
   end
 


### PR DESCRIPTION
Broken in 3.0, Registration UI form displays incorrect
name & path to OS 'host initial configuration' template.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
