### PR TITLE
Fixes #33987 - HostMix using Concern properly

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,7 +1,7 @@
 class ApplicationRecord < ActiveRecord::Base
   extend ApipieDSL::Class
-  extend HostMix
 
+  include HostMix
   include HasManyCommon
   include StripWhitespace
   include Parameterizable::ById

--- a/app/models/concerns/host_mix.rb
+++ b/app/models/concerns/host_mix.rb
@@ -1,11 +1,13 @@
 module HostMix
   extend ActiveSupport::Concern
 
-  def has_many_hosts(options = {})
-    has_many :hosts, {:class_name => "Host::Managed"}.merge(options)
-  end
+  class_methods do
+    def has_many_hosts(options = {})
+      has_many :hosts, {:class_name => "Host::Managed"}.merge(options)
+    end
 
-  def belongs_to_host(options = {})
-    belongs_to :host, {:class_name => "Host::Managed", :foreign_key => :host_id}.merge(options)
+    def belongs_to_host(options = {})
+      belongs_to :host, {:class_name => "Host::Managed", :foreign_key => :host_id}.merge(options)
+    end
   end
 end


### PR DESCRIPTION
ActiveSupport::Concern is supposed to be included and it looks weird to extend a class by it.
We should use `class_methods` to define class methods instead of extending.