### PR TITLE
Fixes #33992 - drop truncate_bytes method

### DIFF
--- a/lib/core_extensions.rb
+++ b/lib/core_extensions.rb
@@ -166,33 +166,6 @@ class String
     index('<%')
   end
 
-  # TODO Remove me after Rails 6 upgrade: https://github.com/rails/rails/commit/4940cc49ddb361d584d51bc3eb4675ff8ece4a2b
-  def truncate_bytes(truncate_at, omission: "…")
-    omission ||= ""
-
-    if bytesize <= truncate_at
-      dup
-    elsif omission.bytesize > truncate_at
-      raise ArgumentError, "Omission #{omission.inspect} is #{omission.bytesize}, larger than the truncation length of #{truncate_at} bytes"
-    elsif omission.bytesize == truncate_at
-      omission.dup
-    else
-      self.class.new.tap do |cut|
-        cut_at = truncate_at - omission.bytesize
-
-        scan(/\X/) do |grapheme|
-          if cut.bytesize + grapheme.bytesize <= cut_at
-            cut << grapheme
-          else
-            break
-          end
-        end
-
-        cut << omission
-      end
-    end
-  end
-
   def integer?
     to_i.to_s == self
   end


### PR DESCRIPTION
This method was added in Rails 6 to ActiveSupport.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
