### PR TITLE
Puppet Environment in taxonomy ignore_types

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -58,6 +58,16 @@ namespace :purge do
     Filter.where.not(id: Filtering.distinct.select(:filter_id)).destroy_all
 
     Feature.where(name: 'Puppet').destroy_all
+
+    organizations = Organization.where("ignore_types LIKE '%Environment%'")
+    locations = Location.where("ignore_types LIKE '%Environment%'")
+
+    User.as_anonymous_admin do
+      (organizations + locations).each do |tax|
+        new_types = tax.ignore_types.reject { |type| type == "Environment" }
+        tax.update ignore_types: new_types
+      end
+    end
   end
 
   task all: ['purge:trends', 'purge:puppet']


### PR DESCRIPTION
Fix for issue with `uninitialized constant Environment`.

Steps to reproduce the issue:
```ruby
organization = Organization.first
organization.update ignore_types: ['Environment']

organization.selected_ids # => Error with uninitialized constant Environment

```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
