### PR TITLE
Fixes #34026 - authorize puppet reports via Proxy

### DIFF
--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -8,7 +8,7 @@ module Api
       before_action :setup_search_options, :only => [:index, :last]
       before_action :compatibility, :only => :create
 
-      add_smart_proxy_filters :create, :features => proc { ConfigReportImporter.authorized_smart_proxy_features }
+      add_smart_proxy_filters :create, :features => proc { ReportImporter.authorized_smart_proxy_features }
 
       api :GET, "/config_reports/", N_("List all reports")
       param_group :search_and_pagination, ::Api::V2::BaseController

--- a/app/services/config_report_importer.rb
+++ b/app/services/config_report_importer.rb
@@ -1,10 +1,18 @@
 class ConfigReportImporter < ReportImporter
-  def self.authorized_smart_proxy_features
-    @authorized_smart_proxy_features ||= super + ['Puppet']
-  end
-
   def report_name_class
     ConfigReport
+  end
+
+  def self.authorized_smart_proxy_features
+    ReportImporter.authorized_smart_proxy_features
+  end
+
+  def self.register_smart_proxy_feature(feature)
+    ReportImporter.register_smart_proxy_feature(feature)
+  end
+
+  def self.unregister_smart_proxy_feature(feature)
+    ReportImporter.unregister_smart_proxy_feature(feature)
   end
 
   private

--- a/app/services/report_importer.rb
+++ b/app/services/report_importer.rb
@@ -5,12 +5,13 @@ class ReportImporter
   attr_reader :report, :report_scanners
 
   # When writing your own Report importer, provide feature(s) of authorized Smart Proxies
+  # via ReportImporter.register_smart_proxy_feature method. Do not override this method!
   def self.authorized_smart_proxy_features
     @authorized_smart_proxy_features ||= []
   end
 
   def self.register_smart_proxy_feature(feature)
-    @authorized_smart_proxy_features = (authorized_smart_proxy_features + [feature]).uniq
+    @authorized_smart_proxy_features = (authorized_smart_proxy_features + [feature.freeze]).uniq
   end
 
   def self.unregister_smart_proxy_feature(feature)

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -58,4 +58,6 @@ Rails.application.config.to_prepare do
   Foreman.input_types_registry.register(InputType::UserInput)
   Foreman.input_types_registry.register(InputType::FactInput)
   Foreman.input_types_registry.register(InputType::VariableInput)
+
+  ReportImporter.register_smart_proxy_feature("Puppet")
 end


### PR DESCRIPTION
The patch https://github.com/theforeman/foreman/pull/5010 changed how fact importer features are registered, the change was made in the host controller but not in the API controller. Therefore uploading reports via host controller works fine, however, using the API endpoint does not authorize automatically as the feature is not found.