### PR TITLE
Fixes #33986 - moves Callback ensures to separate files

### DIFF
--- a/app/models/concerns/ensure_no_cycle.rb
+++ b/app/models/concerns/ensure_no_cycle.rb
@@ -1,0 +1,45 @@
+require 'tsort'
+
+# ActiveRecord Callback class
+# TODO: it would deserve its own folder
+class EnsureNoCycle
+  include TSort
+
+  def initialize(base, source, target)
+    @source, @target = source, target
+    @base = base.map { |record| [record.send(@source), record.send(@target)] }
+    @nodes = @base.flatten.uniq
+    @graph = Hash.new { |h, k| h[k] = [] }
+    @base.each { |s, t| @graph[s] << t }
+  end
+
+  def tsort_each_node(&block)
+    @nodes.each(&block)
+  end
+
+  def tsort_each_child(node, &block)
+    @graph[node].each(&block)
+  end
+
+  def ensure(record)
+    @record = record
+    add_new_edges
+    detect_cycle
+  end
+
+  private
+
+  def add_new_edges
+    edges = @graph[@record.send(@source) || 0]
+    edges << @record.send(@target) unless edges.include?(@record.send(@target))
+  end
+
+  def detect_cycle
+    if strongly_connected_components.any? { |component| component.size > 1 }
+      @record.errors.add :base, _("Adding would cause a cycle!")
+      raise ::Foreman::CyclicGraphException, @record
+    else
+      true
+    end
+  end
+end

--- a/app/models/concerns/ensure_not_used_by.rb
+++ b/app/models/concerns/ensure_not_used_by.rb
@@ -1,0 +1,31 @@
+# ActiveRecord Callback class
+# TODO: it would deserve its own folder
+class EnsureNotUsedBy
+  attr_reader :klasses
+  def initialize(*attribute)
+    @klasses = attribute
+  end
+
+  def before_destroy(record)
+    klasses.each do |klass, klass_name = klass|
+      association = record.association(klass.to_sym)
+      association_scope = ActiveRecord::Associations::AssociationScope.scope(association)
+      next if association_scope.empty?
+      authorized_associations = AssociationAuthorizer.authorized_associations(association.klass, klass_name, false).all.pluck(:id)
+      association_scope.find_each do |what|
+        if authorized_associations.include?(what.id)
+          what = what.to_label
+          error_message = _("%{record} is used by %{what}")
+        else
+          what = _(what.class.name)
+          error_message = _("%{record} is being used by a hidden %{what} resource")
+        end
+        record.errors.add :base, error_message % { :record => record, :what => what }
+      end
+    end
+    if record.errors.present?
+      Rails.logger.error "You may not destroy #{record.to_label} as it is in use!"
+      throw :abort
+    end
+  end
+end

--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -1,4 +1,3 @@
-require 'tsort'
 # Add an empty method to nil. Now no need for if x and x.empty?. Just x.empty?
 class NilClass
   def empty?
@@ -27,79 +26,6 @@ class ActiveRecord::Base
       "WHERE #{self.class.quoted_primary_key} = #{quote_value(id)}",
       "#{self.class.name} Attribute Update"
     )
-  end
-
-  # ActiveRecord Callback class
-  class EnsureNotUsedBy
-    attr_reader :klasses
-    def initialize(*attribute)
-      @klasses = attribute
-    end
-
-    def before_destroy(record)
-      klasses.each do |klass, klass_name = klass|
-        association = record.association(klass.to_sym)
-        association_scope = ActiveRecord::Associations::AssociationScope.scope(association)
-        next if association_scope.empty?
-        authorized_associations = AssociationAuthorizer.authorized_associations(association.klass, klass_name, false).all.pluck(:id)
-        association_scope.find_each do |what|
-          if authorized_associations.include?(what.id)
-            what = what.to_label
-            error_message = _("%{record} is used by %{what}")
-          else
-            what = _(what.class.name)
-            error_message = _("%{record} is being used by a hidden %{what} resource")
-          end
-          record.errors.add :base, error_message % { :record => record, :what => what }
-        end
-      end
-      if record.errors.present?
-        Rails.logger.error "You may not destroy #{record.to_label} as it is in use!"
-        throw :abort
-      end
-    end
-  end
-
-  class EnsureNoCycle
-    include TSort
-
-    def initialize(base, source, target)
-      @source, @target = source, target
-      @base = base.map { |record| [record.send(@source), record.send(@target)] }
-      @nodes = @base.flatten.uniq
-      @graph = Hash.new { |h, k| h[k] = [] }
-      @base.each { |s, t| @graph[s] << t }
-    end
-
-    def tsort_each_node(&block)
-      @nodes.each(&block)
-    end
-
-    def tsort_each_child(node, &block)
-      @graph[node].each(&block)
-    end
-
-    def ensure(record)
-      @record = record
-      add_new_edges
-      detect_cycle
-    end
-
-    private
-
-    def add_new_edges
-      edges = @graph[@record.send(@source) || 0]
-      edges << @record.send(@target) unless edges.include?(@record.send(@target))
-    end
-
-    def detect_cycle
-      if strongly_connected_components.any? { |component| component.size > 1 }
-        @record.errors.add :base, _("Adding would cause a cycle!")
-        raise ::Foreman::CyclicGraphException, @record
-      else
-        true
-      end
-    end
   end
 
   def id_and_type

--- a/test/models/usergroup_member_test.rb
+++ b/test/models/usergroup_member_test.rb
@@ -102,7 +102,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   test "add new memership to the root" do
     setup_admins_scenario
 
-    ActiveRecord::Base::EnsureNoCycle.any_instance.expects(:ensure).once
+    EnsureNoCycle.any_instance.expects(:ensure).once
 
     basic      = FactoryBot.create :usergroup, :name => 'um_basic'
     basic_role = FactoryBot.create :role, :name => 'um_basic_role'
@@ -122,7 +122,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   test "add new memership to the middle of chain" do
     setup_admins_scenario
 
-    ActiveRecord::Base::EnsureNoCycle.any_instance.expects(:ensure).once
+    EnsureNoCycle.any_instance.expects(:ensure).once
 
     basic      = FactoryBot.create :usergroup, :name => 'um_basic'
     basic_role = FactoryBot.create :role, :name => 'um_basic_role'
@@ -142,7 +142,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   test "add new memership to the leaf" do
     setup_admins_scenario
 
-    ActiveRecord::Base::EnsureNoCycle.any_instance.expects(:ensure).once
+    EnsureNoCycle.any_instance.expects(:ensure).once
 
     basic      = FactoryBot.create :usergroup, :name => 'um_basic'
     basic_role = FactoryBot.create :role, :name => 'um_basic_role'
@@ -205,7 +205,7 @@ class UsergroupMemberTest < ActiveSupport::TestCase
   end
 
   test "add new user memership" do
-    ActiveRecord::Base::EnsureNoCycle.any_instance.expects(:ensure).never
+    EnsureNoCycle.any_instance.expects(:ensure).never
 
     test_user1 = FactoryBot.create(:user, :login => 'test_user1')
     basic      = FactoryBot.create :usergroup, :name => 'um_basic'

--- a/test/unit/ensure_no_cycle_test.rb
+++ b/test/unit/ensure_no_cycle_test.rb
@@ -8,7 +8,7 @@ class EnsureNoCycleTest < ActiveSupport::TestCase
     base.push Edge.new(3, 4)
     base.push Edge.new(3, 5)
     base.push Edge.new(2, 6)
-    @graph = ActiveRecord::Base::EnsureNoCycle.new(base, :source, :target)
+    @graph = EnsureNoCycle.new(base, :source, :target)
   end
 
   class Edge < OpenStruct


### PR DESCRIPTION
We do not need to define the Ensure classes in core_extensions.
These are better off in separate files.