### PR TITLE
Fixes #34063 - Drop deprecated Host#import_facts method

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -138,11 +138,6 @@ module Host
       host
     end
 
-    def import_facts(facts, source_proxy = nil)
-      Foreman::Deprecation.deprecation_warning('2.5', 'Use HostFactImporter#import_facts method instead of Host#import_facts')
-      HostFactImporter.new(self).import_facts(facts, source_proxy)
-    end
-
     def attributes_to_import_from_facts
       [:model]
     end


### PR DESCRIPTION
Katello test will fail, as will some other plugins that still use this method. Will open PRs to clean up there as well.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
