### PR TITLE
Fixes #33985 - move identifiers to ApplicationRecord

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -38,4 +38,14 @@ class ApplicationRecord < ActiveRecord::Base
       @graphql_type || superclass.try(:graphql_type)
     end
   end
+
+  def <=>(other)
+    name <=> other.name
+  end
+
+  def id_and_type
+    "#{id}-#{self.class.table_name.humanize}"
+  end
+  alias_attribute :to_label, :name_method
+  alias_attribute :to_s, :to_label
 end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -6,16 +6,6 @@ class NilClass
 end
 
 class ActiveRecord::Base
-  def <=>(other)
-    name <=> other.name
-  end
-
-  def id_and_type
-    "#{id}-#{self.class.table_name.humanize}"
-  end
-  alias_attribute :to_label, :name_method
-  alias_attribute :to_s, :to_label
-
   def self.unconfigured?
     where(nil).reorder('').limit(1).pluck(base_class.primary_key).empty?
   end


### PR DESCRIPTION
Move identifiers to ApplicationRecord from core_extensions.