### PR TITLE
Fixes #34042 - prometheus worker grouping enabled

### DIFF
--- a/lib/foreman/telemetry_sinks/prometheus_sink.rb
+++ b/lib/foreman/telemetry_sinks/prometheus_sink.rb
@@ -10,8 +10,10 @@ module Foreman
         FileUtils.mkdir_p(PROMETHEUS_STORE_DIR)
         # but clean it during startup as files will accumulate over time
         FileUtils.rm_f(Dir.glob("#{PROMETHEUS_STORE_DIR}/*.bin"))
-        Prometheus::Client.config.data_store =
-          Prometheus::Client::DataStores::DirectFileStore.new(dir: PROMETHEUS_STORE_DIR)
+        Prometheus::Client.config.data_store = Prometheus::Client::DataStores::DirectFileStore.new(
+          dir: PROMETHEUS_STORE_DIR,
+          proctitles: /^puma: cluster worker.*/
+        )
         @prom = ::Prometheus::Client.registry
       end
 


### PR DESCRIPTION
I wrote a patch for prometheus Ruby client which should solve our problem of getting many temporary data files behind when Puma recycles processes.

https://github.com/prometheus/client_ruby/pull/235

This patch makes use of it.

DO NOT MERGE until the contributed patch is merged, new release of the gem is made and we bump the dependency in Foreman.