### PR TITLE
Fixes #34008 Add org + loc params to scoped search

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -251,6 +251,10 @@ module Hostext
               conditions << "hosts.hostgroup_id IN (#{param.hostgroup.subtree_ids.join(', ')})"
             when 'HostParameter'
               conditions << "hosts.id = #{param.reference_id}"
+            when 'OrganizationParameter'
+              conditions << "hosts.organization_id = #{param.reference_id}"
+            when 'LocationParameter'
+              conditions << "hosts.location_id = #{param.reference_id}"
             when 'SubnetParameter'
               conditions << "nics.subnet_id = #{param.reference_id} OR nics.subnet6_id = #{param.reference_id}"
           end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1896,6 +1896,24 @@ class HostTest < ActiveSupport::TestCase
       results = Host.search_for(%{params.#{parameter.name} = "#{parameter.searchable_value}"})
       refute results.include?(host)
     end
+
+    test "can search hosts by organization parameter" do
+      host = FactoryBot.create(:host, :managed)
+      org = host.organization
+      org.organization_parameters << OrganizationParameter.create(:name => "test_param", :value => "true", :parameter_type => 'boolean')
+      parameter = org.organization_parameters.first
+      results = Host.search_for(%{params.#{parameter.name} = "#{parameter.searchable_value}"})
+      assert results.include?(host)
+    end
+
+    test "can search hosts by location parameter" do
+      host = FactoryBot.create(:host, :managed)
+      location = host.location
+      location.location_parameters << LocationParameter.create(:name => "test_param", :value => "true", :parameter_type => 'boolean')
+      parameter = location.location_parameters.first
+      results = Host.search_for(%{params.#{parameter.name} = "#{parameter.searchable_value}"})
+      assert results.include?(host)
+    end
   end
 
   test "can search hosts by current_user" do


### PR DESCRIPTION
OrganizationParameter and LocationParameter were missing from host's scoped_search definition for searching by `param.foo`

Reproduce:
create an org parameter `foo` with type boolean with the value `true` for a non-empty org
search for `params.foo = t`
observe empty results.