### PR TITLE
Fixes #34064 - don't override magic `klass` variable

### DIFF
--- a/test/unit/parameter_filter_test.rb
+++ b/test/unit/parameter_filter_test.rb
@@ -1,12 +1,12 @@
 require 'test_helper'
 
 class ParameterFilterTest < ActiveSupport::TestCase
-  let(:klass) do
+  let(:klass1) do
     mock('Example').tap do |k|
       k.stubs(:name).returns('Example')
     end
   end
-  let(:filter) { Foreman::ParameterFilter.new(klass) }
+  let(:filter) { Foreman::ParameterFilter.new(klass1) }
   let(:ui_context) { Foreman::ParameterFilter::Context.new(:ui, 'examples', 'create') }
 
   test "permitting second-level attributes via permit(Symbol)" do
@@ -93,7 +93,7 @@ class ParameterFilterTest < ActiveSupport::TestCase
   context "with plugin registered filters" do
     test "permits plugin-added attribute" do
       plugin = mock('plugin')
-      plugin.expects(:parameter_filters).with(klass).returns([[:plugin_ext, :another]])
+      plugin.expects(:parameter_filters).with(klass1).returns([[:plugin_ext, :another]])
       Foreman::Plugin.expects(:all).returns([plugin])
       assert_equal({'plugin_ext' => 'b'}, filter.filter_params(params(:example => {:test => 'a', :plugin_ext => 'b'}), ui_context).to_h)
     end
@@ -101,7 +101,7 @@ class ParameterFilterTest < ActiveSupport::TestCase
     test "permits plugin-added attributes from blocks" do
       plugin = mock('plugin')
       rule = [proc { |ctx| ctx.permit(:plugin_ext) }]
-      plugin.expects(:parameter_filters).with(klass).returns([rule])
+      plugin.expects(:parameter_filters).with(klass1).returns([rule])
       Foreman::Plugin.expects(:all).returns([plugin])
       assert_equal({'plugin_ext' => 'b'}, filter.filter_params(params(:example => {:test => 'a', :plugin_ext => 'b'}), ui_context).to_h)
       refute_empty(rule)


### PR DESCRIPTION
when you let(:klass), it somehow touches the `Mocha::Mock` class,
instead of creating a new thing, freaking out Mocha in the process.

before:

    $ bundle exec rake test TEST=test/unit/parameter_filter_test.rb TESTOPTS=-v
    #<Mocha::Mock:0x0000557bf12cf750>#test_0002_permits plugin-added attributes from blocks = 0.49 s = .
    #<Mocha::Mock:0x0000557bf1f22e30>#test_0001_permits plugin-added attribute = 0.04 s = .
    …

after:

    $ bundle exec rake test TEST=test/unit/parameter_filter_test.rb TESTOPTS=-v
    ParameterFilterTest::with nested object#test_0001_constructs permit() args for nested attribute through second filter 0.52 = .
    ParameterFilterTest::with nested object#test_0002_permits nested attribute through second filter 0.04 = .
    …


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
