### PR TITLE
Fixes #34006 - use rbac_registry for all plugin rbac

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -303,6 +303,13 @@ module Foreman #:nodoc:
       end
     end
 
+    # This method gets called once the Foreman is fully initialized
+    # It finalizes the plugin initialization process
+    def finalize_setup!
+      ActiveSupport.run_load_hooks(@id, self)
+      # TBD - nothing so far
+    end
+
     # Adds setting definition
     #
     # ===== Example

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -16,8 +16,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require_dependency 'foreman/plugin/logging'
-require_dependency 'foreman/plugin/rbac_registry'
-require_dependency 'foreman/plugin/rbac_support'
 require_dependency 'foreman/plugin/report_scanner_registry'
 require_dependency 'foreman/plugin/report_origin_registry'
 require_dependency 'foreman/plugin/medium_providers_registry'
@@ -174,7 +172,7 @@ module Foreman #:nodoc:
     def initialize(id)
       @id = id.to_sym
       @logging = Plugin::Logging.new(@id)
-      @rbac_registry = Plugin::RbacRegistry.new
+      @rbac_registry = Plugin::RbacRegistry.new(@id)
       @provision_methods = {}
       @compute_resources = []
       @to_prepare_callbacks = []
@@ -307,7 +305,7 @@ module Foreman #:nodoc:
     # It finalizes the plugin initialization process
     def finalize_setup!
       ActiveSupport.run_load_hooks(@id, self)
-      # TBD - nothing so far
+      rbac_registry.setup!
     end
 
     # Adds setting definition

--- a/app/registries/foreman/plugin/rbac_registry.rb
+++ b/app/registries/foreman/plugin/rbac_registry.rb
@@ -3,7 +3,8 @@ module Foreman
     class RbacRegistry
       attr_accessor :role_ids, :default_roles, :registered_permissions
 
-      def initialize
+      def initialize(plugin_id)
+        @plugin_id = plugin_id
         @role_ids = []
         @registered_permissions = []
         @default_roles = {}
@@ -25,6 +26,10 @@ module Foreman
 
       def permission_names
         registered_permissions.map(&:first)
+      end
+
+      def setup!
+        # setup the plugin Rbac in DB
       end
     end
   end

--- a/app/registries/foreman/plugin/rbac_registry.rb
+++ b/app/registries/foreman/plugin/rbac_registry.rb
@@ -46,14 +46,14 @@ module Foreman
       end
 
       def setup_permissions!
-        return false if Rails.env.test? || Foreman.in_setup_db_rake? || !permission_table_exists?
+        return false if Foreman.in_setup_db_rake? || !permission_table_exists?
         registered_permissions.each do |(name, options)|
           Permission.where(:name => name).first_or_create(:resource_type => options[:resource_type])
         end
       end
 
       def setup_roles!
-        return false if Foreman.in_setup_db_rake? || Rails.env.test? || !permission_table_exists? || User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).nil?
+        return false if Foreman.in_setup_db_rake? || !permission_table_exists? || User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).nil?
         Role.without_auditing do
           Filter.without_auditing do
             default_roles.each do |name, permissions|

--- a/app/registries/foreman/plugin/rbac_registry.rb
+++ b/app/registries/foreman/plugin/rbac_registry.rb
@@ -2,12 +2,19 @@ module Foreman
   class Plugin
     class RbacRegistry
       attr_accessor :role_ids, :default_roles, :registered_permissions
+      attr_accessor :add_all_permissions_to_default_roles
+      attr_reader :modified_roles
+      attr_reader :added_resource_permissions
 
       def initialize(plugin_id)
         @plugin_id = plugin_id
         @role_ids = []
         @registered_permissions = []
         @default_roles = {}
+        @default_role_descriptions = {}
+        @modified_roles = {}
+        @added_resource_permissions = []
+        @add_all_permissions_to_default_roles = false
       end
 
       def registered_roles
@@ -16,6 +23,11 @@ module Foreman
 
       def register(name, options)
         @registered_permissions << [name, options]
+      end
+
+      def register_role(name, permissions, description = '')
+        default_roles[name] = permissions
+        @default_role_descriptions[name] = description
       end
 
       # needed for fixtures permissions.yml,
@@ -29,7 +41,47 @@ module Foreman
       end
 
       def setup!
-        # setup the plugin Rbac in DB
+        setup_permissions!
+        setup_roles!
+      end
+
+      def setup_permissions!
+        return false if Rails.env.test? || Foreman.in_setup_db_rake? || !permission_table_exists?
+        registered_permissions.each do |(name, options)|
+          Permission.where(:name => name).first_or_create(:resource_type => options[:resource_type])
+        end
+      end
+
+      def setup_roles!
+        return false if Foreman.in_setup_db_rake? || Rails.env.test? || !permission_table_exists? || User.unscoped.find_by_login(User::ANONYMOUS_ADMIN).nil?
+        Role.without_auditing do
+          Filter.without_auditing do
+            default_roles.each do |name, permissions|
+              Plugin::RoleLock.new(@plugin_id).register_role name, permissions, self, @default_role_descriptions[name] || ''
+            rescue PermissionMissingException => e
+              Rails.logger.warn(_("Could not create role '%{name}': %{message}") % {:name => name, :message => e.message})
+              return false if Foreman.in_rake?
+              Rails.logger.error(_('Cannot continue because some permissions were not found, please run rake db:seed and retry'))
+              raise e
+            end
+
+            next unless permission_table_exists?
+            rbac_support = Plugin::RbacSupport.new
+            rbac_support.add_all_permissions_to_default_roles(Permission.where(name: permission_names)) if add_all_permissions_to_default_roles
+            rbac_support.add_permissions_to_default_roles(modified_roles) if modified_roles.any?
+            added_resource_permissions.each do |(resources, opts)|
+              rbac_support.add_resource_permissions_to_default_roles resources, opts
+            end
+          end
+        end
+      end
+
+      private
+
+      def permission_table_exists?
+        exists = Permission.connection.table_exists?(Permission.table_name)
+        Rails.logger.debug("Not adding permissions from plugin #{@id} to default roles - permissions table not found") if !exists && !Rails.env.test?
+        exists
       end
     end
   end

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -37,6 +37,12 @@ end
 Foreman::Plugin.initialize_default_registries
 Foreman::Plugin.medium_providers_registry.register MediumProviders::Default
 
+Rails.application.config.after_initialize do
+  Foreman::Plugin.registered_plugins.each do |_name, plugin|
+    plugin.finalize_setup!
+  end
+end
+
 Rails.application.config.to_prepare do
   # clear our users topbar cache
   # The users table may not be exist during initial migration of the database

--- a/test/unit/plugin/rbac_registry_test.rb
+++ b/test/unit/plugin/rbac_registry_test.rb
@@ -6,7 +6,7 @@ class RbacRegistryTest < ActiveSupport::TestCase
     destroy_hosts = "Destroy hosts"
     role_1 = Role.find_by :name => edit_hosts
     role_2 = Role.find_by :name => destroy_hosts
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:test)
     registry.role_ids = [role_1.id, role_2.id]
     result = registry.registered_roles
     assert_equal 2, result.count
@@ -15,7 +15,7 @@ class RbacRegistryTest < ActiveSupport::TestCase
   end
 
   def test_registered_permissions
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:test)
     registry.register :view_hosts, :resource_type => 'Host'
     registry.register :create_hosts, :resource_type => 'Host'
     result = registry.registered_permissions
@@ -27,7 +27,7 @@ class RbacRegistryTest < ActiveSupport::TestCase
   end
 
   def test_permissions
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:test)
     registry.register :view_hosts, :resource_type => 'Host'
     result = registry.permissions
     assert_equal "Host", result[:view_hosts][:resource_type]

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -485,6 +485,8 @@ class PluginTest < ActiveSupport::TestCase
     Foreman::Plugin.register :test_plugin do
       add_resource_permissions_to_default_roles ["Test::Resource"], :except => [:create_test]
     end
+    Foreman::Plugin.find(:test_plugin).finalize_setup!
+
     manager = Role.find_by :name => "Manager"
     org_admin = Role.find_by :name => "Organization admin"
     viewer = Role.find_by :name => "Viewer"
@@ -499,6 +501,8 @@ class PluginTest < ActiveSupport::TestCase
     Foreman::Plugin.register :test_plugin do
       add_permissions_to_default_roles "Viewer" => [:misc_test]
     end
+    Foreman::Plugin.find(:test_plugin).finalize_setup!
+
     assert viewer.permissions.find_by :name => "misc_test"
   end
 
@@ -512,6 +516,8 @@ class PluginTest < ActiveSupport::TestCase
       end
       add_all_permissions_to_default_roles
     end
+    Foreman::Plugin.find(:test_plugin).finalize_setup!
+
     manager = Role.find_by :name => "Manager"
     viewer = Role.find_by :name => "Viewer"
     org_admin = Role.find_by :name => "Organization admin"

--- a/test/unit/role_lock_test.rb
+++ b/test/unit/role_lock_test.rb
@@ -118,7 +118,7 @@ class RoleLockTest < ActiveSupport::TestCase
 
   test "should register role" do
     name = "Test Manager"
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:foreman_test)
     assert_empty registry.role_ids
     @role_lock.register_role name, @permissions, registry
     refute_empty registry.role_ids
@@ -127,7 +127,7 @@ class RoleLockTest < ActiveSupport::TestCase
 
   test "should update description of register role" do
     name = "Test Manager"
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:foreman_test)
     assert_empty registry.role_ids
     @role_lock.register_role name, @permissions, registry
     role = Role.find(registry.role_ids.first)


### PR DESCRIPTION
Before this change we have executed all the changes to the Roles and Permissions right away in the plugins.
This pushes all the changes into the rbac_registry and uses it to initialize the changes only after Rails are ready.
