### PR TITLE
Fixes #33996 - Clean up deprecated methods

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -159,19 +159,6 @@ module ApplicationHelper
     controller.respond_to?(:auto_complete_controller_name) ? controller.auto_complete_controller_name : controller_name
   end
 
-  def auto_complete_search(name, val, options = {})
-    Foreman::Deprecation.deprecation_warning('2.5', 'use #auto_complete_f, possibly with #form_with if you need to avoid of object scope')
-    options.merge!(
-      {
-        url: options[:full_path] || (options[:path] || send("#{auto_complete_controller_name}_path")) + "/auto_complete_#{name}",
-        controller: options[:path] || auto_complete_controller_name,
-        search_query: '',
-        use_key_shortcuts: options[:use_key_shortcuts] || false,
-      }
-    )
-    Tags::ReactInput.new(nil, name, self, options.merge(value: val, type: 'autocomplete', only_input: true)).render
-  end
-
   def sort(field, permitted: [], **kwargs)
     kwargs[:url_options] ||= current_url_params(permitted: permitted)
     super(field, kwargs)
@@ -196,37 +183,6 @@ module ApplicationHelper
 
   def edit_select(object, property, options = {})
     edit_inline(object, property, options.merge({:type => "select"}))
-  end
-
-  def flot_pie_chart(name, title, data, options = {})
-    Foreman::Deprecation.deprecation_warning('3.1', '#flot_pie_chart is now rendered by react Donut chart with default configuration. '\
-                                                    'Please render the Donut chart component directly.')
-    data = data.map { |k, v| [k.to_s.humanize, v] } if data.is_a?(Hash)
-    react_component('ChartBox', type: 'donut',
-                                status: 'RESOLVED',
-                                title: title,
-                                chart: {
-                                  data: data,
-                                  search: options[:search] ? hosts_path(search: options[:search]) : nil,
-                                })
-  end
-
-  def flot_chart(name, xaxis_label, yaxis_label, data, options = {})
-    Foreman::Deprecation.deprecation_warning('3.1', '#flot_chart is rendering its react version by default now. '\
-                                                    'Please move to rendering React Component directly.')
-    data = data.map { |k, v| {:label => k.to_s.humanize, :data => v} } if data.is_a?(Hash)
-    time = ['time'].concat(data[0][:data].map { |d| d.first })
-    data = data.map { |d_hash| [d_hash[:label]].concat(d_hash[:data].map { |d| d.second }) }
-    data.unshift(time)
-    react_component('AreaChart', id: name, xAxisLabel: xaxis_label, yAxisLabel: yaxis_label, data: data)
-  end
-
-  def flot_bar_chart(name, xaxis_label, yaxis_label, data, options = {})
-    Foreman::Deprecation.deprecation_warning('3.1', '#flot_bar_chart is rendering its react version now. '\
-                                                    'Please move to rendering React Component directly.')
-    content_tag(:div, id: name) do
-      react_component('BarChart', data: data, xAxisLabel: xaxis_label, yAxisLabel: yaxis_label)
-    end
   end
 
   def select_action_button(title, options = {}, *args)
@@ -401,11 +357,6 @@ module ApplicationHelper
     return true if params[:action] == 'clone'
     # check if the user set the field explicitly despite setting a hostgroup.
     params[:host] && params[:host][:hostgroup_id] && params[:host][field]
-  end
-
-  def notifications
-    Foreman::Deprecation.deprecation_warning('3.1', 'notifications method is deprecated, and instead, toasts alerts are handled in the root of the React app.')
-    nil
   end
 
   def toast_notifications_data

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -1,12 +1,5 @@
 require 'webpack-rails'
 module ReactjsHelper
-  def mount_react_component(name, selector, data = [], opts = {})
-    Foreman::Deprecation.deprecation_warning('2.5', 'use #react_component instead of #mount_react_component')
-    javascript_tag defer: 'defer' do
-      "$(tfm.reactMounter.mount('#{name}', '#{selector}', #{data}, #{opts[:flatten_data] || false}));".html_safe
-    end
-  end
-
   # Mount react component in views
   # Params:
   # +name+:: the component name from the componentRegistry

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -162,7 +162,7 @@ class Host::Managed < Host::Base
     property :comment, String, desc: 'Returns comment/description of this host'
   end
   class Jail < ::Safemode::Jail
-    allow :id, :name, :created_at, :diskLayout, :puppetmaster, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :ptable, :hostgroup,
+    allow :id, :name, :created_at, :diskLayout, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :ptable, :hostgroup,
       :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :ip6, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :subnet6, :token, :location, :organization, :provision_method,
       :image_build?, :pxe_build?, :otp, :realm, :nil?, :indent, :primary_interface,
@@ -171,11 +171,6 @@ class Host::Managed < Host::Base
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
       :ssh_authorized_keys, :pxe_loader, :global_status, :get_status, :puppetca_token, :last_report, :build?, :smart_proxies, :host_param,
       :virtual, :ram, :sockets, :cores, :params, :pxe_loader_efi?, :comment
-
-    def puppetmaster
-      Foreman::Deprecation.deprecation_warning('3.0', 'Host#puppetmaster is deprecated, please use host_puppet_server macro instead')
-      @source.puppet_server
-    end
   end
 
   scope :recent, lambda { |interval = Setting[:outofsync_interval]|

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -108,16 +108,11 @@ class Hostgroup < ApplicationRecord
     property :title, String, desc: 'Returns full title of this host group, e.g. Base/CentOS 7'
   end
   class Jail < Safemode::Jail
-    allow :id, :name, :diskLayout, :puppetmaster, :puppet_server, :operatingsystem, :architecture,
+    allow :id, :name, :diskLayout, :puppet_server, :operatingsystem, :architecture,
       :ptable, :url_for_boot, :params, :puppet_proxy, :puppet_ca_server,
       :os, :arch, :domain, :subnet, :subnet6, :hosts, :realm,
       :root_pass, :description, :pxe_loader, :title,
       :children, :parent
-
-    def puppetmaster
-      Foreman::Deprecation.deprecation_warning('3.0', 'Hostgroup#puppetmaster is deprecated, please use host_puppet_server macro instead')
-      @source.puppet_server
-    end
   end
 
   # TODO: add a method that returns the valid os for a hostgroup

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -8,11 +8,6 @@ class Message < ApplicationRecord
     value
   end
 
-  # DEPRECATED: use Rails method (no warning because this is called many times)
-  def self.find_or_create(value)
-    find_or_create_by(value: value)
-  end
-
   def skip_strip_attrs
     ['value']
   end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -8,11 +8,6 @@ class Source < ApplicationRecord
     value
   end
 
-  # DEPRECATED: use Rails method (no warning because this is called many times)
-  def self.find_or_create(value)
-    find_or_create_by(value: value)
-  end
-
   def skip_strip_attrs
     ['value']
   end

--- a/app/models/template_input.rb
+++ b/app/models/template_input.rb
@@ -34,26 +34,6 @@ class TemplateInput < ApplicationRecord
     Foreman.input_types_registry.get(input_type).new if input_type
   end
 
-  def user_template_input?
-    Foreman::Deprecation.deprecation_warning('2.5', 'use #input_type or #input_type_instance to determine input type')
-    input_type == 'user'
-  end
-
-  def fact_template_input?
-    Foreman::Deprecation.deprecation_warning('2.5', 'use #input_type or #input_type_instance to determine input type')
-    input_type == 'fact'
-  end
-
-  def variable_template_input?
-    Foreman::Deprecation.deprecation_warning('2.5', 'use #input_type or #input_type_instance to determine input type')
-    input_type == 'variable'
-  end
-
-  def puppet_parameter_template_input?
-    Foreman::Deprecation.deprecation_warning('2.5', 'use #input_type or #input_type_instance to determine input type')
-    input_type == 'puppet_parameter'
-  end
-
   def preview(scope)
     resolver(scope).preview
   end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -77,11 +77,6 @@ module Foreman #:nodoc:
         end
       end
 
-      def medium_providers
-        Foreman::Deprecation.deprecation_warning('2.5', 'Plugin.medium_providers is deprecated, use Plugin.medium_providers_registry instead')
-        medium_providers_registry
-      end
-
       def def_field(*names)
         class_eval do
           names.each do |name|
@@ -577,10 +572,6 @@ module Foreman #:nodoc:
 
     def add_histogram_telemetry(name, description, instance_labels = [], buckets = Foreman::Telemetry::DEFAULT_BUCKETS)
       Foreman::Telemetry.instance.add_histogram(name, description, instance_labels, buckets)
-    end
-
-    def medium_providers
-      self.class.medium_providers
     end
 
     def smart_proxy_reference(hash)

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -7,21 +7,6 @@ class FactParser
   VLANS = /\A([a-z0-9]+)\.([0-9]+)\Z/
   VIRTUAL_NAMES = /#{ALIASES}|#{VLANS}|#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
 
-  def self.parser_for(type)
-    Foreman::Deprecation.deprecation_warning('3.2', 'FactParser.parser_for() is deprecated, use FactParserRegistry[] instead')
-    Foreman::Plugin.fact_parser_registry[type]
-  end
-
-  def self.parsers
-    Foreman::Deprecation.deprecation_warning('3.2', 'FactParser.parsers is deprecated, use FactParserRegistry.parsers instead')
-    Foreman::Plugin.fact_parser_registry.parsers
-  end
-
-  def self.register_fact_parser(key, klass, default = false)
-    Foreman::Deprecation.deprecation_warning('3.2', 'FactParser.register_fact_parser() is deprecated, use FactParserRegistry.register() instead')
-    Foreman::Plugin.fact_parser_registry.register(key, klass, default)
-  end
-
   attr_reader :facts
 
   # facts are hash of fresh data coming from fact upload in following format

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -92,8 +92,8 @@ class ReportImporter
       msg   = log['log']['messages']['message']
       src   = log['log']['sources']['source']
 
-      message = Message.find_or_create msg
-      source  = Source.find_or_create src
+      message = Message.find_or_create_by(value: msg)
+      source  = Source.find_or_create_by(value: src)
 
       # Symbols get turned into strings via the JSON API, so convert back here if it matches
       # and expected log level. Log objects can't be created without one, so raise if not

--- a/test/models/host_jail_test.rb
+++ b/test/models/host_jail_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class HostJailTest < ActiveSupport::TestCase
   def test_jail_should_include_these_methods
-    allowed = [:name, :diskLayout, :puppetmaster, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :ptable, :hostgroup,
+    allowed = [:name, :diskLayout, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :ptable, :hostgroup,
                :organization, :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :mac, :shortname, :architecture,
                :model, :certname, :capabilities, :provider, :subnet, :token, :location, :organization, :provision_method, :image_build?,
                :pxe_build?, :otp, :realm, :nil?, :indent, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :facts,
@@ -11,11 +11,5 @@ class HostJailTest < ActiveSupport::TestCase
     allowed.each do |m|
       assert Host::Managed::Jail.allowed?(m), "Method #{m} is not available in Host::Managed::Jail while should be allowed."
     end
-  end
-
-  test '#puppetmaster should be deprecated' do
-    Foreman::Deprecation.expects(:deprecation_warning)
-    host = FactoryBot.build_stubbed(:host)
-    host.to_jail.puppetmaster
   end
 end

--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -28,16 +28,6 @@ import * as lookupKeys from './foreman_lookup_keys';
 import './foreman_overrides';
 import './bundle_novnc';
 
-const numFieldsDeprecationOnly = {
-  initAll: () => {
-    window.tfm.tools.deprecate(
-      'initAll()',
-      'does nothing as of now, please stop calling it',
-      '3.2'
-    );
-  },
-};
-
 // Set the public path for dynamic imports
 if (process.env.NODE_ENV !== 'production') {
   /* eslint-disable-next-line */
@@ -53,7 +43,6 @@ window.tfm = Object.assign(window.tfm || {}, {
   hosts,
   httpProxies,
   toastNotifications,
-  numFields: numFieldsDeprecationOnly,
   reactMounter,
   editor,
   nav,

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -5,7 +5,6 @@ import URI from 'urijs';
 import { push } from 'connected-react-router';
 import store from './react_app/redux';
 import * as LayoutActions from './react_app/components/Layout/LayoutActions';
-import { deprecate } from './react_app/common/DeprecationService';
 
 export const visit = url => {
   window.location.href = url;
@@ -31,14 +30,6 @@ export const showLoading = () => {
 
 export const hideLoading = () => {
   store.dispatch(LayoutActions.hideLoading());
-};
-
-export const changeLocation = loc => {
-  deprecate('changeLocation', 'Context', '2.6');
-};
-
-export const changeOrganization = org => {
-  deprecate('changeOrganization', 'Context', '2.6');
 };
 
 export const changeActive = active => {

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
@@ -1,6 +1,5 @@
-import { get, snakeCase } from 'lodash';
+import { snakeCase } from 'lodash';
 import { noop } from '../../common/helpers';
-import { deprecate } from '../../common/DeprecationService';
 
 export const selectLayout = state => state.layout;
 
@@ -8,14 +7,6 @@ export const selectMenuItems = state => selectLayout(state).items;
 export const selectActiveMenu = state => selectLayout(state).activeMenu;
 export const selectIsLoading = state => selectLayout(state).isLoading;
 export const selectIsCollapsed = state => selectLayout(state).isCollapsed;
-export const selectCurrentLocation = state => {
-  deprecate('selectCurrentLocation', 'useForemanLocation hook', 2.5);
-  return get(selectLayout(state), 'currentLocation');
-};
-export const selectCurrentOrganization = state => {
-  deprecate('selectCurrentOrganization', 'useForemanOrganization hook', 2.5);
-  return get(selectLayout(state), 'currentOrganization');
-};
 
 export const patternflyMenuItemsSelector = (
   state,

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/LayoutSelectors.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/LayoutSelectors.test.js
@@ -50,9 +50,6 @@ const fixtures = {
 
   'should return isLoading from selector': () => selectIsLoading(state),
   'should return isCollapsed from selector': () => selectIsCollapsed(state),
-  'should return location from selector': () => selectCurrentLocation(state),
-  'should return organization from selector': () =>
-    selectCurrentOrganization(state),
 };
 
 describe('Layout selectors', () => testSelectorsSnapshotWithFixtures(fixtures));

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutSelectors.test.js.snap
@@ -126,7 +126,3 @@ exports[`Layout selectors should return empty array of items 1`] = `Array []`;
 exports[`Layout selectors should return isCollapsed from selector 1`] = `false`;
 
 exports[`Layout selectors should return isLoading from selector 1`] = `true`;
-
-exports[`Layout selectors should return location from selector 1`] = `"loc1"`;
-
-exports[`Layout selectors should return organization from selector 1`] = `"org1"`;

--- a/webpack/assets/javascripts/react_app/redux/actions/toasts/index.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/toasts/index.js
@@ -1,9 +1,0 @@
-import { deprecate } from '../../../common/DeprecationService';
-
-deprecate('import from redux/action/toasts', 'components/ToastsList', '3.2');
-
-export {
-  addToast,
-  deleteToast,
-  clearToasts,
-} from '../../../components/ToastsList';


### PR DESCRIPTION
Cleans up all methods that have been marked for removal in 3.2 or older.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
