### PR TITLE
Fixes #34009, #34010 - add finalization hook to plugin and RBAC

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -308,6 +308,13 @@ module Foreman #:nodoc:
       end
     end
 
+    # This method gets called once the Foreman is fully initialized
+    # It finalizes the plugin initialization process
+    def finalize_setup!
+      ActiveSupport.run_load_hooks(@id, self)
+      # TBD - nothing so far
+    end
+
     # Adds setting definition
     #
     # ===== Example

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -16,8 +16,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 require_dependency 'foreman/plugin/logging'
-require_dependency 'foreman/plugin/rbac_registry'
-require_dependency 'foreman/plugin/rbac_support'
 require_dependency 'foreman/plugin/report_scanner_registry'
 require_dependency 'foreman/plugin/report_origin_registry'
 require_dependency 'foreman/plugin/medium_providers_registry'
@@ -179,7 +177,7 @@ module Foreman #:nodoc:
     def initialize(id)
       @id = id.to_sym
       @logging = Plugin::Logging.new(@id)
-      @rbac_registry = Plugin::RbacRegistry.new
+      @rbac_registry = Plugin::RbacRegistry.new(@id)
       @provision_methods = {}
       @compute_resources = []
       @to_prepare_callbacks = []
@@ -312,7 +310,7 @@ module Foreman #:nodoc:
     # It finalizes the plugin initialization process
     def finalize_setup!
       ActiveSupport.run_load_hooks(@id, self)
-      # TBD - nothing so far
+      rbac_registry.setup!
     end
 
     # Adds setting definition

--- a/app/registries/foreman/plugin/rbac_registry.rb
+++ b/app/registries/foreman/plugin/rbac_registry.rb
@@ -3,7 +3,8 @@ module Foreman
     class RbacRegistry
       attr_accessor :role_ids, :default_roles, :registered_permissions
 
-      def initialize
+      def initialize(plugin_id)
+        @plugin_id = plugin_id
         @role_ids = []
         @registered_permissions = []
         @default_roles = {}
@@ -25,6 +26,10 @@ module Foreman
 
       def permission_names
         registered_permissions.map(&:first)
+      end
+
+      def setup!
+        # setup the plugin Rbac in DB
       end
     end
   end

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -40,6 +40,12 @@ end
 Foreman::Plugin.initialize_default_registries
 Foreman::Plugin.medium_providers_registry.register MediumProviders::Default
 
+Rails.application.config.after_initialize do
+  Foreman::Plugin.registered_plugins.each do |_name, plugin|
+    plugin.finalize_setup!
+  end
+end
+
 Rails.application.config.to_prepare do
   # clear our users topbar cache
   # The users table may not be exist during initial migration of the database

--- a/test/unit/plugin/rbac_registry_test.rb
+++ b/test/unit/plugin/rbac_registry_test.rb
@@ -6,7 +6,7 @@ class RbacRegistryTest < ActiveSupport::TestCase
     destroy_hosts = "Destroy hosts"
     role_1 = Role.find_by :name => edit_hosts
     role_2 = Role.find_by :name => destroy_hosts
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:test)
     registry.role_ids = [role_1.id, role_2.id]
     result = registry.registered_roles
     assert_equal 2, result.count
@@ -15,7 +15,7 @@ class RbacRegistryTest < ActiveSupport::TestCase
   end
 
   def test_registered_permissions
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:test)
     registry.register :view_hosts, :resource_type => 'Host'
     registry.register :create_hosts, :resource_type => 'Host'
     result = registry.registered_permissions
@@ -27,7 +27,7 @@ class RbacRegistryTest < ActiveSupport::TestCase
   end
 
   def test_permissions
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:test)
     registry.register :view_hosts, :resource_type => 'Host'
     result = registry.permissions
     assert_equal "Host", result[:view_hosts][:resource_type]

--- a/test/unit/role_lock_test.rb
+++ b/test/unit/role_lock_test.rb
@@ -118,7 +118,7 @@ class RoleLockTest < ActiveSupport::TestCase
 
   test "should register role" do
     name = "Test Manager"
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:foreman_test)
     assert_empty registry.role_ids
     @role_lock.register_role name, @permissions, registry
     refute_empty registry.role_ids
@@ -127,7 +127,7 @@ class RoleLockTest < ActiveSupport::TestCase
 
   test "should update description of register role" do
     name = "Test Manager"
-    registry = Foreman::Plugin::RbacRegistry.new
+    registry = Foreman::Plugin::RbacRegistry.new(:foreman_test)
     assert_empty registry.role_ids
     @role_lock.register_role name, @permissions, registry
     role = Role.find(registry.role_ids.first)


### PR DESCRIPTION
Add a method, that finalizes the plugin setup.
This should serve as a hook to do stuff that needs to be done only after the initialization of Foreman completed.

First step to achieve #8954 