### PR TITLE
Fixes #34068 - Inconsistent name of Job invocation report template

### DIFF
--- a/app/views/unattended/report_templates/job_invocation_-_report_template.erb
+++ b/app/views/unattended/report_templates/job_invocation_-_report_template.erb
@@ -1,11 +1,11 @@
 <%#
-name: Jobs - Invocation report template
+name: Job invocation - report template
 snippet: false
 template_inputs:
 - name: job_id
   required: true
   input_type: user
-  description: ID of job to report
+  description: Id of job invocation to report
   advanced: false
   value_type: plain
   resource_type: JobInvocation


### PR DESCRIPTION
Job invocation report template has bad name. It looks that the report template belongs to "Jobs" object but it isn't. It belongs to Job invocation object.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
