### PR TITLE
Fixes #34058 - extract multiline string for translation

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,7 +1,7 @@
 group :assets do
   gem 'jquery-ui-rails', '~> 6.0'
   gem 'patternfly-sass', '~> 3.59.4'
-  gem 'gettext_i18n_rails_js', '~> 1.0'
+  gem 'gettext_i18n_rails_js', '~> 1.3.1'
   gem 'execjs', '>= 1.4.0', '< 3.0'
   gem 'uglifier', '>= 1.0.3'
   gem 'sass-rails', '~> 6.0'

--- a/locale/cs_CZ/foreman.po
+++ b/locale/cs_CZ/foreman.po
@@ -25,9 +25,6 @@ msgstr ""
 msgid " Documentation"
 msgstr "Dokumentace"
 
-msgid " Remove"
-msgstr "Odebrat"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -39,9 +36,6 @@ msgstr "${progress}%% dokončeno"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr ""
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s – kurzor uvolníte stisknutím Shift-F12."
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s – následující hostitelé budou změněni"
@@ -63,9 +57,6 @@ msgstr[1] ""
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s Parametr aktualizován, další informace viz níže"
-
-msgid "%s Template"
-msgstr "%s Šablona"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -124,9 +115,6 @@ msgstr[1] "před %s měsíci"
 msgstr[2] "před %s měsíci"
 msgstr[3] "před %s měsíci"
 
-msgid "%s out of sync disabled"
-msgstr ""
-
 msgid "%s selected hosts"
 msgstr "vybráno %s strojů"
 
@@ -146,9 +134,6 @@ msgid "%s widget loading..."
 msgstr "načítání ovládacího prvku %s…"
 
 msgid "%s you had selected as your context has been deleted"
-msgstr ""
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
 msgstr ""
 
 msgid "%{action} %{vm}"
@@ -220,6 +205,9 @@ msgstr "%{match} se neshoduje s existující skupinou hostitelů"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} změněn z %{label1} na %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr ""
@@ -301,6 +289,9 @@ msgid "(filtered from %s total entries)"
 msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
+msgstr ""
+
+msgid "(updated %s)"
 msgstr ""
 
 msgid "*Clear %s proxy*"
@@ -494,12 +485,6 @@ msgstr "Přidat svazek"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr "Přidat virtuálnímu stroji jednotku optických disků."
 
-msgid "Add a Puppet class to host"
-msgstr "Přidat hostiteli Puppet třídu"
-
-msgid "Add a Puppet class to host group"
-msgstr "Přidat skupině hostitelů puppet třídu"
-
 msgid "Add a template combination"
 msgstr "Přidat kombinaci šablony"
 
@@ -545,9 +530,6 @@ msgstr ""
 msgid "Additional information about this host"
 msgstr "Další informace o tomto stroji"
 
-msgid "Address to connect to"
-msgstr "Adresa na kterou se připojit"
-
 msgid "Admin permissions required"
 msgstr ""
 
@@ -590,9 +572,6 @@ msgstr ""
 msgid "All"
 msgstr "Vše"
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr "Všechny stroje"
 
@@ -600,6 +579,12 @@ msgid "All Reports"
 msgstr "Všechny výkazy"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -761,9 +746,6 @@ msgstr ""
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr ""
-
 msgid "Are you sure you want to log out?"
 msgstr "Opravdu se chcete odhlásit?"
 
@@ -820,6 +802,12 @@ msgstr "Přiřadit organizaci"
 
 msgid "Assign Selected Hosts"
 msgstr "Přiřadit označené stroje"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1305,6 +1293,9 @@ msgstr ""
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr ""
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "Vnitřní účet správce není možné smazat"
 
@@ -1386,8 +1377,8 @@ msgstr ""
 msgid "Certificate path for GCE only"
 msgstr ""
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Certifikát který bude Foreman použit pro šifrování websoket"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "Certifikáty"
@@ -1446,6 +1437,9 @@ msgstr ""
 msgid "Clear"
 msgstr "Vyčistit"
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr ""
 
@@ -1457,12 +1451,6 @@ msgstr ""
 
 msgid "Click to log in again"
 msgstr "Kliknutím se opětovně přihlásíte"
-
-msgid "Click to remove %s"
-msgstr "%s odeberete kliknutím"
-
-msgid "Click to remove config group"
-msgstr "Kliknutím skupinu nastavení odeberete"
 
 msgid "Client Email"
 msgstr "E-mail klienta"
@@ -1626,14 +1614,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "Získávání nastavení"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "ConfigGroup|Název"
-
 msgid "Configuration"
 msgstr "Nastavení"
 
@@ -1676,8 +1656,8 @@ msgstr "Byly zjištěny střety"
 msgid "Connected"
 msgstr "Připojeno"
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "Připojeno (nešifrovaně) k: %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "Připojování (nešifrovaně) k: %s"
@@ -1727,7 +1707,7 @@ msgstr ""
 msgid "Cores per socket"
 msgstr "Jader na patici"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
 msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
@@ -1904,9 +1884,6 @@ msgstr ""
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-msgid "Create a Puppet class"
-msgstr "Vytvořit puppet třídu"
-
 msgid "Create a bookmark"
 msgstr "Vytvořit záložku"
 
@@ -1918,9 +1895,6 @@ msgstr "Nastavit výpočetní profil"
 
 msgid "Create a compute resource"
 msgstr "Vytvořit výpočetní prostředek"
-
-msgid "Create a config group"
-msgstr "Vytvořit skupinu nastavení"
 
 msgid "Create a default template combination for an operating system"
 msgstr ""
@@ -1994,9 +1968,6 @@ msgstr "Vytvořit podsíť"
 msgid "Create a template input"
 msgstr "Vytvořit vstup šablony"
 
-msgid "Create a trend counter"
-msgstr "Vytvořit čítač trendů"
-
 msgid "Create a user"
 msgstr "Vytvořit uživatele"
 
@@ -2012,9 +1983,6 @@ msgstr "Vytvořit LDAP zdroj ověřování"
 msgid "Create an architecture"
 msgstr "Vytvořit architekturu"
 
-msgid "Create an environment"
-msgstr "Vytvořit prostředí"
-
 msgid "Create an external user group linked to a user group"
 msgstr "Vytvořit externí skupinu uživatelů propojenou se skupinou uživatelů"
 
@@ -2027,14 +1995,14 @@ msgstr "Vytvořit na stroji rozhraní"
 msgid "Create an operating system"
 msgstr "Vytvořit operační systém"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr ""
-
 msgid "Create autosign entry"
 msgstr "Vytvořit položku automatického přihlášení"
 
 msgid "Create image"
 msgstr "Vytvořit obraz"
+
+msgid "Create model"
+msgstr ""
 
 msgid "Create new boot volume from image"
 msgstr ""
@@ -2050,6 +2018,9 @@ msgstr ""
 
 msgid "Created"
 msgstr "Vytvořeno"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr ""
@@ -2079,18 +2050,6 @@ msgid "Custom instance type"
 msgstr "Uživatelsky určený typ instance"
 
 msgid "DB pending seed"
-msgstr ""
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
 msgstr ""
 
 msgid "DHCP"
@@ -2183,7 +2142,7 @@ msgstr "Výchozí"
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2205,9 +2164,6 @@ msgid "Default PXE menu item in global template - 'local', 'discovery' or custom
 msgstr ""
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
-msgstr ""
-
-msgid "Default Puppet environment"
 msgstr ""
 
 msgid "Default VNC Keyboard"
@@ -2291,9 +2247,6 @@ msgstr "Smazat certifikáty vydané PuppetCA pro %s"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr ""
 
-msgid "Delete a Puppet class"
-msgstr "Smazat Puppet třídu"
-
 msgid "Delete a Virtual Machine"
 msgstr "Smazat virtuální stroj"
 
@@ -2305,9 +2258,6 @@ msgstr "Smazat výpočetní profil"
 
 msgid "Delete a compute resource"
 msgstr "Smazat výpočetní prostředek"
-
-msgid "Delete a config group"
-msgstr "Smazat skupinu nastavení"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "Smazat výchozí kombinaci šablony pro operační systém"
@@ -2390,9 +2340,6 @@ msgstr "Smazat kombinaci šablony"
 msgid "Delete a template input"
 msgstr "Smazat vstup šablony"
 
-msgid "Delete a trend counter"
-msgstr "Smazat čítač trendů"
-
 msgid "Delete a user"
 msgstr "Smazat uživatele"
 
@@ -2432,9 +2379,6 @@ msgstr "Smazat SSH klíč pro uživatele"
 msgid "Delete an architecture"
 msgstr "Smazat architekturu"
 
-msgid "Delete an environment"
-msgstr "Smazat prostředí"
-
 msgid "Delete an external user group"
 msgstr "Smazat externí skupinu uživatelů"
 
@@ -2444,14 +2388,17 @@ msgstr "Smazat obraz"
 msgid "Delete an operating system"
 msgstr "Smazat operační systém"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr ""
-
 msgid "Delete autosign entry"
 msgstr ""
 
 msgid "Delete filter?"
 msgstr "Smazat filtr?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr ""
@@ -2523,9 +2470,6 @@ msgid "Disable alerts for selected hosts"
 msgstr "Vypnout  výstrahy pro označené stroje"
 
 msgid "Disable all filters overriding"
-msgstr ""
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2644,10 +2588,10 @@ msgstr "Stáhne vytvořený výkaz"
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr ""
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"
@@ -2655,9 +2599,6 @@ msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "ENC prostředí"
 
 msgid "ERROR or FATAL"
 msgstr ""
@@ -2700,6 +2641,9 @@ msgstr "Upravit tento stroj"
 
 msgid "Editor"
 msgstr "Editor"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "Předvolby e-mailu"
@@ -2776,10 +2720,6 @@ msgstr "Koncová IP adresa pro automatické doporučování IP adres"
 msgid "Entries per page"
 msgstr "Položek na stránku"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Prostředí"
-
 msgid "Environment IDs"
 msgstr "Identifikátory prostředí"
 
@@ -2794,10 +2734,6 @@ msgstr ""
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Environment|Název"
 
 msgid "Error"
 msgstr "Chyba"
@@ -2836,6 +2772,9 @@ msgid "Error loading scheduler hint filters information: %s"
 msgstr ""
 
 msgid "Error removing widget from dashboard."
+msgstr ""
+
+msgid "Error statuses"
 msgstr ""
 
 msgid "Error submitting data:"
@@ -3305,14 +3244,14 @@ msgstr ""
 msgid "Fix All Mismatches"
 msgstr "Opravit všechny neshody"
 
-msgid "Fix DB cache"
-msgstr "Opravit mezipaměť databáze"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Opravit mezipaměť databáze při příštím restart Foreman"
-
 msgid "Fix Mismatches"
 msgstr "Opravit neshody"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr ""
@@ -3356,9 +3295,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr ""
 
-msgid "Force a Puppet agent run on the host"
-msgstr "Vynutit spuštění Puppet agenta na hostiteli"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr ""
 
@@ -3392,6 +3328,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr ""
 
@@ -3400,6 +3340,10 @@ msgstr ""
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman nyní už nespravuje cyklus sestavení pro %s"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr ""
@@ -3428,7 +3372,7 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
 msgstr ""
 
 msgid "Foreman will create the host when a report is received"
@@ -3437,19 +3381,13 @@ msgstr ""
 msgid "Foreman will create the host when new facts are received"
 msgstr "Při obdržení nových faktů Foreman vytvoří hostitele"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr ""
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr ""
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr ""
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
+msgid "Foreman will load the new UI for host details"
 msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
@@ -3459,9 +3397,6 @@ msgid "Foreman will parse ERB in parameters value in the ENC output"
 msgstr ""
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
-msgstr ""
-
-msgid "Foreman will update a host's environment from its facts"
 msgstr ""
 
 msgid "Foreman will update a host's hostgroup from its facts"
@@ -3480,6 +3415,18 @@ msgid "Foreman will use random UUIDs for certificate signing instead of hostname
 msgstr ""
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
 msgstr ""
 
 msgid "Form was successfully created."
@@ -3507,6 +3454,9 @@ msgid "Full screen"
 msgstr "Celá obrazovka"
 
 msgid "Function not available for %s"
+msgstr ""
+
+msgid "Further Information"
 msgstr ""
 
 msgid "GMT time"
@@ -3578,8 +3528,8 @@ msgstr ""
 msgid "Get default dashboard widgets"
 msgstr ""
 
-msgid "Get statistics"
-msgstr "Získat statistiky"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "Získat stav stroje"
@@ -3701,6 +3651,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr "Modely hardware"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr ""
 
@@ -3746,10 +3702,16 @@ msgstr "Historie"
 msgid "Host"
 msgstr "Stroj"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "Stroj %s je sestaven"
 
 msgid "Host %s is not associated with a VM"
+msgstr ""
+
+msgid "Host %s will be built next boot"
 msgstr ""
 
 msgid "Host Configuration Chart"
@@ -3785,8 +3747,14 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "Parametry stroje"
 
-msgid "Host Wizard"
-msgstr "Průvodce pro stroj"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
+msgstr ""
 
 msgid "Host audit entries"
 msgstr ""
@@ -3794,12 +3762,12 @@ msgstr ""
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr ""
-
 msgid "Host details"
 msgstr "Podrobnosti o stroji"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr ""
@@ -3937,8 +3905,32 @@ msgid "Host::Base|Uuid"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "HostConfigGroup|Typ stroje"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4166,9 +4158,6 @@ msgstr "Identifikátor šablony nastavení"
 msgid "ID of domain"
 msgstr "Identifikátor domény"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr "Identifikátor stroje"
 
@@ -4235,7 +4224,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4298,9 +4287,6 @@ msgstr "automatické doporučování IP adresy"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr ""
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr "IP adresa:"
 
@@ -4324,6 +4310,9 @@ msgstr "IPv4 podsíť"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr ""
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "IPv4 adresa rozhraní"
 
@@ -4343,6 +4332,9 @@ msgstr[1] ""
 
 msgid "IPv6 Subnet"
 msgstr "IPv6 podsíť"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "IPv6 adresa rozhraní"
@@ -4404,14 +4396,14 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr ""
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr ""
-
 msgid "Ignore facts for domain"
 msgstr "Ignorovat fakta pro doménu"
 
 msgid "Ignore facts for operating system"
 msgstr "Ignorovat fakta o operačním systému"
+
+msgid "Ignore interfaces facts for provisioning"
+msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
 msgstr ""
@@ -4491,12 +4483,6 @@ msgstr "Importovat jako nespravovaný stroj"
 
 msgid "Import of facts failed for host %s"
 msgstr "Import faktů pro stroj %s se nezdařil"
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Importovat puppet třídy z puppet proxy"
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr ""
 
 msgid "Imported IPv4 Subnets"
 msgstr "Importované IPv4 podsítě"
@@ -4609,6 +4595,9 @@ msgstr "Chyba instalace"
 msgid "Installation medium configuration"
 msgstr "Nastavení instalačního média"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "Nainstalováno"
 
@@ -4673,6 +4662,9 @@ msgid "Invalid %{assoc} selection, you must select at least one of yours and hav
 msgstr ""
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
+msgstr ""
+
+msgid "Invalid HTTP(S) URL"
 msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
@@ -4840,13 +4832,13 @@ msgstr "Nejnovější události"
 msgid "Launch Console"
 msgstr "Spustit konzoli"
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr ""
 
 msgid "Learn more about LDAP authentication in the documentation."
+msgstr ""
+
+msgid "Legacy UI"
 msgstr ""
 
 msgid "Length"
@@ -4881,24 +4873,6 @@ msgstr "Vypsat všechny zdroje LDAP ověřování"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr ""
-
-msgid "List all Puppet class IDs for host"
-msgstr "Vypsat všechny identifikátory Puppet tříd pro hostitele"
-
-msgid "List all Puppet class IDs for host group"
-msgstr ""
-
-msgid "List all Puppet classes"
-msgstr "Vypsat všechny puppet třídy"
-
-msgid "List all Puppet classes for a host"
-msgstr "Vypsat všechny Puppet třídy pro hostitele"
-
-msgid "List all Puppet classes for a host group"
-msgstr ""
-
-msgid "List all Puppet classes for an environment"
-msgstr "Vypsat všechny Puppet třídy pro prostředí"
 
 msgid "List all SSH keys for a user"
 msgstr "Vypsat všechny SSH klíče uživatele"
@@ -4935,9 +4909,6 @@ msgstr "Vypsat všechny výpočetní prostředky"
 
 msgid "List all email notifications for a user"
 msgstr ""
-
-msgid "List all environments"
-msgstr "Vypsat všechny prostředí"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr ""
@@ -5074,9 +5045,6 @@ msgstr "Vypsat všechny role"
 msgid "List all settings"
 msgstr "Vypsat veškerá nastavení"
 
-msgid "List all smart class parameters"
-msgstr ""
-
 msgid "List all smart proxies"
 msgstr ""
 
@@ -5155,15 +5123,6 @@ msgstr ""
 msgid "List default templates combinations for an operating system"
 msgstr ""
 
-msgid "List environments of Puppet class"
-msgstr ""
-
-msgid "List environments per location"
-msgstr ""
-
-msgid "List environments per organization"
-msgstr ""
-
 msgid "List external authentication sources"
 msgstr ""
 
@@ -5171,6 +5130,9 @@ msgid "List external authentication sources per location"
 msgstr ""
 
 msgid "List external authentication sources per organization"
+msgstr ""
+
+msgid "List hosts forming the Foreman instance"
 msgstr ""
 
 msgid "List hosts per location"
@@ -5206,9 +5168,6 @@ msgstr ""
 msgid "List of compute profiles"
 msgstr "Seznam výpočetních profilů"
 
-msgid "List of config groups"
-msgstr "Seznam skupin nastavení"
-
 msgid "List of domains"
 msgstr "Seznam domén"
 
@@ -5224,34 +5183,19 @@ msgstr ""
 msgid "List of email notifications"
 msgstr ""
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr ""
 
 msgid "List of hosts which answer to the provided query"
 msgstr ""
 
-msgid "List of override values for a specific smart class parameter"
-msgstr ""
-
 msgid "List of realms"
 msgstr ""
 
 msgid "List of resources types that will be automatically associated"
-msgstr ""
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr ""
-
-msgid "List of smart class parameters for a specific environment"
-msgstr ""
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr ""
-
-msgid "List of smart class parameters for a specific host"
-msgstr ""
-
-msgid "List of smart class parameters for a specific host group"
 msgstr ""
 
 msgid "List of subnets"
@@ -5270,9 +5214,6 @@ msgid "List of table preferences for a user"
 msgstr ""
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
-msgstr ""
-
-msgid "List of trends counters"
 msgstr ""
 
 msgid "List of user selected columns"
@@ -5458,6 +5399,10 @@ msgid "LookupKey|Key type"
 msgstr "LookupKey|Typ klíče"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5506,6 +5451,9 @@ msgstr "MAC adresa"
 
 msgid "MAC Address"
 msgstr "MAC adresa"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr ""
@@ -5588,6 +5536,9 @@ msgstr "Spravovat"
 msgid "Manage Bookmarks"
 msgstr ""
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr ""
 
@@ -5595,6 +5546,9 @@ msgid "Manage Organizations"
 msgstr ""
 
 msgid "Manage PuppetCA"
+msgstr ""
+
+msgid "Manage all statuses"
 msgstr ""
 
 msgid "Manage host"
@@ -5696,10 +5650,6 @@ msgid "Message"
 msgstr "Zpráva"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Message|Hodnota"
 
@@ -5717,6 +5667,9 @@ msgstr ""
 
 msgid "Metrics"
 msgstr "Metriky"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "Před minutami"
@@ -5795,6 +5748,9 @@ msgstr "Můj účet"
 msgid "N/A"
 msgstr "Není"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr ""
 
@@ -5816,7 +5772,7 @@ msgstr "Název média"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr ""
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
 msgstr ""
 
 msgid "Name of the host group"
@@ -5894,6 +5850,9 @@ msgstr "Nová organizace"
 msgid "New SSH key"
 msgstr "Nový SSH klíč"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "Nový virtuální stroj"
 
@@ -5909,8 +5868,8 @@ msgstr ""
 msgid "New filter"
 msgstr "Nový filtr"
 
-msgid "New window"
-msgstr "Nové okno"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Další"
@@ -6037,6 +5996,9 @@ msgstr "Žádná TFTP funkce"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "Nejsou určené žádné TFTP proxy, není možno pokračovat"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr ""
 
@@ -6075,6 +6037,9 @@ msgstr "Žádné e-maily"
 
 msgid "No entries found"
 msgstr "Nenalezeny žádné položky"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr ""
@@ -6172,6 +6137,9 @@ msgstr ""
 msgid "No smart proxies to show"
 msgstr "Žádné smart proxy k zobrazení"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "Žádné podsítě"
 
@@ -6208,11 +6176,11 @@ msgstr ""
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr ""
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "Nenainstalováno"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr ""
 
 msgid "Not implemented"
 msgstr "Neimplementováno"
@@ -6379,6 +6347,9 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "Obraz operačního systému"
 
@@ -6449,9 +6420,6 @@ msgstr ""
 
 msgid "Open"
 msgstr "Otevřít"
-
-msgid "Open Spice in a new window"
-msgstr "Otevřít Spice v novém okně"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr ""
@@ -6552,9 +6520,6 @@ msgstr "Volitelné ověřování zadání"
 msgid "Optional array of log hashes"
 msgstr ""
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr ""
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr ""
 
@@ -6618,9 +6583,6 @@ msgstr ""
 msgid "Override"
 msgstr "Přebít"
 
-msgid "Override Value"
-msgstr ""
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr ""
 
@@ -6633,8 +6595,17 @@ msgstr "Přehled"
 msgid "Overwrite"
 msgstr "Přepsat"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "Vlastní"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "Vlastník"
@@ -6718,6 +6689,10 @@ msgstr "Parameter|Název"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Parameter|Priorita"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr ""
@@ -6954,9 +6929,6 @@ msgstr ""
 msgid "Plugins"
 msgstr "Zásuvné moduly"
 
-msgid "Port to connect to"
-msgstr "Port na který se připojit"
-
 msgid "Possible values"
 msgstr "Možné hodnoty"
 
@@ -6969,7 +6941,13 @@ msgstr "Napájení"
 msgid "Power ON this machine"
 msgstr "Zapnout tento stroj"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
+msgstr ""
+
+msgid "Power has been set to \"%s\" successfully"
 msgstr ""
 
 msgid "Power operations are not enabled on this host."
@@ -7038,7 +7016,7 @@ msgstr ""
 msgid "Private"
 msgstr "Soukromé"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Proceed to Edit"
@@ -7136,6 +7114,9 @@ msgstr "Proxy"
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7184,9 +7165,6 @@ msgstr "Puppet třída"
 msgid "Puppet error state"
 msgstr "Puppet chybový stav"
 
-msgid "Puppet interval"
-msgstr ""
-
 msgid "Puppet parameter"
 msgstr "Puppet parametr"
 
@@ -7195,14 +7173,6 @@ msgstr ""
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Puppetclass|Název"
 
 msgid "Query"
 msgstr "Dotaz"
@@ -7277,6 +7247,9 @@ msgstr "Realm|Název"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
+msgstr ""
+
+msgid "Reboot"
 msgstr ""
 
 msgid "Reboot and build"
@@ -7379,12 +7352,6 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr "Odebrat parametr"
 
-msgid "Remove a Puppet class from host"
-msgstr ""
-
-msgid "Remove a Puppet class from host group"
-msgstr ""
-
 msgid "Remove an email notification for a user"
 msgstr ""
 
@@ -7392,6 +7359,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7476,6 +7446,9 @@ msgstr "ReportTemplate|Název"
 msgid "ReportTemplate|Snippet"
 msgstr ""
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "Hlášeno v"
 
@@ -7487,6 +7460,9 @@ msgstr "Nahlásil %s"
 
 msgid "Reports"
 msgstr "Výkazy"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7531,6 +7507,9 @@ msgstr ""
 msgid "Required when user want to change own password"
 msgstr "Vyžadováno pokud uživatel chce změnit své heslo"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
@@ -7574,6 +7553,9 @@ msgstr "Výsledek výkazu %s"
 msgid "Resume"
 msgstr "Obnovit"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr ""
 
@@ -7599,7 +7581,13 @@ msgstr ""
 msgid "Revert Local Changes"
 msgstr "Vzít zpět místní změny"
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
+msgstr ""
+
+msgid "Review before build"
 msgstr ""
 
 msgid "Review build status for %s"
@@ -7609,6 +7597,9 @@ msgid "Revoke"
 msgstr "Odvolat"
 
 msgid "Revoke a Personal Access Token for a user"
+msgstr ""
+
+msgid "Revoke personal access token"
 msgstr ""
 
 msgid "Revoked"
@@ -7691,6 +7682,9 @@ msgstr ""
 msgid "SMTP address"
 msgstr "SMTP adresa"
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "SMTP ověřování"
 
@@ -7705,6 +7699,9 @@ msgstr "SMTP heslo"
 
 msgid "SMTP port"
 msgstr "SMTP port"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr "SMTP uživatelské jméno"
@@ -7724,13 +7721,19 @@ msgstr "Časový limit SSH"
 msgid "SSL CA file"
 msgstr ""
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
 msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr ""
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
 msgstr ""
 
 msgid "SSL certificate"
@@ -7780,6 +7783,9 @@ msgstr "Uložit něco a zkusit znovu"
 
 msgid "Saved Bookmarks"
 msgstr "Uložené záložky"
+
+msgid "Saved audits interval"
+msgstr ""
 
 msgid "Schedule generating of a report"
 msgstr "Plán vytváření výkazů"
@@ -7957,6 +7963,9 @@ msgstr "Argumenty pro sendmail"
 msgid "Sendmail location"
 msgstr "Umístění sendmail"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr ""
 
@@ -7987,6 +7996,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr "Nastavit IP adresu pro %s"
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr ""
 
@@ -8007,9 +8019,6 @@ msgstr "Nastavit pořadí, ve kterém jsou hodnoty překládány."
 
 msgid "Set up compute instance %s"
 msgstr "Nastavit výpočetní instanci %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8077,6 +8086,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr ""
 
@@ -8110,18 +8125,6 @@ msgstr ""
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-msgid "Show a Puppet class"
-msgstr "Zobrazit puppet třídu"
-
-msgid "Show a Puppet class for a host group"
-msgstr ""
-
-msgid "Show a Puppet class for an environment"
-msgstr "Zobrazit Puppet třídu pro prostředí"
-
-msgid "Show a Puppet class for host"
-msgstr "Zobrazit Puppet třídu pro hostitele"
-
 msgid "Show a bookmark"
 msgstr "Zobrazit záložku"
 
@@ -8133,9 +8136,6 @@ msgstr "Zobrazit výpočetní profil"
 
 msgid "Show a compute resource"
 msgstr "Zobrazit výpočetní prostředek"
-
-msgid "Show a config group"
-msgstr "Zobrazit skupinu nastavení"
 
 msgid "Show a default template combination for an operating system"
 msgstr "Zobrazit výchozí kombinaci šablony pro operační systém"
@@ -8203,17 +8203,11 @@ msgstr "Zobrazit roli"
 msgid "Show a setting"
 msgstr "Zobrazit nastavení"
 
-msgid "Show a smart class parameter"
-msgstr ""
-
 msgid "Show a smart proxy"
 msgstr ""
 
 msgid "Show a subnet"
 msgstr "Zobrazit podsíť"
-
-msgid "Show a trend"
-msgstr ""
 
 msgid "Show a user"
 msgstr "Zobrazit uživatele"
@@ -8248,9 +8242,6 @@ msgstr "Zobrazit audit"
 msgid "Show an email notification"
 msgstr ""
 
-msgid "Show an environment"
-msgstr "Zobrazit prostředí"
-
 msgid "Show an external authentication source"
 msgstr ""
 
@@ -8271,9 +8262,6 @@ msgstr ""
 
 msgid "Show an operating system"
 msgstr "Zobrazit operační systém"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr ""
 
 msgid "Show available API links"
 msgstr ""
@@ -8356,9 +8344,6 @@ msgstr "Přeskočeno"
 msgid "Skipped|S"
 msgstr ""
 
-msgid "Smart Class Parameter"
-msgstr ""
-
 msgid "Smart Class Parameters"
 msgstr ""
 
@@ -8426,6 +8411,9 @@ msgstr "Některé rozhraní nejsou platná"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr ""
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr ""
 
@@ -8449,10 +8437,6 @@ msgid "Source"
 msgstr "Zdroj"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Source|Otisk"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Source|Hodnota"
 
@@ -8474,8 +8458,8 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr ""
 
-msgid "Specify additional options to sendmail"
-msgstr "Zadejte další volby pro sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "Specify authentication type, if required"
 msgstr "Zadejte typ ověřování se (pokud je vyžadováno)"
@@ -8518,7 +8502,7 @@ msgstr "Stav"
 msgid "Status %s does not exist."
 msgstr ""
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
 msgstr ""
 
 msgid "Stop updating Operating System from facts"
@@ -8615,6 +8599,10 @@ msgid "Subnet|Dns secondary"
 msgstr "Subnet|Záložní DNS"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Subnet|Od"
 
@@ -8641,6 +8629,10 @@ msgstr "Subnet|Název"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Subnet|Síť"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8713,6 +8705,12 @@ msgstr ""
 
 msgid "Supported Formats"
 msgstr "Podporované formáty"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "Synchronizovat skupinu ze zdroje ověřování"
@@ -8871,12 +8869,20 @@ msgid "TemplateInput|Advanced"
 msgstr "TemplateInput|Pokročilé"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "TemplateInput|Popis"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "TemplateInput|Název faktu"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8945,6 +8951,10 @@ msgid "Template|Default"
 msgstr "Template|Výchozí"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Template|Zamčeno"
 
@@ -8995,7 +9005,7 @@ msgstr ""
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9141,7 +9151,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9158,8 +9168,8 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The location of the sendmail executable"
-msgstr "Umístění spustitelného souboru se sendmail"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "Označené kolonky potřebují revizi"
@@ -9185,9 +9195,6 @@ msgid ""
 msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
-msgstr ""
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
 msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
@@ -9252,6 +9259,9 @@ msgid "There may be more information in the server's logs."
 msgstr "V záznamech událostí serveru (log) mohou být další podrobnosti."
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
+msgstr ""
+
+msgid "There was a problem processing the request. Please try again."
 msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
@@ -9379,7 +9389,7 @@ msgstr "Tato hodnota není skrytá"
 msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9404,15 +9414,6 @@ msgid "Timezone to use for new users"
 msgstr "Časová zóna, kterou použít pro nové uživatele"
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9444,9 +9445,6 @@ msgstr ""
 
 msgid "Token Expiry"
 msgstr "Skončení platnosti tokenu"
-
-msgid "Token duration"
-msgstr ""
 
 msgid "Token expired"
 msgstr "Platnost tokenu skončila"
@@ -9485,40 +9483,7 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Čítač trendu"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "TrendCounter|Počet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "TrendCounter|Konec intervalu"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "TrendCounter|Začátek intervalu"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Trend|Název faktu"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Trend|Hodnota faktu"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Trend|Název"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
+msgid "Total: %s"
 msgstr ""
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
@@ -9800,6 +9765,12 @@ msgstr ""
 msgid "Unallowed template for dashboard widget: %s"
 msgstr ""
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr ""
 
@@ -9857,6 +9828,9 @@ msgstr ""
 msgid "Unknown status: %s"
 msgstr "Neznámý stav: %s"
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "Odemknout"
 
@@ -9884,9 +9858,6 @@ msgstr ""
 msgid "Update IP from built request"
 msgstr ""
 
-msgid "Update a Puppet class"
-msgstr "Aktualizovat puppet třídu"
-
 msgid "Update a bookmark"
 msgstr "Aktualizovat záložku"
 
@@ -9898,9 +9869,6 @@ msgstr "Aktualizovat výpočetní profil"
 
 msgid "Update a compute resource"
 msgstr "Aktualizovat výpočetní prostředek"
-
-msgid "Update a config group"
-msgstr "Aktualizovat skupinu nastavení"
 
 msgid "Update a default template combination for an operating system"
 msgstr "Aktualizovat výchozí kombinaci šablony pro operační systém"
@@ -9968,9 +9936,6 @@ msgstr "Aktualizovat roli"
 msgid "Update a setting"
 msgstr "Aktualizovat nastavení"
 
-msgid "Update a smart class parameter"
-msgstr ""
-
 msgid "Update a smart proxy"
 msgstr "Aktualizovat smart proxy"
 
@@ -10001,9 +9966,6 @@ msgstr "Aktualizovat architekturu"
 msgid "Update an email notification for a user"
 msgstr ""
 
-msgid "Update an environment"
-msgstr "Aktualizovat prostředí"
-
 msgid "Update an external authentication source"
 msgstr ""
 
@@ -10012,12 +9974,6 @@ msgstr "Aktualizovat obraz"
 
 msgid "Update an operating system"
 msgstr "Aktualizovat operační systém"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr ""
-
-msgid "Update environment from facts"
-msgstr "Aktualizovat prostředí z faktů"
 
 msgid "Update external user group"
 msgstr ""
@@ -10254,6 +10210,10 @@ msgid "User|Description"
 msgstr "User|Popis"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "User|Jméno"
 
@@ -10390,8 +10350,8 @@ msgstr "Proměnná"
 msgid "Variables"
 msgstr "Proměnné"
 
-msgid "Vendor Class"
-msgstr "Třída výrobce"
+msgid "Vendor class"
+msgstr ""
 
 msgid "Verify"
 msgstr "Ověřit"
@@ -10453,6 +10413,9 @@ msgstr "Čeká se až bude %s dostupné"
 msgid "Warning"
 msgstr "Varování"
 
+msgid "Warning statuses"
+msgstr ""
+
 msgid "Warning!"
 msgstr "Varování!"
 
@@ -10513,6 +10476,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10635,6 +10601,9 @@ msgid "Yes (override)"
 msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
+msgstr ""
+
+msgid "You are about to clear %s status. Are you sure?"
 msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
@@ -10790,6 +10759,9 @@ msgstr "vše"
 msgid "already exists"
 msgstr "už existuje"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "organizace"
 
@@ -10801,9 +10773,6 @@ msgstr "pole"
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "náleží do skupiny nastavení"
 
 msgid "boolean"
 msgstr ""
@@ -10984,9 +10953,6 @@ msgstr "zapnout ukládání do mezipaměti – pouze pro VMware"
 
 msgid "enabled"
 msgstr ""
-
-msgid "environment id"
-msgstr "identifikátor prostředí"
 
 msgid "expected a value of type %s"
 msgstr ""
@@ -11238,8 +11204,7 @@ msgstr "propojit tuto a externí skupinu uživatelů"
 msgid "list"
 msgstr "seznam"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "Česky"
 
@@ -11418,12 +11383,6 @@ msgid "physical @ NAT %s"
 msgstr ""
 
 msgid "physical @ bridge %s"
-msgstr ""
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
 msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"

--- a/locale/cs_CZ/foreman.po
+++ b/locale/cs_CZ/foreman.po
@@ -392,6 +392,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Vyskytl se problém při zjišťování typu hostitele: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -677,6 +680,9 @@ msgstr "Je zapotřebí e-mailové adresy – aktualizujte podrobnosti svého ú�
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr ""
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -744,6 +750,12 @@ msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr ""
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 msgid "Are you sure you want to log out?"
@@ -1128,6 +1140,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "Prázdná šablona"
 
@@ -1222,6 +1237,9 @@ msgid "Build PXE Default"
 msgstr "Sestavit PXE Default"
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2606,6 +2624,12 @@ msgstr ""
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3313,6 +3337,12 @@ msgstr ""
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3607,6 +3637,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4369,7 +4402,19 @@ msgstr ""
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr ""
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4379,6 +4424,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4394,6 +4442,9 @@ msgid "If this setting needs to be changed in file, it will have the file path."
 msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
+msgstr ""
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
 msgstr ""
 
 msgid "Ignore facts for domain"
@@ -4541,6 +4592,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "Infrastruktura"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Převzít nadřazené (%s)"
 
@@ -4584,6 +4638,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5530,6 +5587,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr "MailNotification|Typ předplatného"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Spravovat"
 
@@ -6368,6 +6428,9 @@ msgstr "Název operačního systému z nástroje facter – např. RedHat"
 msgid "Off"
 msgstr "Vypnuto"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "OK"
 
@@ -6411,6 +6474,9 @@ msgstr ""
 
 msgid "Only one volume can be bootable"
 msgstr "Zaveditelný může být jen jediný svazek"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "Jejda!"
@@ -6820,6 +6886,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7501,6 +7570,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr ""
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr ""
 
@@ -8086,6 +8158,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8320,6 +8395,11 @@ msgstr ""
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -8409,6 +8489,12 @@ msgid "Some interfaces are invalid"
 msgstr "Některé rozhraní nejsou platná"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
+msgstr ""
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
 msgstr ""
 
 msgid "Something went wrong"
@@ -9073,6 +9159,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr ""
 
@@ -9083,6 +9172,9 @@ msgid "The class of CPU supplied in this machine. This is primarily used by Spar
 msgstr ""
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
+msgstr ""
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
 msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
@@ -9276,6 +9368,12 @@ msgstr "Došlo k chybě při vypisování virt. strojů: %(status)s %(statusText
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr ""
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr ""
 
@@ -9289,6 +9387,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9345,6 +9446,9 @@ msgstr ""
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9365,6 +9469,12 @@ msgstr ""
 
 msgid "This service is only available for authenticated users"
 msgstr "Tato služba je k dispozici pouze přihlášeným uživatelům"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "Tato šablona je uzamčena a není možné ji odebrat."
@@ -9390,6 +9500,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9434,6 +9547,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10287,6 +10403,9 @@ msgstr "Atributy virt. stroje (%s)"
 msgid "VM already associated with a host"
 msgstr "Virt. stroj už je přiřazený k hostiteli"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "Vírt. stro přiřazen k hostiteli %s"
 
@@ -10426,6 +10545,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr ""
@@ -10609,10 +10731,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr ""
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/de/foreman.po
+++ b/locale/de/foreman.po
@@ -422,6 +422,9 @@ msgstr "Eine Benachrichtigung, wenn der Host-Bericht einen Konfigurationsfehler 
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Es trat ein Problem auf bei der Erkennung des Hosttyp: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr "Eine Zusammenfassung des Audit-Änderungsberichts <br> Gefiltert nach einer Abfrage, falls erforderlich"
 
@@ -707,6 +710,9 @@ msgstr "Eine E-Mail Adresse ist erforderlich. Bitte die Konto Einstellungen aktu
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "Beim Verbindungsversuch zu LDAP ist ein Fehler aufgetreten. Bitte prüfen Sie den Status des Host der  Authentifizierungsquelle und ob dieser durch den Foreman Host erreicht werden kann."
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr "Ein Fehler ist aufgetreten."
 
@@ -775,6 +781,12 @@ msgstr "Sind Sie sicher, dass Sie den Host %s löschen möchten? Diese Aktion is
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Sind Sie sicher, dass Sie den Host %s löschen möchten? Dies wird die Virtuelle Maschine und alle Laufwerke unwiderruflich löschen. Dieses Verhalten lässt sich durch globale Einstellungen anpassen: \"Destroy associated VM on host delete\""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr "Sind Sie sicher, dass Sie sich abmelden möchten?"
@@ -1158,6 +1170,9 @@ msgstr "Beachten Sie, dass dies gefährlich ist und zu Leistungs- und Sicherheit
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr "Aufgrund der unterschiedlichen Längen der ERB-Tags kann das Einrücken der ERB-Syntax unübersichtlich erscheinen. Die ERB-Syntax ignoriert Leerzeichen. Eine Methode zur Handhabung der Einrückung besteht darin, das ERB-Tag am Anfang jeder neuen Zeile zu deklarieren und dann Leerzeichen innerhalb des ERB-Tags zu verwenden, um die Beziehungen innerhalb der Syntax zu skizzieren, zum Beispiel:"
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "Leere Vorlage"
 
@@ -1253,6 +1268,9 @@ msgstr "PXE-Standard erstellen"
 
 msgid "Build duration"
 msgstr "Build-Dauer"
+
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
 
 msgid "Build errors"
 msgstr "Build-Fehler"
@@ -2636,6 +2654,12 @@ msgstr "FEHLER oder SCHWERWIEGENDER FEHLER"
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr "Die Rendering-Fähigkeiten jedes Vorlagentyps unterscheiden sich geringfügig, z. eine Bereitstellungsvorlage wird immer für ein einzelnes Hostobjekt gerendert und daher wird eine @host-Variable definiert. Ein weiteres Beispiel ist eine Berichtsvorlage, in der spezielle Makros für die Berichtsformatierung verfügbar sind."
 
@@ -3348,6 +3372,12 @@ msgstr "Foreman Auditzusammenfassung"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr "Foreman kann Informationen über das Netzwerk-Setup eines bereitgestellten Hosts speichern, die zum Konfigurieren der virtuellen Maschine verwendet werden, die richtigen IP-Adressen und Netzwerkressourcen zuweisen und dann das Betriebssystem während des Bereitstellungsprozesses richtig konfigurieren."
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr "Foreman betrachtet eine Domäne und eine DNS-Zone als dasselbe. Das heißt, wenn Sie planen, eine Site zu verwalten, auf der alle Maschinen die Form hostname haben. irgendwo.com, dann ist die Domäne irgendwo.com. Dadurch kann Foreman eine Puppet-Variable mit einer Domäne/Site verknüpfen und diese Variable automatisch an alle externen Knotenanforderungen anhängen, die von Maschinen an dieser Site gestellt werden. Das Feld fullname wird für die menschliche Lesbarkeit in Berichten und anderen Seiten verwendet, die sich auf Domänen beziehen, und ist auch als externer Knotenparameter verfügbar."
 
@@ -3643,6 +3673,9 @@ msgstr "HTTP-UEFI-Boot erfordert Proxy mit httpboot-Funktion"
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr "HTTP-Boot erfordert einen Proxy mit httpboot-Funktion und http_port ausgesetzter Einstellung"
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
+msgstr ""
 
 msgid "HTTP(S) proxy"
 msgstr "HTTP(S) Proxy"
@@ -4407,8 +4440,20 @@ msgstr "Wenn ERB in einem Parameterwert benutzt wird, dann wird die Validierung 
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "Falls aktiviert, wird dies einen Fehler erzeugen, wenn kein Standardwert vorhanden ist und kein Treffer einen Wert vorschlägt."
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
 msgstr "Wenn Besitzer-Typ spezifiziert wurde, muss auch ein Besitzer spezifiziert sein."
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
 msgstr "Wenn festgelegt, wird der geplante Bericht per E-Mail zugestellt. Verwenden Sie ''%s', um mehrere E-Mail-Adressen zu trennen."
@@ -4418,6 +4463,9 @@ msgstr "Wenn das Flag Managed deaktiviert ist, wird keiner der Dienste für dies
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
 msgstr "Wenn das Flag Managed aktiviert ist, werden externe Dienste wie DHCP, DNS und TFTP gemäß den bereitgestellten Informationen konfiguriert."
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
+msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
 msgstr "Wenn die Vorlage die Formatauswahl unterstützt, kann der Benutzer das bevorzugte Format auswählen. <br>Normalerweise muss die Vorlage das Makro report_render verwenden. <br> <br> Wenn die Verwendung dieses Makros in der Vorlage nicht gefunden wird, wird <br> dieses Feld deaktiviert und das Ausgabeformat wird standardmäßig auf Nur-Text eingestellt. <br> <br> Wenn die Vorlage die Filterauswahl unterstützt, aber das Makro report_render nicht verwendet, in <br> Um dieses Feld zu aktivieren, fügen Sie einen Kommentar zur Vorlage hinzu, der den Namen des Makros report_render enthält."
@@ -4433,6 +4481,9 @@ msgstr "Wenn diese Einstellung in der Datei geändert werden muss, enthält sie 
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Wir bitten Sie eine neue Anfrage zu öffnen, wenn Sie glauben, dass dies ein Fehler von Foreman ist"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr "Domäne Fakten ignorieren"
@@ -4579,6 +4630,9 @@ msgstr "Informationen zur aktualisierten Einstellung"
 msgid "Infrastructure"
 msgstr "Infrastruktur"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Von übergeordnetem Objekt erben (%s)"
 
@@ -4629,6 +4683,9 @@ msgstr "Unsicher"
 
 msgid "Install packages"
 msgstr "Pakete installieren"
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
+msgstr ""
 
 msgid "Installation Media"
 msgstr "Installationsmedien"
@@ -5574,6 +5631,9 @@ msgstr "MailNotification|Abonnierbar"
 msgid "MailNotification|Subscription type"
 msgstr "MailNotification|Abonnementtyp"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Verwalten"
 
@@ -6412,6 +6472,9 @@ msgstr "Betriebssystemname von Facter; z. B. Red Hat"
 msgid "Off"
 msgstr "Aus"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "OK"
 
@@ -6460,6 +6523,9 @@ msgstr "Nur eine Angabe eines Proxys erlaubt"
 
 msgid "Only one volume can be bootable"
 msgstr "Nur ein Datenträger kann bootbar sein"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "Hoppla!!"
@@ -6870,6 +6936,9 @@ msgstr "Persönliches Zugriffstoken wurde erfolgreich erstellt."
 
 msgid "Personal Access Tokens"
 msgstr "Persönliche Zugriffstoken"
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Personal access token"
@@ -7554,6 +7623,9 @@ msgstr "UUID anfordern"
 msgid "Require SSL for smart proxies"
 msgstr "SSL für Smart-Proxys erfordern"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "Notwendig, es sei denn der Benutzer nutzt eine externe Authentifizierungsquelle"
 
@@ -8139,6 +8211,9 @@ msgstr "Setup Insights"
 msgid "Setup REX"
 msgstr "REX einrichten"
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8373,6 +8448,11 @@ msgstr "Signieren"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr "Ähnlich wie beim Eingabetyp Variable lädt er jedoch den Wert für einen bestimmten Smart-Class-Parameter. Der Benutzer muss beim Definieren der Eingabe die Puppet-Klasse und den Parameternamen der Smart-Klasse angeben."
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "Ein Host auf dieser Seite wurde ausgewählt."
@@ -8463,6 +8543,12 @@ msgstr "Einige Schnittstellen sind ungültig"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Einige der Schnittstellen sind ungültig. Bitte überprüfen Sie die nachstehende Tabelle."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9126,6 +9212,9 @@ msgstr "Der Ruby-Code innerhalb der ERB-Tags enthält normalerweise Ausdrücke. 
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr " Der Algorithmus, der zur Kodierung des JWT im OpenID-Anbieter verwendet wird."
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "Die Authentifizierungsquelle Ihrer externen Benutzergruppen konnte sich nicht, mit den angegebenen Zugangsdaten, zum LDAP Server verbinden. Bitte prüfen Sie, ob die Zugangsdaten gültig sind."
 
@@ -9137,6 +9226,9 @@ msgstr "Die CPU Klasse der Maschine. Dies wird primär für Sparc Solaris Builds
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Die Klasse der Maschine wie von Open Boot Prom ermittelt. Dies wird primär für Sparc Solaris Builds verwendet und kann für andere Architekturen leer sein. Der Wert kann auf Solaris mittels uname -i|cut -f2 -d ermittelt werden."
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr "Die Konsole ist nicht verfügbar, da die VM nicht eingeschalten ist"
@@ -9329,6 +9421,12 @@ msgstr "Es gab ein Fehler bei der VMs Aufzählung: %(status)s %(statusText)s"
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "Es gab einen Fehler beim Ausführen der Vorlage %{name}: %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "Keine aktive Bridge-Schnittstelle in libvirt gefunden, falls Auflistung nicht unterstützt wird, können Sie den Bridgenamen manuell eingeben (z.b. br0)"
 
@@ -9343,6 +9441,9 @@ msgstr "Dies wird die verlinkten VMs und deren Festplatten unumkehrbar<b> lösch
 
 msgid "This IP address has already been reserved in External IPAM"
 msgstr "Diese IP-Adresse wurde bereits in externem IPAM reserviert"
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
 msgstr "Diese E-Mail wurde von Foreman gesendet, identifiziert durch UUID %{uuid}"
@@ -9398,6 +9499,9 @@ msgstr "Dies kann durch die fehlende Verfügbarkeit einiger Dienste, einem falsc
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Dies kann eine Weile dauern, weil alle Systeme, Fakten und Berichte auch <b>gelöscht werden</b>. %s Dieses Verhalten kann über die globalen Einstellungen geändert werden \"Lösche VM auf dem Host\"."
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr "Dies bietet dieselbe Funktionalität wie <code><%,</code> aber wenn die Vorlage ausgeführt wird, wird die Codeausgabe in die Vorlage eingefügt. Dies ist nützlich für die Variablenersetzung, zum Beispiel:"
 
@@ -9418,6 +9522,12 @@ msgstr "Dieser Dienst ist für nicht authentifizierte Benutzer nicht verfügbar"
 
 msgid "This service is only available for authenticated users"
 msgstr "Dieser Dienst ist nur für authentifizierte Benutzer verfügbar"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "Diese Vorlage ist gesperrt und darf nicht entfernt werden."
@@ -9445,6 +9555,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "Dieser Wert wird auch als Name für die Primärschnittstelle des Hosts verwendet."
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9492,6 +9605,9 @@ msgid ""
 msgstr ""
 "Um die Benutzerliste zu aktualisieren, klicken Sie auf die Registerkarte \"Extern\".\n"
 "Gruppen\" dann \"Aktualisieren\"."
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
+msgstr ""
 
 msgid "Today"
 msgstr "Heute"
@@ -10344,6 +10460,9 @@ msgstr "VM-Attribute (%s)"
 msgid "VM already associated with a host"
 msgstr "VM ist bereits einem Host zugeordnet"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "VM zu Host %s zugeordnet"
 
@@ -10483,6 +10602,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] "Warnung! Dies wird %{name} von %{number} Benutzer entfernen. Sind sie sicher?"
 msgstr[1] "Warnung! Dies wird %{name} von %{number} Benutzern entfernen. Sind sie sicher?"
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "Achtung: dies wird den Host und alle seine Daten löschen!"
@@ -10684,11 +10806,17 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr "Sie sind im Begriff %s zu löschen. Sind Sie sicher?"
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "Sie sind im Begriff, eine gesperrte Vorlage zu entsperren."
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
 msgstr "Sie führen bereits einen Identitätswechsel durch, klicken Sie auf das Symbol für den Identitätswechsel in der oberen Leiste, bevor Sie einen neuen Identitätswechsel starten."
+
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
 
 msgid "You are not authorized to lock templates."
 msgstr "Sie sind nicht berechtigt, Vorlagen zu sperren."

--- a/locale/de/foreman.po
+++ b/locale/de/foreman.po
@@ -51,9 +51,6 @@ msgstr ""
 msgid " Documentation"
 msgstr "Dokumentation"
 
-msgid " Remove"
-msgstr "Entfernen"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr "und es wird dringend empfohlen, auch die foreman-debug-Ausgabe hinzuzufügen."
 
@@ -65,9 +62,6 @@ msgstr "${progress} %% abgeschlossen"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr "%(name)s (free: %(free)s , prov: %(prov)s , total: %(total)s )"
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - Drücke Umschalttaste-F12, um den Cursor freizugeben."
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - Die folgenden Hosts werden geändert"
@@ -87,9 +81,6 @@ msgstr[1] "%s Protokollmeldungen"
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s Parameter aktualisiert, weitere Informationen unten"
-
-msgid "%s Template"
-msgstr "%s Vorlage"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -142,9 +133,6 @@ msgid_plural "%s months ago"
 msgstr[0] "vor %s Monat"
 msgstr[1] "vor %s Monaten"
 
-msgid "%s out of sync disabled"
-msgstr "%s \"nicht-synchronisiert\" deaktiviert"
-
 msgid "%s selected hosts"
 msgstr "%s ausgewählte Hosts"
 
@@ -163,9 +151,6 @@ msgstr "%s Widget lädt ..."
 
 msgid "%s you had selected as your context has been deleted"
 msgstr "%s die Sie als Kontext gewählt hatten, wurde gelöscht."
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
-msgstr "%s , überprüfen Sie die 'SSL CA-Datei' in Einstellungen > Authentifizierung"
 
 msgid "%{action} %{vm}"
 msgstr "%{action} %{vm}"
@@ -236,6 +221,9 @@ msgstr "%{match} passt zu keiner existierenden Gruppe"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} wurde von %{label1} zu %{label2} geändert"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr "%{object_name} ist %{object_class}, Subnetz erwartet"
@@ -318,6 +306,9 @@ msgstr "(gefiltert aus %s Gesamteinträgen)"
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(optional) IAM-Rolle für Fog verwenden, wenn das Abbild erstellt wird."
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*%s Proxy löschen*"
@@ -524,12 +515,6 @@ msgstr "Medium hinzufügen"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr "Fügen Sie ein CD-ROM-Laufwerk zur virtuellen Maschine hinzu."
 
-msgid "Add a Puppet class to host"
-msgstr "Puppet-Klasse dem Host zuweisen"
-
-msgid "Add a Puppet class to host group"
-msgstr "Puppet-Klasse der Hostgruppe zuweisen"
-
 msgid "Add a template combination"
 msgstr "Vorlage-Kombination hinzufügen"
 
@@ -575,9 +560,6 @@ msgstr "Zusätzliche Rechenressourcen-spezifische Attribute"
 msgid "Additional information about this host"
 msgstr "Weitere Informationen über diesen Host"
 
-msgid "Address to connect to"
-msgstr "Adresse zum Verbinden"
-
 msgid "Admin permissions required"
 msgstr "Administratorberechtigungen erdorderlich"
 
@@ -620,9 +602,6 @@ msgstr "Alias oder VLAN-Gerät"
 msgid "All"
 msgstr "Alle"
 
-msgid "All Audits"
-msgstr "Alle Prüfungen"
-
 msgid "All Hosts"
 msgstr "Alle Hosts"
 
@@ -631,6 +610,12 @@ msgstr "Alle Berichte"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
 msgstr "Der gesamte Ruby-Code ist in <code><&#37; &#37;></code> in einer ERB-Vorlage eingeschlossen. Der Code wird ausgeführt, wenn die Vorlage gerendert wird. Es kann sowohl Ruby-Kontrollflussstrukturen als auch anwendungsspezifische Makros und Variablen enthalten. Zum Beispiel:"
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
+msgstr ""
 
 msgid "All compute resources"
 msgstr "Alle Rechenressourcen"
@@ -791,9 +776,6 @@ msgstr "Sind Sie sicher, dass Sie den Host %s löschen möchten? Diese Aktion is
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Sind Sie sicher, dass Sie den Host %s löschen möchten? Dies wird die Virtuelle Maschine und alle Laufwerke unwiderruflich löschen. Dieses Verhalten lässt sich durch globale Einstellungen anpassen: \"Destroy associated VM on host delete\""
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "Sind Sie sicher, dass Sie des Widget aus Ihrer Übersichtsseite löschen möchten?"
-
 msgid "Are you sure you want to log out?"
 msgstr "Sind Sie sicher, dass Sie sich abmelden möchten?"
 
@@ -850,6 +832,12 @@ msgstr "Organisation zuweisen"
 
 msgid "Assign Selected Hosts"
 msgstr "Ausgewählte Hosts zuweisen"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1335,6 +1323,9 @@ msgstr "Kann über CLI oder RC-Datei abgerufen werden. Kann leer bleiben. Nur f�
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr "Kann über CLI oder RC-Datei abgerufen werden. Kann auf 'Standard' gesetzt werden. Nur für v3-Authentifizierung."
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "Kann den internen Admin-Account nicht löschen"
 
@@ -1416,8 +1407,8 @@ msgstr "Zertifikatschlüssel ist kein gültiger JSON"
 msgid "Certificate path for GCE only"
 msgstr "Zertifikats-Pfad for GCE nur"
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Zertifikat, das Foreman zum Verschlüsseln von WebSockets verwendet"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "Zertifikate"
@@ -1476,6 +1467,9 @@ msgstr "PuppetCA Zertifikate für %s bereinigen"
 msgid "Clear"
 msgstr "Klar"
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr "Säubere den Sub-Status des Host"
 
@@ -1487,12 +1481,6 @@ msgstr "Klicken Sie auf den Link einer Rechenressource, um dessen Standard-VM-At
 
 msgid "Click to log in again"
 msgstr "Klicken Sie hier, um sich erneut anzumelden"
-
-msgid "Click to remove %s"
-msgstr "Klicken um %s zu entfernen"
-
-msgid "Click to remove config group"
-msgstr "Klicken um Konfigurationsgruppe zu entfernen"
 
 msgid "Client Email"
 msgstr "Client-E-Mail"
@@ -1656,14 +1644,6 @@ msgstr "Konfigurationsberichte"
 msgid "Config Retrieval"
 msgstr "Konfigurationsabfrage"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "Konfigurationsgruppe"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "Name"
-
 msgid "Configuration"
 msgstr "Konfiguration"
 
@@ -1706,8 +1686,8 @@ msgstr "Konflikte wurden entdeckt"
 msgid "Connected"
 msgstr "Verbunden"
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "Verbinde (unverschlüsselt) mit: %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "Verbinde (unverschlüsselt) mit: %s"
@@ -1757,8 +1737,8 @@ msgstr "Foreman Core und Proxy Versionen stimmen nicht überein. Foreman: %{fore
 msgid "Cores per socket"
 msgstr "Kerne pro Socket"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
-msgstr "Kostenwert der bcrypt-Passwort-Hash-Funktion für interne Authentifizierungsquellen (4-30). Ein höherer Wert ist sicherer, aber die Überprüfung ist langsamer, insbesondere bei zustandslosen API-Aufrufen und UI-Anmeldungen. Passwortänderung erforderlich, um wirksam zu werden."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
+msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
 msgstr "Berechtigungen konnten nicht der Manager und Viewer Rolle: %s hinzugefügt werden"
@@ -1934,9 +1914,6 @@ msgstr "Benutzergruppe erstellen"
 msgid "Create a Personal Access Token for a user"
 msgstr "Erstelle ein persönliches Zugriffstoken für einen User"
 
-msgid "Create a Puppet class"
-msgstr "Erstelle eine Puppet-Klasse"
-
 msgid "Create a bookmark"
 msgstr "Lesezeichen erstellen"
 
@@ -1948,9 +1925,6 @@ msgstr "Rechenprofil erstellen"
 
 msgid "Create a compute resource"
 msgstr "Rechenressource erstellen"
-
-msgid "Create a config group"
-msgstr "Konfigurationsgruppe erstellen"
 
 msgid "Create a default template combination for an operating system"
 msgstr "Standardvorlagen-Kombination für ein Betriebssystem erstellen"
@@ -2024,9 +1998,6 @@ msgstr "Subnetz erstellen"
 msgid "Create a template input"
 msgstr "Vorlageneingabe erstellen"
 
-msgid "Create a trend counter"
-msgstr "Trendzähler erstellen"
-
 msgid "Create a user"
 msgstr "Einen Benutzer erstellen"
 
@@ -2042,9 +2013,6 @@ msgstr "LDAP-Authentifizierungsquelle erstellen"
 msgid "Create an architecture"
 msgstr "Architektur erstellen"
 
-msgid "Create an environment"
-msgstr "Umgebung erstellen"
-
 msgid "Create an external user group linked to a user group"
 msgstr "Mit einer Benutzergruppe verknüpfte, externe Benutzergruppe erstellen"
 
@@ -2057,14 +2025,14 @@ msgstr "Schnittstelle auf einem Host erstellen"
 msgid "Create an operating system"
 msgstr "Betriebssystem erstellen"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "Überschreibungswert für einen bestimmten Smart-Klassenparameter erzeugen"
-
 msgid "Create autosign entry"
 msgstr "Autosign-Eintrag erstellen"
 
 msgid "Create image"
 msgstr "Abbild erstellen"
+
+msgid "Create model"
+msgstr ""
 
 msgid "Create new boot volume from image"
 msgstr "Neues Boot Volumen von Abbild erstellen"
@@ -2080,6 +2048,9 @@ msgstr "Realm-Eintrag für %s erstellen"
 
 msgid "Created"
 msgstr "Erstellt"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr "Erstellt eine Tabelleneinstellung für eine bestimmte Tabelle"
@@ -2110,18 +2081,6 @@ msgstr "Benutzerdefinierter Instanz-Typ"
 
 msgid "DB pending seed"
 msgstr "DB ausstehender Startwert"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr "EINGESTELLT: Eine Vorlagenkombination hinzufügen"
-
-msgid "DEPRECATED: List template combination"
-msgstr "VERALTET: Listenvorlagenkombination"
-
-msgid "DEPRECATED: Show template combination"
-msgstr "VERALTET: Vorlagenkombination anzeigen"
-
-msgid "DEPRECATED: Update template combination"
-msgstr "VERALTET: Vorlagenkombination aktualisieren"
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2213,8 +2172,8 @@ msgstr "Standard"
 msgid "Default 'Host initial configuration' template"
 msgstr "Standardvorlage \"Host-Erstkonfiguration\""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
-msgstr "Standard 'Host initial configuration'  für die Erstkonfiguration des Hosts, die automatisch zugewiesen wird, wenn ein neues Betriebssystem erstellt wird"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
+msgstr ""
 
 msgid "Default Behavior"
 msgstr "Standardmäßiges Verhalten"
@@ -2236,9 +2195,6 @@ msgstr "Standard-PXE-Menüpunkt in der globalen Vorlage - 'local', 'discovery' o
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr "Standard-PXE-Menüpunkt in der lokalen Vorlage - 'local', 'local_chain_hd0' oder benutzerdefiniert, leer für Vorlagenvorgabe verwenden"
-
-msgid "Default Puppet environment"
-msgstr "Standardmäßige Puppet-Umgebung"
 
 msgid "Default VNC Keyboard"
 msgstr "Standard-VNC-Tastatur"
@@ -2321,9 +2277,6 @@ msgstr "Puppet-CA-Zertifikate für %s löschen"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr "Löschen TFTP %{kind} Konfiguration für %{host}"
 
-msgid "Delete a Puppet class"
-msgstr "Puppet-Klasse löschen"
-
 msgid "Delete a Virtual Machine"
 msgstr "Eine virtuelle Maschine löschen"
 
@@ -2335,9 +2288,6 @@ msgstr "Rechenprofil löschen"
 
 msgid "Delete a compute resource"
 msgstr "Rechenressource löschen"
-
-msgid "Delete a config group"
-msgstr "Konfigurationsgruppe löschen"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "Standardvorlagen-Kombination für ein Betriebssystem löschen"
@@ -2420,9 +2370,6 @@ msgstr "Vorlagenkombination löschen"
 msgid "Delete a template input"
 msgstr "Vorlageneingabe löschen"
 
-msgid "Delete a trend counter"
-msgstr "Trendzähler löschen"
-
 msgid "Delete a user"
 msgstr "Benutzer löschen"
 
@@ -2462,9 +2409,6 @@ msgstr "SSH-Schlüssel eines Benutzers löschen"
 msgid "Delete an architecture"
 msgstr "Architektur löschen"
 
-msgid "Delete an environment"
-msgstr "Umgebung löschen"
-
 msgid "Delete an external user group"
 msgstr "Externe Benutzergruppe löschen"
 
@@ -2474,14 +2418,17 @@ msgstr "Abbild löschen"
 msgid "Delete an operating system"
 msgstr "Betriebssystem löschen"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "Überschreibungswert für einen bestimmten Smart-Klassenparameter löschen"
-
 msgid "Delete autosign entry"
 msgstr "Autosign-Eintrag löschen"
 
 msgid "Delete filter?"
 msgstr "Filter löschen?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "Realm-Eintrag für %s löschen"
@@ -2554,9 +2501,6 @@ msgstr "Benachrichtigungen für ausgewählte Systeme deaktivieren"
 
 msgid "Disable all filters overriding"
 msgstr "Alle überschreibenden Filter deaktivieren"
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "Deaktiviere Host Konfigurations Status Änderung zu \"nicht-snychronisiert\" für %s falls der Bericht nicht im konfigurierten Intervall ankommt"
 
 msgid "Disable overriding"
 msgstr "Überschreiben deaktivieren"
@@ -2674,20 +2618,17 @@ msgstr "Läd einen generierten Bericht herunter"
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "Doppelte Eingaben gefunden: %{duplicated_inputs}"
 
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
+msgstr ""
+
 msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr "Dauer in Minuten, nachdem die Server als nicht synchronisiert eingestuft werden. Sie können dies auf Hosts überschreiben, indem Sie einen Parameter \"outofsync_interval\" hinzufügen."
-
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr "Zeitraum in Minuten, nachdem Server, welche über Puppet Rückmeldung geben, als \"nicht-synchronisiert\" klassifiziert werden."
 
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "ENC-Umgebung"
 
 msgid "ERROR or FATAL"
 msgstr "FEHLER oder SCHWERWIEGENDER FEHLER"
@@ -2730,6 +2671,9 @@ msgstr "Diesen Host bearbeiten"
 
 msgid "Editor"
 msgstr "Editor"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "E-Mail-Einstellungen"
@@ -2806,10 +2750,6 @@ msgstr "Abschließende IP-Adresse für automatischen IP-Vorschlag"
 msgid "Entries per page"
 msgstr "Einträge pro Seite"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Umgebung"
-
 msgid "Environment IDs"
 msgstr "Umgebungskennungen"
 
@@ -2824,10 +2764,6 @@ msgstr "Umgebungsvariable, die den Verifizierungsstatus eines Client-SSL-Zertifi
 
 msgid "Environments got deprecated from this endpoint."
 msgstr "Umgebungen sind von diesem Endpunkt aus veraltet."
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Name"
 
 msgid "Error"
 msgstr "Fehler"
@@ -2867,6 +2803,9 @@ msgstr "Fehler beim Laden der Informationen zum Planerhinweisfilter: %s"
 
 msgid "Error removing widget from dashboard."
 msgstr "Fehler beim Entfernen des Widgets aus der Übersichtsseite."
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr "Fehler beim Versand der Daten:"
@@ -3337,14 +3276,14 @@ msgstr "Korrigiere %s bei Fehlzuweisung"
 msgid "Fix All Mismatches"
 msgstr "Alle Fehlzuweisungen beheben"
 
-msgid "Fix DB cache"
-msgstr "DB-Cache reparieren"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "DB-Cache beim nächsten Foreman-Neustart korrigieren"
-
 msgid "Fix Mismatches"
 msgstr "Fehlzuweisungen beheben"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "Variante"
@@ -3391,9 +3330,6 @@ msgstr "Weitere Informationen finden Sie unter"
 msgid "For values of type search, this is the resource the value searches in"
 msgstr "Bei Werten vom Typ search ist dies die Ressource, in der der Wert sucht"
 
-msgid "Force a Puppet agent run on the host"
-msgstr "Puppet-Agent-Lauf auf dem Host erzwingen"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "Foreman API v2 ist zurzeit die Standard-API-Version."
 
@@ -3427,6 +3363,10 @@ msgstr "Foreman hat Definitionen unbekannter Klassen in Ihrer Datenbank gefunden
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr "Foreman-Instanz-ID, die diese Foreman-Instanz eindeutig identifiziert."
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "Foreman-Matcher werden von Kindern geerbt, wenn Smart-Class-Parameter für Hostgruppen, Organisationen und Standorte bewertet werden"
 
@@ -3435,6 +3375,10 @@ msgstr "Foreman verwaltet nun den Erstellungsablauf für %s"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman verwaltet nun nicht mehr den Erstellungsablauf für %s"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Foreman Berichte werden um <em>%s</em> erzeugt"
@@ -3463,8 +3407,8 @@ msgstr "Foreman wird Domäne-Namen anhängen, sobald neue Hosts bereitgestellt w
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman automatisiert die Zertifikatssignierung bei der Bereitstellung eines neuen Hosts"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
-msgstr "Foreman blockiert Benutzeranmeldungen für 5 Minuten anhand der IP Adresse nach dieser Nummer an fehlgeschlagen Anmeldeversuchen. Auf 0 setzen um bruteforce protection zu deaktivieren."
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
+msgstr ""
 
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman erstellt den Host, wenn ein Bericht erhalten wird"
@@ -3472,20 +3416,14 @@ msgstr "Foreman erstellt den Host, wenn ein Bericht erhalten wird"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman erstellt den Host, wenn neue Fakten erhalten werden"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "Foreman nutzt standardmäßig diese Puppet-Umgebung, falls automatisch keine Umgebung gefunden werden kann"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Foreman löscht virtuelle Maschine, wenn Bereitstellungsskript mit Exitcode ungleich-Null endet"
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr "Foreman wertet die Smart-Class-Parameter des Hosts standardmäßig in dieser Reihenfolge aus"
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman legt ausdrücklich die Puppet-Umgebung in der ENC-yaml-Ausgabe fest. Dies vermeidet Konflikte zwischen der Umgebung in der puppet.conf und der in Foreman festgelegten Umgebung"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman weist Benutzer anhand des Benutzernamens im Anfrageheader zu. Ist dies auf \"false\" gesetzt, erhalten OAuth-Anfragen Administratorrechte."
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "Foreman wird diesen Parameter nicht in der Klassifizierungsausgabe verwenden"
@@ -3495,9 +3433,6 @@ msgstr "Foreman analysiert ERB in Parameterwerten in der ENC-Ausgabe"
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman fragt den lokal konfigurierten Resolver ab anstelle der SOA/NS-Einträge"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman aktualisiert die Umgebung eines Hosts basierend auf dessen Fakten"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "Foreman aktualisiert die Hostgruppe eines Hosts anhand seiner Fakten"
@@ -3516,6 +3451,18 @@ msgstr "Foreman verwendet zufällige UUIDs zur Zertifikatssignierung anstelle vo
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman verwendet den kurzen Hostnamen anstelle des FQDN zur Erstellung neuer virtueller Maschinen"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr "Formular wurde erfolgreich erstellt."
@@ -3543,6 +3490,9 @@ msgstr "Vollbildansicht"
 
 msgid "Function not available for %s"
 msgstr "Funktion für %s nicht verfügbar"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "Zeitzone GMT (Greenwich Mean Time)"
@@ -3613,8 +3563,8 @@ msgstr "Übersichtsseitendetails abholen"
 msgid "Get default dashboard widgets"
 msgstr "Standard-Übersichtsseiten-Widgets abholen"
 
-msgid "Get statistics"
-msgstr "Statistiken abholen"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "Hoststatus abholen"
@@ -3736,6 +3686,12 @@ msgstr "Hardwaremodell %s wurde erfolgreich gelöscht"
 msgid "Hardware Models"
 msgstr "Hardwaremodelle"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr "Wirkt sich nur auf die netzwerkbasierte Bereitstellung aus"
 
@@ -3781,11 +3737,17 @@ msgstr "Verlauf"
 msgid "Host"
 msgstr "Host"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "Host %s wurde gebaut"
 
 msgid "Host %s is not associated with a VM"
 msgstr "Host %s ist keiner VM zugewiesen"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "Hostkonfigurationsdiagramm"
@@ -3823,8 +3785,14 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "Host-Parameter"
 
-msgid "Host Wizard"
-msgstr "Host-Assistent"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
+msgstr ""
 
 msgid "Host audit entries"
 msgstr "Hostaudit-Einträge"
@@ -3832,12 +3800,12 @@ msgstr "Hostaudit-Einträge"
 msgid "Host built"
 msgstr "Host gebaut"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "Host-Konfigurationsgruppe"
-
 msgid "Host details"
 msgstr "Host-Details"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "Hostgruppe"
@@ -3975,8 +3943,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "Host-Typ"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4204,9 +4196,6 @@ msgstr "Kennung der Konfigurationsvorlage"
 msgid "ID of domain"
 msgstr "Kennung der Domäne"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr "ID der Umgebung - DEPRECATED hat keine Auswirkung"
-
 msgid "ID of host"
 msgstr "Hostkennung"
 
@@ -4273,8 +4262,8 @@ msgstr "Kennung der Organisation, bei der der Gastgeber registriert wird"
 msgid "ID of the Organization to register the host in."
 msgstr "ID der Organisation, in der der Gastgeber registriert werden soll."
 
-msgid "ID of the Smart Proxy"
-msgstr "ID des Smart Proxys"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
+msgstr ""
 
 msgid "ID of the user"
 msgstr "Kennung des Benutzers"
@@ -4336,9 +4325,6 @@ msgstr "IP-Adresse automatisch vorschlagen"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr "IP-Adressen die nicht vorgeschlagen werden sollen"
 
-msgid "IP6 Address"
-msgstr "IP6-Adresse"
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4362,6 +4348,9 @@ msgstr "IPv4-Subnetz"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr "Für die PXE-basierte Bereitstellung ist ein IPv4-Subnetz mit zugehörigem TFTP-Smart-Proxy erforderlich."
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "IPv4-Adresse der Schnittstelle"
 
@@ -4381,6 +4370,9 @@ msgstr[1] "IPv6-DNS-Einträge"
 
 msgid "IPv6 Subnet"
 msgstr "IPv6-Subnetz"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "IPv6-Adresse der Schnittstelle"
@@ -4442,14 +4434,14 @@ msgstr "Wenn diese Einstellung in der Datei geändert werden muss, enthält sie 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Wir bitten Sie eine neue Anfrage zu öffnen, wenn Sie glauben, dass dies ein Fehler von Foreman ist"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "Puppet-Fakten für Bereitstellung ignorieren"
-
 msgid "Ignore facts for domain"
 msgstr "Domäne Fakten ignorieren"
 
 msgid "Ignore facts for operating system"
 msgstr "Ignoriere Fakten für Betriebssystem"
+
+msgid "Ignore interfaces facts for provisioning"
+msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
 msgstr "Schnittstellen mit übereinstimmender Kennung ignorieren"
@@ -4529,12 +4521,6 @@ msgstr "Als nicht verwalteter Host importieren"
 
 msgid "Import of facts failed for host %s"
 msgstr "Import von Fakten für Host %s fehlgeschlagen"
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Puppet-Klassen vom Puppet-Proxy importieren"
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "Puppet-Klassen von Puppet-Proxy für eine Umgebung importieren"
 
 msgid "Imported IPv4 Subnets"
 msgstr "Importierte IPv4-Subnetze"
@@ -4653,6 +4639,9 @@ msgstr "Installationsfehler"
 msgid "Installation medium configuration"
 msgstr "Konfiguration der Installationsmedien"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "Installiert"
 
@@ -4718,6 +4707,9 @@ msgstr "Ungültige Auswahl von %{assoc}. Sie müssen mindestens eine von Ihren a
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
 msgstr "Ungültiger Google JSON-Schlüssel. Bitte überprüfen Sie, ob die E-Mail- und privaten Schlüsseloptionen des Kunden vorhanden sind"
+
+msgid "Invalid HTTP(S) URL"
+msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
 msgstr "Ungültige Architektur '%{arch}' für '%{os}'"
@@ -4884,14 +4876,14 @@ msgstr "Neueste Ereignisse"
 msgid "Launch Console"
 msgstr "Konsole starten"
 
-msgid "Launch loading wizard"
-msgstr "Ladeassistent starten"
-
 msgid "Learn more about External authentication in the documentation."
 msgstr "Weitere Informationen zur externen Authentifizierung finden Sie in der Dokumentation."
 
 msgid "Learn more about LDAP authentication in the documentation."
 msgstr "Weitere Informationen zur LDAP-Authentifizierung finden Sie in der Dokumentation."
+
+msgid "Legacy UI"
+msgstr ""
 
 msgid "Length"
 msgstr "Länge"
@@ -4925,24 +4917,6 @@ msgstr "Alle LDAP-Authentifizierungs-Quellen auflisten"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr "Alle persönlichen Zugriffstoken eines Users auflisten"
-
-msgid "List all Puppet class IDs for host"
-msgstr "Alle Puppet-Klassen-Kennungen für den Host auflisten"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "Alle Puppet-Klassen-Kennungen für die Hostgruppe auflisten"
-
-msgid "List all Puppet classes"
-msgstr "Alle Puppet-Klassen auflisten"
-
-msgid "List all Puppet classes for a host"
-msgstr "Alle Puppet-Klassen für einen Host auflisten"
-
-msgid "List all Puppet classes for a host group"
-msgstr "Alle Puppet-Klassen für eine Hostgruppe auflisten"
-
-msgid "List all Puppet classes for an environment"
-msgstr "Alle Puppet-Klassen für eine Umgebung auflisten"
 
 msgid "List all SSH keys for a user"
 msgstr "Alle SSH-Schlüssel eines Benutzers auflisten"
@@ -4979,9 +4953,6 @@ msgstr "Alle Rechenressourcen auflisten"
 
 msgid "List all email notifications for a user"
 msgstr "Auflisten alle Email Benachrichtigungen eines Nutzers"
-
-msgid "List all environments"
-msgstr "Alle Umgebungen auflisten"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "Alle externen Benutzergruppen für die LDAP-Authentifizierungsquelle auflisten"
@@ -5118,9 +5089,6 @@ msgstr "Alle Rollen auflisten"
 msgid "List all settings"
 msgstr "Alle Einstellungen auflisten"
 
-msgid "List all smart class parameters"
-msgstr "Alle Smart-Klassenparameter auflisten"
-
 msgid "List all smart proxies"
 msgstr "Alle Smart-Proxys auflisten"
 
@@ -5199,15 +5167,6 @@ msgstr "Bootdateien für ein Betriebssystem auflisten"
 msgid "List default templates combinations for an operating system"
 msgstr "Standardvorlagen-Kombinationen für ein Betriebssystem auflisten"
 
-msgid "List environments of Puppet class"
-msgstr "Umgebungen der Puppet-Klasse auflisten"
-
-msgid "List environments per location"
-msgstr "Umgebungen pro Standort auflisten"
-
-msgid "List environments per organization"
-msgstr "Umgebungen pro Organisation auflisten"
-
 msgid "List external authentication sources"
 msgstr "Externe Authentifzierungsdienste auflisten"
 
@@ -5216,6 +5175,9 @@ msgstr "Externe Authentifizierungsdienste pro Standort auflisten"
 
 msgid "List external authentication sources per organization"
 msgstr "Externe Authentifizierungsdienste pro Organisation auflisten"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "Hosts pro Standort auflisten"
@@ -5250,9 +5212,6 @@ msgstr "Auflisten von Compute-Eigenschaften für bereitgestellte Compute-Profile
 msgid "List of compute profiles"
 msgstr "Liste mit Rechenprofilen"
 
-msgid "List of config groups"
-msgstr "Alle Konfigurationsgruppen auflisten"
-
 msgid "List of domains"
 msgstr "Liste der Domänen"
 
@@ -5268,35 +5227,20 @@ msgstr "Liste der Domänen pro Subnetz"
 msgid "List of email notifications"
 msgstr "Lister der E-Mail-Benachrichtigungen"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr "Liste von Hostnamen, IPv4-, IPv6-Adressen oder Subnetzen, denen zusätzlich zu Smart Proxies für den Zugriff auf Fakten-/Berichtsimporter und ENC-Ausgabe vertraut werden soll"
 
 msgid "List of hosts which answer to the provided query"
 msgstr "Liste von Hosts, die zur Anfrage passen"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "Liste der Überschreibungswerte für einen bestimmten Smart-Klassenparameter"
-
 msgid "List of realms"
 msgstr "Liste der Realms"
 
 msgid "List of resources types that will be automatically associated"
 msgstr "Auflisten aller Ressourcetypen die automatisch zugewiesen werden"
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "Liste der Smart-Klassenparameter für eine bestimmte Puppetklasse"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "Liste der Smart-Klassenparameter für eine bestimmte Umgebung"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "Liste der Smart-Klassenparameter für eine bestimmte Umgebung/Puppet-Klasse-Kombination"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "Liste der Smart-Klassenparameter für einen bestimmten Host"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "Liste der Smart-Klassenparameter für eine bestimmte Hostgruppe"
 
 msgid "List of subnets"
 msgstr "Liste von Subnetzen"
@@ -5315,9 +5259,6 @@ msgstr "Liste der Tabelleneinstellungen für einen Benutzer"
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
 msgstr "Liste der Zeitüberschreitungen (in Sekunden) für DNS-Lookup-Versuche wie das dns_lookup-Makro und die DNS-Eintragskonfliktvalidierung"
-
-msgid "List of trends counters"
-msgstr "Trendzähler auflisten"
 
 msgid "List of user selected columns"
 msgstr "Vom Nutzer gewählte Spalten auflisten"
@@ -5502,6 +5443,10 @@ msgid "LookupKey|Key type"
 msgstr "Schlüsseltyp"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr "LookupKey|Standard für Zusammenführen"
 
@@ -5550,6 +5495,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "MAC-Adresse"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "MAC-Adresse der Schnittstelle. Erforderlich für gemanagte Bare-Metal-Schnittstellen."
@@ -5632,6 +5580,9 @@ msgstr "Verwalten"
 msgid "Manage Bookmarks"
 msgstr "Lesezeichen verwalten"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "Standorte verwalten"
 
@@ -5640,6 +5591,9 @@ msgstr "Organisationen verwalten"
 
 msgid "Manage PuppetCA"
 msgstr "PuppetCA verwalten"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "Host verwalten"
@@ -5740,10 +5694,6 @@ msgid "Message"
 msgstr "Nachricht"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Kurzfassung"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Wert"
 
@@ -5761,6 +5711,9 @@ msgstr "Die Metrik wurde bereits registriert: %s"
 
 msgid "Metrics"
 msgstr "Metriken"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "Vergangene Minuten"
@@ -5839,6 +5792,9 @@ msgstr "Mein Account"
 msgid "N/A"
 msgstr "Nicht verfügbar"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "Nicht verfügbar"
 
@@ -5860,8 +5816,8 @@ msgstr "Name des Mediums"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr "Name der OpenID Connect Audience, die für die Authentifizierung verwendet wird. Im Falle von Keycloak ist dies die Client-ID."
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
-msgstr "Name der externen Auth-Quelle, in der unbekannte, extern authentifizierte Benutzer (siehe authorize_login_delegation) erstellt werden sollen (Wenn Sie die automatische Erstellung verhindern möchten, lassen Sie sie unset)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
+msgstr ""
 
 msgid "Name of the host group"
 msgstr "Name der Hostgruppe"
@@ -5938,6 +5894,9 @@ msgstr "Neue Organisation"
 msgid "New SSH key"
 msgstr "Neuer SSH-Schlüssel"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "Neue virtuelle Maschine"
 
@@ -5953,8 +5912,8 @@ msgstr "Neue Verbindung wurde abgelehnt. Grund: %"
 msgid "New filter"
 msgstr "Neuer Filter"
 
-msgid "New window"
-msgstr "Neues Fenster"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Weiter"
@@ -6081,6 +6040,9 @@ msgstr "Keine TFTP-Funktion"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "Keine TFTP-Proxys definiert, kann nicht fortfahren"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr "Keine VMs passen zu einem Host"
 
@@ -6119,6 +6081,9 @@ msgstr "Keine E-Mails"
 
 msgid "No entries found"
 msgstr "Keine Einträge gefunden"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "Keine Funktionen von diesem Proxy gefunden, bitte stelle sicher, dass mindestens eine Funktion aktiviert ist"
@@ -6216,6 +6181,9 @@ msgstr "Keine Smart-Proxys gefunden."
 msgid "No smart proxies to show"
 msgstr "Keine Smart Proxys zum Anzeigen"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "Keine Subnetze"
 
@@ -6252,11 +6220,11 @@ msgstr "Normal"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr "Normalerweise wird beim aufsetzen einer Rechenressource automatisch für Sie ein Schlüssel-Paar (privat und öffentlich) erzeugt."
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "Nicht installiert"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr "Ungültige URL für einen HTTP-Proxy"
 
 msgid "Not implemented"
 msgstr "Nicht implementiert"
@@ -6423,6 +6391,9 @@ msgstr "OIDC JWKs URL"
 msgid "OK"
 msgstr "OK"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "Betriebssystemabbild"
 
@@ -6498,9 +6469,6 @@ msgstr "Bitte entschuldigen Sie, etwas ist schief gelaufen"
 
 msgid "Open"
 msgstr "Öffnen"
-
-msgid "Open Spice in a new window"
-msgstr "Öffne Spice in einem neuen Fenster"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr "Zeitüberschreitung für das Öffnen und Lesen von HTTP-Anfragen von Foreman an Smart Proxy (in Sekunden)"
@@ -6601,9 +6569,6 @@ msgstr "Optionaler Eingabe-Validator"
 msgid "Optional array of log hashes"
 msgstr "Optionales Array der Log-Hashes"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "Optionaler kommaseparierter String, der entweder \"neu\", \"aktualisiert\" oder \"veraltet\" enthält und dazu verwendet wird, die importierten Puppet-Klassen einzuschränken."
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "Optional: Abschließende IP-Adresse für automatischen IP-Vorschlag"
 
@@ -6667,9 +6632,6 @@ msgstr "Ausgabeformat"
 msgid "Override"
 msgstr "Überschreiben"
 
-msgid "Override Value"
-msgstr "Wert überstimmen"
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "Standardwert des Puppet-Klassenparameters überschreiben."
 
@@ -6682,8 +6644,17 @@ msgstr "Übersicht"
 msgid "Overwrite"
 msgstr "Überschreiben"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "Gehört"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "Besitzer"
@@ -6767,6 +6738,10 @@ msgstr "Name"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Priorität"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr "Typ"
@@ -7005,9 +6980,6 @@ msgstr "Bitte auf die Bearbeitung der Anfrage warten"
 msgid "Plugins"
 msgstr "Plugins"
 
-msgid "Port to connect to"
-msgstr "Port zum Verbinden"
-
 msgid "Possible values"
 msgstr "Mögliche Werte"
 
@@ -7020,8 +6992,14 @@ msgstr "Power"
 msgid "Power ON this machine"
 msgstr "System starten"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
 msgstr "Schalte eine Virtuelle Maschine an"
+
+msgid "Power has been set to \"%s\" successfully"
+msgstr ""
 
 msgid "Power operations are not enabled on this host."
 msgstr "Power-Operationen werden auf diesem Host nicht unterstützt"
@@ -7089,8 +7067,8 @@ msgstr "Priorisiere Eigenschaft-Reihenfolge"
 msgid "Private"
 msgstr "Privat"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
-msgstr "Privater Schlüssel den Foreman benutzt um Web-Sockets zu verschlüsseln"
+msgid "Private key file path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Proceed to Edit"
 msgstr "Zum Ändern fortfahren"
@@ -7189,6 +7167,9 @@ msgstr "Proxys"
 msgid "Proxy ID to use within this realm"
 msgstr "Proxy Kennung zur Verwendung innerhalb dieses Realms"
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr "Proxy-Referenz sollte wie folgt lauten: { :relation => [:column_name, ...] }"
 
@@ -7237,9 +7218,6 @@ msgstr "Puppet-Klasse"
 msgid "Puppet error state"
 msgstr "Puppet Fehlerzustand"
 
-msgid "Puppet interval"
-msgstr "Puppet-Intervall"
-
 msgid "Puppet parameter"
 msgstr "Puppet-Parameter"
 
@@ -7248,14 +7226,6 @@ msgstr "Puppet-Proxy Kennung"
 
 msgid "Puppet summary"
 msgstr "Puppet Zusammenfassung"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppet-Klasse"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Name"
 
 msgid "Query"
 msgstr "Abfrage"
@@ -7331,6 +7301,9 @@ msgstr "Name"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "Realm-Typ"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "Neustarten und erstellen"
@@ -7432,12 +7405,6 @@ msgstr "Prüfwert entfernen"
 msgid "Remove Parameter"
 msgstr "Parameter entfernen"
 
-msgid "Remove a Puppet class from host"
-msgstr "Puppet-Klasse vom Host entfernen"
-
-msgid "Remove a Puppet class from host group"
-msgstr "Puppet-Klasse von Hostgruppe entfernen"
-
 msgid "Remove an email notification for a user"
 msgstr "Entferne eine Email-Benachrichtigung für einen Benutzer"
 
@@ -7446,6 +7413,9 @@ msgstr "Konflikt: %{type} für %{host} entfernen"
 
 msgid "Remove tag"
 msgstr "Tag entfernen"
+
+msgid "Remove widget"
+msgstr ""
 
 msgid "Removed %{from} to %{to}"
 msgstr "%{from} von %{to} entfernt"
@@ -7529,6 +7499,9 @@ msgstr "Name"
 msgid "ReportTemplate|Snippet"
 msgstr "Berichtsvorlage|Ausschnitt"
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "Berichtet am"
 
@@ -7540,6 +7513,9 @@ msgstr "Berichtet von %s"
 
 msgid "Reports"
 msgstr "Berichte"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7584,6 +7560,9 @@ msgstr "Notwendig, es sei denn der Benutzer nutzt eine externe Authentifizierung
 msgid "Required when user want to change own password"
 msgstr "Voraussetzung wenn der Benutzer sein Passwort ändern möchte"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr "PuppetCA Zertifikatsname für %s zurücksetzen "
 
@@ -7627,6 +7606,9 @@ msgstr "Ergebnis des Berichts %s"
 msgid "Resume"
 msgstr "Fortsetzen"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "Gibt einen String aus, der für einen Hoststatus eines bestimmten Typen steht"
 
@@ -7652,8 +7634,14 @@ msgstr "Zurücksetzen fehlgeschlagen, ${err}"
 msgid "Revert Local Changes"
 msgstr "Lokale Änderungen rückgängig machen"
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "Überprüfung"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "Build-Status für %s prüfen"
@@ -7663,6 +7651,9 @@ msgstr "Widerrufen"
 
 msgid "Revoke a Personal Access Token for a user"
 msgstr "Widerrufe ein persönliches Zugriffstoken für einen User"
+
+msgid "Revoke personal access token"
+msgstr ""
 
 msgid "Revoked"
 msgstr "Widerrufen"
@@ -7744,6 +7735,9 @@ msgstr "SMTP OpenSSL Verifizierungsmodus"
 msgid "SMTP address"
 msgstr "SMTP-Adresse"
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "SMTP-Authentifizierung"
 
@@ -7758,6 +7752,9 @@ msgstr "SMTP-Passwort"
 
 msgid "SMTP port"
 msgstr "SMTP-Port"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr "SMTP-Benutzername"
@@ -7777,14 +7774,20 @@ msgstr "SSH Timeout"
 msgid "SSL CA file"
 msgstr "SSL-CA-Datei"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "SSL-CA-Datei, die Foreman bei der Kommunikation mit dessen Proxys verwenden wird"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "SSL-Zertifikatspfad, das Foreman bei der Kommunikation mit seinen Proxys verwendet"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Private SSL-Schlüsseldatei, die Foreman bei der Kommunikation mit dessen Proxys verwenden wird"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "SSL-Zertifikat"
@@ -7833,6 +7836,9 @@ msgstr "Speichern und erneut versuchen"
 
 msgid "Saved Bookmarks"
 msgstr "Gespeicherte Lesezeichen"
+
+msgid "Saved audits interval"
+msgstr ""
 
 msgid "Schedule generating of a report"
 msgstr "Plane die Generierung eines Berichts"
@@ -8010,6 +8016,9 @@ msgstr "Sendmail-Argumente"
 msgid "Sendmail location"
 msgstr "Sendmail-Pfadname"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr "Servergruppe"
 
@@ -8040,6 +8049,9 @@ msgstr "Setzen Sie den Parameter 'host_registration_remote_execution' für den H
 msgid "Set IP addresses for %s"
 msgstr "IP-Adressen für %s festlegen"
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr "Zufälliges Passwort für die VNC Verbindung generieren"
 
@@ -8060,9 +8072,6 @@ msgstr "Reihenfolge festlegen, in der die Werte aufgelöst werden."
 
 msgid "Set up compute instance %s"
 msgstr "Recheninstanz %s einrichten"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr "Legt einen Proxy für alle von Foreman ausgehenden HTTP-Verbindungen fest. Systemweite Proxys müssen auf der Ebene des Betriebssystems konfiguriert werden."
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8130,6 +8139,12 @@ msgstr "Setup Insights"
 msgid "Setup REX"
 msgstr "REX einrichten"
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "Soll `foreman-rake db:seed` beim nächsten Lauf der Installer-Module ausgeführt werden?"
 
@@ -8163,18 +8178,6 @@ msgstr "Zeige Experimental Labs"
 msgid "Show a Personal Access Token for a user"
 msgstr "Zeige ein persönliches Zugriffstoken eines Users"
 
-msgid "Show a Puppet class"
-msgstr "Puppet-Klasse anzeigen"
-
-msgid "Show a Puppet class for a host group"
-msgstr "Puppet-Klasse für eine Hostgruppe anzeigen"
-
-msgid "Show a Puppet class for an environment"
-msgstr "Puppet-Klasse für eine Umgebung anzeigen"
-
-msgid "Show a Puppet class for host"
-msgstr "Puppet-Klasse für Host anzeigen"
-
 msgid "Show a bookmark"
 msgstr "Lesezeichen anzeigen"
 
@@ -8186,9 +8189,6 @@ msgstr "Rechenprofil anzeigen"
 
 msgid "Show a compute resource"
 msgstr "Rechenressource anzeigen"
-
-msgid "Show a config group"
-msgstr "Konfigurationsgruppe anzeigen"
 
 msgid "Show a default template combination for an operating system"
 msgstr "Standardvorlagen-Kombination für ein Betriebssystem anzeigen"
@@ -8256,17 +8256,11 @@ msgstr "Rolle anzeigen"
 msgid "Show a setting"
 msgstr "Einstellung anzeigen"
 
-msgid "Show a smart class parameter"
-msgstr "Smart-Klassenparameter anzeigen"
-
 msgid "Show a smart proxy"
 msgstr "Smart-Proxy anzeigen"
 
 msgid "Show a subnet"
 msgstr "Subnetz anzeigen"
-
-msgid "Show a trend"
-msgstr "Trend anzeigen"
 
 msgid "Show a user"
 msgstr "Benutzer anzeigen"
@@ -8301,9 +8295,6 @@ msgstr "Audit anzeigen"
 msgid "Show an email notification"
 msgstr "E-Mail-Benachrichtigung anzeigen"
 
-msgid "Show an environment"
-msgstr "Umgebung anzeigen"
-
 msgid "Show an external authentication source"
 msgstr "Externe Authentifizierungs-Quelle anzeigen"
 
@@ -8324,9 +8315,6 @@ msgstr "Interne Authentifizierungs-Quelle anzeigen"
 
 msgid "Show an operating system"
 msgstr "Betriebssystem anzeigen"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "Überschreibungswert für einen bestimmten Smart-Klassenparameter anzeigen"
 
 msgid "Show available API links"
 msgstr "Verfügbare API-Verknüpfungen anzeigen"
@@ -8409,9 +8397,6 @@ msgstr "Übersprungen"
 msgid "Skipped|S"
 msgstr "Ü"
 
-msgid "Smart Class Parameter"
-msgstr "Smart-Class-Parameter"
-
 msgid "Smart Class Parameters"
 msgstr "Smart-Class-Parameter"
 
@@ -8479,6 +8464,9 @@ msgstr "Einige Schnittstellen sind ungültig"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Einige der Schnittstellen sind ungültig. Bitte überprüfen Sie die nachstehende Tabelle."
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "Bei der Änderung des Systemtyps %s ist ein Fehler aufgetreten"
 
@@ -8502,10 +8490,6 @@ msgid "Source"
 msgstr "Quelle"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Zusammenfassung"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Wert"
 
@@ -8527,8 +8511,8 @@ msgstr "Der angegebene Wert ist höher als das empfohlene Maximum %s"
 msgid "Specify Matchers"
 msgstr "Prüfwert spezifizieren"
 
-msgid "Specify additional options to sendmail"
-msgstr "Zusätzliche Sendmail-Optionen"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "Specify authentication type, if required"
 msgstr "Authentifizierungsart, wenn benötigt"
@@ -8571,8 +8555,8 @@ msgstr "Status"
 msgid "Status %s does not exist."
 msgstr "Status %s existiert nicht"
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "Aktualisierung von IP-Adressen und MAC-Werten aus den Puppet-Fakten stoppen (wirkt sich auf alle Schnittstellen aus)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr "Beenden der Aktualisierung von Domänen Werten aus Fakten"
@@ -8668,6 +8652,10 @@ msgid "Subnet|Dns secondary"
 msgstr "Sekundärer DNS"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Von"
 
@@ -8694,6 +8682,10 @@ msgstr "Subnetz|Name"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Subnetz|Netzwerk"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8766,6 +8758,12 @@ msgstr "Die Unterstützung für %{feature} wurde eingestellt und wird in Version
 
 msgid "Supported Formats"
 msgstr "Unterstützte Formate"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "Gruppe von Authentifizierungsquelle synchronisieren"
@@ -8924,12 +8922,20 @@ msgid "TemplateInput|Advanced"
 msgstr "TemplateInput|Erweitert"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "Beschreibung"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "Faktenname"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8998,6 +9004,10 @@ msgid "Template|Default"
 msgstr "Standard"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Gesperrt"
 
@@ -9048,8 +9058,8 @@ msgstr "Test-E-Mail"
 msgid "Tester"
 msgstr "Tester"
 
-msgid "Text to be shown in the login-page footer"
-msgstr "Zusätzlicher Text zur Anzeige auf der Login-Seite"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
+msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
@@ -9194,8 +9204,8 @@ msgstr "Der für Menschen lesbare Name der Einstellungskategorie"
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr "Die Informationen von oben können z.B. um eine NetworkManager-Konfigurationsdatei für jede Schnittstelle in der Bereitstellungsvorlage zu erstellen."
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
-msgstr "Der Titel der Instanz wird in der oberen Navigationsleiste angezeigt (erfordert ein Neuladen der Seite)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
+msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
 msgstr "Der iss (issuer) Claim identifiziert den Principal, der den JWT ausgestellt hat, der bei den meisten OpenID Providern in einer `/.well-known/openid-configuration` existiert."
@@ -9211,8 +9221,8 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] "Die Liste schließt %{count} %{link_start}physikalischen Host%{link_end} aus."
 msgstr[1] "Die Liste schließt %{count} %{link_start}physikalische Hosts %{link_end} aus."
 
-msgid "The location of the sendmail executable"
-msgstr "Pfad zum Sendmail-Programms"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "Die markierten Felder benötigen eine Prüfung"
@@ -9241,9 +9251,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "Der Energiezustand des ausgewählten Hosts wird auf %s festgelegt"
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr "Die Puppetrun-Funktion wurde entfernt, Sie können jedoch das Remote Execution Plugin verwenden, um Puppet-Befehle auszuführen"
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "Name des Realms, z.B. EXAMPLE.COM"
@@ -9306,6 +9313,9 @@ msgstr "Es könnten mehr Informationen dazu in den Server Logs zu finden sein."
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
 msgstr "Es muss mindestens ein Smart Proxy vorhanden sein, auf dem ein externes IPAM-Plugin installiert und konfiguriert ist"
+
+msgid "There was a problem processing the request. Please try again."
+msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
 msgstr "Es ist ein Fehler aufgetreten beim erzeugen der PXE Datei: %s"
@@ -9434,8 +9444,8 @@ msgstr "Dieser Wert ist nicht versteckt"
 msgid "This value is used also as the host's primary interface name."
 msgstr "Dieser Wert wird auch als Name für die Primärschnittstelle des Hosts verwendet."
 
-msgid "This will be one of our coolest pages."
-msgstr "Dies wird eine unserer coolsten Seiten sein."
+msgid "This will change the host power status, are you sure?"
+msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
 msgstr "Dies wird einen Bericht %s generieren. Abhängig von der Definition, kann dies eine lange Zeit zum verarbeiten in Kauf nehmen."
@@ -9460,15 +9470,6 @@ msgstr "Zu verwendende Zeitzone für neue Benutzer"
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
 msgstr "Um auf die %s API zuzugreifen, müssen Sie das Foreman Puppet-Plugin installieren"
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr "Um auf die /statistics API zuzugreifen, müssen Sie das Foreman Statistics-Plugin installieren"
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr "Um auf die /trends API zuzugreifen, müssen Sie das Foreman Statistics-Plugin installieren"
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
-msgstr "Um auf die import_puppetclasses API zuzugreifen, müssen Sie das Foreman Puppet-Plugin installieren"
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
 msgstr "Um das Standardverhalten zu ändern, ändern Sie die einschließende Markierung mit <code>-&#37;></code>:"
@@ -9501,9 +9502,6 @@ msgstr "Token"
 
 msgid "Token Expiry"
 msgstr "Token Ablauf"
-
-msgid "Token duration"
-msgstr "Tokendauer"
 
 msgid "Token expired"
 msgstr "Token abgelaufen"
@@ -9542,41 +9540,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] "Insgesamt ein Host"
 msgstr[1] "Insgesamt %{hosts} Hosts"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "Trend"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Trendzähler"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Summe"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "Intervall-Ende"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "Intervall-Start"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Faktenname"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Faktenwert"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Name"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Trend-Typen"
+msgid "Total: %s"
+msgstr ""
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "True/False-Flag, ob ein Host gemanagt oder ungemanagt ist. Hinweis: Dieser Wert bestimmt außerdem, ob mehrere Parameter erforderlich sind oder nicht."
@@ -9857,6 +9822,12 @@ msgstr "websockets_ssl_key kann nicht abgeschaltet werden, wenn websockets_encry
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "Vorlage %s für das Übersichtsseiten-Widget nicht erlaubt"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "Unbeaufsichtigte URL"
 
@@ -9914,6 +9885,9 @@ msgstr "Unbekannte Datensätze in der Datenbank gefunden"
 msgid "Unknown status: %s"
 msgstr "Unbekannter Status: %s"
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "Entsperren"
 
@@ -9941,9 +9915,6 @@ msgstr ":a_resource aktualisieren"
 msgid "Update IP from built request"
 msgstr "IP aus gebauter Anfrage aktualisieren"
 
-msgid "Update a Puppet class"
-msgstr "Puppet-Klasse aktualisieren"
-
 msgid "Update a bookmark"
 msgstr "Lesezeichen Aktualisieren"
 
@@ -9955,9 +9926,6 @@ msgstr "Rechenprofil aktualisieren"
 
 msgid "Update a compute resource"
 msgstr "Rechenressource aktualisieren"
-
-msgid "Update a config group"
-msgstr "Konfigurationsgruppe Aktualisieren"
 
 msgid "Update a default template combination for an operating system"
 msgstr "Standardvorlagen-Kombination für ein Betriebssystem aktualisieren"
@@ -10025,9 +9993,6 @@ msgstr "Rolle aktualisieren"
 msgid "Update a setting"
 msgstr "Einstellung aktualisieren"
 
-msgid "Update a smart class parameter"
-msgstr "Smart-Klassenparameter aktualisieren"
-
 msgid "Update a smart proxy"
 msgstr "Smart proxy aktualisieren"
 
@@ -10058,9 +10023,6 @@ msgstr "Architektur aktualisieren"
 msgid "Update an email notification for a user"
 msgstr "Aktualisiere eine Email-Benachrichtigung eines Benutzers"
 
-msgid "Update an environment"
-msgstr "Umgebung aktualisieren"
-
 msgid "Update an external authentication source"
 msgstr "Aktualisierung einer externen Authentifzierungs-Quelle"
 
@@ -10069,12 +10031,6 @@ msgstr "Abbild aktualisieren"
 
 msgid "Update an operating system"
 msgstr "Betriebssystem aktualisieren"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "Überschreibungswert für einen bestimmten Smart-Klassenparameter aktualisieren"
-
-msgid "Update environment from facts"
-msgstr "Umgebung nach Fakten aktualisieren"
 
 msgid "Update external user group"
 msgstr "Externe Benutzergruppe aktualisieren"
@@ -10311,6 +10267,10 @@ msgid "User|Description"
 msgstr "Beschreibung"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "Vorname"
 
@@ -10447,8 +10407,8 @@ msgstr "Variable"
 msgid "Variables"
 msgstr "Variablen"
 
-msgid "Vendor Class"
-msgstr "Herstellerklasse"
+msgid "Vendor class"
+msgstr ""
 
 msgid "Verify"
 msgstr "Überprüfen"
@@ -10509,6 +10469,9 @@ msgstr "Warten, bis %s verfügbar wird"
 
 msgid "Warning"
 msgstr "Warnung"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "Warnung!"
@@ -10577,6 +10540,9 @@ msgstr ""
 "Beim Bearbeiten einer Vorlage müssen Sie eine Liste \\\n"
 "von Betriebssystemen zuweisen, mit denen diese Vorlage verwendet werden kann. Optional können Sie \\\n"
 "Sie eine Vorlage auf eine Liste von Hostgruppen beschränken."
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
+msgstr ""
 
 msgid ""
 "When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.\n"
@@ -10711,6 +10677,9 @@ msgstr "Ja (überschreiben)"
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "Sie sind im Begriff, das Standard-PXE-Menü auf allen konfigurierten TFTP-Servern zu ändern - fortfahren?"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr "Sie sind im Begriff %s zu löschen. Sind Sie sicher?"
@@ -10865,6 +10834,9 @@ msgstr "alle"
 msgid "already exists"
 msgstr "existiert bereits"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "eine Organisation"
 
@@ -10876,9 +10848,6 @@ msgstr "Array"
 
 msgid "auxiliary field"
 msgstr "Hilfsfeld"
-
-msgid "belongs to config group"
-msgstr "gehört zur Konfigurationsgruppe"
 
 msgid "boolean"
 msgstr "Boolean"
@@ -11059,9 +11028,6 @@ msgstr "Caching aktivieren, nur für VMware"
 
 msgid "enabled"
 msgstr "aktiviert"
-
-msgid "environment id"
-msgstr "Umgebungskennung"
 
 msgid "expected a value of type %s"
 msgstr "erwartet einen Wert vom Typ %s"
@@ -11311,8 +11277,7 @@ msgstr "externe Benutzergruppe mit dieser Benutzergruppe verknüpfen"
 msgid "list"
 msgstr "Liste"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "Deutsch"
 
@@ -11492,12 +11457,6 @@ msgstr "physikalisch @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "physikalisch @ Bridge %s"
-
-msgid "plugin action 1"
-msgstr "Plugin-Aktion 1"
-
-msgid "plugin action 2"
-msgstr "Plugin-Aktion 2"
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "Energieaktion, gültige Aktionen sind (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"

--- a/locale/en/foreman.po
+++ b/locale/en/foreman.po
@@ -380,6 +380,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr ""
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -665,6 +668,9 @@ msgstr ""
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr ""
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -732,6 +738,12 @@ msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr ""
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 msgid "Are you sure you want to log out?"
@@ -1116,6 +1128,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr ""
 
@@ -1210,6 +1225,9 @@ msgid "Build PXE Default"
 msgstr ""
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2594,6 +2612,12 @@ msgstr ""
 msgid "EUI-64"
 msgstr ""
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3301,6 +3325,12 @@ msgstr ""
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3595,6 +3625,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4357,7 +4390,19 @@ msgstr ""
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr ""
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4367,6 +4412,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4382,6 +4430,9 @@ msgid "If this setting needs to be changed in file, it will have the file path."
 msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
+msgstr ""
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
 msgstr ""
 
 msgid "Ignore facts for domain"
@@ -4529,6 +4580,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr ""
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr ""
 
@@ -4572,6 +4626,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5518,6 +5575,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr ""
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr ""
 
@@ -6356,6 +6416,9 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr ""
 
@@ -6398,6 +6461,9 @@ msgid "Only one declaration of a proxy is allowed"
 msgstr ""
 
 msgid "Only one volume can be bootable"
+msgstr ""
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
 msgstr ""
 
 msgid "Oops!!"
@@ -6808,6 +6874,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7489,6 +7558,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr ""
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr ""
 
@@ -8074,6 +8146,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8308,6 +8383,11 @@ msgstr ""
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -8397,6 +8477,12 @@ msgid "Some interfaces are invalid"
 msgstr ""
 
 msgid "Some of the interfaces are invalid. Please check the table below."
+msgstr ""
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
 msgstr ""
 
 msgid "Something went wrong"
@@ -9061,6 +9147,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr ""
 
@@ -9072,6 +9161,9 @@ msgstr ""
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "The class of the machine as reported by the OpenBoot PROM. This is primarily used by Solaris SPARC builds and can be left blank for other architectures. The value can be determined on Solaris via `uname -i|cut -f2 -d`."
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
@@ -9262,6 +9354,12 @@ msgstr ""
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr ""
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr ""
 
@@ -9275,6 +9373,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9331,6 +9432,9 @@ msgstr ""
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9350,6 +9454,12 @@ msgid "This service is available for unauthenticated users"
 msgstr ""
 
 msgid "This service is only available for authenticated users"
+msgstr ""
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
 msgstr ""
 
 msgid "This template is locked and may not be removed."
@@ -9376,6 +9486,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9420,6 +9533,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10273,6 +10389,9 @@ msgstr ""
 msgid "VM already associated with a host"
 msgstr ""
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr ""
 
@@ -10412,6 +10531,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr ""
@@ -10595,10 +10717,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr ""
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/en/foreman.po
+++ b/locale/en/foreman.po
@@ -54,9 +54,6 @@ msgstr[1] ""
 msgid "%s Parameters updated, see below for more information"
 msgstr ""
 
-msgid "%s Template"
-msgstr ""
-
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
 msgstr[0] ""
@@ -107,9 +104,6 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
-
-msgid "%s out of sync disabled"
-msgstr ""
 
 msgid "%s selected hosts"
 msgstr ""
@@ -1608,14 +1602,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr ""
-
 msgid "Configuration"
 msgstr ""
 
@@ -2168,9 +2154,6 @@ msgstr ""
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr ""
 
-msgid "Default Puppet environment"
-msgstr ""
-
 msgid "Default VNC Keyboard"
 msgstr ""
 
@@ -2477,9 +2460,6 @@ msgstr ""
 msgid "Disable all filters overriding"
 msgstr ""
 
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr ""
-
 msgid "Disable overriding"
 msgstr ""
 
@@ -2602,16 +2582,10 @@ msgstr ""
 msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr ""
-
 msgid "EC2"
 msgstr ""
 
 msgid "EFI"
-msgstr ""
-
-msgid "ENC environment"
 msgstr ""
 
 msgid "ERROR or FATAL"
@@ -2734,10 +2708,6 @@ msgstr ""
 msgid "Entries per page"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr ""
-
 msgid "Environment IDs"
 msgstr ""
 
@@ -2752,10 +2722,6 @@ msgstr ""
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Name"
 
 msgid "Error"
 msgstr ""
@@ -3266,12 +3232,6 @@ msgstr ""
 msgid "Fix All Mismatches"
 msgstr ""
 
-msgid "Fix DB cache"
-msgstr ""
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr ""
-
 msgid "Fix Mismatches"
 msgstr ""
 
@@ -3356,6 +3316,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr ""
 
@@ -3363,6 +3327,10 @@ msgid "Foreman now manages the build cycle for %s"
 msgstr ""
 
 msgid "Foreman now no longer manages the build cycle for %s"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
 msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
@@ -3401,16 +3369,13 @@ msgstr ""
 msgid "Foreman will create the host when new facts are received"
 msgstr ""
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr ""
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr ""
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
+msgid "Foreman will load the new UI for host details"
 msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
@@ -3420,9 +3385,6 @@ msgid "Foreman will parse ERB in parameters value in the ENC output"
 msgstr ""
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
-msgstr ""
-
-msgid "Foreman will update a host's environment from its facts"
 msgstr ""
 
 msgid "Foreman will update a host's hostgroup from its facts"
@@ -3441,6 +3403,18 @@ msgid "Foreman will use random UUIDs for certificate signing instead of hostname
 msgstr ""
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
 msgstr ""
 
 msgid "Form was successfully created."
@@ -3468,6 +3442,9 @@ msgid "Full screen"
 msgstr ""
 
 msgid "Function not available for %s"
+msgstr ""
+
+msgid "Further Information"
 msgstr ""
 
 msgid "GMT time"
@@ -3773,11 +3750,11 @@ msgstr ""
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
+msgid "Host details"
 msgstr ""
 
-msgid "Host details"
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
 msgstr ""
 
 msgid "Host group"
@@ -3916,7 +3893,31 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -4211,7 +4212,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -5386,6 +5387,10 @@ msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5633,10 +5638,6 @@ msgid "Message"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Value"
 
@@ -5853,6 +5854,9 @@ msgid "New connection has been rejected with reason: %"
 msgstr ""
 
 msgid "New filter"
+msgstr ""
+
+msgid "New host details UI"
 msgstr ""
 
 msgid "Next"
@@ -6674,6 +6678,10 @@ msgstr "Name"
 msgid "Parameter|Priority"
 msgstr "Priority"
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
+
 msgid "Parameter|Type"
 msgstr ""
 
@@ -7094,6 +7102,9 @@ msgstr ""
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7142,9 +7153,6 @@ msgstr ""
 msgid "Puppet error state"
 msgstr ""
 
-msgid "Puppet interval"
-msgstr ""
-
 msgid "Puppet parameter"
 msgstr ""
 
@@ -7153,14 +7161,6 @@ msgstr ""
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppet class"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Class name"
 
 msgid "Query"
 msgstr ""
@@ -8425,10 +8425,6 @@ msgid "Source"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Value"
 
@@ -8591,6 +8587,10 @@ msgid "Subnet|Dns secondary"
 msgstr "Secondary DNS server"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Start of IP range"
 
@@ -8617,6 +8617,10 @@ msgstr "Name"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Network address"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8853,11 +8857,19 @@ msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8927,6 +8939,10 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -8977,7 +8993,7 @@ msgstr ""
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9455,42 +9471,6 @@ msgstr[1] ""
 
 msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Count"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Fact name"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Fact value"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Name"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Trend type"
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr ""
@@ -9981,9 +9961,6 @@ msgstr ""
 msgid "Update an operating system"
 msgstr ""
 
-msgid "Update environment from facts"
-msgstr ""
-
 msgid "Update external user group"
 msgstr ""
 
@@ -10216,6 +10193,10 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages

--- a/locale/en_GB/foreman.po
+++ b/locale/en_GB/foreman.po
@@ -23,9 +23,6 @@ msgstr ""
 msgid " Documentation"
 msgstr ""
 
-msgid " Remove"
-msgstr " Remove"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -36,9 +33,6 @@ msgid "${progress}%% Complete"
 msgstr ""
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
-msgstr ""
-
-msgid "%s - Press Shift-F12 to release the cursor."
 msgstr ""
 
 msgid "%s - The following hosts are about to be changed"
@@ -58,9 +52,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "%s Parameters updated, see below for more information"
-msgstr ""
-
-msgid "%s Template"
 msgstr ""
 
 msgid "%s VM failed while processing: check logs for more details."
@@ -114,9 +105,6 @@ msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "%s out of sync disabled"
-msgstr ""
-
 msgid "%s selected hosts"
 msgstr ""
 
@@ -134,9 +122,6 @@ msgid "%s widget loading..."
 msgstr ""
 
 msgid "%s you had selected as your context has been deleted"
-msgstr ""
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
 msgstr ""
 
 msgid "%{action} %{vm}"
@@ -207,6 +192,9 @@ msgid "%{match} does not match an existing host group"
 msgstr ""
 
 msgid "%{name} changed from %{label1} to %{label2}"
+msgstr ""
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
 msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
@@ -289,6 +277,9 @@ msgid "(filtered from %s total entries)"
 msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
+msgstr ""
+
+msgid "(updated %s)"
 msgstr ""
 
 msgid "*Clear %s proxy*"
@@ -482,12 +473,6 @@ msgstr ""
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr ""
 
-msgid "Add a Puppet class to host"
-msgstr ""
-
-msgid "Add a Puppet class to host group"
-msgstr ""
-
 msgid "Add a template combination"
 msgstr ""
 
@@ -533,9 +518,6 @@ msgstr ""
 msgid "Additional information about this host"
 msgstr ""
 
-msgid "Address to connect to"
-msgstr ""
-
 msgid "Admin permissions required"
 msgstr ""
 
@@ -578,9 +560,6 @@ msgstr ""
 msgid "All"
 msgstr ""
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr ""
 
@@ -588,6 +567,12 @@ msgid "All Reports"
 msgstr ""
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -749,9 +734,6 @@ msgstr ""
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "Are you sure you want to delete this widget from your dashboard?"
-
 msgid "Are you sure you want to log out?"
 msgstr ""
 
@@ -807,6 +789,12 @@ msgid "Assign Organization"
 msgstr "Assign Organisation"
 
 msgid "Assign Selected Hosts"
+msgstr ""
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
 msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1293,6 +1281,9 @@ msgstr ""
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr ""
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr ""
 
@@ -1374,7 +1365,7 @@ msgstr ""
 msgid "Certificate path for GCE only"
 msgstr ""
 
-msgid "Certificate that Foreman will use to encrypt websockets "
+msgid "Certificate path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Certificates"
@@ -1434,6 +1425,9 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr ""
 
@@ -1445,12 +1439,6 @@ msgstr ""
 
 msgid "Click to log in again"
 msgstr ""
-
-msgid "Click to remove %s"
-msgstr "Click to remove %s"
-
-msgid "Click to remove config group"
-msgstr "Click to remove config group"
 
 msgid "Client Email"
 msgstr ""
@@ -1614,14 +1602,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr ""
-
 msgid "Configuration"
 msgstr ""
 
@@ -1664,7 +1644,7 @@ msgstr ""
 msgid "Connected"
 msgstr ""
 
-msgid "Connected (unencrypted) to: %s"
+msgid "Connected to: %s"
 msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
@@ -1715,7 +1695,7 @@ msgstr ""
 msgid "Cores per socket"
 msgstr ""
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
 msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
@@ -1892,9 +1872,6 @@ msgstr ""
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-msgid "Create a Puppet class"
-msgstr ""
-
 msgid "Create a bookmark"
 msgstr ""
 
@@ -1905,9 +1882,6 @@ msgid "Create a compute profile"
 msgstr ""
 
 msgid "Create a compute resource"
-msgstr ""
-
-msgid "Create a config group"
 msgstr ""
 
 msgid "Create a default template combination for an operating system"
@@ -1982,9 +1956,6 @@ msgstr ""
 msgid "Create a template input"
 msgstr ""
 
-msgid "Create a trend counter"
-msgstr ""
-
 msgid "Create a user"
 msgstr ""
 
@@ -2000,9 +1971,6 @@ msgstr ""
 msgid "Create an architecture"
 msgstr ""
 
-msgid "Create an environment"
-msgstr ""
-
 msgid "Create an external user group linked to a user group"
 msgstr ""
 
@@ -2015,13 +1983,13 @@ msgstr ""
 msgid "Create an operating system"
 msgstr ""
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr ""
-
 msgid "Create autosign entry"
 msgstr ""
 
 msgid "Create image"
+msgstr ""
+
+msgid "Create model"
 msgstr ""
 
 msgid "Create new boot volume from image"
@@ -2037,6 +2005,9 @@ msgid "Create realm entry for %s"
 msgstr ""
 
 msgid "Created"
+msgstr ""
+
+msgid "Created %s by %s"
 msgstr ""
 
 msgid "Creates a table preference for a given table"
@@ -2067,18 +2038,6 @@ msgid "Custom instance type"
 msgstr ""
 
 msgid "DB pending seed"
-msgstr ""
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
 msgstr ""
 
 msgid "DHCP"
@@ -2171,7 +2130,7 @@ msgstr ""
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2193,9 +2152,6 @@ msgid "Default PXE menu item in global template - 'local', 'discovery' or custom
 msgstr ""
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
-msgstr ""
-
-msgid "Default Puppet environment"
 msgstr ""
 
 msgid "Default VNC Keyboard"
@@ -2279,9 +2235,6 @@ msgstr ""
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr ""
 
-msgid "Delete a Puppet class"
-msgstr ""
-
 msgid "Delete a Virtual Machine"
 msgstr ""
 
@@ -2292,9 +2245,6 @@ msgid "Delete a compute profile"
 msgstr ""
 
 msgid "Delete a compute resource"
-msgstr ""
-
-msgid "Delete a config group"
 msgstr ""
 
 msgid "Delete a default template combination for an operating system"
@@ -2378,9 +2328,6 @@ msgstr ""
 msgid "Delete a template input"
 msgstr ""
 
-msgid "Delete a trend counter"
-msgstr ""
-
 msgid "Delete a user"
 msgstr ""
 
@@ -2420,9 +2367,6 @@ msgstr ""
 msgid "Delete an architecture"
 msgstr ""
 
-msgid "Delete an environment"
-msgstr ""
-
 msgid "Delete an external user group"
 msgstr ""
 
@@ -2432,13 +2376,16 @@ msgstr ""
 msgid "Delete an operating system"
 msgstr ""
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr ""
-
 msgid "Delete autosign entry"
 msgstr ""
 
 msgid "Delete filter?"
+msgstr ""
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
 msgstr ""
 
 msgid "Delete realm entry for %s"
@@ -2511,9 +2458,6 @@ msgid "Disable alerts for selected hosts"
 msgstr ""
 
 msgid "Disable all filters overriding"
-msgstr ""
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2632,19 +2576,16 @@ msgstr ""
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr ""
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"
 msgstr ""
 
 msgid "EFI"
-msgstr ""
-
-msgid "ENC environment"
 msgstr ""
 
 msgid "ERROR or FATAL"
@@ -2687,6 +2628,9 @@ msgid "Edit this host"
 msgstr ""
 
 msgid "Editor"
+msgstr ""
+
+msgid "Email"
 msgstr ""
 
 msgid "Email Preferences"
@@ -2764,10 +2708,6 @@ msgstr ""
 msgid "Entries per page"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr ""
-
 msgid "Environment IDs"
 msgstr ""
 
@@ -2782,10 +2722,6 @@ msgstr ""
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Name"
 
 msgid "Error"
 msgstr "Error"
@@ -2825,6 +2761,9 @@ msgstr ""
 
 msgid "Error removing widget from dashboard."
 msgstr "Error removing widget from dashboard."
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr ""
@@ -3293,13 +3232,13 @@ msgstr ""
 msgid "Fix All Mismatches"
 msgstr ""
 
-msgid "Fix DB cache"
-msgstr ""
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr ""
-
 msgid "Fix Mismatches"
+msgstr ""
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
 msgstr ""
 
 msgid "Flavor"
@@ -3344,9 +3283,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr ""
 
-msgid "Force a Puppet agent run on the host"
-msgstr ""
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr ""
 
@@ -3380,6 +3316,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr ""
 
@@ -3387,6 +3327,10 @@ msgid "Foreman now manages the build cycle for %s"
 msgstr ""
 
 msgid "Foreman now no longer manages the build cycle for %s"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
 msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
@@ -3416,7 +3360,7 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr ""
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
 msgstr ""
 
 msgid "Foreman will create the host when a report is received"
@@ -3425,19 +3369,13 @@ msgstr ""
 msgid "Foreman will create the host when new facts are received"
 msgstr ""
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr ""
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr ""
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr ""
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
+msgid "Foreman will load the new UI for host details"
 msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
@@ -3447,9 +3385,6 @@ msgid "Foreman will parse ERB in parameters value in the ENC output"
 msgstr ""
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
-msgstr ""
-
-msgid "Foreman will update a host's environment from its facts"
 msgstr ""
 
 msgid "Foreman will update a host's hostgroup from its facts"
@@ -3468,6 +3403,18 @@ msgid "Foreman will use random UUIDs for certificate signing instead of hostname
 msgstr ""
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
 msgstr ""
 
 msgid "Form was successfully created."
@@ -3495,6 +3442,9 @@ msgid "Full screen"
 msgstr ""
 
 msgid "Function not available for %s"
+msgstr ""
+
+msgid "Further Information"
 msgstr ""
 
 msgid "GMT time"
@@ -3566,7 +3516,7 @@ msgstr ""
 msgid "Get default dashboard widgets"
 msgstr ""
 
-msgid "Get statistics"
+msgid "Get hosts forming the smart proxy"
 msgstr ""
 
 msgid "Get status of host"
@@ -3689,6 +3639,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr ""
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr ""
 
@@ -3734,10 +3690,16 @@ msgstr ""
 msgid "Host"
 msgstr "Host"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr ""
 
 msgid "Host %s is not associated with a VM"
+msgstr ""
+
+msgid "Host %s will be built next boot"
 msgstr ""
 
 msgid "Host Configuration Chart"
@@ -3773,7 +3735,13 @@ msgstr ""
 msgid "Host Parameters"
 msgstr ""
 
-msgid "Host Wizard"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
 msgstr ""
 
 msgid "Host audit entries"
@@ -3782,11 +3750,11 @@ msgstr ""
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
+msgid "Host details"
 msgstr ""
 
-msgid "Host details"
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
 msgstr ""
 
 msgid "Host group"
@@ -3925,7 +3893,31 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -4154,9 +4146,6 @@ msgstr ""
 msgid "ID of domain"
 msgstr ""
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr ""
 
@@ -4223,7 +4212,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4286,9 +4275,6 @@ msgstr ""
 msgid "IP addresses that should be excluded from suggestion"
 msgstr ""
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr ""
 
@@ -4312,6 +4298,9 @@ msgstr ""
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr ""
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr ""
 
@@ -4330,6 +4319,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "IPv6 Subnet"
+msgstr ""
+
+msgid "IPv6 address"
 msgstr ""
 
 msgid "IPv6 address of interface"
@@ -4392,13 +4384,13 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr ""
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr ""
-
 msgid "Ignore facts for domain"
 msgstr ""
 
 msgid "Ignore facts for operating system"
+msgstr ""
+
+msgid "Ignore interfaces facts for provisioning"
 msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
@@ -4478,12 +4470,6 @@ msgid "Import as unmanaged Host"
 msgstr ""
 
 msgid "Import of facts failed for host %s"
-msgstr ""
-
-msgid "Import puppet classes from puppet proxy"
-msgstr ""
-
-msgid "Import puppet classes from puppet proxy for an environment"
 msgstr ""
 
 msgid "Imported IPv4 Subnets"
@@ -4597,6 +4583,9 @@ msgstr ""
 msgid "Installation medium configuration"
 msgstr ""
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr ""
 
@@ -4661,6 +4650,9 @@ msgid "Invalid %{assoc} selection, you must select at least one of yours and hav
 msgstr ""
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
+msgstr ""
+
+msgid "Invalid HTTP(S) URL"
 msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
@@ -4828,13 +4820,13 @@ msgstr ""
 msgid "Launch Console"
 msgstr ""
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr ""
 
 msgid "Learn more about LDAP authentication in the documentation."
+msgstr ""
+
+msgid "Legacy UI"
 msgstr ""
 
 msgid "Length"
@@ -4868,24 +4860,6 @@ msgid "List all LDAP authentication sources"
 msgstr ""
 
 msgid "List all Personal Access Tokens for a user"
-msgstr ""
-
-msgid "List all Puppet class IDs for host"
-msgstr ""
-
-msgid "List all Puppet class IDs for host group"
-msgstr ""
-
-msgid "List all Puppet classes"
-msgstr ""
-
-msgid "List all Puppet classes for a host"
-msgstr ""
-
-msgid "List all Puppet classes for a host group"
-msgstr ""
-
-msgid "List all Puppet classes for an environment"
 msgstr ""
 
 msgid "List all SSH keys for a user"
@@ -4922,9 +4896,6 @@ msgid "List all compute resources"
 msgstr ""
 
 msgid "List all email notifications for a user"
-msgstr ""
-
-msgid "List all environments"
 msgstr ""
 
 msgid "List all external user groups for LDAP authentication source"
@@ -5062,9 +5033,6 @@ msgstr ""
 msgid "List all settings"
 msgstr ""
 
-msgid "List all smart class parameters"
-msgstr ""
-
 msgid "List all smart proxies"
 msgstr ""
 
@@ -5143,15 +5111,6 @@ msgstr ""
 msgid "List default templates combinations for an operating system"
 msgstr ""
 
-msgid "List environments of Puppet class"
-msgstr ""
-
-msgid "List environments per location"
-msgstr ""
-
-msgid "List environments per organization"
-msgstr "List environments per organisation"
-
 msgid "List external authentication sources"
 msgstr ""
 
@@ -5159,6 +5118,9 @@ msgid "List external authentication sources per location"
 msgstr ""
 
 msgid "List external authentication sources per organization"
+msgstr ""
+
+msgid "List hosts forming the Foreman instance"
 msgstr ""
 
 msgid "List hosts per location"
@@ -5194,9 +5156,6 @@ msgstr ""
 msgid "List of compute profiles"
 msgstr ""
 
-msgid "List of config groups"
-msgstr ""
-
 msgid "List of domains"
 msgstr ""
 
@@ -5212,34 +5171,19 @@ msgstr ""
 msgid "List of email notifications"
 msgstr ""
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr ""
 
 msgid "List of hosts which answer to the provided query"
 msgstr ""
 
-msgid "List of override values for a specific smart class parameter"
-msgstr ""
-
 msgid "List of realms"
 msgstr ""
 
 msgid "List of resources types that will be automatically associated"
-msgstr ""
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr ""
-
-msgid "List of smart class parameters for a specific environment"
-msgstr ""
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr ""
-
-msgid "List of smart class parameters for a specific host"
-msgstr ""
-
-msgid "List of smart class parameters for a specific host group"
 msgstr ""
 
 msgid "List of subnets"
@@ -5258,9 +5202,6 @@ msgid "List of table preferences for a user"
 msgstr ""
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
-msgstr ""
-
-msgid "List of trends counters"
 msgstr ""
 
 msgid "List of user selected columns"
@@ -5446,6 +5387,10 @@ msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5493,6 +5438,9 @@ msgid "MAC"
 msgstr "MAC"
 
 msgid "MAC Address"
+msgstr ""
+
+msgid "MAC address"
 msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
@@ -5576,6 +5524,9 @@ msgstr ""
 msgid "Manage Bookmarks"
 msgstr ""
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr ""
 
@@ -5583,6 +5534,9 @@ msgid "Manage Organizations"
 msgstr "Manage Organisations"
 
 msgid "Manage PuppetCA"
+msgstr ""
+
+msgid "Manage all statuses"
 msgstr ""
 
 msgid "Manage host"
@@ -5684,10 +5638,6 @@ msgid "Message"
 msgstr "Message"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Value"
 
@@ -5704,6 +5654,9 @@ msgid "Metric already registered: %s"
 msgstr ""
 
 msgid "Metrics"
+msgstr ""
+
+msgid "Migrate Reports to new format"
 msgstr ""
 
 msgid "Minutes Ago"
@@ -5783,6 +5736,9 @@ msgstr ""
 msgid "N/A"
 msgstr "N/A"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr ""
 
@@ -5804,7 +5760,7 @@ msgstr ""
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr ""
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
 msgstr ""
 
 msgid "Name of the host group"
@@ -5882,6 +5838,9 @@ msgstr "New Organisation"
 msgid "New SSH key"
 msgstr ""
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr ""
 
@@ -5897,7 +5856,7 @@ msgstr ""
 msgid "New filter"
 msgstr ""
 
-msgid "New window"
+msgid "New host details UI"
 msgstr ""
 
 msgid "Next"
@@ -6025,6 +5984,9 @@ msgstr ""
 msgid "No TFTP proxies defined, can't continue"
 msgstr ""
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr ""
 
@@ -6062,6 +6024,9 @@ msgid "No emails"
 msgstr ""
 
 msgid "No entries found"
+msgstr ""
+
+msgid "No errors detected"
 msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
@@ -6160,6 +6125,9 @@ msgstr ""
 msgid "No smart proxies to show"
 msgstr ""
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr ""
 
@@ -6196,10 +6164,10 @@ msgstr ""
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr ""
 
-msgid "Not Installed"
+msgid "Not Available"
 msgstr ""
 
-msgid "Not a valid URL for a HTTP proxy"
+msgid "Not Installed"
 msgstr ""
 
 msgid "Not implemented"
@@ -6367,6 +6335,9 @@ msgstr ""
 msgid "OK"
 msgstr ""
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr ""
 
@@ -6436,9 +6407,6 @@ msgid "Oops, we're sorry but something went wrong"
 msgstr ""
 
 msgid "Open"
-msgstr ""
-
-msgid "Open Spice in a new window"
 msgstr ""
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
@@ -6540,9 +6508,6 @@ msgstr ""
 msgid "Optional array of log hashes"
 msgstr ""
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr ""
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr ""
 
@@ -6606,9 +6571,6 @@ msgstr ""
 msgid "Override"
 msgstr ""
 
-msgid "Override Value"
-msgstr ""
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr ""
 
@@ -6621,7 +6583,16 @@ msgstr ""
 msgid "Overwrite"
 msgstr ""
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
+msgstr ""
+
+msgid "Owned: %s"
 msgstr ""
 
 msgid "Owner"
@@ -6706,6 +6677,10 @@ msgstr "Name"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Priority"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr ""
@@ -6942,9 +6917,6 @@ msgstr ""
 msgid "Plugins"
 msgstr ""
 
-msgid "Port to connect to"
-msgstr ""
-
 msgid "Possible values"
 msgstr ""
 
@@ -6957,7 +6929,13 @@ msgstr ""
 msgid "Power ON this machine"
 msgstr ""
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
+msgstr ""
+
+msgid "Power has been set to \"%s\" successfully"
 msgstr ""
 
 msgid "Power operations are not enabled on this host."
@@ -7026,7 +7004,7 @@ msgstr ""
 msgid "Private"
 msgstr ""
 
-msgid "Private key file that Foreman will use to encrypt websockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Proceed to Edit"
@@ -7124,6 +7102,9 @@ msgstr ""
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7172,9 +7153,6 @@ msgstr ""
 msgid "Puppet error state"
 msgstr ""
 
-msgid "Puppet interval"
-msgstr ""
-
 msgid "Puppet parameter"
 msgstr ""
 
@@ -7183,14 +7161,6 @@ msgstr ""
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Class name"
 
 msgid "Query"
 msgstr ""
@@ -7265,6 +7235,9 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
+msgstr ""
+
+msgid "Reboot"
 msgstr ""
 
 msgid "Reboot and build"
@@ -7367,12 +7340,6 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr ""
 
-msgid "Remove a Puppet class from host"
-msgstr ""
-
-msgid "Remove a Puppet class from host group"
-msgstr ""
-
 msgid "Remove an email notification for a user"
 msgstr ""
 
@@ -7380,6 +7347,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7464,6 +7434,9 @@ msgstr ""
 msgid "ReportTemplate|Snippet"
 msgstr ""
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr ""
 
@@ -7474,6 +7447,9 @@ msgid "Reported by %s"
 msgstr ""
 
 msgid "Reports"
+msgstr ""
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7519,6 +7495,9 @@ msgstr ""
 msgid "Required when user want to change own password"
 msgstr ""
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
@@ -7562,6 +7541,9 @@ msgstr ""
 msgid "Resume"
 msgstr ""
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr ""
 
@@ -7587,7 +7569,13 @@ msgstr ""
 msgid "Revert Local Changes"
 msgstr ""
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
+msgstr ""
+
+msgid "Review before build"
 msgstr ""
 
 msgid "Review build status for %s"
@@ -7597,6 +7585,9 @@ msgid "Revoke"
 msgstr ""
 
 msgid "Revoke a Personal Access Token for a user"
+msgstr ""
+
+msgid "Revoke personal access token"
 msgstr ""
 
 msgid "Revoked"
@@ -7679,6 +7670,9 @@ msgstr ""
 msgid "SMTP address"
 msgstr ""
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr ""
 
@@ -7692,6 +7686,9 @@ msgid "SMTP password"
 msgstr ""
 
 msgid "SMTP port"
+msgstr ""
+
+msgid "SMTP port to connect to"
 msgstr ""
 
 msgid "SMTP username"
@@ -7712,13 +7709,19 @@ msgstr ""
 msgid "SSL CA file"
 msgstr ""
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
 msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr ""
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
 msgstr ""
 
 msgid "SSL certificate"
@@ -7767,6 +7770,9 @@ msgid "Save something and try again"
 msgstr ""
 
 msgid "Saved Bookmarks"
+msgstr ""
+
+msgid "Saved audits interval"
 msgstr ""
 
 msgid "Schedule generating of a report"
@@ -7945,6 +7951,9 @@ msgstr ""
 msgid "Sendmail location"
 msgstr ""
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr ""
 
@@ -7975,6 +7984,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr ""
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr ""
 
@@ -7994,9 +8006,6 @@ msgid "Set the order in which values are resolved."
 msgstr ""
 
 msgid "Set up compute instance %s"
-msgstr ""
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8065,6 +8074,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr ""
 
@@ -8098,18 +8113,6 @@ msgstr ""
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-msgid "Show a Puppet class"
-msgstr ""
-
-msgid "Show a Puppet class for a host group"
-msgstr ""
-
-msgid "Show a Puppet class for an environment"
-msgstr ""
-
-msgid "Show a Puppet class for host"
-msgstr ""
-
 msgid "Show a bookmark"
 msgstr ""
 
@@ -8120,9 +8123,6 @@ msgid "Show a compute profile"
 msgstr ""
 
 msgid "Show a compute resource"
-msgstr ""
-
-msgid "Show a config group"
 msgstr ""
 
 msgid "Show a default template combination for an operating system"
@@ -8191,16 +8191,10 @@ msgstr ""
 msgid "Show a setting"
 msgstr ""
 
-msgid "Show a smart class parameter"
-msgstr ""
-
 msgid "Show a smart proxy"
 msgstr ""
 
 msgid "Show a subnet"
-msgstr ""
-
-msgid "Show a trend"
 msgstr ""
 
 msgid "Show a user"
@@ -8236,9 +8230,6 @@ msgstr ""
 msgid "Show an email notification"
 msgstr ""
 
-msgid "Show an environment"
-msgstr ""
-
 msgid "Show an external authentication source"
 msgstr ""
 
@@ -8258,9 +8249,6 @@ msgid "Show an internal authentication source"
 msgstr ""
 
 msgid "Show an operating system"
-msgstr ""
-
-msgid "Show an override value for a specific smart class parameter"
 msgstr ""
 
 msgid "Show available API links"
@@ -8344,9 +8332,6 @@ msgstr ""
 msgid "Skipped|S"
 msgstr ""
 
-msgid "Smart Class Parameter"
-msgstr ""
-
 msgid "Smart Class Parameters"
 msgstr ""
 
@@ -8414,6 +8399,9 @@ msgstr ""
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr ""
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr ""
 
@@ -8437,10 +8425,6 @@ msgid "Source"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Value"
 
@@ -8462,7 +8446,7 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr ""
 
-msgid "Specify additional options to sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "Specify authentication type, if required"
@@ -8506,7 +8490,7 @@ msgstr ""
 msgid "Status %s does not exist."
 msgstr ""
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
 msgstr ""
 
 msgid "Stop updating Operating System from facts"
@@ -8603,6 +8587,10 @@ msgid "Subnet|Dns secondary"
 msgstr "Secondary DNS server"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Start of IP range"
 
@@ -8629,6 +8617,10 @@ msgstr "Name"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Network address"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8700,6 +8692,12 @@ msgid "Support for %{feature} has been deprecated and will be removed in version
 msgstr ""
 
 msgid "Supported Formats"
+msgstr ""
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
 msgstr ""
 
 msgid "Synchronize group from authentication source"
@@ -8859,11 +8857,19 @@ msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8933,6 +8939,10 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -8983,7 +8993,7 @@ msgstr ""
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9129,7 +9139,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9146,7 +9156,7 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The location of the sendmail executable"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "The marked fields will need reviewing"
@@ -9173,9 +9183,6 @@ msgid ""
 msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
-msgstr ""
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
 msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
@@ -9238,6 +9245,9 @@ msgid "There may be more information in the server's logs."
 msgstr ""
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
+msgstr ""
+
+msgid "There was a problem processing the request. Please try again."
 msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
@@ -9365,7 +9375,7 @@ msgstr ""
 msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9390,15 +9400,6 @@ msgid "Timezone to use for new users"
 msgstr ""
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9429,9 +9430,6 @@ msgid "Token"
 msgstr ""
 
 msgid "Token Expiry"
-msgstr ""
-
-msgid "Token duration"
 msgstr ""
 
 msgid "Token expired"
@@ -9471,41 +9469,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
+msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Count"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Fact name"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Fact value"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Name"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Trend type"
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr ""
@@ -9786,6 +9751,12 @@ msgstr ""
 msgid "Unallowed template for dashboard widget: %s"
 msgstr ""
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr ""
 
@@ -9843,6 +9814,9 @@ msgstr ""
 msgid "Unknown status: %s"
 msgstr ""
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr ""
 
@@ -9870,9 +9844,6 @@ msgstr ""
 msgid "Update IP from built request"
 msgstr ""
 
-msgid "Update a Puppet class"
-msgstr ""
-
 msgid "Update a bookmark"
 msgstr ""
 
@@ -9883,9 +9854,6 @@ msgid "Update a compute profile"
 msgstr ""
 
 msgid "Update a compute resource"
-msgstr ""
-
-msgid "Update a config group"
 msgstr ""
 
 msgid "Update a default template combination for an operating system"
@@ -9954,9 +9922,6 @@ msgstr ""
 msgid "Update a setting"
 msgstr ""
 
-msgid "Update a smart class parameter"
-msgstr ""
-
 msgid "Update a smart proxy"
 msgstr ""
 
@@ -9987,9 +9952,6 @@ msgstr ""
 msgid "Update an email notification for a user"
 msgstr ""
 
-msgid "Update an environment"
-msgstr ""
-
 msgid "Update an external authentication source"
 msgstr ""
 
@@ -9997,12 +9959,6 @@ msgid "Update an image"
 msgstr ""
 
 msgid "Update an operating system"
-msgstr ""
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr ""
-
-msgid "Update environment from facts"
 msgstr ""
 
 msgid "Update external user group"
@@ -10240,6 +10196,10 @@ msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "First name"
 
@@ -10376,7 +10336,7 @@ msgstr ""
 msgid "Variables"
 msgstr ""
 
-msgid "Vendor Class"
+msgid "Vendor class"
 msgstr ""
 
 msgid "Verify"
@@ -10439,6 +10399,9 @@ msgstr ""
 msgid "Warning"
 msgstr "Warning"
 
+msgid "Warning statuses"
+msgstr ""
+
 msgid "Warning!"
 msgstr ""
 
@@ -10499,6 +10462,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10621,6 +10587,9 @@ msgid "Yes (override)"
 msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
+msgstr ""
+
+msgid "You are about to clear %s status. Are you sure?"
 msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
@@ -10776,6 +10745,9 @@ msgstr ""
 msgid "already exists"
 msgstr ""
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "an organisation"
 
@@ -10787,9 +10759,6 @@ msgstr ""
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "belongs to config group"
 
 msgid "boolean"
 msgstr ""
@@ -10969,9 +10938,6 @@ msgid "enable caching, for VMware only"
 msgstr ""
 
 msgid "enabled"
-msgstr ""
-
-msgid "environment id"
 msgstr ""
 
 msgid "expected a value of type %s"
@@ -11222,8 +11188,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "English (United Kingdom)"
 
@@ -11403,12 +11368,6 @@ msgstr "physical @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "physical @ bridge %s"
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
-msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr ""

--- a/locale/en_GB/foreman.po
+++ b/locale/en_GB/foreman.po
@@ -380,6 +380,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr ""
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -665,6 +668,9 @@ msgstr ""
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr ""
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -732,6 +738,12 @@ msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr ""
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 msgid "Are you sure you want to log out?"
@@ -1116,6 +1128,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr ""
 
@@ -1210,6 +1225,9 @@ msgid "Build PXE Default"
 msgstr ""
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2594,6 +2612,12 @@ msgstr ""
 msgid "EUI-64"
 msgstr ""
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3301,6 +3325,12 @@ msgstr ""
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3595,6 +3625,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4357,7 +4390,19 @@ msgstr ""
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr ""
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4367,6 +4412,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4382,6 +4430,9 @@ msgid "If this setting needs to be changed in file, it will have the file path."
 msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
+msgstr ""
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
 msgstr ""
 
 msgid "Ignore facts for domain"
@@ -4529,6 +4580,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr ""
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr ""
 
@@ -4572,6 +4626,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5518,6 +5575,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr ""
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr ""
 
@@ -6356,6 +6416,9 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr ""
 
@@ -6398,6 +6461,9 @@ msgid "Only one declaration of a proxy is allowed"
 msgstr ""
 
 msgid "Only one volume can be bootable"
+msgstr ""
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
 msgstr ""
 
 msgid "Oops!!"
@@ -6808,6 +6874,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7489,6 +7558,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr ""
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr ""
 
@@ -8074,6 +8146,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8308,6 +8383,11 @@ msgstr ""
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -8397,6 +8477,12 @@ msgid "Some interfaces are invalid"
 msgstr ""
 
 msgid "Some of the interfaces are invalid. Please check the table below."
+msgstr ""
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
 msgstr ""
 
 msgid "Something went wrong"
@@ -9061,6 +9147,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr ""
 
@@ -9072,6 +9161,9 @@ msgstr ""
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "The class of the machine as reported by the OpenBoot PROM. This is primarily used by Solaris SPARC builds and can be left blank for other architectures. The value can be determined on Solaris via `uname -i|cut -f2 -d`."
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
@@ -9262,6 +9354,12 @@ msgstr "There was an error listing VMs: %(status)s %(statusText)s"
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr ""
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr ""
 
@@ -9275,6 +9373,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9331,6 +9432,9 @@ msgstr ""
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9350,6 +9454,12 @@ msgid "This service is available for unauthenticated users"
 msgstr ""
 
 msgid "This service is only available for authenticated users"
+msgstr ""
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
 msgstr ""
 
 msgid "This template is locked and may not be removed."
@@ -9376,6 +9486,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9420,6 +9533,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10273,6 +10389,9 @@ msgstr ""
 msgid "VM already associated with a host"
 msgstr ""
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr ""
 
@@ -10412,6 +10531,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr ""
@@ -10595,10 +10717,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr ""
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/es/foreman.po
+++ b/locale/es/foreman.po
@@ -41,9 +41,6 @@ msgstr ""
 msgid " Documentation"
 msgstr " Documentación"
 
-msgid " Remove"
-msgstr "Quitar"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -55,9 +52,6 @@ msgstr "${progreso}%% completado"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr "%(name)s (libre: %(free)s, prov: %(prov)s, total: %(total)s)"
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - Pulse Shift-F12 para liberar el cursor."
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - Los siguientes equipos están a punto de ser modificados"
@@ -77,9 +71,6 @@ msgstr[1] "%s mensajes de registro"
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s Parámetros actualizados, ver a continuación para más información"
-
-msgid "%s Template"
-msgstr "%s Plantilla"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -132,9 +123,6 @@ msgid_plural "%s months ago"
 msgstr[0] "Hace %s mes"
 msgstr[1] "Hace % meses"
 
-msgid "%s out of sync disabled"
-msgstr "%s fuera de sincronización deshabilitado"
-
 msgid "%s selected hosts"
 msgstr "%s hosts seleccionados"
 
@@ -153,9 +141,6 @@ msgstr "Cargando widget %s…"
 
 msgid "%s you had selected as your context has been deleted"
 msgstr "El %s que seleccionó como contexto se ha eliminado"
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
-msgstr ""
 
 msgid "%{action} %{vm}"
 msgstr "%{action} %{vm}"
@@ -226,6 +211,9 @@ msgstr "%{match} no coincide con un grupo de host"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} ha cambiado de %{label1} a %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr "%{object_name} es un %{object_class}; se esperó una subred"
@@ -308,6 +296,9 @@ msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(opcional) Rol IAM para que Fog utilice al crear  esta imagen"
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*Eliminar proxy %s*"
@@ -514,12 +505,6 @@ msgstr "Añadir Volumen"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr "Agregue una unidad de CD-ROM a la máquina virtual."
 
-msgid "Add a Puppet class to host"
-msgstr "Añadir una clase Puppet al host"
-
-msgid "Add a Puppet class to host group"
-msgstr "Añadir una clase Puppet al grupo de hosts"
-
 msgid "Add a template combination"
 msgstr "Añadir una combinación de plantillas"
 
@@ -565,9 +550,6 @@ msgstr "Atributos adicionales específicos del recurso de computación"
 msgid "Additional information about this host"
 msgstr "Información adicional sobre este host"
 
-msgid "Address to connect to"
-msgstr "Dirección para conectarse con"
-
 msgid "Admin permissions required"
 msgstr "Se necesitan permisos de administración"
 
@@ -610,9 +592,6 @@ msgstr "Dispositivo VLAN o alias"
 msgid "All"
 msgstr "Todos"
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr "Todos los hosts"
 
@@ -620,6 +599,12 @@ msgid "All Reports"
 msgstr "Todos los informes"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -781,9 +766,6 @@ msgstr "¿Está seguro de que desea eliminar el host %s? Esta acción es irrever
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "¿Está seguro de que desea eliminar el host %s? Esto eliminará la máquina virtual y sus discos, y es irreversible. Este comportamiento se puede cambiar a través del ajuste global \"Destruir máquina virtual asociada con la eliminación del host\"."
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "¿Esta seguro de que desea eliminar este asistente de su tablero?"
-
 msgid "Are you sure you want to log out?"
 msgstr "¿Está seguro de que desea cerrar sesión?"
 
@@ -840,6 +822,12 @@ msgstr "Asignar Organización"
 
 msgid "Assign Selected Hosts"
 msgstr "Asignar hosts seleccionados"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1325,6 +1313,9 @@ msgstr "Puede recuperarse a través de un archivo CLI o RC. Puede dejarse en bla
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr "Puede recuperarseo a través de un archivo CLI o RC. Se puede configurar como \"predeterminado\". Solo para la autenticación v3."
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "No se puede eliminar la cuenta de administración interna"
 
@@ -1406,8 +1397,8 @@ msgstr "La clave del certificado no es un JSON válido"
 msgid "Certificate path for GCE only"
 msgstr "Ruta de certificación solo para GCE"
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Certificado usado por Foreman para encriptar websockets"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "Certificados"
@@ -1466,6 +1457,9 @@ msgstr "Limpiar los certificados PuppetCA para %s"
 msgid "Clear"
 msgstr "Borrar"
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr "Eliminar el subestado del host"
 
@@ -1477,12 +1471,6 @@ msgstr "Haga clic en el enlace de un recurso de cómputo para editar los  atribu
 
 msgid "Click to log in again"
 msgstr "Haga clic para volver a iniciar sesión"
-
-msgid "Click to remove %s"
-msgstr "Haga clic para eliminar %s"
-
-msgid "Click to remove config group"
-msgstr "Haga clic para eliminar el grupo de configuración"
 
 msgid "Client Email"
 msgstr "Cliente de correo-e"
@@ -1646,14 +1634,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "Recuperar configuración"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "Grupo de configuración"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "Nombre"
-
 msgid "Configuration"
 msgstr "Configuración"
 
@@ -1696,8 +1676,8 @@ msgstr "Se han detectado conflictos"
 msgid "Connected"
 msgstr "Conectado"
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "Conectado (sin cifrar) a: %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "Conexión (sin cifrar) a: %s"
@@ -1747,8 +1727,8 @@ msgstr "Las versiones del núcleo y proxy no coinciden. foreman: %{foreman_versi
 msgid "Cores per socket"
 msgstr "Núcleos por socket"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
-msgstr "Valor de coste de la función de cifrado de contraseñas de bcrypt para las fuentes de autenticación internas (4-30). Un valor más alto es más seguro pero la verificación es más lenta, especialmente para las llamadas a la API y los inicios de sesión de la interfaz de usuario sin estado. Es necesario cambiar la contraseña para que surta efecto."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
+msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
 msgstr "No se pudieron agregar permisos a los roles de Gerente y Observador: %s"
@@ -1924,9 +1904,6 @@ msgstr "Crear grupo de usuarios"
 msgid "Create a Personal Access Token for a user"
 msgstr "Crear un token de acceso personal para un usuario"
 
-msgid "Create a Puppet class"
-msgstr "Crear una clase Puppet"
-
 msgid "Create a bookmark"
 msgstr "Crear un marcador"
 
@@ -1938,9 +1915,6 @@ msgstr "Crear un perfil de computación"
 
 msgid "Create a compute resource"
 msgstr "Crear un recurso de cómputo"
-
-msgid "Create a config group"
-msgstr "Crear un grupo de configuración"
 
 msgid "Create a default template combination for an operating system"
 msgstr "Crear una combinación de plantilla predeterminada para un sistema operativo"
@@ -2014,9 +1988,6 @@ msgstr "Crear una subred"
 msgid "Create a template input"
 msgstr "Crear una entrada de la plantilla"
 
-msgid "Create a trend counter"
-msgstr "Crear un contador de tendencias"
-
 msgid "Create a user"
 msgstr "Crear un usuario"
 
@@ -2032,9 +2003,6 @@ msgstr "Crear una fuente de autenticación LDAP"
 msgid "Create an architecture"
 msgstr "Crear una arquitectura"
 
-msgid "Create an environment"
-msgstr "Crear un entorno"
-
 msgid "Create an external user group linked to a user group"
 msgstr "Crear un grupo de usuarios externos vinculado a un grupo de usuarios"
 
@@ -2047,14 +2015,14 @@ msgstr "Crear una interfaz en un host"
 msgid "Create an operating system"
 msgstr "Crear un sistema operativo"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "Crear un valor de sobrescritura para un parámetro específico de clase inteligente"
-
 msgid "Create autosign entry"
 msgstr "Crear entrada de autofirmado"
 
 msgid "Create image"
 msgstr "Crear imagen"
+
+msgid "Create model"
+msgstr ""
 
 msgid "Create new boot volume from image"
 msgstr "Crear nuevo volumen de inicio desde la imagen"
@@ -2070,6 +2038,9 @@ msgstr "Crear entrada de reino para %s"
 
 msgid "Created"
 msgstr "Creado"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr "Crea una preferencia de tabla para una determinada tabla"
@@ -2100,18 +2071,6 @@ msgstr "Tipo de instancia personalizada"
 
 msgid "DB pending seed"
 msgstr "Valor de inicialización pendiente de la base de datos"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
-msgstr ""
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2203,7 +2162,7 @@ msgstr "Predeterminado"
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2226,9 +2185,6 @@ msgstr "Elemento de menú PXE predeterminado en plantilla global - 'local', 'dis
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr "Elemento de menú PXE predeterminado en plantilla local - 'local', 'local_chain_hd0' o personalizado; dejar en blanco para plantilla predeterminada"
-
-msgid "Default Puppet environment"
-msgstr "Entorno Puppet predeterminado"
 
 msgid "Default VNC Keyboard"
 msgstr "Teclado VNC por defecto"
@@ -2311,9 +2267,6 @@ msgstr "Borrar certificados PuppetCA para %s"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr "Eliminar configuración TFTP %{kind} para %{host}"
 
-msgid "Delete a Puppet class"
-msgstr "Borrar una clase Puppet"
-
 msgid "Delete a Virtual Machine"
 msgstr "Borrar una máquina virtual"
 
@@ -2325,9 +2278,6 @@ msgstr "Borrar un perfil de computación"
 
 msgid "Delete a compute resource"
 msgstr "Borrar un recurso de cómputo"
-
-msgid "Delete a config group"
-msgstr "Borrar un grupo de configuración"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "Borrar una combinación de plantilla prederterminada para un sistema operativo"
@@ -2410,9 +2360,6 @@ msgstr "Borrar una combinación de plantillas"
 msgid "Delete a template input"
 msgstr "Eliminar una entrada de la plantilla"
 
-msgid "Delete a trend counter"
-msgstr "Eliminar un contador de tendencias"
-
 msgid "Delete a user"
 msgstr "Borrar un usuario"
 
@@ -2452,9 +2399,6 @@ msgstr "Eliminar una clave SSH para un usuario"
 msgid "Delete an architecture"
 msgstr "Borrar una arquitectura"
 
-msgid "Delete an environment"
-msgstr "Borrar un entorno"
-
 msgid "Delete an external user group"
 msgstr "Borrar un grupo de usuarios externo"
 
@@ -2464,14 +2408,17 @@ msgstr "Borrar una imagen"
 msgid "Delete an operating system"
 msgstr "Borrar un sistema operativo"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "Borrar un valor de sobrescritura para un parámetro de clase inteligente específico"
-
 msgid "Delete autosign entry"
 msgstr "Eliminar entrada de autofirmado"
 
 msgid "Delete filter?"
 msgstr "¿Borrar el filtro?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "Borrar entrada de reino para %s"
@@ -2544,9 +2491,6 @@ msgstr "Inhabilitar alertas para los hosts seleccionados"
 
 msgid "Disable all filters overriding"
 msgstr "Deshabilitar todas las anulaciones de filtro"
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "Deshabilitar el estado de configuración de host que pasa a fuera de sincronización para %s si el informe no llega dentro del intervalo configurado"
 
 msgid "Disable overriding"
 msgstr "Deshabilitar anulación"
@@ -2664,20 +2608,17 @@ msgstr "Descarga un informe generado"
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "Entradas duplicadas detectadas: %{duplicated_inputs}"
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr "Duración en minutos después de que los servidores que informan mediante Puppet se clasifiquen como fuera de sincronización."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgstr ""
 
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "Entorno ENC"
 
 msgid "ERROR or FATAL"
 msgstr "ERROR o FATAL"
@@ -2720,6 +2661,9 @@ msgstr "Editar este host"
 
 msgid "Editor"
 msgstr "Editor"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "Preferencias de correo electrónico"
@@ -2796,10 +2740,6 @@ msgstr "Dirección IP final para sugerencias"
 msgid "Entries per page"
 msgstr "Entradas por página"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Entorno"
-
 msgid "Environment IDs"
 msgstr "ID de entorno"
 
@@ -2814,10 +2754,6 @@ msgstr "Variable de entorno que contiene la verificación del estado de un certi
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Nombre"
 
 msgid "Error"
 msgstr "Error"
@@ -2857,6 +2793,9 @@ msgstr "Error al cargar la información de los filtros de indicación del progra
 
 msgid "Error removing widget from dashboard."
 msgstr "Error al eliminar el asistente del tablero"
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr "Error al enviar datos:"
@@ -3327,14 +3266,14 @@ msgstr "Corregir %s en discordancias"
 msgid "Fix All Mismatches"
 msgstr "Arreglar todas las discordancias"
 
-msgid "Fix DB cache"
-msgstr "Corregir caché de la base de datos"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Arreglar la caché de la base de datos en el próximo reinicio de Foreman"
-
 msgid "Fix Mismatches"
 msgstr "Arreglar discordancias"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "Clase"
@@ -3380,9 +3319,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr "Para los valores de búsqueda de tipo, este es el recurso en el que busca el valor"
 
-msgid "Force a Puppet agent run on the host"
-msgstr "Forzar una ejecución del agente Puppet en el host"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "La versión 2 de la API de Foreman es actualmente la versión de la API predeterminada."
 
@@ -3416,6 +3352,10 @@ msgstr "Foreman ha detectado definiciones de clases desconocidas en su base de d
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr "La ID de instancia de Foreman identifica de manera única esta instancia de Foreman."
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "Las concordancias de Foreman se heredan por los elementos secundarios al evaluar parámetros de clase inteligente para grupos de hosts, organizaciones y ubicaciones"
 
@@ -3424,6 +3364,10 @@ msgstr "Foreman ahora controla el ciclo de vida de %s"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman ha dejado de controlar el ciclo de vida de %s"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "El tiempo de creación del informe de Foreman es <em>%s</em>"
@@ -3452,8 +3396,8 @@ msgstr "Foreman anexará nombres de dominio cuando se aprovisionen los hosts nue
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman automatizará la firma de certificados tras el aprovisionamiento de un nuevo host"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
-msgstr "Foreman bloqueará el inicio de sesión del usuario después de esta cantidad de intentos de inicio de sesión fallidos durante 5 minutos desde la dirección IP infractora. Configure 0 para deshabilitar la protección de fuerza bruta"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
+msgstr ""
 
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman creará el host cuando se reciba un reporte"
@@ -3461,20 +3405,14 @@ msgstr "Foreman creará el host cuando se reciba un reporte"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman creará el host cuando se reciban los nuevos eventos"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "Foreman usará este entorno Puppet si no puede detectar uno automáticamente"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Foreman eliminará la máquina virtual si el script de aprovisionamiento termina con un código de salida distinto de cero."
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr "Foreman evaluará parámetros de clase inteligente de los hosts en este orden por defecto"
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman establecerá explícitamente el entorno puppet en las salida yaml de ENC. Esto evitará conflictos entre el entorno de puppet.conf y el establecido en Foreman"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman mapeará los usuarios por nombre de usuario en la cabecera de la solicitud. Si se establece como falso, las peticiones de OAuth tendrán privilegios administrativos."
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "Foreman no enviará este parámetro en el resultado de clasificación."
@@ -3484,9 +3422,6 @@ msgstr "Foreman analizará ERB en los valores de los parámetros de la salida EN
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman preguntará al servidor de nombres local en lugar de a las autoridades SOA/NS"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman actualizará el entorno del host mediante eventos"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "Foreman actualizará una subred de host en función de sus eventos"
@@ -3505,6 +3440,18 @@ msgstr "Foreman usará UUID aleatorios para la firma de certificados en lugar de
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman usará el nombre corto en lugar del FQDN para crear máquinas virtuales"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr ""
@@ -3532,6 +3479,9 @@ msgstr "Pantalla completa"
 
 msgid "Function not available for %s"
 msgstr "Función no disponible para %s"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "Hora GMT"
@@ -3602,8 +3552,8 @@ msgstr "Detalles del tablero de mandos"
 msgid "Get default dashboard widgets"
 msgstr "Obtener asistentes de tablero predeterminados"
 
-msgid "Get statistics"
-msgstr "Estadísticas"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "Estado del host"
@@ -3725,6 +3675,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr "Modelos de hardware"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr "Tiene efecto solo para el aprovisionamiento basado en la red"
 
@@ -3770,11 +3726,17 @@ msgstr "Historial"
 msgid "Host"
 msgstr "host"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "El host %s está construido."
 
 msgid "Host %s is not associated with a VM"
 msgstr "El host %s no está asociado con una máquinas virtual"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "Cuadro de configuración de host"
@@ -3812,8 +3774,14 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "Parámetros de host"
 
-msgid "Host Wizard"
-msgstr "Asistente de host"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
+msgstr ""
 
 msgid "Host audit entries"
 msgstr "Registros de auditoría de host"
@@ -3821,12 +3789,12 @@ msgstr "Registros de auditoría de host"
 msgid "Host built"
 msgstr "Host compilado"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "Group de configuración de hosts"
-
 msgid "Host details"
 msgstr "Información de host"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "Grupo de hosts"
@@ -3964,8 +3932,32 @@ msgid "Host::Base|Uuid"
 msgstr "Uuid"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "Tipo de host"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4193,9 +4185,6 @@ msgstr "ID de la plantilla de configuración"
 msgid "ID of domain"
 msgstr "ID del dominio"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr "ID del host"
 
@@ -4262,7 +4251,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4325,9 +4314,6 @@ msgstr "Dirección IP autosugerida"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr "Direcciones IP que deben excluirse de la sugerencia"
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4351,6 +4337,9 @@ msgstr "Subred de IPv4"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr "Se requiere una subred IPv4 con un proxy inteligente TFTP asociado para el aprovisionamiento basado en PXE."
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "Dirección IPv4 de la interfaz"
 
@@ -4370,6 +4359,9 @@ msgstr[1] "Registros DNS de IPv6"
 
 msgid "IPv6 Subnet"
 msgstr "Subred de IPv6"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "Dirección IPv6 de la interfaz"
@@ -4431,14 +4423,14 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Si cree que esto es un error de Foreman, por favor, reporte una incidencia con"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "Ignorar eventos Puppet para aprovisionamiento"
-
 msgid "Ignore facts for domain"
 msgstr "Ignorar datos para el dominio"
 
 msgid "Ignore facts for operating system"
 msgstr "Ignorar los datos para el sistema operativo"
+
+msgid "Ignore interfaces facts for provisioning"
+msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
 msgstr "Ignorar interfaces con identificador de coincidencias"
@@ -4518,12 +4510,6 @@ msgstr "Importar como host no administrado"
 
 msgid "Import of facts failed for host %s"
 msgstr "No se pudieron importar los eventos para host %s"
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Importar clases puppet desde el proxy de puppet"
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "Importar clases puppet desde el proxy puppet de un entorno"
 
 msgid "Imported IPv4 Subnets"
 msgstr "Subredes de IPv4 importadas"
@@ -4642,6 +4628,9 @@ msgstr "Error de instalación"
 msgid "Installation medium configuration"
 msgstr "Configuración del medio de instalación"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "Instalado"
 
@@ -4707,6 +4696,9 @@ msgstr "Selección %{assoc} inválida. Debe seleccionar, al menos, uno de los su
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
 msgstr "Clave de Google JSON no válida. Verifique que las opciones de cliente de correo electrónico y llave privada estén presentes"
+
+msgid "Invalid HTTP(S) URL"
+msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
 msgstr "Arquitectura '%{arch}' no válida para '%{os}'"
@@ -4873,14 +4865,14 @@ msgstr "Últimos eventos"
 msgid "Launch Console"
 msgstr "Lanzar consola"
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr "Obtenga más información sobre la autenticación externa en la documentación."
 
 msgid "Learn more about LDAP authentication in the documentation."
 msgstr "Obtenga más información sobre la autenticación LDAP en la documentación."
+
+msgid "Legacy UI"
+msgstr ""
 
 msgid "Length"
 msgstr "Longitud "
@@ -4914,24 +4906,6 @@ msgstr "Listar todas las fuentes de autenticación LDAP"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr "Mostrar todos los tokens de acceso personal para un usuario"
-
-msgid "List all Puppet class IDs for host"
-msgstr "Listar todos los ID de clases Puppet para  host"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "Listar todos los ID de clases Puppet del grupo de hosts"
-
-msgid "List all Puppet classes"
-msgstr "Listar todas las clases Puppet"
-
-msgid "List all Puppet classes for a host"
-msgstr "Listar todas las clases Puppet de un host"
-
-msgid "List all Puppet classes for a host group"
-msgstr "Listar todas las clases Puppet de un grupo de hosts"
-
-msgid "List all Puppet classes for an environment"
-msgstr "Listar todas las clases Puppet de un entorno"
 
 msgid "List all SSH keys for a user"
 msgstr "Mencionar las claves SSH para un usuario"
@@ -4968,9 +4942,6 @@ msgstr "Listar todos los recursos de cómputo"
 
 msgid "List all email notifications for a user"
 msgstr ""
-
-msgid "List all environments"
-msgstr "Listar todos los entornos"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "Listar los grupos de usuarios externos para la fuente de autenticación LDAP"
@@ -5107,9 +5078,6 @@ msgstr "Listar todos los roles"
 msgid "List all settings"
 msgstr "Listar todos los parámetros"
 
-msgid "List all smart class parameters"
-msgstr "Listar todos los parámetros de clase inteligentes"
-
 msgid "List all smart proxies"
 msgstr "Listar todos los proxis inteligentes"
 
@@ -5188,15 +5156,6 @@ msgstr "Listar archivos de arranque para un sistema operativo"
 msgid "List default templates combinations for an operating system"
 msgstr "Listar las combinaciones de plantillas predeterminadas para un sistema operativo"
 
-msgid "List environments of Puppet class"
-msgstr "Listar entornos de clase Puppet"
-
-msgid "List environments per location"
-msgstr "Listar entornos por ubicación"
-
-msgid "List environments per organization"
-msgstr "Listar entornos por organización"
-
 msgid "List external authentication sources"
 msgstr "Enumerar las fuentes de autenticación externa"
 
@@ -5205,6 +5164,9 @@ msgstr "Enumerar las fuentes de autenticación externa por ubicación"
 
 msgid "List external authentication sources per organization"
 msgstr "Enumerar las fuentes de autenticación externa por organización"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "Listar hosts por ubicación"
@@ -5239,9 +5201,6 @@ msgstr "Lista de atributos de cómputo para el perfil de cómputo y el recurso d
 msgid "List of compute profiles"
 msgstr "Listar perfiles de computación"
 
-msgid "List of config groups"
-msgstr "Lista de grupos de computación"
-
 msgid "List of domains"
 msgstr "Lista de dominios"
 
@@ -5257,35 +5216,20 @@ msgstr "Lista de dominios por subred"
 msgid "List of email notifications"
 msgstr "Lista de notificaciones por correo electrónico"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr "Lista de nombres de host, direcciones IPv4, IPv6 o subredes en las que se puede confiar además de los proxies inteligentes para acceder a importadores de eventos/informes y salida ENC"
 
 msgid "List of hosts which answer to the provided query"
 msgstr "Lista de hosts que han respondido a la búsqueda"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "Lista de valores de sobrescritura para un parámetro específico de clase inteligente"
-
 msgid "List of realms"
 msgstr "Lista de reinos"
 
 msgid "List of resources types that will be automatically associated"
 msgstr "Lista de tipos de recurso que se asociarán automáticamente"
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "Lista de parámetros de clase inteligentes para una clase Puppet específica"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "Lista de parámetros de clase inteligentes para un entorno determinado"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "Lista de parámetros de clase inteligentes para una combinación determinada entorno/clase Puppet"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "Lista de parámetros de clase inteligentes para un host determinado"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "Lista de parámetros de clase inteligentes para un grupo de hosts determinado"
 
 msgid "List of subnets"
 msgstr "Lista de subredes"
@@ -5304,9 +5248,6 @@ msgstr "Lista de preferencias de tabla para un usuario"
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
 msgstr "Lista de tiempos de espera (en segundos) para los intentos de búsqueda de DNS como la macro dns_lookup y la validación de conflictos de registros DNS"
-
-msgid "List of trends counters"
-msgstr "Lista de contadores de tendencias"
 
 msgid "List of user selected columns"
 msgstr "Lista de columnas seleccionadas por el usuario"
@@ -5491,6 +5432,10 @@ msgid "LookupKey|Key type"
 msgstr "Clave de búsqueda|Tipo de clave"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr "LookupKey|Combinar valores predeterminados"
 
@@ -5539,6 +5484,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "Dirección MAC"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "Dirección MAC de la interfaz. Requerida para interfaces administradas bare metal."
@@ -5621,6 +5569,9 @@ msgstr "Administrar"
 msgid "Manage Bookmarks"
 msgstr "Gestionar Marcadores"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "Administrar ubicaciones"
 
@@ -5629,6 +5580,9 @@ msgstr "Administrar organizaciones"
 
 msgid "Manage PuppetCA"
 msgstr "Administrar PuppetCA"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "Administrar host"
@@ -5729,10 +5683,6 @@ msgid "Message"
 msgstr "Mensaje"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Asimilar"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Valor"
 
@@ -5750,6 +5700,9 @@ msgstr "La métrica ya está registrada: %s"
 
 msgid "Metrics"
 msgstr "Métrica"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "Hace minutos"
@@ -5828,6 +5781,9 @@ msgstr "Mi cuenta"
 msgid "N/A"
 msgstr "N/C"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "ND"
 
@@ -5849,8 +5805,8 @@ msgstr "Nombre de medio"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr "Nombre de la audiencia de OpenID Connect que se está usando para la autenticación. En caso de Keycloak, es el ID del cliente."
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
-msgstr "Nombre de la fuente de autenticación externa donde se deben crear los usuarios externos desconocidos (ver authorize_login_delegation), (si quiere evitar la creación automática, dejar sin establecer)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
+msgstr ""
 
 msgid "Name of the host group"
 msgstr "Nombre del grupo de hosts"
@@ -5927,6 +5883,9 @@ msgstr "Nueva organización"
 msgid "New SSH key"
 msgstr "Nueva clave SSH"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "Nueva máquina virtual"
 
@@ -5942,8 +5901,8 @@ msgstr "Se rechazó la nueva conexión con el motivo: %"
 msgid "New filter"
 msgstr "Nuevo filtro"
 
-msgid "New window"
-msgstr "Ventana nueva"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Siguiente"
@@ -6070,6 +6029,9 @@ msgstr "Ninguna funcionalidad TFTP"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "No se han definido proxis TFTP, no puede continuar"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr "No se encontraron MV que coincidan con un host."
 
@@ -6108,6 +6070,9 @@ msgstr "No correo-e"
 
 msgid "No entries found"
 msgstr "No se encontraron entradas"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "No se han encontrado funciones en este proxy, por favor asegúrese de que haya por lo menos una función habilitada"
@@ -6205,6 +6170,9 @@ msgstr "No se encontraron proxis inteligentes."
 msgid "No smart proxies to show"
 msgstr "No hay proxis inteligentes para mostrar"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "No hay subredes"
 
@@ -6241,11 +6209,11 @@ msgstr "Normal"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr "Por lo general, al configurar un recurso de cómputo, se crea para usted un par de claves (privada y pública) en forma automática."
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "No instalado"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr "URL inválida para un proxy HTTP"
 
 msgid "Not implemented"
 msgstr "No se implementó"
@@ -6412,6 +6380,9 @@ msgstr "URL de JWK de OIDC"
 msgid "OK"
 msgstr "Aceptar"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "Imagen SO"
 
@@ -6487,9 +6458,6 @@ msgstr "Lo sentimos algo ha salido mal"
 
 msgid "Open"
 msgstr "Abrir"
-
-msgid "Open Spice in a new window"
-msgstr "Abrir Spice en una nueva ventana"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr "Abrir y leer el tiempo de espera para las solicitudes HTTP de Foreman al proxy inteligente (en segundos)"
@@ -6590,9 +6558,6 @@ msgstr "Validador de entrada opcional"
 msgid "Optional array of log hashes"
 msgstr "Array opcional de hash de registro"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "Cadena opcional delimitada por comas, que contiene 'nuevo', 'actualizado' u 'obsoleto', utilizada para limitar las clases Puppet importadas."
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "Opcional: Última dirección para autosugerencia de IP"
 
@@ -6656,9 +6621,6 @@ msgstr "Formato de salida"
 msgid "Override"
 msgstr "Sobrescribir"
 
-msgid "Override Value"
-msgstr "Sobrescribir Valor"
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "Sustituir el valor predeterminado del parámetro de clase Puppet"
 
@@ -6671,8 +6633,17 @@ msgstr "Sinopsis"
 msgid "Overwrite"
 msgstr "Sobrescribir"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "Propiedad de"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "Propietario"
@@ -6756,6 +6727,10 @@ msgstr "Nombre"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Prioridad"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr "Parameter|Tipo"
@@ -6994,9 +6969,6 @@ msgstr "Espere mientras se procesa su solicitud."
 msgid "Plugins"
 msgstr "Plugins"
 
-msgid "Port to connect to"
-msgstr "Puerto para conectarse con"
-
 msgid "Possible values"
 msgstr "Valores posibles"
 
@@ -7009,8 +6981,14 @@ msgstr "Energía"
 msgid "Power ON this machine"
 msgstr "Encender esta máquina"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
 msgstr "Encender una máquina virtual"
+
+msgid "Power has been set to \"%s\" successfully"
+msgstr ""
 
 msgid "Power operations are not enabled on this host."
 msgstr "Las operaciones de encendido no están habilitadas en este host."
@@ -7078,8 +7056,8 @@ msgstr "Priorizar orden de atributos"
 msgid "Private"
 msgstr "Privado"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
-msgstr "Archivo de clave privada que Foreman utilizará para cifrar websockets"
+msgid "Private key file path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Proceed to Edit"
 msgstr "Proceder a editar"
@@ -7178,6 +7156,9 @@ msgstr "Proxis"
 msgid "Proxy ID to use within this realm"
 msgstr "ID de proxy que se utilizará dentro de este dominio"
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr "La referencia de proxy debe ser { :relation => [:column_name, ...] }"
 
@@ -7226,9 +7207,6 @@ msgstr "Clase Puppet"
 msgid "Puppet error state"
 msgstr "Estado de error de Puppet"
 
-msgid "Puppet interval"
-msgstr "Intervalo Puppet"
-
 msgid "Puppet parameter"
 msgstr "Parámetro Puppet"
 
@@ -7237,14 +7215,6 @@ msgstr "ID del Proxy Puppet"
 
 msgid "Puppet summary"
 msgstr "Resumen de Puppet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Clasepuppet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Nombre"
 
 msgid "Query"
 msgstr "Petición"
@@ -7320,6 +7290,9 @@ msgstr "Nombre"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "Tipo de reino"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "Reiniciar y reconstruir"
@@ -7421,12 +7394,6 @@ msgstr "Eliminar concordancia"
 msgid "Remove Parameter"
 msgstr "Borrar parámetro"
 
-msgid "Remove a Puppet class from host"
-msgstr "Eliminar clase Puppet desde host"
-
-msgid "Remove a Puppet class from host group"
-msgstr "Eliminar clase Puppet de grupo de hosts"
-
 msgid "Remove an email notification for a user"
 msgstr ""
 
@@ -7434,6 +7401,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr "Eliminar %{type} en conflicto para %{host}"
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7518,6 +7488,9 @@ msgstr "ReportTemplate|Name"
 msgid "ReportTemplate|Snippet"
 msgstr "ReportTemplate|Snippet"
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "Reportado en"
 
@@ -7529,6 +7502,9 @@ msgstr "Informado por %s"
 
 msgid "Reports"
 msgstr "Informes"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7573,6 +7549,9 @@ msgstr "Obligatorio, a menos que el usuario sea una fuente de autenticación ext
 msgid "Required when user want to change own password"
 msgstr "Requerido cuando el usuario quiere modificar su propia contraseña"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr "Reiniciar nombre de certificado PuppetCA para %s"
 
@@ -7616,6 +7595,9 @@ msgstr "Resultado del informe %s"
 msgid "Resume"
 msgstr "Reanudar"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "Devuelve cadenas que representan el estado de un host de un tipo determinado"
 
@@ -7641,8 +7623,14 @@ msgstr "Error al revertir, ${err}"
 msgid "Revert Local Changes"
 msgstr "Revertir cambios locales"
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "Revisión"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "Revisar el estado de compilación por %s"
@@ -7652,6 +7640,9 @@ msgstr "Revocar"
 
 msgid "Revoke a Personal Access Token for a user"
 msgstr "Revocar un token de acceso personal para un usuario"
+
+msgid "Revoke personal access token"
+msgstr ""
 
 msgid "Revoked"
 msgstr ""
@@ -7733,6 +7724,9 @@ msgstr "Modo de verificación de OpenSSL de SMTP"
 msgid "SMTP address"
 msgstr "Dirección SMTP"
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "Autenticación SMTP"
 
@@ -7747,6 +7741,9 @@ msgstr "Contraseña SMTP"
 
 msgid "SMTP port"
 msgstr "Puerto SMTP"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr "Nombre de usuario SMTP"
@@ -7766,14 +7763,20 @@ msgstr "Tiempo de espera de SSH"
 msgid "SSL CA file"
 msgstr "Archivo SSL CA"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Archivo SSL CA que usará Foreman para comunicarse con sus proxis"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Ruta del Certificado SSL que usará Foreman para comunicarse con sus proxis"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Archivo de la llave privada SSL que usará Foreman para comunicarse con sus proxis"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "Certificado SSL"
@@ -7822,6 +7825,9 @@ msgstr "Guarde algo y reinténtelo"
 
 msgid "Saved Bookmarks"
 msgstr "Marcadores guardados"
+
+msgid "Saved audits interval"
+msgstr ""
 
 msgid "Schedule generating of a report"
 msgstr "Programar la generación de un informe"
@@ -7999,6 +8005,9 @@ msgstr "Argumentos de sendmail"
 msgid "Sendmail location"
 msgstr "Ubicación de sendmail"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr "Grupo de servidores"
 
@@ -8029,6 +8038,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr "Configurar direcciones IP para %s"
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr "Definir una contraseña generada en forma aleatoria en la conexión de la pantalla de VNC"
 
@@ -8049,9 +8061,6 @@ msgstr "Establecer el orden en el cual se resuelven los valores"
 
 msgid "Set up compute instance %s"
 msgstr "Configurar instancia de cómputo %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr "Establece un proxy para todas las conexiones HTTP salientes de Foreman. Los proxies de todo el sistema deben ser configurados a nivel del sistema operativo."
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8119,6 +8128,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "¿Debería ejecutarse `foreman-rake db:seed` la próxima vez que se ejecuten los módulos del instalador?"
 
@@ -8152,18 +8167,6 @@ msgstr "Mostrar laboratorios experimentales"
 msgid "Show a Personal Access Token for a user"
 msgstr "Mostrar un token de acceso personal para un usuario"
 
-msgid "Show a Puppet class"
-msgstr "Mostrar una clase Puppet"
-
-msgid "Show a Puppet class for a host group"
-msgstr "Mostrar una clase Puppet para un grupo de hosts"
-
-msgid "Show a Puppet class for an environment"
-msgstr "Mostrar una clase  Puppet para un entorno"
-
-msgid "Show a Puppet class for host"
-msgstr "Mostrar una clase Puppet para un host"
-
 msgid "Show a bookmark"
 msgstr "Mostrar un marcador"
 
@@ -8175,9 +8178,6 @@ msgstr "Mostrar un perfil de computación"
 
 msgid "Show a compute resource"
 msgstr "Mostrar un recurso de computación"
-
-msgid "Show a config group"
-msgstr "Mostrar un grupo de configuración"
 
 msgid "Show a default template combination for an operating system"
 msgstr "Mostrar una combinación de plantilla predeterminada para un sistema operativo"
@@ -8245,17 +8245,11 @@ msgstr "Mostrar un rol"
 msgid "Show a setting"
 msgstr "Mostrar una preferencia"
 
-msgid "Show a smart class parameter"
-msgstr "Mostrar un parametro de clase inteligente"
-
 msgid "Show a smart proxy"
 msgstr "Mostrar un proxy inteligente"
 
 msgid "Show a subnet"
 msgstr "Mostrar una subred"
-
-msgid "Show a trend"
-msgstr "Mostrar una tendencia"
 
 msgid "Show a user"
 msgstr "Mostrar un usuario"
@@ -8290,9 +8284,6 @@ msgstr "Mostrar un registro de auditoría"
 msgid "Show an email notification"
 msgstr "Mostrar una notificación por correo electrónico"
 
-msgid "Show an environment"
-msgstr "Mostrar un entorno"
-
 msgid "Show an external authentication source"
 msgstr "Mostrar una fuente de autenticación externa"
 
@@ -8313,9 +8304,6 @@ msgstr "Mostrar una fuente de autenticación interna"
 
 msgid "Show an operating system"
 msgstr "Mostrar un sistema operativo"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "Mostrar un valor de sobrescritura para un parámetro específico de clase inteligente"
 
 msgid "Show available API links"
 msgstr "Mostrar enlaces disponibles del API"
@@ -8398,9 +8386,6 @@ msgstr "Omitido"
 msgid "Skipped|S"
 msgstr "O"
 
-msgid "Smart Class Parameter"
-msgstr "Parámetro de clase Inteligente"
-
 msgid "Smart Class Parameters"
 msgstr "Parámetros de clase inteligente"
 
@@ -8468,6 +8453,9 @@ msgstr "algunas interfaces no son válidas"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Algunas de las interfaces no son válidas. Por favor verifique la tabla de abajo."
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "Algo ha fallado al cambiar el tipo de host - %s"
 
@@ -8491,10 +8479,6 @@ msgid "Source"
 msgstr "Fuente"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Asimilar"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Valor"
 
@@ -8516,8 +8500,8 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr "Especificar concordancias"
 
-msgid "Specify additional options to sendmail"
-msgstr "Especificar opciones adicionales para sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "Specify authentication type, if required"
 msgstr "Especificar tipo de autenticación, si es requerido"
@@ -8560,8 +8544,8 @@ msgstr "Estado"
 msgid "Status %s does not exist."
 msgstr "El estado %s no existe."
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "Detener la actualización de la dirección IP y de los valores MAC de los eventos de Puppet (afecta a todas las interfaces)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr "Dejar de actualizar el sistema operativo con datos"
@@ -8657,6 +8641,10 @@ msgid "Subnet|Dns secondary"
 msgstr "DNS Secundario"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Desde"
 
@@ -8683,6 +8671,10 @@ msgstr "Nombre"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Red"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8755,6 +8747,12 @@ msgstr "La compatibilidad de %{feature} es obsoleta y será eliminada en la vers
 
 msgid "Supported Formats"
 msgstr "Formatos soportados"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "Sincronizar grupo desde fuente de autenticación"
@@ -8913,12 +8911,20 @@ msgid "TemplateInput|Advanced"
 msgstr "TemplateInput|Advanced"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "TemplateInput|Description"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "TemplateInput|Fact name"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8987,6 +8993,10 @@ msgid "Template|Default"
 msgstr "Plantilla|Predeterminada"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Plantilla|Bloqueada"
 
@@ -9037,8 +9047,8 @@ msgstr "Correo electrónico de prueba"
 msgid "Tester"
 msgstr "Evaluador"
 
-msgid "Text to be shown in the login-page footer"
-msgstr "Texto que se mostrará en el pie de la página de inicio de sesión"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
+msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
@@ -9183,7 +9193,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9200,8 +9210,8 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] "La lista excluye %{count} %{link_start}host físico%{link_end}."
 msgstr[1] "La lista excluye %{count} %{link_start}hosts físicos%{link_end}."
 
-msgid "The location of the sendmail executable"
-msgstr "La ubicación de sendmail ejecutable"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "Los campos marcados deben ser revisados"
@@ -9230,9 +9240,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "El estado de energía de los hosts seleccionados se establecerá en %s."
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "Nombre de reino, p. ej., EXAMPLE.COM"
@@ -9295,6 +9302,9 @@ msgstr "Es posible que los registros del servidor contengan más información."
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
 msgstr "Debe haber al menos un proxy inteligente con un plugin IPAM externo instalado y configurado"
+
+msgid "There was a problem processing the request. Please try again."
+msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
 msgstr "Se produjo un error al crear el archivo PXE: %s"
@@ -9423,7 +9433,7 @@ msgstr "Este valor no está oculto"
 msgid "This value is used also as the host's primary interface name."
 msgstr "Este valor se utiliza también como el nombre de la interfaz principal del host."
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9448,15 +9458,6 @@ msgid "Timezone to use for new users"
 msgstr "Zona horaria a utilizar para los nuevos usuarios"
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9488,9 +9489,6 @@ msgstr "Token"
 
 msgid "Token Expiry"
 msgstr "Vencimiento del token"
-
-msgid "Token duration"
-msgstr "Duración del símbolo"
 
 msgid "Token expired"
 msgstr "Token caducado"
@@ -9529,41 +9527,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] "Total de un host"
 msgstr[1] "Total de %{hosts} hosts"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "Tendencia"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Contador de Tendencias"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Contador"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "TrendCounter|Fin de intervalo"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "TrendCounter|Inicio de intervalo"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Nombre de evento"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Valor de evento"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Nombre"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Tipo de tendencia"
+msgid "Total: %s"
+msgstr ""
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "Indicador verdadero/falso que indica si el host es administradoo no.  Nota: este valor también determina si ciertos parámetros son obligatorios."
@@ -9844,6 +9809,12 @@ msgstr "No se puede no asignar websockets_ssl_key cuando websockets_encrypt est�
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "Plantilla no permitida para el asistente del tablero: %s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "URL desatendida"
 
@@ -9901,6 +9872,9 @@ msgstr "Se encontraron registros desconocidos en la base de datos"
 msgid "Unknown status: %s"
 msgstr "Estado desconocido: %s"
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "Desbloquear"
 
@@ -9928,9 +9902,6 @@ msgstr "Actualizar :a_resource"
 msgid "Update IP from built request"
 msgstr "Actualizar IP desde la solicitud de construcción"
 
-msgid "Update a Puppet class"
-msgstr "Actualizar una clase Puppet"
-
 msgid "Update a bookmark"
 msgstr "Actualizar un marcador"
 
@@ -9942,9 +9913,6 @@ msgstr "Actualizar un perfil de computación"
 
 msgid "Update a compute resource"
 msgstr "Actualizar un recurso de cómputo"
-
-msgid "Update a config group"
-msgstr "Actualizar un grupo de configuración"
 
 msgid "Update a default template combination for an operating system"
 msgstr "Actualizar una combinación de plantilla predeterminada para un sistema operativo"
@@ -10012,9 +9980,6 @@ msgstr "Actualizar un rol"
 msgid "Update a setting"
 msgstr "Actualizar un parámetro"
 
-msgid "Update a smart class parameter"
-msgstr "Actualizar un parámetro de clase inteligente"
-
 msgid "Update a smart proxy"
 msgstr "Actualizar un proxy inteligente"
 
@@ -10045,9 +10010,6 @@ msgstr "Actualizar una arquitectura"
 msgid "Update an email notification for a user"
 msgstr ""
 
-msgid "Update an environment"
-msgstr "Actualizar un entorno"
-
 msgid "Update an external authentication source"
 msgstr "Actualizar una fuente de autenticación externa"
 
@@ -10056,12 +10018,6 @@ msgstr "Actualizar una imagen"
 
 msgid "Update an operating system"
 msgstr "Actualizar un sistema operativo"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "Actualizar un valor de sobrescritura para un parámetro específico de clase inteligente"
-
-msgid "Update environment from facts"
-msgstr "Actualizar el entorno a partir de los eventos"
 
 msgid "Update external user group"
 msgstr "Actualizar grupo de usuarios externos"
@@ -10298,6 +10254,10 @@ msgid "User|Description"
 msgstr "Usuario|Descripción"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "Nombre"
 
@@ -10434,8 +10394,8 @@ msgstr "Variable"
 msgid "Variables"
 msgstr "Variables"
 
-msgid "Vendor Class"
-msgstr "Clase de proveedor"
+msgid "Vendor class"
+msgstr ""
 
 msgid "Verify"
 msgstr "Verificar"
@@ -10496,6 +10456,9 @@ msgstr "Esperar a que %s esté en línea"
 
 msgid "Warning"
 msgstr "Advertencia"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "¡Advertencia!"
@@ -10560,6 +10523,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10692,6 +10658,9 @@ msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "Está por modificar el menú PXE predeterminado en todos los servidores TFTP configurados, ¿desea continuar?"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
@@ -10846,6 +10815,9 @@ msgstr "todos"
 msgid "already exists"
 msgstr "ya existe"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "una organización"
 
@@ -10857,9 +10829,6 @@ msgstr "array"
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "pertenece a un grupo de configuración"
 
 msgid "boolean"
 msgstr "marcador"
@@ -11040,9 +11009,6 @@ msgstr "habilitar caché solo para VMware"
 
 msgid "enabled"
 msgstr ""
-
-msgid "environment id"
-msgstr "ID de entorno"
 
 msgid "expected a value of type %s"
 msgstr "se espera un valor de tipo %s"
@@ -11292,8 +11258,7 @@ msgstr "enlazar grupo de usuarios externos con este grupo de usuario"
 msgid "list"
 msgstr "lista"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "Español"
 
@@ -11473,12 +11438,6 @@ msgstr "físico en NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "físico en puente %s"
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
-msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "acción de encendido, las acciones válidas incluyen (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"

--- a/locale/es/foreman.po
+++ b/locale/es/foreman.po
@@ -412,6 +412,9 @@ msgstr "Una notificación cuando un host informa un error de configuración"
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Ha ocurrido un problema al detectar el tipo de host: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr "Un resumen del informe de cambios de auditoría <br> Filtrado por una consulta, en caso de ser necesario"
 
@@ -697,6 +700,9 @@ msgstr "Se requiere una dirección de correo electrónico; actualice los detalle
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "Ocurrió un error al intentar conectarse a LDAP. Corrobore que el host de Foreman pueda llegar al host fuente de autenticación y que esté en línea."
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -765,6 +771,12 @@ msgstr "¿Está seguro de que desea eliminar el host %s? Esta acción es irrever
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "¿Está seguro de que desea eliminar el host %s? Esto eliminará la máquina virtual y sus discos, y es irreversible. Este comportamiento se puede cambiar a través del ajuste global \"Destruir máquina virtual asociada con la eliminación del host\"."
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr "¿Está seguro de que desea cerrar sesión?"
@@ -1148,6 +1160,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "Plantilla en blanco"
 
@@ -1243,6 +1258,9 @@ msgstr "Generar 'PXE predeterminado'"
 
 msgid "Build duration"
 msgstr "Duración de la compilación"
+
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
 
 msgid "Build errors"
 msgstr "Errores de compilación"
@@ -2626,6 +2644,12 @@ msgstr "ERROR o FATAL"
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3337,6 +3361,12 @@ msgstr "Resumen de auditoría de Foreman"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr "Foreman puede almacenar información sobre la configuración de red de un host al cual aprovisiona y que puede utilizarse para configurar la máquina virtual, asignar las direcciones IP y los recursos de red correspondientes, y, luego, configurar el sistema operativo en forma correcta durante el  proceso de aprovisionamiento."
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3632,6 +3662,9 @@ msgstr "El arranque HTTP UEFI requiere un proxy con la característica httpboot"
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr "El arranque HTTP requiere un proxy con la función httpboot y la configuración http_port exposed"
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
+msgstr ""
 
 msgid "HTTP(S) proxy"
 msgstr "Proxy HTTP(S)"
@@ -4396,8 +4429,20 @@ msgstr "Si ERB se utiliza en un valor de parámetro, la validación del valor oc
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "Al seleccionarlo, aparecerá un error si no existe un valor predeterminado y no existe ningún comparador que pueda proporcionar el valor."
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
 msgstr "Si se especifica el tipo de propietario, también debe especificarse el propietario."
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
 msgstr "Si se configura, el informe programado se entregará por correo electrónico. Utilice \"%s\" para separar múltiples direcciones de correo electrónico."
@@ -4407,6 +4452,9 @@ msgstr "Si la marca administrada está habilitada, ninguno de los servicios se c
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
 msgstr "Si la marca administrada está habilitada, los servicios externos, como DHCP, DNS, y TFTP, se configurarán de acuerdo con la información proporcionada."
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
+msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
 msgstr "Si la plantilla admite la selección de formato, el usuario puede elegir el formato preferido.<br> Normalmente la plantilla necesita utilizar el macro report_render.<br><br>Si el uso de este macro no se encuentra en la plantilla,<br>este campo está desactivado y el formato de salida es por defecto texto sin formato.<br><br>Si la plantilla admite la selección de filtro, pero no utiliza el macro report_render,<br>para habilitar este campo, añada un comentario a la plantilla mencionando el nombre del macro report_render."
@@ -4422,6 +4470,9 @@ msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Si cree que esto es un error de Foreman, por favor, reporte una incidencia con"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr "Ignorar datos para el dominio"
@@ -4568,6 +4619,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "Infraestructuras"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Heredar padre (%s)"
 
@@ -4617,6 +4671,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5563,6 +5620,9 @@ msgstr "MailNotification|Suscribible"
 msgid "MailNotification|Subscription type"
 msgstr "MailNotification|Tipo de suscripción"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Administrar"
 
@@ -6401,6 +6461,9 @@ msgstr "Nombre del SO procedente de facter; p. e.j., RedHat"
 msgid "Off"
 msgstr "Desactivar"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "Ok"
 
@@ -6449,6 +6512,9 @@ msgstr "Solo se permite una declaración"
 
 msgid "Only one volume can be bootable"
 msgstr "Solo un volumen puede ser arrancable"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "¡Error!"
@@ -6858,6 +6924,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7543,6 +7612,9 @@ msgstr "Solicitar UUID"
 msgid "Require SSL for smart proxies"
 msgstr "Requiere SSL para proxy inteligentes"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "Obligatorio, a menos que el usuario sea una fuente de autenticación externa"
 
@@ -8128,6 +8200,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8362,6 +8437,11 @@ msgstr "Registrar"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "Se seleccionó un solo host en esta página."
@@ -8452,6 +8532,12 @@ msgstr "algunas interfaces no son válidas"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Algunas de las interfaces no son válidas. Por favor verifique la tabla de abajo."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9115,6 +9201,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr "El algoritmo utilizado para codificar el JWT en el proveedor de OpenID."
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "La fuente de autenticación de sus grupos de usuarios externos no pudo conectarse a LDAP con las credenciales proporcionadas. Corrobore que las credenciales sigan siendo válidas."
 
@@ -9126,6 +9215,9 @@ msgstr "La clase de CPU suministrada en esta máquina. Se utiliza principalmente
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "La clase de la máquina reportada por el Open Boot Prom. Se utiliza principalmente para arquitecturas Sparc Solaris y se puede dejar en blanco para otras arquitecturas. El valor puede determinarse en Solaris con el comando uname -i|cut -f2 -d"
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr "La consola no está disponible porque la MV no está encendida"
@@ -9318,6 +9410,12 @@ msgstr "Ha habido un error al listar las máquinas virtuales: %(status)s %(statu
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "Ocurrió un error al reproducir la plantilla %{name}: %{error}."
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "No había ninguna interfaz de puente activa en libvirt, si no soporta el listado, puede ingresar el nombre del puente de forma manual (e.g. br0)"
 
@@ -9332,6 +9430,9 @@ msgstr "Esto <b>eliminará</b> las máquinas virtuales vinculadas y sus discos, 
 
 msgid "This IP address has already been reserved in External IPAM"
 msgstr "Esta dirección IP ya ha sido reservada en el IPAM externo"
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
 msgstr ""
@@ -9387,6 +9488,9 @@ msgstr "Esto se puede deber a la falta de disponibilidad de algún servicio requ
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Esto puede demorar un tiempo, ya que también se <b>eliminarán</b> todos los hosts, eventos e informes. %s Este comportamiento se puede cambiar a través del ajuste global \"Destruir máquina virtual asociada con la eliminación del host\"."
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9407,6 +9511,12 @@ msgstr "Este servicio está disponible para usuarios no autenticados"
 
 msgid "This service is only available for authenticated users"
 msgstr "Este servicio solo está disponible para usuarios autenticados"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "La plantilla está bloqueada y no puede eliminarse"
@@ -9434,6 +9544,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "Este valor se utiliza también como el nombre de la interfaz principal del host."
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9479,6 +9592,9 @@ msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
 msgstr "Para actualizar la lista de usuarios, haga clic en la pestaña \"Grupos externos\" y, luego, en \"Actualizar\"."
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
+msgstr ""
 
 msgid "Today"
 msgstr "Hoy"
@@ -10331,6 +10447,9 @@ msgstr "Atributos de máquina virtual (%s)"
 msgid "VM already associated with a host"
 msgstr "La máquina virtual ya está asociada a este host"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "Máquinas virtuales asociadas al host %s"
 
@@ -10470,6 +10589,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] "¡Advertencia! Esto eliminará %{name} de %{number} usuario. ¿Está seguro de que desea continuar?"
 msgstr[1] "¡Advertencia! Esto eliminará %{name} de %{number} usuarios. ¿Está seguro de que desea continuar?"
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "Advertencia: ¡esta acción borrará este host y todos sus datos!"
@@ -10665,11 +10787,17 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "Está por desbloquear una plantilla bloqueada."
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
 msgstr "Si ya está imitando, haga clic en el icono de imitación la barra superior antes de empezar una nueva imitación."
+
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
 
 msgid "You are not authorized to lock templates."
 msgstr "No tiene autorización para bloquear plantillas."

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: foreman 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-29 22:04+0530\n"
-"PO-Revision-Date: 2021-10-29 22:04+0530\n"
+"POT-Creation-Date: 2021-12-22 15:17+0100\n"
+"PO-Revision-Date: 2021-12-22 15:17+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -73,22 +73,22 @@ msgstr ""
 msgid "Loading virtual machine information ..."
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:491
+#: ../app/assets/javascripts/host_edit.js:497
 msgid "Loading parameters..."
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:649
+#: ../app/assets/javascripts/host_edit.js:647
 #: ../app/helpers/hosts_nic_helper.rb:22
 #: ../app/views/hostgroups/_form.html.erb:50
 #: ../app/views/hostgroups/_form.html.erb:57
 msgid "No subnets"
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:815
+#: ../app/assets/javascripts/host_edit.js:813
 msgid "Error generating IP: %s"
 msgstr ""
 
-#: ../app/assets/javascripts/host_edit.js:949
+#: ../app/assets/javascripts/host_edit.js:947
 msgid "Manual configuration is needed."
 msgstr ""
 
@@ -136,7 +136,7 @@ msgstr ""
 #: ../app/helpers/hosts_helper.rb:374 ../app/helpers/hosts_helper.rb:376
 #: ../app/models/host_status/build_status.rb:27
 #: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js:54
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:63
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:68
 msgid "Build"
 msgstr ""
 
@@ -146,7 +146,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/assets/javascripts/jquery.multi-select.js:8
-#: ../app/views/filters/_form.html.erb:6 model_attributes.rb:148
+#: ../app/views/filters/_form.html.erb:6 model_attributes.rb:140
 msgid "Filter"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 #: ../app/assets/javascripts/subnets.js:104
 #: ../app/models/lookup_keys/lookup_key.rb:170
 #: ../app/models/nic/interface.rb:101 ../app/models/nic/interface.rb:102
-#: ../app/models/subnet.rb:395
+#: ../app/models/subnet.rb:398
 #: ../app/services/foreman/parameters/validator.rb:29
 #: ../app/validators/email_validator.rb:14
 msgid "is invalid"
@@ -1280,12 +1280,12 @@ msgid "Clone a host group"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:103
-#: ../app/controllers/api/v2/hosts_controller.rb:316
+#: ../app/controllers/api/v2/hosts_controller.rb:319
 msgid "Rebuild orchestration config"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:105
-#: ../app/controllers/api/v2/hosts_controller.rb:318
+#: ../app/controllers/api/v2/hosts_controller.rb:321
 msgid "Limit rebuild steps, valid steps are %{host_rebuild_steps}"
 msgstr ""
 
@@ -1294,12 +1294,12 @@ msgid "Operate on child hostgroup hosts"
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:115
-#: ../app/controllers/api/v2/hosts_controller.rb:323
+#: ../app/controllers/api/v2/hosts_controller.rb:326
 msgid "Configuration successfully rebuilt."
 msgstr ""
 
 #: ../app/controllers/api/v2/hostgroups_controller.rb:118
-#: ../app/controllers/api/v2/hosts_controller.rb:325
+#: ../app/controllers/api/v2/hosts_controller.rb:328
 msgid "Configuration rebuild failed for: %s."
 msgstr ""
 
@@ -1463,23 +1463,23 @@ msgstr ""
 msgid "Overwrite existing host (true by default)"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:152
+#: ../app/controllers/api/v2/hosts_controller.rb:155
 msgid "Update a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:168
+#: ../app/controllers/api/v2/hosts_controller.rb:171
 msgid "Delete a host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:175
+#: ../app/controllers/api/v2/hosts_controller.rb:178
 msgid "Get ENC values of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:182
+#: ../app/controllers/api/v2/hosts_controller.rb:185
 msgid "Get status of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:184
+#: ../app/controllers/api/v2/hosts_controller.rb:187
 msgid ""
 "status type, can be one of\n"
 "* global\n"
@@ -1487,119 +1487,119 @@ msgid ""
 "* build\n"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:193
+#: ../app/controllers/api/v2/hosts_controller.rb:196
 msgid "Returns string representing a host status of a given type"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:200
-#: ../app/controllers/api/v2/hosts_controller.rb:218
+#: ../app/controllers/api/v2/hosts_controller.rb:203
+#: ../app/controllers/api/v2/hosts_controller.rb:221
 msgid "Status %s does not exist."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:204
+#: ../app/controllers/api/v2/hosts_controller.rb:207
 msgid "Clear sub-status of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:206
+#: ../app/controllers/api/v2/hosts_controller.rb:209
 msgid ""
 "status type\n"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:212
+#: ../app/controllers/api/v2/hosts_controller.rb:215
 msgid "Clears a host sub-status of a given type"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:216
+#: ../app/controllers/api/v2/hosts_controller.rb:219
 msgid "Cannot delete global status."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:224
+#: ../app/controllers/api/v2/hosts_controller.rb:227
 msgid "Get vm attributes of host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:247
+#: ../app/controllers/api/v2/hosts_controller.rb:250
 msgid "Disassociate the host from a VM"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:254
+#: ../app/controllers/api/v2/hosts_controller.rb:257
 msgid "Run a power operation on host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:256
+#: ../app/controllers/api/v2/hosts_controller.rb:259
 msgid ""
 "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/"
 "reset), (state/status)"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:260
+#: ../app/controllers/api/v2/hosts_controller.rb:263
 #: ../app/services/power_manager/power_status.rb:15
 msgid "Power operations are not enabled on this host."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:267
+#: ../app/controllers/api/v2/hosts_controller.rb:270
 msgid "Unknown power action: available methods are %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:271
+#: ../app/controllers/api/v2/hosts_controller.rb:274
 msgid ""
 "Fetch the status of whether the host is powered on or not. Supported hosts are"
 " VMs and physical hosts with BMCs."
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:281
+#: ../app/controllers/api/v2/hosts_controller.rb:284
 #: ../app/graphql/resolvers/host/power_status.rb:19
 msgid "Failed to fetch power status: %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:287
+#: ../app/controllers/api/v2/hosts_controller.rb:290
 msgid "Boot host from specified device"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:289
+#: ../app/controllers/api/v2/hosts_controller.rb:292
 msgid "boot device, valid devices are disk, cdrom, pxe, bios"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:296
+#: ../app/controllers/api/v2/hosts_controller.rb:299
 msgid "Unknown device: available devices are %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:302
+#: ../app/controllers/api/v2/hosts_controller.rb:305
 msgid "Upload facts for a host, creating the host if required"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:303
+#: ../app/controllers/api/v2/hosts_controller.rb:306
 msgid "hostname of the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:304
+#: ../app/controllers/api/v2/hosts_controller.rb:307
 msgid "hash containing the facts for the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:305
+#: ../app/controllers/api/v2/hosts_controller.rb:308
 msgid "optional: certname of the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:306
+#: ../app/controllers/api/v2/hosts_controller.rb:309
 msgid "optional: the STI type of host to create"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:329
+#: ../app/controllers/api/v2/hosts_controller.rb:332
 msgid "Preview rendered provisioning template content"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:331
+#: ../app/controllers/api/v2/hosts_controller.rb:334
 msgid "Template kinds, available values: %{template_kinds}"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:335
+#: ../app/controllers/api/v2/hosts_controller.rb:338
 msgid "No template with kind %{kind} for %{host}"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:414
+#: ../app/controllers/api/v2/hosts_controller.rb:417
 msgid "Invalid type for host creation via facts: %s"
 msgstr ""
 
-#: ../app/controllers/api/v2/hosts_controller.rb:417
+#: ../app/controllers/api/v2/hosts_controller.rb:420
 msgid "A problem occurred when detecting host type: %s"
 msgstr ""
 
@@ -2544,67 +2544,69 @@ msgstr ""
 msgid "Delete a realm"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:7
+#: ../app/controllers/api/v2/registration_commands_controller.rb:9
 msgid "Generate global registration command"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:9
+#: ../app/controllers/api/v2/registration_commands_controller.rb:11
 msgid "ID of the Organization to register the host in"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:10
+#: ../app/controllers/api/v2/registration_commands_controller.rb:12
 msgid "ID of the Location to register the host in"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:11
+#: ../app/controllers/api/v2/registration_commands_controller.rb:13
 msgid "ID of the Host group to register the host in"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:12
+#: ../app/controllers/api/v2/registration_commands_controller.rb:14
 msgid ""
 "ID of the Operating System to register the host in. Operating system must have"
 " a `host_init_config` template assigned"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:13
-msgid "ID of the Smart Proxy"
+#: ../app/controllers/api/v2/registration_commands_controller.rb:15
+msgid ""
+"ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and '"
+"Registration' features"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:14
+#: ../app/controllers/api/v2/registration_commands_controller.rb:16
 msgid ""
 "Set 'host_registration_insights' parameter for the host. If it is set to true,"
 " insights client will be installed and registered on Red Hat family operating "
 "systems"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:15
+#: ../app/controllers/api/v2/registration_commands_controller.rb:17
 msgid ""
 "Set 'host_registration_remote_execution' parameter for the host. If it is set "
 "to true, SSH keys will be installed on the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:16
+#: ../app/controllers/api/v2/registration_commands_controller.rb:18
 msgid "Expiration of the authorization token (in hours)"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:17
+#: ../app/controllers/api/v2/registration_commands_controller.rb:19
 msgid "Enable insecure argument for the initial curl"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:18
+#: ../app/controllers/api/v2/registration_commands_controller.rb:20
 #: ../app/controllers/api/v2/registration_controller.rb:24
 msgid ""
 "Packages to install on the host when registered. Can be set by `host_packages`"
 " parameter. Example: `pkg1 pkg2`"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:19
+#: ../app/controllers/api/v2/registration_commands_controller.rb:21
 #: ../app/controllers/api/v2/registration_controller.rb:25
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/UpdatePackages.js:19
 msgid "Update all packages on the host"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:20
+#: ../app/controllers/api/v2/registration_commands_controller.rb:22
 #: ../app/controllers/api/v2/registration_controller.rb:26
 msgid ""
 "Repository URL / details, for example for Debian OS family: 'deb http://deb.ex"
@@ -2612,12 +2614,12 @@ msgid ""
 "nt/latest/el8/x86_64/'"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:21
+#: ../app/controllers/api/v2/registration_commands_controller.rb:23
 #: ../app/controllers/api/v2/registration_controller.rb:27
 msgid "URL of the GPG key for the repository"
 msgstr ""
 
-#: ../app/controllers/api/v2/registration_commands_controller.rb:25
+#: ../app/controllers/api/v2/registration_commands_controller.rb:27
 msgid "Operating system doesn't have a 'host_init_config' template assigned."
 msgstr ""
 
@@ -3438,7 +3440,7 @@ msgid "The virtual machine is being deleted."
 msgstr ""
 
 #: ../app/controllers/compute_resources_vms_controller.rb:90
-#: ../app/controllers/hosts_controller.rb:358
+#: ../app/controllers/hosts_controller.rb:359
 msgid "Failed to set console: %s"
 msgstr ""
 
@@ -3599,25 +3601,25 @@ msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:23
-#: ../app/controllers/hosts_controller.rb:834
+#: ../app/controllers/hosts_controller.rb:835
 msgid "No proxy selected!"
 msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:29
-#: ../app/controllers/hosts_controller.rb:840
+#: ../app/controllers/hosts_controller.rb:841
 msgid "Invalid proxy selected!"
 msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:50
-#: ../app/controllers/hosts_controller.rb:861
+#: ../app/controllers/hosts_controller.rb:862
 msgid "Failed to set %{proxy_type} proxy for %{host}."
 msgstr ""
 
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:56
-#: ../app/controllers/hosts_controller.rb:867
+#: ../app/controllers/hosts_controller.rb:868
 msgid "The %{proxy_type} proxy of the selected hosts was set to %{proxy_name}"
 msgstr ""
 
@@ -3630,7 +3632,7 @@ msgstr ""
 #:
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:61
 #: ../app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb:76
-#: ../app/controllers/hosts_controller.rb:872
+#: ../app/controllers/hosts_controller.rb:873
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
 msgstr[0] ""
@@ -3654,6 +3656,10 @@ msgstr ""
 
 #: ../app/controllers/concerns/foreman/controller/registration.rb:94
 msgid "URL in :url parameter is missing a scheme, please set http:// or https://"
+msgstr ""
+
+#: ../app/controllers/concerns/foreman/controller/registration_commands.rb:56
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
 msgstr ""
 
 #: ../app/controllers/concerns/foreman/controller/taxonomies_controller.rb:127
@@ -3713,6 +3719,11 @@ msgid "Cannot delete group %{current} because it has nested groups."
 msgstr ""
 
 #: ../app/controllers/hosts_controller.rb:16
+#: ../app/models/compute_resources/foreman/model/vmware.rb:207
+msgid "BIOS"
+msgstr ""
+
+#: ../app/controllers/hosts_controller.rb:16
 #: ../app/views/compute_resources_vms/show/_libvirt.html.erb:45
 #: ../app/views/compute_resources_vms/show/_ovirt.html.erb:45
 msgid "Disk"
@@ -3724,11 +3735,6 @@ msgstr ""
 
 #: ../app/controllers/hosts_controller.rb:16
 msgid "PXE"
-msgstr ""
-
-#: ../app/controllers/hosts_controller.rb:16
-#: ../app/models/compute_resources/foreman/model/vmware.rb:207
-msgid "BIOS"
 msgstr ""
 
 #: ../app/controllers/hosts_controller.rb:90
@@ -3760,7 +3766,7 @@ msgstr ""
 
 #: ../app/controllers/hosts_controller.rb:246
 #: ../app/controllers/hosts_controller.rb:249
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:90
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:95
 msgid "Canceled pending build for %s"
 msgstr ""
 
@@ -3778,165 +3784,165 @@ msgstr ""
 msgid "Failed to %{action} %{host}: %{e}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:347
+#: ../app/controllers/hosts_controller.rb:348
 msgid "%{host} now boots from %{device}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:349
+#: ../app/controllers/hosts_controller.rb:350
 msgid "Failed to configure %{host} to boot from %{device}: %{e}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:365
+#: ../app/controllers/hosts_controller.rb:366
 msgid "Foreman now manages the build cycle for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:367
+#: ../app/controllers/hosts_controller.rb:368
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:371
+#: ../app/controllers/hosts_controller.rb:372
 msgid "Failed to modify the build cycle for %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:378
+#: ../app/controllers/hosts_controller.rb:379
 msgid "%s has been disassociated from VM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:380
+#: ../app/controllers/hosts_controller.rb:381
 msgid "Host %s is not associated with a VM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:396
+#: ../app/controllers/hosts_controller.rb:397
 msgid "No parameters were allocated to the selected hosts, can't mass assign"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:416
+#: ../app/controllers/hosts_controller.rb:417
 msgid "Updated all hosts!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:420
+#: ../app/controllers/hosts_controller.rb:421
 msgid "%s Parameters updated, see below for more information"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:430
+#: ../app/controllers/hosts_controller.rb:431
 msgid "No host group selected!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:441
+#: ../app/controllers/hosts_controller.rb:442
 msgid "Updated hosts: changed host group"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:452
+#: ../app/controllers/hosts_controller.rb:453
 msgid "No owner selected!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:463
+#: ../app/controllers/hosts_controller.rb:464
 msgid "Updated hosts: changed owner"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:475
+#: ../app/controllers/hosts_controller.rb:476
 msgid "Failed to set power state for %s."
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:479
+#: ../app/controllers/hosts_controller.rb:480
 msgid "The power state of the selected hosts will be set to %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:505
+#: ../app/controllers/hosts_controller.rb:506
 msgid "%{config_type} rebuild failed for host: %{host_names}."
 msgid_plural "%{config_type} rebuild failed for hosts: %{host_names}."
 msgstr[0] ""
 msgstr[1] ""
 
-#: ../app/controllers/hosts_controller.rb:512
+#: ../app/controllers/hosts_controller.rb:513
 msgid "Configuration successfully rebuilt"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:529
+#: ../app/controllers/hosts_controller.rb:530
 msgid "Failed to redeploy %s."
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:538
+#: ../app/controllers/hosts_controller.rb:539
 msgid "The selected hosts were enabled for reboot and rebuild"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:540
+#: ../app/controllers/hosts_controller.rb:541
 msgid "The selected hosts will execute a build operation on next reboot"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:543
+#: ../app/controllers/hosts_controller.rb:544
 msgid "The following hosts failed the build operation: %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:552
+#: ../app/controllers/hosts_controller.rb:553
 msgid "Destroyed selected hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:554
+#: ../app/controllers/hosts_controller.rb:555
 msgid "The following hosts were not deleted: %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:582
+#: ../app/controllers/hosts_controller.rb:583
 msgid "Updated hosts: Disassociated from VM"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:588
+#: ../app/controllers/hosts_controller.rb:589
 msgid "Hosts with errors"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:593
+#: ../app/controllers/hosts_controller.rb:594
 msgid "Active Hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:598
+#: ../app/controllers/hosts_controller.rb:599
 msgid "Pending Hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:603
+#: ../app/controllers/hosts_controller.rb:604
 msgid "Hosts which didn't report in the last %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:608
+#: ../app/controllers/hosts_controller.rb:609
 msgid "Hosts with notifications disabled"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:729
+#: ../app/controllers/hosts_controller.rb:730
 msgid "invalid type: %s requested"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:734
+#: ../app/controllers/hosts_controller.rb:735
 msgid "Something went wrong while changing host type - %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:764
+#: ../app/controllers/hosts_controller.rb:765
 msgid "No hosts were found with that id, name or query filter"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:769
+#: ../app/controllers/hosts_controller.rb:770
 msgid "No hosts selected"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:776
+#: ../app/controllers/hosts_controller.rb:777
 msgid "Something went wrong while selecting hosts - %s"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:789
+#: ../app/controllers/hosts_controller.rb:790
 msgid "%s selected hosts"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:791
+#: ../app/controllers/hosts_controller.rb:792
 msgid "The following hosts were not %{action}: %{missed_hosts}"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:818
+#: ../app/controllers/hosts_controller.rb:819
 msgid "No or invalid power state selected!"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:869
+#: ../app/controllers/hosts_controller.rb:870
 msgid "The %{proxy_type} proxy of the selected hosts was cleared"
 msgstr ""
 
-#: ../app/controllers/hosts_controller.rb:884
+#: ../app/controllers/hosts_controller.rb:885
 msgid "No templates found"
 msgstr ""
 
@@ -4173,7 +4179,7 @@ msgstr ""
 #: ../app/views/hosts/_interfaces.html.erb:34
 #: ../app/views/puppetca/_list.html.erb:31
 #: ../webpack/assets/javascripts/dashboard/index.js:67
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:81
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:86
 #: ../webpack/assets/javascripts/react_app/components/common/table/components/DeleteButton.js:9
 #: ../webpack/assets/javascripts/react_app/routes/Models/ModelsPage/components/ModelDeleteModal.js:25
 msgid "Delete"
@@ -4197,12 +4203,12 @@ msgstr ""
 msgid "Export to CSV"
 msgstr ""
 
-#: ../app/helpers/application_helper.rb:181
+#: ../app/helpers/application_helper.rb:168
 #: ../app/views/templates/_form.html.erb:22
 msgid "Help"
 msgstr ""
 
-#: ../app/helpers/application_helper.rb:308
+#: ../app/helpers/application_helper.rb:250
 #: ../app/views/about/index.html.erb:125
 #: ../webpack/assets/javascripts/react_app/components/PF4/DocumentationLink/index.js:20
 #: ../webpack/assets/javascripts/react_app/components/common/DocumentationLink/index.js:19
@@ -4210,20 +4216,20 @@ msgstr ""
 msgid "Documentation"
 msgstr ""
 
-#: ../app/helpers/application_helper.rb:313
+#: ../app/helpers/application_helper.rb:255
 #: ../webpack/assets/javascripts/react_app/components/Bookmarks/Bookmarks.js:76
 #: ../webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarkItems.js:38
 msgid "None found"
 msgstr ""
 
-#: ../app/helpers/application_helper.rb:333
+#: ../app/helpers/application_helper.rb:275
 #: ../app/views/users/logout.html.erb:3
 #: ../webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingValueField.js:29
 #: ../webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js:70
 msgid "Yes"
 msgstr ""
 
-#: ../app/helpers/application_helper.rb:333
+#: ../app/helpers/application_helper.rb:275
 #: ../webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingValueField.js:30
 #: ../webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js:72
 msgid "No"
@@ -4280,7 +4286,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/helpers/audits_helper.rb:126 ../app/helpers/audits_helper.rb:344
 #: ../app/registries/menu/loader.rb:13 ../app/views/users/_form.html.erb:6
-#: model_attributes.rb:704
+#: model_attributes.rb:706
 msgid "User"
 msgstr ""
 
@@ -4297,7 +4303,7 @@ msgstr ""
 #: ../db/seeds.d/170-notification_blueprints.rb:3
 #: ../db/seeds.d/170-notification_blueprints.rb:17
 #: ../db/seeds.d/170-notification_blueprints.rb:23
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/index.js:78
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/index.js:87
 #: ../webpack/assets/javascripts/react_app/components/ModelsTable/ModelsTableSchema.js:42
 msgid "Hosts"
 msgstr ""
@@ -4458,6 +4464,7 @@ msgstr ""
 #: ../app/helpers/compute_resources_vms_helper.rb:20
 #: ../app/helpers/compute_resources_vms_helper.rb:278
 #: ../app/views/compute_resources_vms/index/_vmware.html.erb:27
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:96
 msgid "Console"
 msgstr ""
 
@@ -4584,15 +4591,15 @@ msgstr ""
 msgid "Restarted"
 msgstr ""
 
-#. TRANSLATORS: initial character of Failed
-#: ../app/helpers/dashboard_helper.rb:115
-msgid "Failed|F"
-msgstr ""
-
 #: ../app/helpers/dashboard_helper.rb:115 ../app/helpers/hosts_helper.rb:200
 #: ../app/models/config_report.rb:79
 #: ../app/views/config_reports/_list.html.erb:11
 msgid "Failed"
+msgstr ""
+
+#. TRANSLATORS: initial character of Failed
+#: ../app/helpers/dashboard_helper.rb:115
+msgid "Failed|F"
 msgstr ""
 
 #. TRANSLATORS: initial characters of Failed Restarts
@@ -4614,15 +4621,15 @@ msgstr ""
 msgid "Skipped"
 msgstr ""
 
-#. TRANSLATORS: initial character of Pending
-#: ../app/helpers/dashboard_helper.rb:121
-msgid "Pending|P"
-msgstr ""
-
 #: ../app/helpers/dashboard_helper.rb:121
 #: ../app/models/host_status/configuration_status.rb:77
 #: ../app/views/config_reports/_list.html.erb:14
 msgid "Pending"
+msgstr ""
+
+#. TRANSLATORS: initial character of Pending
+#: ../app/helpers/dashboard_helper.rb:121
+msgid "Pending|P"
 msgstr ""
 
 #: ../app/helpers/dashboard_helper.rb:144
@@ -4790,7 +4797,7 @@ msgid "Build duration"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/helpers/host_description_helper.rb:65 model_attributes.rb:662
+#: ../app/helpers/host_description_helper.rb:65 model_attributes.rb:682
 msgid "Token"
 msgstr ""
 
@@ -4798,7 +4805,7 @@ msgstr ""
 #: ../app/helpers/host_description_helper.rb:66
 #: ../app/views/domains/_form.html.erb:4
 #: ../app/views/hostgroups/_form.html.erb:47
-#: ../app/views/subnets/_form.html.erb:25 model_attributes.rb:116
+#: ../app/views/subnets/_form.html.erb:25 model_attributes.rb:112
 msgid "Domain"
 msgstr ""
 
@@ -4806,7 +4813,7 @@ msgstr ""
 #: ../app/helpers/host_description_helper.rb:67
 #: ../app/views/hostgroups/_form.html.erb:62
 #: ../app/views/realms/_form.html.erb:4
-#: ../app/views/smart_proxies/plugins/_realm.html.erb:2 model_attributes.rb:480
+#: ../app/views/smart_proxies/plugins/_realm.html.erb:2 model_attributes.rb:492
 msgid "Realm"
 msgstr ""
 
@@ -4910,7 +4917,7 @@ msgstr ""
 #: ../app/views/images/_list.html.erb:20
 #: ../app/views/operatingsystems/index.html.erb:16
 #: ../app/views/taxonomies/index.html.erb:28
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:131
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:145
 msgid "Edit"
 msgstr ""
 
@@ -4925,7 +4932,7 @@ msgstr ""
 #: ../app/views/operatingsystems/index.html.erb:17
 #: ../app/views/roles/index.html.erb:28
 #: ../app/views/taxonomies/index.html.erb:30
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:72
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:77
 msgid "Clone"
 msgstr ""
 
@@ -4934,7 +4941,7 @@ msgid "Clone this host"
 msgstr ""
 
 #: ../app/helpers/host_description_helper.rb:97
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:63
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:68
 msgid "Cancel build"
 msgstr ""
 
@@ -4956,9 +4963,8 @@ msgstr ""
 
 #: ../app/helpers/host_description_helper.rb:137
 #: ../app/registries/foreman/settings/facts.rb:2
-#: ../app/registries/foreman/settings/facts.rb:105
 #: ../app/registries/menu/loader.rb:45
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:90
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:104
 msgid "Facts"
 msgstr ""
 
@@ -4972,7 +4978,7 @@ msgstr ""
 #: ../app/views/config_reports/index.html.erb:22
 #: ../db/seeds.d/170-notification_blueprints.rb:65
 #: ../webpack/assets/javascripts/react_app/components/ConfigReports/Welcome.js:22
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:99
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:113
 msgid "Reports"
 msgstr ""
 
@@ -5094,7 +5100,7 @@ msgid "Allocation (GB)"
 msgstr ""
 
 #: ../app/helpers/hosts_helper.rb:322 ../app/helpers/lookup_keys_helper.rb:36
-#: ../app/registries/foreman/settings/facts.rb:81 ../app/services/ipam.rb:2
+#: ../app/registries/foreman/settings/facts.rb:88 ../app/services/ipam.rb:2
 msgid "None"
 msgstr ""
 
@@ -5171,7 +5177,7 @@ msgstr ""
 #: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:77
 #: ../app/views/compute_resources_vms/form/rackspace/_base.html.erb:9
 #: ../app/views/compute_resources_vms/form/vmware/_base.html.erb:49
-#: model_attributes.rb:246
+#: model_attributes.rb:260
 msgid "Image"
 msgstr ""
 
@@ -5525,7 +5531,7 @@ msgid "Refresh features"
 msgstr ""
 
 #: ../app/helpers/smart_proxies_helper.rb:89
-#: ../app/registries/foreman/settings/facts.rb:81
+#: ../app/registries/foreman/settings/facts.rb:88
 msgid "All"
 msgstr ""
 
@@ -5660,7 +5666,7 @@ msgid "clone"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/helpers/templates_helper.rb:44 model_attributes.rb:630
+#: ../app/helpers/templates_helper.rb:44 model_attributes.rb:646
 msgid "Template input"
 msgstr ""
 
@@ -5777,7 +5783,7 @@ msgstr ""
 msgid "invalid LDAP filter syntax"
 msgstr ""
 
-#: ../app/models/compute_attribute.rb:27
+#: ../app/models/compute_attribute.rb:28
 msgid "%s is an unknown attribute"
 msgstr ""
 
@@ -6022,6 +6028,18 @@ msgstr ""
 
 #: ../app/models/concerns/dns_interface.rb:81
 msgid "%s is not a valid DNS record type"
+msgstr ""
+
+#: ../app/models/concerns/ensure_no_cycle.rb:39
+msgid "Adding would cause a cycle!"
+msgstr ""
+
+#: ../app/models/concerns/ensure_not_used_by.rb:18
+msgid "%{record} is used by %{what}"
+msgstr ""
+
+#: ../app/models/concerns/ensure_not_used_by.rb:21
+msgid "%{record} is being used by a hidden %{what} resource"
 msgstr ""
 
 #: ../app/models/concerns/fog_extensions/libvirt/server.rb:43
@@ -6338,7 +6356,7 @@ msgid "This IP address has already been reserved in External IPAM"
 msgstr ""
 
 #: ../app/models/concerns/orchestration/external_ipam.rb:26
-#: ../app/models/host/managed.rb:928
+#: ../app/models/host/managed.rb:898
 msgid "Some interfaces are invalid"
 msgstr ""
 
@@ -6548,7 +6566,7 @@ msgstr ""
 msgid "is not found in the authentication source"
 msgstr ""
 
-#: ../app/models/external_usergroup.rb:38 ../app/models/user.rb:747
+#: ../app/models/external_usergroup.rb:38 ../app/models/user.rb:749
 msgid "is not permitted"
 msgstr ""
 
@@ -6562,126 +6580,126 @@ msgstr ""
 msgid "invalid search query: %s"
 msgstr ""
 
-#: ../app/models/filter.rb:100
+#: ../app/models/filter.rb:101
 msgid "filter for %s role"
 msgstr ""
 
-#: ../app/models/filter.rb:113 ../app/views/filters/_form.html.erb:28
+#: ../app/models/filter.rb:114 ../app/views/filters/_form.html.erb:28
 msgid "(Miscellaneous)"
 msgstr ""
 
-#: ../app/models/filter.rb:207
+#: ../app/models/filter.rb:208
 msgid "must be of same resource type (%{types}) - Role (%{role})"
 msgstr ""
 
-#: ../app/models/filter.rb:217
+#: ../app/models/filter.rb:218
 msgid "You must select at least one permission"
 msgstr ""
 
-#: ../app/models/filter.rb:222
+#: ../app/models/filter.rb:223
 msgid "You can't assign organizations to this resource"
 msgstr ""
 
-#: ../app/models/filter.rb:226
+#: ../app/models/filter.rb:227
 msgid "You can't assign locations to this resource"
 msgstr ""
 
-#: ../app/models/filter.rb:236
+#: ../app/models/filter.rb:237
 msgid "is locked for user modifications."
 msgstr ""
 
-#: ../app/models/host/base.rb:584
+#: ../app/models/host/base.rb:579
 msgid "host must have one primary interface"
 msgstr ""
 
-#: ../app/models/host/base.rb:590
+#: ../app/models/host/base.rb:585
 msgid "managed host must have one provision interface"
 msgstr ""
 
-#: ../app/models/host/base.rb:609
+#: ../app/models/host/base.rb:604
 msgid "some interfaces are invalid"
 msgstr ""
 
-#: ../app/models/host/managed.rb:271
+#: ../app/models/host/managed.rb:266
 msgid "invalid time range"
 msgstr ""
 
-#: ../app/models/host/managed.rb:317 ../app/models/hostgroup.rb:26
+#: ../app/models/host/managed.rb:312 ../app/models/hostgroup.rb:26
 msgid "should be 8 characters or more"
 msgstr ""
 
-#: ../app/models/host/managed.rb:318
+#: ../app/models/host/managed.rb:313
 msgid "should not be blank - consider setting a global or host group default"
 msgstr ""
 
-#: ../app/models/host/managed.rb:320
+#: ../app/models/host/managed.rb:315
 msgid "can't be blank unless a custom partition has been defined"
 msgstr ""
 
-#: ../app/models/host/managed.rb:322
+#: ../app/models/host/managed.rb:317
 msgid "is unknown"
 msgstr ""
 
-#: ../app/models/host/managed.rb:326
+#: ../app/models/host/managed.rb:321
 msgid "must belong to host's operating system"
 msgstr ""
 
-#: ../app/models/host/managed.rb:534
+#: ../app/models/host/managed.rb:504
 msgid "Network Based"
 msgstr ""
 
-#: ../app/models/host/managed.rb:535
+#: ../app/models/host/managed.rb:505
 msgid "Image Based"
 msgstr ""
 
-#: ../app/models/host/managed.rb:691
+#: ../app/models/host/managed.rb:661
 #: ../app/models/parameters/host_parameter.rb:11
 msgid "host"
 msgstr ""
 
-#: ../app/models/host/managed.rb:692
+#: ../app/models/host/managed.rb:662
 msgid "hostgroup"
 msgstr ""
 
-#: ../app/models/host/managed.rb:693
+#: ../app/models/host/managed.rb:663
 msgid "global setting"
 msgstr ""
 
-#: ../app/models/host/managed.rb:713
+#: ../app/models/host/managed.rb:683
 msgid "An interface marked as provision is missing"
 msgstr ""
 
-#: ../app/models/host/managed.rb:714
+#: ../app/models/host/managed.rb:684
 msgid "An interface marked as primary is missing"
 msgstr ""
 
-#: ../app/models/host/managed.rb:759
+#: ../app/models/host/managed.rb:729
 msgid "No BMC NIC available for host %s"
 msgstr ""
 
-#: ../app/models/host/managed.rb:875
+#: ../app/models/host/managed.rb:845
 msgid ""
 "There are orchestration modules with methods for configuration rebuild that ha"
 "ve identical name: '%s'"
 msgstr ""
 
-#: ../app/models/host/managed.rb:953
+#: ../app/models/host/managed.rb:923
 msgid "%{value} does not belong to %{os} operating system"
 msgstr ""
 
-#: ../app/models/host/managed.rb:968
+#: ../app/models/host/managed.rb:938
 msgid "is an unsupported provisioning method, available: %s"
 msgstr ""
 
-#: ../app/models/host/managed.rb:973
+#: ../app/models/host/managed.rb:943
 msgid "can't be updated after host is provisioned"
 msgstr ""
 
-#: ../app/models/host/managed.rb:978 ../app/models/nic/interface.rb:138
+#: ../app/models/host/managed.rb:948 ../app/models/nic/interface.rb:138
 msgid "must not include periods"
 msgstr ""
 
-#: ../app/models/host/managed.rb:1027
+#: ../app/models/host/managed.rb:997
 msgid ""
 "with id %{object_id} doesn't exist or is not assigned to proper organization a"
 "nd/or location"
@@ -6725,15 +6743,15 @@ msgstr ""
 msgid "Global"
 msgstr ""
 
-#: ../app/models/hostgroup.rb:153
+#: ../app/models/hostgroup.rb:148
 msgid "Default value"
 msgstr ""
 
-#: ../app/models/hostgroup.rb:282 ../app/models/nic/base.rb:338
+#: ../app/models/hostgroup.rb:282 ../app/models/nic/base.rb:339
 msgid "must be of type Subnet::Ipv4."
 msgstr ""
 
-#: ../app/models/hostgroup.rb:283 ../app/models/nic/base.rb:339
+#: ../app/models/hostgroup.rb:283 ../app/models/nic/base.rb:340
 msgid "must be of type Subnet::Ipv6."
 msgstr ""
 
@@ -6741,7 +6759,7 @@ msgstr ""
 msgid "is not valid."
 msgstr ""
 
-#: ../app/models/image.rb:26
+#: ../app/models/image.rb:27
 msgid "could not be found in %s"
 msgstr ""
 
@@ -6801,7 +6819,7 @@ msgstr ""
 msgid "Monthly"
 msgstr ""
 
-#: ../app/models/mail_notifications/mail_notification.rb:40
+#: ../app/models/mail_notifications/mail_notification.rb:41
 msgid "Subscribe"
 msgstr ""
 
@@ -6809,39 +6827,39 @@ msgstr ""
 msgid "does not appear to be a valid nfs mount path"
 msgstr ""
 
-#: ../app/models/medium.rb:64
+#: ../app/models/medium.rb:65
 msgid "%{record} is used by host in build mode %{what}"
 msgstr ""
 
-#: ../app/models/nic/base.rb:279
+#: ../app/models/nic/base.rb:280
 msgid "Unnamed"
 msgstr ""
 
-#: ../app/models/nic/base.rb:293
+#: ../app/models/nic/base.rb:294
 msgid "can't find domain with this id"
 msgstr ""
 
-#: ../app/models/nic/base.rb:309
+#: ../app/models/nic/base.rb:310
 msgid "can't delete primary interface of managed host"
 msgstr ""
 
-#: ../app/models/nic/base.rb:312
+#: ../app/models/nic/base.rb:313
 msgid "can't delete provision interface of managed host"
 msgstr ""
 
-#: ../app/models/nic/base.rb:321 ../app/models/nic/base.rb:328
+#: ../app/models/nic/base.rb:322 ../app/models/nic/base.rb:329
 msgid "interface is already set on the host"
 msgstr ""
 
-#: ../app/models/nic/base.rb:347
+#: ../app/models/nic/base.rb:348
 msgid "must be a unicast MAC address"
 msgstr ""
 
-#: ../app/models/nic/base.rb:352
+#: ../app/models/nic/base.rb:353
 msgid "can't be changed once the interface is saved"
 msgstr ""
 
-#: ../app/models/nic/base.rb:370
+#: ../app/models/nic/base.rb:371
 msgid "can't be set for this interface because it's provided by the compute resource"
 msgstr ""
 
@@ -6880,18 +6898,18 @@ msgstr ""
 msgid "Operating system version already exists"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:192 ../app/models/operatingsystem.rb:199
-#: ../app/models/operatingsystem.rb:228
+#: ../app/models/operatingsystem.rb:193 ../app/models/operatingsystem.rb:200
+#: ../app/models/operatingsystem.rb:229
 msgid ""
 "Please provide a medium provider. It can be found as @medium_provider in templ"
 "ates, or Foreman::Plugin.medium_providers_registry.find_provider(host)"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:261
+#: ../app/models/operatingsystem.rb:262
 msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
-#: ../app/models/operatingsystem.rb:289
+#: ../app/models/operatingsystem.rb:290
 msgid ""
 "Attempting to construct an operating system image filename but %s cannot be bu"
 "ilt from an image"
@@ -6946,35 +6964,35 @@ msgstr ""
 msgid "subnet"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:105
+#: ../app/models/provisioning_template.rb:106
 msgid "Must provide template kind"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:106
+#: ../app/models/provisioning_template.rb:107
 msgid "Must provide an operating system"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:139
+#: ../app/models/provisioning_template.rb:140
 msgid "No TFTP proxies defined, can't continue"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:146
+#: ../app/models/provisioning_template.rb:147
 msgid "Could not find a Configuration Template with the name \"%s\", please create one."
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:169
+#: ../app/models/provisioning_template.rb:170
 msgid "PXE files for templates %s have been deployed to all Smart Proxies"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:171
+#: ../app/models/provisioning_template.rb:172
 msgid "There was an error creating the PXE file: %s"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:228
+#: ../app/models/provisioning_template.rb:229
 msgid "can't assign operating system to Registration template"
 msgstr ""
 
-#: ../app/models/provisioning_template.rb:240
+#: ../app/models/provisioning_template.rb:241
 msgid "specified template \"%s\" kind was not found"
 msgstr ""
 
@@ -6994,57 +7012,57 @@ msgstr ""
 msgid "Input %s: "
 msgstr ""
 
-#: ../app/models/role.rb:107
+#: ../app/models/role.rb:108
 msgid "Unable to create the default role."
 msgstr ""
 
-#: ../app/models/role.rb:279
+#: ../app/models/role.rb:280
 msgid ""
 "One or more of the associated filters are invalid which prevented the role to "
 "be saved"
 msgstr ""
 
-#: ../app/models/role.rb:280
+#: ../app/models/role.rb:281
 msgid "Unable to submit role: Problem with associated filter %s"
 msgstr ""
 
-#: ../app/models/role.rb:295
+#: ../app/models/role.rb:296
 msgid "Cannot delete built-in role"
 msgstr ""
 
-#: ../app/models/role.rb:301
+#: ../app/models/role.rb:302
 msgid "This role is locked from being modified by users."
 msgstr ""
 
-#: ../app/models/role.rb:335
+#: ../app/models/role.rb:336
 msgid "some permissions were not found: %s"
 msgstr ""
 
-#: ../app/models/setting.rb:143
+#: ../app/models/setting.rb:144
 msgid "must be boolean"
 msgstr ""
 
-#: ../app/models/setting.rb:153
+#: ../app/models/setting.rb:154
 msgid "must be integer"
 msgstr ""
 
-#: ../app/models/setting.rb:166
+#: ../app/models/setting.rb:167
 msgid "must be an array"
 msgstr ""
 
-#: ../app/models/setting.rb:178
+#: ../app/models/setting.rb:179
 msgid "parsing settings type '%s' from string is not defined"
 msgstr ""
 
-#: ../app/models/setting.rb:312
+#: ../app/models/setting.rb:317
 msgid "Host owner is invalid"
 msgstr ""
 
-#: ../app/models/setting.rb:316
+#: ../app/models/setting.rb:321
 msgid "is invalid: %s"
 msgstr ""
 
-#: ../app/models/setting.rb:328
+#: ../app/models/setting.rb:333
 msgid "is not allowed to change"
 msgstr ""
 
@@ -7052,53 +7070,53 @@ msgstr ""
 msgid "Only one declaration of a proxy is allowed"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:68 ../app/models/smart_proxy.rb:158
+#: ../app/models/smart_proxy.rb:69 ../app/models/smart_proxy.rb:159
 msgid ""
 "An invalid response was received while requesting available features from this"
 " proxy"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:71 ../app/models/smart_proxy.rb:177
+#: ../app/models/smart_proxy.rb:72 ../app/models/smart_proxy.rb:178
 msgid "Unable to communicate with the proxy: %s"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:116
+#: ../app/models/smart_proxy.rb:117
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:124
+#: ../app/models/smart_proxy.rb:125
 msgid "HTTPS boot requires proxy with httpboot feature and https_port exposed setting"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:170
+#: ../app/models/smart_proxy.rb:171
 msgid ""
 "Features \"%s\" in this proxy are not recognized by Foreman. If these features c"
 "ome from a Smart Proxy plugin, make sure Foreman has the plugin installed too."
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:173
+#: ../app/models/smart_proxy.rb:174
 msgid ""
 "No features found on this proxy, please make sure you enable at least one feat"
 "ure"
 msgstr ""
 
-#: ../app/models/smart_proxy.rb:178
+#: ../app/models/smart_proxy.rb:179
 msgid "Please check the proxy is configured and running on the host."
 msgstr ""
 
-#: ../app/models/ssh_key.rb:23
+#: ../app/models/ssh_key.rb:24
 msgid "must be in OpenSSH public key format"
 msgstr ""
 
-#: ../app/models/ssh_key.rb:26
+#: ../app/models/ssh_key.rb:27
 msgid "should be a single line"
 msgstr ""
 
-#: ../app/models/ssh_key.rb:30
+#: ../app/models/ssh_key.rb:31
 msgid "could not be generated"
 msgstr ""
 
-#: ../app/models/ssh_key.rb:33
+#: ../app/models/ssh_key.rb:34
 msgid "could not be calculated"
 msgstr ""
 
@@ -7218,55 +7236,55 @@ msgstr ""
 msgid "not supported by this protocol"
 msgstr ""
 
-#: ../app/models/subnet.rb:295
+#: ../app/models/subnet.rb:298
 msgid ""
 "There must be at least one Smart Proxy present with an External IPAM plugin in"
 "stalled and configured"
 msgstr ""
 
-#: ../app/models/subnet.rb:297
+#: ../app/models/subnet.rb:300
 msgid ""
 "A Smart Proxy with an External IPAM feature enabled must be selected in the Pr"
 "oxies tab."
 msgstr ""
 
-#: ../app/models/subnet.rb:299
+#: ../app/models/subnet.rb:302
 msgid "Subnet not found in the configured External IPAM instance"
 msgstr ""
 
-#: ../app/models/subnet.rb:301
+#: ../app/models/subnet.rb:304
 msgid "Group not found in the configured External IPAM instance"
 msgstr ""
 
-#: ../app/models/subnet.rb:303
+#: ../app/models/subnet.rb:306
 msgid "Subnet not found in the specified External IPAM group"
 msgstr ""
 
-#: ../app/models/subnet.rb:330
+#: ../app/models/subnet.rb:333
 msgid "Unsupported IPAM mode for %s"
 msgstr ""
 
-#: ../app/models/subnet.rb:370
+#: ../app/models/subnet.rb:373
 msgid "must be specified if to is defined"
 msgstr ""
 
-#: ../app/models/subnet.rb:371
+#: ../app/models/subnet.rb:374
 msgid "must be specified if from is defined"
 msgstr ""
 
-#: ../app/models/subnet.rb:374 ../app/models/subnet.rb:375
+#: ../app/models/subnet.rb:377 ../app/models/subnet.rb:378
 msgid "does not belong to subnet"
 msgstr ""
 
-#: ../app/models/subnet.rb:376
+#: ../app/models/subnet.rb:379
 msgid "can't be bigger than to range"
 msgstr ""
 
-#: ../app/models/subnet.rb:381
+#: ../app/models/subnet.rb:384
 msgid "can't be updated after subnet is saved"
 msgstr ""
 
-#: ../app/models/subnet.rb:435
+#: ../app/models/subnet.rb:438
 msgid "unknown network_type"
 msgstr ""
 
@@ -7295,7 +7313,7 @@ msgid "You are not authorized to make a template default."
 msgstr ""
 
 #: ../app/models/template.rb:310 ../app/models/template.rb:329
-#: ../app/models/template_input.rb:84
+#: ../app/models/template_input.rb:65
 msgid "This template is locked. Please clone it to a new template to customize."
 msgstr ""
 
@@ -7303,120 +7321,120 @@ msgstr ""
 msgid "Cannot add audit comment to a locked template."
 msgstr ""
 
-#: ../app/models/template_input.rb:77
+#: ../app/models/template_input.rb:58
 msgid "Cannot delete template input as template is locked."
 msgstr ""
 
-#: ../app/models/template_kind.rb:14
+#: ../app/models/template_kind.rb:15
 msgid "PXELinux template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:15
+#: ../app/models/template_kind.rb:16
 msgid "PXEGrub template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:16
+#: ../app/models/template_kind.rb:17
 msgid "PXEGrub2 template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:17
+#: ../app/models/template_kind.rb:18
 msgid "iPXE template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:18
+#: ../app/models/template_kind.rb:19
 msgid "Provisioning template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:19
+#: ../app/models/template_kind.rb:20
 msgid "Finish template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:20
+#: ../app/models/template_kind.rb:21
 msgid "Script template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:21
+#: ../app/models/template_kind.rb:22
 msgid "User data template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:22
+#: ../app/models/template_kind.rb:23
 msgid "ZTP PXE template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:23
+#: ../app/models/template_kind.rb:24
 msgid "POAP PXE template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:24
+#: ../app/models/template_kind.rb:25
 msgid "Cloud-init template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:25
+#: ../app/models/template_kind.rb:26
 msgid "Host initial configuration template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:26
+#: ../app/models/template_kind.rb:27
 msgid "Registration template"
 msgstr ""
 
-#: ../app/models/template_kind.rb:32
+#: ../app/models/template_kind.rb:33
 msgid ""
 "Used when PXELinux loader is set, loads pxelinux.0 which loads content generat"
 "ed by this template."
 msgstr ""
 
-#: ../app/models/template_kind.rb:33
+#: ../app/models/template_kind.rb:34
 msgid ""
 "Used when Grub2 loader is set, loads grub/bootx64.efi which loads content gene"
 "rated by this template."
 msgstr ""
 
-#: ../app/models/template_kind.rb:34
+#: ../app/models/template_kind.rb:35
 msgid ""
 "Used when PXELinux loader is set, loads grub/grubx64.efi which loads content g"
 "enerated by this template."
 msgstr ""
 
-#: ../app/models/template_kind.rb:35
+#: ../app/models/template_kind.rb:36
 msgid "Used in iPXE environments."
 msgstr ""
 
-#: ../app/models/template_kind.rb:36
+#: ../app/models/template_kind.rb:37
 msgid ""
 "Template for OS installer, for example kickstart, preseed or jumpstart. Depend"
 "s on the operating system."
 msgstr ""
 
-#: ../app/models/template_kind.rb:37
+#: ../app/models/template_kind.rb:38
 msgid ""
 "Post-install script for preseed-based or cloud instance. Connection is made vi"
 "a SSH, credentials or key must exist and inventory IP address must match. Only"
 " used when 'user data' is not set."
 msgstr ""
 
-#: ../app/models/template_kind.rb:38
+#: ../app/models/template_kind.rb:39
 msgid "An arbitrary script, must be manually downloaded using wget/curl."
 msgstr ""
 
-#: ../app/models/template_kind.rb:39
+#: ../app/models/template_kind.rb:40
 msgid ""
 "Template with seed data for virtual or cloud instances when 'user data' flag i"
 "s set, typically cloud-init or ignition format."
 msgstr ""
 
-#: ../app/models/template_kind.rb:40
+#: ../app/models/template_kind.rb:41
 msgid "Provisioning Junos devices (Junos 12.2+)."
 msgstr ""
 
-#: ../app/models/template_kind.rb:41
+#: ../app/models/template_kind.rb:42
 msgid "Provisioning for switches running NX-OS."
 msgstr ""
 
-#: ../app/models/template_kind.rb:42
+#: ../app/models/template_kind.rb:43
 msgid "Template for cloud-init unattended endpoint."
 msgstr ""
 
-#: ../app/models/template_kind.rb:43
+#: ../app/models/template_kind.rb:44
 msgid ""
 "Contains the instructions in form of a bash script for the initial host config"
 "uration, after the host is registered in Foreman"
@@ -7426,68 +7444,68 @@ msgstr ""
 msgid "already exists"
 msgstr ""
 
-#: ../app/models/user.rb:240 ../app/models/user.rb:244
-#: ../app/models/user.rb:248
+#: ../app/models/user.rb:242 ../app/models/user.rb:246
+#: ../app/models/user.rb:250
 msgid "Anonymous admin user %s is missing, run foreman-rake db:seed"
 msgstr ""
 
-#: ../app/models/user.rb:653
+#: ../app/models/user.rb:655
 msgid "Incorrect password"
 msgstr ""
 
-#: ../app/models/user.rb:661
+#: ../app/models/user.rb:663
 msgid "A user group already exists with this name"
 msgstr ""
 
-#: ../app/models/user.rb:667
+#: ../app/models/user.rb:669
 msgid "Can't delete the last admin account"
 msgstr ""
 
-#: ../app/models/user.rb:675 ../app/models/usergroup.rb:112
+#: ../app/models/user.rb:677 ../app/models/usergroup.rb:113
 msgid "cannot be removed from the last admin account"
 msgstr ""
 
-#: ../app/models/user.rb:684
+#: ../app/models/user.rb:686
 msgid "Can't delete internal admin account"
 msgstr ""
 
-#: ../app/models/user.rb:693
+#: ../app/models/user.rb:695
 msgid "cannot be removed from an internal protected account"
 msgstr ""
 
-#: ../app/models/user.rb:699
+#: ../app/models/user.rb:701
 msgid "cannot be changed on an internal protected account"
 msgstr ""
 
-#: ../app/models/user.rb:711
+#: ../app/models/user.rb:713
 msgid "you can't assign some of roles you selected"
 msgstr ""
 
-#: ../app/models/user.rb:718
+#: ../app/models/user.rb:720
 msgid "you can't change administrator flag"
 msgstr ""
 
-#: ../app/models/user.rb:729
+#: ../app/models/user.rb:731
 msgid "cannot be changed by a non-admin user"
 msgstr ""
 
-#: ../app/models/user.rb:735
+#: ../app/models/user.rb:737
 msgid "default locations need to be user locations first"
 msgstr ""
 
-#: ../app/models/user.rb:741
+#: ../app/models/user.rb:743
 msgid "default organizations need to be user organizations first"
 msgstr ""
 
-#: ../app/models/user.rb:754
+#: ../app/models/user.rb:756
 msgid "It is not possible to change external users login"
 msgstr ""
 
-#: ../app/models/user.rb:756
+#: ../app/models/user.rb:758
 msgid "You do not have permission to edit the login"
 msgstr ""
 
-#: ../app/models/user.rb:763
+#: ../app/models/user.rb:765
 msgid "It is not possible to disable yourself"
 msgstr ""
 
@@ -7495,15 +7513,15 @@ msgstr ""
 msgid "has this role already"
 msgstr ""
 
-#: ../app/models/usergroup.rb:107
+#: ../app/models/usergroup.rb:108
 msgid "is already used by a user account"
 msgstr ""
 
-#: ../app/models/usergroup.rb:120
+#: ../app/models/usergroup.rb:121
 msgid "Can't delete the last admin user group"
 msgstr ""
 
-#: ../app/models/usergroup.rb:131
+#: ../app/models/usergroup.rb:132
 msgid "admin flag can only be modified by admins"
 msgstr ""
 
@@ -7511,31 +7529,31 @@ msgstr ""
 msgid "cannot contain itself as member"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:249
+#: ../app/registries/foreman/plugin.rb:230
 msgid "%{id} plugin requires Foreman %{matcher} but current is %{current}"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:259
+#: ../app/registries/foreman/plugin.rb:240
 msgid "%{id} plugin requires the %{plugin_name} plugin, not found"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:263
+#: ../app/registries/foreman/plugin.rb:244
 msgid ""
 "%{id} plugin requires the %{plugin_name} plugin %{matcher} but current is %{pl"
 "ugin_version}"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:378
+#: ../app/registries/foreman/plugin.rb:359
 msgid "Could not create role '%{name}': %{message}"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:380
+#: ../app/registries/foreman/plugin.rb:361
 msgid ""
 "Cannot continue because some permissions were not found, please run rake db:se"
 "ed and retry"
 msgstr ""
 
-#: ../app/registries/foreman/plugin.rb:472
+#: ../app/registries/foreman/plugin.rb:453
 msgid "Cannot register compute resource, wrong type supplied"
 msgstr ""
 
@@ -7567,11 +7585,11 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: ../app/registries/foreman/setting_manager.rb:68
+#: ../app/registries/foreman/setting_manager.rb:120
 msgid "Setting '%s' is already defined, please avoid collisions"
 msgstr ""
 
-#: ../app/registries/foreman/setting_manager.rb:69
+#: ../app/registries/foreman/setting_manager.rb:121
 msgid "Setting '%s' has an invalid type definition. Please use a valid type."
 msgstr ""
 
@@ -7859,7 +7877,6 @@ msgid "OIDC Algorithm"
 msgstr ""
 
 #: ../app/registries/foreman/settings/cfgmgmt.rb:2
-#: ../app/registries/foreman/settings/cfgmgmt.rb:32
 #: ../app/registries/menu/loader.rb:48
 msgid "Config Management"
 msgstr ""
@@ -7906,26 +7923,6 @@ msgstr ""
 
 #: ../app/registries/foreman/settings/cfgmgmt.rb:27
 msgid "Always show configuration status"
-msgstr ""
-
-#: ../app/registries/foreman/settings/cfgmgmt.rb:35
-msgid ""
-"Duration in minutes after servers reporting via Puppet are classed as out of s"
-"ync."
-msgstr ""
-
-#: ../app/registries/foreman/settings/cfgmgmt.rb:37
-msgid "Puppet interval"
-msgstr ""
-
-#: ../app/registries/foreman/settings/cfgmgmt.rb:40
-msgid ""
-"Disable host configuration status turning to out of sync for %s after report d"
-"oes not arrive within configured interval"
-msgstr ""
-
-#: ../app/registries/foreman/settings/cfgmgmt.rb:42
-msgid "%s out of sync disabled"
 msgstr ""
 
 #: ../app/registries/foreman/settings/email.rb:2
@@ -8069,100 +8066,100 @@ msgstr ""
 msgid "Invalid sendmail location, use settings.yaml for arbitrary location"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:36
+#: ../app/registries/foreman/settings/facts.rb:43
 msgid "Foreman will create the host when new facts are received"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:38
+#: ../app/registries/foreman/settings/facts.rb:45
 msgid "Create new host when facts are uploaded"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:41
+#: ../app/registries/foreman/settings/facts.rb:48
 msgid ""
 "Hosts created after a puppet run will be placed in the location this fact dict"
 "ates. The content of this fact should be the full label of the location."
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:43
+#: ../app/registries/foreman/settings/facts.rb:50
 msgid "Location fact"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:46
+#: ../app/registries/foreman/settings/facts.rb:53
 msgid ""
 "Hosts created after a puppet run will be placed in the organization this fact "
 "dictates. The content of this fact should be the full label of the organizatio"
 "n."
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:48
+#: ../app/registries/foreman/settings/facts.rb:55
 msgid "Organization fact"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:51
+#: ../app/registries/foreman/settings/facts.rb:58
 msgid ""
 "Hosts created after a puppet run that did not send a location fact will be pla"
 "ced in this location"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:53
+#: ../app/registries/foreman/settings/facts.rb:60
 msgid "Default location"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:57
+#: ../app/registries/foreman/settings/facts.rb:64
 msgid ""
 "Hosts created after a puppet run that did not send a organization fact will be"
 " placed in this organization"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:59
+#: ../app/registries/foreman/settings/facts.rb:66
 msgid "Default organization"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:63
+#: ../app/registries/foreman/settings/facts.rb:70
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:65
+#: ../app/registries/foreman/settings/facts.rb:72
 msgid "Update hostgroup from facts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:68
+#: ../app/registries/foreman/settings/facts.rb:75
 msgid "Stop updating Operating System from facts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:70
+#: ../app/registries/foreman/settings/facts.rb:77
 msgid "Ignore facts for operating system"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:73
+#: ../app/registries/foreman/settings/facts.rb:80
 msgid "Stop updating domain values from facts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:75
+#: ../app/registries/foreman/settings/facts.rb:82
 msgid "Ignore facts for domain"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:78
+#: ../app/registries/foreman/settings/facts.rb:85
 msgid "Foreman will update a host's subnet from its facts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:80
+#: ../app/registries/foreman/settings/facts.rb:87
 msgid "Update subnets from facts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:81
+#: ../app/registries/foreman/settings/facts.rb:88
 msgid "Provisioning only"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:84
+#: ../app/registries/foreman/settings/facts.rb:91
 msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:86
+#: ../app/registries/foreman/settings/facts.rb:93
 msgid "Ignore interfaces facts for provisioning"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:89
+#: ../app/registries/foreman/settings/facts.rb:96
 msgid ""
 "Skip creating or updating host network interfaces objects with identifiers mat"
 "ching these values from incoming facts. You can use * wildcard to match identi"
@@ -8170,11 +8167,11 @@ msgid ""
 "ll stored in the DB, see the 'Exclude pattern' setting for more details."
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:91
+#: ../app/registries/foreman/settings/facts.rb:98
 msgid "Ignore interfaces with matching identifier"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:94
+#: ../app/registries/foreman/settings/facts.rb:101
 msgid ""
 "Exclude pattern for all types of imported facts (puppet, ansible, rhsm). Those"
 " facts won't be stored in foreman's database. You can use * wildcard to match "
@@ -8182,35 +8179,8 @@ msgid ""
 "::ignore or even a::ignore123::b"
 msgstr ""
 
-#: ../app/registries/foreman/settings/facts.rb:96
+#: ../app/registries/foreman/settings/facts.rb:103
 msgid "Exclude pattern for facts stored in foreman"
-msgstr ""
-
-#: ../app/registries/foreman/settings/facts.rb:108
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr ""
-
-#: ../app/registries/foreman/settings/facts.rb:110
-msgid "Default Puppet environment"
-msgstr ""
-
-#: ../app/registries/foreman/settings/facts.rb:114
-msgid ""
-"Foreman will explicitly set the puppet environment in the ENC yaml output. Thi"
-"s will avoid conflicts between the environment in puppet.conf and the environm"
-"ent set in Foreman"
-msgstr ""
-
-#: ../app/registries/foreman/settings/facts.rb:116
-msgid "ENC environment"
-msgstr ""
-
-#: ../app/registries/foreman/settings/facts.rb:119
-msgid "Foreman will update a host's environment from its facts"
-msgstr ""
-
-#: ../app/registries/foreman/settings/facts.rb:121
-msgid "Update environment from facts"
 msgstr ""
 
 #: ../app/registries/foreman/settings/general.rb:2
@@ -8250,141 +8220,150 @@ msgid "Entries per page"
 msgstr ""
 
 #: ../app/registries/foreman/settings/general.rb:25
-msgid "Fix DB cache on next Foreman restart"
-msgstr ""
-
-#: ../app/registries/foreman/settings/general.rb:27
-msgid "Fix DB cache"
-msgstr ""
-
-#: ../app/registries/foreman/settings/general.rb:30
 msgid ""
 "Should the `foreman-rake db:seed` be executed on the next run of the installer"
 " modules?"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:32
+#: ../app/registries/foreman/settings/general.rb:27
 msgid "DB pending seed"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:35
+#: ../app/registries/foreman/settings/general.rb:30
 msgid ""
 "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in second"
 "s)"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:37
+#: ../app/registries/foreman/settings/general.rb:32
 msgid "Smart Proxy request timeout"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:40
-msgid "Text to be shown in the login-page footer"
+#: ../app/registries/foreman/settings/general.rb:35
+msgid ""
+"Text to be shown in the login-page footer. Keyword $VERSION is replaced by cur"
+"rent version."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:42
+#: ../app/registries/foreman/settings/general.rb:36
+#: ../app/views/about/index.html.erb:28 ../app/views/about/index.html.erb:103
+#: ../app/views/smart_proxies/plugins/_plugin_version.html.erb:2
+#: ../app/views/smart_proxies/show.html.erb:43
+msgid "Version"
+msgstr ""
+
+#: ../app/registries/foreman/settings/general.rb:37
 msgid "Login page footer text"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:45
+#: ../app/registries/foreman/settings/general.rb:40
 msgid ""
 "Show power status on host index page. This feature calls to compute resource p"
 "roviders which may lead to decreased performance on host listing page."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:47
+#: ../app/registries/foreman/settings/general.rb:42
 msgid "Show host power status"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:50
+#: ../app/registries/foreman/settings/general.rb:45
 msgid ""
 "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide pro"
 "xies must be configured at the operating system level."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:52
+#: ../app/registries/foreman/settings/general.rb:47
 msgid "HTTP(S) proxy"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:56
+#: ../app/registries/foreman/settings/general.rb:51
 msgid ""
 "Set hostnames to which requests are not to be proxied. Requests to the local h"
 "ost are excluded by default."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:58
+#: ../app/registries/foreman/settings/general.rb:53
 msgid "HTTP(S) proxy except hosts"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:61
+#: ../app/registries/foreman/settings/general.rb:56
 msgid ""
 "Whether or not to show a menu to access experimental lab features (requires re"
 "load of page)"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:63
+#: ../app/registries/foreman/settings/general.rb:58
 msgid "Show Experimental Labs"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:66
+#: ../app/registries/foreman/settings/general.rb:61
 msgid "Foreman will append domain names when new hosts are provisioned"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:68
+#: ../app/registries/foreman/settings/general.rb:63
 msgid "Append domain names to the host"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:71
+#: ../app/registries/foreman/settings/general.rb:66
 msgid ""
 "Duration in minutes after servers are classed as out of sync. You can override"
 " this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:73
+#: ../app/registries/foreman/settings/general.rb:68
 msgid "Out of sync interval"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:76
+#: ../app/registries/foreman/settings/general.rb:71
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:78
+#: ../app/registries/foreman/settings/general.rb:73
 msgid "Foreman UUID"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:82
+#: ../app/registries/foreman/settings/general.rb:77
 msgid "Language to use for new users"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:84
+#: ../app/registries/foreman/settings/general.rb:79
 msgid "Default language"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:88
+#: ../app/registries/foreman/settings/general.rb:83
 msgid "Timezone to use for new users"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:90
+#: ../app/registries/foreman/settings/general.rb:85
 msgid "Default timezone"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:94
+#: ../app/registries/foreman/settings/general.rb:89
 msgid ""
 "The instance title is shown on the top navigation bar (requires a page reload)"
 "."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:96
+#: ../app/registries/foreman/settings/general.rb:91
 msgid "Instance title"
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:99
+#: ../app/registries/foreman/settings/general.rb:94
 msgid ""
 "Duration in days to preserve audits for. Leave empty to disable the audits cle"
 "anup."
 msgstr ""
 
-#: ../app/registries/foreman/settings/general.rb:101
+#: ../app/registries/foreman/settings/general.rb:96
 msgid "Saved audits interval"
+msgstr ""
+
+#: ../app/registries/foreman/settings/general.rb:99
+msgid "Foreman will load the new UI for host details"
+msgstr ""
+
+#: ../app/registries/foreman/settings/general.rb:101
+msgid "New host details UI"
 msgstr ""
 
 #: ../app/registries/foreman/settings/notification.rb:2
@@ -8933,7 +8912,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/services/classification/values_hash_query.rb:153
-#: model_attributes.rb:276
+#: model_attributes.rb:290
 msgid "LookupKey|Default value"
 msgstr ""
 
@@ -8984,6 +8963,81 @@ msgstr ""
 
 #: ../app/services/foreman/parameters/validator.rb:39
 msgid "%{value} is not one of %{rules}"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:11
+msgid ""
+"Syntax error occurred while parsing the template %{name}, make sure you have a"
+"ll ERB tags properly closed and the Ruby syntax is valid. The Ruby error: %{me"
+"ssage}"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:15
+msgid "%{object_name} is a %{object_class}, expected a subnet"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:19
+msgid "This templates requires a host to render but none was specified"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:23
+msgid "Parameter %{name} is not set for host %{host}"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:27
+msgid ""
+"Parameter %{name} is not set in host %{host} ENC output, resolving failed on s"
+"tep %{step}"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:31
+msgid "Global setting %{name} is not accessible in safe-mode"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:35
+msgid ""
+"Unknown host status \"%{status}\" was specified in host_status macro, use one of"
+" %{statuses}"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:39
+msgid "Rendering failed, no input with name \"%{s}\" for input macro found"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:43
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:47
+msgid ""
+"Rendering failed, one or more unknown columns specified for ordering - \"%{unkn"
+"own}\""
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:51
+msgid "Hostgroup not found or not accessible"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:55
+msgid "Undefined setting '%{setting}'"
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:59
+msgid "Unsupported or no operating system found for this host."
+msgstr ""
+
+#: ../app/services/foreman/renderer/errors.rb:63
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
+#: ../app/services/foreman/renderer/scope/macros/base.rb:368
+msgid ""
+"SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Setting"
+"s > Authentication"
+msgstr ""
+
+#: ../app/services/foreman/renderer/scope/macros/snippet_rendering.rb:65
+msgid "The snippet '%{name}' threw an error: %{exc}"
 msgstr ""
 
 #: ../app/services/foreman/unattended_installation/host_verifier.rb:32
@@ -9037,7 +9091,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/services/input_type/fact_input.rb:21
 #: ../app/views/apipie_dsl/apipie_dsls/help.html.erb:288
-#: model_attributes.rb:140
+#: model_attributes.rb:132
 msgid "Fact value"
 msgstr ""
 
@@ -9221,6 +9275,179 @@ msgstr ""
 msgid "Error has occurred while communicating with %{cr}: %{e}"
 msgstr ""
 
+#: ../app/services/proxy_api/bmc.rb:16
+msgid "Unable to get BMC providers"
+msgstr ""
+
+#: ../app/services/proxy_api/bmc.rb:23
+msgid "Unable to get installed BMC providers"
+msgstr ""
+
+#: ../app/services/proxy_api/bmc.rb:43
+msgid "Unable to perform boot BMC operation"
+msgstr ""
+
+#: ../app/services/proxy_api/bmc.rb:65
+msgid "Unable to perform power BMC operation"
+msgstr ""
+
+#: ../app/services/proxy_api/bmc.rb:84
+msgid "Unable to perform identify BMC operation"
+msgstr ""
+
+#: ../app/services/proxy_api/bmc.rb:101
+msgid "Unable to perform lan BMC operation"
+msgstr ""
+
+#: ../app/services/proxy_api/dhcp.rb:14
+msgid "Unable to retrieve DHCP subnets"
+msgstr ""
+
+#: ../app/services/proxy_api/dhcp.rb:20
+msgid "Unable to retrieve DHCP subnet"
+msgstr ""
+
+#: ../app/services/proxy_api/dhcp.rb:38
+msgid "Unable to retrieve unused IP"
+msgstr ""
+
+#: ../app/services/proxy_api/dhcp.rb:56 ../app/services/proxy_api/dhcp.rb:76
+msgid "Unable to retrieve DHCP entry for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/dhcp.rb:89
+msgid "Unable to set DHCP entry"
+msgstr ""
+
+#: ../app/services/proxy_api/dhcp.rb:99
+msgid "Unable to delete DHCP entry for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/dns.rb:15
+msgid "Unable to set DNS entry"
+msgstr ""
+
+#: ../app/services/proxy_api/dns.rb:27
+msgid "Unable to delete DNS entry"
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:70
+msgid "Unable to retrieve the next available IP for subnet %{subnet} External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:102
+msgid "Unable to add IP %{ip} to the subnet %{subnet} in External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:129
+msgid "Unable to obtain groups from External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:152
+msgid "Unable to obtain group %{group} from External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:179
+msgid "Unable to obtain subnets in group %{group} from External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:203
+msgid "Unable to obtain subnet %{subnet} from External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:233
+msgid "Unable to obtain IP address for subnet %{subnet} in External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/external_ipam.rb:261
+msgid "Unable to delete IP %{ip} from the subnet %{subnet} in External IPAM."
+msgstr ""
+
+#: ../app/services/proxy_api/features.rb:11
+#: ../app/services/proxy_api/v2/features.rb:13
+msgid "Unable to detect features"
+msgstr ""
+
+#: ../app/services/proxy_api/logs.rb:11
+msgid "Unable to fetch logs"
+msgstr ""
+
+#: ../app/services/proxy_api/proxy_exception.rb:11
+msgid "for proxy"
+msgstr ""
+
+#: ../app/services/proxy_api/puppet.rb:11
+msgid "Unable to get environments from Puppet"
+msgstr ""
+
+#: ../app/services/proxy_api/puppet.rb:17
+msgid "Unable to get environment from Puppet"
+msgstr ""
+
+#: ../app/services/proxy_api/puppet.rb:27
+#: ../app/services/proxy_api/puppet.rb:35
+msgid "Unable to get classes from Puppet for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/puppetca.rb:11
+msgid "Unable to get PuppetCA autosign"
+msgstr ""
+
+#: ../app/services/proxy_api/puppetca.rb:17
+msgid "Unable to set PuppetCA autosign for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/puppetca.rb:26
+msgid "Unable to delete PuppetCA autosign for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/puppetca.rb:32
+msgid "Unable to sign PuppetCA certificate for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/puppetca.rb:41
+msgid "Unable to delete PuppetCA certificate for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/puppetca.rb:47
+msgid "Unable to get PuppetCA certificates"
+msgstr ""
+
+#: ../app/services/proxy_api/realm.rb:14
+msgid "Unable to create realm entry"
+msgstr ""
+
+#: ../app/services/proxy_api/resource.rb:145
+msgid ""
+"Unable to read SSL certification or key for proxy communication, check setting"
+"s for ssl_certificate, ssl_ca_file and ssl_priv_key and ensure they are readab"
+"le by the foreman user."
+msgstr ""
+
+#: ../app/services/proxy_api/tftp.rb:17
+msgid "Unable to set TFTP boot entry for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/tftp.rb:27
+msgid "Unable to delete TFTP boot entry for %s"
+msgstr ""
+
+#: ../app/services/proxy_api/tftp.rb:38
+msgid "Unable to fetch TFTP boot file"
+msgstr ""
+
+#: ../app/services/proxy_api/tftp.rb:50
+msgid "Unable to detect TFTP boot server"
+msgstr ""
+
+#: ../app/services/proxy_api/tftp.rb:60
+msgid "Unable to create default TFTP boot menu"
+msgstr ""
+
+#: ../app/services/proxy_api/version.rb:11
+msgid "Unable to detect version"
+msgstr ""
+
 #: ../app/services/proxy_reference_registry.rb:19
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
@@ -9237,11 +9464,11 @@ msgstr ""
 msgid "Could not locate CA certificate."
 msgstr ""
 
-#: ../app/services/report_importer.rb:32
+#: ../app/services/report_importer.rb:33
 msgid "Invalid report"
 msgstr ""
 
-#: ../app/services/report_importer.rb:100
+#: ../app/services/report_importer.rb:101
 msgid "Invalid log level: %s"
 msgstr ""
 
@@ -9412,14 +9639,6 @@ msgstr ""
 #: ../app/views/about/index.html.erb:26
 #: ../app/views/smart_proxies/index.html.erb:12
 msgid "Features"
-msgstr ""
-
-#: ../app/views/about/index.html.erb:28 ../app/views/about/index.html.erb:103
-#: ../app/views/smart_proxies/plugins/_plugin_version.html.erb:2
-#: ../app/views/smart_proxies/show.html.erb:43
-#: ../webpack/assets/javascripts/react_app/components/ExternalLogout/ExternalLogout.js:26
-#: ../webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js:32
-msgid "Version"
 msgstr ""
 
 #: ../app/views/about/index.html.erb:49
@@ -9923,7 +10142,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/apipie_dsl/apipie_dsls/help.html.erb:249
 #: ../app/views/compute_resources_vms/form/ovirt/_base.html.erb:16
-#: ../app/views/templates/_form.html.erb:12 model_attributes.rb:614
+#: ../app/views/templates/_form.html.erb:12 model_attributes.rb:628
 msgid "Template"
 msgstr ""
 
@@ -10465,12 +10684,12 @@ msgid "Create Parameter"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/common_parameters/index.html.erb:10 model_attributes.rb:452
+#: ../app/views/common_parameters/index.html.erb:10 model_attributes.rb:466
 msgid "Parameter|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/common_parameters/index.html.erb:11 model_attributes.rb:456
+#: ../app/views/common_parameters/index.html.erb:11 model_attributes.rb:472
 msgid "Parameter|Value"
 msgstr ""
 
@@ -10913,7 +11132,7 @@ msgstr ""
 #: ../app/views/compute_resources_vms/form/ec2/_base.html.erb:15
 #: ../app/views/hosts/_bmc_missing_proxy.html.erb:10
 #: ../app/views/hosts/_nics.html.erb:35 ../app/views/subnets/_form.html.erb:5
-#: model_attributes.rb:562
+#: model_attributes.rb:572
 msgid "Subnet"
 msgstr ""
 
@@ -11352,7 +11571,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/config_reports/_output.html.erb:6
 #: ../app/views/smart_proxies/logs/_list.html.erb:17
-#: ../app/views/smart_proxies/logs/_modal.html.erb:30 model_attributes.rb:342
+#: ../app/views/smart_proxies/logs/_modal.html.erb:30 model_attributes.rb:358
 msgid "Message"
 msgstr ""
 
@@ -11475,6 +11694,7 @@ msgstr ""
 
 #: ../app/views/dashboard/index.html.erb:1
 #: ../app/views/smart_proxies/show.html.erb:8
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js:13
 msgid "Overview"
 msgstr ""
 
@@ -11500,7 +11720,7 @@ msgid "Create Domain"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/domains/index.html.erb:8 model_attributes.rb:118
+#: ../app/views/domains/index.html.erb:8 model_attributes.rb:114
 msgid "Domain|Fullname"
 msgstr ""
 
@@ -11526,7 +11746,7 @@ msgid "Fact Values"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/fact_values/index.html.erb:17 model_attributes.rb:142
+#: ../app/views/fact_values/index.html.erb:17 model_attributes.rb:134
 msgid "FactValue|Value"
 msgstr ""
 
@@ -11549,7 +11769,7 @@ msgid "Selected role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/_form.html.erb:34 model_attributes.rb:458
+#: ../app/views/filters/_form.html.erb:34 model_attributes.rb:474
 msgid "Permission"
 msgstr ""
 
@@ -11600,7 +11820,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/filters/index.html.erb:24 ../app/views/roles/_form.html.erb:5
-#: model_attributes.rb:496
+#: model_attributes.rb:508
 msgid "Role"
 msgstr ""
 
@@ -11617,12 +11837,12 @@ msgid "Filter|Unlimited"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/index.html.erb:29 model_attributes.rb:150
+#: ../app/views/filters/index.html.erb:29 model_attributes.rb:142
 msgid "Filter|Override"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/filters/index.html.erb:30 model_attributes.rb:152
+#: ../app/views/filters/index.html.erb:30 model_attributes.rb:144
 msgid "Filter|Search"
 msgstr ""
 
@@ -11753,7 +11973,7 @@ msgstr ""
 #: ../app/views/hostgroups/_form.html.erb:6
 #: ../app/views/hosts/select_multiple_hostgroup.html.erb:5
 #: ../app/views/provisioning_templates/_combination.html.erb:2
-#: model_attributes.rb:212
+#: model_attributes.rb:226
 msgid "Hostgroup"
 msgstr ""
 
@@ -11801,7 +12021,7 @@ msgid "Create Host Group"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/hostgroups/index.html.erb:8 model_attributes.rb:224
+#: ../app/views/hostgroups/index.html.erb:8 model_attributes.rb:238
 msgid "Hostgroup|Name"
 msgstr ""
 
@@ -12006,7 +12226,7 @@ msgid "items selected. Uncheck to Clear"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/hosts/_list.html.erb:12 model_attributes.rb:348
+#: ../app/views/hosts/_list.html.erb:12 model_attributes.rb:362
 msgid "Model"
 msgstr ""
 
@@ -12058,10 +12278,6 @@ msgstr ""
 
 #: ../app/views/hosts/_provisioning.html.erb:4
 msgid "Templates resolved for this operating system"
-msgstr ""
-
-#: ../app/views/hosts/_provisioning.html.erb:7
-msgid "%s Template"
 msgstr ""
 
 #: ../app/views/hosts/_resources.html.erb:3
@@ -12406,17 +12622,17 @@ msgid ""
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:4 model_attributes.rb:250
+#: ../app/views/images/_list.html.erb:4 model_attributes.rb:264
 msgid "Image|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:6 model_attributes.rb:256
+#: ../app/views/images/_list.html.erb:6 model_attributes.rb:270
 msgid "Image|Username"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/images/_list.html.erb:7 model_attributes.rb:258
+#: ../app/views/images/_list.html.erb:7 model_attributes.rb:272
 msgid "Image|Uuid"
 msgstr ""
 
@@ -12635,7 +12851,7 @@ msgstr ""
 #: ../app/views/media/_form.html.erb:5
 #: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.fixtures.js:8
 #: ../webpack/assets/javascripts/react_app/components/PasswordStrength/PasswordStrength.js:38
-#: model_attributes.rb:328
+#: model_attributes.rb:344
 msgid "Medium"
 msgstr ""
 
@@ -12678,12 +12894,12 @@ msgid "Create Medium"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/media/index.html.erb:9 model_attributes.rb:336
+#: ../app/views/media/index.html.erb:9 model_attributes.rb:352
 msgid "Medium|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/media/index.html.erb:10 model_attributes.rb:340
+#: ../app/views/media/index.html.erb:10 model_attributes.rb:356
 msgid "Medium|Path"
 msgstr ""
 
@@ -12980,7 +13196,7 @@ msgid "Create Operating System"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/operatingsystems/index.html.erb:8 model_attributes.rb:444
+#: ../app/views/operatingsystems/index.html.erb:8 model_attributes.rb:458
 msgid "Operatingsystem|Title"
 msgstr ""
 
@@ -13149,7 +13365,7 @@ msgid "Create Realm"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/realms/index.html.erb:8 model_attributes.rb:482
+#: ../app/views/realms/index.html.erb:8 model_attributes.rb:494
 msgid "Realm|Name"
 msgstr ""
 
@@ -13332,12 +13548,12 @@ msgid "Create Role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/roles/index.html.erb:9 model_attributes.rb:502
+#: ../app/views/roles/index.html.erb:9 model_attributes.rb:514
 msgid "Role|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/roles/index.html.erb:10 model_attributes.rb:500
+#: ../app/views/roles/index.html.erb:10 model_attributes.rb:512
 msgid "Role|Description"
 msgstr ""
 
@@ -13384,7 +13600,7 @@ msgid "Create Smart Proxy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/smart_proxies/index.html.erb:9 model_attributes.rb:528
+#: ../app/views/smart_proxies/index.html.erb:9 model_attributes.rb:540
 msgid "SmartProxy|Name"
 msgstr ""
 
@@ -13639,17 +13855,17 @@ msgid "Create Subnet"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/subnets/index.html.erb:10 model_attributes.rb:582
+#: ../app/views/subnets/index.html.erb:10 model_attributes.rb:594
 msgid "Subnet|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/subnets/index.html.erb:11 model_attributes.rb:584
+#: ../app/views/subnets/index.html.erb:11 model_attributes.rb:596
 msgid "Subnet|Network"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/subnets/index.html.erb:13 model_attributes.rb:590
+#: ../app/views/subnets/index.html.erb:13 model_attributes.rb:604
 msgid "Subnet|Vlanid"
 msgstr ""
 
@@ -13745,7 +13961,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/taxonomies/index.html.erb:16 model_attributes.rb:610
+#: ../app/views/taxonomies/index.html.erb:16 model_attributes.rb:624
 msgid "Taxonomy|Name"
 msgstr ""
 
@@ -14036,7 +14252,7 @@ msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: ../app/views/usergroups/_form.html.erb:38
-#: ../app/views/usergroups/index.html.erb:8 model_attributes.rb:750
+#: ../app/views/usergroups/index.html.erb:8 model_attributes.rb:754
 msgid "Usergroup|Name"
 msgstr ""
 
@@ -14149,37 +14365,41 @@ msgid "Create User"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:8 model_attributes.rb:720
+#: ../app/views/users/index.html.erb:8 model_attributes.rb:724
 msgid "User|Login"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:9 model_attributes.rb:712
+#: ../app/views/users/index.html.erb:9 model_attributes.rb:716
 msgid "User|Firstname"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:10 model_attributes.rb:716
+#: ../app/views/users/index.html.erb:10 model_attributes.rb:720
 msgid "User|Lastname"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:11 model_attributes.rb:724
+#: ../app/views/users/index.html.erb:11 model_attributes.rb:728
 msgid "User|Mail"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:12 model_attributes.rb:706
+#: ../app/views/users/index.html.erb:12 model_attributes.rb:708
 msgid "User|Admin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: ../app/views/users/index.html.erb:13 model_attributes.rb:714
+#: ../app/views/users/index.html.erb:13 model_attributes.rb:718
 msgid "User|Last login on"
 msgstr ""
 
 #: ../app/views/users/logout.html.erb:2
 msgid "Are you sure you want to log out?"
+msgstr ""
+
+#: ../config/initializers/deprecations.rb:21
+msgid "Further Information"
 msgstr ""
 
 #: ../db/seeds.d/160-mail_notifications.rb:8
@@ -14188,7 +14408,7 @@ msgstr ""
 
 #: ../db/seeds.d/160-mail_notifications.rb:9
 #: ../webpack/assets/javascripts/react_app/components/ExternalLogout/ExternalLogout.js:25
-#: ../webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js:31
+#: ../webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js:29
 msgid "Welcome"
 msgstr ""
 
@@ -14277,18 +14497,6 @@ msgstr ""
 msgid "Report is ready to download"
 msgstr ""
 
-#: ../lib/core_extensions.rb:48
-msgid "%{record} is used by %{what}"
-msgstr ""
-
-#: ../lib/core_extensions.rb:51
-msgid "%{record} is being used by a hidden %{what} resource"
-msgstr ""
-
-#: ../lib/core_extensions.rb:97
-msgid "Adding would cause a cycle!"
-msgstr ""
-
 #. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 #: ../lib/foreman/gettext/support.rb:61
 msgid "locale_name"
@@ -14308,84 +14516,9 @@ msgstr ""
 msgid "Unknown password hash method: %s"
 msgstr ""
 
-#: ../lib/foreman/renderer/errors.rb:11
-msgid ""
-"Syntax error occurred while parsing the template %{name}, make sure you have a"
-"ll ERB tags properly closed and the Ruby syntax is valid. The Ruby error: %{me"
-"ssage}"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:15
-msgid "%{object_name} is a %{object_class}, expected a subnet"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:19
-msgid "This templates requires a host to render but none was specified"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:23
-msgid "Parameter %{name} is not set for host %{host}"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:27
-msgid ""
-"Parameter %{name} is not set in host %{host} ENC output, resolving failed on s"
-"tep %{step}"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:31
-msgid "Global setting %{name} is not accessible in safe-mode"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:35
-msgid ""
-"Unknown host status \"%{status}\" was specified in host_status macro, use one of"
-" %{statuses}"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:39
-msgid "Rendering failed, no input with name \"%{s}\" for input macro found"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:43
-msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:47
-msgid ""
-"Rendering failed, one or more unknown columns specified for ordering - \"%{unkn"
-"own}\""
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:51
-msgid "Hostgroup not found or not accessible"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:55
-msgid "Undefined setting '%{setting}'"
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:59
-msgid "Unsupported or no operating system found for this host."
-msgstr ""
-
-#: ../lib/foreman/renderer/errors.rb:63
-msgid "Unkown '%{klass}' resource class"
-msgstr ""
-
-#: ../lib/foreman/renderer/scope/macros/base.rb:363
-msgid ""
-"SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Setting"
-"s > Authentication"
-msgstr ""
-
-#: ../lib/foreman/renderer/scope/macros/snippet_rendering.rb:65
-msgid "The snippet '%{name}' threw an error: %{exc}"
-msgstr ""
-
-#: ../lib/foreman/telemetry_sinks/statsd_sink.rb:12
-#: ../lib/foreman/telemetry_sinks/statsd_sink.rb:17
-#: ../lib/foreman/telemetry_sinks/statsd_sink.rb:22
+#: ../lib/foreman/telemetry_sinks/statsd_sink.rb:13
+#: ../lib/foreman/telemetry_sinks/statsd_sink.rb:18
+#: ../lib/foreman/telemetry_sinks/statsd_sink.rb:23
 msgid "Metric already registered: %s"
 msgstr ""
 
@@ -14421,177 +14554,6 @@ msgstr[1] ""
 msgid ""
 "hostname can contain only lowercase letters, numbers, dashes and dots accordin"
 "g to RFC921, RFC952 and RFC1123"
-msgstr ""
-
-#: ../lib/proxy_api/bmc.rb:16
-msgid "Unable to get BMC providers"
-msgstr ""
-
-#: ../lib/proxy_api/bmc.rb:23
-msgid "Unable to get installed BMC providers"
-msgstr ""
-
-#: ../lib/proxy_api/bmc.rb:43
-msgid "Unable to perform boot BMC operation"
-msgstr ""
-
-#: ../lib/proxy_api/bmc.rb:64
-msgid "Unable to perform power BMC operation"
-msgstr ""
-
-#: ../lib/proxy_api/bmc.rb:82
-msgid "Unable to perform identify BMC operation"
-msgstr ""
-
-#: ../lib/proxy_api/bmc.rb:98
-msgid "Unable to perform lan BMC operation"
-msgstr ""
-
-#: ../lib/proxy_api/dhcp.rb:14
-msgid "Unable to retrieve DHCP subnets"
-msgstr ""
-
-#: ../lib/proxy_api/dhcp.rb:20
-msgid "Unable to retrieve DHCP subnet"
-msgstr ""
-
-#: ../lib/proxy_api/dhcp.rb:38
-msgid "Unable to retrieve unused IP"
-msgstr ""
-
-#: ../lib/proxy_api/dhcp.rb:56 ../lib/proxy_api/dhcp.rb:76
-msgid "Unable to retrieve DHCP entry for %s"
-msgstr ""
-
-#: ../lib/proxy_api/dhcp.rb:89
-msgid "Unable to set DHCP entry"
-msgstr ""
-
-#: ../lib/proxy_api/dhcp.rb:99
-msgid "Unable to delete DHCP entry for %s"
-msgstr ""
-
-#: ../lib/proxy_api/dns.rb:15
-msgid "Unable to set DNS entry"
-msgstr ""
-
-#: ../lib/proxy_api/dns.rb:27
-msgid "Unable to delete DNS entry"
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:70
-msgid "Unable to retrieve the next available IP for subnet %{subnet} External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:102
-msgid "Unable to add IP %{ip} to the subnet %{subnet} in External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:129
-msgid "Unable to obtain groups from External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:152
-msgid "Unable to obtain group %{group} from External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:179
-msgid "Unable to obtain subnets in group %{group} from External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:203
-msgid "Unable to obtain subnet %{subnet} from External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:233
-msgid "Unable to obtain IP address for subnet %{subnet} in External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/external_ipam.rb:261
-msgid "Unable to delete IP %{ip} from the subnet %{subnet} in External IPAM."
-msgstr ""
-
-#: ../lib/proxy_api/features.rb:11 ../lib/proxy_api/v2/features.rb:13
-msgid "Unable to detect features"
-msgstr ""
-
-#: ../lib/proxy_api/logs.rb:11
-msgid "Unable to fetch logs"
-msgstr ""
-
-#: ../lib/proxy_api/proxy_exception.rb:11
-msgid "for proxy"
-msgstr ""
-
-#: ../lib/proxy_api/puppet.rb:11
-msgid "Unable to get environments from Puppet"
-msgstr ""
-
-#: ../lib/proxy_api/puppet.rb:17
-msgid "Unable to get environment from Puppet"
-msgstr ""
-
-#: ../lib/proxy_api/puppet.rb:27 ../lib/proxy_api/puppet.rb:35
-msgid "Unable to get classes from Puppet for %s"
-msgstr ""
-
-#: ../lib/proxy_api/puppetca.rb:11
-msgid "Unable to get PuppetCA autosign"
-msgstr ""
-
-#: ../lib/proxy_api/puppetca.rb:17
-msgid "Unable to set PuppetCA autosign for %s"
-msgstr ""
-
-#: ../lib/proxy_api/puppetca.rb:26
-msgid "Unable to delete PuppetCA autosign for %s"
-msgstr ""
-
-#: ../lib/proxy_api/puppetca.rb:32
-msgid "Unable to sign PuppetCA certificate for %s"
-msgstr ""
-
-#: ../lib/proxy_api/puppetca.rb:41
-msgid "Unable to delete PuppetCA certificate for %s"
-msgstr ""
-
-#: ../lib/proxy_api/puppetca.rb:47
-msgid "Unable to get PuppetCA certificates"
-msgstr ""
-
-#: ../lib/proxy_api/realm.rb:14
-msgid "Unable to create realm entry"
-msgstr ""
-
-#: ../lib/proxy_api/resource.rb:137
-msgid ""
-"Unable to read SSL certification or key for proxy communication, check setting"
-"s for ssl_certificate, ssl_ca_file and ssl_priv_key and ensure they are readab"
-"le by the foreman user."
-msgstr ""
-
-#: ../lib/proxy_api/tftp.rb:17
-msgid "Unable to set TFTP boot entry for %s"
-msgstr ""
-
-#: ../lib/proxy_api/tftp.rb:27
-msgid "Unable to delete TFTP boot entry for %s"
-msgstr ""
-
-#: ../lib/proxy_api/tftp.rb:38
-msgid "Unable to fetch TFTP boot file"
-msgstr ""
-
-#: ../lib/proxy_api/tftp.rb:50
-msgid "Unable to detect TFTP boot server"
-msgstr ""
-
-#: ../lib/proxy_api/tftp.rb:60
-msgid "Unable to create default TFTP boot menu"
-msgstr ""
-
-#: ../lib/proxy_api/version.rb:11
-msgid "Unable to detect version"
 msgstr ""
 
 #: ../lib/ws_proxy.rb:55
@@ -14953,7 +14915,7 @@ msgid "Theme"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/ExternalLogout/ExternalLogout.js:38
+#: ../webpack/assets/javascripts/react_app/components/ExternalLogout/ExternalLogout.js:37
 msgid "Click to log in again"
 msgstr ""
 
@@ -15000,47 +14962,47 @@ msgid "No errors detected"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:14
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:18
 msgid "Host %s has been removed successfully"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:45
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:39
 msgid "Delete host?"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:46
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:40
 msgid "Delete host"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:74
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:79
 msgid "Host %s will be built next boot"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:107
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:121
 msgid "Legacy UI"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:120
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js:134
 msgid "Share feedback"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js:48
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js:49
 msgid "Recent Audits"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js:50
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js:51
 msgid "All audits"
 msgstr ""
 
 #:
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js:59
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js:60
 msgid "No Results found"
 msgstr ""
 
@@ -15164,11 +15126,11 @@ msgstr ""
 msgid "Manage Host's Statuses"
 msgstr ""
 
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/index.js:141
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/index.js:150
 msgid "Created %s by %s"
 msgstr ""
 
-#: ../webpack/assets/javascripts/react_app/components/HostDetails/index.js:145
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/index.js:154
 msgid "(updated %s)"
 msgstr ""
 
@@ -15226,7 +15188,7 @@ msgstr ""
 msgid "Loading"
 msgstr ""
 
-#: ../webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js:37
+#: ../webpack/assets/javascripts/react_app/components/LoginPage/LoginPage.js:32
 msgid "Log in to your account"
 msgstr ""
 
@@ -15705,7 +15667,7 @@ msgstr ""
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/SmartProxy.js:22
-#: model_attributes.rb:524
+#: model_attributes.rb:536
 msgid "Smart proxy"
 msgstr ""
 
@@ -16048,1421 +16010,1431 @@ msgid "ComputeResource|Uuid"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:112
-msgid "Config group"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:114
-msgid "ConfigGroup|Name"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:120
+#: model_attributes.rb:116
 msgid "Domain|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:122
-msgid "Environment"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:124
-msgid "Environment|Name"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:126
+#: model_attributes.rb:118
 msgid "External usergroup"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:128
+#: model_attributes.rb:120
 msgid "ExternalUsergroup|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:130
+#: model_attributes.rb:122
 msgid "Fact name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:132
+#: model_attributes.rb:124
 msgid "FactName|Ancestry"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:134
+#: model_attributes.rb:126
 msgid "FactName|Compose"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:136
+#: model_attributes.rb:128
 msgid "FactName|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:138
+#: model_attributes.rb:130
 msgid "FactName|Short name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:144
+#: model_attributes.rb:136
 msgid "Feature"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:146
+#: model_attributes.rb:138
 msgid "Feature|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:154
+#: model_attributes.rb:146
 msgid "Filter|Taxonomy search"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:148
+msgid "Foreman internal"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:150
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:152
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:154
+msgid "Foreman register/registration facet"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:156
-msgid "Host::Base|Build"
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:158
-msgid "Host::Base|Build errors"
+msgid "Host::Base|Build"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:160
-msgid "Host::Base|Certname"
+msgid "Host::Base|Build errors"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:162
-msgid "Host::Base|Comment"
+msgid "Host::Base|Certname"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:164
-msgid "Host::Base|Disk"
+msgid "Host::Base|Comment"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:166
-msgid "Host::Base|Enabled"
+msgid "Host::Base|Disk"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:168
-msgid "Host::Base|Global status"
+msgid "Host::Base|Enabled"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:170
-msgid "Host::Base|Grub pass"
+msgid "Host::Base|Global status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:172
-msgid "Host::Base|Image file"
+msgid "Host::Base|Grub pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:174
-msgid "Host::Base|Initiated at"
+msgid "Host::Base|Image file"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:176
-msgid "Host::Base|Installed at"
+msgid "Host::Base|Initiated at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:178
-msgid "Host::Base|Last compile"
+msgid "Host::Base|Installed at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:180
-msgid "Host::Base|Last report"
+msgid "Host::Base|Last compile"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:182
-msgid "Host::Base|Lookup value matcher"
+msgid "Host::Base|Last report"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:184
-msgid "Host::Base|Managed"
+msgid "Host::Base|Lookup value matcher"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:186
-msgid "Host::Base|Name"
+msgid "Host::Base|Managed"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:188
-msgid "Host::Base|Otp"
+msgid "Host::Base|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:190
-msgid "Host::Base|Owner type"
+msgid "Host::Base|Otp"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:192
-msgid "Host::Base|Provision method"
+msgid "Host::Base|Owner type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:194
-msgid "Host::Base|Pxe loader"
+msgid "Host::Base|Provision method"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:196
-msgid "Host::Base|Root pass"
+msgid "Host::Base|Pxe loader"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:198
-msgid "Host::Base|Use image"
+msgid "Host::Base|Root pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:200
-msgid "Host::Base|Uuid"
+msgid "Host::Base|Use image"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:202
-msgid "Host config group"
+msgid "Host::Base|Uuid"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:204
-msgid "HostConfigGroup|Host type"
+msgid "Host facets/base"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:206
-msgid "Host status/status"
+msgid "HostFacets::Base|Boot time"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:208
-msgid "HostStatus::Status|Reported at"
+msgid "HostFacets::Base|Cores"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:210
-msgid "HostStatus::Status|Status"
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:212
+msgid "HostFacets::Base|Foreman instance"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:214
-msgid "Hostgroup|Ancestry"
+msgid "HostFacets::Base|Ram"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:216
-msgid "Hostgroup|Description"
+msgid "HostFacets::Base|Sockets"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:218
-msgid "Hostgroup|Grub pass"
+msgid "HostFacets::Base|Virtual"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:220
-msgid "Hostgroup|Image file"
+msgid "Host status/status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:222
-msgid "Hostgroup|Lookup value matcher"
+msgid "HostStatus::Status|Reported at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:226
-msgid "Hostgroup|Pxe loader"
+#: model_attributes.rb:224
+msgid "HostStatus::Status|Status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:228
-msgid "Hostgroup|Root pass"
+msgid "Hostgroup|Ancestry"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:230
-msgid "Hostgroup|Title"
+msgid "Hostgroup|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:232
-msgid "Hostgroup|Use image"
+msgid "Hostgroup|Grub pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:234
-msgid "Hostgroup|Vm defaults"
+msgid "Hostgroup|Image file"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:236
-msgid "Http proxy"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:238
-msgid "HttpProxy|Name"
+msgid "Hostgroup|Lookup value matcher"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:240
-msgid "HttpProxy|Password"
+msgid "Hostgroup|Pxe loader"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:242
-msgid "HttpProxy|Url"
+msgid "Hostgroup|Root pass"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:244
-msgid "HttpProxy|Username"
+msgid "Hostgroup|Title"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:246
+msgid "Hostgroup|Use image"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:248
-msgid "Image|Iam role"
+msgid "Hostgroup|Vm defaults"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:250
+msgid "Http proxy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:252
-msgid "Image|Password"
+msgid "HttpProxy|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:254
-msgid "Image|User data"
+msgid "HttpProxy|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:260
-msgid "Jwt secret"
+#: model_attributes.rb:256
+msgid "HttpProxy|Url"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:258
+msgid "HttpProxy|Username"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:262
-msgid "JwtSecret|Token"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:264
-msgid "Key pair"
+msgid "Image|Iam role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:266
-msgid "KeyPair|Name"
+msgid "Image|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:268
-msgid "KeyPair|Public"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:270
-msgid "KeyPair|Secret"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:272
-msgid "Lookup key"
+msgid "Image|User data"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:274
-msgid "LookupKey|Avoid duplicates"
+msgid "Jwt secret"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:276
+msgid "JwtSecret|Token"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:278
-msgid "LookupKey|Description"
+msgid "Key pair"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:280
-msgid "LookupKey|Hidden value"
+msgid "KeyPair|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:282
-msgid "LookupKey|Key"
+msgid "KeyPair|Public"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:284
-msgid "LookupKey|Key type"
+msgid "KeyPair|Secret"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:286
-msgid "LookupKey|Merge default"
+msgid "Lookup key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:288
-msgid "LookupKey|Merge overrides"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:290
-msgid "LookupKey|Omit"
+msgid "LookupKey|Avoid duplicates"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:292
-msgid "LookupKey|Override"
+msgid "LookupKey|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:294
-msgid "LookupKey|Path"
+msgid "LookupKey|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:296
-msgid "LookupKey|Required"
+msgid "LookupKey|Key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:298
-msgid "LookupKey|Validator rule"
+msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:300
-msgid "LookupKey|Validator type"
+msgid "LookupKey|Lookup values count"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:302
-msgid "Lookup value"
+msgid "LookupKey|Merge default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:304
-msgid "LookupValue|Match"
+msgid "LookupKey|Merge overrides"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:306
-msgid "LookupValue|Omit"
+msgid "LookupKey|Omit"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:308
-msgid "LookupValue|Value"
+msgid "LookupKey|Override"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:310
-msgid "Mail notification"
+msgid "LookupKey|Path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:312
-msgid "MailNotification|Default interval"
+msgid "LookupKey|Required"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:314
-msgid "MailNotification|Description"
+msgid "LookupKey|Validator rule"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:316
-msgid "MailNotification|Mailer"
+msgid "LookupKey|Validator type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:318
-msgid "MailNotification|Method"
+msgid "Lookup value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:320
-msgid "MailNotification|Name"
+msgid "LookupValue|Match"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:322
-msgid "MailNotification|Queryable"
+msgid "LookupValue|Omit"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:324
-msgid "MailNotification|Subscriptable"
+msgid "LookupValue|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:326
-msgid "MailNotification|Subscription type"
+msgid "Mail notification"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:328
+msgid "MailNotification|Default interval"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:330
-msgid "Medium|Config path"
+msgid "MailNotification|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:332
-msgid "Medium|Image path"
+msgid "MailNotification|Mailer"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:334
-msgid "Medium|Media path"
+msgid "MailNotification|Method"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:336
+msgid "MailNotification|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:338
-msgid "Medium|Os family"
+msgid "MailNotification|Queryable"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:344
-msgid "Message|Digest"
+#: model_attributes.rb:340
+msgid "MailNotification|Subscriptable"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:342
+msgid "MailNotification|Subscription type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:346
-msgid "Message|Value"
+msgid "Medium|Config path"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:348
+msgid "Medium|Image path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:350
-msgid "Model|Hardware model"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:352
-msgid "Model|Info"
+msgid "Medium|Media path"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:354
-msgid "Model|Name"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:356
-msgid "Model|Vendor class"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:358
-msgid "Nic::Base|Attached devices"
+msgid "Medium|Os family"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:360
-msgid "Nic::Base|Attached to"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:362
-msgid "Nic::Base|Attrs"
+msgid "Message|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:364
-msgid "Nic::Base|Bond options"
+msgid "Model|Hardware model"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:366
-msgid "Nic::Base|Compute attributes"
+msgid "Model|Info"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:368
-msgid "Nic::Base|Identifier"
+msgid "Model|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:370
-msgid "Nic::Base|Ip"
+msgid "Model|Vendor class"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:372
-msgid "Nic::Base|Ip6"
+msgid "Nic::Base|Attached devices"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:374
-msgid "Nic::Base|Link"
+msgid "Nic::Base|Attached to"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:376
-msgid "Nic::Base|Mac"
+msgid "Nic::Base|Attrs"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:378
-msgid "Nic::Base|Managed"
+msgid "Nic::Base|Bond options"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:380
-msgid "Nic::Base|Mode"
+msgid "Nic::Base|Compute attributes"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:382
-msgid "Nic::Base|Name"
+msgid "Nic::Base|Identifier"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:384
-msgid "Nic::Base|Password"
+msgid "Nic::Base|Ip"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:386
-msgid "Nic::Base|Primary"
+msgid "Nic::Base|Ip6"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:388
-msgid "Nic::Base|Provider"
+msgid "Nic::Base|Link"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:390
-msgid "Nic::Base|Provision"
+msgid "Nic::Base|Mac"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:392
-msgid "Nic::Base|Tag"
+msgid "Nic::Base|Managed"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:394
-msgid "Nic::Base|Username"
+msgid "Nic::Base|Mode"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:396
-msgid "Nic::Base|Virtual"
+msgid "Nic::Base|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:398
-msgid "Notification"
+msgid "Nic::Base|Password"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:400
-msgid "Notification|Actions"
+msgid "Nic::Base|Primary"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:402
-msgid "Notification|Audience"
+msgid "Nic::Base|Provider"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:404
-msgid "Notification|Expired at"
+msgid "Nic::Base|Provision"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:406
-msgid "Notification|Message"
+msgid "Nic::Base|Tag"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:408
-msgid "Notification|Subject type"
+msgid "Nic::Base|Username"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:410
-msgid "Notification blueprint"
+msgid "Nic::Base|Virtual"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:412
-msgid "NotificationBlueprint|Actions"
+msgid "Notification"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:414
-msgid "NotificationBlueprint|Expires in"
+msgid "Notification|Actions"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:416
-msgid "NotificationBlueprint|Group"
+msgid "Notification|Audience"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:418
-msgid "NotificationBlueprint|Level"
+msgid "Notification|Expired at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:420
-msgid "NotificationBlueprint|Message"
+msgid "Notification|Message"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:422
-msgid "NotificationBlueprint|Name"
+msgid "Notification|Subject type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:424
-msgid "Notification recipient"
+msgid "Notification blueprint"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:426
-msgid "NotificationRecipient|Seen"
+msgid "NotificationBlueprint|Actions"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:428
-msgid "Operatingsystem"
+msgid "NotificationBlueprint|Expires in"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:430
-msgid "Operatingsystem|Description"
+msgid "NotificationBlueprint|Group"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:432
-msgid "Operatingsystem|Major"
+msgid "NotificationBlueprint|Level"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:434
-msgid "Operatingsystem|Minor"
+msgid "NotificationBlueprint|Message"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:436
-msgid "Operatingsystem|Name"
+msgid "NotificationBlueprint|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:438
-msgid "Operatingsystem|Nameindicator"
+msgid "Notification recipient"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:440
-msgid "Operatingsystem|Password hash"
+msgid "NotificationRecipient|Seen"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:442
-msgid "Operatingsystem|Release name"
+msgid "Operatingsystem"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:444
+msgid "Operatingsystem|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:446
-msgid "Parameter"
+msgid "Operatingsystem|Major"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:448
-msgid "Parameter|Hidden value"
+msgid "Operatingsystem|Minor"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:450
-msgid "Parameter|Key type"
+msgid "Operatingsystem|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:452
+msgid "Operatingsystem|Nameindicator"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:454
-msgid "Parameter|Priority"
+msgid "Operatingsystem|Password hash"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:456
+msgid "Operatingsystem|Release name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:460
-msgid "Permission|Name"
+msgid "Parameter"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:462
-msgid "Permission|Resource type"
+msgid "Parameter|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:464
-msgid "Personal access token"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:466
-msgid "PersonalAccessToken|Expires at"
+msgid "Parameter|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:468
-msgid "PersonalAccessToken|Last used at"
+msgid "Parameter|Priority"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:470
-msgid "PersonalAccessToken|Name"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:472
-msgid "PersonalAccessToken|Revoked"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:474
-msgid "PersonalAccessToken|Token"
+msgid "Parameter|Searchable value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:476
-msgid "Puppetclass"
+msgid "Permission|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:478
-msgid "Puppetclass|Name"
+msgid "Permission|Resource type"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:480
+msgid "Personal access token"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:482
+msgid "PersonalAccessToken|Expires at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:484
-msgid "Realm|Realm type"
+msgid "PersonalAccessToken|Last used at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:486
-msgid "Report"
+msgid "PersonalAccessToken|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:488
-msgid "Report|Metrics"
+msgid "PersonalAccessToken|Revoked"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:490
-msgid "Report|Origin"
+msgid "PersonalAccessToken|Token"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:492
-msgid "Report|Reported at"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:494
-msgid "Report|Status"
+#: model_attributes.rb:496
+msgid "Realm|Realm type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:498
-msgid "Role|Builtin"
+msgid "Report"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:500
+msgid "Report|Metrics"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:502
+msgid "Report|Origin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:504
-msgid "Role|Origin"
+msgid "Report|Reported at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:506
-msgid "Setting"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:508
-msgid "Setting|Category"
+msgid "Report|Status"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:510
-msgid "Setting|Default"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:512
-msgid "Setting|Description"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:514
-msgid "Setting|Encrypted"
+msgid "Role|Builtin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:516
-msgid "Setting|Full name"
+msgid "Role|Origin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:518
-msgid "Setting|Name"
+msgid "Setting"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:520
-msgid "Setting|Settings type"
+msgid "Setting|Category"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:522
-msgid "Setting|Value"
+msgid "Setting|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:524
+msgid "Setting|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:526
-msgid "SmartProxy|Expired logs"
+msgid "Setting|Encrypted"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:528
+msgid "Setting|Full name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:530
-msgid "SmartProxy|Url"
+msgid "Setting|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:532
-msgid "Smart proxy feature"
+msgid "Setting|Settings type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:534
-msgid "SmartProxyFeature|Capabilities"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:536
-msgid "SmartProxyFeature|Settings"
+msgid "Setting|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:538
-msgid "Source"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:540
-msgid "Source|Digest"
+msgid "SmartProxy|Expired logs"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:542
-msgid "Source|Value"
+msgid "SmartProxy|Url"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:544
-msgid "Ssh key"
+msgid "Smart proxy feature"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:546
-msgid "SshKey|Fingerprint"
+msgid "SmartProxyFeature|Capabilities"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:548
-msgid "SshKey|Key"
+msgid "SmartProxyFeature|Settings"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:550
-msgid "SshKey|Length"
+msgid "Source"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:552
-msgid "SshKey|Name"
+msgid "Source|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:554
-msgid "Stored value"
+msgid "Ssh key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:556
-msgid "StoredValue|Expire at"
+msgid "SshKey|Fingerprint"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:558
-msgid "StoredValue|Key"
+msgid "SshKey|Key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:560
-msgid "StoredValue|Value"
+msgid "SshKey|Length"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:562
+msgid "SshKey|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:564
-msgid "Subnet|Boot mode"
+msgid "Stored value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:566
-msgid "Subnet|Description"
+msgid "StoredValue|Expire at"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:568
-msgid "Subnet|Dns primary"
+msgid "StoredValue|Key"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:570
-msgid "Subnet|Dns secondary"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:572
-msgid "Subnet|From"
+msgid "StoredValue|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:574
-msgid "Subnet|Gateway"
+msgid "Subnet|Boot mode"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:576
-msgid "Subnet|Ipam"
+msgid "Subnet|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:578
-msgid "Subnet|Mask"
+msgid "Subnet|Dns primary"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:580
-msgid "Subnet|Mtu"
+msgid "Subnet|Dns secondary"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:582
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:584
+msgid "Subnet|From"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:586
-msgid "Subnet|Priority"
+msgid "Subnet|Gateway"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:588
-msgid "Subnet|To"
+msgid "Subnet|Ipam"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:590
+msgid "Subnet|Mask"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:592
-msgid "Table preference"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:594
-msgid "TablePreference|Columns"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:596
-msgid "TablePreference|Name"
+msgid "Subnet|Mtu"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:598
-msgid "Taxable taxonomy"
+msgid "Subnet|Nic delay"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:600
-msgid "TaxableTaxonomy|Taxable type"
+msgid "Subnet|Priority"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:602
-msgid "Taxonomy"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:604
-msgid "Taxonomy|Ancestry"
+msgid "Subnet|To"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:606
-msgid "Taxonomy|Description"
+msgid "Table preference"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:608
-msgid "Taxonomy|Ignore types"
+msgid "TablePreference|Columns"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:610
+msgid "TablePreference|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:612
-msgid "Taxonomy|Title"
+msgid "Taxable taxonomy"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:614
+msgid "TaxableTaxonomy|Taxable type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:616
-msgid "Template|Default"
+msgid "Taxonomy"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:618
-msgid "Template|Locked"
+msgid "Taxonomy|Ancestry"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:620
-msgid "Template|Name"
+msgid "Taxonomy|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:622
-msgid "Template|Os family"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:624
-msgid "Template|Snippet"
+msgid "Taxonomy|Ignore types"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:626
-msgid "Template|Template"
+msgid "Taxonomy|Title"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:628
-msgid "Template|Vendor"
+#: model_attributes.rb:630
+msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:632
-msgid "TemplateInput|Advanced"
+msgid "Template|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:634
-msgid "TemplateInput|Description"
+msgid "Template|Locked"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:636
-msgid "TemplateInput|Fact name"
+msgid "Template|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:638
-msgid "TemplateInput|Input type"
+msgid "Template|Os family"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:640
-msgid "TemplateInput|Name"
+msgid "Template|Snippet"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:642
-msgid "TemplateInput|Options"
+msgid "Template|Template"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:644
-msgid "TemplateInput|Puppet class name"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:646
-msgid "TemplateInput|Puppet parameter name"
+msgid "Template|Vendor"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:648
-msgid "TemplateInput|Required"
+msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:650
-msgid "TemplateInput|Resource type"
+msgid "TemplateInput|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:652
-msgid "TemplateInput|Value type"
+msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:654
-msgid "TemplateInput|Variable name"
+msgid "TemplateInput|Fact name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:656
-msgid "Template kind"
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:658
-msgid "TemplateKind|Description"
+msgid "TemplateInput|Input type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:660
-msgid "TemplateKind|Name"
+msgid "TemplateInput|Name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:662
+msgid "TemplateInput|Options"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:664
-msgid "Token|Expires"
+msgid "TemplateInput|Puppet class name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:666
-msgid "Token|Value"
+msgid "TemplateInput|Puppet parameter name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:668
-msgid "Trend"
+msgid "TemplateInput|Required"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:670
-msgid "Trend|Fact name"
+msgid "TemplateInput|Resource type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:672
-msgid "Trend|Fact value"
+msgid "TemplateInput|Value type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:674
-msgid "Trend|Name"
+msgid "TemplateInput|Variable name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:676
-msgid "Trend|Trendable type"
+msgid "Template kind"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:678
-msgid "Trend counter"
+msgid "TemplateKind|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:680
-msgid "TrendCounter|Count"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:682
-msgid "TrendCounter|Interval end"
+msgid "TemplateKind|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:684
-msgid "TrendCounter|Interval start"
+msgid "Token|Expires"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:686
-msgid "Upgrade task"
+msgid "Token|Value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:688
-msgid "UpgradeTask|Always run"
+msgid "Upgrade task"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:690
-msgid "UpgradeTask|Last run time"
+msgid "UpgradeTask|Always run"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:692
-msgid "UpgradeTask|Long running"
+msgid "UpgradeTask|Last run time"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:694
-msgid "UpgradeTask|Name"
+msgid "UpgradeTask|Long running"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:696
-msgid "UpgradeTask|Ordering"
+msgid "UpgradeTask|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:698
-msgid "UpgradeTask|Skip failure"
+msgid "UpgradeTask|Ordering"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:700
-msgid "UpgradeTask|Subject"
+msgid "UpgradeTask|Skip failure"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:702
+msgid "UpgradeTask|Subject"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:704
 msgid "UpgradeTask|Task name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:708
+#: model_attributes.rb:710
 msgid "User|Avatar hash"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:710
+#: model_attributes.rb:712
 msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:718
-msgid "User|Locale"
+#: model_attributes.rb:714
+msgid "User|Disabled"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:722
-msgid "User|Lower login"
+msgid "User|Locale"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:726
-msgid "User|Mail enabled"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:728
-msgid "User|Password hash"
+msgid "User|Lower login"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:730
-msgid "User|Password salt"
+msgid "User|Mail enabled"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:732
-msgid "User|Timezone"
+msgid "User|Password hash"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:734
-msgid "User mail notification"
+msgid "User|Password salt"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:736
-msgid "UserMailNotification|Interval"
+msgid "User|Timezone"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:738
-msgid "UserMailNotification|Last sent"
+msgid "User mail notification"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:740
-msgid "UserMailNotification|Mail query"
+msgid "UserMailNotification|Interval"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:742
-msgid "User role"
+msgid "UserMailNotification|Last sent"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:744
-msgid "UserRole|Owner type"
+msgid "UserMailNotification|Mail query"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:746
-msgid "Usergroup"
+msgid "User role"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:748
-msgid "Usergroup|Admin"
+msgid "UserRole|Owner type"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:750
+msgid "Usergroup"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:752
-msgid "Usergroup member"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-#: model_attributes.rb:754
-msgid "UsergroupMember|Member type"
+msgid "Usergroup|Admin"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:756
-msgid "Widget"
+msgid "Usergroup member"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:758
-msgid "Widget|Col"
+msgid "UsergroupMember|Member type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:760
-msgid "Widget|Data"
+msgid "Widget"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:762
-msgid "Widget|Name"
+msgid "Widget|Col"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:764
-msgid "Widget|Row"
+msgid "Widget|Data"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:766
-msgid "Widget|Sizex"
+msgid "Widget|Name"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:768
-msgid "Widget|Sizey"
+msgid "Widget|Row"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 #: model_attributes.rb:770
+msgid "Widget|Sizex"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:772
+msgid "Widget|Sizey"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+#: model_attributes.rb:774
 msgid "Widget|Template"
 msgstr ""

--- a/locale/foreman.pot
+++ b/locale/foreman.pot
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: foreman 1.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-22 15:17+0100\n"
-"PO-Revision-Date: 2021-12-22 15:17+0100\n"
+"POT-Creation-Date: 2021-12-22 15:18+0100\n"
+"PO-Revision-Date: 2021-12-22 15:18+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -88,6 +88,10 @@ msgstr ""
 msgid "Error generating IP: %s"
 msgstr ""
 
+#: ../app/assets/javascripts/host_edit.js:943
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
+
 #: ../app/assets/javascripts/host_edit.js:947
 msgid "Manual configuration is needed."
 msgstr ""
@@ -111,6 +115,18 @@ msgstr ""
 
 #: ../app/assets/javascripts/host_edit_interfaces.js:198
 msgid "Managed"
+msgstr ""
+
+#: ../app/assets/javascripts/host_edit_interfaces.js:269
+msgid ""
+"Some other interface is already set as primary. Are you sure you want to use t"
+"his one instead?"
+msgstr ""
+
+#: ../app/assets/javascripts/host_edit_interfaces.js:289
+msgid ""
+"Some other interface is already set as provisioning. Are you sure you want to "
+"use this one instead?"
 msgstr ""
 
 #: ../app/assets/javascripts/host_edit_interfaces.js:359
@@ -10525,6 +10541,7 @@ msgid "You are not authorized to perform this action."
 msgstr ""
 
 #: ../app/views/common/403.html.erb:11
+#: ../webpack/assets/javascripts/react_app/components/PermissionDenied/PermissionDenied.js:53
 msgid ""
 "Please request one of the required permissions listed below from a Foreman adm"
 "inistrator:"
@@ -12378,6 +12395,7 @@ msgid "Disassociate host"
 msgstr ""
 
 #: ../app/views/hosts/index.html.erb:7
+#: ../webpack/assets/javascripts/hosts/tableCheckboxes.js:165
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -12462,6 +12480,7 @@ msgid "Rebuild orchestration configuration"
 msgstr ""
 
 #: ../app/views/hosts/review_before_build.html.erb:3
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js:96
 msgid "The following errors may prevent a successful build:"
 msgstr ""
 
@@ -14576,6 +14595,12 @@ msgstr ""
 msgid "Connected"
 msgstr ""
 
+#: ../webpack/assets/javascripts/bundle_novnc.js:59
+msgid ""
+"The connection was closed by the browser. please verify that the certificate a"
+"uthority is valid"
+msgstr ""
+
 #: ../webpack/assets/javascripts/bundle_novnc.js:91
 #: ../webpack/assets/javascripts/foreman_tools.js:51
 msgid "Loading..."
@@ -14587,6 +14612,10 @@ msgstr ""
 
 #: ../webpack/assets/javascripts/dashboard/index.js:63
 msgid "Remove widget"
+msgstr ""
+
+#: ../webpack/assets/javascripts/dashboard/index.js:64
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 #: ../webpack/assets/javascripts/dashboard/index.js:75
@@ -14619,6 +14648,10 @@ msgstr ""
 
 #: ../webpack/assets/javascripts/foreman_compute_resource.js:118
 msgid "Test connection was successful"
+msgstr ""
+
+#: ../webpack/assets/javascripts/foreman_compute_resource.js:125
+msgid "An error occurred while testing the connection: "
 msgstr ""
 
 #: ../webpack/assets/javascripts/foreman_editor.js:10
@@ -14703,13 +14736,48 @@ msgstr ""
 msgid "Please select hosts to perform action on."
 msgstr ""
 
+#: ../webpack/assets/javascripts/hosts/tableCheckboxes.js:144
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 #: ../webpack/assets/javascripts/hosts/tableCheckboxes.js:151
 msgid "Undo selection"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/Architectures/Welcome.js:12
+msgid ""
+"Each entry represents a particular hardware architecture, most commonly <b>x86"
+"_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system fam"
+"ily, which includes <b>sparc</b> based systems."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/Architectures/Welcome.js:16
+msgid ""
+"Before you proceed to using Foreman you should provide information about one o"
+"r more architectures."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/Architectures/Welcome.js:20
+msgid ""
+"Each architecture can also be associated with more than one operating system a"
+"nd a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/AuditsList/ShowInlineRequestUuid.js:11
 msgid "Request UUID"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/AuditsList/ShowInlineRequestUuid.js:19
+msgid ""
+"HTTP request UUID, clicking will filter audits for this request. It can also b"
+"e used for searching in application logs."
 msgstr ""
 
 #:
@@ -14737,8 +14805,22 @@ msgstr ""
 msgid "Filter audits for this resource only"
 msgstr ""
 
+#: ../webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js:8
+msgid ""
+"The authentication process currently requires an LDAP provider, such as <em>Fr"
+"eeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js:13
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 #: ../webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js:18
 msgid "Learn more about LDAP authentication in the documentation."
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js:21
+msgid "Foreman can use External service for user information and authentication."
 msgstr ""
 
 #: ../webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js:26
@@ -14815,6 +14897,14 @@ msgstr ""
 #: ../webpack/assets/javascripts/react_app/components/ConfigReports/ConfigReports.js:56
 #: ../webpack/assets/javascripts/react_app/components/HostStatuses/Status/Details.js:9
 msgid "Total"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/ConfigReports/Welcome.js:7
+msgid ""
+"If you wish to configure Puppet to forward its reports to Foreman, please foll"
+"ow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> an"
+"d <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
 msgstr ""
 
 #:
@@ -14957,6 +15047,16 @@ msgid "Review before build"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js:68
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js:78
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/BuildModal.js:90
 msgid "No errors detected"
 msgstr ""
@@ -14967,6 +15067,20 @@ msgid "Host %s has been removed successfully"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:26
+msgid ""
+"This will delete the VM and its disks. This behavior can be changed via global"
+" setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:29
+msgid ""
+"VM and its disks will not be deleted. This behavior can be changed via global "
+"setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:39
 msgid "Delete host?"
 msgstr ""
@@ -14974,6 +15088,13 @@ msgstr ""
 #:
 #: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:40
 msgid "Delete host"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js:58
+msgid ""
+"Are you sure you want to delete host {host}? This action is irreversible. {cas"
+"cade}"
 msgstr ""
 
 #:
@@ -15054,6 +15175,11 @@ msgstr ""
 #:
 #: ../webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js:85
 msgid "MAC address"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/HostDetails/ExperimentalAlert.js:19
+msgid "This page redesign is experimental and under active development."
 msgstr ""
 
 #:
@@ -15170,8 +15296,18 @@ msgid "Any Location"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIcon.js:20
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIcon.js:42
 msgid "Confirm Action"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIcon.js:43
+msgid "You are about to stop impersonating other user. Are you sure?"
 msgstr ""
 
 #:
@@ -15314,6 +15450,13 @@ msgid "Setting was successfully updated."
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingValueField.js:53
+msgid ""
+"This setting is encrypted. Empty input field is displayed instead of the setti"
+"ng value."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js:100
 msgid "Not set"
 msgstr ""
@@ -15321,6 +15464,11 @@ msgstr ""
 #:
 #: ../webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableHelpers.js:101
 msgid "Empty"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingCell.js:21
+msgid "This setting is defined in the configuration file %s and is read-only."
 msgstr ""
 
 #:
@@ -15356,6 +15504,13 @@ msgstr ""
 #:
 #: ../webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.js:42
 msgid "There was a problem processing the request. Please try again."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/components/common/ErrorBoundary/index.js:46
+msgid ""
+"To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foreman"
+"Url( '/links/issues' )}>click here</a>"
 msgstr ""
 
 #:
@@ -15475,6 +15630,13 @@ msgid "Your New Personal Access Token"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.js:16
+msgid ""
+"Make sure to copy your new personal access token now. You won’t be able to see"
+" it again!"
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokenForm.js:21
 msgid "Cannot be in the past"
 msgstr ""
@@ -15515,6 +15677,13 @@ msgid "Inactive Personal Access Tokens"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokens.js:76
+msgid ""
+"Personal Access Tokens allow you to authenticate API requests without using yo"
+"ur password, e.g. "
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokensActions.js:34
 msgid "Token was successfully revoked."
 msgstr ""
@@ -15547,6 +15716,12 @@ msgstr ""
 
 #: ../webpack/assets/javascripts/react_app/redux/actions/common/forms.js:42
 msgid "Error submitting data:"
+msgstr ""
+
+#: ../webpack/assets/javascripts/react_app/redux/actions/common/forms.js:90
+msgid ""
+"Oh no! Something went wrong while submitting the form, the server returned the"
+" following error: %s"
 msgstr ""
 
 #:
@@ -15610,6 +15785,13 @@ msgid "Generating ..."
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Command.js:19
+msgid ""
+"There was an error while generating the command, see the logs for more informa"
+"tion."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Command.js:26
 msgid "Registration command"
 msgstr ""
@@ -15622,6 +15804,11 @@ msgstr ""
 #:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js:22
 msgid "no"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js:23
+msgid "Inherit from host parameter"
 msgstr ""
 
 #:
@@ -15640,8 +15827,28 @@ msgid "Setup REX"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js:43
+msgid ""
+"Setup remote execution. If set to `Yes`, SSH keys will be installed on the reg"
+"istered host. The inherited value is based on the `host_registration_remote_ex"
+"ecution` parameter. It can be inherited e.g. from host group, operating system"
+", organization. When overridden, the selected value will be stored on host par"
+"ameter level."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js:63
 msgid "Setup Insights"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js:68
+msgid ""
+"If set to `Yes`, Insights client will be installed and registered on Red Hat f"
+"amily operating systems. It has no effect on other OS families that do not sup"
+"port it. The inherited value is based on the `host_registration_insights` para"
+"meter. It can be inherited e.g. from host group, operating system, organizatio"
+"n. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 #:
@@ -15650,8 +15857,33 @@ msgid "Insecure"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Insecure.js:16
+msgid ""
+"If the target machine does not trust the host SSL certificate, the initial con"
+"nection could be subject to Man in the middle attack. If you accept the risk a"
+"nd do not require the server authenticity to be verified, you can enable insec"
+"ure argument for the initial curl. Note that all subsequent communication is t"
+"hen properly secured, because the initial request deploys the SSL certificate "
+"for the rest of the registration process."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/OperatingSystem.js:79
+msgid ""
+"Required for registration without subscription manager. Can be specified by ho"
+"st group."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Packages.js:12
 msgid "Install packages"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Packages.js:19
+msgid ""
+"Install packages on the host when registered. Can be set by `host_packages` pa"
+"rameter"
 msgstr ""
 
 #:
@@ -15660,8 +15892,26 @@ msgid "Repository"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Repository.js:23
+msgid ""
+"A repository to be added before the registration is performed. It can be usefu"
+"l to e.g. make the subscription-manager packages available for the purpose of "
+"the registration. For Red Hat family distributions, this should be the URL of "
+"the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's t"
+"he whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Repository.js:38
 msgid "Repository GPG key URL"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Repository.js:42
+msgid ""
+"If packages are GPG signed, the public key can be specified here to verify the"
+" packages signatures. It needs to be specified in the ascii form with the GPG "
+"public key header."
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -15672,9 +15922,26 @@ msgid "Smart proxy"
 msgstr ""
 
 #:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/SmartProxy.js:26
+msgid ""
+"Only smart proxies with enabled `Templates` and `Registration` features are di"
+"splayed."
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Taxonomies.js:29
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
+#:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Taxonomies.js:43
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Taxonomies.js:70
 msgid "Not specified"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/Taxonomies.js:56
+msgid "If no location is set, the default location of the user is assumed."
 msgstr ""
 
 #:
@@ -15705,6 +15972,11 @@ msgstr ""
 #:
 #: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js:214
 msgid "Advanced"
+msgstr ""
+
+#:
+#: ../webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js:226
+msgid "There was an error while loading the data, see the logs for more information."
 msgstr ""
 
 #: ../webpack/assets/javascripts/react_app/routes/common/EmptyPage/index.js:10

--- a/locale/fr/foreman.po
+++ b/locale/fr/foreman.po
@@ -81,9 +81,6 @@ msgstr[1] "%s Messages Log"
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s Paramètres mis à jour, voir ci-dessous pour plus d'informations"
 
-msgid "%s Template"
-msgstr "%s Modèle"
-
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
 msgstr[0] "%s VM en échec pendant le traitement : consulter les journaux pour plus de détails."
@@ -134,9 +131,6 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "Il y a %s mois"
 msgstr[1] "Il y a %s mois"
-
-msgid "%s out of sync disabled"
-msgstr "Désynchronisation de %s désactivée"
 
 msgid "%s selected hosts"
 msgstr "%s hôtes sélectionnés"
@@ -1649,14 +1643,6 @@ msgstr "Rapports de configuration"
 msgid "Config Retrieval"
 msgstr "Récupération de configuration"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "Groupe de configuration"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "Nom"
-
 msgid "Configuration"
 msgstr "Configuration"
 
@@ -2209,9 +2195,6 @@ msgstr "Élément de menu PXE par défaut dans le modèle global - 'local', 'dis
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr "Éléments de menu PXE par défaut dans le modèle local - 'local', 'local_chain_hd0' ou personnalisé, utiliser 'blank' (vide) comme modèle par défaut"
 
-msgid "Default Puppet environment"
-msgstr "Environnements Puppet par défaut"
-
 msgid "Default VNC Keyboard"
 msgstr "Clavier VNC par défaut"
 
@@ -2518,9 +2501,6 @@ msgstr "Désactiver les alertes pour les hôtes sélectionnés"
 msgid "Disable all filters overriding"
 msgstr "Désactiver tous les filtres surchargés"
 
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "Désactiver l'état de la configuration de l'hôte à 'out of sync' pour %s, après que le rapport n'est pas arrivé dans l'intervalle configuré"
-
 msgid "Disable overriding"
 msgstr "Supprimer Remplacement"
 
@@ -2643,17 +2623,11 @@ msgstr ""
 msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr "Durée en minutes après laquelle les serveurs sont classés comme non synchronisés. Vous pouvez modifier cette durée sur les hôtes en ajoutant le paramètre \"outofsync_interval\"."
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr "Durée en minutes après laquelle les serveurs envoyant des rapports via Puppet sont classés comme désynchronisés."
-
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "Environnement de l'ENC"
 
 msgid "ERROR or FATAL"
 msgstr "ERROR ou FATAL"
@@ -2775,10 +2749,6 @@ msgstr "Adresse IP de fin pour l'autosuggestion d'adresse IP"
 msgid "Entries per page"
 msgstr "Entrées par page"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Environnement"
-
 msgid "Environment IDs"
 msgstr "IDs des environnements"
 
@@ -2793,10 +2763,6 @@ msgstr "Variable d'environnement contenant le statut de vérification d'un certi
 
 msgid "Environments got deprecated from this endpoint."
 msgstr "Les environnements ont été dépréciés à partir de ce point de terminaison."
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Nom"
 
 msgid "Error"
 msgstr "Erreur"
@@ -3139,8 +3105,7 @@ msgid "Failed to perform rollback on %{task} - %{e}"
 msgstr "Impossible d'effectuer un rollback sur %{task} - %{e}"
 
 msgid "Failed to power up a compute %{compute_resource} instance %{name}: %{e}"
-msgstr ""
-"Échec de la création d'une instance %{compute_resource} de compute %{name}: %{e}"
+msgstr "Échec de la création d'une instance %{compute_resource} de compute %{name}: %{e}"
 
 msgid "Failed to reboot %s."
 msgstr "Impossible de redémarrer %s"
@@ -3310,12 +3275,6 @@ msgstr "Fixer %s échec de concordance"
 msgid "Fix All Mismatches"
 msgstr "Corriger toutes les erreurs de concordance"
 
-msgid "Fix DB cache"
-msgstr "Correction cache DB"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Correction du cache DB au prochain redémarrage de Foreman"
-
 msgid "Fix Mismatches"
 msgstr "Corriger les erreurs de concordance"
 
@@ -3403,6 +3362,10 @@ msgstr "Foreman a détecté des définitions de classes inconnues dans votre bas
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr "ID d’instance de Foreman, identifie uniquement cette instance Foreman."
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "Les matchers de Foreman sont hérités par les dépendants lors de l'évaluation des paramètres pour les groupes d’hôtes, les organisations et les lieux."
 
@@ -3411,6 +3374,10 @@ msgstr "Foreman gère désormais le cycle d'installation pour %s"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman ne gère plus le cycle d'installation pour %s"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "L'heure de création du rapport Foreman est <em>%s</em>"
@@ -3448,17 +3415,14 @@ msgstr "Foreman créera l'hôte à la réception d'un rapport"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman créé l'hôte à la réception des facts"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "L'environnement Puppet par défaut si Foreman n'arrive pas à le détecter automatiquement"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Foreman va supprimer la machine virtuelle si le script d'attribution renvoie un code d'erreur de sortie non nul"
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr "Foreman évaluera par défaut les paramètres de classe smart de l'hôte dans cette ordre"
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman fournira l'environnement Puppet dans la sortie YAML de l'ENC. Cela supprime  les incohérences entre l'environnement dans puppet.conf et l'environnement dans l'ENC."
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "Foreman n'enverra pas ce paramètre dans la sortie de la classification."
@@ -3468,9 +3432,6 @@ msgstr "Foreman va interpréter le code ERB des paramètres lors de la sortie de
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman interrogera le resolver local au lieu des champs SOA/NS autoritaires pour la zone"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman mettra à jour l'environnement de l'hôte d'après les facts"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "Foreman mettra à jour le sous-réseau de l'hôte d'après ses facts"
@@ -3489,6 +3450,18 @@ msgstr "Foreman utilisera les UUID des certificats plutôt que les noms de machi
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman utilisera le nom court au lieu du FQDN lors de la création des machines virtuelles"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr "Le formulaire a été créé avec succès."
@@ -3516,6 +3489,9 @@ msgstr "Plein écran"
 
 msgid "Function not available for %s"
 msgstr "Fonction non disponible pour %s"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "Heure UTC"
@@ -3823,12 +3799,12 @@ msgstr "Entrées d'audit de l'hôte"
 msgid "Host built"
 msgstr "Hôte construit"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "Groupe de configuration de l'hôte"
-
 msgid "Host details"
 msgstr "Détails de l'Hôte"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "Groupe d'hôtes"
@@ -3966,8 +3942,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "Type d'hôte"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4261,8 +4261,8 @@ msgstr "ID de l'organisation dans laquelle enregistrer l'hôte."
 msgid "ID of the Organization to register the host in."
 msgstr "ID de l'organisation dans laquelle enregistrer l'hôte."
 
-msgid "ID of the Smart Proxy"
-msgstr "Id du proxy smart"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
+msgstr ""
 
 msgid "ID of the user"
 msgstr "ID de l'utilisateur"
@@ -5442,6 +5442,10 @@ msgid "LookupKey|Key type"
 msgstr "Type de clé"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr "Fusionner la valeur par défaut"
 
@@ -5689,10 +5693,6 @@ msgid "Message"
 msgstr "Message"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Valeur"
 
@@ -5910,6 +5910,9 @@ msgstr "La nouvelle connexion a été rejetée avec la raison : %"
 
 msgid "New filter"
 msgstr "Nouveau filtre"
+
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Suivant"
@@ -6735,6 +6738,10 @@ msgstr "Nom"
 msgid "Parameter|Priority"
 msgstr "Priorité"
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
+
 msgid "Parameter|Type"
 msgstr "Type"
 
@@ -7159,6 +7166,9 @@ msgstr "Proxies"
 msgid "Proxy ID to use within this realm"
 msgstr "ID Proxy à utiliser dans ce domaine"
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr "La référence du proxy doit être { :relation => [:column_name, ...] }"
 
@@ -7207,9 +7217,6 @@ msgstr "Classe Puppet"
 msgid "Puppet error state"
 msgstr "État d'erreur Puppet"
 
-msgid "Puppet interval"
-msgstr "Intervalle de temps pour Puppet"
-
 msgid "Puppet parameter"
 msgstr "Paramètre Puppet"
 
@@ -7218,14 +7225,6 @@ msgstr "ID du Proxy Puppet"
 
 msgid "Puppet summary"
 msgstr "Résumé Puppet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppetclass"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Nom"
 
 msgid "Query"
 msgstr "Requête"
@@ -8490,10 +8489,6 @@ msgid "Source"
 msgstr "Source"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Valeur"
 
@@ -8656,6 +8651,10 @@ msgid "Subnet|Dns secondary"
 msgstr "DNS Secondaire"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "De"
 
@@ -8682,6 +8681,10 @@ msgstr "Nom"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Réseau"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8918,12 +8921,20 @@ msgid "TemplateInput|Advanced"
 msgstr "Avancé"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "Description"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "Nom du fait"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8992,6 +9003,10 @@ msgid "Template|Default"
 msgstr "Valeur par défaut"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Verrouillé"
 
@@ -9042,8 +9057,8 @@ msgstr "Courrier de test"
 msgid "Tester"
 msgstr "Testeur"
 
-msgid "Text to be shown in the login-page footer"
-msgstr "Texte qui doit s'afficher sans le pied de page de la page de connexion"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
+msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
@@ -9526,42 +9541,6 @@ msgstr[1] "Total de %{hosts} hôtes"
 
 msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "Tendance"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Compteur de tendance"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Nombre"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "Fin de l'intervalle"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "Début de l'intervalle"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Nom du fact"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Valeur du fact"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Nom"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Type de tendance"
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "Drapeau True/False pour déterminer si un hôte est géré ou non géré. Note : Cette valeur détermine aussi si certains paramètres sont obligatoires."
@@ -10052,9 +10031,6 @@ msgstr "Mise à jour d'une image"
 msgid "Update an operating system"
 msgstr "Mettre à jour un système d'exploitation"
 
-msgid "Update environment from facts"
-msgstr "Mise à jour de l'environnement depuis les facts"
-
 msgid "Update external user group"
 msgstr "Mettre à jour un groupe d'utilisateurs externe"
 
@@ -10288,6 +10264,10 @@ msgstr "Hash de l'avatar"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Description"
 msgstr "Description"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
@@ -11296,8 +11276,7 @@ msgstr "joindre un group d'utilisateur externe avec ce groupe d'utilisateur"
 msgid "list"
 msgstr "liste"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "Français"
 

--- a/locale/fr/foreman.po
+++ b/locale/fr/foreman.po
@@ -421,6 +421,9 @@ msgstr "Notification lorsqu'un hôte signale une erreur de configuration"
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Un problème est survenu lors de la détection du type d'hôte : %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr "Résumé du rapport de modifications d'audit <br>Filtré par une requête si nécessaire"
 
@@ -706,6 +709,9 @@ msgstr "Une adresse email est nécessaire, merci de mettre à jour vos détails 
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "Une erreur s'est produite lors de la tentative de connexion à LDAP. Veuillez vérifier que l'hôte source de l'authentification est accessible depuis l'hôte Foreman et qu'il est en ligne."
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr "Une erreur s'est produite"
 
@@ -774,6 +780,12 @@ msgstr "Êtes-vous sûr de supprimer l'hôte %s ? Cette action est irréversible
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Voulez-vous supprimer l'hôte %s ? Cela supprime la machine virtuelle et ses disques, et est irréversible. Ce comportement peut être modifié via le paramètre global « Détruire la VM associée lors de la suppression de l'hôte »."
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr "Etes-vous certain de vouloir vous déconnecter ?"
@@ -1157,6 +1169,9 @@ msgstr "Soyez conscient que c'est dangereux et que cela peut entraîner des prob
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr "En raison de la longueur variable des balises ERB, l'indentation de la syntaxe ERB peut sembler désordonnée. La syntaxe ERB ignore l'espace blanc. Une méthode de traitement de l'indentation consiste à déclarer la balise ERB au début de chaque nouvelle ligne, puis à utiliser l'espace blanc à l'intérieur de la balise ERB pour souligner les relations au sein de la syntaxe, par exemple :"
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "Modèle vide"
 
@@ -1252,6 +1267,9 @@ msgstr "Créer le fichier PXE par défaut"
 
 msgid "Build duration"
 msgstr "Temps de construction"
+
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
 
 msgid "Build errors"
 msgstr "Erreurs de construction"
@@ -2635,6 +2653,12 @@ msgstr "ERROR ou FATAL"
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr "Les capacités de rendu de chaque type de modèle diffèrent légèrement; par exemple un modèle de provisionnement est toujours rendu pour un seul objet hôte et une variable @host est donc définie. Un autre exemple est un modèle de rapport, dans lequel des macros spécifiques de formatage de rapport sont disponibles."
 
@@ -3347,6 +3371,12 @@ msgstr "Rapport d'audits de Foreman"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr "Foreman peut stocker des informations sur la configuration réseau d'un hôte qu'il provisionne. Elles peuvent servir à configurer la machine virtuelle, à attribuer les adresses IP correctes et les ressources réseau, et à configurer le système d'exploitation correctement pendant le processus d'attribution."
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr "Foreman considère qu'un domaine et une zone DNS sont la même chose. Autrement dit, si vous envisagez de gérer un site dont toutes les machines sont de la forme hostname. somewhere.com, alors le domaine est somewhere.com. Cela permet à Foreman d'associer une variable puppet à un domaine/site et d'ajouter automatiquement cette variable à toutes les demandes de nœuds externes faites par les machines de ce site. Le champ fullname est utilisé pour la lisibilité humaine dans les rapports et autres pages qui se réfèrent à des domaines, et également disponible comme paramètre de nœud externe."
 
@@ -3642,6 +3672,9 @@ msgstr "Le démarrage HTTP UEFI nécessite un proxy avec la fonction httpboot"
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr "Le démarrage HTTP nécessite un proxy avec la fonction httpboot et le paramètre http_port exposed"
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
+msgstr ""
 
 msgid "HTTP(S) proxy"
 msgstr "Proxy HTTP(S)"
@@ -4406,8 +4439,20 @@ msgstr "Si vous utilisez ERB en valeur de paramètre, la valeur résultante va �
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "Si coché, Foreman va générer une erreur s'il n'y a pas de valeur par défaut et aucune valeur n'est retournée "
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
 msgstr "Si le type de propriétaire est spécifié, le propriétaire doit être spécifié également."
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
 msgstr "S'il est fixé, le rapport prévu sera transmis par courrier électronique. Utilisez « %s » pour séparer plusieurs adresses électroniques."
@@ -4417,6 +4462,9 @@ msgstr "Si l'indicateur Géré est désactivé, aucun des services ne sera confi
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
 msgstr "Si l'indicateur Géré est activé, les services externes tels que DHCP, DNS et TFTP seront configurés en fonction des informations fournies."
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
+msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
 msgstr "Si le modèle prend en charge la sélection du format, l'utilisateur peut choisir le format préféré.<br> En général, le modèle doit utiliser la macro report_render.<br><br>Si l'utilisation de cette macro ne se trouve pas dans le modèle,<br>ce champ est désactivé et le format de sortie est par défaut du texte brut.<br><br>Si le modèle prend en charge la sélection du filtre, mais n'utilise pas la macro report_render, <br>afin d'activer ce champ, ajoutez un commentaire au modèle en mentionnant le nom de la macro report_render."
@@ -4432,6 +4480,9 @@ msgstr "Si ce paramètre doit être modifié dans le fichier, il aura le chemin 
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Si vous pensez qu'il s'agisse d'une erreur de Foreman, merci d'ouvrir un ticket avec"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr "Ignorer les faits pour le domaine"
@@ -4578,6 +4629,9 @@ msgstr "Informations sur le paramètre mis à jour"
 msgid "Infrastructure"
 msgstr "Infrastructure"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Hérité du parent (%s)"
 
@@ -4628,6 +4682,9 @@ msgstr "Insécurité"
 
 msgid "Install packages"
 msgstr "Installer les packages"
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
+msgstr ""
 
 msgid "Installation Media"
 msgstr "Média d'installation"
@@ -5573,6 +5630,9 @@ msgstr "Convertible en indice"
 msgid "MailNotification|Subscription type"
 msgstr "Type d'abonnement"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Gérer"
 
@@ -6411,6 +6471,9 @@ msgstr "Nom du système d'exploitation depuis facter; par exemple RedHat"
 msgid "Off"
 msgstr "Désactivé"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "Ok"
 
@@ -6459,6 +6522,9 @@ msgstr "Une seule déclaration de proxy est autorisée à être déclarée"
 
 msgid "Only one volume can be bootable"
 msgstr "Un seul volume peut être déclaré pour le démarrage"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "Oh !"
@@ -6869,6 +6935,9 @@ msgstr "Le jeton d'accès personnel a été créé."
 
 msgid "Personal Access Tokens"
 msgstr "Jeton d'accès personnel"
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Personal access token"
@@ -7553,6 +7622,9 @@ msgstr "Demande d'UUID"
 msgid "Require SSL for smart proxies"
 msgstr "SSL pour les smart proxies requis"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "Obligatoire sauf si l'utilisateur se trouve dans une source d'authentification externe"
 
@@ -8138,6 +8210,9 @@ msgstr "Installation d’Insight"
 msgid "Setup REX"
 msgstr "Configuration du REX"
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8372,6 +8447,11 @@ msgstr "Signer"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr "Comme le type d'entrée variable, cependant, il charge la valeur d'un paramètre spécifique de la classe intelligente. L'utilisateur doit spécifier la classe Puppet et le nom du paramètre de classe smart lors de la définition de l'entrée."
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "L'hôte sur cette page est sélectionné."
@@ -8462,6 +8542,12 @@ msgstr "Certaines interfaces sont invalides"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Certaines interfaces ne sont pas valides. Veuillez vérifier le tableau ci-dessous."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9125,6 +9211,9 @@ msgstr "Le code Ruby à l'intérieur des balises ERB contient généralement des
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr "L'algorithme utilisé pour coder le JWT dans le fournisseur OpenID."
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "La source d'authentification de vos groupes d'utilisateurs externes n'a pas pu se connecter à LDAP avec les identifiants fournis. Vérifiez la validité des identifiants."
 
@@ -9136,6 +9225,9 @@ msgstr "Le type de CPU fourni dans cette machine. C'est principalement utilisé 
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Le type de machine remonté par Open Boot Prom. C'est utilisé principalement pour les installations Solaris et peut être laissé vide pour les autres architectures. Cette valeur peut être déterminée sous Solaris via la commande \"uname -i|cut -f2 -d\"."
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr "La console n'est pas disponible car la VM n'est pas activée"
@@ -9328,6 +9420,12 @@ msgstr "Il y a eu une erreur dans la liste des VMs : %(status)s %(statusText)s"
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "Il y a eu une erreur de rendu du modèle %{name}  : %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "Aucune interface pont active trouvée avec libvirt, si le listing n'est pas supporté, vous pouvez définir le nom du pont manuellement (par ex. br0)"
 
@@ -9342,6 +9440,9 @@ msgstr "Cette opération <b>va supprimer</b> les machines virtuelles liées et l
 
 msgid "This IP address has already been reserved in External IPAM"
 msgstr "Cette adresse IP a déjà été réservée dans l'IPAM externe"
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
 msgstr "Cet email a été envoyé par Foreman identifié par UUID %{uuid}"
@@ -9397,6 +9498,9 @@ msgstr "Cela peut être dû à l'indisponibilité d'un service requis, à un app
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Ceci peut prendre un certain temps, car tous les hôtes, faits et rapports <b>seront supprimés</b> également.  %s Ce comportement peut être modifié via le paramètre global « Détruire la machine virtuelle associée lors de la suppression de l'hôte »."
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr "Cela offre la même fonctionnalité que <code><%</code> mais lorsque le modèle est exécuté, la sortie de code est insérée dans le modèle. Ceci est utile pour la substitution de variables, par exemple :"
 
@@ -9417,6 +9521,12 @@ msgstr "Ce service est disponible pour les utilisateurs non authentifiés"
 
 msgid "This service is only available for authenticated users"
 msgstr "Ce service est disponible pour les utilisateurs authentifiés uniquement"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "Ce modèle est verrouillé et ne peux pas être supprimé."
@@ -9444,6 +9554,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "Cette valeur est aussi utilisé pour l'interface primaire de l'hôte."
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9491,6 +9604,9 @@ msgid ""
 msgstr ""
 "Pour actualiser la liste des utilisateurs, cliquez sur l'onglet « Groupes \n"
 "                externes », puis sur « Actualiser »."
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
+msgstr ""
 
 msgid "Today"
 msgstr "Aujourd'hui"
@@ -10343,6 +10459,9 @@ msgstr "Attributs de machine virtuelle (%s)"
 msgid "VM already associated with a host"
 msgstr "Cette VM est déjà associée à un hôte"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "Cette VM est associée à l'hôte %s"
 
@@ -10482,6 +10601,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] "Attention ! Ceci va supprimer %{name} de l’utilisateur %{number}. Êtes-vous sûr ?"
 msgstr[1] "Attention ! Ceci va supprimer %{name} des utilisateurs %{number}. Êtes-vous sûr ?"
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "Attention : Cette action va supprimer l'hôte et toutes ses données !"
@@ -10683,11 +10805,17 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr "Vous êtes sur le point de supprimer %s. Êtes-vous sûr ?"
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "Vous êtes sur le point de déverrouiller un modèle verrouillé."
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
 msgstr "Vous usurpez déjà une autre identité, cliquez sur l'icône d'usurpation d'identité dans la barre supérieure avant de commencer une nouvelle usurpation d'identité."
+
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
 
 msgid "You are not authorized to lock templates."
 msgstr "Vous n'êtes pas autorisé à verrouiller les modèles."

--- a/locale/it/foreman.po
+++ b/locale/it/foreman.po
@@ -383,6 +383,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Si è verificato un errore durante il rilevamento del tipo di host: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -668,6 +671,9 @@ msgstr ""
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr ""
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -735,6 +741,12 @@ msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr ""
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 msgid "Are you sure you want to log out?"
@@ -1119,6 +1131,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr ""
 
@@ -1213,6 +1228,9 @@ msgid "Build PXE Default"
 msgstr "Creazione PXE predefinito"
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2597,6 +2615,12 @@ msgstr "ERROR o FATAL"
 msgid "EUI-64"
 msgstr ""
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3304,6 +3328,12 @@ msgstr ""
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3598,6 +3628,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4363,7 +4396,19 @@ msgstr ""
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "Se selezionato, verrà generato un errore se nessun valore predefinito è stato impostato, o se nessun dispositivo di confronto fornisce un valore. "
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4373,6 +4418,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4389,6 +4437,9 @@ msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Se credi che questo sia un errore di Foreman, apri un nuovo caso con"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr ""
@@ -4535,6 +4586,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "Infrastruttura"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Eredita valore genitore (%s)"
 
@@ -4578,6 +4632,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5524,6 +5581,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr ""
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Gestisci"
 
@@ -6362,6 +6422,9 @@ msgstr "Nome OS di Facter; es. RedHat"
 msgid "Off"
 msgstr "Off"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "Ok"
 
@@ -6405,6 +6468,9 @@ msgstr "È permessa solo una dichiarazione per proxy"
 
 msgid "Only one volume can be bootable"
 msgstr "È possibile avviare un solo volume"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "Ops!!"
@@ -6814,6 +6880,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7495,6 +7564,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr ""
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr ""
 
@@ -8080,6 +8152,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8314,6 +8389,11 @@ msgstr "Accedi"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -8404,6 +8484,12 @@ msgstr ""
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Alcune interfacce non sono valide. Controllare la tabella di seguito riportata."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9067,6 +9153,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr ""
 
@@ -9078,6 +9167,9 @@ msgstr "La classe della CPU presente in questa macchina. Principalmente usata da
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "La classe della macchina riportata da Open Boot Prom. Principalmente usata da Sparc Solaris, può essere lasciata vuota per altre architetture. Il valore può essere determinato su Solaris tramite uname -i|cut -f2 -d,"
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
@@ -9268,6 +9360,12 @@ msgstr "Si è verificato un errore durante l'elenco delle VM: %(status)s %(statu
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "Si è verificato un errore nel rendering del template %{name} : %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr ""
 
@@ -9281,6 +9379,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9337,6 +9438,9 @@ msgstr "Questo può essere causato dalla indisponibilità di alcuni servizi nece
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9357,6 +9461,12 @@ msgstr "Questo servizio è disponibile per utenti non autenticati"
 
 msgid "This service is only available for authenticated users"
 msgstr "Questo servizio è disponibile solo per utenti autenticati"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "Questo template è bloccato e non può essere rimosso."
@@ -9384,6 +9494,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9428,6 +9541,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10281,6 +10397,9 @@ msgstr "Attributi VM (%s)"
 msgid "VM already associated with a host"
 msgstr "VM già associata con un host"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "VM associata all'host %s"
 
@@ -10420,6 +10539,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "Attenzione: Questa operazione cancellerà l'host insieme ai suoi dati"
@@ -10606,10 +10728,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "Stai per sbloccare un template bloccato."
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/it/foreman.po
+++ b/locale/it/foreman.po
@@ -26,9 +26,6 @@ msgstr ""
 msgid " Documentation"
 msgstr ""
 
-msgid " Remove"
-msgstr " Rimuovi"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -40,9 +37,6 @@ msgstr ""
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr ""
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - Premere Shift-F12 per rilasciare il cursore."
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - I seguenti host stanno per essere modificati"
@@ -62,9 +56,6 @@ msgstr[1] ""
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "I parametri %s sono stati aggiornati, consultare le informazioni riportate qui di seguito"
-
-msgid "%s Template"
-msgstr "Modello %s"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -117,9 +108,6 @@ msgid_plural "%s months ago"
 msgstr[0] "%s mese fa"
 msgstr[1] "%s mesi fa"
 
-msgid "%s out of sync disabled"
-msgstr ""
-
 msgid "%s selected hosts"
 msgstr "%s host selezionato"
 
@@ -137,9 +125,6 @@ msgid "%s widget loading..."
 msgstr ""
 
 msgid "%s you had selected as your context has been deleted"
-msgstr ""
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
 msgstr ""
 
 msgid "%{action} %{vm}"
@@ -211,6 +196,9 @@ msgstr "%{match} non corrisponde a un gruppo di host esistente"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} è stato modificato da %{label1} a %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr ""
@@ -293,6 +281,9 @@ msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(facoltativo) Ruolo IAM di Fog da usare durante la creazione di questa immagine."
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr ""
@@ -485,12 +476,6 @@ msgstr "Aggiungi volume"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr ""
 
-msgid "Add a Puppet class to host"
-msgstr "Aggiungi una classe Puppet all'host"
-
-msgid "Add a Puppet class to host group"
-msgstr "Aggiungi una classe Puppet al gruppo di host"
-
 msgid "Add a template combination"
 msgstr "Aggiungi una combinazione di template"
 
@@ -536,9 +521,6 @@ msgstr "Attributi addizionali specific per risosa di calcolo"
 msgid "Additional information about this host"
 msgstr "Informazioni aggiuntive su questo host"
 
-msgid "Address to connect to"
-msgstr ""
-
 msgid "Admin permissions required"
 msgstr "Sono necessari i permessi di amministrazione"
 
@@ -581,9 +563,6 @@ msgstr "Dispositivo VLAN o Alias"
 msgid "All"
 msgstr "Tutte"
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr ""
 
@@ -591,6 +570,12 @@ msgid "All Reports"
 msgstr "Tutti i riporti"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -752,9 +737,6 @@ msgstr ""
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr ""
-
 msgid "Are you sure you want to log out?"
 msgstr ""
 
@@ -811,6 +793,12 @@ msgstr "Assegna organizzazione"
 
 msgid "Assign Selected Hosts"
 msgstr "Assegna host selezionati"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1296,6 +1284,9 @@ msgstr ""
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr ""
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "Impossibile rimuovere l'account di amministrazione interno"
 
@@ -1377,8 +1368,8 @@ msgstr ""
 msgid "Certificate path for GCE only"
 msgstr ""
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Certificato che verrà utilizzato da Foreman per cifrare i websocket"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "Certificati"
@@ -1437,6 +1428,9 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr ""
 
@@ -1448,12 +1442,6 @@ msgstr "Selezionare il link di una risorsa di calcolo per modificarne l'attribut
 
 msgid "Click to log in again"
 msgstr ""
-
-msgid "Click to remove %s"
-msgstr "Seleziona per rimuovere %s"
-
-msgid "Click to remove config group"
-msgstr "Seleziona per rimuovere il gruppo di configurazione"
 
 msgid "Client Email"
 msgstr "Email client"
@@ -1617,14 +1605,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "Recupero configurazione"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "Gruppo di configurazioni"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "Nome"
-
 msgid "Configuration"
 msgstr "Configurazione"
 
@@ -1667,8 +1647,8 @@ msgstr "Sono stati rilevati alcuni conflitti"
 msgid "Connected"
 msgstr ""
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "Connessione (non cifrata) a: %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "Connessione a (non cifrata) in corso: %s"
@@ -1718,7 +1698,7 @@ msgstr ""
 msgid "Cores per socket"
 msgstr "Core per socket"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
 msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
@@ -1895,9 +1875,6 @@ msgstr ""
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-msgid "Create a Puppet class"
-msgstr "Crea classe puppet"
-
 msgid "Create a bookmark"
 msgstr "Crea un segnalibro"
 
@@ -1909,9 +1886,6 @@ msgstr "Crea un profilo di calcolo"
 
 msgid "Create a compute resource"
 msgstr "Crea una risorsa di calcolo"
-
-msgid "Create a config group"
-msgstr "Crea un gruppo di configurazione"
 
 msgid "Create a default template combination for an operating system"
 msgstr "Crea una combinazione del template predefinito per un sistema operativo"
@@ -1985,9 +1959,6 @@ msgstr "Crea una sottorete"
 msgid "Create a template input"
 msgstr "Crea un template di input"
 
-msgid "Create a trend counter"
-msgstr ""
-
 msgid "Create a user"
 msgstr "Crea un utente"
 
@@ -2003,9 +1974,6 @@ msgstr "Crea una fonte di autenticazione LDAP"
 msgid "Create an architecture"
 msgstr "Crea una architettura"
 
-msgid "Create an environment"
-msgstr "Crea un ambiente"
-
 msgid "Create an external user group linked to a user group"
 msgstr "Crea un gruppo di utenti esterno collegato ad un gruppo di utenti"
 
@@ -2018,13 +1986,13 @@ msgstr "Crea una interfaccia su un host"
 msgid "Create an operating system"
 msgstr "Crea un sistema operativo"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "Crea un valore di override per uno specifico parametro di smart class"
-
 msgid "Create autosign entry"
 msgstr "Crea auto firma"
 
 msgid "Create image"
+msgstr ""
+
+msgid "Create model"
 msgstr ""
 
 msgid "Create new boot volume from image"
@@ -2041,6 +2009,9 @@ msgstr "Crea una voce dell'area di autenticazione per %s"
 
 msgid "Created"
 msgstr "Creato"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr ""
@@ -2070,18 +2041,6 @@ msgid "Custom instance type"
 msgstr ""
 
 msgid "DB pending seed"
-msgstr ""
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
 msgstr ""
 
 msgid "DHCP"
@@ -2174,7 +2133,7 @@ msgstr "Predefinito"
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2196,9 +2155,6 @@ msgid "Default PXE menu item in global template - 'local', 'discovery' or custom
 msgstr ""
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
-msgstr ""
-
-msgid "Default Puppet environment"
 msgstr ""
 
 msgid "Default VNC Keyboard"
@@ -2282,9 +2238,6 @@ msgstr "Cancellare i certificati PuppetCA per %s"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr ""
 
-msgid "Delete a Puppet class"
-msgstr "Cancella una classe puppet"
-
 msgid "Delete a Virtual Machine"
 msgstr "Elimina una macchina virtuale"
 
@@ -2296,9 +2249,6 @@ msgstr "Cancella un profile di calcolo"
 
 msgid "Delete a compute resource"
 msgstr "Cancella una risorsa di calcolo"
-
-msgid "Delete a config group"
-msgstr "Cancella un gruppo di configurazione"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "Cancella una combinazione del template predefinito per un sistema operativo"
@@ -2381,9 +2331,6 @@ msgstr "Cancella una combinazione di template"
 msgid "Delete a template input"
 msgstr "Elimina un template di input"
 
-msgid "Delete a trend counter"
-msgstr ""
-
 msgid "Delete a user"
 msgstr "Cancella un utente"
 
@@ -2423,9 +2370,6 @@ msgstr ""
 msgid "Delete an architecture"
 msgstr "Cancella una architettura"
 
-msgid "Delete an environment"
-msgstr "Cancella un ambiente"
-
 msgid "Delete an external user group"
 msgstr "Cancella un gruppo di utenti esterno"
 
@@ -2435,14 +2379,17 @@ msgstr "Cancella una immagine"
 msgid "Delete an operating system"
 msgstr "Cancella un sistema operativo"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "Cancella un valore di override per uno specifico parametro di smart class"
-
 msgid "Delete autosign entry"
 msgstr ""
 
 msgid "Delete filter?"
 msgstr "Cancella filtro?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "Rimuovi la voce dell'area di autenticazione per %s"
@@ -2514,9 +2461,6 @@ msgid "Disable alerts for selected hosts"
 msgstr "Disabilita gli avvisi per host selezionati"
 
 msgid "Disable all filters overriding"
-msgstr ""
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2635,19 +2579,16 @@ msgstr ""
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr ""
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
-msgstr ""
-
-msgid "ENC environment"
 msgstr ""
 
 msgid "ERROR or FATAL"
@@ -2690,6 +2631,9 @@ msgid "Edit this host"
 msgstr ""
 
 msgid "Editor"
+msgstr ""
+
+msgid "Email"
 msgstr ""
 
 msgid "Email Preferences"
@@ -2767,10 +2711,6 @@ msgstr "Indirizzo IP finale per il suggerimento automatico degli IP"
 msgid "Entries per page"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Ambiente"
-
 msgid "Environment IDs"
 msgstr "ID ambiente"
 
@@ -2785,10 +2725,6 @@ msgstr "Variabile d'ambiente contentente lo stato di verifica di un certificato 
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Nome"
 
 msgid "Error"
 msgstr "Errore"
@@ -2827,6 +2763,9 @@ msgid "Error loading scheduler hint filters information: %s"
 msgstr ""
 
 msgid "Error removing widget from dashboard."
+msgstr ""
+
+msgid "Error statuses"
 msgstr ""
 
 msgid "Error submitting data:"
@@ -3296,14 +3235,14 @@ msgstr "Correggi %s previa corrispondenza errata"
 msgid "Fix All Mismatches"
 msgstr "Correggi tutte le corrispondenze errate"
 
-msgid "Fix DB cache"
-msgstr ""
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Correggi DB cache al riavvio successivo di Foreman"
-
 msgid "Fix Mismatches"
 msgstr "Correggi le corrispondenze errate"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "Tipo di istanza"
@@ -3347,9 +3286,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr ""
 
-msgid "Force a Puppet agent run on the host"
-msgstr "Forza l'esecuzione di un Puppet agent su un host"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "La Foreman API v2 è attualmente la versione API di default"
 
@@ -3383,6 +3319,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "Foreman matchers sarà ereditato dai figli quando verranno valutati i parametri della smartclass per gruppi di host, organizzazioni e localizzazioni"
 
@@ -3391,6 +3331,10 @@ msgstr "Foreman gestisce ora il ciclo di compilazione per %s"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman non gestisce più il ciclo di compilazione per %s"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "L'orario di creazione del riporto di Foreman è <em>%s</em>"
@@ -3419,7 +3363,7 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman automatizzerà la firma dei certificati previa presenza di un nuovo host "
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
 msgstr ""
 
 msgid "Foreman will create the host when a report is received"
@@ -3428,20 +3372,14 @@ msgstr "Foreman creerà un host previa ricezione di un riporto"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman creerà un host previa ricezione di un nuovo evento"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "Foreman eseguirà il default su questo ambiente puppet se non è in grado di rilevarne uno"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr ""
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman imposterà in modo esplicito l'ambiente puppet all'interno dell'output yalm ENC. Ciò eviterà di avere dei conflitti con l'ambiente puppet.conf e quello impostato in Foreman"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman mapperà gli utenti per nome utente in intestazione-richiesta. Se impostato su falso, le richieste OAuth avranno i permessi di amministrazione."
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr ""
@@ -3451,9 +3389,6 @@ msgstr "Foreman analizzerà ERB in un valore del parametro all'interno dell'outp
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman interrogherà il resolver configurato localmente al posto dei resolver SOA"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman aggiornerà l'ambiente di un host usando i propri eventi"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr ""
@@ -3472,6 +3407,18 @@ msgstr "Foreman utilizzerà UUID randomici per la firma dei certificati al posto
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman utilizzerà l'hostname abbreviato al posto del FQDN per la creazione di nuove macchine virtuali"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr ""
@@ -3498,6 +3445,9 @@ msgid "Full screen"
 msgstr "Schermo intero"
 
 msgid "Function not available for %s"
+msgstr ""
+
+msgid "Further Information"
 msgstr ""
 
 msgid "GMT time"
@@ -3569,8 +3519,8 @@ msgstr "Acquisisci i dettali della dashboard"
 msgid "Get default dashboard widgets"
 msgstr ""
 
-msgid "Get statistics"
-msgstr "Acquisisci le statistiche"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "Acquisisci stato dell'host"
@@ -3692,6 +3642,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr "Modelli hardware"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr ""
 
@@ -3737,11 +3693,17 @@ msgstr "Cronologia"
 msgid "Host"
 msgstr "Host"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr ""
 
 msgid "Host %s is not associated with a VM"
 msgstr "Host %s non è associato con una VM"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "Grafico configurazione host"
@@ -3779,7 +3741,13 @@ msgstr ""
 msgid "Host Parameters"
 msgstr ""
 
-msgid "Host Wizard"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
 msgstr ""
 
 msgid "Host audit entries"
@@ -3788,12 +3756,12 @@ msgstr "Voci per la verifica dell'host"
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "Gruppo di configurazioni dell'host"
-
 msgid "Host details"
 msgstr "Informazioni host"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "Gruppo di host"
@@ -3931,8 +3899,32 @@ msgid "Host::Base|Uuid"
 msgstr "Uuid"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "Tipo di host"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4160,9 +4152,6 @@ msgstr "ID del template di configurazione"
 msgid "ID of domain"
 msgstr "ID del dominio"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr "ID host"
 
@@ -4229,7 +4218,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4292,9 +4281,6 @@ msgstr "suggerisci automaticamente l'indirizzo IP"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr ""
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr ""
 
@@ -4318,6 +4304,9 @@ msgstr ""
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr ""
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr ""
 
@@ -4336,6 +4325,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "IPv6 Subnet"
+msgstr ""
+
+msgid "IPv6 address"
 msgstr ""
 
 msgid "IPv6 address of interface"
@@ -4398,13 +4390,13 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Se credi che questo sia un errore di Foreman, apri un nuovo caso con"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr ""
-
 msgid "Ignore facts for domain"
 msgstr ""
 
 msgid "Ignore facts for operating system"
+msgstr ""
+
+msgid "Ignore interfaces facts for provisioning"
 msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
@@ -4485,12 +4477,6 @@ msgstr ""
 
 msgid "Import of facts failed for host %s"
 msgstr ""
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Importa le classi puppet dal puppet proxy."
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "Importa le classi del puppet dal puppet proxy per un ambiente"
 
 msgid "Imported IPv4 Subnets"
 msgstr ""
@@ -4603,6 +4589,9 @@ msgstr ""
 msgid "Installation medium configuration"
 msgstr "Configurazione supporto di installazione"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "Installato"
 
@@ -4667,6 +4656,9 @@ msgid "Invalid %{assoc} selection, you must select at least one of yours and hav
 msgstr ""
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
+msgstr ""
+
+msgid "Invalid HTTP(S) URL"
 msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
@@ -4834,13 +4826,13 @@ msgstr "Ultimissimi eventi"
 msgid "Launch Console"
 msgstr ""
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr ""
 
 msgid "Learn more about LDAP authentication in the documentation."
+msgstr ""
+
+msgid "Legacy UI"
 msgstr ""
 
 msgid "Length"
@@ -4875,24 +4867,6 @@ msgstr "Elenca tutte le fonti di atutenticazione LDAP"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr ""
-
-msgid "List all Puppet class IDs for host"
-msgstr "Elenca tutti gli ID delle classi puppet per l'host"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "Elenca tutti gli ID delle classi puppet per il gruppo di host"
-
-msgid "List all Puppet classes"
-msgstr "Elenca tutti gli ID delle classi puppet"
-
-msgid "List all Puppet classes for a host"
-msgstr "Elenca tutte le classi puppet per un host"
-
-msgid "List all Puppet classes for a host group"
-msgstr "Elenca tutte le classi puppet per un gruppo di host"
-
-msgid "List all Puppet classes for an environment"
-msgstr "Elenca tutte le classi puppet per un ambiente"
 
 msgid "List all SSH keys for a user"
 msgstr ""
@@ -4929,9 +4903,6 @@ msgstr "Elenca tutte le risorse di calcolo"
 
 msgid "List all email notifications for a user"
 msgstr ""
-
-msgid "List all environments"
-msgstr "Elenca gli ambienti"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "Elenca tutti i gruppi di utenti esterni per il sorgente di autenticazione LDAP"
@@ -5068,9 +5039,6 @@ msgstr "Elenca tutti i ruoli"
 msgid "List all settings"
 msgstr "Elenca tutte le impostazioni"
 
-msgid "List all smart class parameters"
-msgstr "Elenca tutti i parametri di classe smart"
-
 msgid "List all smart proxies"
 msgstr "Elenca tutti gli smart proxies"
 
@@ -5149,15 +5117,6 @@ msgstr "Elenca i file boot per un sistema operativo"
 msgid "List default templates combinations for an operating system"
 msgstr "Elenca le combinazioni di template predefiniti per un sistema operativo"
 
-msgid "List environments of Puppet class"
-msgstr "Elenca ambienti della classe puppet"
-
-msgid "List environments per location"
-msgstr "Elenca ambienti per localizzazione"
-
-msgid "List environments per organization"
-msgstr "Elenca gli ambienti per organizzazione"
-
 msgid "List external authentication sources"
 msgstr "Elenca le fonti di autenticazione esterne"
 
@@ -5166,6 +5125,9 @@ msgstr "Elenca le fonti di autenticazione esterne per localizzazione"
 
 msgid "List external authentication sources per organization"
 msgstr "Elenca le fonti di autenticazione esterne per organizzazione"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "Elenca host per localizzazione"
@@ -5200,9 +5162,6 @@ msgstr "Elenco degli attributi di calcolo per profilo e risorsa di calcolo"
 msgid "List of compute profiles"
 msgstr "Elenco dei profili di calcolo"
 
-msgid "List of config groups"
-msgstr "Elenco gruppi di configurazioni"
-
 msgid "List of domains"
 msgstr "Elenco dei domini"
 
@@ -5218,35 +5177,20 @@ msgstr "Elenco di domini per sottorete"
 msgid "List of email notifications"
 msgstr "Elenco delle notifiche email"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr ""
 
 msgid "List of hosts which answer to the provided query"
 msgstr "Elenco di host che rispondono all'interrogazione fornita"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "Elenco di valori di override per uno specifico parametro di smart class"
-
 msgid "List of realms"
 msgstr "Elenco di realm"
 
 msgid "List of resources types that will be automatically associated"
 msgstr ""
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "Elenco parametri di classe smart per una classe puppet specifica"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "Elenco parametri di classe smart per un ambiente specifico"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "Elenco parametri di classe smart per una combinazione classe puppet/ambiente specifica"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "Elenco parametri di classe smart per un host specifico"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "Elenco parametri di classe smart per un gruppo di host specifico"
 
 msgid "List of subnets"
 msgstr "Elenco di sottoreti"
@@ -5264,9 +5208,6 @@ msgid "List of table preferences for a user"
 msgstr ""
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
-msgstr ""
-
-msgid "List of trends counters"
 msgstr ""
 
 msgid "List of user selected columns"
@@ -5452,6 +5393,10 @@ msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5500,6 +5445,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "Indirizzo MAC"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr ""
@@ -5582,6 +5530,9 @@ msgstr "Gestisci"
 msgid "Manage Bookmarks"
 msgstr "Gestisci i segnalibri"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "Gestisci le posizioni"
 
@@ -5589,6 +5540,9 @@ msgid "Manage Organizations"
 msgstr "Gestisci le organizzazioni"
 
 msgid "Manage PuppetCA"
+msgstr ""
+
+msgid "Manage all statuses"
 msgstr ""
 
 msgid "Manage host"
@@ -5690,10 +5644,6 @@ msgid "Message"
 msgstr "Messaggio"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Valore"
 
@@ -5711,6 +5661,9 @@ msgstr ""
 
 msgid "Metrics"
 msgstr "Metriche"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "Minuti fa"
@@ -5789,6 +5742,9 @@ msgstr ""
 msgid "N/A"
 msgstr "N/A"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "NA"
 
@@ -5810,7 +5766,7 @@ msgstr "Nome del dispositivo"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr ""
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
 msgstr ""
 
 msgid "Name of the host group"
@@ -5888,6 +5844,9 @@ msgstr "Nuova organizzazione"
 msgid "New SSH key"
 msgstr ""
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "Nuova Macchina Virtuale"
 
@@ -5903,8 +5862,8 @@ msgstr ""
 msgid "New filter"
 msgstr "Nuovo filtro"
 
-msgid "New window"
-msgstr "Nuova finestra"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Successivo"
@@ -6031,6 +5990,9 @@ msgstr ""
 msgid "No TFTP proxies defined, can't continue"
 msgstr "Nessun prefisso TFTP definito, impossibile continuare"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr ""
 
@@ -6069,6 +6031,9 @@ msgstr "Nessuna email"
 
 msgid "No entries found"
 msgstr "Nessuna voce trovata"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "Nessuna funzionalità trovata su questo proxy, assicurati di abilitarne almeno una"
@@ -6166,6 +6131,9 @@ msgstr "Nessuno smart proxy trovato."
 msgid "No smart proxies to show"
 msgstr "Nessuno smart proxy da visualizzare"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "Nessuna rete secondaria"
 
@@ -6202,11 +6170,11 @@ msgstr "Normale"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr "Normalmente quando si imposta una Risorsa di Calcolo, viene creata automaticamente una coppia di chiavi (privata e pubblica)"
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "Non installate"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr ""
 
 msgid "Not implemented"
 msgstr "Non implementato"
@@ -6373,6 +6341,9 @@ msgstr ""
 msgid "OK"
 msgstr "OK"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "ImmagineOS"
 
@@ -6443,9 +6414,6 @@ msgstr "Attenzione, si è verificato un errore"
 
 msgid "Open"
 msgstr ""
-
-msgid "Open Spice in a new window"
-msgstr "Aprire Spice in una nuova finestra"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr ""
@@ -6546,9 +6514,6 @@ msgstr ""
 msgid "Optional array of log hashes"
 msgstr "Insieme opzionale di log hash"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "Testo opzionale delimitato da virgole contenente 'new', 'updated' o 'obsolete' usati per limitare le classi dei puppet importati"
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "Opzionale: Indirizzo IP finale per il suggerimento automatico degli IP"
 
@@ -6612,9 +6577,6 @@ msgstr ""
 msgid "Override"
 msgstr ""
 
-msgid "Override Value"
-msgstr ""
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr ""
 
@@ -6627,8 +6589,17 @@ msgstr "Panoramica"
 msgid "Overwrite"
 msgstr "Sovrascrivi"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "Posseduto da"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "Proprietario"
@@ -6712,6 +6683,10 @@ msgstr "Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Priorità"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr ""
@@ -6948,9 +6923,6 @@ msgstr ""
 msgid "Plugins"
 msgstr "Plugin"
 
-msgid "Port to connect to"
-msgstr ""
-
 msgid "Possible values"
 msgstr ""
 
@@ -6963,8 +6935,14 @@ msgstr "Alimentazione"
 msgid "Power ON this machine"
 msgstr "Attiva questa macchina"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
 msgstr "Accendi una macchina virtuale"
+
+msgid "Power has been set to \"%s\" successfully"
+msgstr ""
 
 msgid "Power operations are not enabled on this host."
 msgstr ""
@@ -7032,7 +7010,7 @@ msgstr ""
 msgid "Private"
 msgstr "Privata"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Proceed to Edit"
@@ -7130,6 +7108,9 @@ msgstr "Proxy"
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7178,9 +7159,6 @@ msgstr "Classe del puppet"
 msgid "Puppet error state"
 msgstr ""
 
-msgid "Puppet interval"
-msgstr ""
-
 msgid "Puppet parameter"
 msgstr ""
 
@@ -7189,14 +7167,6 @@ msgstr ""
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppetclass"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Nome"
 
 msgid "Query"
 msgstr ""
@@ -7272,6 +7242,9 @@ msgstr "Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "Area di autenticazione | Tipo di area di autenticazione"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "Riavvia e compila"
@@ -7373,12 +7346,6 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr "Rimuovi il parametro"
 
-msgid "Remove a Puppet class from host"
-msgstr "Rimuovi una classe Puppet dall'host"
-
-msgid "Remove a Puppet class from host group"
-msgstr "Rimuovi una classe Puppet dal gruppo di host"
-
 msgid "Remove an email notification for a user"
 msgstr "Rimuovere una notifica email per un utente"
 
@@ -7386,6 +7353,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7470,6 +7440,9 @@ msgstr ""
 msgid "ReportTemplate|Snippet"
 msgstr ""
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "Riportato"
 
@@ -7481,6 +7454,9 @@ msgstr ""
 
 msgid "Reports"
 msgstr "Report"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7523,6 +7499,9 @@ msgid "Required unless user is in an external authentication source"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset"
 msgstr ""
 
 msgid "Reset PuppetCA certname for %s"
@@ -7568,6 +7547,9 @@ msgstr ""
 msgid "Resume"
 msgstr "Riprendi"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "Restituisce una stringa che rappresenta uno stato host di un determinato tipo"
 
@@ -7593,8 +7575,14 @@ msgstr ""
 msgid "Revert Local Changes"
 msgstr ""
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "Revisione"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "Ricontrolla lo stato della compilazione per %s"
@@ -7603,6 +7591,9 @@ msgid "Revoke"
 msgstr ""
 
 msgid "Revoke a Personal Access Token for a user"
+msgstr ""
+
+msgid "Revoke personal access token"
 msgstr ""
 
 msgid "Revoked"
@@ -7685,6 +7676,9 @@ msgstr ""
 msgid "SMTP address"
 msgstr ""
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr ""
 
@@ -7698,6 +7692,9 @@ msgid "SMTP password"
 msgstr ""
 
 msgid "SMTP port"
+msgstr ""
+
+msgid "SMTP port to connect to"
 msgstr ""
 
 msgid "SMTP username"
@@ -7718,14 +7715,20 @@ msgstr ""
 msgid "SSL CA file"
 msgstr ""
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "File SSL CA che Foreman utilizzerà per comunicare con i propri proxy"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Percorso del certificato SSL che Foreman utilizza per comunicare con i propri proxy"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "File chiave privata SSL che Foreman dovrà usare per comunicare con i propri proxy"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr ""
@@ -7773,6 +7776,9 @@ msgid "Save something and try again"
 msgstr "Salva qualcosa e riprova"
 
 msgid "Saved Bookmarks"
+msgstr ""
+
+msgid "Saved audits interval"
 msgstr ""
 
 msgid "Schedule generating of a report"
@@ -7951,6 +7957,9 @@ msgstr ""
 msgid "Sendmail location"
 msgstr "Localizzazione sendmail"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr ""
 
@@ -7981,6 +7990,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr ""
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr ""
 
@@ -8001,9 +8013,6 @@ msgstr ""
 
 msgid "Set up compute instance %s"
 msgstr "Impostazione istanza di calcolo %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8071,6 +8080,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "Eseguire `foreman-rake db:seed` durante l'esecuzione successiva dei moduli dell'installer?"
 
@@ -8104,18 +8119,6 @@ msgstr ""
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-msgid "Show a Puppet class"
-msgstr "Mostra una classe puppet"
-
-msgid "Show a Puppet class for a host group"
-msgstr "Mostra una classe Puppet per un gruppo di host"
-
-msgid "Show a Puppet class for an environment"
-msgstr "Mostra una classe puppet per un ambiente"
-
-msgid "Show a Puppet class for host"
-msgstr "Mostra una classe Puppet per un host"
-
 msgid "Show a bookmark"
 msgstr "Mostra un segnalibro"
 
@@ -8127,9 +8130,6 @@ msgstr "Mostra profilo di calcolo"
 
 msgid "Show a compute resource"
 msgstr "Mostra una risorsa di calcolo"
-
-msgid "Show a config group"
-msgstr "Mostra un gruppo di configurazione"
 
 msgid "Show a default template combination for an operating system"
 msgstr "Mostra una combinazione del template predefinito per un sistema operativo"
@@ -8197,17 +8197,11 @@ msgstr "Mostra un ruolo"
 msgid "Show a setting"
 msgstr "Mostra una impostazione"
 
-msgid "Show a smart class parameter"
-msgstr "Mostra un parametro di classe smart"
-
 msgid "Show a smart proxy"
 msgstr "Mostra uno smart proxy"
 
 msgid "Show a subnet"
 msgstr "Mostra una sottorete"
-
-msgid "Show a trend"
-msgstr ""
 
 msgid "Show a user"
 msgstr "Mostra un utente"
@@ -8242,9 +8236,6 @@ msgstr "Mostra un audit"
 msgid "Show an email notification"
 msgstr "Mostra una notifica email"
 
-msgid "Show an environment"
-msgstr "Mostra un ambiente"
-
 msgid "Show an external authentication source"
 msgstr "Mostra una fonte di autenticazione esterna"
 
@@ -8265,9 +8256,6 @@ msgstr "Mostra una fonte di autenticazione itnerna"
 
 msgid "Show an operating system"
 msgstr "Mostra un sistema operativo"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "Mostra un valore override per uno specifico parametro di smart class"
 
 msgid "Show available API links"
 msgstr "Mostra i link API disponibili"
@@ -8350,9 +8338,6 @@ msgstr "Saltato"
 msgid "Skipped|S"
 msgstr "S"
 
-msgid "Smart Class Parameter"
-msgstr "Parametro classe smart"
-
 msgid "Smart Class Parameters"
 msgstr ""
 
@@ -8420,6 +8405,9 @@ msgstr ""
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Alcune interfacce non sono valide. Controllare la tabella di seguito riportata."
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "Si è verificato un errore durante la modifica del tipo di host - %s"
 
@@ -8443,10 +8431,6 @@ msgid "Source"
 msgstr "Origine"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Valore"
 
@@ -8468,7 +8452,7 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr ""
 
-msgid "Specify additional options to sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "Specify authentication type, if required"
@@ -8512,7 +8496,7 @@ msgstr "Stato"
 msgid "Status %s does not exist."
 msgstr "Lo Status %s non esiste."
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
 msgstr ""
 
 msgid "Stop updating Operating System from facts"
@@ -8609,6 +8593,10 @@ msgid "Subnet|Dns secondary"
 msgstr "Dns secondario"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Da"
 
@@ -8635,6 +8623,10 @@ msgstr "Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Rete"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8707,6 +8699,12 @@ msgstr ""
 
 msgid "Supported Formats"
 msgstr "Formati supportati"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "Sincronizza gruppo dal sorgente di autenticazione"
@@ -8865,11 +8863,19 @@ msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8939,6 +8945,10 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -8989,7 +8999,7 @@ msgstr ""
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9135,7 +9145,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9152,8 +9162,8 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The location of the sendmail executable"
-msgstr "La localizzazione dell'eseguibile sendmail"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "Ricontrollare i campi contrassegnati"
@@ -9179,9 +9189,6 @@ msgid ""
 msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
-msgstr ""
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
 msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
@@ -9244,6 +9251,9 @@ msgid "There may be more information in the server's logs."
 msgstr "Ci possono essere ulteriori informazioni nei log del server."
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
+msgstr ""
+
+msgid "There was a problem processing the request. Please try again."
 msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
@@ -9373,7 +9383,7 @@ msgstr ""
 msgid "This value is used also as the host's primary interface name."
 msgstr ""
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9398,15 +9408,6 @@ msgid "Timezone to use for new users"
 msgstr ""
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9437,9 +9438,6 @@ msgid "Token"
 msgstr "Token"
 
 msgid "Token Expiry"
-msgstr ""
-
-msgid "Token duration"
 msgstr ""
 
 msgid "Token expired"
@@ -9479,41 +9477,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "Tendenza"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Contatore di trend"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Numero"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
+msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Nome evento"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Valore evento"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Nome"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Tipo di tendenza"
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "Flag True/False se l'host è gestito o non gestito. Nota: questo valore indica anche se è necessario usare alcuni parametri"
@@ -9794,6 +9759,12 @@ msgstr ""
 msgid "Unallowed template for dashboard widget: %s"
 msgstr ""
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr ""
 
@@ -9851,6 +9822,9 @@ msgstr ""
 msgid "Unknown status: %s"
 msgstr ""
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "Sblocca"
 
@@ -9878,9 +9852,6 @@ msgstr "Aggiorna :a_resource"
 msgid "Update IP from built request"
 msgstr ""
 
-msgid "Update a Puppet class"
-msgstr "Aggiorna una classe puppet"
-
 msgid "Update a bookmark"
 msgstr "Aggiorna un segnalibro"
 
@@ -9892,9 +9863,6 @@ msgstr "Aggiorna un profilo di calcolo"
 
 msgid "Update a compute resource"
 msgstr "Aggiorna una risorsa di calcolo"
-
-msgid "Update a config group"
-msgstr "Aggiorna un gruppo di configurazione"
 
 msgid "Update a default template combination for an operating system"
 msgstr "Aggiorna una combinazione del template predefinito per un sistema operativo"
@@ -9962,9 +9930,6 @@ msgstr "Aggiorna un ruolo"
 msgid "Update a setting"
 msgstr "Aggiorna una impostazione"
 
-msgid "Update a smart class parameter"
-msgstr "Aggiorna un parametro classe smart"
-
 msgid "Update a smart proxy"
 msgstr "Aggiorna uno smart proxy"
 
@@ -9995,9 +9960,6 @@ msgstr "Aggiorna una architettura"
 msgid "Update an email notification for a user"
 msgstr "Aggiorna una notifica email per un utente"
 
-msgid "Update an environment"
-msgstr "Aggiorna un ambiente"
-
 msgid "Update an external authentication source"
 msgstr "Aggiorna una fonte di autenticazione esterna"
 
@@ -10006,12 +9968,6 @@ msgstr "Aggiorna una immagine"
 
 msgid "Update an operating system"
 msgstr "Aggiorna un sistema operativo"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "Aggiorna un valore override per uno specifico parametro di smart class"
-
-msgid "Update environment from facts"
-msgstr ""
 
 msgid "Update external user group"
 msgstr "Aggiorna un gruppo di utenti esterno"
@@ -10248,6 +10204,10 @@ msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "Nome"
 
@@ -10384,7 +10344,7 @@ msgstr "Variabile"
 msgid "Variables"
 msgstr "Variabili"
 
-msgid "Vendor Class"
+msgid "Vendor class"
 msgstr ""
 
 msgid "Verify"
@@ -10446,6 +10406,9 @@ msgstr "Attendi che %s risulti online"
 
 msgid "Warning"
 msgstr "Attenzione"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "Attenzione!"
@@ -10510,6 +10473,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10632,6 +10598,9 @@ msgid "Yes (override)"
 msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
+msgstr ""
+
+msgid "You are about to clear %s status. Are you sure?"
 msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
@@ -10787,6 +10756,9 @@ msgstr "tutto"
 msgid "already exists"
 msgstr "è già esistente"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "una organizzazione"
 
@@ -10798,9 +10770,6 @@ msgstr "array"
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "appartiene al gruppo di configurazione"
 
 msgid "boolean"
 msgstr "booleano"
@@ -10981,9 +10950,6 @@ msgstr "abilita la memorizzazione nella cache, solo per VMware"
 
 msgid "enabled"
 msgstr ""
-
-msgid "environment id"
-msgstr "id ambiente"
 
 msgid "expected a value of type %s"
 msgstr ""
@@ -11233,8 +11199,7 @@ msgstr "collega il gruppo di utenti esterno a questo gruppo"
 msgid "list"
 msgstr "elenco"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -11413,12 +11378,6 @@ msgid "physical @ NAT %s"
 msgstr ""
 
 msgid "physical @ bridge %s"
-msgstr ""
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
 msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"

--- a/locale/ja/foreman.po
+++ b/locale/ja/foreman.po
@@ -377,6 +377,9 @@ msgstr "ホストが設定エラーをレポートする際の通知"
 msgid "A problem occurred when detecting host type: %s"
 msgstr "ホストタイプの検出時に問題が発生しました: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr "監査変更レポートの概要 <br> 必要に応じてクエリー別にフィルタリング"
 
@@ -662,6 +665,9 @@ msgstr "メールアドレスが必要です。アカウント詳細を更新し
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "LDAP に接続を試行中にエラーが発生しました。認証ソースホストが Foreman ホストから到達でき、オンラインであることを確認してください。"
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr "エラーが発生しました。"
 
@@ -730,6 +736,12 @@ msgstr "ホスト %s を削除してもよろしいですか? この操作を取
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "ホスト %s を削除してもよろしいですか? これにより、仮想マシンとそのディスクが削除されます。この動作はグローバル設定「ホストの削除時に関連の仮想マシンを破棄」から変更できます。"
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr "ログアウトしてもよろしいですか?"
@@ -1112,6 +1124,9 @@ msgstr "この操作はリスクを伴い、パフォーマンスおよびセキ
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr "ERB タグの長さが異なるため、ERB 構文にインデントを入れると見にくい場合があります。ERB 構文は空白を無視します。インデントを処理する方法の 1 つは、新しい行の各行頭に ERB タグを宣言し、ERB タグ内の空白を使用して構文内の関係を説明することです。以下に例を示します。"
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "空白のテンプレート"
 
@@ -1207,6 +1222,9 @@ msgstr "PXE デフォルトのビルド"
 
 msgid "Build duration"
 msgstr "ビルド期間"
+
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
 
 msgid "Build errors"
 msgstr "ビルドエラー"
@@ -2589,6 +2607,12 @@ msgstr "ERROR または FATAL"
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr "レンダリング機能はテンプレートタイプごとに若干異なります。たとえば、プロビジョニングは常に、単一ホストオブジェクト向けにレンダリングされるので、@host 変数が定義されます。別の例として、レポート形式固有のマクロが利用できるレポートのテンプレートもあります。"
 
@@ -3299,6 +3323,12 @@ msgstr "Foreman 監査概要"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr "Foreman は、プロビジョニングしているホストのネットワーク設定の情報を保存でき、この情報を使用してプロビジョニングプロセス時の仮想マシンの設定、適切な IP アドレスとネットワークリソースの割り当て、また OS の正しい設定ができます。"
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr "Foreman は、ドメインと DNS ゾーンを同じものと解釈するので、管理予定のサイトにあるマシンの形式がすべて hostname.somewhere.com の場合には、ドメインは somewhere.com になります。これにより、Foreman は Puppet 変数をドメイン/サイトに関連付けて、対象のサイトにあるマシンが作成した外部ノード要求に対して、この変数を自動的に追加できるようになります。完全名のフィールドは、ドメインを参照するレポートやその他のページで人が判読できるように使用されるだけでなく、外部ノードパラメーターとしても使用できます。"
 
@@ -3594,6 +3624,9 @@ msgstr "HTTP UEFI ブートには、httpboot 機能を備えたプロキシー�
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr "HTTP ブートには、httpboot 機能と http_port 公開設定を備えたプロキシーが必要です"
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
+msgstr ""
 
 msgid "HTTP(S) proxy"
 msgstr "HTTP(S) プロキシー"
@@ -4356,8 +4389,20 @@ msgstr "ERB をパラメーター値で使用する場合、値は ENC 要求時
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "チェックが付けられていると、デフォルト値がなく Matcher が値を指定しない場合にエラーが出されます。"
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
 msgstr "所有者タイプが指定されている場合は、所有者も指定する必要があります。"
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
 msgstr "設定している場合には、スケジュールされたレポートがメールで配信されます。「%s」を使用して、複数のメールアドレスを区切ります。"
@@ -4367,6 +4412,9 @@ msgstr "管理フラグが無効になっている場合は、サービスがサ
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
 msgstr "管理フラグが有効になっている場合は、DHCP、DNS、および TFTP といった外部サービスは、提供された情報に従って設定されます。"
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
+msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
 msgstr "テンプレートで形式を選択できる場合には、任意の形式を選択できます。<br>通常、テンプレートは report_render マクロを使用する必要があります。<br><br>テンプレートでマクロが使用されていない場合には<br>このフィールドが無効になっており、出力形式がデフォルトのプレーンテキストに設定されています。<br><br>テンプレートでフィルターの選択をサポートしているが、report_render マクロを使用していない場合には、<br>report_render のマクロ名が記載されているテンプレートのコメントを追加して、このフィールドを有効にしてください。"
@@ -4382,6 +4430,9 @@ msgstr "この設定をファイルで変更する必要がある場合は、フ
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "これが Foreman 自体のエラーであると思われる場合は、新規の問題として提出してください。"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr "ドメインのファクトを無視"
@@ -4528,6 +4579,9 @@ msgstr "更新された設定に関する情報"
 msgid "Infrastructure"
 msgstr "インフラストラクチャー"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "親の継承 (%s)"
 
@@ -4578,6 +4632,9 @@ msgstr "安全でない"
 
 msgid "Install packages"
 msgstr "パッケージのインストール"
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
+msgstr ""
 
 msgid "Installation Media"
 msgstr "インストールメディア"
@@ -5523,6 +5580,9 @@ msgstr "サブスクライブ可能"
 msgid "MailNotification|Subscription type"
 msgstr "サブスクリプションタイプ"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "管理"
 
@@ -6361,6 +6421,9 @@ msgstr "Facter からの OS 名 (例: RedHat)"
 msgid "Off"
 msgstr "オフ"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "OK"
 
@@ -6409,6 +6472,9 @@ msgstr "プロキシーの 1 つの宣言のみが許可されます"
 
 msgid "Only one volume can be bootable"
 msgstr "1 つのボリュームのみがブート可能です"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "エラー!!"
@@ -6819,6 +6885,9 @@ msgstr "パーソナルアクセストークンが正常に作成されました
 
 msgid "Personal Access Tokens"
 msgstr "パーソナルアクセストークン"
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Personal access token"
@@ -7501,6 +7570,9 @@ msgstr "UUID の要求"
 msgid "Require SSL for smart proxies"
 msgstr "Smart Proxy に SSL を必要とする"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "ユーザーが外部認証ソースに含まれていない場合に必須"
 
@@ -8083,6 +8155,9 @@ msgstr "Insights の設定"
 msgid "Setup REX"
 msgstr "REX のセットアップ"
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8317,6 +8392,11 @@ msgstr "サイン"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr "ただし、変数入力タイプと同様に、特定のスマートクラスパラメーターの値を読み込みます。ユーザーは、入力を定義する場合には Puppet クラスと、スマートクラスパラメーター名を指定する必要があります。"
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "このページのホストが 1 台選択されています。"
@@ -8406,6 +8486,12 @@ msgstr "一部のインターフェースが無効です"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "一部のインターフェースが無効です。以下の表を確認してください。"
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9068,6 +9154,9 @@ msgstr "ERB タグ内の Ruby コードには通常、式が含まれます。�
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr "OpenID プロバイダーで JWT をエンコードするために使用されるアルゴリズム。"
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "外部ユーザーグループの認証ソースは、指定の認証情報で LDAP に接続できませんでした。認証情報がまだ有効であることを確認してください。"
 
@@ -9079,6 +9168,9 @@ msgstr "このマシンに搭載されている CPU のクラスです。ハー�
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Open Boot Prom でレポートされるマシンのクラスです。このベンダークラスは主に、Sparc Solaris ビルドで使用し、他のアーキテクチャーの場合は空白のままにしてください。この値は、Solaris で uname -i|cut -f2 -d, を実行して確認できます。"
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr "仮想マシンの電源がオンになっていないため、コンソールは利用できません"
@@ -9269,6 +9361,12 @@ msgstr "%(status)s を表示中にエラーが発生しました: %(statusText)s
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "%{name} テンプレートのレンダリング中にエラーが発生しました: %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "libvirt にアクティブなブリッジインターフェースがありませんでした。一覧表示がサポートされていない場合は、手動でブリッジ名を入力できます (例: br0)"
 
@@ -9283,6 +9381,9 @@ msgstr "この操作では、リンクされている仮想マシンとそのデ
 
 msgid "This IP address has already been reserved in External IPAM"
 msgstr "この IP アドレスはすでに外部 IPAM で確保されています。"
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
 msgstr "このメールは UUID %{uuid} によって特定される Foreman から送信されました。"
@@ -9338,6 +9439,9 @@ msgstr "これは、必要なサービスが利用できない、API 呼び出�
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "ホスト、ファクト、レポートすべてが <b>削除されるので</b>、しばらく時間がかかる可能性があります。%sこの動きはグローバル設定「ホストの削除時に関連の仮想マシンを破棄」から変更できます。"
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr "これは、<code><%</code> の機能と同じですが、テンプレートが実行されると、コード出力がテンプレートに挿入されます。これは変数の置き換えに便利です。以下に例を示します。"
 
@@ -9358,6 +9462,12 @@ msgstr "このサービスは未認証ユーザーが使用できます"
 
 msgid "This service is only available for authenticated users"
 msgstr "このサービスは認証ユーザーのみが使用できます"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "このテンプレートはロックされており、削除することができません。"
@@ -9385,6 +9495,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "この値は、ホストのプライマリーインターフェース名としても使用されます。"
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9432,6 +9545,9 @@ msgid ""
 msgstr ""
 "ユーザー一覧を更新するには、\"External groups\" タブ、\n"
 "                \"Refresh\" の順にクリックしてください。"
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
+msgstr ""
 
 msgid "Today"
 msgstr "今日"
@@ -10283,6 +10399,9 @@ msgstr "VM 属性 (%s)"
 msgid "VM already associated with a host"
 msgstr "ホストにすでに関連付けられている VM"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "ホスト %s に関連付けられている VM"
 
@@ -10421,6 +10540,9 @@ msgstr "警告! "
 msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] "警告! これにより、%{number} 人のユーザーから %{name} が削除されます。続行してもよろしいでしょうか?"
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "警告: これにより、このホストとそのデータのすべてが削除されます!"
@@ -10622,11 +10744,17 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr "%s を削除しようとしています。削除してもよろしいでしょうか?"
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "ロックされたテンプレートをロック解除します。"
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
 msgstr "すでにユーザーを切り替えています。新たに別のユーザーに切り替える前に、トップバーのユーザーアイコンをクリックしてください。"
+
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
 
 msgid "You are not authorized to lock templates."
 msgstr "テンプレートをロックする権限がありません。"

--- a/locale/ja/foreman.po
+++ b/locale/ja/foreman.po
@@ -29,9 +29,6 @@ msgstr ""
 msgid " Documentation"
 msgstr " ドキュメント"
 
-msgid " Remove"
-msgstr " 削除"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr " また、foreman-debug 出力を添付することを強く推奨します。"
 
@@ -43,9 +40,6 @@ msgstr "${progress}%% 完了"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr "%(name)s (空き: %(free)s、プロビジョニング: %(prov)s、合計: %(total)s)"
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s: Shift+F12 を押してカーソルを解放します。"
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s: 以下のホストはまもなく変更されます"
@@ -63,9 +57,6 @@ msgstr[0] "%s 件のログメッセージ"
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s パラメーターが更新されました。詳細は以下を参照してください"
-
-msgid "%s Template"
-msgstr "%s テンプレート"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -112,9 +103,6 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "%s か月前"
 
-msgid "%s out of sync disabled"
-msgstr "%s の非同期切り替えを無効にしました"
-
 msgid "%s selected hosts"
 msgstr "選択したホスト %s 台"
 
@@ -131,9 +119,6 @@ msgstr "%s ウィジェットのロード中..."
 
 msgid "%s you had selected as your context has been deleted"
 msgstr "コンテキストとして選択した %s は削除されました"
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
-msgstr "%s、設定 > 認証 で「SSL CA ファイル」を確認してください"
 
 msgid "%{action} %{vm}"
 msgstr "%{action} %{vm}"
@@ -202,6 +187,9 @@ msgstr "%{match} と既存のホストグループは一致しません"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} が %{label1} から %{label2} に変更されました"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr "%{object_name} は %{object_class} ですが、サブネットが必要です"
@@ -282,6 +270,9 @@ msgstr "(エントリー総数 %s からフィルタリング)"
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(オプション) このイメージを作成する際に使用する Fog の IAM ロールです。"
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*%s プロキシーの消去*"
@@ -479,12 +470,6 @@ msgstr "ボリュームの追加"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr "CD-ROM ドライブを仮想マシンに追加します。"
 
-msgid "Add a Puppet class to host"
-msgstr "Puppet クラスをホストに追加"
-
-msgid "Add a Puppet class to host group"
-msgstr "Puppet クラスをホストグループに追加"
-
 msgid "Add a template combination"
 msgstr "テンプレートの組み合わせの追加"
 
@@ -530,9 +515,6 @@ msgstr "追加のコンピュートリソース固有の属性。"
 msgid "Additional information about this host"
 msgstr "このホストについての追加情報"
 
-msgid "Address to connect to"
-msgstr "接続先アドレス"
-
 msgid "Admin permissions required"
 msgstr "管理者パーミッションが必要です"
 
@@ -575,9 +557,6 @@ msgstr "エイリアスまたは VLAN デバイス"
 msgid "All"
 msgstr "すべて"
 
-msgid "All Audits"
-msgstr "すべての監査"
-
 msgid "All Hosts"
 msgstr "すべてのホスト"
 
@@ -586,6 +565,12 @@ msgstr "すべてのレポート"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
 msgstr "すべての Ruby コードは、ERB テンプレートの <code><&#37; &#37;></code> で囲まれています。コードはテンプレートのレンダリング時に実行されます。これには Ruby の制御フロー構造と、アプリケーション固有のマクロおよび変数を含めることができます。以下に例を示します。"
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
+msgstr ""
 
 msgid "All compute resources"
 msgstr "すべてのコンピュートリソース"
@@ -746,9 +731,6 @@ msgstr "ホスト %s を削除してもよろしいですか? この操作を取
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "ホスト %s を削除してもよろしいですか? これにより、仮想マシンとそのディスクが削除されます。この動作はグローバル設定「ホストの削除時に関連の仮想マシンを破棄」から変更できます。"
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "ダッシュボードからこのウィジェットを削除してもよろしいですか?"
-
 msgid "Are you sure you want to log out?"
 msgstr "ログアウトしてもよろしいですか?"
 
@@ -805,6 +787,12 @@ msgstr "組織の割り当て"
 
 msgid "Assign Selected Hosts"
 msgstr "選択したホストの割り当て"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1289,6 +1277,9 @@ msgstr "CLI または RC ファイル (「redhat.com」など) で取得でき�
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr "CLI または RC ファイル (「redhat.com」など) で取得できます。「デフォルト」に設定できます。v3認証のみ。"
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "内部管理者アカウントを削除できません"
 
@@ -1370,8 +1361,8 @@ msgstr "証明書キーは有効な JSON ではありません"
 msgid "Certificate path for GCE only"
 msgstr "GCE 専用の証明書パス"
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Foreman で websocket を暗号化するために使用する証明書 "
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "証明書"
@@ -1430,6 +1421,9 @@ msgstr "%s の Puppet CA 証明書のクリーンアップ"
 msgid "Clear"
 msgstr "消去"
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr "ホストのサブステータスの消去"
 
@@ -1441,12 +1435,6 @@ msgstr "コンピュートリソースのリンクをクリックして、デフ
 
 msgid "Click to log in again"
 msgstr "クリックして再ログインします。"
-
-msgid "Click to remove %s"
-msgstr "クリックして %s を削除"
-
-msgid "Click to remove config group"
-msgstr "クリックして設定グループを削除"
 
 msgid "Client Email"
 msgstr "クライアントメール"
@@ -1610,14 +1598,6 @@ msgstr "設定レポート"
 msgid "Config Retrieval"
 msgstr "設定の取得"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "設定グループ"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "名前"
-
 msgid "Configuration"
 msgstr "設定"
 
@@ -1660,8 +1640,8 @@ msgstr "競合が検出されました"
 msgid "Connected"
 msgstr "接続"
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "接続先 (暗号化なし): %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "接続先 (暗号化なし): %s"
@@ -1711,8 +1691,8 @@ msgstr "コアとプロキシーのバージョンが一致しません。%{fore
 msgid "Cores per socket"
 msgstr "1 ソケットあたりのコア数"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
-msgstr "内部認証ソースに使用する bcrypt パスワードハッシュ関数のコスト値 (4-30)。値が高いほど安全ですが、特にステートレス API 呼び出しと UI ログインの検証は時間がかかります。有効にするにはパスワードの変更が必要です。"
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
+msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
 msgstr "パーミッションを管理者および閲覧者のロールに追加できませんでした: %s"
@@ -1888,9 +1868,6 @@ msgstr "ユーザーグループの作成"
 msgid "Create a Personal Access Token for a user"
 msgstr "ユーザーのパーソナルアクセストークンを作成"
 
-msgid "Create a Puppet class"
-msgstr "Puppet クラスの作成"
-
 msgid "Create a bookmark"
 msgstr "ブックマークの作成"
 
@@ -1902,9 +1879,6 @@ msgstr "コンピュートプロファイルの作成"
 
 msgid "Create a compute resource"
 msgstr "コンピュートリソースの作成"
-
-msgid "Create a config group"
-msgstr "設定グループの作成"
 
 msgid "Create a default template combination for an operating system"
 msgstr "オペレーティングシステムのデフォルトのテンプレートの組み合わせを作成"
@@ -1978,9 +1952,6 @@ msgstr "サブネットの作成"
 msgid "Create a template input"
 msgstr "テンプレート入力を作成"
 
-msgid "Create a trend counter"
-msgstr "トレンドカウンターの作成"
-
 msgid "Create a user"
 msgstr "ユーザーの作成"
 
@@ -1996,9 +1967,6 @@ msgstr "LDAP 認証ソースの作成"
 msgid "Create an architecture"
 msgstr "アーキテクチャーの作成"
 
-msgid "Create an environment"
-msgstr "環境の作成"
-
 msgid "Create an external user group linked to a user group"
 msgstr "ユーザーグループにリンクされた外部ユーザーグループの作成"
 
@@ -2011,14 +1979,14 @@ msgstr "ホスト上のインターフェースを作成"
 msgid "Create an operating system"
 msgstr "オペレーティングシステムの作成"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "特定スマートクラスパラメーターの上書き値を作成"
-
 msgid "Create autosign entry"
 msgstr "自動署名エントリーの作成"
 
 msgid "Create image"
 msgstr "イメージの作成"
+
+msgid "Create model"
+msgstr ""
 
 msgid "Create new boot volume from image"
 msgstr "イメージから新規起動ボリュームを作成"
@@ -2034,6 +2002,9 @@ msgstr "%s のレルムエントリーの作成"
 
 msgid "Created"
 msgstr "作成日時"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr "特定のテーブルの設定を作成します"
@@ -2064,18 +2035,6 @@ msgstr "カスタムインスタンスタイプ"
 
 msgid "DB pending seed"
 msgstr "シードを保留中の DB"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr "非推奨: テンプレートの組み合わせの追加"
-
-msgid "DEPRECATED: List template combination"
-msgstr "非推奨: テンプレートの組み合わせを一覧表示"
-
-msgid "DEPRECATED: Show template combination"
-msgstr "非推奨: テンプレートの組み合わせの表示"
-
-msgid "DEPRECATED: Update template combination"
-msgstr "非推奨: テンプレートの組み合わせの更新"
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2167,8 +2126,8 @@ msgstr "デフォルト"
 msgid "Default 'Host initial configuration' template"
 msgstr "デフォルトの「ホスト初期設定」テンプレート"
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
-msgstr "デフォルトの「ホスト初期設定」テンプレート。新しいオペレーティングシステムが作成されると自動的に割り当てられます。"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
+msgstr ""
 
 msgid "Default Behavior"
 msgstr "デフォルト動作"
@@ -2190,9 +2149,6 @@ msgstr "グローバルテンプレートでのデフォルトの PXE メニュ�
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr "ローカルテンプレートでのデフォルトの PXE メニューアイテム - 'local'、'local_chain_hd0' またはカスタム。デフォルトテンプレートには blank を使用します"
-
-msgid "Default Puppet environment"
-msgstr "デフォルトの Puppet 環境"
 
 msgid "Default VNC Keyboard"
 msgstr "デフォルトの VNC キーボード"
@@ -2275,9 +2231,6 @@ msgstr "%s の Puppet CA 証明書の削除"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr "{host} の TFTP %{kind} 設定の削除"
 
-msgid "Delete a Puppet class"
-msgstr "Puppet クラスの削除"
-
 msgid "Delete a Virtual Machine"
 msgstr "仮想マシンの削除"
 
@@ -2289,9 +2242,6 @@ msgstr "コンピュートプロファイルの削除"
 
 msgid "Delete a compute resource"
 msgstr "コンピュートリソースの削除"
-
-msgid "Delete a config group"
-msgstr "設定グループの削除"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "オペレーティングシステムのデフォルトのテンプレートの組み合わせを削除"
@@ -2374,9 +2324,6 @@ msgstr "テンプレートの組み合わせの削除"
 msgid "Delete a template input"
 msgstr "テンプレート入力を削除"
 
-msgid "Delete a trend counter"
-msgstr "トレンドカウンターの削除"
-
 msgid "Delete a user"
 msgstr "ユーザーの削除"
 
@@ -2416,9 +2363,6 @@ msgstr "ユーザーの SSH キーの削除"
 msgid "Delete an architecture"
 msgstr "アーキテクチャーの削除"
 
-msgid "Delete an environment"
-msgstr "環境の削除"
-
 msgid "Delete an external user group"
 msgstr "外部ユーザーグループの削除"
 
@@ -2428,14 +2372,17 @@ msgstr "イメージの削除"
 msgid "Delete an operating system"
 msgstr "オペレーティングシステムの削除"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "特定スマートクラスパラメーターの上書き値を削除"
-
 msgid "Delete autosign entry"
 msgstr "自動署名エントリーの削除"
 
 msgid "Delete filter?"
 msgstr "フィルターを削除しますか?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "%s のレルムエントリーの削除"
@@ -2508,9 +2455,6 @@ msgstr "選択ホストの警告の無効化"
 
 msgid "Disable all filters overriding"
 msgstr "すべてのフィルター上書きの無効化"
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "設定した間隔でレポートが到達しない場合に、%s のホスト設定ステータスが非同期に切り替わらないように無効にします"
 
 msgid "Disable overriding"
 msgstr "上書きの無効化"
@@ -2627,20 +2571,17 @@ msgstr "生成したレポートをダウンロードします"
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "重複した入力が検出されました: ％{duplicated_inputs}"
 
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
+msgstr ""
+
 msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr "サーバーが非同期として分類されるまでの時間 (分単位)。ホストでこれを上書きするには、パラメーター \"outofsync_interval\" を追加します。"
-
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr "Puppet 経由で報告するサーバーが非同期として分類されるまでの期間 (分単位)。"
 
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "ENC 環境"
 
 msgid "ERROR or FATAL"
 msgstr "ERROR または FATAL"
@@ -2683,6 +2624,9 @@ msgstr "このホストの編集"
 
 msgid "Editor"
 msgstr "エディター"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "メール設定"
@@ -2759,10 +2703,6 @@ msgstr "IP 自動補完の終了 IP アドレス"
 msgid "Entries per page"
 msgstr "1 ページあたりのエントリー"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "環境"
-
 msgid "Environment IDs"
 msgstr "環境 ID"
 
@@ -2777,10 +2717,6 @@ msgstr "クライアント SSL 証明書の検証ステータスを含む環境�
 
 msgid "Environments got deprecated from this endpoint."
 msgstr "環境がこのエンドポイントから非推奨となりました。"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "名前"
 
 msgid "Error"
 msgstr "エラー"
@@ -2820,6 +2756,9 @@ msgstr "スケジューラーヒントフィルター情報のロード中にエ
 
 msgid "Error removing widget from dashboard."
 msgstr "ダッシュボードからウィジェットを削除する際にエラーが発生しました。"
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr "データ送信時にエラーが発生しました:"
@@ -3288,14 +3227,14 @@ msgstr "不一致 の %s を修正"
 msgid "Fix All Mismatches"
 msgstr "すべての不一致を修正"
 
-msgid "Fix DB cache"
-msgstr "DB キャッシュの修正"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Foreman の次回起動時に DB キャッシュを修正"
-
 msgid "Fix Mismatches"
 msgstr "不一致の修正"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "フレーバー"
@@ -3342,9 +3281,6 @@ msgstr "詳細は、以下を参照してください: "
 msgid "For values of type search, this is the resource the value searches in"
 msgstr "タイプを検索する値の場合には、これは値が検索するリソースです"
 
-msgid "Force a Puppet agent run on the host"
-msgstr "ホスト上で Puppet エージェントの実行を強制します"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "Foreman API v2 は現在デフォルトの API バージョンです。"
 
@@ -3378,6 +3314,10 @@ msgstr "Foreman は、データベースで不明なクラスの定義を検出�
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr "Foreman インスタンス ID。この Foreman インスタンスの一意の ID。"
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "Foreman matcher は、ホストグループ、組織、ロケーションのスマートクラスパラメーターの評価時に、子によって継承されます。"
 
@@ -3386,6 +3326,10 @@ msgstr "%s のビルドサイクルが Foreman の管理対象となりました
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "%s のビルドサイクルが Foreman の管理対象外となりました"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Foreman レポートの作成時間は <em>%s</em> です"
@@ -3414,8 +3358,8 @@ msgstr "Foreman は、新規ホストのプロビジョニング時にドメイ�
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman は、新規ホストのプロビジョニング時に証明書の署名を自動化します"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
-msgstr "Foreman は IP アドレスの違反をしてから 5 分間で、ログイン失敗回数が指定の数に達した場合には、ユーザーのログインをブロックします。0 に設定すると総当たり攻撃からの保護が無効になります。"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
+msgstr ""
 
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman はレポートの受信時にホストを作成します"
@@ -3423,20 +3367,14 @@ msgstr "Foreman はレポートの受信時にホストを作成します"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman は新規ファクトの受信時にホストを作成します"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "Foreman は、自動検出できない場合にこの puppet 環境にデフォルト設定されます"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Foreman は、プロビジョニングスクリプトがゼロ以外の終了コードで終了する場合に仮想マシンを削除します"
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr "Foreman は、デフォルトではこの順番でホストのスマートクラスパラメーターを評価します"
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman は ENC YAML 出力で puppet 環境を明示的に設定します。これにより、puppet.conf の環境と Foreman で設定される環境間の競合を避けられます"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman は request-header のユーザーをユーザー名でマッピングします。これが false に設定されると、OAuth 要求には管理特権が設定されます。"
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "Foreman では、このパラメーターは分類出力で送信されません。"
@@ -3446,9 +3384,6 @@ msgstr "Foreman は ENC 出力にあるパラメーター値の ERB を解析し
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman は SOA/NS 権限ではなく、ローカルで設定されたリゾルバーをクエリーします"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman はホスト環境をそのファクトで更新します"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "Foreman はホストのホストグループをファクトから更新します"
@@ -3467,6 +3402,18 @@ msgstr "Foreman は、証明書の署名にホスト名ではなくランダム 
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman は、新規仮想マシンの作成に FQDN ではなく省略されたホスト名を使用します"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr "フォームが正常に作成されました"
@@ -3494,6 +3441,9 @@ msgstr "全画面"
 
 msgid "Function not available for %s"
 msgstr "%s で使用できない機能"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "GMT 時間"
@@ -3564,8 +3514,8 @@ msgstr "ダッシュボードの詳細を取得"
 msgid "Get default dashboard widgets"
 msgstr "デフォルトのダッシュボードウィジェットの取得"
 
-msgid "Get statistics"
-msgstr "統計の取得"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "ホストのステータスの取得"
@@ -3687,6 +3637,12 @@ msgstr "ハードウェアモデル %s は正常に削除されました"
 msgid "Hardware Models"
 msgstr "ハードウェアモデル"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr "ネットワークベースのプロビジョニングにのみ効果があります"
 
@@ -3732,11 +3688,17 @@ msgstr "履歴"
 msgid "Host"
 msgstr "ホスト"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "ホスト %s が構築されました"
 
 msgid "Host %s is not associated with a VM"
 msgstr "ホスト %s は VM に関連付けられていません"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "ホスト設定チャート"
@@ -3774,8 +3736,14 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "ホストパラメーター"
 
-msgid "Host Wizard"
-msgstr "ホストウィザード"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
+msgstr ""
 
 msgid "Host audit entries"
 msgstr "ホスト監査エントリー"
@@ -3783,12 +3751,12 @@ msgstr "ホスト監査エントリー"
 msgid "Host built"
 msgstr "ホストのビルド"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "ホスト設定グループ"
-
 msgid "Host details"
 msgstr "ホストの詳細"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "ホストグループ"
@@ -3926,8 +3894,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "ホストタイプ"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4155,9 +4147,6 @@ msgstr "設定テンプレートの ID"
 msgid "ID of domain"
 msgstr "ドメインの ID"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr "環境の ID - DEPRECATED (非推奨) は効果がありません"
-
 msgid "ID of host"
 msgstr "ホストの ID"
 
@@ -4224,8 +4213,8 @@ msgstr "ホストを登録する組織の ID"
 msgid "ID of the Organization to register the host in."
 msgstr "ホストを登録する組織の ID。"
 
-msgid "ID of the Smart Proxy"
-msgstr "Smart Proxy の ID"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
+msgstr ""
 
 msgid "ID of the user"
 msgstr "ユーザーの ID"
@@ -4287,9 +4276,6 @@ msgstr "IP アドレスの自動補完"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr "提案から除外する必要がある IP アドレス"
 
-msgid "IP6 Address"
-msgstr "IP6 アドレス"
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4312,6 +4298,9 @@ msgstr "IPv4 サブネット"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr "関連付けられた TFTP Smart Proxy と IPv4 サブネットは、PXE ベースのプロビジョニングに必要です。"
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "インターフェースの IPv4 アドレス"
 
@@ -4330,6 +4319,9 @@ msgstr[0] "IPv6 DNS レコード"
 
 msgid "IPv6 Subnet"
 msgstr "IPv6 サブネット"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "インターフェースの IPv6 アドレス"
@@ -4391,14 +4383,14 @@ msgstr "この設定をファイルで変更する必要がある場合は、フ
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "これが Foreman 自体のエラーであると思われる場合は、新規の問題として提出してください。"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "プロビジョニングでは Puppet ファクトを無視する"
-
 msgid "Ignore facts for domain"
 msgstr "ドメインのファクトを無視"
 
 msgid "Ignore facts for operating system"
 msgstr "オペレーティングシステムのファクトを無視"
+
+msgid "Ignore interfaces facts for provisioning"
+msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
 msgstr "ID が一致するインターフェースを無視する"
@@ -4478,12 +4470,6 @@ msgstr "管理対象外ホストとしてインポート"
 
 msgid "Import of facts failed for host %s"
 msgstr "ホスト %s のファクトのインポートに失敗しました"
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Puppet プロキシーから Puppet クラスをインポート"
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "環境について Puppet プロキシーから Puppet クラスをインポート"
 
 msgid "Imported IPv4 Subnets"
 msgstr "インポート済みの IPv4 サブネット"
@@ -4602,6 +4588,9 @@ msgstr "インストールエラー"
 msgid "Installation medium configuration"
 msgstr "インストールメディア設定"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "インストール済み"
 
@@ -4667,6 +4656,9 @@ msgstr "%{assoc} の選択が無効です。少なくとも 1 つ以上選択し
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
 msgstr "Google JSON キーが無効です。クライアントのメールと秘密鍵のオプションが存在することを確認してください"
+
+msgid "Invalid HTTP(S) URL"
+msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
 msgstr "'%{os}' の '%{arch}' アーキテクチャーが無効です"
@@ -4833,14 +4825,14 @@ msgstr "最新イベント"
 msgid "Launch Console"
 msgstr "コンソールの起動"
 
-msgid "Launch loading wizard"
-msgstr "ロードウィザードを起動します"
-
 msgid "Learn more about External authentication in the documentation."
 msgstr "ドキュメントで外部認証の詳細を確認してください。"
 
 msgid "Learn more about LDAP authentication in the documentation."
 msgstr "ドキュメントで LDAP 認証の詳細を確認してださい。"
+
+msgid "Legacy UI"
+msgstr ""
 
 msgid "Length"
 msgstr "長さ"
@@ -4874,24 +4866,6 @@ msgstr "すべての LDAP 認証ソースを一覧表示"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr "ユーザーのすべてのパーソナルアクセストークンを一覧表示"
-
-msgid "List all Puppet class IDs for host"
-msgstr "ホストのすべての Puppet クラス ID を一覧表示"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "ホストグループのすべての Puppet クラス ID を一覧表示"
-
-msgid "List all Puppet classes"
-msgstr "すべての Puppet クラスを一覧表示"
-
-msgid "List all Puppet classes for a host"
-msgstr "ホストのすべての Puppet クラスを一覧表示"
-
-msgid "List all Puppet classes for a host group"
-msgstr "ホストグループのすべての Puppet クラスを一覧表示"
-
-msgid "List all Puppet classes for an environment"
-msgstr "環境のすべての Puppet クラスを一覧表示"
 
 msgid "List all SSH keys for a user"
 msgstr "ユーザーのすべての SSH キーを一覧表示"
@@ -4928,9 +4902,6 @@ msgstr "すべてのコンピュートリソースを一覧表示"
 
 msgid "List all email notifications for a user"
 msgstr "ユーザーの全メール通知を一覧表示します。"
-
-msgid "List all environments"
-msgstr "すべての環境を一覧表示"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "LDAP 認証ソースのすべての外部ユーザーグループを一覧表示"
@@ -5067,9 +5038,6 @@ msgstr "すべてのロールを一覧表示"
 msgid "List all settings"
 msgstr "すべての設定を一覧表示"
 
-msgid "List all smart class parameters"
-msgstr "すべてのスマートクラスパラメーターを一覧表示"
-
 msgid "List all smart proxies"
 msgstr "すべての Smart Proxy を一覧表示"
 
@@ -5148,15 +5116,6 @@ msgstr "オペレーティングシステムのブートファイルを一覧表
 msgid "List default templates combinations for an operating system"
 msgstr "オペレーティングシステムのデフォルトのテンプレートの組み合わせを一覧表示"
 
-msgid "List environments of Puppet class"
-msgstr "Puppet クラスの環境を一覧表示"
-
-msgid "List environments per location"
-msgstr "ロケーションごとに環境を一覧表示"
-
-msgid "List environments per organization"
-msgstr "組織ごとに環境を一覧表示"
-
 msgid "List external authentication sources"
 msgstr "外部認証ソースを一覧表示"
 
@@ -5165,6 +5124,9 @@ msgstr "ロケーションごとの外部認証ソースを一覧表示します
 
 msgid "List external authentication sources per organization"
 msgstr "組織ごとの外部認証ソースを一覧表示します"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "ロケーションごとにホストを一覧表示"
@@ -5199,9 +5161,6 @@ msgstr "指定のコンピュートプロファイルとコンピュートリソ
 msgid "List of compute profiles"
 msgstr "コンピュートプロファイルの一覧"
 
-msgid "List of config groups"
-msgstr "設定グループの一覧"
-
 msgid "List of domains"
 msgstr "ドメインの一覧"
 
@@ -5217,35 +5176,20 @@ msgstr "サブネットごとのドメインの一覧"
 msgid "List of email notifications"
 msgstr "メール通知の一覧"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr "ファクト/レポートインポーターおよび ENC 出力にアクセスするための Smart Proxy に加え、信頼されるホスト名、IPv4、IPv6 アドレスまたはサブネットの一覧。"
 
 msgid "List of hosts which answer to the provided query"
 msgstr "提供されるクエリーに応答するホストの一覧"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "特定スマートクラスパラメーターの上書き値の一覧"
-
 msgid "List of realms"
 msgstr "レルム一覧"
 
 msgid "List of resources types that will be automatically associated"
 msgstr "自動的に関連付けられるリソースタイプの一覧"
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "特定 Puppet クラスのスマートクラスパラメーターの一覧"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "特定の環境のスマートクラスパラメーターの一覧"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "特定の環境/Puppet クラスの組み合わせ用のスマートクラスパラメーターの一覧"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "特定ホストのスマートクラスパラメーターの一覧"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "特定ホストグループのスマートクラスパラメーターの一覧"
 
 msgid "List of subnets"
 msgstr "サブネットの一覧"
@@ -5264,9 +5208,6 @@ msgstr "ユーザーのテーブル設定一覧"
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
 msgstr "dns_lookup マクロや DNS レコードの競合検証など、DNS ルックアップ試行のタイムアウト (秒単位) の一覧"
-
-msgid "List of trends counters"
-msgstr "トレンドカウンターのリスト"
 
 msgid "List of user selected columns"
 msgstr "ユーザーが選択したコラムの一覧"
@@ -5451,6 +5392,10 @@ msgid "LookupKey|Key type"
 msgstr "キータイプ"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr "デフォルトのマージ"
 
@@ -5499,6 +5444,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "MAC アドレス"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "インターフェースの MAC アドレス。ベアメタルの管理対象インターフェースに必要です。"
@@ -5581,6 +5529,9 @@ msgstr "管理"
 msgid "Manage Bookmarks"
 msgstr "ブックマークの管理"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "ロケーションの管理"
 
@@ -5589,6 +5540,9 @@ msgstr "組織の管理"
 
 msgid "Manage PuppetCA"
 msgstr "PuppetCA の管理"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "ホストの管理"
@@ -5689,10 +5643,6 @@ msgid "Message"
 msgstr "メッセージ"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "ダイジェスト"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "値"
 
@@ -5710,6 +5660,9 @@ msgstr "メトリックは登録済みです: %s"
 
 msgid "Metrics"
 msgstr "メトリックス"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "分前"
@@ -5788,6 +5741,9 @@ msgstr "マイアカウント"
 msgid "N/A"
 msgstr "N/A"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "NA"
 
@@ -5809,8 +5765,8 @@ msgstr "メディアの名前"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr "認証に使用されている OpenID Connect Audience の名前。 Keycloakの場合は、これはクライアント ID です。"
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
-msgstr "外部認証ソースの名前。このソースでは、不明な外部認証ユーザー (authorize_login_delegation を参照) を作成する必要のあるです (自動作成を回避するには設定を解除します)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
+msgstr ""
 
 msgid "Name of the host group"
 msgstr "ホストグループの名前"
@@ -5887,6 +5843,9 @@ msgstr "新規組織"
 msgid "New SSH key"
 msgstr "新規の SSH キー"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "新規仮想マシン"
 
@@ -5902,8 +5861,8 @@ msgstr "以下の理由で新規接続が拒否されました: %"
 msgid "New filter"
 msgstr "新規フィルター"
 
-msgid "New window"
-msgstr "新規ウィンドウ"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "次へ"
@@ -6030,6 +5989,9 @@ msgstr "TFTP 機能なし"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "TFTP プロキシーが定義されていないため、続行できません"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr "ホストに一致する VM はありません。"
 
@@ -6068,6 +6030,9 @@ msgstr "メールなし"
 
 msgid "No entries found"
 msgstr "エントリーが見つかりません"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "このプロキシーに機能が見つかりません。少なくとも 1 つの機能を有効にしていることを確認してください"
@@ -6165,6 +6130,9 @@ msgstr "Smart Proxy が見つかりません。"
 msgid "No smart proxies to show"
 msgstr "表示する Smart Proxy がありません"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "サブネットなし"
 
@@ -6201,11 +6169,11 @@ msgstr "標準"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr "通常は、コンピュートリソースの設定時にキーペア (秘密および公開) が自動的に作成されます。"
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "インストールされていません"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr "HTTP プロキシーで有効な URL ではありません"
 
 msgid "Not implemented"
 msgstr "実装されていません"
@@ -6372,6 +6340,9 @@ msgstr "OIDC JWK URL"
 msgid "OK"
 msgstr "OK"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "OS イメージ"
 
@@ -6447,9 +6418,6 @@ msgstr "エラー。問題が発生しました。"
 
 msgid "Open"
 msgstr "開く"
-
-msgid "Open Spice in a new window"
-msgstr "新規ウィンドウで SPICE を開く"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr "Foreman から Smart Proxy への HTTP 要求の表示および読み取りタイムアウト (秒単位)"
@@ -6550,9 +6518,6 @@ msgstr "オプションの入力バリデーター"
 msgid "Optional array of log hashes"
 msgstr "ログハッシュのオプション配列"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "インポートされた Puppe クラスを制限するために使用される '新規'、'更新済み'、または '旧版' のいずれかが含まれる、オプションのコンマ区切りの文字列"
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "オプション: IP 自動補完の終了 IP アドレス"
 
@@ -6616,9 +6581,6 @@ msgstr "出力形式"
 msgid "Override"
 msgstr "上書き"
 
-msgid "Override Value"
-msgstr "値の上書き"
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "Puppet クラスパラメーターのデフォルト値を上書きします。"
 
@@ -6631,8 +6593,17 @@ msgstr "概要"
 msgid "Overwrite"
 msgstr "上書き"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "所有者"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "所有者"
@@ -6716,6 +6687,10 @@ msgstr "名前"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "優先度"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr "タイプ"
@@ -6954,9 +6929,6 @@ msgstr "要求が処理されるまでお持ちください"
 msgid "Plugins"
 msgstr "プラグイン"
 
-msgid "Port to connect to"
-msgstr "接続先ポート"
-
 msgid "Possible values"
 msgstr "設定可能な値"
 
@@ -6969,8 +6941,14 @@ msgstr "電源"
 msgid "Power ON this machine"
 msgstr "このマシンのパワーをオンにする"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
 msgstr "仮想マシンの電源をオンにする"
+
+msgid "Power has been set to \"%s\" successfully"
+msgstr ""
 
 msgid "Power operations are not enabled on this host."
 msgstr "このホストでは電源操作が有効ではありません。"
@@ -7038,8 +7016,8 @@ msgstr "属性の順序の優先順位付け"
 msgid "Private"
 msgstr "秘密"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
-msgstr "websocket の暗号化に Foreman が使用する秘密鍵ファイル "
+msgid "Private key file path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Proceed to Edit"
 msgstr "編集に進む"
@@ -7138,6 +7116,9 @@ msgstr "プロキシー"
 msgid "Proxy ID to use within this realm"
 msgstr "このレルム内で使用するプロキシー ID"
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr "プロキシー参照は { :relation => [:column_name, ...] } でなければなりません"
 
@@ -7186,9 +7167,6 @@ msgstr "Puppet クラス"
 msgid "Puppet error state"
 msgstr "Puppet のエラー状態"
 
-msgid "Puppet interval"
-msgstr "Puppet の間隔"
-
 msgid "Puppet parameter"
 msgstr "Puppet パラメーター"
 
@@ -7197,14 +7175,6 @@ msgstr "Puppet プロキシー ID"
 
 msgid "Puppet summary"
 msgstr "Puppet の概要"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppet クラス"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "名前"
 
 msgid "Query"
 msgstr "Query"
@@ -7280,6 +7250,9 @@ msgstr "名前"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "レルムタイプ"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "再起動およびビルド"
@@ -7379,12 +7352,6 @@ msgstr "Matcher の削除"
 msgid "Remove Parameter"
 msgstr "パラメーターの削除"
 
-msgid "Remove a Puppet class from host"
-msgstr "ホストから Puppet クラスを削除"
-
-msgid "Remove a Puppet class from host group"
-msgstr "ホストグループから Puppet クラスを削除"
-
 msgid "Remove an email notification for a user"
 msgstr "ユーザーのメール通知を削除します。"
 
@@ -7393,6 +7360,9 @@ msgstr "%{host} の競合する %{type} の削除"
 
 msgid "Remove tag"
 msgstr "タグの削除"
+
+msgid "Remove widget"
+msgstr ""
 
 msgid "Removed %{from} to %{to}"
 msgstr "%{to} に %{from} を削除しました"
@@ -7476,6 +7446,9 @@ msgstr "名前"
 msgid "ReportTemplate|Snippet"
 msgstr "スニペット"
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "レポート日時"
 
@@ -7487,6 +7460,9 @@ msgstr "%s で報告済み"
 
 msgid "Reports"
 msgstr "レポート"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7531,6 +7507,9 @@ msgstr "ユーザーが外部認証ソースに含まれていない場合に必
 msgid "Required when user want to change own password"
 msgstr "ユーザーが独自のパスワードを変更する場合に必須"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr "%s の PuppetCA certname のリセット"
 
@@ -7574,6 +7553,9 @@ msgstr "レポート %s の結果"
 msgid "Resume"
 msgstr "再開"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "該当するタイプのホストステータスを表す文字列を返します"
 
@@ -7597,8 +7579,14 @@ msgstr "元に戻せませんでした。${err}"
 msgid "Revert Local Changes"
 msgstr "ローカルの変更を元に戻す"
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "確認"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "%s のビルドステータスの確認"
@@ -7608,6 +7596,9 @@ msgstr "取り消し"
 
 msgid "Revoke a Personal Access Token for a user"
 msgstr "ユーザーのパーソナルアクセストークンを取り消し"
+
+msgid "Revoke personal access token"
+msgstr ""
 
 msgid "Revoked"
 msgstr "取り消し済み"
@@ -7689,6 +7680,9 @@ msgstr "SMTP OpenSSL 検証モード"
 msgid "SMTP address"
 msgstr "SMTP アドレス"
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "SMTP 認証"
 
@@ -7703,6 +7697,9 @@ msgstr "SMTP パスワード"
 
 msgid "SMTP port"
 msgstr "SMTP ポート"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr "SMTP ユーザー名"
@@ -7722,14 +7719,20 @@ msgstr "SSH タイムアウト"
 msgid "SSL CA file"
 msgstr "SSL CA ファイル"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Foreman がプロキシーと通信するために使用する SSL CA ファイル"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Foreman がプロキシーと通信するために使用する SSL 証明書パス"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "プロキシーとの通信に Foreman が使用する SSL 秘密鍵"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "SSL 証明書"
@@ -7778,6 +7781,9 @@ msgstr "保存してからやり直してください"
 
 msgid "Saved Bookmarks"
 msgstr "保存済みブックマーク"
+
+msgid "Saved audits interval"
+msgstr ""
 
 msgid "Schedule generating of a report"
 msgstr "レポートの生成をスケジュールします"
@@ -7954,6 +7960,9 @@ msgstr "Sendmail の引数"
 msgid "Sendmail location"
 msgstr "Sendmail のロケーション"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr "サーバーグループ"
 
@@ -7984,6 +7993,9 @@ msgstr "ホストの「host_registration_remote_execution」パラメーター�
 msgid "Set IP addresses for %s"
 msgstr "%s の IP アドレスの設定"
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr "VNC ディスプレイ接続時にランダムに生成されたパスワードを設定します"
 
@@ -8004,9 +8016,6 @@ msgstr "値が解決される順序を設定します。"
 
 msgid "Set up compute instance %s"
 msgstr "コンピュートインスタンス %s の設定"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr "Foreman からの HTTP 送信接続すべてにプロキシーを設定します。システム全体のプロキシーはオペレーティングシステムレベルで設定する必要があります。"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8074,6 +8083,12 @@ msgstr "Insights の設定"
 msgid "Setup REX"
 msgstr "REX のセットアップ"
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "インストーラーモジュールの次回実行時に `foreman-rake db:seed` を実行する必要がありますか?"
 
@@ -8107,18 +8122,6 @@ msgstr "実験的ラボの表示"
 msgid "Show a Personal Access Token for a user"
 msgstr "ユーザーのパーソナルアクセストークンを表示"
 
-msgid "Show a Puppet class"
-msgstr "Puppet クラスの表示"
-
-msgid "Show a Puppet class for a host group"
-msgstr "ホストグループの Puppet クラスの表示"
-
-msgid "Show a Puppet class for an environment"
-msgstr "環境の Puppet クラスの表示"
-
-msgid "Show a Puppet class for host"
-msgstr "ホストの Puppet クラスの表示"
-
 msgid "Show a bookmark"
 msgstr "ブックマークの表示"
 
@@ -8130,9 +8133,6 @@ msgstr "コンピュートプロファイルの表示"
 
 msgid "Show a compute resource"
 msgstr "コンピュートリソースの表示"
-
-msgid "Show a config group"
-msgstr "設定グループの表示"
 
 msgid "Show a default template combination for an operating system"
 msgstr "オペレーティングシステムのデフォルトのテンプレートの組み合わせを表示"
@@ -8200,17 +8200,11 @@ msgstr "ロールの表示"
 msgid "Show a setting"
 msgstr "設定の表示"
 
-msgid "Show a smart class parameter"
-msgstr "スマートクラスパラメーターの表示"
-
 msgid "Show a smart proxy"
 msgstr "Smart Proxy の表示"
 
 msgid "Show a subnet"
 msgstr "サブネットの表示"
-
-msgid "Show a trend"
-msgstr "トレンドの表示"
 
 msgid "Show a user"
 msgstr "ユーザーの表示"
@@ -8245,9 +8239,6 @@ msgstr "監査の表示"
 msgid "Show an email notification"
 msgstr "メール通知の表示"
 
-msgid "Show an environment"
-msgstr "環境の表示"
-
 msgid "Show an external authentication source"
 msgstr "外部認証ソースの表示"
 
@@ -8268,9 +8259,6 @@ msgstr "内部認証ソースの表示"
 
 msgid "Show an operating system"
 msgstr "オペレーティングシステムの表示"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "特定スマートクラスパラメーターの上書き値を表示"
 
 msgid "Show available API links"
 msgstr "利用可能な API リンクの表示"
@@ -8352,9 +8340,6 @@ msgstr "スキップ"
 msgid "Skipped|S"
 msgstr "S"
 
-msgid "Smart Class Parameter"
-msgstr "スマートクラスパラメーター"
-
 msgid "Smart Class Parameters"
 msgstr "スマートクラスパラメーター"
 
@@ -8422,6 +8407,9 @@ msgstr "一部のインターフェースが無効です"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "一部のインターフェースが無効です。以下の表を確認してください。"
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "ホストタイプの変更中に問題が発生しました: %s"
 
@@ -8445,10 +8433,6 @@ msgid "Source"
 msgstr "ソース"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "ダイジェスト"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "値"
 
@@ -8470,8 +8454,8 @@ msgstr "推奨される最大値 %s よりも大きい値が指定されてい�
 msgid "Specify Matchers"
 msgstr "Matcher の指定"
 
-msgid "Specify additional options to sendmail"
-msgstr "sendmail の追加オプションを指定します"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "Specify authentication type, if required"
 msgstr "認証タイプを指定します (必要な場合)"
@@ -8514,8 +8498,8 @@ msgstr "ステータス"
 msgid "Status %s does not exist."
 msgstr "ステータス %s が存在しません。"
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "Puppet ファクトからの IP アドレスと MAC 値の更新を停止します (すべてのインターフェースに影響します)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr "ファクトからのオペレーティングシステムの更新を停止"
@@ -8611,6 +8595,10 @@ msgid "Subnet|Dns secondary"
 msgstr "セカンダリー DNS"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "開始アドレス"
 
@@ -8637,6 +8625,10 @@ msgstr "名前"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "ネットワーク"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8709,6 +8701,12 @@ msgstr "%{feature} のサポートは非推奨になり、バージョン %{vers
 
 msgid "Supported Formats"
 msgstr "対応している形式"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "認証ソースからグループを同期"
@@ -8867,12 +8865,20 @@ msgid "TemplateInput|Advanced"
 msgstr "詳細"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "説明"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "ファクト名"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8941,6 +8947,10 @@ msgid "Template|Default"
 msgstr "デフォルト"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "ロック"
 
@@ -8991,8 +9001,8 @@ msgstr "テストメール"
 msgid "Tester"
 msgstr "テスター"
 
-msgid "Text to be shown in the login-page footer"
-msgstr "ログインページフッターに表示されるテキスト"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
+msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
@@ -9136,8 +9146,8 @@ msgstr "設定カテゴリーの人間が判読できる名前"
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr "たとえば、上記の情報を使用して、プロビジョニングテンプレートでインターフェースごとに NetworkManager の設定ファイルを作成できます。"
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
-msgstr "インスタンスのタイトルは上部のナビゲーションバーに表示されます (ページを再読み込みする必要があります)。"
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
+msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
 msgstr "iss (issuer) 要求は、JWT を発行したプリンシパルを特定します。大半の OpenID プロバイダーの場合には `/.well-known/openid-configuration` にあります。"
@@ -9152,8 +9162,8 @@ msgid "The list is excluding %{count} %{link_start}physical host%{link_end}."
 msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_end}."
 msgstr[0] "この一覧は %{count} %{link_start}physical host%{link_end} を除外しています。"
 
-msgid "The location of the sendmail executable"
-msgstr "sendmail 実行可能ファイルのロケーション"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "マークが付いたフィールドは確認が必要です"
@@ -9182,9 +9192,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "選択したホストの電源状態は %s に設定されます"
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr "puppetrun 機能は削除されましたが、リモート実行プラグインを使用して Puppet コマンドを実行できます"
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "レルム名 (例: EXAMPLE.COM)"
@@ -9246,6 +9253,9 @@ msgstr "サーバーのログに詳細にわたる情報が含まれる可能性
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
 msgstr "外部 IPAM プラグインをインストールし、設定した Smart Proxyが最低でも 1 つ必要です。"
+
+msgid "There was a problem processing the request. Please try again."
+msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
 msgstr "PXE ファイルの作成時にエラーが発生しました: %s"
@@ -9374,8 +9384,8 @@ msgstr "この値は非表示になりません"
 msgid "This value is used also as the host's primary interface name."
 msgstr "この値は、ホストのプライマリーインターフェース名としても使用されます。"
 
-msgid "This will be one of our coolest pages."
-msgstr "これは最もクールなページの 1 つになります。"
+msgid "This will change the host power status, are you sure?"
+msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
 msgstr "これにより、レポート %s が生成されます。レポートの定義によっては処理時間が長くなる可能性があります。"
@@ -9400,15 +9410,6 @@ msgstr "新しいユーザーに使用するタイムゾーン"
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
 msgstr "%s API にアクセスするには、Foreman Puppet プラグインをインストールする必要があります。"
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr "/statistics API にアクセスするには Foreman Statistics プラグインをインストールする必要があります。"
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr "/trends API にアクセスするには Foreman Statistics プラグインをインストールする必要があります。"
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
-msgstr "import_puppetclasses API にアクセスするには、Foreman Puppet プラグインをインストールする必要があります。"
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
 msgstr "デフォルトの動作を変更するには、<code>-&#37;></code> で囲みマークを変更します。"
@@ -9441,9 +9442,6 @@ msgstr "トークン"
 
 msgid "Token Expiry"
 msgstr "トークンの失効"
-
-msgid "Token duration"
-msgstr "トークン期間"
 
 msgid "Token expired"
 msgstr "トークンは期限切れです"
@@ -9481,41 +9479,8 @@ msgid "Total of one host"
 msgid_plural "Total of %{hosts} hosts"
 msgstr[0] "合計ホスト 1 台"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "トレンド"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "トレンドカウンター"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "カウント"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "インターバルの終了"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "インターバルの開始"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "ファクト名"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "ファクト値"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "名前"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "トレンドタイプ"
+msgid "Total: %s"
+msgstr ""
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "ホストを管理対象とするかどうかについての True/False フラグです。注意: この値は複数のパラメーターが必要となるかどうかも決定します。"
@@ -9796,6 +9761,12 @@ msgstr "websockets_encrypt がオンの場合は websockets_ssl_key を設定解
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "ダッシュボードウィジェットのテンプレートは許可されません: %s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "自動 URL"
 
@@ -9853,6 +9824,9 @@ msgstr "データベースで不明なレコードが見つかりました"
 msgid "Unknown status: %s"
 msgstr "不明なステータス: %s"
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "ロック解除"
 
@@ -9880,9 +9854,6 @@ msgstr ":a_resource の更新"
 msgid "Update IP from built request"
 msgstr "ビルド要求からの IP の更新"
 
-msgid "Update a Puppet class"
-msgstr "Puppet クラスの更新"
-
 msgid "Update a bookmark"
 msgstr "ブックマークの更新"
 
@@ -9894,9 +9865,6 @@ msgstr "コンピュートプロファイルの更新"
 
 msgid "Update a compute resource"
 msgstr "コンピュートリソースの更新"
-
-msgid "Update a config group"
-msgstr "設定グループの更新"
 
 msgid "Update a default template combination for an operating system"
 msgstr "オペレーティングシステムのデフォルトのテンプレートの組み合わせを更新"
@@ -9964,9 +9932,6 @@ msgstr "ロールの更新"
 msgid "Update a setting"
 msgstr "設定の更新"
 
-msgid "Update a smart class parameter"
-msgstr "スマートクラスパラメーターの更新"
-
 msgid "Update a smart proxy"
 msgstr "Smart Proxy の更新"
 
@@ -9997,9 +9962,6 @@ msgstr "アーキテクチャーの更新"
 msgid "Update an email notification for a user"
 msgstr "ユーザーのメール通知を更新します。"
 
-msgid "Update an environment"
-msgstr "環境の更新"
-
 msgid "Update an external authentication source"
 msgstr "外部認証ソースの更新"
 
@@ -10008,12 +9970,6 @@ msgstr "イメージの更新"
 
 msgid "Update an operating system"
 msgstr "オペレーティングシステムの更新"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "特定スマートクラスパラメーターの上書き値を更新"
-
-msgid "Update environment from facts"
-msgstr "ファクトから環境を更新"
 
 msgid "Update external user group"
 msgstr "外部ユーザーグループの更新"
@@ -10250,6 +10206,10 @@ msgid "User|Description"
 msgstr "説明"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "名"
 
@@ -10386,8 +10346,8 @@ msgstr "変数"
 msgid "Variables"
 msgstr "変数"
 
-msgid "Vendor Class"
-msgstr "ベンダークラス"
+msgid "Vendor class"
+msgstr ""
 
 msgid "Verify"
 msgstr "確認"
@@ -10448,6 +10408,9 @@ msgstr "%s がオンラインになるのを待機"
 
 msgid "Warning"
 msgstr "警告"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "警告!"
@@ -10515,6 +10478,9 @@ msgstr ""
 "テンプレートの編集時に、このテンプレートを使用できる \\\n"
 "オペレーティングシステムの一覧を割り当てる必要があります。オプションで、テンプレート \\\n"
 "をホストグループの一覧に制限することができます。"
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
+msgstr ""
 
 msgid ""
 "When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.\n"
@@ -10649,6 +10615,9 @@ msgstr "Yes (上書き)"
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "設定済みの全 TFTP サーバーのデフォルト PXE メニューを変更しようとしています。続行しますか?"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr "%s を削除しようとしています。削除してもよろしいでしょうか?"
@@ -10803,6 +10772,9 @@ msgstr "すべて"
 msgid "already exists"
 msgstr "すでに存在します"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "組織"
 
@@ -10814,9 +10786,6 @@ msgstr "配列"
 
 msgid "auxiliary field"
 msgstr "補助フィールド"
-
-msgid "belongs to config group"
-msgstr "設定グループに属します"
 
 msgid "boolean"
 msgstr "ブール値"
@@ -10997,9 +10966,6 @@ msgstr "VMware 専用キャッシュの有効化"
 
 msgid "enabled"
 msgstr "有効化"
-
-msgid "environment id"
-msgstr "環境 ID"
 
 msgid "expected a value of type %s"
 msgstr "タイプ %s の値が必要です"
@@ -11248,8 +11214,7 @@ msgstr "外部ユーザーグループをこのユーザーグループにリン
 msgid "list"
 msgstr "list"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "日本語"
 
@@ -11429,12 +11394,6 @@ msgstr "物理 @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "物理 @ bridge %s"
-
-msgid "plugin action 1"
-msgstr "プラグインアクション 1"
-
-msgid "plugin action 2"
-msgstr "プラグインアクション 2"
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "電源アクション。有効なアクションは (on/start)、(off/stop)、(soft/reboot)、(cycle/reset)、(state/status) です。"

--- a/locale/ko/foreman.po
+++ b/locale/ko/foreman.po
@@ -20,9 +20,6 @@ msgstr ""
 msgid " Documentation"
 msgstr ""
 
-msgid " Remove"
-msgstr "삭제 "
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -34,9 +31,6 @@ msgstr ""
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr ""
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - Shift-F12 키를 눌러  커서를 해제합니다. "
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - 다음 호스트는 즉시 변경됩니다 "
@@ -56,9 +50,6 @@ msgstr[1] ""
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s 매개 변수가 업데이트되었습니다. 보다 자세한 내용은 아래에서 참조하십시오 "
-
-msgid "%s Template"
-msgstr "%s 템플릿 "
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -108,9 +99,6 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "%s 개월 전 "
 
-msgid "%s out of sync disabled"
-msgstr ""
-
 msgid "%s selected hosts"
 msgstr "%s 선택된 호스트 "
 
@@ -127,9 +115,6 @@ msgid "%s widget loading..."
 msgstr ""
 
 msgid "%s you had selected as your context has been deleted"
-msgstr ""
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
 msgstr ""
 
 msgid "%{action} %{vm}"
@@ -200,6 +185,9 @@ msgstr "%{match}은(는) 기존 호스트 그룹과 일치하지 않습니다 "
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} 이(가) %{label1}에서 %{label2}로 변경되었습니다 "
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr ""
@@ -282,6 +270,9 @@ msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(옵션) 이미지를 생성할 때 사용할 Fog의 IAM 역할입니다. "
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*%s 프록시 삭제*"
@@ -476,12 +467,6 @@ msgstr "볼륨 추가 "
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr ""
 
-msgid "Add a Puppet class to host"
-msgstr "호스트에 Puppet 클래스 추가 "
-
-msgid "Add a Puppet class to host group"
-msgstr "호스트 그룹에 Puppet 클래스 추가 "
-
 msgid "Add a template combination"
 msgstr "템플릿 조합 추가 "
 
@@ -527,9 +512,6 @@ msgstr "컴퓨팅 리소스별 추가 속성입니다."
 msgid "Additional information about this host"
 msgstr "호스트에 대한 추가 정보 "
 
-msgid "Address to connect to"
-msgstr ""
-
 msgid "Admin permissions required"
 msgstr "관리 권한이 필요합니다 "
 
@@ -572,9 +554,6 @@ msgstr "별칭 또는 VLAN 장치 "
 msgid "All"
 msgstr "모두"
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr ""
 
@@ -582,6 +561,12 @@ msgid "All Reports"
 msgstr "전체 보고서 "
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -743,9 +728,6 @@ msgstr "%s 호스트를 삭제하시겠습니까? 이 작업은 되돌릴 수 �
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "이 위젯을 대시보드에서 삭제하시겠습니까?"
-
 msgid "Are you sure you want to log out?"
 msgstr ""
 
@@ -802,6 +784,12 @@ msgstr "조직 지정 "
 
 msgid "Assign Selected Hosts"
 msgstr "선택된 호스트 지정 "
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1286,6 +1274,9 @@ msgstr ""
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr ""
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "내부 관리 계정을 삭제할 수 없음 "
 
@@ -1367,8 +1358,8 @@ msgstr ""
 msgid "Certificate path for GCE only"
 msgstr ""
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Foreman이 websocket을 암호화하는데 사용하는 인증서 "
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "인증서"
@@ -1427,6 +1418,9 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr ""
 
@@ -1438,12 +1432,6 @@ msgstr "기본값 VM 속성을 편집하기 위해 컴퓨팅 리소스 링크를
 
 msgid "Click to log in again"
 msgstr ""
-
-msgid "Click to remove %s"
-msgstr "클릭하여 %s 삭제 "
-
-msgid "Click to remove config group"
-msgstr "클릭하여 설정 그룹 삭제 "
 
 msgid "Client Email"
 msgstr "클라이언트 이메일 "
@@ -1607,14 +1595,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "설정 검색 "
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "설정 그룹 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "이름 "
-
 msgid "Configuration"
 msgstr "설정"
 
@@ -1657,8 +1637,8 @@ msgstr "충돌이 감지되었습니다 "
 msgid "Connected"
 msgstr ""
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "다음에 연결 (암호화 해제): %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "다음에 연결 중 (암호화 해제): %s"
@@ -1708,7 +1688,7 @@ msgstr ""
 msgid "Cores per socket"
 msgstr "소켓당 코어 수 "
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
 msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
@@ -1885,9 +1865,6 @@ msgstr ""
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-msgid "Create a Puppet class"
-msgstr "Puppet 클래스 생성 "
-
 msgid "Create a bookmark"
 msgstr "북마크 생성 "
 
@@ -1899,9 +1876,6 @@ msgstr "컴퓨터 프로파일 생성 "
 
 msgid "Create a compute resource"
 msgstr "컴퓨터 리소스 생성 "
-
-msgid "Create a config group"
-msgstr "설정 그룹 생성 "
 
 msgid "Create a default template combination for an operating system"
 msgstr "운영 체제의 기본값 템플릿 조합 생성 "
@@ -1975,9 +1949,6 @@ msgstr "서브넷 생성 "
 msgid "Create a template input"
 msgstr "템플릿 입력 생성"
 
-msgid "Create a trend counter"
-msgstr ""
-
 msgid "Create a user"
 msgstr "사용자 생성 "
 
@@ -1993,9 +1964,6 @@ msgstr "LDAP 인증 소스 생성 "
 msgid "Create an architecture"
 msgstr "아키텍처 생성 "
 
-msgid "Create an environment"
-msgstr "환경 생성 "
-
 msgid "Create an external user group linked to a user group"
 msgstr "사용자 그룹에 연결된 외부 사용자 그룹 생성 "
 
@@ -2008,13 +1976,13 @@ msgstr "호스트에 인터페이스 생성 "
 msgid "Create an operating system"
 msgstr "운영 체제 생성 "
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "특정 스마트 클래스 매개 변수의 덮어쓰기 값 생성 "
-
 msgid "Create autosign entry"
 msgstr ""
 
 msgid "Create image"
+msgstr ""
+
+msgid "Create model"
 msgstr ""
 
 msgid "Create new boot volume from image"
@@ -2031,6 +1999,9 @@ msgstr "%s의 영역 항목 생성 "
 
 msgid "Created"
 msgstr "생성 일시 "
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr ""
@@ -2061,18 +2032,6 @@ msgstr ""
 
 msgid "DB pending seed"
 msgstr "DB 보류 중인 시드"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
-msgstr ""
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2164,7 +2123,7 @@ msgstr "기본값 "
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2187,9 +2146,6 @@ msgstr ""
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr ""
-
-msgid "Default Puppet environment"
-msgstr "기본 Puppet 환경"
 
 msgid "Default VNC Keyboard"
 msgstr ""
@@ -2272,9 +2228,6 @@ msgstr "%s의 PuppetCA 인증서 삭제 "
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr ""
 
-msgid "Delete a Puppet class"
-msgstr "Puppet 클래스 삭제 "
-
 msgid "Delete a Virtual Machine"
 msgstr ""
 
@@ -2286,9 +2239,6 @@ msgstr "컴퓨터 프로파일 삭제 "
 
 msgid "Delete a compute resource"
 msgstr "컴퓨터 리소스 삭제 "
-
-msgid "Delete a config group"
-msgstr "설정 그룹 삭제 "
 
 msgid "Delete a default template combination for an operating system"
 msgstr "운영 체제의 기본값 템플릿 조합 삭제 "
@@ -2371,9 +2321,6 @@ msgstr "템플릿 조합 삭제 "
 msgid "Delete a template input"
 msgstr "템플릿 입력 삭제"
 
-msgid "Delete a trend counter"
-msgstr ""
-
 msgid "Delete a user"
 msgstr "사용자 삭제 "
 
@@ -2413,9 +2360,6 @@ msgstr ""
 msgid "Delete an architecture"
 msgstr "아키텍처 삭제"
 
-msgid "Delete an environment"
-msgstr "환경 삭제 "
-
 msgid "Delete an external user group"
 msgstr "외부 사용자 그룹 삭제 "
 
@@ -2425,14 +2369,17 @@ msgstr "이미지 삭제"
 msgid "Delete an operating system"
 msgstr "운영 체제 삭제 "
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "특정 스마트 클랙스 매개 변수의 덮어쓰기 값 삭제 "
-
 msgid "Delete autosign entry"
 msgstr ""
 
 msgid "Delete filter?"
 msgstr "필터를 삭제하시겠습니까?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "%s의 영역 항목 삭제 "
@@ -2504,9 +2451,6 @@ msgid "Disable alerts for selected hosts"
 msgstr "선택한 호스트의 통지 비활성화 "
 
 msgid "Disable all filters overriding"
-msgstr ""
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2625,10 +2569,10 @@ msgstr ""
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "중복된 입력이 감지되었습니다: %{duplicated_inputs}"
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"
@@ -2636,9 +2580,6 @@ msgstr "EC2"
 
 msgid "EFI"
 msgstr ""
-
-msgid "ENC environment"
-msgstr "ENC 환경"
 
 msgid "ERROR or FATAL"
 msgstr "오류 또는 치명적 오류"
@@ -2680,6 +2621,9 @@ msgid "Edit this host"
 msgstr ""
 
 msgid "Editor"
+msgstr ""
+
+msgid "Email"
 msgstr ""
 
 msgid "Email Preferences"
@@ -2757,10 +2701,6 @@ msgstr "IP 자동 제안의 종료 IP 주소 "
 msgid "Entries per page"
 msgstr "페이지당 항목 수"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "환경 "
-
 msgid "Environment IDs"
 msgstr "환경 ID"
 
@@ -2775,10 +2715,6 @@ msgstr "클라이언트 SSL 인증서의 유효성 검사 상태가 들어 있�
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "이름 "
 
 msgid "Error"
 msgstr "오류 "
@@ -2818,6 +2754,9 @@ msgstr ""
 
 msgid "Error removing widget from dashboard."
 msgstr "대시보드에서 위젯을 삭제하는 도중 오류가 발생했습니다."
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr ""
@@ -3288,14 +3227,14 @@ msgstr "불일치로 인해 %s 수정"
 msgid "Fix All Mismatches"
 msgstr "모든 불일치 수정 "
 
-msgid "Fix DB cache"
-msgstr "DB 캐시 고정"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Foreman 시작 시 DB 캐시 수정 "
-
 msgid "Fix Mismatches"
 msgstr "불일치 수정 "
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "종류 "
@@ -3342,9 +3281,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr ""
 
-msgid "Force a Puppet agent run on the host"
-msgstr "호스트에서 Puppet 에이전트 실행을 강제합니다 "
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "Foreman API v2가 현재 기본 API 버전입니다."
 
@@ -3378,6 +3314,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr ""
 
@@ -3386,6 +3326,10 @@ msgstr "Foreman은 %s의 빌드 주기를 관리합니다 "
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman은 %s의 빌드 주기를 더이상 관리하지 않습니다 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Foreman 보고서 생성 시간은 <em>%s</em>입니다 "
@@ -3414,7 +3358,7 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman은 새 호스트의 프로비저닝에서 인증서 서명을 자동화합니다 "
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
 msgstr ""
 
 msgid "Foreman will create the host when a report is received"
@@ -3423,20 +3367,14 @@ msgstr "Foreman은 보고서를 수신할 때 호스트를 생성합니다 "
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman은 새 정보를 수신할 때 호스트를 생성합니다 "
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "Foreman은 자동으로 검색하지 못 할 경우 puppet 환경에 기본값 설정됩니다 "
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "프로비저닝 스크립트가 0이 아닌 종료 코드로 끝나면 Foreman이 가상 머신을 삭제합니다."
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman은 ENC yaml 출력에서 puppet 환경을 명시적으로 설정합니다. 이로 인해 puppet.conf의 환경과 Foreman으로 설정되는 환경 간의 충돌을 방지할 수 있습니다  "
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman은 request-header로 사용자를 사용자 이름으로 매핑합니다. 이것이 false로 설정되어 있을 경우 OAuth 요청이 관리 권한을 갖게 됩니다. "
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr ""
@@ -3446,9 +3384,6 @@ msgstr "Foreman은 ENC 출력의 매개 변수 값 ERB를 구문 분석합니다
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman은 SOA/NS 권한 대신 로컬 설정 분석기를 쿼리합니다 "
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman은 정보에서 호스트 환경을 업데이트합니다 "
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr ""
@@ -3467,6 +3402,18 @@ msgstr "Foreman은 인증서 서명을 위해 호스트 이름 대신 임의의 
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman은 새 가상 머신을 생성하기 위해 FQDN 대신 짧은 호스트 이름을 사용합니다 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr ""
@@ -3494,6 +3441,9 @@ msgstr "전체 화면 "
 
 msgid "Function not available for %s"
 msgstr "%s에 사용할 수 없는 기능"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "GMT 시간"
@@ -3564,8 +3514,8 @@ msgstr "대시보드 상세 정보 얻기 "
 msgid "Get default dashboard widgets"
 msgstr "기본 대시보드 위젯 가져오기"
 
-msgid "Get statistics"
-msgstr "통계 검색 "
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "호스트 상태 가져오기 "
@@ -3687,6 +3637,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr "하드웨어 모델 "
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr ""
 
@@ -3732,11 +3688,17 @@ msgstr "기록 "
 msgid "Host"
 msgstr "호스트 "
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "%s 호스트가 빌드되었습니다."
 
 msgid "Host %s is not associated with a VM"
 msgstr "호스트 %s는 VM에 연결되어 있지 않습니다 "
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "호스트 설정 차트 "
@@ -3771,7 +3733,13 @@ msgstr ""
 msgid "Host Parameters"
 msgstr ""
 
-msgid "Host Wizard"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
 msgstr ""
 
 msgid "Host audit entries"
@@ -3780,12 +3748,12 @@ msgstr "호스트 감사 항목 "
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "호스트 설정 그룹 "
-
 msgid "Host details"
 msgstr "호스트 상세 정보 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "호스트 그룹 "
@@ -3923,8 +3891,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "호스트 유형 "
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4152,9 +4144,6 @@ msgstr "구성 템플릿 ID"
 msgid "ID of domain"
 msgstr "도메인 ID"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr "호스트 ID "
 
@@ -4221,7 +4210,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4284,9 +4273,6 @@ msgstr "IP 주소 자동 제시 "
 msgid "IP addresses that should be excluded from suggestion"
 msgstr ""
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4310,6 +4296,9 @@ msgstr ""
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr ""
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr ""
 
@@ -4328,6 +4317,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "IPv6 Subnet"
+msgstr ""
+
+msgid "IPv6 address"
 msgstr ""
 
 msgid "IPv6 address of interface"
@@ -4390,13 +4382,13 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "이것이 Foreman 자체의 오류라고 생각되시면 새로운 문제로 제출하십시오"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "프로비저닝에서 Puppet 팩트 무시"
-
 msgid "Ignore facts for domain"
 msgstr ""
 
 msgid "Ignore facts for operating system"
+msgstr ""
+
+msgid "Ignore interfaces facts for provisioning"
 msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
@@ -4477,12 +4469,6 @@ msgstr ""
 
 msgid "Import of facts failed for host %s"
 msgstr ""
-
-msgid "Import puppet classes from puppet proxy"
-msgstr ""
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "환경에 대한 Puppet 프록시에서 Puppet 클래스를 가져옵니다"
 
 msgid "Imported IPv4 Subnets"
 msgstr ""
@@ -4595,6 +4581,9 @@ msgstr ""
 msgid "Installation medium configuration"
 msgstr "설치 미디어 설정 "
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "설치됨 "
 
@@ -4659,6 +4648,9 @@ msgid "Invalid %{assoc} selection, you must select at least one of yours and hav
 msgstr ""
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
+msgstr ""
+
+msgid "Invalid HTTP(S) URL"
 msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
@@ -4826,13 +4818,13 @@ msgstr "최신 이벤트 "
 msgid "Launch Console"
 msgstr ""
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr ""
 
 msgid "Learn more about LDAP authentication in the documentation."
+msgstr ""
+
+msgid "Legacy UI"
 msgstr ""
 
 msgid "Length"
@@ -4867,24 +4859,6 @@ msgstr "모든 LDAP 인증 소스 나열 "
 
 msgid "List all Personal Access Tokens for a user"
 msgstr ""
-
-msgid "List all Puppet class IDs for host"
-msgstr "호스트의 모든 Puppet 클래스 ID 나열 "
-
-msgid "List all Puppet class IDs for host group"
-msgstr "호스트 그룹의 모든 Puppet 클래스 ID 나열 "
-
-msgid "List all Puppet classes"
-msgstr "모든 Puppet 클래스 나열 "
-
-msgid "List all Puppet classes for a host"
-msgstr "호스트의 모든 Puppet 클래스 나열 "
-
-msgid "List all Puppet classes for a host group"
-msgstr "호스트 그룹의 모든 Puppet 클래스 나열 "
-
-msgid "List all Puppet classes for an environment"
-msgstr "환경의 모든 Puppet 클래스 나열 "
 
 msgid "List all SSH keys for a user"
 msgstr ""
@@ -4921,9 +4895,6 @@ msgstr "모든 컴퓨터 리소스 목록 나열 "
 
 msgid "List all email notifications for a user"
 msgstr ""
-
-msgid "List all environments"
-msgstr "모든 환경 목록 나열 "
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "LDAP 인증 소스에 대한 모든 외부 사용자 그룹 나열 "
@@ -5060,9 +5031,6 @@ msgstr "모든 역할 나열 "
 msgid "List all settings"
 msgstr "모든 설정 목록 나열 "
 
-msgid "List all smart class parameters"
-msgstr "모든 스마트 클래스 매개 변수 나열 "
-
 msgid "List all smart proxies"
 msgstr "모든 스마트 프록시 나열 "
 
@@ -5141,15 +5109,6 @@ msgstr "운영 체제의 부트 파일을 나열 "
 msgid "List default templates combinations for an operating system"
 msgstr "운영 체제의 기본값 템플릿 조합 나열 "
 
-msgid "List environments of Puppet class"
-msgstr "Puppet 클래스 환경 목록 나열 "
-
-msgid "List environments per location"
-msgstr "위치 별 환경 나열 "
-
-msgid "List environments per organization"
-msgstr "조직 별 환경 나열 "
-
 msgid "List external authentication sources"
 msgstr ""
 
@@ -5157,6 +5116,9 @@ msgid "List external authentication sources per location"
 msgstr ""
 
 msgid "List external authentication sources per organization"
+msgstr ""
+
+msgid "List hosts forming the Foreman instance"
 msgstr ""
 
 msgid "List hosts per location"
@@ -5192,9 +5154,6 @@ msgstr ""
 msgid "List of compute profiles"
 msgstr "컴퓨터 프로파일 목록 "
 
-msgid "List of config groups"
-msgstr "설정 그룹 목록"
-
 msgid "List of domains"
 msgstr "도메인 목록 "
 
@@ -5210,35 +5169,20 @@ msgstr "서브넷 별 도메인 목록"
 msgid "List of email notifications"
 msgstr "이메일 통지의 목록"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr ""
 
 msgid "List of hosts which answer to the provided query"
 msgstr "제공되는 쿼리에 응답하는 호스트 목록 "
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "특정 스마트 클래스 매개 변수의 덮어쓰기 값 목록 "
-
 msgid "List of realms"
 msgstr "영역 목록 "
 
 msgid "List of resources types that will be automatically associated"
 msgstr ""
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "특정 Puppet 클래스의 스마트 클래스 매개 변수 목록 "
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "특정 환경의 스마트 클래스 매개 변수 목록 "
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "특정 환경/Puppet 클래스 조합의 스마트 클래스 매개 변수 목록 "
-
-msgid "List of smart class parameters for a specific host"
-msgstr "특정 호스트의 스마트 클래스 매개 변수 목록 "
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "특정 호스트 그룹의 스마트 클래스 매개 변수 목록 "
 
 msgid "List of subnets"
 msgstr "서브넷 목록 "
@@ -5256,9 +5200,6 @@ msgid "List of table preferences for a user"
 msgstr ""
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
-msgstr ""
-
-msgid "List of trends counters"
 msgstr ""
 
 msgid "List of user selected columns"
@@ -5444,6 +5385,10 @@ msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5492,6 +5437,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "MAC 주소 "
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "인터페이스의 MAC 주소입니다. 베어 메탈에서 관리형 인터페이스에 필요합니다."
@@ -5574,6 +5522,9 @@ msgstr "관리 "
 msgid "Manage Bookmarks"
 msgstr "북마크 관리 "
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "위치 관리 "
 
@@ -5582,6 +5533,9 @@ msgstr "조직 관리 "
 
 msgid "Manage PuppetCA"
 msgstr "PuppetCA 관리"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "호스트 관리 "
@@ -5682,10 +5636,6 @@ msgid "Message"
 msgstr "메세지 "
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "다이제스트 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "값 "
 
@@ -5703,6 +5653,9 @@ msgstr ""
 
 msgid "Metrics"
 msgstr "메트릭스 "
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "분 전 "
@@ -5781,6 +5734,9 @@ msgstr ""
 msgid "N/A"
 msgstr "해당 없음 "
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "해당 없음 "
 
@@ -5802,7 +5758,7 @@ msgstr "미디어 이름"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr ""
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
 msgstr ""
 
 msgid "Name of the host group"
@@ -5880,6 +5836,9 @@ msgstr "새 조직 "
 msgid "New SSH key"
 msgstr ""
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "새 가상 머신 "
 
@@ -5895,8 +5854,8 @@ msgstr ""
 msgid "New filter"
 msgstr "새 필터 "
 
-msgid "New window"
-msgstr "새 창 "
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "다음"
@@ -6023,6 +5982,9 @@ msgstr "TFTP 기능 없음"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "TFTP 프록시가 지정되어 있지 않습니다, 계속 진행할 수 없습니다 "
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr ""
 
@@ -6061,6 +6023,9 @@ msgstr "이메일이 없음"
 
 msgid "No entries found"
 msgstr "항목을 찾을 수 없음 "
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "이 프록시의 기능이 없습니다. 적어도 하나의 기능을 활성화하고 있는지 확인하십시오"
@@ -6158,6 +6123,9 @@ msgstr "스마트 프록시를 찾을 수 없습니다. "
 msgid "No smart proxies to show"
 msgstr "표시할 스마트 프록시가 없음 "
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "서브넷이 없음 "
 
@@ -6194,11 +6162,11 @@ msgstr "적절함"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr ""
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "설치되지 않음 "
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr ""
 
 msgid "Not implemented"
 msgstr "구현되지 않습니다"
@@ -6365,6 +6333,9 @@ msgstr ""
 msgid "OK"
 msgstr "확인"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "OS 이미지 "
 
@@ -6435,9 +6406,6 @@ msgstr "오류. 문제가 발생했습니다 "
 
 msgid "Open"
 msgstr ""
-
-msgid "Open Spice in a new window"
-msgstr "새 창에서 Spice 열기 "
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr ""
@@ -6538,9 +6506,6 @@ msgstr ""
 msgid "Optional array of log hashes"
 msgstr "로그 해시 옵션 배열 "
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "가져오기한 Puppet 클래스를 제한하는데 사용하는 'new', 'updated', 'obsolete' 중 하나가 포함된 콤마로 구분된 문자열 옵션 "
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "옵션: IP 자동 제안의 종료 IP 주소 "
 
@@ -6604,9 +6569,6 @@ msgstr ""
 msgid "Override"
 msgstr ""
 
-msgid "Override Value"
-msgstr ""
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "Puppet 클래스 매개 변수의 기본값을 덮어씁니다."
 
@@ -6619,8 +6581,17 @@ msgstr "개요 "
 msgid "Overwrite"
 msgstr "덮어쓰기"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "소유자 "
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "소유자 "
@@ -6704,6 +6675,10 @@ msgstr "이름 "
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "우선 순위 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr ""
@@ -6940,9 +6915,6 @@ msgstr "요청을 처리하는 동안 잠시 기다려 주십시오."
 msgid "Plugins"
 msgstr "플러그인"
 
-msgid "Port to connect to"
-msgstr ""
-
 msgid "Possible values"
 msgstr ""
 
@@ -6955,7 +6927,13 @@ msgstr "전원"
 msgid "Power ON this machine"
 msgstr "컴퓨터의 전원 켜기 "
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
+msgstr ""
+
+msgid "Power has been set to \"%s\" successfully"
 msgstr ""
 
 msgid "Power operations are not enabled on this host."
@@ -7024,7 +7002,7 @@ msgstr ""
 msgid "Private"
 msgstr "비공개"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Proceed to Edit"
@@ -7122,6 +7100,9 @@ msgstr "프록시 "
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7170,9 +7151,6 @@ msgstr "Puppet 클래스 "
 msgid "Puppet error state"
 msgstr ""
 
-msgid "Puppet interval"
-msgstr "Puppet 간격"
-
 msgid "Puppet parameter"
 msgstr "Puppet 매개 변수"
 
@@ -7181,14 +7159,6 @@ msgstr "Puppet 프록시 ID"
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppetclass"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "이름 "
 
 msgid "Query"
 msgstr ""
@@ -7264,6 +7234,9 @@ msgstr "이름 "
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "영역 유형 "
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "다시 시작 및 빌드 "
@@ -7365,12 +7338,6 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr "매개 변수 삭제 "
 
-msgid "Remove a Puppet class from host"
-msgstr "호스트에 Puppet 클래스 삭제 "
-
-msgid "Remove a Puppet class from host group"
-msgstr "호스트 그룹에서 Puppet 클래스 삭제 "
-
 msgid "Remove an email notification for a user"
 msgstr ""
 
@@ -7378,6 +7345,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7462,6 +7432,9 @@ msgstr ""
 msgid "ReportTemplate|Snippet"
 msgstr ""
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "보고 "
 
@@ -7473,6 +7446,9 @@ msgstr ""
 
 msgid "Reports"
 msgstr "보고서 "
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7515,6 +7491,9 @@ msgid "Required unless user is in an external authentication source"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset"
 msgstr ""
 
 msgid "Reset PuppetCA certname for %s"
@@ -7560,6 +7539,9 @@ msgstr ""
 msgid "Resume"
 msgstr "다시 시작 "
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "지정한 유형의 호스트 상태를 나타내는 문자열을 반환합니다."
 
@@ -7585,8 +7567,14 @@ msgstr ""
 msgid "Revert Local Changes"
 msgstr ""
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "확인 "
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "%s의 빌드 상태 확인 "
@@ -7595,6 +7583,9 @@ msgid "Revoke"
 msgstr "취소"
 
 msgid "Revoke a Personal Access Token for a user"
+msgstr ""
+
+msgid "Revoke personal access token"
 msgstr ""
 
 msgid "Revoked"
@@ -7677,6 +7668,9 @@ msgstr ""
 msgid "SMTP address"
 msgstr ""
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr ""
 
@@ -7690,6 +7684,9 @@ msgid "SMTP password"
 msgstr ""
 
 msgid "SMTP port"
+msgstr ""
+
+msgid "SMTP port to connect to"
 msgstr ""
 
 msgid "SMTP username"
@@ -7710,14 +7707,20 @@ msgstr ""
 msgid "SSL CA file"
 msgstr "SSL CA 파일"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Foreman이 프록시와 통신하는데 사용할 SSL CA 파일 "
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Foreman이 프록시와 통신하는데 사용할 SSL 인증서 경로 "
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Foreman이 프록시와 통신하는데 사용할 SSL 비공개 키 파일 "
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "SSL 인증서"
@@ -7765,6 +7768,9 @@ msgid "Save something and try again"
 msgstr "저장 후 다시 시도하십시오 "
 
 msgid "Saved Bookmarks"
+msgstr ""
+
+msgid "Saved audits interval"
 msgstr ""
 
 msgid "Schedule generating of a report"
@@ -7943,6 +7949,9 @@ msgstr ""
 msgid "Sendmail location"
 msgstr ""
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr ""
 
@@ -7973,6 +7982,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr ""
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr ""
 
@@ -7993,9 +8005,6 @@ msgstr "값을 확인하는 순서를 설정합니다."
 
 msgid "Set up compute instance %s"
 msgstr "컴퓨터 인스턴스 %s 설정 "
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8063,6 +8072,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "다음번 설치 프로그램 모듈 실행 시 `foreman-rake db:seed`를 실행해야 합니까? "
 
@@ -8096,18 +8111,6 @@ msgstr ""
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-msgid "Show a Puppet class"
-msgstr "Puppet 클래스 표시 "
-
-msgid "Show a Puppet class for a host group"
-msgstr "호스트 그룹의 Puppet 클래스 표시 "
-
-msgid "Show a Puppet class for an environment"
-msgstr "환경의 Puppet 클래스 표시 "
-
-msgid "Show a Puppet class for host"
-msgstr "호스트의 Puppet 클래스 표시 "
-
 msgid "Show a bookmark"
 msgstr "북마크 표시 "
 
@@ -8119,9 +8122,6 @@ msgstr "컴퓨터 프로파일 표시 "
 
 msgid "Show a compute resource"
 msgstr "컴퓨터 리소스 표시 "
-
-msgid "Show a config group"
-msgstr "설정 그룹 표시 "
 
 msgid "Show a default template combination for an operating system"
 msgstr "운영 체제의 기본값 템플릿 조합 표시 "
@@ -8189,17 +8189,11 @@ msgstr "역할 표시 "
 msgid "Show a setting"
 msgstr "설정 표시"
 
-msgid "Show a smart class parameter"
-msgstr "스마트 클래스 매개 변수 표시"
-
 msgid "Show a smart proxy"
 msgstr "스마트 프록시 표시"
 
 msgid "Show a subnet"
 msgstr "서브넷 표시"
-
-msgid "Show a trend"
-msgstr ""
 
 msgid "Show a user"
 msgstr "사용자 표시 "
@@ -8234,9 +8228,6 @@ msgstr "감사 보기 "
 msgid "Show an email notification"
 msgstr "이메일 통지 표시"
 
-msgid "Show an environment"
-msgstr "환경 표시 "
-
 msgid "Show an external authentication source"
 msgstr ""
 
@@ -8257,9 +8248,6 @@ msgstr ""
 
 msgid "Show an operating system"
 msgstr "운영 체제 표시 "
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "특정 스마트 클래스 매개 변수의 덮어쓰기 값 표시 "
 
 msgid "Show available API links"
 msgstr "사용 가능한 API 링크 표시"
@@ -8342,9 +8330,6 @@ msgstr "건너 뛰기 "
 msgid "Skipped|S"
 msgstr "S"
 
-msgid "Smart Class Parameter"
-msgstr "스마트 클래스 매개 변수 "
-
 msgid "Smart Class Parameters"
 msgstr ""
 
@@ -8412,6 +8397,9 @@ msgstr "일부 인터페이스가 유효하지 않습니다."
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "일부 인터페이스는 사용할 수 없습니다. 아래 표를 확인하십시오."
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "호스트 유형을 변경하는 도중 문제가 발생했습니다 - %s"
 
@@ -8435,10 +8423,6 @@ msgid "Source"
 msgstr "소스 "
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "다이제스트 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "값 "
 
@@ -8460,7 +8444,7 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr ""
 
-msgid "Specify additional options to sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "Specify authentication type, if required"
@@ -8504,8 +8488,8 @@ msgstr "상태 "
 msgid "Status %s does not exist."
 msgstr ""
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "Puppet 팩트에서 IP 주소 및 MAC 값 업데이트 중지(모든 인터페이스에 적용)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr ""
@@ -8601,6 +8585,10 @@ msgid "Subnet|Dns secondary"
 msgstr "2차 DNS"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "시작 "
 
@@ -8627,6 +8615,10 @@ msgstr "이름 "
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "네트워크 "
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8699,6 +8691,12 @@ msgstr ""
 
 msgid "Supported Formats"
 msgstr "지원되는 형식 "
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "인증 소스에서 그룹 동기화 "
@@ -8857,11 +8855,19 @@ msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8931,6 +8937,10 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -8981,7 +8991,7 @@ msgstr "테스트 이메일"
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9127,7 +9137,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9144,7 +9154,7 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The location of the sendmail executable"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "The marked fields will need reviewing"
@@ -9174,9 +9184,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "선택한 호스트의 전원 상태가 %s(으)로 설정됩니다."
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "영역 이름 예: EXAMPLE.COM"
@@ -9237,6 +9244,9 @@ msgid "There may be more information in the server's logs."
 msgstr ""
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
+msgstr ""
+
+msgid "There was a problem processing the request. Please try again."
 msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
@@ -9364,7 +9374,7 @@ msgstr ""
 msgid "This value is used also as the host's primary interface name."
 msgstr "이 값은 호스트의 기본 인터페이스 이름으로도 사용됩니다."
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9389,15 +9399,6 @@ msgid "Timezone to use for new users"
 msgstr ""
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9429,9 +9430,6 @@ msgstr "토큰 "
 
 msgid "Token Expiry"
 msgstr ""
-
-msgid "Token duration"
-msgstr "토큰 기간"
 
 msgid "Token expired"
 msgstr ""
@@ -9470,41 +9468,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "트렌드 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "트렌드 카운터 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "카운트 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
+msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "정보 이름 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "정보 값 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "이름 "
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "트렌드 유형 "
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "호스트를 관리할 지 또는 관리하지 않을지에 대한 True/False 플래그입니다. 알림: 이 값은 여러 매개 변수가 필요할 지 또는 필요하지 않을 지에 대한 여부를 결정합니다 "
@@ -9785,6 +9750,12 @@ msgstr "websockets_encrypt가 켜져 있는 경우 websockets_ssl_key를 설정 
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "대시보드 위젯에 허용되지 않는 템플릿: %s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "자동 URL"
 
@@ -9842,6 +9813,9 @@ msgstr ""
 msgid "Unknown status: %s"
 msgstr ""
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "잠금 해제"
 
@@ -9869,9 +9843,6 @@ msgstr ":a_resource 업데이트 "
 msgid "Update IP from built request"
 msgstr "빌드 요청에서 IP 업데이트"
 
-msgid "Update a Puppet class"
-msgstr "Puppet 클래스 업데이트 "
-
 msgid "Update a bookmark"
 msgstr "북마크 업데이트 "
 
@@ -9883,9 +9854,6 @@ msgstr "컴퓨터 프로파일 업데이트 "
 
 msgid "Update a compute resource"
 msgstr "컴퓨터 리소스 업데이트 "
-
-msgid "Update a config group"
-msgstr "설정 그룹 업데이트 "
 
 msgid "Update a default template combination for an operating system"
 msgstr "운영 체제의 기본값 템플릿 조합 업데이트 "
@@ -9953,9 +9921,6 @@ msgstr "역할 업데이트 "
 msgid "Update a setting"
 msgstr "설정 업데이트 "
 
-msgid "Update a smart class parameter"
-msgstr "스마트 클래스 매개 변수 업데이트 "
-
 msgid "Update a smart proxy"
 msgstr "스마트 프록시 업데이트 "
 
@@ -9986,9 +9951,6 @@ msgstr "아키텍처 업데이트 "
 msgid "Update an email notification for a user"
 msgstr ""
 
-msgid "Update an environment"
-msgstr "환경 업데이트 "
-
 msgid "Update an external authentication source"
 msgstr ""
 
@@ -9997,12 +9959,6 @@ msgstr "이미지 업데이트 "
 
 msgid "Update an operating system"
 msgstr "운영 체제 업데이트 "
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "특정 스마트 클래스 매개 변수의 덮어쓰기 값 업데이트  "
-
-msgid "Update environment from facts"
-msgstr "팩트에서 환경 업데이트"
 
 msgid "Update external user group"
 msgstr "외부 사용자 그룹 업데이트 "
@@ -10239,6 +10195,10 @@ msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "이름 "
 
@@ -10375,7 +10335,7 @@ msgstr "변수 "
 msgid "Variables"
 msgstr "변수 "
 
-msgid "Vendor Class"
+msgid "Vendor class"
 msgstr ""
 
 msgid "Verify"
@@ -10438,6 +10398,9 @@ msgstr "온라인 상에 있을 때 까지 %s 동안 대기 "
 msgid "Warning"
 msgstr "경고 "
 
+msgid "Warning statuses"
+msgstr ""
+
 msgid "Warning!"
 msgstr "경고!"
 
@@ -10498,6 +10461,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10621,6 +10587,9 @@ msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "구성된 모든 TFTP 서버에 있는 기본 PXE 메뉴가 변경됩니다. 계속하시겠습니까?"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
@@ -10775,6 +10744,9 @@ msgstr "모두 일치"
 msgid "already exists"
 msgstr "이미 존재합니다 "
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "조직 "
 
@@ -10786,9 +10758,6 @@ msgstr "어레이 "
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "설정 그룹에 속합니다 "
 
 msgid "boolean"
 msgstr "부울 "
@@ -10969,9 +10938,6 @@ msgstr ""
 
 msgid "enabled"
 msgstr ""
-
-msgid "environment id"
-msgstr "환경 ID "
 
 msgid "expected a value of type %s"
 msgstr ""
@@ -11220,8 +11186,7 @@ msgstr "외부 사용자 그룹이 이 사용자 그룹에 연결되어 있습�
 msgid "list"
 msgstr "목록"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "한국어"
 
@@ -11401,12 +11366,6 @@ msgstr "물리 @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "물리 @ 브리지 %s"
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
-msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "전원 동작, 유효한 동작은 (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)입니다."

--- a/locale/ko/foreman.po
+++ b/locale/ko/foreman.po
@@ -374,6 +374,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr "호스트 유형을 감지하는 동안 문제가 발생했습니다: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -659,6 +662,9 @@ msgstr ""
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr ""
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -726,6 +732,12 @@ msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr "%s 호스트를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다."
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 msgid "Are you sure you want to log out?"
@@ -1109,6 +1121,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr ""
 
@@ -1203,6 +1218,9 @@ msgid "Build PXE Default"
 msgstr "PXE 기본값 빌드 "
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2587,6 +2605,12 @@ msgstr "오류 또는 치명적 오류"
 msgid "EUI-64"
 msgstr ""
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3299,6 +3323,12 @@ msgstr "Foreman 감사 요약"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3593,6 +3623,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4355,7 +4388,19 @@ msgstr "매개 변수 값에 ERB를 사용하는 경우 ENC 요청 시에 값을
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "체크되어 있을 경우 기본값이 없고 matcher가 값을 지정하지 않을 경우 오류가 표시됩니다."
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4365,6 +4410,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4381,6 +4429,9 @@ msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "이것이 Foreman 자체의 오류라고 생각되시면 새로운 문제로 제출하십시오"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr ""
@@ -4527,6 +4578,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "인프라 "
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "부모 상속 (%s)"
 
@@ -4570,6 +4624,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5516,6 +5573,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr ""
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "관리 "
 
@@ -6354,6 +6414,9 @@ msgstr "정보에서 OS 이름, 예: RedHat"
 msgid "Off"
 msgstr "비활성화 "
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "확인"
 
@@ -6397,6 +6460,9 @@ msgstr "하나의 프록시만 지정할 수 있습니다 "
 
 msgid "Only one volume can be bootable"
 msgstr "하나의 볼륨만 부팅할 수 있습니다 "
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "죄송합니다!"
@@ -6806,6 +6872,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7487,6 +7556,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr "스마트 프록시에 대해 SSL 요구"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr ""
 
@@ -8072,6 +8144,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8306,6 +8381,11 @@ msgstr "로그인 "
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -8396,6 +8476,12 @@ msgstr "일부 인터페이스가 유효하지 않습니다."
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "일부 인터페이스는 사용할 수 없습니다. 아래 표를 확인하십시오."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9059,6 +9145,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr ""
 
@@ -9070,6 +9159,9 @@ msgstr "이 시스템에 제공되는 CPU 클래스입니다. 이는 주로 Spar
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Open Boot Prom에서 보고되는 시스템 클래스입니다. 이는 주로 Sparc Solaris 빌드에 사용되며 다른 아키텍처의 경우 빈 칸으로 둡니다. 값은  uname -i|cut -f2 -d를 사용하여 Solaris에서 확인할 수 있습니다. "
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
@@ -9261,6 +9353,12 @@ msgstr "VM을 나열하는 도중 오류가 발생했습니다: %(status)s %(sta
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "%{name} 템플릿을 렌더링하는 도중 오류가 발생했습니다: %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr ""
 
@@ -9274,6 +9372,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9330,6 +9431,9 @@ msgstr ""
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9350,6 +9454,12 @@ msgstr "서비스는 인증되지 않은 사용자가 사용할 수 있습니다
 
 msgid "This service is only available for authenticated users"
 msgstr "이 서비스는 인증된 사용자만 사용할 수 있습니다 "
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "템플릿이 잠겨 있어 삭제할 수 없습니다. "
@@ -9375,6 +9485,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "이 값은 호스트의 기본 인터페이스 이름으로도 사용됩니다."
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9419,6 +9532,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10272,6 +10388,9 @@ msgstr "VM 속성 (%s)"
 msgid "VM already associated with a host"
 msgstr "호스트에 이미 연결된 VM"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "호스트 %s에 연결된 VM"
 
@@ -10411,6 +10530,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "경고: 이 호스트와 호스트의 데이터가 모두 삭제됩니다!"
@@ -10594,10 +10716,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "잠긴 템플릿을 잠금 해제합니다."
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/model_attributes.rb
+++ b/locale/model_attributes.rb
@@ -109,19 +109,11 @@ _('ComputeResource|User')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('ComputeResource|Uuid')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Config group')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('ConfigGroup|Name')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Domain')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Domain|Fullname')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Domain|Name')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Environment')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Environment|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('External usergroup')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -152,6 +144,16 @@ _('Filter|Override')
 _('Filter|Search')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Filter|Taxonomy search')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Foreman internal')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('ForemanInternal|Key')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('ForemanInternal|Value')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Foreman register/registration facet')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('ForemanRegister::RegistrationFacet|Jwt secret')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Build')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -199,9 +201,21 @@ _('Host::Base|Use image')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host::Base|Uuid')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Host config group')
+_('Host facets/base')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('HostConfigGroup|Host type')
+_('HostFacets::Base|Boot time')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('HostFacets::Base|Cores')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('HostFacets::Base|Disks total')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('HostFacets::Base|Foreman instance')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('HostFacets::Base|Ram')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('HostFacets::Base|Sockets')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('HostFacets::Base|Virtual')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Host status/status')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -283,6 +297,8 @@ _('LookupKey|Key')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('LookupKey|Key type')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('LookupKey|Lookup values count')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('LookupKey|Merge default')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('LookupKey|Merge overrides')
@@ -340,8 +356,6 @@ _('Medium|Os family')
 _('Medium|Path')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Message')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Message|Digest')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Message|Value')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -453,6 +467,8 @@ _('Parameter|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Parameter|Priority')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Parameter|Searchable value')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Parameter|Value')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Permission')
@@ -472,10 +488,6 @@ _('PersonalAccessToken|Name')
 _('PersonalAccessToken|Revoked')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('PersonalAccessToken|Token')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Puppetclass')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Puppetclass|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Realm')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -537,8 +549,6 @@ _('SmartProxyFeature|Settings')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Source')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Source|Digest')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Source|Value')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Ssh key')
@@ -569,6 +579,8 @@ _('Subnet|Dns primary')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Dns secondary')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Subnet|Externalipam group')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|From')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Gateway')
@@ -582,6 +594,8 @@ _('Subnet|Mtu')
 _('Subnet|Name')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Network')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Subnet|Nic delay')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Subnet|Priority')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -615,6 +629,8 @@ _('Template')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Default')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('Template|Description')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Locked')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Template|Name')
@@ -631,9 +647,13 @@ _('Template input')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('TemplateInput|Advanced')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('TemplateInput|Default')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('TemplateInput|Description')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('TemplateInput|Fact name')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('TemplateInput|Hidden value')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('TemplateInput|Input type')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -665,24 +685,6 @@ _('Token|Expires')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Token|Value')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Trend')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Trend|Fact name')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Trend|Fact value')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Trend|Name')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Trend|Trendable type')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('Trend counter')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('TrendCounter|Count')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('TrendCounter|Interval end')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-_('TrendCounter|Interval start')
-# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('Upgrade task')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('UpgradeTask|Always run')
@@ -708,6 +710,8 @@ _('User|Admin')
 _('User|Avatar hash')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('User|Description')
+# TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+_('User|Disabled')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 _('User|Firstname')
 # TRANSLATORS: "Table name" or "Table name|Column name" for error messages

--- a/locale/pt_BR/foreman.po
+++ b/locale/pt_BR/foreman.po
@@ -43,9 +43,6 @@ msgstr ""
 msgid " Documentation"
 msgstr " Documentação"
 
-msgid " Remove"
-msgstr "Remover"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -57,9 +54,6 @@ msgstr "${progress}%% concluído(s)"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr "%(name)s (livre: %(free)s, prov.: %(prov)s, total: %(total)s)"
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - Pressione Shift-F12 para liberar o cursor."
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - Os hosts a seguir devem ser modificados em breve"
@@ -79,9 +73,6 @@ msgstr[1] "%s mensagens de log"
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s Parâmetros atualizados, veja abaixo para maiores informações"
-
-msgid "%s Template"
-msgstr "%s Modelo"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -134,9 +125,6 @@ msgid_plural "%s months ago"
 msgstr[0] "%s mês atrás"
 msgstr[1] "%s meses atrás"
 
-msgid "%s out of sync disabled"
-msgstr "%s fora de sincronização desabilitado"
-
 msgid "%s selected hosts"
 msgstr "%s hosts selecinados"
 
@@ -155,9 +143,6 @@ msgstr "Widget %s carregando..."
 
 msgid "%s you had selected as your context has been deleted"
 msgstr "%s que você selecionou como seu contexto foi excluído"
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
-msgstr ""
 
 msgid "%{action} %{vm}"
 msgstr "%{action} %{vm}"
@@ -228,6 +213,9 @@ msgstr "%{match} não coincide com um grupo de host existente"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} alterado de %{label1} para %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr "%{object_name} é um %{object_class}, uma sub-rede era esperada"
@@ -310,6 +298,9 @@ msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(opcional) Usar função IAM para Fog ao criar esta imagem."
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*Limpar %s proxy*"
@@ -516,12 +507,6 @@ msgstr "Adicionar volume"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr "Adicione um drive de CD-ROM na máquina virtual."
 
-msgid "Add a Puppet class to host"
-msgstr "Adicionar uma classe Puppet para o host"
-
-msgid "Add a Puppet class to host group"
-msgstr "Adicionar uma classe Puppet para o grupo"
-
 msgid "Add a template combination"
 msgstr "Adicionar uma combinação de template"
 
@@ -567,9 +552,6 @@ msgstr "Atributos específicos adicionais de recurso de computação."
 msgid "Additional information about this host"
 msgstr "Informação adicional sobre este host"
 
-msgid "Address to connect to"
-msgstr "Endereço para conexão"
-
 msgid "Admin permissions required"
 msgstr "Permissões de Admin necessárias"
 
@@ -612,9 +594,6 @@ msgstr "Alias ou VLAN"
 msgid "All"
 msgstr "Todos(as)"
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr "Todos os hosts"
 
@@ -622,6 +601,12 @@ msgid "All Reports"
 msgstr "Todos os relatórios"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -783,9 +768,6 @@ msgstr "Você tem certeza que quer apagar esse host %s? Essa ação é irrevers�
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Tem certeza de que deseja excluir o host %s? Isso excluirá a VM e seus discos, e essa ação é irreversível. Esse comportamento pode ser alterado por meio da configuração global \"Destruir VM associada na exclusão do host\"."
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "Você tem certeza que deseja remover esse widget do seu painel?"
-
 msgid "Are you sure you want to log out?"
 msgstr "Você está certo que quer fazer logout?"
 
@@ -842,6 +824,12 @@ msgstr "Atribuir Organização"
 
 msgid "Assign Selected Hosts"
 msgstr "Associar hosts selecinados"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1327,6 +1315,9 @@ msgstr "Pode ser recuperado por meio de arquivo RC ou CLI. Pode ser deixado em b
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr "Pode ser recuperado por meio de arquivo RC ou CLI. Pode ser definido como 'padrão'. Apenas para autenticação v3."
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "Não foi possível apagar conta interna de administrador"
 
@@ -1408,8 +1399,8 @@ msgstr "A chave de certificado não é um JSON válido"
 msgid "Certificate path for GCE only"
 msgstr "Caminho de certificado apenas para GCE"
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Certificado que o Foreman usará para criptografar websockets"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "Certificados"
@@ -1468,6 +1459,9 @@ msgstr "Limpar certificados PuppetCA para %s"
 msgid "Clear"
 msgstr "Limpar"
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr "Limpar substatus de host"
 
@@ -1479,12 +1473,6 @@ msgstr "Clique no link de um recurso de computação para editar seus atributos 
 
 msgid "Click to log in again"
 msgstr "Clique para fazer login novamente"
-
-msgid "Click to remove %s"
-msgstr "Clique para remover %s"
-
-msgid "Click to remove config group"
-msgstr "Clique para remover o grupo de configuração"
 
 msgid "Client Email"
 msgstr "Cliente de email"
@@ -1648,14 +1636,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "Obter configuração"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "Grupo de configuração"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "Nome"
-
 msgid "Configuration"
 msgstr "Configuração"
 
@@ -1698,8 +1678,8 @@ msgstr "Foram detectados conflitos"
 msgid "Connected"
 msgstr "Conectado"
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "Conectado (não criptografado) a: %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "Conectando (descriptografado) em: %s"
@@ -1749,8 +1729,8 @@ msgstr "As versões de núcleo e proxy não correspondem. foreman: %{foreman_ver
 msgid "Cores per socket"
 msgstr "Núcleos por soquete"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
-msgstr "Valor de custo da função de hash de senha bcrypt para fontes de autenticação internas (4-30). Um valor maior é mais seguro, mas a verificação será mais lenta, particularmente para chamadas de API sem estado e logins de UI. É necessário alterar a senha para que entre em vigor."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
+msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
 msgstr "Não foi possível adicionar permissões às funções de gerente e visualizador: %s"
@@ -1926,9 +1906,6 @@ msgstr "Criar grupo de usuários"
 msgid "Create a Personal Access Token for a user"
 msgstr "Criar um token de acesso pessoal para um usuário"
 
-msgid "Create a Puppet class"
-msgstr "Criar uma classe Puppet"
-
 msgid "Create a bookmark"
 msgstr "Criar um favorito"
 
@@ -1940,9 +1917,6 @@ msgstr "Criar um perfil computacional"
 
 msgid "Create a compute resource"
 msgstr "Criar um recurso de computação"
-
-msgid "Create a config group"
-msgstr "Criar um grupo de configuração"
 
 msgid "Create a default template combination for an operating system"
 msgstr "Ciar um combinação de template padrão para um sistema operacional"
@@ -2016,9 +1990,6 @@ msgstr "Criar uma subrete"
 msgid "Create a template input"
 msgstr "Criar uma entrada de modelo"
 
-msgid "Create a trend counter"
-msgstr "Criar um contador de tendências"
-
 msgid "Create a user"
 msgstr "Criar um usuário"
 
@@ -2034,9 +2005,6 @@ msgstr "Criar uma fonte de autenticação LDAP"
 msgid "Create an architecture"
 msgstr "Criar uma arquitetura"
 
-msgid "Create an environment"
-msgstr "Criar um ambiente"
-
 msgid "Create an external user group linked to a user group"
 msgstr "Criar um grupo externo ligado a um grupo de usuário"
 
@@ -2049,14 +2017,14 @@ msgstr "Criar uma interface no host"
 msgid "Create an operating system"
 msgstr "Criar um sistema operacional"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "Criar um valor de substituição para um parâmetro de classe inteligente específico"
-
 msgid "Create autosign entry"
 msgstr "Criar entrada de autoassinatura"
 
 msgid "Create image"
 msgstr "Criar imagem"
+
+msgid "Create model"
+msgstr ""
 
 msgid "Create new boot volume from image"
 msgstr "Criar novo volume de inicialização a partir da imagem "
@@ -2072,6 +2040,9 @@ msgstr "Criar entrada de realm para %s"
 
 msgid "Created"
 msgstr "Criado(a)"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr "Cria uma preferência de tabelas para uma determinada tabela"
@@ -2102,18 +2073,6 @@ msgstr "Tipo de instância personalizado"
 
 msgid "DB pending seed"
 msgstr "Propagação pendente de DB"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
-msgstr ""
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2205,7 +2164,7 @@ msgstr "Padrão"
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2228,9 +2187,6 @@ msgstr "O item do menu PXE padrão no modelo global - 'local', 'descoberta' ou p
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr "O item do menu PXE padrão no modelo local - 'local', 'local_chain_hd0' ou personalizado. Use o espaço em branco para o padrão do modelo."
-
-msgid "Default Puppet environment"
-msgstr "Ambiente Puppet padrão "
 
 msgid "Default VNC Keyboard"
 msgstr "Teclado VNC padrão"
@@ -2313,9 +2269,6 @@ msgstr "Apagar certificados PuppetCA para %s"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr "Excluir config %{kind} TFTP para %{host}"
 
-msgid "Delete a Puppet class"
-msgstr "Apagar uma classe Puppet"
-
 msgid "Delete a Virtual Machine"
 msgstr "Excluir uma máquina virtual"
 
@@ -2327,9 +2280,6 @@ msgstr "Apagar um perfil computacional"
 
 msgid "Delete a compute resource"
 msgstr "Remover um recurso de computação"
-
-msgid "Delete a config group"
-msgstr "Apagar um grupo de configuração"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "Apagar uma combinação padrão de template para um sistema operacional"
@@ -2412,9 +2362,6 @@ msgstr "Apagar uma combinação de template"
 msgid "Delete a template input"
 msgstr "Remover uma entrada de modelo "
 
-msgid "Delete a trend counter"
-msgstr "Excluir um contador de tendências"
-
 msgid "Delete a user"
 msgstr "Apagar um usuário"
 
@@ -2454,9 +2401,6 @@ msgstr "Excluir uma chave SSH para um usuário"
 msgid "Delete an architecture"
 msgstr "Apagar um arquitetura"
 
-msgid "Delete an environment"
-msgstr "Apagar um ambiente"
-
 msgid "Delete an external user group"
 msgstr "Apagar um grupo de usuários externo"
 
@@ -2466,14 +2410,17 @@ msgstr "Apagar uma imagem"
 msgid "Delete an operating system"
 msgstr "Apagar um sistema operacional"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "Remover um valor de substituição para um parâmetro de classe inteligente específico "
-
 msgid "Delete autosign entry"
 msgstr "Excluir entrada de autoassinatura"
 
 msgid "Delete filter?"
 msgstr "Apagar filtro?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "Remover entrada do realm para %s"
@@ -2546,9 +2493,6 @@ msgstr "Desabilitar alertas para os hosts selecionados"
 
 msgid "Disable all filters overriding"
 msgstr "Desativar toda a substituição de filtros"
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "Desabilitar o status de configuração do host para que fique fora de sincronização para %s depois que o relatório não chegar no intervalo configurado"
 
 msgid "Disable overriding"
 msgstr "Desativar substituição"
@@ -2666,20 +2610,17 @@ msgstr "Faz download de um relatório gerado"
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "Entradas duplicadas detectadas: %{duplicated_inputs}"
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr "Duração em minutos depois que os servidores que geram relatórios via Puppet são classificado como fora de sincronização."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgstr ""
 
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "Ambiente ENC"
 
 msgid "ERROR or FATAL"
 msgstr "ERRO ou FATAL"
@@ -2722,6 +2663,9 @@ msgstr "Editar esse host"
 
 msgid "Editor"
 msgstr "Editor"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "Preferências de email"
@@ -2798,10 +2742,6 @@ msgstr "Endereço IP final para auto sugestão"
 msgid "Entries per page"
 msgstr "Entradas por página"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Ambiente"
-
 msgid "Environment IDs"
 msgstr "IDs de Ambiente"
 
@@ -2816,10 +2756,6 @@ msgstr "Variável de ambiente contendo o status de verificação de um certifica
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Nome"
 
 msgid "Error"
 msgstr "Erro"
@@ -2859,6 +2795,9 @@ msgstr "Erro ao carregar informações de filtros dicas do agendador: %s"
 
 msgid "Error removing widget from dashboard."
 msgstr "Erro ao remover widget do painel."
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr "Erro ao enviar dados:"
@@ -3327,14 +3266,14 @@ msgstr "Corrigir %s em incompatibilidades"
 msgid "Fix All Mismatches"
 msgstr "Corrigir todas as incompatibilidades"
 
-msgid "Fix DB cache"
-msgstr "Corrigir cache DB "
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Corrigir cache DB na próxima inicialização do Foreman"
-
 msgid "Fix Mismatches"
 msgstr "Corrigir as incompatibilidades"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "Sabor"
@@ -3381,9 +3320,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr "Para valores de pesquisa de tipo, este é o recurso no qual o valor é pesquisado"
 
-msgid "Force a Puppet agent run on the host"
-msgstr "Força uma execução do agente Puppet no host"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "Foreman API v2 é atualmente a versão de API padrão."
 
@@ -3417,6 +3353,10 @@ msgstr "O Foreman detectou definições de classes desconhecidas em seu banco de
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr "ID da instância do Foreman, identifica de modo único esta instância do Foreman."
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "As correspondências do Foreman serão herdadas por filhos durante a avaliação de parâmetros de classe inteligentes para grupos de hosts, organizações e locais."
 
@@ -3425,6 +3365,10 @@ msgstr "Foreman agora gerencia o ciclo de construção para %s"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman agora não gerencia mais o ciclo de construção para %s"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Tempo de criação de relatório do Foreman é  <em>%s</em>"
@@ -3453,8 +3397,8 @@ msgstr "O Foreman acrescentará nomes de domínio quando novos hosts forem provi
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "O Foreman automatizará a assinatura de certificados sob a provisão de um novo host"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
-msgstr "O Foreman bloqueará o login do usuário após esse número de tentativas de login com falha por 5 minutes a partir do endereço IP ofensivo. Definir como 0 para desabilitar a proteção contra força bruta"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
+msgstr ""
 
 msgid "Foreman will create the host when a report is received"
 msgstr "O Foreman criará o host ao receber um relatório"
@@ -3462,20 +3406,14 @@ msgstr "O Foreman criará o host ao receber um relatório"
 msgid "Foreman will create the host when new facts are received"
 msgstr "O Foreman criará o host ao receber novos fatos "
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "O Foreman usará este ambiente puppet como padrão se não conseguir detectar um automaticamente."
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Foreman removerá a máquina virtual caso o scrip de provisionamento termine com um código de saída não zero "
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr "O Foreman avaliará os parâmetros de classe de host inteligentes nesta ordem por padrão"
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "O Foreman definirá explicitamente o ambiente puppet na saída yaml ENC. Isto evitará conflitos entre o ambiente no puppet.conf e o ambiente definido no Foreman"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "O Foreman mapeará os usuários pelo nome de usuário no cabecalho de requisição. Caso isto seja definido como falso, as solicitações do OAuth terão direitos de admin."
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "O Foreman não enviará este parâmetro na saída de classificação."
@@ -3485,9 +3423,6 @@ msgstr "O Foreman analisará o ERB nos valores de parâmetros na saída ENC"
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "O Foreman pesquisará o resolvedor configurado localmente em vez de autoridades SOA/NS "
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "O Foreman atualizará um ambiente de host a partir de seus fatos"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "O Foreman atualizará o grupo de hosts de um host a partir de seus fatos"
@@ -3506,6 +3441,18 @@ msgstr "O Foreman utilizará UUIDs aleatórios para a assinatura de certificado 
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "O Foreman usará o nome de host curto em vez do FQDN para a criação de novas máquinas virtuais."
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr ""
@@ -3533,6 +3480,9 @@ msgstr "Tela cheia"
 
 msgid "Function not available for %s"
 msgstr "Função não disponível para %s"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "Hora GMT "
@@ -3603,8 +3553,8 @@ msgstr "Obter detalhes do painel"
 msgid "Get default dashboard widgets"
 msgstr "Obter widgets de painel padrão "
 
-msgid "Get statistics"
-msgstr "Gerar estatísticas"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "Obter status do host"
@@ -3726,6 +3676,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr "Modelos de hardware"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr "Tem efeito apenas para o provisionamento baseado em rede"
 
@@ -3771,11 +3727,17 @@ msgstr "Histórico"
 msgid "Host"
 msgstr "Máquina"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "Máquina %s está construída"
 
 msgid "Host %s is not associated with a VM"
 msgstr "Host %s não está associado com uma VM"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "Tabela de Configuração do Host"
@@ -3813,8 +3775,14 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "Parâmetros de host"
 
-msgid "Host Wizard"
-msgstr "Assistente de host"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
+msgstr ""
 
 msgid "Host audit entries"
 msgstr "Registros de auditoria do Host"
@@ -3822,12 +3790,12 @@ msgstr "Registros de auditoria do Host"
 msgid "Host built"
 msgstr "Host construído"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "Grupo de config do Host"
-
 msgid "Host details"
 msgstr "Detalhes do Host"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "Grupo de Host"
@@ -3965,8 +3933,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "HostConfigGroup|Host type"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4194,9 +4186,6 @@ msgstr "ID do modelo de configuração"
 msgid "ID of domain"
 msgstr "ID para um domínio"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr "ID do host"
 
@@ -4263,7 +4252,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4326,9 +4315,6 @@ msgstr "Auto-sugestão de endereço IP"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr "Endereços IP que devem ser excluídos da sugestão"
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4352,6 +4338,9 @@ msgstr "Subrede IPv4"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr "É necessária uma sub-rede IPv4 com proxy inteligente TFTP associado para o provisionamento baseado em PXE."
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "endereço IPv4 da interface"
 
@@ -4371,6 +4360,9 @@ msgstr[1] "Registros DNS IPv6"
 
 msgid "IPv6 Subnet"
 msgstr "Subrede IPv6"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "endereço IPv6 da interface"
@@ -4434,14 +4426,14 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Se você acha que isso é um erro com o próprio Foreman, por favor, registre um novo problema com"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "Ignorar fatos Puppet para provisionamento "
-
 msgid "Ignore facts for domain"
 msgstr "Ignorar fatos do domínio"
 
 msgid "Ignore facts for operating system"
 msgstr "Ignorar fatos do sistema operacional"
+
+msgid "Ignore interfaces facts for provisioning"
+msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
 msgstr "Ignorar as interfaces que correspondam ao identificador"
@@ -4521,12 +4513,6 @@ msgstr "Importar como host não gerenciado"
 
 msgid "Import of facts failed for host %s"
 msgstr "Falha ao importar fatos para o host %s "
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Importar classes de puppet a partir do proxy de puppet"
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "Classes de puppet de importação do proxy do puppet para um ambiente"
 
 msgid "Imported IPv4 Subnets"
 msgstr "Redes IPV4 importadas"
@@ -4645,6 +4631,9 @@ msgstr "Erro de instalação"
 msgid "Installation medium configuration"
 msgstr "Configuração de mídia de instalação"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "Instalados"
 
@@ -4710,6 +4699,9 @@ msgstr "Seleção %{assoc} inválida, você deve selecionar pelo menos uma das s
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
 msgstr "Chave Google JSON inválida. Verifique se as opções de chave privada e e-mail do cliente estão presentes"
+
+msgid "Invalid HTTP(S) URL"
+msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
 msgstr "Arquitetura inválida '%{arch}' para '%{os}'"
@@ -4876,14 +4868,14 @@ msgstr "Últimos eventos"
 msgid "Launch Console"
 msgstr "Iniciar console"
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr "Saiba mais sobre a autenticação externa na documentação."
 
 msgid "Learn more about LDAP authentication in the documentation."
 msgstr "Saiba mais sobre a autenticação LDAP na documentação."
+
+msgid "Legacy UI"
+msgstr ""
 
 msgid "Length"
 msgstr "Comprimento"
@@ -4917,24 +4909,6 @@ msgstr "Listar todas as fontes de autenticação LDAP"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr "Listar todos os tokens de acesso pessoal para um usuário"
-
-msgid "List all Puppet class IDs for host"
-msgstr "Listar todos os IDs de classes puppet para host"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "Listar todas os Ids de classes Puppet para grupo de host"
-
-msgid "List all Puppet classes"
-msgstr "Listar todas as classes Puppet"
-
-msgid "List all Puppet classes for a host"
-msgstr "Listar todas as classes de puppet para um host"
-
-msgid "List all Puppet classes for a host group"
-msgstr "Listar todas as classes Puppet para um host"
-
-msgid "List all Puppet classes for an environment"
-msgstr "Listar todas as classes Puppet para um ambiente"
 
 msgid "List all SSH keys for a user"
 msgstr "Listar todas as chaves SSH para um usuário"
@@ -4971,9 +4945,6 @@ msgstr "Listar todos os recursos de computação"
 
 msgid "List all email notifications for a user"
 msgstr ""
-
-msgid "List all environments"
-msgstr "Listar todos os ambientes"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "Listar todos os grupos de usuários para fonte de autenticação LDAP"
@@ -5110,9 +5081,6 @@ msgstr "Listar todas as regras"
 msgid "List all settings"
 msgstr "Listar toda as configurações"
 
-msgid "List all smart class parameters"
-msgstr "Listar todos os parâmetros de classe inteligentes"
-
 msgid "List all smart proxies"
 msgstr "Listar todos os proxies inteligentes"
 
@@ -5191,15 +5159,6 @@ msgstr "Lista arquivos de inicialização para um sistema operacional"
 msgid "List default templates combinations for an operating system"
 msgstr "Lista de modelos padrões de combinados para um sistema operacional"
 
-msgid "List environments of Puppet class"
-msgstr "Listar ambientes de uma classe Puppet"
-
-msgid "List environments per location"
-msgstr "Listar ambientes por localização"
-
-msgid "List environments per organization"
-msgstr "Listar ambientes por organização"
-
 msgid "List external authentication sources"
 msgstr "Listar fontes de autenticação externas"
 
@@ -5208,6 +5167,9 @@ msgstr "Listar fontes de autenticação externa por localização"
 
 msgid "List external authentication sources per organization"
 msgstr "Listar fontes de autenticação por organização"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "Listar hosts por localização"
@@ -5242,9 +5204,6 @@ msgstr "Lista de atributos de computação para perfil computacional e recurso d
 msgid "List of compute profiles"
 msgstr "Lista de perfis computacionais"
 
-msgid "List of config groups"
-msgstr "Lista  de grupos de configuração"
-
 msgid "List of domains"
 msgstr "Lista de domínios"
 
@@ -5260,35 +5219,20 @@ msgstr "Lista de domínios por subrede"
 msgid "List of email notifications"
 msgstr "Lista de notificações por emails"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr "Lista de nomes de hosts, endereços IPv4, IPv6 ou sub-redes que serão confiáveis, além dos Proxies Inteligentes, para acesso aos importadores de fatos/relatórios e saída ENC"
 
 msgid "List of hosts which answer to the provided query"
 msgstr "Lista de hosts que responderam a consulta feita"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "Lista de valores de substituição para um parâmetro de classe inteligente específico "
-
 msgid "List of realms"
 msgstr "Lista de realms"
 
 msgid "List of resources types that will be automatically associated"
 msgstr "Lista de tipos de recurso que serão associados automaticamente"
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "Lista de parâmetros de classe inteligentes para uma classe de Puppet"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "Lista de parâmetros de classe inteligentes para um ambiente específico"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "Lista de parâmetros de classe inteligentes para uma combinação de classe de Puppet/ambiente específico"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "Lista de parâmetros de classe inteligentes para um host específico"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "Lista de parâmetros de classe inteligentes para um grupo de host específico"
 
 msgid "List of subnets"
 msgstr "Listar as sub-redes"
@@ -5307,9 +5251,6 @@ msgstr "Lista de preferências da tabela para um usuário"
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
 msgstr "Lista de tempos limite (em segundos) para tentativas de pesquisa de DNS, como a macro dns_lookup e a validação de conflitos de registros DNS"
-
-msgid "List of trends counters"
-msgstr "Lista de contadores de tendências"
 
 msgid "List of user selected columns"
 msgstr "Lista de colunas selecionadas do usuário"
@@ -5494,6 +5435,10 @@ msgid "LookupKey|Key type"
 msgstr "LookupKey|Tipo de chave"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr "LookupKey|Mesclar padrão"
 
@@ -5542,6 +5487,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "Endereço MAC"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "Endereço MAC da interface. Necessário para interfaces gerenciadas em bare metal."
@@ -5624,6 +5572,9 @@ msgstr "Gerenciar"
 msgid "Manage Bookmarks"
 msgstr "Gerenciar favoritos"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "Gerenciar Localizações"
 
@@ -5632,6 +5583,9 @@ msgstr "Gerenciar Organizações"
 
 msgid "Manage PuppetCA"
 msgstr "Gerenciar PuppetCA"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "Gerenciar host"
@@ -5732,10 +5686,6 @@ msgid "Message"
 msgstr "Mensagem"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Valor"
 
@@ -5753,6 +5703,9 @@ msgstr "A métrica já está registrada: %s"
 
 msgid "Metrics"
 msgstr "Métricas"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "Minutos atrás"
@@ -5831,6 +5784,9 @@ msgstr "Minha conta"
 msgid "N/A"
 msgstr "N/D"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "NA"
 
@@ -5852,8 +5808,8 @@ msgstr "Nome da mídia"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr "Nome da Audiência do OpenID Connect que está sendo usado para autenticação. No caso do Keycloak, esta é a ID de cliente."
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
-msgstr "Nome da fonte de autenticação externa, onde os usuários de autenticação desconhecidos externamente (consulte authorize_login_delegation) devem ser criados (mantenha desativado se quiser evitar a criação automática)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
+msgstr ""
 
 msgid "Name of the host group"
 msgstr "Nome do grupo de hosts"
@@ -5930,6 +5886,9 @@ msgstr "Nova Organização"
 msgid "New SSH key"
 msgstr "Nova chave SSH"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "Nova Máquina Virtual"
 
@@ -5945,8 +5904,8 @@ msgstr "A nova conexão for rejeitada com o motivo: %"
 msgid "New filter"
 msgstr "Novo filtro"
 
-msgid "New window"
-msgstr "Nova janela"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Próximo"
@@ -6073,6 +6032,9 @@ msgstr "Nenhum recurso TFTP"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "Nenhum TFTP proxies definido, não é possível continuar"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr "Nenhuma VM correspondeu a nenhum host."
 
@@ -6111,6 +6073,9 @@ msgstr "Nenhum email"
 
 msgid "No entries found"
 msgstr "Nenhuma entrada localizada"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "Nenhum recurso encontrado neste proxy, por favor certifique-se de que você ativou ao menos um recurso."
@@ -6208,6 +6173,9 @@ msgstr "Não foi encontrado nenhum proxy."
 msgid "No smart proxies to show"
 msgstr "Nenhum proxy inteligente para exibição"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "Nenhuma subrede"
 
@@ -6244,11 +6212,11 @@ msgstr "Normal"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr "Normalmente, ao configurar um recurso de computação, um par de chaves (privada e pública) é criado para você automaticamente."
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "Não instalado"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr "Não é uma URL válida para um proxy HTTP"
 
 msgid "Not implemented"
 msgstr "Não implantado"
@@ -6415,6 +6383,9 @@ msgstr "OIDC JWKs URL"
 msgid "OK"
 msgstr "OK"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "Imagem S.O."
 
@@ -6490,9 +6461,6 @@ msgstr "Oops, desculpe-nos, mas algo deu errado"
 
 msgid "Open"
 msgstr "Abrir"
-
-msgid "Open Spice in a new window"
-msgstr "Abra o Spice em uma nova janela"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr "Tempo limite de abertura e leitura para solicitações HTTP do Foreman para o Proxy Inteligente (em segundos)"
@@ -6593,9 +6561,6 @@ msgstr "Validador de entrada opcional"
 msgid "Optional array of log hashes"
 msgstr "Matriz opcional de hashes de log"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "Faixa delimitada por vírgulas opcional sendo \"nova\", \"atualizada\" ou \"obsoleta\" que seja utilizada para limitar as classes importadas de Puppet"
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "Opcional: Endereço IP final para sugestão automática de IP"
 
@@ -6659,9 +6624,6 @@ msgstr "Formato de saída"
 msgid "Override"
 msgstr "Substituir"
 
-msgid "Override Value"
-msgstr ""
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "Substituir o valor padrão do parâmetro de classe do Puppet. "
 
@@ -6674,8 +6636,17 @@ msgstr "Visão Geral"
 msgid "Overwrite"
 msgstr "Substituir"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "Propriedade de"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "Proprietário"
@@ -6759,6 +6730,10 @@ msgstr "Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Prioridade"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr "Parâmetro|Tipo"
@@ -6997,9 +6972,6 @@ msgstr "Por favor, aguarde enquanto a sua solicitação está sendo processada"
 msgid "Plugins"
 msgstr "Plugins"
 
-msgid "Port to connect to"
-msgstr "Porta para conexão"
-
 msgid "Possible values"
 msgstr "Valores possíveis"
 
@@ -7012,8 +6984,14 @@ msgstr "Energia"
 msgid "Power ON this machine"
 msgstr "Ligar essa máquina"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
 msgstr "Ligar uma máquina virtual"
+
+msgid "Power has been set to \"%s\" successfully"
+msgstr ""
 
 msgid "Power operations are not enabled on this host."
 msgstr "As operações de energia não estão ativadas neste host."
@@ -7081,8 +7059,8 @@ msgstr "Priorizar ordem de atributos "
 msgid "Private"
 msgstr "Privado"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
-msgstr "Arquivo de chave privada que o Foreman usará para criptografar WebSockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Proceed to Edit"
 msgstr "Proceda para Editar"
@@ -7181,6 +7159,9 @@ msgstr "Proxies"
 msgid "Proxy ID to use within this realm"
 msgstr "ID do proxy a ser usado neste realm"
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr "As referências de proxy devem ser { :relation => [:column_name, ...] }"
 
@@ -7229,9 +7210,6 @@ msgstr "Classe de puppet"
 msgid "Puppet error state"
 msgstr "Estado de erro do Puppet"
 
-msgid "Puppet interval"
-msgstr "Intervalo de Puppet"
-
 msgid "Puppet parameter"
 msgstr "Parâmetro do puppet"
 
@@ -7240,14 +7218,6 @@ msgstr "Relatório de Marionete ID"
 
 msgid "Puppet summary"
 msgstr "Resumo do Puppet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Classe Puppet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Nome"
 
 msgid "Query"
 msgstr "Pesquisa"
@@ -7323,6 +7293,9 @@ msgstr "Realm|Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "Realm|Tipo de realm "
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "Reiniciar e compilar"
@@ -7424,12 +7397,6 @@ msgstr "Remover correspondência"
 msgid "Remove Parameter"
 msgstr "Remover Parâmetro"
 
-msgid "Remove a Puppet class from host"
-msgstr "Remover uma classe Puppet do host"
-
-msgid "Remove a Puppet class from host group"
-msgstr "Remover uma classe Puppet de um grupo de host"
-
 msgid "Remove an email notification for a user"
 msgstr ""
 
@@ -7437,6 +7404,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr "Remove %{type} conflitande de %{host}"
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7521,6 +7491,9 @@ msgstr "Modelo de relatório|Nome"
 msgid "ReportTemplate|Snippet"
 msgstr "Modelo de relatório|Snippet"
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "Relatar em"
 
@@ -7532,6 +7505,9 @@ msgstr "Relatado por %s"
 
 msgid "Reports"
 msgstr "Relatórios"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7576,6 +7552,9 @@ msgstr "Exigido a menos que o usuário esteja em uma fonte de autenticação ext
 msgid "Required when user want to change own password"
 msgstr "Exigido quando o usuário quer alterar sua senha"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr "Redefinir nome do certificado PuppetCA para %s"
 
@@ -7619,6 +7598,9 @@ msgstr "Resultado do relatório %s"
 msgid "Resume"
 msgstr "Retomar"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "Retorna uma \"string\" que representa o status de host de um determinado tipo"
 
@@ -7644,8 +7626,14 @@ msgstr "Falha ao reverter, ${err}"
 msgid "Revert Local Changes"
 msgstr "Reverter alterações locais"
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "Revisão"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "Revisar status de construção para %s"
@@ -7655,6 +7643,9 @@ msgstr "Revogar"
 
 msgid "Revoke a Personal Access Token for a user"
 msgstr "Revogar um token de acesso pessoal para um usuário"
+
+msgid "Revoke personal access token"
+msgstr ""
 
 msgid "Revoked"
 msgstr ""
@@ -7736,6 +7727,9 @@ msgstr "Modo de verificação do OpenSSL do SMTP"
 msgid "SMTP address"
 msgstr "Endereço do SMTP"
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "Autenticação do SMTP"
 
@@ -7750,6 +7744,9 @@ msgstr "Senha do SMTP"
 
 msgid "SMTP port"
 msgstr "Porta do SMTP"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr "Nome de usuário do SMTP"
@@ -7769,14 +7766,20 @@ msgstr "Tempo limite SSH"
 msgid "SSL CA file"
 msgstr "Arquivo CA SSL"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Arquivo CA SSL que o Foreman utiliza para se comunicar com seus proxies."
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Caminho do Certificado SSL  que o Foreman usaria para se comunicar com seus proxies."
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Arquivo da Chave Privada de SSL que o Foreman utiliza para se comunicar com seus proxies."
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "Certificado SSL"
@@ -7825,6 +7828,9 @@ msgstr "Salve alguma coisa e tente novamente"
 
 msgid "Saved Bookmarks"
 msgstr "Salvo nos favoritos"
+
+msgid "Saved audits interval"
+msgstr ""
 
 msgid "Schedule generating of a report"
 msgstr "Geração agenadda de um relatório"
@@ -8002,6 +8008,9 @@ msgstr "Argumentos de sendmail"
 msgid "Sendmail location"
 msgstr "Localização de sendmail"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr "Grupo de servidores"
 
@@ -8032,6 +8041,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr "Definir endereços IP para %s"
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr "Definir uma senha gerada aleatoriamente na conexão de exibição VCN"
 
@@ -8052,9 +8064,6 @@ msgstr "Definir a ordem em que os valores serão resolvidos. "
 
 msgid "Set up compute instance %s"
 msgstr "Configurar instância de computação %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr "Define um proxy para todas as conexões HTTP de saída do Foreman. Os proxies de todo o sistema devem ser configurados no nível do sistema operacional."
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8122,6 +8131,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "O `foreman-rake db:migrate`deve ser migrado na próxima execução dos módulos instaladores?"
 
@@ -8155,18 +8170,6 @@ msgstr "Mostrar laboratórios experimentais"
 msgid "Show a Personal Access Token for a user"
 msgstr "Mostrar um token de acesso pessoal de um usuário"
 
-msgid "Show a Puppet class"
-msgstr "Exibir uma classe Puppet"
-
-msgid "Show a Puppet class for a host group"
-msgstr "Exibir uma classe Puppet para um grupo de host"
-
-msgid "Show a Puppet class for an environment"
-msgstr "Exibir Classe de puppet para um ambiente"
-
-msgid "Show a Puppet class for host"
-msgstr "Exibir uma classe Puppet para host"
-
 msgid "Show a bookmark"
 msgstr "Mostrar um marcador"
 
@@ -8178,9 +8181,6 @@ msgstr "Exibir um perfil computacional"
 
 msgid "Show a compute resource"
 msgstr "Exibir um recurso de computação"
-
-msgid "Show a config group"
-msgstr "Mostrar um grupo de configuração"
 
 msgid "Show a default template combination for an operating system"
 msgstr "Mostrar o modelo padrão de combinação para um sistema operacional"
@@ -8248,17 +8248,11 @@ msgstr "Mostrar um perfil"
 msgid "Show a setting"
 msgstr "Mostrar uma configuração"
 
-msgid "Show a smart class parameter"
-msgstr "Exibir parâmetro de classe inteligente"
-
 msgid "Show a smart proxy"
 msgstr "Exibir um proxy inteligente"
 
 msgid "Show a subnet"
 msgstr "Mostrar uma sub-rede"
-
-msgid "Show a trend"
-msgstr "Mostrar uma tendência"
 
 msgid "Show a user"
 msgstr "Mostrar um usuário"
@@ -8293,9 +8287,6 @@ msgstr "Exibir uma auditoria"
 msgid "Show an email notification"
 msgstr "Mostrar uma notificação por email"
 
-msgid "Show an environment"
-msgstr "Exibir um ambiente"
-
 msgid "Show an external authentication source"
 msgstr "Mostrar uma fonte de autenticação externa"
 
@@ -8316,9 +8307,6 @@ msgstr "Mostrar uma fonte de autenticação interna"
 
 msgid "Show an operating system"
 msgstr "Mostrat um sistema operacional"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "Exibir um valor de substituição para um parâmetro de classe inteligente específico"
 
 msgid "Show available API links"
 msgstr "Mostrar links API disponíveis"
@@ -8401,9 +8389,6 @@ msgstr "Ignorado"
 msgid "Skipped|S"
 msgstr "S"
 
-msgid "Smart Class Parameter"
-msgstr "Parâmetro de Classe Inteligente"
-
 msgid "Smart Class Parameters"
 msgstr "Parâmetros de classe inteligentes"
 
@@ -8471,6 +8456,9 @@ msgstr "Algumas interfaces são inválidas"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Algumas das interfaces são inválidas. Por favor verifique a tabela abaixo."
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "Algo saiu errado ao mudar o tipo do host - %s"
 
@@ -8494,10 +8482,6 @@ msgid "Source"
 msgstr "Origem"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Digest"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Value"
 
@@ -8519,8 +8503,8 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr "Especificar correspondências "
 
-msgid "Specify additional options to sendmail"
-msgstr "Especificar opções adicionais para sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "Specify authentication type, if required"
 msgstr "Especificar tipo de autenticação, se necessário"
@@ -8563,8 +8547,8 @@ msgstr "Status"
 msgid "Status %s does not exist."
 msgstr "O status %s não existe."
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "Encerrar a atualização do endereço IP e valores MAC dos fatos Puppet (afeta todas as interfaces) "
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr "Interromper atualização do sistema operacional a partir de fatos"
@@ -8660,6 +8644,10 @@ msgid "Subnet|Dns secondary"
 msgstr "DNS secundário"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "De"
 
@@ -8686,6 +8674,10 @@ msgstr "Nome"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Rede"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8758,6 +8750,12 @@ msgstr "O suporte a %{feature} foi preterido e será removido na versão %{versi
 
 msgid "Supported Formats"
 msgstr "Formatos suportados"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "Sincronizar grupo a partir da fonte de autenticação"
@@ -8916,12 +8914,20 @@ msgid "TemplateInput|Advanced"
 msgstr "Entrada de modelo|Avançado"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "Entrada de modelo|Descrição"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "Entrada de modelo|Nome do fato"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8990,6 +8996,10 @@ msgid "Template|Default"
 msgstr "Modelo|Padrão"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "Modelo|Bloqueado"
 
@@ -9040,8 +9050,8 @@ msgstr "Email de teste"
 msgid "Tester"
 msgstr "Testador"
 
-msgid "Text to be shown in the login-page footer"
-msgstr "Texto a ser mostrado no rodapé de login-page"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
+msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
@@ -9186,7 +9196,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9203,8 +9213,8 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] "A lista está excluindo %{count} %{link_start}host físico%{link_end}."
 msgstr[1] "A lista está excluindo %{count} %{link_start}hosts físicos%{link_end}."
 
-msgid "The location of the sendmail executable"
-msgstr "A localização do executável de sendmail"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "Os campos marcados precisarão ser revisados."
@@ -9233,9 +9243,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "O estado de energia dos hosts selecionados será definido como %s"
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "O nome de realm, ex: EXAMPLE.COM"
@@ -9298,6 +9305,9 @@ msgstr "Pode haver mais informações nos registros do servidor."
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
 msgstr "Deve haver pelo menos um Proxy Inteligente presente com um plugin externo do IPAM instalado e configurado"
+
+msgid "There was a problem processing the request. Please try again."
+msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
 msgstr "Ocorreu um erro ao criar o arquivo PIXE: %s"
@@ -9426,7 +9436,7 @@ msgstr "Este valor não está oculto"
 msgid "This value is used also as the host's primary interface name."
 msgstr "Este valor também é usado como o nome de interface primário do host. "
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9451,15 +9461,6 @@ msgid "Timezone to use for new users"
 msgstr "Fuso horário a ser usado para novos usuários"
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9493,9 +9494,6 @@ msgstr "Token"
 
 msgid "Token Expiry"
 msgstr "Expiração do token"
-
-msgid "Token duration"
-msgstr "Duração do token"
 
 msgid "Token expired"
 msgstr "Token expirado"
@@ -9534,41 +9532,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] "Total de um host"
 msgstr[1] "Total de hosts %{hosts}"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "Tendência"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Contador de tendência"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Conta"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "TrendCounter|Fim do intervalo"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "TrendCounter|Início do intevalo"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Nome do fato"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Valor do fato"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Nome"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Trend|Tipo reclinável"
+msgid "Total: %s"
+msgstr ""
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "Sinal Verdadeiro / Falso se um host é gerenciado ou não . Nota: este valor também determina se são necessários vários parâmetros ou não"
@@ -9849,6 +9814,12 @@ msgstr "Não é possível remover a definição de websockets_ssl_key quando web
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "Modelo não permitido para widget de painel: %s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "URL autônomo "
 
@@ -9906,6 +9877,9 @@ msgstr "Registros desconhecidos encontrados no banco de dados"
 msgid "Unknown status: %s"
 msgstr "Status desconhecido: %s"
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "Desbloquear"
 
@@ -9933,9 +9907,6 @@ msgstr "Atualizar:a_resource"
 msgid "Update IP from built request"
 msgstr "Atualizar IP da solicitação de compilação "
 
-msgid "Update a Puppet class"
-msgstr "Atualizar uma classe Puppet"
-
 msgid "Update a bookmark"
 msgstr "Atualizar um marcador"
 
@@ -9947,9 +9918,6 @@ msgstr "Atualizar um perfil computacional"
 
 msgid "Update a compute resource"
 msgstr "Atualizar um recurso de computação"
-
-msgid "Update a config group"
-msgstr "Atualizar um grupo de configuração"
 
 msgid "Update a default template combination for an operating system"
 msgstr "Atualizar o modelo padrão de combinaçãoes para o sistema operacional"
@@ -10017,9 +9985,6 @@ msgstr "Atualizar uma função"
 msgid "Update a setting"
 msgstr "Atualizar uma configuração"
 
-msgid "Update a smart class parameter"
-msgstr "Atualizar um parâmetro de classe inteligente"
-
 msgid "Update a smart proxy"
 msgstr "Atualizar um proxy inteligente"
 
@@ -10050,9 +10015,6 @@ msgstr "Atualizar uma arquitetura"
 msgid "Update an email notification for a user"
 msgstr ""
 
-msgid "Update an environment"
-msgstr "Atualizar um ambiente"
-
 msgid "Update an external authentication source"
 msgstr "Atualizar uma fonte de autenticação externa"
 
@@ -10061,12 +10023,6 @@ msgstr "Atualizar uma imagem"
 
 msgid "Update an operating system"
 msgstr "Atualização do sistema operacional"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "Atualizar um valor de substituição para um parametro de classe inteligente específico"
-
-msgid "Update environment from facts"
-msgstr "Atualizar ambientes a partir dos fatos "
 
 msgid "Update external user group"
 msgstr "Atualizar um grupo de usuário externo"
@@ -10303,6 +10259,10 @@ msgid "User|Description"
 msgstr "Usuário|Descrição"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "User|Nome"
 
@@ -10439,8 +10399,8 @@ msgstr "Variável"
 msgid "Variables"
 msgstr "Variáveis"
 
-msgid "Vendor Class"
-msgstr "Classe de fornecedor"
+msgid "Vendor class"
+msgstr ""
 
 msgid "Verify"
 msgstr "Verificar"
@@ -10501,6 +10461,9 @@ msgstr "Esperando por %s para ficar online"
 
 msgid "Warning"
 msgstr "Aviso"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "Aviso!"
@@ -10565,6 +10528,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10697,6 +10663,9 @@ msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "Você está prestes a mudar o menu padrão do PXE em todos os servidores TFTP configurados - continuar?"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
@@ -10853,6 +10822,9 @@ msgstr "todos"
 msgid "already exists"
 msgstr "já existe"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "uma organização"
 
@@ -10864,9 +10836,6 @@ msgstr "matriz"
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "pertence ao grupo de configuração"
 
 msgid "boolean"
 msgstr "boolean"
@@ -11047,9 +11016,6 @@ msgstr "Habilitar cache somente para VMware"
 
 msgid "enabled"
 msgstr ""
-
-msgid "environment id"
-msgstr "ID de ambiente"
 
 msgid "expected a value of type %s"
 msgstr "valor esperado do tipo %s"
@@ -11299,8 +11265,7 @@ msgstr "grupo de usuário externo com este grupo de usuário"
 msgid "list"
 msgstr "listar"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "Português Brasil"
 
@@ -11480,12 +11445,6 @@ msgstr "física @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "física @ ponte %s"
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
-msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "ação de energia , as ações são válidos ( on / start ) , ( off / stop) , (soft / reboot ) , ( ciclo / reset ) , (estado / status)"

--- a/locale/pt_BR/foreman.po
+++ b/locale/pt_BR/foreman.po
@@ -414,6 +414,9 @@ msgstr "Uma notificação quando um host relata uma configuração de erro"
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Um problema ocorreu enquanto detectando tipo de host: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr "Um resumo do relatório de alterações de auditoria <br> Filtrado por consulta, se necessário"
 
@@ -699,6 +702,9 @@ msgstr "Um endereço de email é necessário, por favor atualize os dados de sua
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "Ocorreu um erro ao tentar conexão com o LDAP, verifique se o host de origem de autenticação pode ser alcançado a partir do host Foreman e se está on-line."
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -767,6 +773,12 @@ msgstr "Você tem certeza que quer apagar esse host %s? Essa ação é irrevers�
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Tem certeza de que deseja excluir o host %s? Isso excluirá a VM e seus discos, e essa ação é irreversível. Esse comportamento pode ser alterado por meio da configuração global \"Destruir VM associada na exclusão do host\"."
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr "Você está certo que quer fazer logout?"
@@ -1150,6 +1162,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "Modelo em branco"
 
@@ -1245,6 +1260,9 @@ msgstr "Compilar Padrão PXE"
 
 msgid "Build duration"
 msgstr "Duração da construção"
+
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
 
 msgid "Build errors"
 msgstr "Erros de construção"
@@ -2628,6 +2646,12 @@ msgstr "ERRO ou FATAL"
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3338,6 +3362,12 @@ msgstr "resumo de auditoria do Foreman "
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr "O Foreman pode armazenar informações sobre a configuração de rede de um host que está provisionando, o que pode ser usado para configurar a máquina virtual, atribuir o endereço IP e os recursos de rede corretos e, depois, configurar o SO corretamente durante o processo de provisionamento. "
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3633,6 +3663,9 @@ msgstr "O boot de UEFI HTTP requer proxy com o recurso httpboot"
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr "O boot de HTTP requer proxy com o recurso httpboot e a configuração http_port exposta"
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
+msgstr ""
 
 msgid "HTTP(S) proxy"
 msgstr "Proxy de HTTP(S)"
@@ -4397,8 +4430,20 @@ msgstr "Se o ERB é usado em um valor de parâmetro, a validação do valor ocor
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "Se verificado, surgirá um erro caso não haja valor padrão e nenhum coincidente fornecer um valor."
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
 msgstr "Se o tipo de proprietário for especificado, o proprietário também deverá ser especificado."
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
 msgstr "Se definido, o relatório agendado será enviado por e-mail. Use '%s' para separar vários endereços de e-mail."
@@ -4410,6 +4455,9 @@ msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and 
 msgstr ""
 "Se o sinalizador gerenciado estiver ativado, os serviços externos como DHCP, DNS, e \n"
 " TFTP serão configurados de acordo com as informações fornecidas."
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
+msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
 msgstr "Se o modelo der suporte à seleção de formato, o usuário poderá escolher o formato de sua preferência.<br> Tipicamente, o modelo precisa usar a macro report_render.<br><br>Se o uso dessa macro não for encontrado no modelo,<br> este campo será desabilitado e o formato de saída padrão será texto sem formatação.<br><br>Se o modelo der suporte à seleção de filtro, mas não usar a macro report_render,<br> para ativar este campo, adicione um comentário ao modelo mencionando o nome da macro, report_render."
@@ -4425,6 +4473,9 @@ msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Se você acha que isso é um erro com o próprio Foreman, por favor, registre um novo problema com"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr "Ignorar fatos do domínio"
@@ -4571,6 +4622,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "Infraestrutura"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Pai herdado (%s)"
 
@@ -4620,6 +4674,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5566,6 +5623,9 @@ msgstr "MailNotification|Assinável"
 msgid "MailNotification|Subscription type"
 msgstr "MailNotification|Tipo de subscrição"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Gerenciar"
 
@@ -6404,6 +6464,9 @@ msgstr "Nome do SO do facter; ex.: RedHat"
 msgid "Off"
 msgstr "Desligado"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "Ok"
 
@@ -6452,6 +6515,9 @@ msgstr "Somente uma declaração de um proxy é permitida"
 
 msgid "Only one volume can be bootable"
 msgstr "Somente um volume pode ser inicializável"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "Oops!!"
@@ -6861,6 +6927,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7546,6 +7615,9 @@ msgstr "Solicitar UUID"
 msgid "Require SSL for smart proxies"
 msgstr "Solicitar SSL para proxies inteligentes"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "Exigido a menos que o usuário esteja em uma fonte de autenticação externa"
 
@@ -8131,6 +8203,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8365,6 +8440,11 @@ msgstr "Assinar"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "Um único host está selecionado nesta página."
@@ -8455,6 +8535,12 @@ msgstr "Algumas interfaces são inválidas"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Algumas das interfaces são inválidas. Por favor verifique a tabela abaixo."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9118,6 +9204,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr "O algoritmo usado para codificar o JWT no provedor do OpenID."
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "A origem de autenticação dos seus grupos externos de usuários não conseguiu se conectar ao LDAP com as credenciais fornecidas. Verifique se as credenciais  ainda são válidas."
 
@@ -9129,6 +9218,9 @@ msgstr "A classe do CPU fornecido nesta máquina. Usada principalmente por compi
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "A classe da máquina reportada pela Open Boot Prom. Usada principalmente por compilações de Sparc Solaris e pode ser deixada em branco por outras arquiteturas. O valor pode ser determinado no Solaris via uname -i|cut -f2 "
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr "O console não está disponível porque a VM não está ligada."
@@ -9321,6 +9413,12 @@ msgstr "Ocorreu um erro ao listar as MVs: %(status)s %(statusText)s"
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "Ocorreu um erro ao renderizar o modelo %{name}: %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "Nenhuma interface de ponte ativa foi localizada no libvirt, caso não haja suporte para listagem, o nome da ponte deve ser inserido manualmente (ex. br0) "
 
@@ -9335,6 +9433,9 @@ msgstr "Isso <b>excluirá</b> as VMs vinculadas e seus discos, e é irreversíve
 
 msgid "This IP address has already been reserved in External IPAM"
 msgstr "Esse endereço IP já foi reservado no IPAM externo"
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
 msgstr ""
@@ -9390,6 +9491,9 @@ msgstr "Isso pode ter ter sido causado pela indisponibilidade de algum serviço 
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Isso pode levar algum tempo, já que todos os hosts, fatos e relatórios também <b>serão excluídos</b>. %s Esse comportamento pode ser alterado por meio da configuração global \"Destruir VM associada na exclusão do host\"."
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9410,6 +9514,12 @@ msgstr "O serviço está disponivel para usuários não autenticados."
 
 msgid "This service is only available for authenticated users"
 msgstr "O serviço está disponivel somente para usuários autenticados."
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "Este modelo está travado e não pode ser removido."
@@ -9437,6 +9547,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "Este valor também é usado como o nome de interface primário do host. "
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9484,6 +9597,9 @@ msgid ""
 msgstr ""
 "Para atualizar a lista de usuários, clique na guia \"Grupos\n"
 "                externos\" e, depois, em \"Atualizar\"."
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
+msgstr ""
 
 msgid "Today"
 msgstr "Hoje"
@@ -10336,6 +10452,9 @@ msgstr "Atributos da VM (%s)"
 msgid "VM already associated with a host"
 msgstr "MV já está associada ao host"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "MV já está associada ao host %s"
 
@@ -10475,6 +10594,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] "Aviso! Isto removerá %{name} de %{number} usuário. Tem certeza?"
 msgstr[1] "Aviso! Isto removerá %{name} de %{number} usuários. Tem certeza?"
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "Aviso: Isto irá remover este host e todos os seus dados!"
@@ -10670,11 +10792,17 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "Você está prestes a desbloquear um modelo bloqueado. "
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
 msgstr "Você já está representando, clique no ícone de representação na barra superior antes de iniciar uma nova representação."
+
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
 
 msgid "You are not authorized to lock templates."
 msgstr "Você não está autorizado a bloquear modelos. "

--- a/locale/ru/foreman.po
+++ b/locale/ru/foreman.po
@@ -33,9 +33,6 @@ msgstr ""
 msgid " Documentation"
 msgstr "Документация"
 
-msgid " Remove"
-msgstr "Удалить"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -47,9 +44,6 @@ msgstr "${progress}%% Выполнено"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr "%(name)s (свободно: %(free)s, распределено: %(prov)s, всего: %(total)s)"
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - нажмите Shift-F12, чтобы освободить курсор."
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s: действие применимо к следующим узлам"
@@ -69,9 +63,6 @@ msgstr[1] ""
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "Обновлено параметров: %s. Подробную информацию можно найти ниже"
-
-msgid "%s Template"
-msgstr "%s"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -132,9 +123,6 @@ msgstr[1] "%s месяца назад"
 msgstr[2] "%s месяцев назад"
 msgstr[3] "%s месяцев назад"
 
-msgid "%s out of sync disabled"
-msgstr ""
-
 msgid "%s selected hosts"
 msgstr "%s выбранных узлов"
 
@@ -156,9 +144,6 @@ msgid "%s widget loading..."
 msgstr ""
 
 msgid "%s you had selected as your context has been deleted"
-msgstr ""
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
 msgstr ""
 
 msgid "%{action} %{vm}"
@@ -234,6 +219,9 @@ msgstr "%{match} не соответствует существующим гру
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} изменён с %{label1} на %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr ""
@@ -316,6 +304,9 @@ msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "Дополнительно: роль IAM для Fog, используемая для создания образа "
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*Очистить %s*"
@@ -510,12 +501,6 @@ msgstr "Добавить том"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr ""
 
-msgid "Add a Puppet class to host"
-msgstr "Добавить класс Puppet к узлу"
-
-msgid "Add a Puppet class to host group"
-msgstr "Добавить класс Puppet к группе узлов"
-
 msgid "Add a template combination"
 msgstr "Добавить комбинацию шаблонов"
 
@@ -561,9 +546,6 @@ msgstr "Дополнительные атрибуты вычислительно
 msgid "Additional information about this host"
 msgstr "Дополнительная информация об этом узле"
 
-msgid "Address to connect to"
-msgstr ""
-
 msgid "Admin permissions required"
 msgstr "Необходимы права администратора"
 
@@ -606,9 +588,6 @@ msgstr "Псевдоним или VLAN устройства."
 msgid "All"
 msgstr "Все"
 
-msgid "All Audits"
-msgstr "Все Аудиты"
-
 msgid "All Hosts"
 msgstr "Все Узлы"
 
@@ -616,6 +595,12 @@ msgid "All Reports"
 msgstr "Все отчеты"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -777,9 +762,6 @@ msgstr "Вы действительно хотите удалить узел %s?
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Вы уверены, что хотите удалить узел %s? Это приведет к удалению виртуальной машины, ее дисков и будет необратимым. Это поведение можно изменить с помощью глобальной настройки \"Уничтожить связанную виртуальную машину на удаленном узле\"."
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "Вы действительно хотите удалить этот виджет из окна обзора?"
-
 msgid "Are you sure you want to log out?"
 msgstr ""
 
@@ -836,6 +818,12 @@ msgstr "Выбрать организацию"
 
 msgid "Assign Selected Hosts"
 msgstr "Добавить выбранные"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1323,6 +1311,9 @@ msgstr ""
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr ""
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "Вы не можете удалить внутреннюю учетную запись администратора"
 
@@ -1404,8 +1395,8 @@ msgstr ""
 msgid "Certificate path for GCE only"
 msgstr ""
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Сертификат для шифрования соединений Websocket"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "Сертификаты"
@@ -1464,6 +1455,9 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr ""
 
@@ -1475,12 +1469,6 @@ msgstr "Выберите вычислительный ресурс, чтобы �
 
 msgid "Click to log in again"
 msgstr "Нажмите, чтобы снова войти в систему"
-
-msgid "Click to remove %s"
-msgstr "Нажмите, чтобы удалить %s"
-
-msgid "Click to remove config group"
-msgstr "Нажмите, чтобы удалить группу конфигурации"
 
 msgid "Client Email"
 msgstr "Электронный адрес клиента"
@@ -1644,14 +1632,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "Получение конфигурации"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "Группа конфигурации"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "Имя"
-
 msgid "Configuration"
 msgstr "Конфигурация"
 
@@ -1694,8 +1674,8 @@ msgstr "Обнаружены конфликты"
 msgid "Connected"
 msgstr ""
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "Установлено незашифрованное соединение с %s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "Устанавливается незашифрованное соединение с %s"
@@ -1745,7 +1725,7 @@ msgstr ""
 msgid "Cores per socket"
 msgstr "Ядер на сокет"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
 msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
@@ -1922,9 +1902,6 @@ msgstr ""
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-msgid "Create a Puppet class"
-msgstr "Создать класс Puppet"
-
 msgid "Create a bookmark"
 msgstr "Создать закладку"
 
@@ -1936,9 +1913,6 @@ msgstr "Создать вычислительный профиль"
 
 msgid "Create a compute resource"
 msgstr "Создать вычислительный ресурс"
-
-msgid "Create a config group"
-msgstr "Создать группу конфигурации"
 
 msgid "Create a default template combination for an operating system"
 msgstr "Создать комбинацию шаблонов по умолчанию для операционной системы"
@@ -2012,9 +1986,6 @@ msgstr "Создать подсеть"
 msgid "Create a template input"
 msgstr "Создать входной параметр"
 
-msgid "Create a trend counter"
-msgstr "Создать счетчик трендов"
-
 msgid "Create a user"
 msgstr "Создать пользователя"
 
@@ -2030,9 +2001,6 @@ msgstr "Создать источник аутентификации LDAP"
 msgid "Create an architecture"
 msgstr "Создать архитектуру"
 
-msgid "Create an environment"
-msgstr "Создать окружение"
-
 msgid "Create an external user group linked to a user group"
 msgstr "Создать внешнюю группу пользователей для связи с группой пользователей"
 
@@ -2045,13 +2013,13 @@ msgstr "Создать интерфейс на узле"
 msgid "Create an operating system"
 msgstr "Создать операционную систему"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "Создать переопределение смарт-параметра"
-
 msgid "Create autosign entry"
 msgstr "Создать запись автоматической подписи"
 
 msgid "Create image"
+msgstr ""
+
+msgid "Create model"
 msgstr ""
 
 msgid "Create new boot volume from image"
@@ -2068,6 +2036,9 @@ msgstr "Создать запись области определения для
 
 msgid "Created"
 msgstr "Создано"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr ""
@@ -2098,18 +2069,6 @@ msgstr ""
 
 msgid "DB pending seed"
 msgstr "Отложенное заполнение базы данных"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr "УСТАРЕВШИЙ: Добавить комбинацию шаблонов"
-
-msgid "DEPRECATED: List template combination"
-msgstr "УСТАРЕВШИЙ: Список комбинаций шаблонов"
-
-msgid "DEPRECATED: Show template combination"
-msgstr "УСТАРЕВШИЙ: Показать комбинацию шаблонов"
-
-msgid "DEPRECATED: Update template combination"
-msgstr "УСТАРЕВШИЙ: Обновить комбинацию шаблонов"
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2201,7 +2160,7 @@ msgstr "По умолчанию"
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2224,9 +2183,6 @@ msgstr ""
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr ""
-
-msgid "Default Puppet environment"
-msgstr "Окружение Puppet по умолчанию"
 
 msgid "Default VNC Keyboard"
 msgstr ""
@@ -2309,9 +2265,6 @@ msgstr "Удалить сертификаты PuppetCA %s"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr ""
 
-msgid "Delete a Puppet class"
-msgstr "Удалить класс Puppet"
-
 msgid "Delete a Virtual Machine"
 msgstr "Удалить Виртуальную Машину"
 
@@ -2323,9 +2276,6 @@ msgstr "Удалить вычислительный профиль"
 
 msgid "Delete a compute resource"
 msgstr "Удалить вычислительный ресурс"
-
-msgid "Delete a config group"
-msgstr "Удалить группу конфигурации"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "Удалить комбинацию шаблонов по умолчанию для операционной системы"
@@ -2408,9 +2358,6 @@ msgstr "Удалить комбинацию шаблонов"
 msgid "Delete a template input"
 msgstr "Удалить входной параметр"
 
-msgid "Delete a trend counter"
-msgstr "Удалить счетчик трендов"
-
 msgid "Delete a user"
 msgstr "Удалить пользователя"
 
@@ -2450,9 +2397,6 @@ msgstr "Удалить ключ SSH у пользователя "
 msgid "Delete an architecture"
 msgstr "Удалить архитектуру"
 
-msgid "Delete an environment"
-msgstr "Удалить окружение"
-
 msgid "Delete an external user group"
 msgstr "Удалить внешнюю группу пользователей"
 
@@ -2462,14 +2406,17 @@ msgstr "Удалить образ"
 msgid "Delete an operating system"
 msgstr "Удалить операционную систему"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "Удалить значение переопределения смарт-параметра"
-
 msgid "Delete autosign entry"
 msgstr "Удалить запись автоматической подписи"
 
 msgid "Delete filter?"
 msgstr "Удалить фильтр?"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "Удалить запись области определения для %s"
@@ -2542,9 +2489,6 @@ msgstr "Отключить уведомления для выбранных уз
 
 msgid "Disable all filters overriding"
 msgstr ""
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "Запретить переход состояния конфигурации узла в \"несинхронизированно\" в течение %s после того, как отчёт не поступил в течение заданного интервала"
 
 msgid "Disable overriding"
 msgstr "Отключить переопределение"
@@ -2664,10 +2608,10 @@ msgstr ""
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "Обнаружены дубликаты входных данных: %{duplicated_inputs}"
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"
@@ -2675,9 +2619,6 @@ msgstr "EC2"
 
 msgid "EFI"
 msgstr ""
-
-msgid "ENC environment"
-msgstr "Окружение ENC"
 
 msgid "ERROR or FATAL"
 msgstr "ERROR, FATAL"
@@ -2720,6 +2661,9 @@ msgstr "Редактировать узел"
 
 msgid "Editor"
 msgstr "Редактор"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "Почтовые предпочтения"
@@ -2796,10 +2740,6 @@ msgstr "Заключительный IP-адрес для автоматичес
 msgid "Entries per page"
 msgstr "Записей на странице"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "Окружение"
-
 msgid "Environment IDs"
 msgstr "Код окружения"
 
@@ -2814,10 +2754,6 @@ msgstr "Переменная окружения, содержащая стату
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Имя"
 
 msgid "Error"
 msgstr "Ошибка"
@@ -2857,6 +2793,9 @@ msgstr ""
 
 msgid "Error removing widget from dashboard."
 msgstr "Ошибка удаления виджета из окна обзора."
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr "Ошибка при отправке данных:"
@@ -3327,14 +3266,14 @@ msgstr "%s будет корректироваться при несоответ
 msgid "Fix All Mismatches"
 msgstr "Исправить все несоответствия"
 
-msgid "Fix DB cache"
-msgstr "Согласовать кэш БД"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "Согласовать кэш базы данных при перезапуске Foreman"
-
 msgid "Fix Mismatches"
 msgstr "Исправить несоответствия"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "Шаблон конфигурации"
@@ -3381,9 +3320,6 @@ msgstr "За подробной информацией обратитесь к"
 msgid "For values of type search, this is the resource the value searches in"
 msgstr ""
 
-msgid "Force a Puppet agent run on the host"
-msgstr "Принудительный запуск агента Puppet на узле"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "Foreman API v2 используется по умолчанию."
 
@@ -3417,6 +3353,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr ""
 
@@ -3425,6 +3365,10 @@ msgstr "Цикл сборки %s теперь находится под упра
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Цикл сборки %s больше не находится под управлением Foreman."
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Время создания отчета Foreman: <em>%s</em>"
@@ -3453,7 +3397,7 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Автоматизировать процесс подписи сертификатов при подготовке новых узлов"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
 msgstr ""
 
 msgid "Foreman will create the host when a report is received"
@@ -3462,20 +3406,14 @@ msgstr "Foreman будет создавать новый узел на осно�
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman будет создавать новый узел на основании загруженных фактов."
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "Окружение Puppet, которое будет выбрано, если Foreman не сможет автоматически определить окружение"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Удалить виртуальную машину, если сценарий подготовки завершился с ненулевым кодом выхода"
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman передаст информацию об окружении Puppet в YAML-выводе ENC в явном виде — это позволит избежать конфликтов с окружением, заданным в puppet.conf"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Включить авторизацию OAuth и разрешить передавать имена пользователей в заголовках запросов. Запросы OAuth будут иметь административные разрешения."
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "Foreman не будет отправлять этот параметр в вывод классификации."
@@ -3485,9 +3423,6 @@ msgstr "Интерпретировать ERB в значениях параме�
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Опрашивать локальный сервер преобразования имен вместо источников из SOA/NS"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Обновлять окружение узла на основании фактов статистики"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "Foreman обновит группу узлов для узла на основе его фактов"
@@ -3506,6 +3441,18 @@ msgstr "Использовать случайный UUID вместо имени
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Использовать краткое имя узла вместо полного имени домена при создании виртуальных машин"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr "Форма успешно создана."
@@ -3533,6 +3480,9 @@ msgstr "Во весь экран"
 
 msgid "Function not available for %s"
 msgstr "Функция не доступна для %s"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "GMT"
@@ -3603,8 +3553,8 @@ msgstr "Получить подробную сводку о состоянии �
 msgid "Get default dashboard widgets"
 msgstr "Получить виджеты обзора по умолчанию"
 
-msgid "Get statistics"
-msgstr "Получить статистику"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "Получить состояние узла"
@@ -3726,6 +3676,12 @@ msgstr "Модель оборудования %s была успешно уда�
 msgid "Hardware Models"
 msgstr "Оборудование"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr ""
 
@@ -3771,11 +3727,17 @@ msgstr "Журнал"
 msgid "Host"
 msgstr "Узел"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "Идет сборка узла %s"
 
 msgid "Host %s is not associated with a VM"
 msgstr "%s не связан с виртуальной машиной"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "Диаграмма конфигурации узлов"
@@ -3810,7 +3772,13 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "Параметры Узла"
 
-msgid "Host Wizard"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
 msgstr ""
 
 msgid "Host audit entries"
@@ -3819,12 +3787,12 @@ msgstr "Записи событий узла"
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "Узел группы настроек"
-
 msgid "Host details"
 msgstr "Свойства узла"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "Группа узлов"
@@ -3962,8 +3930,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "Тип узла"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4191,9 +4183,6 @@ msgstr "Идентификатор шаблона конфигурации"
 msgid "ID of domain"
 msgstr "Код домена"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr "ID окружения - УСТАРЕВШИЙ не будет иметь никакого эффекта"
-
 msgid "ID of host"
 msgstr "Код узла"
 
@@ -4260,7 +4249,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4323,9 +4312,6 @@ msgstr "Автоматически"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr ""
 
-msgid "IP6 Address"
-msgstr "Адрес IP6"
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4349,6 +4335,9 @@ msgstr "Подсеть IPv4"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr ""
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "IPv4-адрес интерфейса"
 
@@ -4368,6 +4357,9 @@ msgstr[1] ""
 
 msgid "IPv6 Subnet"
 msgstr "Подсеть IPv6"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "IPv6-адрес интерфейса"
@@ -4429,13 +4421,13 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Если вы считаете, что ошибка связана непосредственно с Foreman, создайте отчет."
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "Игнорировать факты Puppet"
-
 msgid "Ignore facts for domain"
 msgstr ""
 
 msgid "Ignore facts for operating system"
+msgstr ""
+
+msgid "Ignore interfaces facts for provisioning"
 msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
@@ -4516,12 +4508,6 @@ msgstr "Импортировать как неуправляемый узел"
 
 msgid "Import of facts failed for host %s"
 msgstr "Не удалось импортировать факты с узла %s"
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "Импорт классов puppet из puppet-прокси "
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "Импорт классов Puppet из прокси Puppet в окружение"
 
 msgid "Imported IPv4 Subnets"
 msgstr "Импртированные IPv4-подсети"
@@ -4634,6 +4620,9 @@ msgstr ""
 msgid "Installation medium configuration"
 msgstr "Конфигурация установочного носителя"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "Установлено"
 
@@ -4698,6 +4687,9 @@ msgid "Invalid %{assoc} selection, you must select at least one of yours and hav
 msgstr ""
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
+msgstr ""
+
+msgid "Invalid HTTP(S) URL"
 msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
@@ -4865,14 +4857,14 @@ msgstr "Последние события"
 msgid "Launch Console"
 msgstr ""
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr "Подробнее о внешней аутентификации читайте в документации."
 
 msgid "Learn more about LDAP authentication in the documentation."
 msgstr "Подробнее об аутентификации LDAP читайте в документации."
+
+msgid "Legacy UI"
+msgstr ""
 
 msgid "Length"
 msgstr ""
@@ -4906,24 +4898,6 @@ msgstr "Список всех источников аутентификации 
 
 msgid "List all Personal Access Tokens for a user"
 msgstr ""
-
-msgid "List all Puppet class IDs for host"
-msgstr "Список всех кодов классов Puppet для узла"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "Список всех кодов классов Puppet для группы узлов"
-
-msgid "List all Puppet classes"
-msgstr "Список всех классов Puppet"
-
-msgid "List all Puppet classes for a host"
-msgstr "Список всех классов Puppet узла"
-
-msgid "List all Puppet classes for a host group"
-msgstr "Список всех классов Puppet группы узлов"
-
-msgid "List all Puppet classes for an environment"
-msgstr "Список всех классов Puppet окружения"
 
 msgid "List all SSH keys for a user"
 msgstr "Список всех SSH-ключей пользователя"
@@ -4960,9 +4934,6 @@ msgstr "Список всех вычислительных ресурсов"
 
 msgid "List all email notifications for a user"
 msgstr "Список всех почтовых уведомлений пользователя"
-
-msgid "List all environments"
-msgstr "Список окружений"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "Список всех внешних групп для источника аутентификации LDAP"
@@ -5099,9 +5070,6 @@ msgstr "Список всех ролей"
 msgid "List all settings"
 msgstr "Список всех настроек"
 
-msgid "List all smart class parameters"
-msgstr "Список всех переопределяемых классов параметров"
-
 msgid "List all smart proxies"
 msgstr "Список всех капсул"
 
@@ -5180,15 +5148,6 @@ msgstr "Список загрузочных файлов операционно�
 msgid "List default templates combinations for an operating system"
 msgstr "Список комбинаций шаблонов по умолчанию для операционной системы"
 
-msgid "List environments of Puppet class"
-msgstr "Список окружений для классов Puppet"
-
-msgid "List environments per location"
-msgstr "Список окружений по местоположениям"
-
-msgid "List environments per organization"
-msgstr "Список окружений по организациям"
-
 msgid "List external authentication sources"
 msgstr "Список внешних источников аутентификации"
 
@@ -5197,6 +5156,9 @@ msgstr "Список внешних источников аутентифика�
 
 msgid "List external authentication sources per organization"
 msgstr "Список внешних источников аутентификации для каждой организации"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "Список узлов по местоположению"
@@ -5231,9 +5193,6 @@ msgstr ""
 msgid "List of compute profiles"
 msgstr "Список вычислительных профилей"
 
-msgid "List of config groups"
-msgstr "Список групп конфигурации"
-
 msgid "List of domains"
 msgstr "Список доменов"
 
@@ -5249,35 +5208,20 @@ msgstr "Список доменов по подсетям"
 msgid "List of email notifications"
 msgstr "Список всех почтовых уведомлений"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr ""
 
 msgid "List of hosts which answer to the provided query"
 msgstr "Список отвечающих узлов"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "Список заменяемых значений для определенного смарт-параметра"
-
 msgid "List of realms"
 msgstr "Список областей"
 
 msgid "List of resources types that will be automatically associated"
 msgstr ""
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "Список смарт-параметров для определенного класса Puppet"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "Список смарт-параметров для определенного окружения"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "Список смарт-параметров для определенной комбинации окружение/класс Puppet"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "Список всех переопределяемых классов параметров для определенного узла"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "Список всех переопределяемых классов параметров для определенной группы узлов"
 
 msgid "List of subnets"
 msgstr "Список подсетей"
@@ -5296,9 +5240,6 @@ msgstr ""
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
 msgstr ""
-
-msgid "List of trends counters"
-msgstr "Список счетчиков трендов"
 
 msgid "List of user selected columns"
 msgstr "Список выбранных пользователем столбцов"
@@ -5483,6 +5424,10 @@ msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5531,6 +5476,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "MAC-адрес"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "MAC адрес интерфейса. Требуется для управления интерфейсами на голом железе."
@@ -5613,6 +5561,9 @@ msgstr "Управление"
 msgid "Manage Bookmarks"
 msgstr "Управление закладками"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "Управление местоположением"
 
@@ -5621,6 +5572,9 @@ msgstr "Управление организациями"
 
 msgid "Manage PuppetCA"
 msgstr "Управление PuppetCA"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "Управление узлом"
@@ -5721,10 +5675,6 @@ msgid "Message"
 msgstr "Сообщение"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "Дайджест"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "Значение"
 
@@ -5742,6 +5692,9 @@ msgstr ""
 
 msgid "Metrics"
 msgstr "Метрика"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "минут назад"
@@ -5820,6 +5773,9 @@ msgstr ""
 msgid "N/A"
 msgstr "нет"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "нет"
 
@@ -5841,8 +5797,8 @@ msgstr "Имя носителя"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr ""
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
-msgstr "Название внешнего источника аутентификации, где будут создаваться неизвестные внешние пользователи (см. authorize_login_delegation). Чтобы запретить автоматическое создание, оставьте пустым."
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
+msgstr ""
 
 msgid "Name of the host group"
 msgstr "Имя группы узлов"
@@ -5919,6 +5875,9 @@ msgstr "Новая организация"
 msgid "New SSH key"
 msgstr "Новый SSH-ключ"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "Новая виртуальная машина"
 
@@ -5934,8 +5893,8 @@ msgstr ""
 msgid "New filter"
 msgstr "Новый фильтр"
 
-msgid "New window"
-msgstr "Новое окно"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "Далее"
@@ -6062,6 +6021,9 @@ msgstr "Нет функций TFTP"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "Для продолжения необходимо определить прокси TFTP. "
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr ""
 
@@ -6100,6 +6062,9 @@ msgstr "Нет"
 
 msgid "No entries found"
 msgstr "Нет записей"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "Функции прокси не включены. Включите хотя бы одну функцию."
@@ -6197,6 +6162,9 @@ msgstr "Капсула не найдена."
 msgid "No smart proxies to show"
 msgstr "Нет капсул для просмотра"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "Нет подсетей"
 
@@ -6233,11 +6201,11 @@ msgstr "Обычный"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr ""
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "Не установлено"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr ""
 
 msgid "Not implemented"
 msgstr "Не реализовано"
@@ -6404,6 +6372,9 @@ msgstr ""
 msgid "OK"
 msgstr "ОК"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "Образ ОС"
 
@@ -6474,9 +6445,6 @@ msgstr "Произошла ошибка"
 
 msgid "Open"
 msgstr "Открыть"
-
-msgid "Open Spice in a new window"
-msgstr "Открыть Spice в новом окне"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr ""
@@ -6577,9 +6545,6 @@ msgstr ""
 msgid "Optional array of log hashes"
 msgstr "Доп. массив хэшей журнала"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "Дополнительная строка для ограничения списка импортируемых классов. Может содержать значения «new», «updated» и «obsolete», разделенные запятой"
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "Дополнительно: конечный IP-адрес для автоматического подбора"
 
@@ -6643,9 +6608,6 @@ msgstr "Выходной формат"
 msgid "Override"
 msgstr "Переопределить"
 
-msgid "Override Value"
-msgstr "Переопределить Значение"
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "Здесь можно переопределить исходное значение параметра класса Puppet."
 
@@ -6658,8 +6620,17 @@ msgstr "Обзор"
 msgid "Overwrite"
 msgstr "Перезаписать"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "Владелец"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "Владелец"
@@ -6743,6 +6714,10 @@ msgstr "Имя"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "Приоритет"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr ""
@@ -6979,9 +6954,6 @@ msgstr "Ваш запрос обрабатывается. Пожалуйста, 
 msgid "Plugins"
 msgstr "Дополнения"
 
-msgid "Port to connect to"
-msgstr ""
-
 msgid "Possible values"
 msgstr ""
 
@@ -6994,7 +6966,13 @@ msgstr "Питание"
 msgid "Power ON this machine"
 msgstr "Включить машину"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
+msgstr ""
+
+msgid "Power has been set to \"%s\" successfully"
 msgstr ""
 
 msgid "Power operations are not enabled on this host."
@@ -7063,7 +7041,7 @@ msgstr ""
 msgid "Private"
 msgstr "Приватный"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Proceed to Edit"
@@ -7161,6 +7139,9 @@ msgstr "Прокси"
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7209,9 +7190,6 @@ msgstr "Класс Puppet"
 msgid "Puppet error state"
 msgstr ""
 
-msgid "Puppet interval"
-msgstr "Интервал Puppet"
-
 msgid "Puppet parameter"
 msgstr "Параметр Puppet"
 
@@ -7220,14 +7198,6 @@ msgstr "Идентификатор прокси Puppet"
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Класс Puppet"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Имя"
 
 msgid "Query"
 msgstr ""
@@ -7303,6 +7273,9 @@ msgstr "Имя"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "Тип области"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "Перезагрузить и собрать"
@@ -7406,12 +7379,6 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr "Удалить параметр"
 
-msgid "Remove a Puppet class from host"
-msgstr "Удалить класс Puppet из узла"
-
-msgid "Remove a Puppet class from host group"
-msgstr "Удалить класс Puppet из группы узлов"
-
 msgid "Remove an email notification for a user"
 msgstr "Удалить уведомление пользователя по email "
 
@@ -7419,6 +7386,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7503,6 +7473,9 @@ msgstr ""
 msgid "ReportTemplate|Snippet"
 msgstr ""
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "Получено"
 
@@ -7514,6 +7487,9 @@ msgstr ""
 
 msgid "Reports"
 msgstr "Отчеты"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7558,6 +7534,9 @@ msgstr "Требуется, если пользователь отсутству
 msgid "Required when user want to change own password"
 msgstr "Требуется, когда пользователь хочет изменить собственный пароль"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr ""
 
@@ -7601,6 +7580,9 @@ msgstr ""
 msgid "Resume"
 msgstr "Возобновить"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "Возвращаемая строка отражает состояние узла данного типа"
 
@@ -7626,8 +7608,14 @@ msgstr ""
 msgid "Revert Local Changes"
 msgstr ""
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "Просмотр"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "Пересмотреть состояние сборки для %s"
@@ -7636,6 +7624,9 @@ msgid "Revoke"
 msgstr "Отозвать"
 
 msgid "Revoke a Personal Access Token for a user"
+msgstr ""
+
+msgid "Revoke personal access token"
 msgstr ""
 
 msgid "Revoked"
@@ -7718,6 +7709,9 @@ msgstr ""
 msgid "SMTP address"
 msgstr ""
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "Аутентификация SMTP"
 
@@ -7732,6 +7726,9 @@ msgstr ""
 
 msgid "SMTP port"
 msgstr "SMTP порт"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr ""
@@ -7751,14 +7748,20 @@ msgstr ""
 msgid "SSL CA file"
 msgstr "Файл центра сертификации SSL"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Файл центра сертификации SSL для защиты соединения Foreman с прокси"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Путь к сертификату SSL, который будет использоваться для безопасного подключения Foreman к прокси"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Файл закрытого ключа SSL для защиты соединения Foreman с прокси"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "Сертификат SSL"
@@ -7806,6 +7809,9 @@ msgid "Save something and try again"
 msgstr "Внесите изменения, сохраните их и повторите попытку."
 
 msgid "Saved Bookmarks"
+msgstr ""
+
+msgid "Saved audits interval"
 msgstr ""
 
 msgid "Schedule generating of a report"
@@ -7984,6 +7990,9 @@ msgstr ""
 msgid "Sendmail location"
 msgstr ""
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr ""
 
@@ -8014,6 +8023,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr ""
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr ""
 
@@ -8034,9 +8046,6 @@ msgstr "Здесь можно настроить порядок обработк
 
 msgid "Set up compute instance %s"
 msgstr "Настроить экземпляр %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8104,6 +8113,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "Выполнить «foreman-rake db:seed» при следующем запуске модулей установки"
 
@@ -8137,18 +8152,6 @@ msgstr ""
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-msgid "Show a Puppet class"
-msgstr "Показать класс Puppet"
-
-msgid "Show a Puppet class for a host group"
-msgstr "Показать класс Puppet группы узлов"
-
-msgid "Show a Puppet class for an environment"
-msgstr "Показать класс Puppet окружения"
-
-msgid "Show a Puppet class for host"
-msgstr "Показать класс Puppet узла"
-
 msgid "Show a bookmark"
 msgstr "Показать закладку"
 
@@ -8160,9 +8163,6 @@ msgstr "Показать вычислительный профиль"
 
 msgid "Show a compute resource"
 msgstr "Показать вычислительный ресурс"
-
-msgid "Show a config group"
-msgstr "Показать группу конфигурации"
 
 msgid "Show a default template combination for an operating system"
 msgstr "Показать комбинацию шаблонов по умолчанию для операционной системы"
@@ -8230,17 +8230,11 @@ msgstr "Показать роль"
 msgid "Show a setting"
 msgstr "Показать настройки"
 
-msgid "Show a smart class parameter"
-msgstr "Создать смарт-параметр"
-
 msgid "Show a smart proxy"
 msgstr "Показать капсулу"
 
 msgid "Show a subnet"
 msgstr "Показать подсеть"
-
-msgid "Show a trend"
-msgstr "Показать тренд"
 
 msgid "Show a user"
 msgstr "Показать пользователя"
@@ -8275,9 +8269,6 @@ msgstr "Показать проверку"
 msgid "Show an email notification"
 msgstr "Показать почтовое уведомление"
 
-msgid "Show an environment"
-msgstr "Показать окружение"
-
 msgid "Show an external authentication source"
 msgstr "Показать внешний источник аутентификации"
 
@@ -8298,9 +8289,6 @@ msgstr "Показать внутренние источники аутенти�
 
 msgid "Show an operating system"
 msgstr "Показать операционную систему"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "Показать значение переопределения для смарт-параметра"
 
 msgid "Show available API links"
 msgstr "Показать ссылки доступных API"
@@ -8385,9 +8373,6 @@ msgstr "Пропущено"
 msgid "Skipped|S"
 msgstr "П"
 
-msgid "Smart Class Parameter"
-msgstr "Смарт-параметры"
-
 msgid "Smart Class Parameters"
 msgstr ""
 
@@ -8455,6 +8440,9 @@ msgstr "Некоторые интерфейсы не верны"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Обнаружены ошибки в настройках интерфейсов (см. таблицу)."
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "Ошибка при изменении типа узла: %s"
 
@@ -8478,10 +8466,6 @@ msgid "Source"
 msgstr "Источник"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "Дайджест"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "Значение"
 
@@ -8503,7 +8487,7 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr ""
 
-msgid "Specify additional options to sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "Specify authentication type, if required"
@@ -8547,8 +8531,8 @@ msgstr "Состояние"
 msgid "Status %s does not exist."
 msgstr ""
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "Не обновлять IP и MAC-адреса на основе фактов Puppet (затрагивает все интерфейсы)"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr "Запретить обновление Операционной Системы на основе фактов"
@@ -8644,6 +8628,10 @@ msgid "Subnet|Dns secondary"
 msgstr "Дополнительный DNS"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "Начиная с"
 
@@ -8670,6 +8658,10 @@ msgstr "Имя"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "Сеть"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8742,6 +8734,12 @@ msgstr ""
 
 msgid "Supported Formats"
 msgstr "Поддерживаемые форматы"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "Синхронизировать группу с источником авторизации"
@@ -8900,11 +8898,19 @@ msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8974,6 +8980,10 @@ msgid "Template|Default"
 msgstr "Шаблон|По умолчанию"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -9024,7 +9034,7 @@ msgstr "Проверочное сообщение"
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9172,7 +9182,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9191,7 +9201,7 @@ msgstr[1] "Из списка исключено %{count} %{link_start}физич
 msgstr[2] "Из списка исключено %{count} %{link_start}физических узлов%{link_end}."
 msgstr[3] "Из списка исключено %{count} %{link_start}физических узлов%{link_end}."
 
-msgid "The location of the sendmail executable"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "The marked fields will need reviewing"
@@ -9221,9 +9231,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "Состояние электропитания выбранных узлов будет изменено на %s"
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "Имя области, например EXAMPLE.COM"
@@ -9287,6 +9294,9 @@ msgid "There may be more information in the server's logs."
 msgstr "Больше информации можно получить в журнале сервера."
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
+msgstr ""
+
+msgid "There was a problem processing the request. Please try again."
 msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
@@ -9414,7 +9424,7 @@ msgstr ""
 msgid "This value is used also as the host's primary interface name."
 msgstr "Это значение также используется для обозначения первичного интерфейса узла."
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9440,15 +9450,6 @@ msgstr ""
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
 msgstr "Чтобы получить доступ к API %s, вам необходимо установить плагин Puppet для Foreman"
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr "Для доступа к API /statistics вам необходимо установить плагин Foreman Statistics"
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr "Для доступа к API /trends вам необходимо установить плагин Foreman Statistics"
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
-msgstr "Чтобы получить доступ к API import_puppetclasses, вам необходимо установить плагин Puppet для Foreman"
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
 msgstr ""
@@ -9479,9 +9480,6 @@ msgstr "Токен"
 
 msgid "Token Expiry"
 msgstr ""
-
-msgid "Token duration"
-msgstr "Время действия установочного ключа"
 
 msgid "Token expired"
 msgstr ""
@@ -9522,41 +9520,8 @@ msgstr[1] "Всего %{hosts} узла"
 msgstr[2] "Всего %{hosts} узлов"
 msgstr[3] "Всего %{hosts} узлов"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "Динамика изменений"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "Показатель"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "Число"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
+msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "Факт"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "Значение"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "Экранное имя"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "Тип"
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "Флаг True/False сообщает, является ли узел контролируемым. Кроме того, в зависимости от этого значения может потребоваться настроить дополнительные параметры."
@@ -9837,6 +9802,12 @@ msgstr "Для того чтобы освободить websockets_ssl_key, не
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "Недопустимый шаблон для виджета страницы обзора: %s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "URL сопровождения"
 
@@ -9894,6 +9865,9 @@ msgstr ""
 msgid "Unknown status: %s"
 msgstr ""
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "Разблокировать"
 
@@ -9921,9 +9895,6 @@ msgstr "Изменить :a_resource"
 msgid "Update IP from built request"
 msgstr "Обновить IP на основании запроса сборки"
 
-msgid "Update a Puppet class"
-msgstr "Изменить класс Puppet"
-
 msgid "Update a bookmark"
 msgstr "Изменить закладку"
 
@@ -9935,9 +9906,6 @@ msgstr "Изменить вычислительный профиль"
 
 msgid "Update a compute resource"
 msgstr "Изменить вычислительный ресурс"
-
-msgid "Update a config group"
-msgstr "Изменить группу конфигурации"
 
 msgid "Update a default template combination for an operating system"
 msgstr "Изменить комбинацию шаблонов по умолчанию для операционной системы"
@@ -10005,9 +9973,6 @@ msgstr "Изменить роль"
 msgid "Update a setting"
 msgstr "Изменить настройки"
 
-msgid "Update a smart class parameter"
-msgstr "Изменить смарт-параметр"
-
 msgid "Update a smart proxy"
 msgstr "Изменить капсулу"
 
@@ -10038,9 +10003,6 @@ msgstr "Изменить архитектуру"
 msgid "Update an email notification for a user"
 msgstr "Обновить уведомление пользователя по email "
 
-msgid "Update an environment"
-msgstr "Изменить окружение"
-
 msgid "Update an external authentication source"
 msgstr "Обновить внешний источник аутентификации"
 
@@ -10049,12 +10011,6 @@ msgstr "Изменить образ"
 
 msgid "Update an operating system"
 msgstr "Изменить операционную систему"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "Обновить значение переопределения смарт-параметра"
-
-msgid "Update environment from facts"
-msgstr "Обновлять окружение на основе фактов"
 
 msgid "Update external user group"
 msgstr "Изменить внешнюю группу пользователей"
@@ -10291,6 +10247,10 @@ msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "Настоящее имя"
 
@@ -10427,7 +10387,7 @@ msgstr "Переменная"
 msgid "Variables"
 msgstr "Переменные"
 
-msgid "Vendor Class"
+msgid "Vendor class"
 msgstr ""
 
 msgid "Verify"
@@ -10489,6 +10449,9 @@ msgstr "Ждать активации %s"
 
 msgid "Warning"
 msgstr "Предупреждение"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "Внимание!"
@@ -10554,6 +10517,9 @@ msgstr ""
 "При редактировании шаблона необходимо назначить список\\\n"
 "операционных систем, с которыми можно использовать этот шаблон. При необходимости вы можете \\\n"
 "ограничить шаблон списком групп узлов."
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
+msgstr ""
 
 msgid ""
 "When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.\n"
@@ -10676,6 +10642,9 @@ msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "Вы собираетесь изменить стандартное меню PXE для всех настроенных серверов TFTP.  Продолжить?"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr "Вы собираетесь удалить %s. Вы уверены?"
@@ -10830,6 +10799,9 @@ msgstr "все"
 msgid "already exists"
 msgstr "уже существует"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "организация"
 
@@ -10841,9 +10813,6 @@ msgstr "массив"
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "принадлежит группе конфигурации"
 
 msgid "boolean"
 msgstr "логический"
@@ -11024,9 +10993,6 @@ msgstr "включить кэширование, только для VMware"
 
 msgid "enabled"
 msgstr "включено"
-
-msgid "environment id"
-msgstr "код окружения"
 
 msgid "expected a value of type %s"
 msgstr "ожидаемое значение типа %s"
@@ -11278,8 +11244,7 @@ msgstr "связать внешнюю группу пользователей с
 msgid "list"
 msgstr "список"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "Русский"
 
@@ -11459,12 +11424,6 @@ msgstr "физический @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "физический @ мост %s"
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
-msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "управление питанием, доступные действия: (включить/запустить), (выключить/остановить), (перезагрузка), (сброс), (состояние)"

--- a/locale/ru/foreman.po
+++ b/locale/ru/foreman.po
@@ -408,6 +408,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr "Возникла проблема при определении типа узла: %s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -693,6 +696,9 @@ msgstr "Адрес электронной почты является обяза
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "Произошла ошибка при попытке подключиться к LDAP, пожалуйста, убедитесь, что узел-источник аутентификационных данных доступен с вашего узла Foreman и находится в сети."
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -761,6 +767,12 @@ msgstr "Вы действительно хотите удалить узел %s?
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "Вы уверены, что хотите удалить узел %s? Это приведет к удалению виртуальной машины, ее дисков и будет необратимым. Это поведение можно изменить с помощью глобальной настройки \"Уничтожить связанную виртуальную машину на удаленном узле\"."
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr ""
@@ -1146,6 +1158,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr ""
 
@@ -1240,6 +1255,9 @@ msgid "Build PXE Default"
 msgstr "Создать PXE default"
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2626,6 +2644,12 @@ msgstr "ERROR, FATAL"
 msgid "EUI-64"
 msgstr ""
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3338,6 +3362,12 @@ msgstr "Сводка аудита Foreman"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3632,6 +3662,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4394,7 +4427,19 @@ msgstr "Если параметр содержит код ERB, его значе
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "Если установлен, генерирует ошибку в случае, если правило подстановки не присвоило значение и если значение по умолчанию тоже не задано."
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4404,6 +4449,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4420,6 +4468,9 @@ msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "Если вы считаете, что ошибка связана непосредственно с Foreman, создайте отчет."
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr ""
@@ -4566,6 +4617,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "Инфраструктура"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "Наследовать от родителя (%s)"
 
@@ -4609,6 +4663,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5555,6 +5612,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr ""
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "Управление"
 
@@ -6393,6 +6453,9 @@ msgstr "Фактическое имя операционной системы, �
 msgid "Off"
 msgstr "Выкл."
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "ОК"
 
@@ -6436,6 +6499,9 @@ msgstr "Объявление этого прокси уже существует
 
 msgid "Only one volume can be bootable"
 msgstr "Только один том может быть загрузочным"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "Упс!!"
@@ -6845,6 +6911,9 @@ msgid "Personal Access Token was successfully created."
 msgstr "Личный Токет Доступа успешно создан."
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7528,6 +7597,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr "Требовать SSL для капсул"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "Требуется, если пользователь отсутствует во внешнем источнике аутентификации"
 
@@ -8113,6 +8185,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8347,6 +8422,11 @@ msgstr "Подписать"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "Выбран один узел на странице"
@@ -8439,6 +8519,12 @@ msgstr "Некоторые интерфейсы не верны"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "Обнаружены ошибки в настройках интерфейсов (см. таблицу)."
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9104,6 +9190,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "Источнику аутентификации внешних групп пользователей не удалось подключиться к LDAP с предоставленными учетными данными. Пожалуйста, убедитесь, что учетные данные все еще действительны."
 
@@ -9115,6 +9204,9 @@ msgstr "Класс процессора. Используется сборкам
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Класс компьютера в OpenBoot Prom. Используется сборками Sparc Solaris и может быть оставлен пустым для других архитектур. Чтобы проверить это значение на Solaris, выполните «uname -i|cut -f2 -d,»"
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
@@ -9311,6 +9403,12 @@ msgstr "Произошла ошибка при получении списка �
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "Произошла ошибка при формировании шаблона %{name}: %{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "Активных мостовых интерфейсов в Libvirt не обнаружено. Если Libvirt не поддерживает возможность получения списка интерфейсов, введите имя моста в явном виде."
 
@@ -9324,6 +9422,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9380,6 +9481,9 @@ msgstr "Это может быть вызвано недоступностью �
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9400,6 +9504,12 @@ msgstr "Эта услуга доступна анонимным пользова
 
 msgid "This service is only available for authenticated users"
 msgstr "Эта услуга доступна только авторизованным пользователям."
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "Шаблон заблокирован и не может быть удален."
@@ -9425,6 +9535,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "Это значение также используется для обозначения первичного интерфейса узла."
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9469,6 +9582,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10324,6 +10440,9 @@ msgstr "Атрибуты виртуальной машины (%s)"
 msgid "VM already associated with a host"
 msgstr "Виртуальная машина уже связана с узлом"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "Виртуальная машина связана с узлом %s"
 
@@ -10463,6 +10582,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "Предупреждение: Это может удалить этот узел и всю его информацию!"
@@ -10649,10 +10771,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr "Вы собираетесь удалить %s. Вы уверены?"
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "Вы пытаетесь разблокировать шаблон."
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/zh_CN/foreman.po
+++ b/locale/zh_CN/foreman.po
@@ -29,9 +29,6 @@ msgstr ""
 msgid " Documentation"
 msgstr " 文档"
 
-msgid " Remove"
-msgstr " 删除"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr " 还强烈推荐附加 foreman-debug 输出结果。"
 
@@ -43,9 +40,6 @@ msgstr "${progress}%% 完成"
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr "%(name)s （可用：%(free)s ，置备：%(prov)s ，总计：%(total)s ）"
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - 按 Shift-F12 释放鼠标光标。"
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - 以下主机即将更改"
@@ -63,9 +57,6 @@ msgstr[0] "%s 日志信息"
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s 参数已变更，详情如下"
-
-msgid "%s Template"
-msgstr "%s 模板"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -112,9 +103,6 @@ msgid "%s month ago"
 msgid_plural "%s months ago"
 msgstr[0] "%s 月前"
 
-msgid "%s out of sync disabled"
-msgstr "%s 不同步被禁用"
-
 msgid "%s selected hosts"
 msgstr "%s 选择的主机"
 
@@ -131,9 +119,6 @@ msgstr "正在加载 %s 小程序..."
 
 msgid "%s you had selected as your context has been deleted"
 msgstr "您已选择作为上下文的 %s 已删除"
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
-msgstr "%s，检查 'SSL CA file' in Settings > Authentication"
 
 msgid "%{action} %{vm}"
 msgstr "%{action} %{vm}"
@@ -202,6 +187,9 @@ msgstr "%{match} 与现有主机组不匹配"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} 从%{label1} 更改为 %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr "％{object_name} 是一个％{object_class} ，预期是一个子网"
@@ -282,6 +270,9 @@ msgstr "（从 %s 总条目中过滤）"
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "（自选）Fog 在创建这个映像时使用的 IAM 角色。"
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*清除 %s 代理服务器*"
@@ -479,12 +470,6 @@ msgstr "添加值"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr "添加 CD-ROM 驱动器到虚拟机。"
 
-msgid "Add a Puppet class to host"
-msgstr "新增 Puppet 類別至主機"
-
-msgid "Add a Puppet class to host group"
-msgstr "为主机组添加一个 Puppet 类"
-
 msgid "Add a template combination"
 msgstr "添加模板组合"
 
@@ -530,9 +515,6 @@ msgstr "其他计算资源特定的属性。"
 msgid "Additional information about this host"
 msgstr "有关主机的附加信息"
 
-msgid "Address to connect to"
-msgstr "要连接的地址"
-
 msgid "Admin permissions required"
 msgstr "需要 Admin 权限"
 
@@ -575,9 +557,6 @@ msgstr "别名或 VLAN 失败"
 msgid "All"
 msgstr "全部"
 
-msgid "All Audits"
-msgstr "所有审计"
-
 msgid "All Hosts"
 msgstr "所有主机"
 
@@ -586,6 +565,12 @@ msgstr "所有报表"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
 msgstr "在 ERB 模板中，所有 Ruby 代码都包含在 <code><&#37; &#37;></code> 之间。在呈现模板时代码会被执行。它可以包含 Ruby 控制流结构以及特定于应用程序的宏和变量。例如："
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
+msgstr ""
 
 msgid "All compute resources"
 msgstr "所有计算资源"
@@ -746,9 +731,6 @@ msgstr "确定要删除主机 %s 吗？这个操作时不可逆的。"
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "您确定要删除主机 %s 吗? 这将会删除虚拟机和它的磁盘，且这些操作是不可逆的。这个行为可以通过 \"Destroy associated VM on host delete\" 全局设置改变。"
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "您确定要从仪表板上删除此小部件吗？"
-
 msgid "Are you sure you want to log out?"
 msgstr "确定要注销吗？"
 
@@ -805,6 +787,12 @@ msgstr "指定机构"
 
 msgid "Assign Selected Hosts"
 msgstr "指定选定的主机"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1289,6 +1277,9 @@ msgstr "可以通过 CLI 或 RC 文件检索。可以留空。仅适用于 v3 �
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr "可以通过 CLI 或 RC 文件检索。可以设置为 'default'。仅用于 v3 身份验证。"
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "无法删除内部管理员帐户"
 
@@ -1370,8 +1361,8 @@ msgstr "证书密钥不是有效的 JSON"
 msgid "Certificate path for GCE only"
 msgstr "仅 GCE 的证书路径"
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Foreman 将用来加密 websocket 的证书"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "憑證"
@@ -1430,6 +1421,9 @@ msgstr "为 %s 清理 PuppetCA 证书"
 msgid "Clear"
 msgstr "清除"
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr "清理主机的子状态"
 
@@ -1441,12 +1435,6 @@ msgstr "点击计算资源链接编辑器默认 VM 属性。"
 
 msgid "Click to log in again"
 msgstr "点击重新登录"
-
-msgid "Click to remove %s"
-msgstr "点删除 %s"
-
-msgid "Click to remove config group"
-msgstr "点删除配置组"
 
 msgid "Client Email"
 msgstr "客户端电子邮件"
@@ -1610,14 +1598,6 @@ msgstr "配置报告"
 msgid "Config Retrieval"
 msgstr "配置检索"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "配置组"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "名称"
-
 msgid "Configuration"
 msgstr "组态"
 
@@ -1660,8 +1640,8 @@ msgstr "探测到冲突"
 msgid "Connected"
 msgstr "已连接"
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "（未加密）连接到：%s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "（未加密）连接到：%s"
@@ -1711,8 +1691,8 @@ msgstr "核心和代理版本不匹配。foreman: %{foreman_version}，foreman-p
 msgid "Cores per socket"
 msgstr "每個插槽的核心數"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
-msgstr "内部身份验证源的 bcrypt 密码哈希函数的成本值（4-30）。较高的值较为安全，但验证速度较慢，尤其是对于无状态 API 调用和 UI 登录而言。需要更改密码才能生效。"
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
+msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
 msgstr "无法为 Manager 和 Viewer 角色添加权限：%s"
@@ -1888,9 +1868,6 @@ msgstr "创建用户组"
 msgid "Create a Personal Access Token for a user"
 msgstr "为用户创建个人访问令牌"
 
-msgid "Create a Puppet class"
-msgstr "创建 Puppet 类别"
-
 msgid "Create a bookmark"
 msgstr "创建书签"
 
@@ -1902,9 +1879,6 @@ msgstr "创建计算配置集"
 
 msgid "Create a compute resource"
 msgstr "建立计算资源"
-
-msgid "Create a config group"
-msgstr "建立配置群組"
 
 msgid "Create a default template combination for an operating system"
 msgstr "为操作系统生成默认模板组合"
@@ -1978,9 +1952,6 @@ msgstr "创建子网"
 msgid "Create a template input"
 msgstr "建立範本輸入"
 
-msgid "Create a trend counter"
-msgstr "创建一个趋势统计"
-
 msgid "Create a user"
 msgstr "创建用户"
 
@@ -1996,9 +1967,6 @@ msgstr "创建 LDAP 认证源"
 msgid "Create an architecture"
 msgstr "建立架构"
 
-msgid "Create an environment"
-msgstr "创建环境"
-
 msgid "Create an external user group linked to a user group"
 msgstr "创建链接到用户组的外部用户组"
 
@@ -2011,14 +1979,14 @@ msgstr "在主机中创建接口"
 msgid "Create an operating system"
 msgstr "创建操作系统"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "为具体智能类别参数创建替代值"
-
 msgid "Create autosign entry"
 msgstr "创建自动签名条目"
 
 msgid "Create image"
 msgstr "创建镜像"
+
+msgid "Create model"
+msgstr ""
 
 msgid "Create new boot volume from image"
 msgstr "使用映象创建新引导卷"
@@ -2034,6 +2002,9 @@ msgstr "为 %s 创建 realm 条目"
 
 msgid "Created"
 msgstr "创建"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr "为一个指定的表创建表偏好"
@@ -2064,18 +2035,6 @@ msgstr "自定义模板类型"
 
 msgid "DB pending seed"
 msgstr "DB 待处理种子"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr "已弃用：添加模板组合"
-
-msgid "DEPRECATED: List template combination"
-msgstr "已弃用：列出模板组合"
-
-msgid "DEPRECATED: Show template combination"
-msgstr "已弃用：显示模板组合"
-
-msgid "DEPRECATED: Update template combination"
-msgstr "已弃用：更新模板组合"
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2167,8 +2126,8 @@ msgstr "默认"
 msgid "Default 'Host initial configuration' template"
 msgstr "默认的“主机初始配置”模板"
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
-msgstr "默认的“主机初始配置”模板，在创建新操作系统时自动分配"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
+msgstr ""
 
 msgid "Default Behavior"
 msgstr "默认行为"
@@ -2190,9 +2149,6 @@ msgstr "全局模板中的默认 PXE 菜单项 - 'local', 'discovery' 或 custom
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr "全局模板中的默认 PXE 菜单项 - 'local', 'local_chain_hd0' 或 custom，空为模板默认设置"
-
-msgid "Default Puppet environment"
-msgstr "默认 Puppet 环境"
 
 msgid "Default VNC Keyboard"
 msgstr "默认 VNC 键盘"
@@ -2275,9 +2231,6 @@ msgstr "为 %s 删除 PuppetCA 证书"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr "为 %{host} 删除 TFTP %{kind} 配置"
 
-msgid "Delete a Puppet class"
-msgstr "删除 Puppet 类别"
-
 msgid "Delete a Virtual Machine"
 msgstr "删除虚拟机器"
 
@@ -2289,9 +2242,6 @@ msgstr "删除计算配置文件"
 
 msgid "Delete a compute resource"
 msgstr "刪除计算资源"
-
-msgid "Delete a config group"
-msgstr "删除配置组"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "删除选择系统的默认模板组合"
@@ -2374,9 +2324,6 @@ msgstr "删除模板组合"
 msgid "Delete a template input"
 msgstr "刪除範本輸入"
 
-msgid "Delete a trend counter"
-msgstr "删除一个趋势统计"
-
 msgid "Delete a user"
 msgstr "删除用户"
 
@@ -2416,9 +2363,6 @@ msgstr "为用户删除 SSH 密钥"
 msgid "Delete an architecture"
 msgstr "删除架构"
 
-msgid "Delete an environment"
-msgstr "删除环境"
-
 msgid "Delete an external user group"
 msgstr "删除外部用户组"
 
@@ -2428,14 +2372,17 @@ msgstr "删除映像"
 msgid "Delete an operating system"
 msgstr "删除操作系统"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "删除具体智能类别参数替代值"
-
 msgid "Delete autosign entry"
 msgstr "删除自动签名条目"
 
 msgid "Delete filter?"
 msgstr "删除过滤器？"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "为 %s 删除 realm 条目"
@@ -2508,9 +2455,6 @@ msgstr "停止选择主机的警告"
 
 msgid "Disable all filters overriding"
 msgstr "禁用所有过滤器覆盖"
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
-msgstr "禁用在配置的间隔时间后没有获得报告时把主机（%s）配置状态变为不同步"
 
 msgid "Disable overriding"
 msgstr "禁用覆盖"
@@ -2627,20 +2571,17 @@ msgstr "下载生成的报告"
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "检测到重复的输入：％{duplicated_inputs}"
 
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
+msgstr ""
+
 msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr "在服务器被认为没有同步后的持续时间（以分钟为单位）。您可以通过添加参数\"outofsync_interval\"在主机上覆盖它。"
-
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
-msgstr "在其时间后（以分钟为单位）经过 Puppet 的服务器报告被认为已不同步。"
 
 msgid "EC2"
 msgstr "EC2"
 
 msgid "EFI"
 msgstr "EFI"
-
-msgid "ENC environment"
-msgstr "ENC 环境"
 
 msgid "ERROR or FATAL"
 msgstr "ERROR 或者 FATAL"
@@ -2683,6 +2624,9 @@ msgstr "编辑此主机"
 
 msgid "Editor"
 msgstr "編輯程式"
+
+msgid "Email"
+msgstr ""
 
 msgid "Email Preferences"
 msgstr "电子邮件首选项"
@@ -2759,10 +2703,6 @@ msgstr "为 IP 自动提示功能提供 IP 地址结尾"
 msgid "Entries per page"
 msgstr "每页的条目数"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "环境"
-
 msgid "Environment IDs"
 msgstr "环境 ID"
 
@@ -2777,10 +2717,6 @@ msgstr "包含来自客户端 SSL 证书确认状态的环境变量"
 
 msgid "Environments got deprecated from this endpoint."
 msgstr "环境已从此端点弃用。"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "Environment|Name"
 
 msgid "Error"
 msgstr "错误"
@@ -2820,6 +2756,9 @@ msgstr "加载调度程序提示过滤器信息时出错：%s"
 
 msgid "Error removing widget from dashboard."
 msgstr "从仪表板中删除挂件出错。"
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr "提交数据时出错："
@@ -3288,14 +3227,14 @@ msgstr "修复 %s 不匹配"
 msgid "Fix All Mismatches"
 msgstr "修复所有不匹配"
 
-msgid "Fix DB cache"
-msgstr "固定 DB 缓存"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "下次 Foreman 重启时修复 DB 缓存"
-
 msgid "Fix Mismatches"
 msgstr "修复不匹配"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "Flavor"
@@ -3342,9 +3281,6 @@ msgstr "查看详情 "
 msgid "For values of type search, this is the resource the value searches in"
 msgstr "对于类型搜索的值，这是值搜索的资源"
 
-msgid "Force a Puppet agent run on the host"
-msgstr "强制在该主机中运行 Puppet 代理"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "目前 Foreman API v2 是默认的 API 版本。"
 
@@ -3378,6 +3314,10 @@ msgstr "Foreman 在您的数据库中监测到未知类的定义。这可能是�
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr "Foreman 实例 ID，此 Foreman 实例的唯一标识。"
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr "为主机组、机构和位置评估智能类别参数时，其下层系统会自动继承 Foreman 的匹配器。"
 
@@ -3386,6 +3326,10 @@ msgstr "Foreman 现在管理 %s 的构建循环"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman 现在不再管理 %s 的构建循环"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Foreman 报告创建时间为 <em>%s</em>"
@@ -3414,8 +3358,8 @@ msgstr "配置新主机后，Foreman 将会附加域名"
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman 会在供应新主机时自动进行证书签署"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
-msgstr "当用户尝试登陆 5 次都失败时，Foreman 将会锁定这个用户从相关 IP 地址进行登陆，锁定时间为 5 分钟。设为 0 可以禁用对蛮力攻击的保护。"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
+msgstr ""
 
 msgid "Foreman will create the host when a report is received"
 msgstr "Foreman 会在收到报告后创建主机"
@@ -3423,20 +3367,14 @@ msgstr "Foreman 会在收到报告后创建主机"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman 会在收到新详情后创建主机"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "如果无法自动探测到环境，Foreman 将默认使用这个 puppet 环境。"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "如果预配脚本最终得到一个非零退出代码，则 Foreman 将删除虚拟机。"
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr "Foreman 将默认以这个顺序评估主机智能类参数"
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman 将在 ENC yaml 输出中明确设置这个 puppet 环境。这样可以避免 puppet.conf 以及 Foreman 中设置的环境冲突。"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman将根据 request-header 中的用户名匹配用户。如果将其设置为 false，OAuth 请求将拥有管理员权限。"
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr "Foreman 不会在分类输出中发送此参数。"
@@ -3446,9 +3384,6 @@ msgstr "Foreman 将解析 ENC 输出中参数值的 ERB"
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman 将在本地查询配置的解析程序，而不是通过 SOA/NS 授权机构查询。"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman 将根据其详情更新主机环境"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr "Foreman 将根据主机的 fact 更新其子网"
@@ -3467,6 +3402,18 @@ msgstr "Foreman 将使用随机 UUIDs 而不是主机名进行证书签署"
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman 将使用简称而不是 FQDN 创建新虚拟机"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr "成功创建表单"
@@ -3494,6 +3441,9 @@ msgstr "全屏"
 
 msgid "Function not available for %s"
 msgstr "功能无法用于 %s"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "GMT 时间"
@@ -3564,8 +3514,8 @@ msgstr "获得仪表板的详情"
 msgid "Get default dashboard widgets"
 msgstr "获取默认仪表板小程序"
 
-msgid "Get statistics"
-msgstr "获取统计数据"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "获取主机状态"
@@ -3687,6 +3637,12 @@ msgstr "硬件型号 %s 已成功删除"
 msgid "Hardware Models"
 msgstr "硬件型号"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr "仅对基于网络的置备有效"
 
@@ -3732,11 +3688,17 @@ msgstr "历史"
 msgid "Host"
 msgstr "主办"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "主机 %s 被构建"
 
 msgid "Host %s is not associated with a VM"
 msgstr "主机 %s 没有与虚拟机关联"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "主机配置图表"
@@ -3774,8 +3736,14 @@ msgstr ""
 msgid "Host Parameters"
 msgstr "主机参数"
 
-msgid "Host Wizard"
-msgstr "主机向导"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
+msgstr ""
 
 msgid "Host audit entries"
 msgstr "主机审计项"
@@ -3783,12 +3751,12 @@ msgstr "主机审计项"
 msgid "Host built"
 msgstr "主机构建"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "主机配置组"
-
 msgid "Host details"
 msgstr "主機詳細資訊"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "主机组"
@@ -3926,8 +3894,32 @@ msgid "Host::Base|Uuid"
 msgstr "Uuid"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "主机类型"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4155,9 +4147,6 @@ msgstr "配置模板的 ID"
 msgid "ID of domain"
 msgstr "域 ID"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr "环境 ID - 已弃用，以后将无效"
-
 msgid "ID of host"
 msgstr "主機的 ID"
 
@@ -4224,8 +4213,8 @@ msgstr "在其中注册主机的机构 ID"
 msgid "ID of the Organization to register the host in."
 msgstr "在其中注册主机的机构 ID。"
 
-msgid "ID of the Smart Proxy"
-msgstr "智能代理 ID"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
+msgstr ""
 
 msgid "ID of the user"
 msgstr "用户 ID"
@@ -4287,9 +4276,6 @@ msgstr "IP 地址自动提示"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr "应从建议中排除的 IP 地址"
 
-msgid "IP6 Address"
-msgstr "IP6 地址"
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4312,6 +4298,9 @@ msgstr "IPv4 子网"
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr "基于 PXE 的置备需要带有关联的 TFTP 智能代理的 IPv4 子网。"
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr "接口的 IPv4 地址"
 
@@ -4330,6 +4319,9 @@ msgstr[0] "IPv6 DNS 记录"
 
 msgid "IPv6 Subnet"
 msgstr "IPv6 子网"
+
+msgid "IPv6 address"
+msgstr ""
 
 msgid "IPv6 address of interface"
 msgstr "接口的 IPv6 地址"
@@ -4391,14 +4383,14 @@ msgstr "如果需要在文件中更改此设置，它将带有文件路径。"
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "如果您认为这是 Foreman 自身的错误，请提交新问题。"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "在预配中忽略 Puppet 系统信息"
-
 msgid "Ignore facts for domain"
 msgstr "忽略域的详情"
 
 msgid "Ignore facts for operating system"
 msgstr "忽略针对操作系统的详情"
+
+msgid "Ignore interfaces facts for provisioning"
+msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
 msgstr "忽略有匹配标识符的接口"
@@ -4478,12 +4470,6 @@ msgstr "作为非管理的主机导入"
 
 msgid "Import of facts failed for host %s"
 msgstr "为主机 %s 导入 facts 失败"
-
-msgid "Import puppet classes from puppet proxy"
-msgstr "从 puppet 代理服务器导入 puppet 类"
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "从 puppet 代理服务器为环境导入 puppet 类别"
 
 msgid "Imported IPv4 Subnets"
 msgstr "已导入 IPv4 子网"
@@ -4602,6 +4588,9 @@ msgstr "安装错误"
 msgid "Installation medium configuration"
 msgstr "配置安装介质"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "已安裝"
 
@@ -4667,6 +4656,9 @@ msgstr "无效的 %{assoc} 选择，必须至少选择一个，并获得 '%{perm
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
 msgstr "无效的 Google JSON 密钥。请验证是否存在客户电子邮件和私钥选项"
+
+msgid "Invalid HTTP(S) URL"
+msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
 msgstr "架构 '%{arch}' 对 '%{os}' 无效"
@@ -4833,14 +4825,14 @@ msgstr "最新事件"
 msgid "Launch Console"
 msgstr "启动控制台"
 
-msgid "Launch loading wizard"
-msgstr "启动加载向导"
-
 msgid "Learn more about External authentication in the documentation."
 msgstr "在文档中了解有关外部身份验证的更多信息。"
 
 msgid "Learn more about LDAP authentication in the documentation."
 msgstr "在文档中了解有关 LDAP 身份验证的更多信息。"
+
+msgid "Legacy UI"
+msgstr ""
 
 msgid "Length"
 msgstr "长度"
@@ -4874,24 +4866,6 @@ msgstr "列出所有 LDAP 认证源"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr "列出用户的所有个人访问令牌"
-
-msgid "List all Puppet class IDs for host"
-msgstr "列出主機的所有 Puppet 類別 ID"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "列出主机组的所有 Puppet 类 ID"
-
-msgid "List all Puppet classes"
-msgstr "列出所有 Puppet 类别"
-
-msgid "List all Puppet classes for a host"
-msgstr "列出主机的所有 Puppet 类别"
-
-msgid "List all Puppet classes for a host group"
-msgstr "列出主机组的所有 Puppet 类别"
-
-msgid "List all Puppet classes for an environment"
-msgstr "列出环境的所有 Puppet 类别"
 
 msgid "List all SSH keys for a user"
 msgstr "列出用户的所有 SSH 密钥"
@@ -4928,9 +4902,6 @@ msgstr "列出所有運算資源"
 
 msgid "List all email notifications for a user"
 msgstr "列出一个用户的所有电子邮件通知"
-
-msgid "List all environments"
-msgstr "列出所有环境"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "列出 LDAP 認證來源的所有外部使用者群組"
@@ -5067,9 +5038,6 @@ msgstr "列出所有角色"
 msgid "List all settings"
 msgstr "列出所有设置"
 
-msgid "List all smart class parameters"
-msgstr "列出所有智能类别参数"
-
 msgid "List all smart proxies"
 msgstr "列出所有智能代理服务器"
 
@@ -5148,15 +5116,6 @@ msgstr "列出操作系统的引导文件"
 msgid "List default templates combinations for an operating system"
 msgstr "列出操作系统的默认模板集合"
 
-msgid "List environments of Puppet class"
-msgstr "列出 Puppet 类的环境"
-
-msgid "List environments per location"
-msgstr "列出各个位置的环境"
-
-msgid "List environments per organization"
-msgstr "列出各个机构的环境"
-
 msgid "List external authentication sources"
 msgstr "列出外部认证源"
 
@@ -5165,6 +5124,9 @@ msgstr "按位置列出外部认证源"
 
 msgid "List external authentication sources per organization"
 msgstr "按j机构列出外部认证源"
+
+msgid "List hosts forming the Foreman instance"
+msgstr ""
 
 msgid "List hosts per location"
 msgstr "列出各個位置中的主機"
@@ -5199,9 +5161,6 @@ msgstr "提供的计算配置集和计算资源的计算属性列表"
 msgid "List of compute profiles"
 msgstr "计算配置文件列表"
 
-msgid "List of config groups"
-msgstr "配置组列表"
-
 msgid "List of domains"
 msgstr "區域清單"
 
@@ -5217,35 +5176,20 @@ msgstr "每个子网的域列表"
 msgid "List of email notifications"
 msgstr "电子邮件通知列表"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr "除智能代理服务器外也信任的主机、 IPv4 地址、IPv6 地址或子网，用来访问详情/报告导入程序及 ENC 输出。"
 
 msgid "List of hosts which answer to the provided query"
 msgstr "查询返回的主机列表"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "具体智能分类参数替代值列表"
-
 msgid "List of realms"
 msgstr "范围列表"
 
 msgid "List of resources types that will be automatically associated"
 msgstr "将会自动关联的资源类型列表"
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "具体 Puppet 类别的智能类别参数列表"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "具体环境的智能类别参数列表"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "具体环境/Puppet 类别组合的智能类别参数列表"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "具体主机的智能类别参数列表"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "具体主机组的智能类别参数列表"
 
 msgid "List of subnets"
 msgstr "子网列表"
@@ -5264,9 +5208,6 @@ msgstr "列出用户的表偏好"
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
 msgstr "DNS 查找尝试的超时列表（以秒为单位），例如 dns_lookup 宏和 DNS 记录冲突验证"
-
-msgid "List of trends counters"
-msgstr "列出趋势统计"
 
 msgid "List of user selected columns"
 msgstr "用户选择的栏目列表"
@@ -5451,6 +5392,10 @@ msgid "LookupKey|Key type"
 msgstr "查找密钥|密钥类型"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr "查找密钥|合并默认"
 
@@ -5499,6 +5444,9 @@ msgstr "苹果电脑"
 
 msgid "MAC Address"
 msgstr "MAC地址"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "接口的 MAC 地址。在裸机中管理的接口需要这个地址。"
@@ -5581,6 +5529,9 @@ msgstr "管理"
 msgid "Manage Bookmarks"
 msgstr "管理书签"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "管理位置"
 
@@ -5589,6 +5540,9 @@ msgstr "管理机构"
 
 msgid "Manage PuppetCA"
 msgstr "管理 PuppetCA"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "管理主机"
@@ -5689,10 +5643,6 @@ msgid "Message"
 msgstr "信息"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "精华"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "值"
 
@@ -5710,6 +5660,9 @@ msgstr "指标已注册：%s"
 
 msgid "Metrics"
 msgstr "度量"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "分钟前"
@@ -5788,6 +5741,9 @@ msgstr "我的帐号"
 msgid "N/A"
 msgstr "不适用"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "不适用"
 
@@ -5809,8 +5765,8 @@ msgstr "介质名称"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr "用于身份验证的 OpenID Connect Audience 的名称。对于Keycloak，这是客户端 ID。"
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
-msgstr "外部认证源名称，可用来创建未知外部认证的用户（请查看 authorize_login_delegation），如果需要防止自动创建，保持为未设置状态。"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
+msgstr ""
 
 msgid "Name of the host group"
 msgstr "主机组的名称"
@@ -5887,6 +5843,9 @@ msgstr "新建机构"
 msgid "New SSH key"
 msgstr "新 SSH 密钥"
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "新建虚拟主机"
 
@@ -5902,8 +5861,8 @@ msgstr "新连接被拒绝，原因：%"
 msgid "New filter"
 msgstr "新建过滤器"
 
-msgid "New window"
-msgstr "新增視窗"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "下一个"
@@ -6030,6 +5989,9 @@ msgstr "TFTP 功能"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "未定义 TFTP 代理，不能继续"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr "没有与任意主机匹配的虚拟机。"
 
@@ -6068,6 +6030,9 @@ msgstr "没有邮件"
 
 msgid "No entries found"
 msgstr "没有找到条目"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "在这个代理服务器中没有找到任何功能，请确定至少启用了一个功能。"
@@ -6165,6 +6130,9 @@ msgstr "未找到智能代理服务器。"
 msgid "No smart proxies to show"
 msgstr "没有智能代理来显示"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "无子网"
 
@@ -6201,11 +6169,11 @@ msgstr "普通的"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr "正常情况下，在设置计算资源时，会自动为您创建一个密钥对（私用和公共）。"
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "未安装"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr "不是 HTTP 代理服务器的有效 URL"
 
 msgid "Not implemented"
 msgstr "没有实现"
@@ -6372,6 +6340,9 @@ msgstr "OIDC JWKs URL"
 msgid "OK"
 msgstr "好"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "操作系统镜像"
 
@@ -6447,9 +6418,6 @@ msgstr "抱歉，什么地方出现问题"
 
 msgid "Open"
 msgstr "打开"
-
-msgid "Open Spice in a new window"
-msgstr "在新窗口中打开"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr "从 Foreman 到 Smart Proxy 的 HTTP 请求的打开和读取超时（以秒为单位）"
@@ -6550,9 +6518,6 @@ msgstr "可选的输入验证程序"
 msgid "Optional array of log hashes"
 msgstr "日志哈希的自选阵列"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "自选用逗号分开包含 'new'、'updated' 或 'obsolete' 的字符串，用来限制导入的 Puppet 类别。"
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "自选：IP 自动提示的结尾 IP 地址"
 
@@ -6616,9 +6581,6 @@ msgstr "输出格式"
 msgid "Override"
 msgstr "覆盖"
 
-msgid "Override Value"
-msgstr "覆盖值"
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "替代 Puppet 分类参数的默认值"
 
@@ -6631,8 +6593,17 @@ msgstr "概况"
 msgid "Overwrite"
 msgstr "覆盖"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "所有者"
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "擁有者"
@@ -6716,6 +6687,10 @@ msgstr "名称"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "优先"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr "参数|类型"
@@ -6954,9 +6929,6 @@ msgstr "正在处理您的请求，请稍候"
 msgid "Plugins"
 msgstr "外掛程式"
 
-msgid "Port to connect to"
-msgstr "要连接的端口"
-
 msgid "Possible values"
 msgstr "可能的值"
 
@@ -6969,8 +6941,14 @@ msgstr "电源"
 msgid "Power ON this machine"
 msgstr "打开本机电源"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
 msgstr "开启一个虚拟主机"
+
+msgid "Power has been set to \"%s\" successfully"
+msgstr ""
 
 msgid "Power operations are not enabled on this host."
 msgstr "此主机上没有启用电源操作。"
@@ -7038,8 +7016,8 @@ msgstr "排列属性优先顺序"
 msgid "Private"
 msgstr "私密"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
-msgstr "Foreman 将用于加密 websocket 的私钥文件"
+msgid "Private key file path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Proceed to Edit"
 msgstr "继续编辑"
@@ -7138,6 +7116,9 @@ msgstr "代理服务器"
 msgid "Proxy ID to use within this realm"
 msgstr "要在此域中使用的代理 ID"
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr "代理服务器应为 { :relation => [:column_name, ...] }"
 
@@ -7186,9 +7167,6 @@ msgstr "Puppet 類別"
 msgid "Puppet error state"
 msgstr "Puppet 错误状态"
 
-msgid "Puppet interval"
-msgstr "Puppet 间隔"
-
 msgid "Puppet parameter"
 msgstr "Puppet 参数"
 
@@ -7197,14 +7175,6 @@ msgstr "Puppet 代理服务器 ID"
 
 msgid "Puppet summary"
 msgstr "Puppet 概述"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppet类"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "Puppetclass|Name"
 
 msgid "Query"
 msgstr "查询"
@@ -7280,6 +7250,9 @@ msgstr "名称"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "范围类型"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "重启并构建"
@@ -7379,12 +7352,6 @@ msgstr "删除匹配器"
 msgid "Remove Parameter"
 msgstr "删除参数"
 
-msgid "Remove a Puppet class from host"
-msgstr "從主機移除一個 Puppet 類別"
-
-msgid "Remove a Puppet class from host group"
-msgstr "从主机组中删除一个 Puppet 类"
-
 msgid "Remove an email notification for a user"
 msgstr "删除用户的电子邮件通知"
 
@@ -7393,6 +7360,9 @@ msgstr "为 %{host} 删除冲突 %{type}"
 
 msgid "Remove tag"
 msgstr "删除标签"
+
+msgid "Remove widget"
+msgstr ""
 
 msgid "Removed %{from} to %{to}"
 msgstr "移除 %{from} 至 %{to}"
@@ -7476,6 +7446,9 @@ msgstr "报告模板|名称"
 msgid "ReportTemplate|Snippet"
 msgstr "报告模板|Snippet"
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "回報於"
 
@@ -7487,6 +7460,9 @@ msgstr "由 %s 报告"
 
 msgid "Reports"
 msgstr "报表"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7531,6 +7507,9 @@ msgstr "必需的，除非用户位于一个外部的认证源"
 msgid "Required when user want to change own password"
 msgstr "用户想要更改自己的密码时需要"
 
+msgid "Reset"
+msgstr ""
+
 msgid "Reset PuppetCA certname for %s"
 msgstr "为 %s 重置 PuppetCA 证书名"
 
@@ -7574,6 +7553,9 @@ msgstr "报告 %s 的结果"
 msgid "Resume"
 msgstr "恢复"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "返回代表一个给定类型的主机状态的字符串"
 
@@ -7597,8 +7579,14 @@ msgstr "还原失败，$${err}"
 msgid "Revert Local Changes"
 msgstr "恢复本地更改"
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "审核"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "审核 %s 的构建状态"
@@ -7608,6 +7596,9 @@ msgstr "调用"
 
 msgid "Revoke a Personal Access Token for a user"
 msgstr "撤销用户的个人访问令牌"
+
+msgid "Revoke personal access token"
+msgstr ""
 
 msgid "Revoked"
 msgstr "撤销"
@@ -7689,6 +7680,9 @@ msgstr "SMTP OpenSSL 验证模式"
 msgid "SMTP address"
 msgstr "SMTP 地址"
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr "SMTP 身份验证"
 
@@ -7703,6 +7697,9 @@ msgstr "SMTP 密码"
 
 msgid "SMTP port"
 msgstr "SMTP 端口"
+
+msgid "SMTP port to connect to"
+msgstr ""
 
 msgid "SMTP username"
 msgstr "SMTP 用户名"
@@ -7722,14 +7719,20 @@ msgstr "SSH 超时"
 msgid "SSL CA file"
 msgstr "SSL CA 文件"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Foreman 用来与其代理服务器沟通的 SSL CA 文件"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Foreman 用来与其代理服务器沟通的 SSL 证书路径"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Foreman 用来与其代理服务器沟通的 SSL 私钥文件"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "CA 证书"
@@ -7778,6 +7781,9 @@ msgstr "保存一些内容然后再试一次"
 
 msgid "Saved Bookmarks"
 msgstr "已保存书签"
+
+msgid "Saved audits interval"
+msgstr ""
 
 msgid "Schedule generating of a report"
 msgstr "调度生成一个报告"
@@ -7954,6 +7960,9 @@ msgstr "Sendmail 参数"
 msgid "Sendmail location"
 msgstr "Sendmail 位置"
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr "服务器组"
 
@@ -7984,6 +7993,9 @@ msgstr "为主机设置 'host_registration_remote_execution' 参数。如果将�
 msgid "Set IP addresses for %s"
 msgstr "为 %s 设置 IP 地址"
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr "在 VNC 显示连接上设置随机生成的密码"
 
@@ -8004,9 +8016,6 @@ msgstr "设定用来解析值的顺序。"
 
 msgid "Set up compute instance %s"
 msgstr "设定计算实例 %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr "为来自 Foreman 的所有传出 HTTP 连接设置代理。系统范围的代理必须在操作系统一级配置。"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8074,6 +8083,12 @@ msgstr "设置 Insights"
 msgid "Setup REX"
 msgstr "设置 REX"
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "是否应在下次运行安装程序模块时执行 `foreman-rake db:seed`？"
 
@@ -8107,18 +8122,6 @@ msgstr "显示实验室"
 msgid "Show a Personal Access Token for a user"
 msgstr "显示用户的个人访问令牌"
 
-msgid "Show a Puppet class"
-msgstr "显示 Puppet 类别"
-
-msgid "Show a Puppet class for a host group"
-msgstr "显示主机组的 Puppet 类别"
-
-msgid "Show a Puppet class for an environment"
-msgstr "显示环境的 Puppet 类别"
-
-msgid "Show a Puppet class for host"
-msgstr "显示主机的 Puppet 类别"
-
 msgid "Show a bookmark"
 msgstr "显示书签"
 
@@ -8130,9 +8133,6 @@ msgstr "显示计算配置集"
 
 msgid "Show a compute resource"
 msgstr "显示计算资源"
-
-msgid "Show a config group"
-msgstr "显示配置组"
 
 msgid "Show a default template combination for an operating system"
 msgstr "显示操作系统的默认模板组合"
@@ -8200,17 +8200,11 @@ msgstr "显示角色"
 msgid "Show a setting"
 msgstr "显示设置"
 
-msgid "Show a smart class parameter"
-msgstr "显示智能类别参数"
-
 msgid "Show a smart proxy"
 msgstr "显示智能代理服务器"
 
 msgid "Show a subnet"
 msgstr "显示子网"
-
-msgid "Show a trend"
-msgstr "显示一个趋势"
 
 msgid "Show a user"
 msgstr "显示用户"
@@ -8245,9 +8239,6 @@ msgstr "显示审计"
 msgid "Show an email notification"
 msgstr "显示电子邮件通知"
 
-msgid "Show an environment"
-msgstr "显示环境"
-
 msgid "Show an external authentication source"
 msgstr "显示一个外部认证源"
 
@@ -8268,9 +8259,6 @@ msgstr "显示一个内部认证源"
 
 msgid "Show an operating system"
 msgstr "显示操作系统"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "显示具体智能类别参数的替代值"
 
 msgid "Show available API links"
 msgstr "显示可用 API 链接"
@@ -8352,9 +8340,6 @@ msgstr "已跳過"
 msgid "Skipped|S"
 msgstr "忽略"
 
-msgid "Smart Class Parameter"
-msgstr "智能代理参数"
-
 msgid "Smart Class Parameters"
 msgstr "智能类参数"
 
@@ -8422,6 +8407,9 @@ msgstr "有些接口无效"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "有些接口无效。请检查下表。"
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "修改主机类型时出错 - %s"
 
@@ -8445,10 +8433,6 @@ msgid "Source"
 msgstr "來源："
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "精华"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "值"
 
@@ -8470,8 +8454,8 @@ msgstr "指定的值比推荐的最大值 %s 大"
 msgid "Specify Matchers"
 msgstr "指定匹配器"
 
-msgid "Specify additional options to sendmail"
-msgstr "指定 sendmail 的其他选项"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "Specify authentication type, if required"
 msgstr "指定身份验证类型（若需要）"
@@ -8514,8 +8498,8 @@ msgstr "状态"
 msgid "Status %s does not exist."
 msgstr "状态%s不存在。"
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "停止更新 Puppet 系统信息中的 IP 地址和 MAC 值（影响所有接口）"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr "停止从详情更新操作系统"
@@ -8611,6 +8595,10 @@ msgid "Subnet|Dns secondary"
 msgstr "从DNS"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "子网开始地址"
 
@@ -8637,6 +8625,10 @@ msgstr "名称"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "网段"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8709,6 +8701,12 @@ msgstr "对 %{feature} 的支持已弃用，将在版本 %{version} 中删除"
 
 msgid "Supported Formats"
 msgstr "支持的格式"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "使用认证源同步组"
@@ -8867,12 +8865,20 @@ msgid "TemplateInput|Advanced"
 msgstr "模板输入|高级"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr "模板输入|描述"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
 msgstr "模板输入|Fact 名称"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Input type"
@@ -8941,6 +8947,10 @@ msgid "Template|Default"
 msgstr "模板|默认"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr "模板|已锁定"
 
@@ -8991,8 +9001,8 @@ msgstr "测试电子邮件"
 msgid "Tester"
 msgstr "测试者"
 
-msgid "Text to be shown in the login-page footer"
-msgstr "要在登录页脚注中显示的文本"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
+msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
 msgid_plural "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}"
@@ -9136,8 +9146,8 @@ msgstr "人类可读的设置类别名称"
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr "上面的信息可以用于例如为置备模板中的每个接口创建 NetworkManager 配置文件。"
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
-msgstr "实例标题显示在顶部导航栏上（需要重新加载页面）。"
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
+msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
 msgstr "iss（发布者）声明标识了发布 JWT 的主体，对于大多数 OpenID 供应商，该主体位于 `/.well-known/openid-configuration`。"
@@ -9152,8 +9162,8 @@ msgid "The list is excluding %{count} %{link_start}physical host%{link_end}."
 msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_end}."
 msgstr[0] "该列表不包括 %{count}％{link_start}物理主机％{link_end} 。"
 
-msgid "The location of the sendmail executable"
-msgstr "sendmail 可执行文件的位置"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
+msgstr ""
 
 msgid "The marked fields will need reviewing"
 msgstr "需要检查标出的字段"
@@ -9182,9 +9192,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "会将所选主机的电源状态设定为 %s"
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr "puppetrun 功能已被删除，但是您可以使用远程执行插件运行 Puppet 命令"
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "范围名称，例如：EXAMPLE.COM"
@@ -9246,6 +9253,9 @@ msgstr "服务器日志中可能包含更多信息。"
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
 msgstr "必须至少有一个安装了并配置了外部 IPAM 插件的智能代理"
+
+msgid "There was a problem processing the request. Please try again."
+msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
 msgstr "创建 PXE 文件时出错：%s"
@@ -9374,8 +9384,8 @@ msgstr "此值不隐藏"
 msgid "This value is used also as the host's primary interface name."
 msgstr "还将这个值作为主机主接口名使用。"
 
-msgid "This will be one of our coolest pages."
-msgstr "这将是我们最酷的页面之一。"
+msgid "This will change the host power status, are you sure?"
+msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
 msgstr "这将生成一个报告 %s。根据其定义，可能需要很长时间才能处理。"
@@ -9400,15 +9410,6 @@ msgstr "新用户使用的时区"
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
 msgstr "要访问 %s API，您需要安装 Foreman Puppet 插件"
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr "要访问 /statistics API，您需要安装 Foreman Statistics 插件"
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr "要访问 /trends API，您需要安装 Foreman Statistics 插件"
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
-msgstr "要访问 import_puppetclasses API，您需要安装 Foreman Puppet 插件"
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
 msgstr "要更改默认行为，使用<code>-＆＃37;></code>修改包围标记："
@@ -9441,9 +9442,6 @@ msgstr "令牌"
 
 msgid "Token Expiry"
 msgstr "令牌过期"
-
-msgid "Token duration"
-msgstr "令牌持续时间"
 
 msgid "Token expired"
 msgstr "令牌已过期"
@@ -9481,41 +9479,8 @@ msgid "Total of one host"
 msgid_plural "Total of %{hosts} hosts"
 msgstr[0] "总共 %{hosts} 台主机"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "趋势"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "趋势统计"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "合计"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
-msgstr "趋势计数器|间隔结束"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr "趋势计数器|间隔开始"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "详情名"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "详情值"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "名称"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "趋势类型"
+msgid "Total: %s"
+msgstr ""
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "True/False 標記代表主機是否受管理。請注意：這個值也能決定是否需要數個參數"
@@ -9796,6 +9761,12 @@ msgstr "打开 websockets_encrypt 时无法取消设置 websockets_ssl_key"
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "仪表板小程序不允许使用的模板：%s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "无人参与的 URL"
 
@@ -9853,6 +9824,9 @@ msgstr "在数据库中找到未知记录"
 msgid "Unknown status: %s"
 msgstr "未知状态：%s"
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "开锁"
 
@@ -9880,9 +9854,6 @@ msgstr "更新：a_resource"
 msgid "Update IP from built request"
 msgstr "更新来自构建请求的 IP"
 
-msgid "Update a Puppet class"
-msgstr "更新 Puppet 类别"
-
 msgid "Update a bookmark"
 msgstr "更新书签"
 
@@ -9894,9 +9865,6 @@ msgstr "更新计算配置集"
 
 msgid "Update a compute resource"
 msgstr "更新计算资源"
-
-msgid "Update a config group"
-msgstr "更新配置群組"
 
 msgid "Update a default template combination for an operating system"
 msgstr "更新操作系统的默认模板组合"
@@ -9964,9 +9932,6 @@ msgstr "更新角色"
 msgid "Update a setting"
 msgstr "更新设置"
 
-msgid "Update a smart class parameter"
-msgstr "更新智能类别参数"
-
 msgid "Update a smart proxy"
 msgstr "更新智慧型代理伺服器"
 
@@ -9997,9 +9962,6 @@ msgstr "更新架构"
 msgid "Update an email notification for a user"
 msgstr "更新用户的电子邮件通知"
 
-msgid "Update an environment"
-msgstr "更新环境"
-
 msgid "Update an external authentication source"
 msgstr "更新一个外部认证源"
 
@@ -10008,12 +9970,6 @@ msgstr "更新映像"
 
 msgid "Update an operating system"
 msgstr "更新操作系统"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "更新具体智能类别参数的替代值"
-
-msgid "Update environment from facts"
-msgstr "根据系统信息更新环境"
 
 msgid "Update external user group"
 msgstr "更新外部使用者群組"
@@ -10250,6 +10206,10 @@ msgid "User|Description"
 msgstr "用户|描述"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "姓"
 
@@ -10386,8 +10346,8 @@ msgstr "变量"
 msgid "Variables"
 msgstr "变量"
 
-msgid "Vendor Class"
-msgstr "厂商类"
+msgid "Vendor class"
+msgstr ""
 
 msgid "Verify"
 msgstr "验证"
@@ -10448,6 +10408,9 @@ msgstr "等待 %s 上线"
 
 msgid "Warning"
 msgstr "警告"
+
+msgid "Warning statuses"
+msgstr ""
 
 msgid "Warning!"
 msgstr "警告"
@@ -10515,6 +10478,9 @@ msgstr ""
 "在编辑模板时，您必须分配可搭配\\\n"
 "此模板使用的一系列操作系统。您也可\\\n"
 "选择将模板限制到一系列主机组。"
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
+msgstr ""
 
 msgid ""
 "When the role's associated %{taxonomies} are changed,<br> the change will propagate to all inheriting filters.\n"
@@ -10649,6 +10615,9 @@ msgstr "是（覆盖）"
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "您要在所有配置的 TFTP 服务器中更改默认 PXE 菜单，要继续吗？"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr "您将要删除 %s。确定吗？"
@@ -10803,6 +10772,9 @@ msgstr "所有"
 msgid "already exists"
 msgstr "已存在"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "机构"
 
@@ -10814,9 +10786,6 @@ msgstr "数组"
 
 msgid "auxiliary field"
 msgstr "辅助字段"
-
-msgid "belongs to config group"
-msgstr "属于配置组"
 
 msgid "boolean"
 msgstr "boolean"
@@ -10997,9 +10966,6 @@ msgstr "启用缓存，仅适用于 VMware"
 
 msgid "enabled"
 msgstr "启用"
-
-msgid "environment id"
-msgstr "环境 ID"
 
 msgid "expected a value of type %s"
 msgstr "预期为 %s 类型的值"
@@ -11248,8 +11214,7 @@ msgstr "将外部用户组与这个用户组关联"
 msgid "list"
 msgstr "列出"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "简体中文"
 
@@ -11429,12 +11394,6 @@ msgstr "物理 @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "物理 @ 网桥 %s"
-
-msgid "plugin action 1"
-msgstr "插件操作 1"
-
-msgid "plugin action 2"
-msgstr "插件操作 2"
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "電源動作，有效的動作為（on/start）、（off/stop）、（soft/reboot）、（cycle/reset）、（state/status）"

--- a/locale/zh_CN/foreman.po
+++ b/locale/zh_CN/foreman.po
@@ -377,6 +377,9 @@ msgstr "当主机报告一个配置错误时的通知"
 msgid "A problem occurred when detecting host type: %s"
 msgstr "删除主机类型时出现错误：%s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr "审计改变报告概述 <br> 如果需要，可以使用查询过滤"
 
@@ -662,6 +665,9 @@ msgstr "电子邮件地址为必填，请更新您的帐户详情"
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr "尝试连接至 LDAP 时出错，请验证认证源主机可以从您的 Foreman 访问并在线。"
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr "发生了一个错误。"
 
@@ -730,6 +736,12 @@ msgstr "确定要删除主机 %s 吗？这个操作时不可逆的。"
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "您确定要删除主机 %s 吗? 这将会删除虚拟机和它的磁盘，且这些操作是不可逆的。这个行为可以通过 \"Destroy associated VM on host delete\" 全局设置改变。"
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
+msgstr ""
 
 msgid "Are you sure you want to log out?"
 msgstr "确定要注销吗？"
@@ -1112,6 +1124,9 @@ msgstr "请注意，这很危险，并且可能导致性能和安全性的问题
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr "由于 ERB 标签的长度是不固定的，所以缩进 ERB 语法可能会显示比较混乱。 ERB 语法忽略空格。处理缩进的一种方法是在每行的开头声明 ERB 标记，然后在 ERB 标记内使用空格来概述语法中的关系，例如："
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr "空模板"
 
@@ -1207,6 +1222,9 @@ msgstr "创建默认PXE"
 
 msgid "Build duration"
 msgstr "构建持续时间"
+
+msgid "Build enables host {hostName} to rebuild on next boot"
+msgstr ""
 
 msgid "Build errors"
 msgstr "构建错误"
@@ -2589,6 +2607,12 @@ msgstr "ERROR 或者 FATAL"
 msgid "EUI-64"
 msgstr "EUI-64"
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr "每个模板类型的呈现功能都会略有不同，例如，一个置备模板总是为一个单独的主机对象进行呈现，因此一个 @host 变量被定义。另一个示例是报告模板，其中包括了特定报告模式的宏。"
 
@@ -3299,6 +3323,12 @@ msgstr "Foreman 审核小结"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr "Foreman 可以保存它所置备的主机的网络设置信息，该信息可用于在置备期间配置虚拟机、分配正确的 IP 地址和网络资源，以及正确配置 OS。"
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr "Foreman 会将域和 DNS 区视为同一事物。即，如果您打算管理一个站点，其中所有计算机都采用 hostname. somewhere.com 的形式，则域为 somewhere.com。这样，Foreman可以将一个 puppet 变量与域/站点相关联，并将该变量自动附加到该站点上的计算机发出的所有外部节点请求中。全名字段用于在报告和引用页中使用人类可读的形式引用域，也可用作外部节点参数。"
 
@@ -3594,6 +3624,9 @@ msgstr "HTTP UEFI 引导需要带有 httpboot 功能的代理"
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
 msgstr "HTTP 引导需要具有 httpboot 功能和 http_port 公开设置的代理"
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
+msgstr ""
 
 msgid "HTTP(S) proxy"
 msgstr "HTTP(S) 代理服务器"
@@ -4356,8 +4389,20 @@ msgstr "如果在参数值中使用 ERB，则会在 ENC 请求过程中要求验
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "检查后，如果没有默认值，且没有映射程序提供数值，则会创建出错信息。"
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
 msgstr "如果指定了所有者类型，则必须同时指定所有者。"
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
 msgstr "如果设置，调度的报告将通过电子邮件发送。使用 '%s' 来分隔多个电子邮件地址。"
@@ -4367,6 +4412,9 @@ msgstr "如果托管标记被禁用，则不会为此接口配置任何服务，
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
 msgstr "启用托管标记之后，将根据提供的信息配置外部服务（例如 DHCP、DNS 和 TFTP）。"
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
+msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
 msgstr "如果模板支持格式选择，则用户可以选择首选格式。<br>通常，模板需要使用 report_render 宏。<br><br>如果在模板中未找到此宏的用法，<br>该字段被禁用<br><br>如果模板支持过滤器选择，但不使用 report_render 宏，<br>为了启用此字段，请在模板上添加注释来提及 report_render 宏名称。"
@@ -4382,6 +4430,9 @@ msgstr "如果需要在文件中更改此设置，它将带有文件路径。"
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "如果您认为这是 Foreman 自身的错误，请提交新问题。"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr "忽略域的详情"
@@ -4528,6 +4579,9 @@ msgstr "有关更新设置的信息"
 msgid "Infrastructure"
 msgstr "基础架构"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "继承上级（%s）"
 
@@ -4578,6 +4632,9 @@ msgstr "不安全"
 
 msgid "Install packages"
 msgstr "安装软件包"
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
+msgstr ""
 
 msgid "Installation Media"
 msgstr "安装介质"
@@ -5523,6 +5580,9 @@ msgstr "邮件通知|可订阅"
 msgid "MailNotification|Subscription type"
 msgstr "邮件通知|订阅类型"
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "管理"
 
@@ -6361,6 +6421,9 @@ msgstr "来自 facter 的 OS 名称：例如：RedHat"
 msgid "Off"
 msgstr "关闭"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "好"
 
@@ -6409,6 +6472,9 @@ msgstr "只允许一个代理服务器声明"
 
 msgid "Only one volume can be bootable"
 msgstr "只能引导一个卷"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "糟糕！"
@@ -6819,6 +6885,9 @@ msgstr "个人访问令牌已成功创建。"
 
 msgid "Personal Access Tokens"
 msgstr "个人访问令牌"
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Personal access token"
@@ -7501,6 +7570,9 @@ msgstr "请求 UUID"
 msgid "Require SSL for smart proxies"
 msgstr "智能代理服务器需要 SSL"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr "必需的，除非用户位于一个外部的认证源"
 
@@ -8083,6 +8155,9 @@ msgstr "设置 Insights"
 msgid "Setup REX"
 msgstr "设置 REX"
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8317,6 +8392,11 @@ msgstr "登入"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr "但是，与变量输入类型类似，它会加载特定智能类参数的值。定义输入时，用户必须指定 Puppet 类和智能类参数名称。"
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] "已选择本页中的单个主机。"
@@ -8406,6 +8486,12 @@ msgstr "有些接口无效"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "有些接口无效。请检查下表。"
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9068,6 +9154,9 @@ msgstr "ERB 标记内的 Ruby 代码通常包含表达式。它们由程序流�
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr "用于在 OpenID 供应商中用来对 JWT 进行编码的算法。"
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr "您的外部用户组的认证源无法通过提供的凭证连接到 LDAP。请验证凭证仍然有效。"
 
@@ -9079,6 +9168,9 @@ msgstr "这台机器中使用的 CPU 类别。主要由 Sparc Solaris 构建使�
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Open Boot Prom 报告的机器的类别。主要由 Sparc Solaris 构建使用，对于其他架构可将其留为空白。在 Solaris 中可用 uname -i|cut -f2 -d 确定它的值。"
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr "由于虚拟机未开机，此控制台不可用"
@@ -9269,6 +9361,12 @@ msgstr "列出虚拟机时出错：%(status)s%(statusText)s"
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "呈现 %{name} 模板时出错：%{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr "在 libvirt 里没有找到活动的桥接口，如果它不支持列表，您可以手动输入桥名称（如 br0）。"
 
@@ -9283,6 +9381,9 @@ msgstr "这<b>将删除</b>连接的虚拟机以及它们的磁盘，且此操�
 
 msgid "This IP address has already been reserved in External IPAM"
 msgstr "此 IP 地址已在外部 IPAM 中保留"
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
+msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
 msgstr "此电子邮件是从由 UUID %{uuid} 标识的 Foreman 发送的。"
@@ -9338,6 +9439,9 @@ msgstr "这可能是某项所需的服务不可用、错误的 API 调用和服�
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr "因为所有主机、fact 和报告也<b>将被删除</b>，所以会需要一段时间完成。%s 这个行为可以通过全局设置 \"Destroy associated VM on host delete\" 改变。"
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr "这提供了与 <code><%</code> 相同的功能，但是在执行模板时，代码输出将插入到模板中。这对于变量替换很有用，例如："
 
@@ -9358,6 +9462,12 @@ msgstr "這項服務可供未受認證的使用者使用"
 
 msgid "This service is only available for authenticated users"
 msgstr "這項服務僅供經過認證的使用者使用"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "这个模板已锁定，无法删除。"
@@ -9385,6 +9495,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "还将这个值作为主机主接口名使用。"
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9432,6 +9545,9 @@ msgid ""
 msgstr ""
 "如需刷新用户列表，请点击选项卡“外部\n"
 "                组”，然后点击“刷新”。"
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
+msgstr ""
 
 msgid "Today"
 msgstr "今天"
@@ -10283,6 +10399,9 @@ msgstr "VM 属性（%s）"
 msgid "VM already associated with a host"
 msgstr "VM 已经与主机关联"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "与主机 %s 关联的虚拟机"
 
@@ -10421,6 +10540,9 @@ msgstr "警告！"
 msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] "警告！这会从 {number} 用户中删除 %{name}。确定吗？"
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "警告：这样会删除这个主机机器所有数据！"
@@ -10622,11 +10744,17 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr "您将要删除 %s。确定吗？"
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "要解锁已锁定的模板。"
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
 msgstr "您已经在模拟身份，请单击顶部栏中的模拟图标，然后再开始新的模拟。"
+
+msgid "You are impersonating another user, click to stop the impersonation"
+msgstr ""
 
 msgid "You are not authorized to lock templates."
 msgstr "您没有锁定模板的授权。"

--- a/locale/zh_TW/foreman.po
+++ b/locale/zh_TW/foreman.po
@@ -383,6 +383,9 @@ msgstr ""
 msgid "A problem occurred when detecting host type: %s"
 msgstr "刪除主機類型時發生錯誤：%s"
 
+msgid "A repository to be added before the registration is performed. It can be useful to e.g. make the subscription-manager packages available for the purpose of the registration. For Red Hat family distributions, this should be the URL of the repository, e.g. 'http://rpm.example.com/'. For Debian OS families, it's the whole list file content, e.g. 'deb http://deb.example.com/ buster 1.0'."
+msgstr ""
+
 msgid "A summary of audit changes report <br> Filtered by a query if needed"
 msgstr ""
 
@@ -668,6 +671,9 @@ msgstr ""
 msgid "An error happened trying to connect to LDAP, please verify the authentication source host is reachable from your Foreman host and is online."
 msgstr ""
 
+msgid "An error occurred while testing the connection: "
+msgstr ""
+
 msgid "An error occurred."
 msgstr ""
 
@@ -735,6 +741,12 @@ msgid "Are you sure you want to delete host %s? This action is irreversible."
 msgstr "確定要刪除主機 %s？這動作是不可逆的。"
 
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
+msgid "Are you sure you want to delete host {host}? This action is irreversible. {cascade}"
+msgstr ""
+
+msgid "Are you sure you want to delete this widget from your dashboard?"
 msgstr ""
 
 msgid "Are you sure you want to log out?"
@@ -1119,6 +1131,9 @@ msgstr ""
 msgid "Because of the varying lengths of the ERB tags, indenting the ERB syntax might seem messy. ERB syntax ignores white space. One method of handling the indentation is to declare the ERB tag at the beginning of each new line and then use white space within the ERB tag to outline the relationships within the syntax, for example:"
 msgstr ""
 
+msgid "Before you proceed to using Foreman you should provide information about one or more architectures."
+msgstr ""
+
 msgid "Blank template"
 msgstr ""
 
@@ -1213,6 +1228,9 @@ msgid "Build PXE Default"
 msgstr "組建 PXE 預設值"
 
 msgid "Build duration"
+msgstr ""
+
+msgid "Build enables host {hostName} to rebuild on next boot"
 msgstr ""
 
 msgid "Build errors"
@@ -2597,6 +2615,12 @@ msgstr "ERROR 或 FATAL"
 msgid "EUI-64"
 msgstr ""
 
+msgid "Each architecture can also be associated with more than one operating system and a selector block is provided to allow you to select valid combinations."
+msgstr ""
+
+msgid "Each entry represents a particular hardware architecture, most commonly <b>x86_64</b> or <b>i386</b>. Foreman also supports the Solaris operating system family, which includes <b>sparc</b> based systems."
+msgstr ""
+
 msgid "Each template type rendering capabilities slightly differ, e.g. a provisioning template is always rendered for a single host object and therefore a @host variable is defined. Another example is a report template, where report formatting specific macros are available."
 msgstr ""
 
@@ -3307,6 +3331,12 @@ msgstr "Foreman 稽核摘要"
 msgid "Foreman can store information about the networking setup of a host that it’s provisioning, which can be used to configure the virtual machine, assign the correct IP addresses and network resources, then configure the OS correctly during the provisioning process."
 msgstr ""
 
+msgid "Foreman can use External service for user information and authentication."
+msgstr ""
+
+msgid "Foreman can use LDAP based service for user information and authentication."
+msgstr ""
+
 msgid "Foreman considers a domain and a DNS zone as the same thing. That is, if you are planning to manage a site where all the machines are of the form hostname. somewhere.com then the domain is somewhere.com. This allows Foreman to associate a puppet variable with a domain/site and automatically append this variable to all external node requests made by machines at that site. The fullname field is used for human readability in reports and other pages that refer to domains, and also available as an external node parameter."
 msgstr ""
 
@@ -3601,6 +3631,9 @@ msgid "HTTP UEFI boot requires proxy with httpboot feature"
 msgstr ""
 
 msgid "HTTP boot requires proxy with httpboot feature and http_port exposed setting"
+msgstr ""
+
+msgid "HTTP request UUID, clicking will filter audits for this request. It can also be used for searching in application logs."
 msgstr ""
 
 msgid "HTTP(S) proxy"
@@ -4363,7 +4396,19 @@ msgstr "如果 ERB 用在參數值中，對這個值的驗證會發生在 ENC �
 msgid "If checked, will raise an error if there is no default value and no matcher provide a value."
 msgstr "若選取而沒有預設值並且比對器未提供值的話，將會造成錯誤發生。"
 
+msgid "If no location is set, the default location of the user is assumed."
+msgstr ""
+
+msgid "If no organization is set, the default organization of the user is assumed."
+msgstr ""
+
 msgid "If owner type is specified, owner must be specified too."
+msgstr ""
+
+msgid "If packages are GPG signed, the public key can be specified here to verify the packages signatures. It needs to be specified in the ascii form with the GPG public key header."
+msgstr ""
+
+msgid "If set to `Yes`, Insights client will be installed and registered on Red Hat family operating systems. It has no effect on other OS families that do not support it. The inherited value is based on the `host_registration_insights` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
 msgstr ""
 
 msgid "If set, scheduled report will be delivered via e-mail. Use '%s' to separate multiple email addresses."
@@ -4373,6 +4418,9 @@ msgid "If the Managed flag is disabled, none of the services will be configured 
 msgstr ""
 
 msgid "If the Managed flag is enabled, external services such as DHCP, DNS, and TFTP will be configured according to the information provided."
+msgstr ""
+
+msgid "If the target machine does not trust the host SSL certificate, the initial connection could be subject to Man in the middle attack. If you accept the risk and do not require the server authenticity to be verified, you can enable insecure argument for the initial curl. Note that all subsequent communication is then properly secured, because the initial request deploys the SSL certificate for the rest of the registration process."
 msgstr ""
 
 msgid "If the template supports format selection, user can choose preferred format.<br> Typically the template needs to use report_render macro.<br><br>If usage of this macro is not found in the template,<br>this field is disabled and the output format defaults to plain text.<br><br>If the template supports filter selection, but does not use the report_render macro,<br>in order to enable this field, add a comment to the template mentioning report_render macro name."
@@ -4389,6 +4437,9 @@ msgstr ""
 
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "若您認為這是 Foreman 本身的錯誤，請提交錯誤"
+
+msgid "If you wish to configure Puppet to forward its reports to Foreman, please follow <a href=${getManualURL( '3.5.4PuppetReports' )}>setting up reporting</a> and <a href=${getWikiURL('Mail_Notifications')}>e-mail reporting</a>"
+msgstr ""
 
 msgid "Ignore facts for domain"
 msgstr ""
@@ -4535,6 +4586,9 @@ msgstr ""
 msgid "Infrastructure"
 msgstr "設備"
 
+msgid "Inherit from host parameter"
+msgstr ""
+
 msgid "Inherit parent (%s)"
 msgstr "繼承 parent（%s）"
 
@@ -4578,6 +4632,9 @@ msgid "Insecure"
 msgstr ""
 
 msgid "Install packages"
+msgstr ""
+
+msgid "Install packages on the host when registered. Can be set by `host_packages` parameter"
 msgstr ""
 
 msgid "Installation Media"
@@ -5524,6 +5581,9 @@ msgstr ""
 msgid "MailNotification|Subscription type"
 msgstr ""
 
+msgid "Make sure to copy your new personal access token now. You won’t be able to see it again!"
+msgstr ""
+
 msgid "Manage"
 msgstr "管理"
 
@@ -6362,6 +6422,9 @@ msgstr "來自於要素的 OS 名稱；例如 RedHat"
 msgid "Off"
 msgstr "關閉"
 
+msgid "Oh no! Something went wrong while submitting the form, the server returned the following error: %s"
+msgstr ""
+
 msgid "Ok"
 msgstr "確定"
 
@@ -6405,6 +6468,9 @@ msgstr "僅允許宣告一個協定"
 
 msgid "Only one volume can be bootable"
 msgstr "只有一個卷冊能作為開機卷冊"
+
+msgid "Only smart proxies with enabled `Templates` and `Registration` features are displayed."
+msgstr ""
 
 msgid "Oops!!"
 msgstr "抱歉！"
@@ -6814,6 +6880,9 @@ msgid "Personal Access Token was successfully created."
 msgstr ""
 
 msgid "Personal Access Tokens"
+msgstr ""
+
+msgid "Personal Access Tokens allow you to authenticate API requests without using your password, e.g. "
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -7495,6 +7564,9 @@ msgstr ""
 msgid "Require SSL for smart proxies"
 msgstr "智慧型代理伺服器需要 SSL"
 
+msgid "Required for registration without subscription manager. Can be specified by host group."
+msgstr ""
+
 msgid "Required unless user is in an external authentication source"
 msgstr ""
 
@@ -8080,6 +8152,9 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Setup remote execution. If set to `Yes`, SSH keys will be installed on the registered host. The inherited value is based on the `host_registration_remote_execution` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+msgstr ""
+
 msgid "Share feedback"
 msgstr ""
 
@@ -8314,6 +8389,11 @@ msgstr "簽署"
 msgid "Similar to the variable input type, however, it loads the value for a specific smart class parameter. The user must specify the Puppet class and the smart class parameter name when defining the input."
 msgstr ""
 
+msgid "Single host is selected in total"
+msgid_plural "All <b> %d </b> hosts are selected."
+msgstr[0] ""
+msgstr[1] ""
+
 msgid "Single host on this page is selected."
 msgid_plural "All %{per_page} hosts on this page are selected."
 msgstr[0] ""
@@ -8404,6 +8484,12 @@ msgstr "一些介面不合規定"
 
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "部分介面卡無法使用。請檢查下列表格。"
+
+msgid "Some other interface is already set as primary. Are you sure you want to use this one instead?"
+msgstr ""
+
+msgid "Some other interface is already set as provisioning. Are you sure you want to use this one instead?"
+msgstr ""
 
 msgid "Something went wrong"
 msgstr ""
@@ -9067,6 +9153,9 @@ msgstr ""
 msgid "The algorithm used to encode the JWT in the OpenID provider."
 msgstr ""
 
+msgid "The authentication process currently requires an LDAP provider, such as <em>FreeIPA</em>, <em>OpenLDAP</em> or <em>Microsoft's Active Directory</em>."
+msgstr ""
+
 msgid "The authentication source of your external user groups could not connect to LDAP with the provided credentials. Please verify the credentials are still valid."
 msgstr ""
 
@@ -9078,6 +9167,9 @@ msgstr "這部機器中所提供的 CPU 類別。這主要會被 Sparc Solaris �
 
 msgid "The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,"
 msgstr "Open Boot Prom 所回報的機器類別。這主要會被 Sparc Solaris 組建所使用，而其它架構則能保留為空白。這個值能在 Solaris 上透過 uname -i|cut -f2 -d 取得"
+
+msgid "The connection was closed by the browser. please verify that the certificate authority is valid"
+msgstr ""
 
 msgid "The console is not available because the VM is not powered on"
 msgstr ""
@@ -9270,6 +9362,12 @@ msgstr "列出虛擬機器時發生了錯誤：%(status)s %(statusText)s"
 msgid "There was an error rendering the %{name} template: %{error}"
 msgstr "轉譯 %{name} 範本時發生錯誤：%{error}"
 
+msgid "There was an error while generating the command, see the logs for more information."
+msgstr ""
+
+msgid "There was an error while loading the data, see the logs for more information."
+msgstr ""
+
 msgid "There was no active bridge interface found in libvirt, if it does not support listing, you can enter the bridge name manually (e.g. br0)"
 msgstr ""
 
@@ -9283,6 +9381,9 @@ msgid "This <b>will delete</b> the linked VMs and their disks, and is irreversib
 msgstr ""
 
 msgid "This IP address has already been reserved in External IPAM"
+msgstr ""
+
+msgid "This action will delete this host and all its data (i.e facts, report)"
 msgstr ""
 
 msgid "This email was sent from Foreman identified by UUID %{uuid}"
@@ -9339,6 +9440,9 @@ msgstr ""
 msgid "This might take a while, as all hosts, facts and reports <b>will be deleted</b> as well. %s This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
+msgid "This page redesign is experimental and under active development."
+msgstr ""
+
 msgid "This provides the same functionality as <code><%</code> but when the template is executed, the code output is inserted into the template. This is useful for variable substitution, for example:"
 msgstr ""
 
@@ -9359,6 +9463,12 @@ msgstr "這項服務可供未受認證的使用者使用"
 
 msgid "This service is only available for authenticated users"
 msgstr "這項服務僅供經過認證的使用者使用"
+
+msgid "This setting is defined in the configuration file %s and is read-only."
+msgstr ""
+
+msgid "This setting is encrypted. Empty input field is displayed instead of the setting value."
+msgstr ""
 
 msgid "This template is locked and may not be removed."
 msgstr "此範本已鎖定，並且不可移除。"
@@ -9384,6 +9494,9 @@ msgid "This value is used also as the host's primary interface name."
 msgstr "這個值也用於主機的主介面名稱。"
 
 msgid "This will change the host power status, are you sure?"
+msgstr ""
+
+msgid "This will delete the VM and its disks. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9428,6 +9541,9 @@ msgstr ""
 msgid ""
 "To refresh the list of users, click on the tab \"External\n"
 "                groups\" then \"Refresh\"."
+msgstr ""
+
+msgid "To report an issue <a target=\"_blank\" rel=\"noopener noreferrer\" href=${foremanUrl( '/links/issues' )}>click here</a>"
 msgstr ""
 
 msgid "Today"
@@ -10281,6 +10397,9 @@ msgstr "VM 屬性（%s）"
 msgid "VM already associated with a host"
 msgstr "VM 早已和一部主機相聯"
 
+msgid "VM and its disks will not be deleted. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
+msgstr ""
+
 msgid "VM associated to host %s"
 msgstr "VM 已和 %s 主機相聯"
 
@@ -10420,6 +10539,9 @@ msgid "Warning! This will remove %{name} from %{number} user. are you sure?"
 msgid_plural "Warning! This will remove %{name} from %{number} users. are you sure?"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "Warning: This combination of loader and OS might not be able to boot."
+msgstr ""
 
 msgid "Warning: This will delete this host and all of its data!"
 msgstr "警告：這將會刪除這部主機及其所有資料！"
@@ -10603,10 +10725,16 @@ msgstr ""
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
 
+msgid "You are about to stop impersonating other user. Are you sure?"
+msgstr ""
+
 msgid "You are about to unlock a locked template."
 msgstr "即將解鎖已鎖定範本。"
 
 msgid "You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation."
+msgstr ""
+
+msgid "You are impersonating another user, click to stop the impersonation"
 msgstr ""
 
 msgid "You are not authorized to lock templates."

--- a/locale/zh_TW/foreman.po
+++ b/locale/zh_TW/foreman.po
@@ -24,9 +24,6 @@ msgstr ""
 msgid " Documentation"
 msgstr ""
 
-msgid " Remove"
-msgstr "移除"
-
 msgid " and it is highly recommended to also attach the foreman-debug output."
 msgstr ""
 
@@ -38,9 +35,6 @@ msgstr ""
 
 msgid "%(name)s (free: %(free)s, prov: %(prov)s, total: %(total)s)"
 msgstr ""
-
-msgid "%s - Press Shift-F12 to release the cursor."
-msgstr "%s - 請點擊 Shift + F12 來釋放滑鼠"
 
 msgid "%s - The following hosts are about to be changed"
 msgstr "%s - 這些主機將要被變更"
@@ -60,9 +54,6 @@ msgstr[1] ""
 
 msgid "%s Parameters updated, see below for more information"
 msgstr "%s 參數已經更新, 請從下方取得更多資訊"
-
-msgid "%s Template"
-msgstr "%s 範本"
 
 msgid "%s VM failed while processing: check logs for more details."
 msgid_plural "%s VMs failed while processing: check logs for more details."
@@ -115,9 +106,6 @@ msgid_plural "%s months ago"
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "%s out of sync disabled"
-msgstr ""
-
 msgid "%s selected hosts"
 msgstr "%s 選擇的主機"
 
@@ -135,9 +123,6 @@ msgid "%s widget loading..."
 msgstr ""
 
 msgid "%s you had selected as your context has been deleted"
-msgstr ""
-
-msgid "%s, check the 'SSL CA file' in Settings > Authentication"
 msgstr ""
 
 msgid "%{action} %{vm}"
@@ -209,6 +194,9 @@ msgstr "%{match} 與目前的主機群組不相符"
 
 msgid "%{name} changed from %{label1} to %{label2}"
 msgstr "%{name} 已經從 %{label1} 變更為 %{label2}"
+
+msgid "%{name} value is a \"%{type}\", expected \"resource\" value type"
+msgstr ""
 
 msgid "%{object_name} is a %{object_class}, expected a subnet"
 msgstr ""
@@ -291,6 +279,9 @@ msgstr ""
 
 msgid "(optional) IAM Role for Fog to use when creating this image."
 msgstr "(選擇性) 當Fog 用來創建此VM時使用的 IAM 角色."
+
+msgid "(updated %s)"
+msgstr ""
 
 msgid "*Clear %s proxy*"
 msgstr "*清除 %s 代理*"
@@ -485,12 +476,6 @@ msgstr "新增卷冊"
 msgid "Add a CD-ROM drive to the virtual machine."
 msgstr ""
 
-msgid "Add a Puppet class to host"
-msgstr "新增 Puppet 類別至主機"
-
-msgid "Add a Puppet class to host group"
-msgstr "新增 Puppet 類別至主機群組"
-
 msgid "Add a template combination"
 msgstr "新增範本組合"
 
@@ -536,9 +521,6 @@ msgstr "額外運算資源特定的屬性。"
 msgid "Additional information about this host"
 msgstr "有關於這部主機的額外資訊"
 
-msgid "Address to connect to"
-msgstr ""
-
 msgid "Admin permissions required"
 msgstr "需要 Admin 權限"
 
@@ -581,9 +563,6 @@ msgstr "別名或 VLAN 裝置"
 msgid "All"
 msgstr "全部"
 
-msgid "All Audits"
-msgstr ""
-
 msgid "All Hosts"
 msgstr ""
 
@@ -591,6 +570,12 @@ msgid "All Reports"
 msgstr "所有報告"
 
 msgid "All Ruby code is enclosed within <code><&#37; &#37;></code> in an ERB template. The code is executed when the template is rendered. It can contain Ruby control flow structures as well as application-specific macros and variables. For example:"
+msgstr ""
+
+msgid "All Statuses are OK"
+msgstr ""
+
+msgid "All audits"
 msgstr ""
 
 msgid "All compute resources"
@@ -752,9 +737,6 @@ msgstr "確定要刪除主機 %s？這動作是不可逆的。"
 msgid "Are you sure you want to delete host %s? This will delete the VM and its disks, and is irreversible. This behavior can be changed via global setting \"Destroy associated VM on host delete\"."
 msgstr ""
 
-msgid "Are you sure you want to delete this widget from your dashboard?"
-msgstr "確定要從面板刪除此小工具？"
-
 msgid "Are you sure you want to log out?"
 msgstr ""
 
@@ -811,6 +793,12 @@ msgstr "指定組織"
 
 msgid "Assign Selected Hosts"
 msgstr "指定選擇的主機"
+
+msgid "Assign a host to the Foreman instance"
+msgstr ""
+
+msgid "Assign a host to the smart proxy"
+msgstr ""
 
 msgid "Assign the %{count} host with no %{taxonomy_single} to %{taxonomy_name}"
 msgid_plural "Assign all %{count} hosts with no %{taxonomy_single} to %{taxonomy_name}"
@@ -1296,6 +1284,9 @@ msgstr ""
 msgid "Can be retrieved via CLI or RC file. Can be set to 'default'. Only for v3 authentication."
 msgstr ""
 
+msgid "Can not load datacenters due to an incorrect user name or password."
+msgstr ""
+
 msgid "Can't delete internal admin account"
 msgstr "無法刪除內部管理帳號"
 
@@ -1377,8 +1368,8 @@ msgstr ""
 msgid "Certificate path for GCE only"
 msgstr ""
 
-msgid "Certificate that Foreman will use to encrypt websockets "
-msgstr "Foreman 會使用來加密 websocket 的憑證"
+msgid "Certificate path that Foreman will use to encrypt websockets"
+msgstr ""
 
 msgid "Certificates"
 msgstr "憑證"
@@ -1437,6 +1428,9 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
+msgid "Clear Host's Status"
+msgstr ""
+
 msgid "Clear sub-status of host"
 msgstr ""
 
@@ -1448,12 +1442,6 @@ msgstr "點選運算資源的連結來編輯其預設 VM 屬性。"
 
 msgid "Click to log in again"
 msgstr ""
-
-msgid "Click to remove %s"
-msgstr "點選以移除 %s"
-
-msgid "Click to remove config group"
-msgstr "點選以移除配置群組"
 
 msgid "Client Email"
 msgstr "客戶端電子郵件"
@@ -1617,14 +1605,6 @@ msgstr ""
 msgid "Config Retrieval"
 msgstr "配置擷取"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Config group"
-msgstr "配置群組"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "ConfigGroup|Name"
-msgstr "名稱"
-
 msgid "Configuration"
 msgstr "組態"
 
@@ -1667,8 +1647,8 @@ msgstr "偵測到了衝突"
 msgid "Connected"
 msgstr ""
 
-msgid "Connected (unencrypted) to: %s"
-msgstr "已連（未加密）至：%s"
+msgid "Connected to: %s"
+msgstr ""
 
 msgid "Connecting (unencrypted) to: %s"
 msgstr "正在連線（未加密）至：%s"
@@ -1718,7 +1698,7 @@ msgstr ""
 msgid "Cores per socket"
 msgstr "每個插槽的核心數"
 
-msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). Higher value is safer but verification is slower particularly for stateless API calls and UI logins. Password change needed to take effect."
+msgid "Cost value of bcrypt password hash function for internal auth-sources (4-30). A higher value is safer but verification is slower, particularly for stateless API calls and UI logins. A password change is needed effect existing passwords."
 msgstr ""
 
 msgid "Could not add permissions to Manager and Viewer roles: %s"
@@ -1895,9 +1875,6 @@ msgstr ""
 msgid "Create a Personal Access Token for a user"
 msgstr ""
 
-msgid "Create a Puppet class"
-msgstr "建立 Puppet 類別"
-
 msgid "Create a bookmark"
 msgstr "建立書籤"
 
@@ -1909,9 +1886,6 @@ msgstr "建立運算設定檔"
 
 msgid "Create a compute resource"
 msgstr "建立運算資源"
-
-msgid "Create a config group"
-msgstr "建立配置群組"
 
 msgid "Create a default template combination for an operating system"
 msgstr "為作業系統建立預設範本"
@@ -1985,9 +1959,6 @@ msgstr "建立子網路"
 msgid "Create a template input"
 msgstr "建立範本輸入"
 
-msgid "Create a trend counter"
-msgstr ""
-
 msgid "Create a user"
 msgstr "建立使用者"
 
@@ -2003,9 +1974,6 @@ msgstr "建立 LDAP 認證來源"
 msgid "Create an architecture"
 msgstr "建立架構"
 
-msgid "Create an environment"
-msgstr "建立環境"
-
 msgid "Create an external user group linked to a user group"
 msgstr "建立連往使用者群組的外部使用者群組"
 
@@ -2018,13 +1986,13 @@ msgstr "在主機上建立介面"
 msgid "Create an operating system"
 msgstr "建立作業系統"
 
-msgid "Create an override value for a specific smart class parameter"
-msgstr "為特定的智慧型類別參數建立置換值"
-
 msgid "Create autosign entry"
 msgstr ""
 
 msgid "Create image"
+msgstr ""
+
+msgid "Create model"
 msgstr ""
 
 msgid "Create new boot volume from image"
@@ -2041,6 +2009,9 @@ msgstr "為 %s 建立領域項目"
 
 msgid "Created"
 msgstr "已建立"
+
+msgid "Created %s by %s"
+msgstr ""
 
 msgid "Creates a table preference for a given table"
 msgstr ""
@@ -2071,18 +2042,6 @@ msgstr ""
 
 msgid "DB pending seed"
 msgstr "DB 尚未處理的種子"
-
-msgid "DEPRECATED: Add a template combination"
-msgstr ""
-
-msgid "DEPRECATED: List template combination"
-msgstr ""
-
-msgid "DEPRECATED: Show template combination"
-msgstr ""
-
-msgid "DEPRECATED: Update template combination"
-msgstr ""
 
 msgid "DHCP"
 msgstr "DHCP"
@@ -2174,7 +2133,7 @@ msgstr "預設值"
 msgid "Default 'Host initial configuration' template"
 msgstr ""
 
-msgid "Default 'Host initial configuration' template, automatically assigned when new operating system is created"
+msgid "Default 'Host initial configuration' template, automatically assigned when a new operating system is created"
 msgstr ""
 
 msgid "Default Behavior"
@@ -2197,9 +2156,6 @@ msgstr ""
 
 msgid "Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"
 msgstr ""
-
-msgid "Default Puppet environment"
-msgstr "預設 Puppet 環境"
 
 msgid "Default VNC Keyboard"
 msgstr ""
@@ -2282,9 +2238,6 @@ msgstr "刪除 %s 的 PuppetCA 憑證"
 msgid "Delete TFTP %{kind} config for %{host}"
 msgstr ""
 
-msgid "Delete a Puppet class"
-msgstr "刪除 Puppet 類別"
-
 msgid "Delete a Virtual Machine"
 msgstr ""
 
@@ -2296,9 +2249,6 @@ msgstr "刪除運算設定檔"
 
 msgid "Delete a compute resource"
 msgstr "刪除運算資源"
-
-msgid "Delete a config group"
-msgstr "刪除配置群組"
 
 msgid "Delete a default template combination for an operating system"
 msgstr "刪除一個作業系統的預設範本組合"
@@ -2381,9 +2331,6 @@ msgstr "刪除範本組合"
 msgid "Delete a template input"
 msgstr "刪除範本輸入"
 
-msgid "Delete a trend counter"
-msgstr ""
-
 msgid "Delete a user"
 msgstr "刪除使用者"
 
@@ -2423,9 +2370,6 @@ msgstr ""
 msgid "Delete an architecture"
 msgstr "刪除架構"
 
-msgid "Delete an environment"
-msgstr "刪除環境"
-
 msgid "Delete an external user group"
 msgstr "刪除外部使用者群組"
 
@@ -2435,14 +2379,17 @@ msgstr "刪除映像檔"
 msgid "Delete an operating system"
 msgstr "刪除作業系統"
 
-msgid "Delete an override value for a specific smart class parameter"
-msgstr "刪除特定智慧型類別參數的置換值"
-
 msgid "Delete autosign entry"
 msgstr ""
 
 msgid "Delete filter?"
 msgstr "刪除篩選器？"
+
+msgid "Delete host"
+msgstr ""
+
+msgid "Delete host?"
+msgstr ""
 
 msgid "Delete realm entry for %s"
 msgstr "刪除 %s 的領域項目"
@@ -2514,9 +2461,6 @@ msgid "Disable alerts for selected hosts"
 msgstr "停用所選主機的警示"
 
 msgid "Disable all filters overriding"
-msgstr ""
-
-msgid "Disable host configuration status turning to out of sync for %s after report does not arrive within configured interval"
 msgstr ""
 
 msgid "Disable overriding"
@@ -2635,10 +2579,10 @@ msgstr ""
 msgid "Duplicated inputs detected: %{duplicated_inputs}"
 msgstr "偵測到重複的輸入：%{duplicated_inputs}"
 
-msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
+msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers reporting via Puppet are classed as out of sync."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"
@@ -2646,9 +2590,6 @@ msgstr "EC2"
 
 msgid "EFI"
 msgstr ""
-
-msgid "ENC environment"
-msgstr "ENC 環境"
 
 msgid "ERROR or FATAL"
 msgstr "ERROR 或 FATAL"
@@ -2690,6 +2631,9 @@ msgid "Edit this host"
 msgstr ""
 
 msgid "Editor"
+msgstr ""
+
+msgid "Email"
 msgstr ""
 
 msgid "Email Preferences"
@@ -2767,10 +2711,6 @@ msgstr "IP 自動建議的結尾 IP 位址"
 msgid "Entries per page"
 msgstr "每頁的項目"
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment"
-msgstr "環境"
-
 msgid "Environment IDs"
 msgstr "環境 ID"
 
@@ -2785,10 +2725,6 @@ msgstr "包含了一個客戶端 SSL 憑證之驗證狀態的環境變數"
 
 msgid "Environments got deprecated from this endpoint."
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Environment|Name"
-msgstr "名稱"
 
 msgid "Error"
 msgstr "錯誤"
@@ -2828,6 +2764,9 @@ msgstr ""
 
 msgid "Error removing widget from dashboard."
 msgstr "從面板移除小工具時發生錯誤。"
+
+msgid "Error statuses"
+msgstr ""
 
 msgid "Error submitting data:"
 msgstr ""
@@ -3296,14 +3235,14 @@ msgstr "項目不相符時修正 %s"
 msgid "Fix All Mismatches"
 msgstr "修正所有不相符項目"
 
-msgid "Fix DB cache"
-msgstr "修正 DB 快取"
-
-msgid "Fix DB cache on next Foreman restart"
-msgstr "在下次 Foreman 重新啟動時修正 DB 快取"
-
 msgid "Fix Mismatches"
 msgstr "修正不相符的項目"
+
+msgid "Flag to indicate whether to include status or not"
+msgstr ""
+
+msgid "Flag to indicate whether to include version or not"
+msgstr ""
 
 msgid "Flavor"
 msgstr "類別"
@@ -3350,9 +3289,6 @@ msgstr ""
 msgid "For values of type search, this is the resource the value searches in"
 msgstr ""
 
-msgid "Force a Puppet agent run on the host"
-msgstr "強制 Puppet 代理程式在主機上執行"
-
 msgid "Foreman API v2 is currently the default API version."
 msgstr "目前 Foreman API v2 是預設的 API 版本。"
 
@@ -3386,6 +3322,10 @@ msgstr ""
 msgid "Foreman instance ID, uniquely identifies this Foreman instance."
 msgstr ""
 
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman internal"
+msgstr ""
+
 msgid "Foreman matchers will be inherited by children when evaluating smart class parameters for hostgroups, organizations and locations"
 msgstr ""
 
@@ -3394,6 +3334,10 @@ msgstr "Foreman 現在會為 %s 管理組建循環"
 
 msgid "Foreman now no longer manages the build cycle for %s"
 msgstr "Foreman 現在已不再會為 %s 管理組建循環"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Foreman register/registration facet"
+msgstr ""
 
 msgid "Foreman report creation time is <em>%s</em>"
 msgstr "Foreman 回報建立時間為 <em>%s</em>"
@@ -3422,7 +3366,7 @@ msgstr ""
 msgid "Foreman will automate certificate signing upon provision of new host"
 msgstr "Foreman 將會在佈建新主機時自動化憑證簽署"
 
-msgid "Foreman will block user login after this number of failed login attempts for 5 minutes from offending IP address. Set to 0 to disable bruteforce protection"
+msgid "Foreman will block user logins from an IP address after this number of failed login attempts for 5 minutes. Set to 0 to disable bruteforce protection"
 msgstr ""
 
 msgid "Foreman will create the host when a report is received"
@@ -3431,20 +3375,14 @@ msgstr "Foreman 將會在收到回報後建立主機"
 msgid "Foreman will create the host when new facts are received"
 msgstr "Foreman 將會在收到新詳情後建立主機"
 
-msgid "Foreman will default to this puppet environment if it cannot auto detect one"
-msgstr "若 Foreman 無法自動偵測 puppet 環境，就預設值它將會使用此 puppet 環境"
-
 msgid "Foreman will delete virtual machine if provisioning script ends with non zero exit code"
 msgstr "Foreman 會偵測虛擬機器，如果佈建 script 最後產生了非零值的退出碼"
 
 msgid "Foreman will evaluate host smart class parameters in this order by default"
 msgstr ""
 
-msgid "Foreman will explicitly set the puppet environment in the ENC yaml output. This will avoid conflicts between the environment in puppet.conf and the environment set in Foreman"
-msgstr "Foreman 將會明確設置 puppet 環境於 ENC yaml 輸出中。這將避免 puppet.conf 和 Foreman 中，環境之間的衝突。"
-
-msgid "Foreman will map users by username in request-header. If this is set to false, OAuth requests will have admin rights."
-msgstr "Foreman 將會在 request-header 中以使用者名稱來對映使用者。若這設為 false 的話，OAuth 請求將會擁有管理權限。"
+msgid "Foreman will load the new UI for host details"
+msgstr ""
 
 msgid "Foreman will not send this parameter in classification output."
 msgstr ""
@@ -3454,9 +3392,6 @@ msgstr "Foreman 將會叵析在 ENC 輸出中之參數裡的 ERB"
 
 msgid "Foreman will query the locally configured resolver instead of the SOA/NS authorities"
 msgstr "Foreman 將會查詢本機配置的解析器，而非 SOA/NS 授權"
-
-msgid "Foreman will update a host's environment from its facts"
-msgstr "Foreman 會藉由主機的環境之詳情來更新它"
 
 msgid "Foreman will update a host's hostgroup from its facts"
 msgstr ""
@@ -3475,6 +3410,18 @@ msgstr "Foreman 將會使用隨機的 UUID 來進行憑證簽署，而非透過�
 
 msgid "Foreman will use the short hostname instead of the FQDN for creating new virtual machines"
 msgstr "Foreman 將會使用簡短的主機名稱而非 FQDN 來建立新的虛擬機器"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Key"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanInternal|Value"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "ForemanRegister::RegistrationFacet|Jwt secret"
+msgstr ""
 
 msgid "Form was successfully created."
 msgstr ""
@@ -3502,6 +3449,9 @@ msgstr "全螢幕"
 
 msgid "Function not available for %s"
 msgstr "%s 的功能不可用"
+
+msgid "Further Information"
+msgstr ""
 
 msgid "GMT time"
 msgstr "GMT 時間"
@@ -3572,8 +3522,8 @@ msgstr "取得控制面板詳細資料"
 msgid "Get default dashboard widgets"
 msgstr "取得預設面板小工具"
 
-msgid "Get statistics"
-msgstr "取得數據"
+msgid "Get hosts forming the smart proxy"
+msgstr ""
 
 msgid "Get status of host"
 msgstr "取得主機的狀態"
@@ -3695,6 +3645,12 @@ msgstr ""
 msgid "Hardware Models"
 msgstr "硬體型號"
 
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hardware models"
+msgstr ""
+
 msgid "Has effect only for network based provisioning"
 msgstr ""
 
@@ -3740,11 +3696,17 @@ msgstr "紀錄"
 msgid "Host"
 msgstr "主機"
 
+msgid "Host %s has been removed successfully"
+msgstr ""
+
 msgid "Host %s is built"
 msgstr "主機 %s 已建立"
 
 msgid "Host %s is not associated with a VM"
 msgstr "主機 %s 不與任何 VM 相聯"
+
+msgid "Host %s will be built next boot"
+msgstr ""
 
 msgid "Host Configuration Chart"
 msgstr "主機配置圖表"
@@ -3779,7 +3741,13 @@ msgstr ""
 msgid "Host Parameters"
 msgstr ""
 
-msgid "Host Wizard"
+msgid "Host Status"
+msgstr ""
+
+msgid "Host Status Overview"
+msgstr ""
+
+msgid "Host Statuses"
 msgstr ""
 
 msgid "Host audit entries"
@@ -3788,12 +3756,12 @@ msgstr "主機稽核項目"
 msgid "Host built"
 msgstr ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Host config group"
-msgstr "主機配置群組"
-
 msgid "Host details"
 msgstr "主機詳細資訊"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Host facets/base"
+msgstr ""
 
 msgid "Host group"
 msgstr "主機群組"
@@ -3931,8 +3899,32 @@ msgid "Host::Base|Uuid"
 msgstr "UUID"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "HostConfigGroup|Host type"
-msgstr "主機類型"
+msgid "HostFacets::Base|Boot time"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Cores"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Disks total"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Foreman instance"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Ram"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Sockets"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "HostFacets::Base|Virtual"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "HostStatus::Status|Reported at"
@@ -4160,9 +4152,6 @@ msgstr "配置範本的 ID"
 msgid "ID of domain"
 msgstr "區域的 ID"
 
-msgid "ID of environment - DEPRECATED will have no effect"
-msgstr ""
-
 msgid "ID of host"
 msgstr "主機的 ID"
 
@@ -4229,7 +4218,7 @@ msgstr ""
 msgid "ID of the Organization to register the host in."
 msgstr ""
 
-msgid "ID of the Smart Proxy"
+msgid "ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features"
 msgstr ""
 
 msgid "ID of the user"
@@ -4292,9 +4281,6 @@ msgstr "自動建議 IP 位址"
 msgid "IP addresses that should be excluded from suggestion"
 msgstr ""
 
-msgid "IP6 Address"
-msgstr ""
-
 msgid "IP:"
 msgstr "IP:"
 
@@ -4318,6 +4304,9 @@ msgstr ""
 msgid "IPv4 Subnet with associated TFTP smart proxy is required for PXE based provisioning."
 msgstr ""
 
+msgid "IPv4 address"
+msgstr ""
+
 msgid "IPv4 address of interface"
 msgstr ""
 
@@ -4336,6 +4325,9 @@ msgstr[0] ""
 msgstr[1] ""
 
 msgid "IPv6 Subnet"
+msgstr ""
+
+msgid "IPv6 address"
 msgstr ""
 
 msgid "IPv6 address of interface"
@@ -4398,13 +4390,13 @@ msgstr ""
 msgid "If you feel this is an error with Foreman itself, please open a new issue with"
 msgstr "若您認為這是 Foreman 本身的錯誤，請提交錯誤"
 
-msgid "Ignore Puppet facts for provisioning"
-msgstr "忽略 Puppet 詳情給佈建用"
-
 msgid "Ignore facts for domain"
 msgstr ""
 
 msgid "Ignore facts for operating system"
+msgstr ""
+
+msgid "Ignore interfaces facts for provisioning"
 msgstr ""
 
 msgid "Ignore interfaces with matching identifier"
@@ -4485,12 +4477,6 @@ msgstr ""
 
 msgid "Import of facts failed for host %s"
 msgstr ""
-
-msgid "Import puppet classes from puppet proxy"
-msgstr ""
-
-msgid "Import puppet classes from puppet proxy for an environment"
-msgstr "為環境由 puppet 代理伺服器匯入 puppet 類別"
 
 msgid "Imported IPv4 Subnets"
 msgstr ""
@@ -4603,6 +4589,9 @@ msgstr ""
 msgid "Installation medium configuration"
 msgstr "安裝媒介配置"
 
+msgid "Installation token lifetime"
+msgstr ""
+
 msgid "Installed"
 msgstr "已安裝"
 
@@ -4667,6 +4656,9 @@ msgid "Invalid %{assoc} selection, you must select at least one of yours and hav
 msgstr ""
 
 msgid "Invalid Google JSON key. Please verify client email & private key options are present"
+msgstr ""
+
+msgid "Invalid HTTP(S) URL"
 msgstr ""
 
 msgid "Invalid architecture '%{arch}' for '%{os}'"
@@ -4834,13 +4826,13 @@ msgstr "最新的事件"
 msgid "Launch Console"
 msgstr ""
 
-msgid "Launch loading wizard"
-msgstr ""
-
 msgid "Learn more about External authentication in the documentation."
 msgstr ""
 
 msgid "Learn more about LDAP authentication in the documentation."
+msgstr ""
+
+msgid "Legacy UI"
 msgstr ""
 
 msgid "Length"
@@ -4875,24 +4867,6 @@ msgstr "列出所有 LDAP 的認證來源"
 
 msgid "List all Personal Access Tokens for a user"
 msgstr ""
-
-msgid "List all Puppet class IDs for host"
-msgstr "列出主機的所有 Puppet 類別 ID"
-
-msgid "List all Puppet class IDs for host group"
-msgstr "列出主機群組的所有 Puppet 類別 ID"
-
-msgid "List all Puppet classes"
-msgstr "列出所有 Puppet 類別"
-
-msgid "List all Puppet classes for a host"
-msgstr "列出主機的所有 Puppet 類別"
-
-msgid "List all Puppet classes for a host group"
-msgstr "列出主機的所有 Puppet 類別"
-
-msgid "List all Puppet classes for an environment"
-msgstr "列出環境的所有 Puppet 類別"
 
 msgid "List all SSH keys for a user"
 msgstr ""
@@ -4929,9 +4903,6 @@ msgstr "列出所有運算資源"
 
 msgid "List all email notifications for a user"
 msgstr ""
-
-msgid "List all environments"
-msgstr "列出所有環境"
 
 msgid "List all external user groups for LDAP authentication source"
 msgstr "列出 LDAP 認證來源的所有外部使用者群組"
@@ -5068,9 +5039,6 @@ msgstr "列出所有角色"
 msgid "List all settings"
 msgstr "列出所有設定"
 
-msgid "List all smart class parameters"
-msgstr "列出所有智慧型類別參數"
-
 msgid "List all smart proxies"
 msgstr "列出所有智慧型代理伺服器"
 
@@ -5149,15 +5117,6 @@ msgstr "列出作業系統的開機檔案"
 msgid "List default templates combinations for an operating system"
 msgstr "列出一個作業系統的預設範本組合"
 
-msgid "List environments of Puppet class"
-msgstr "列出 Puppet 類別的環境"
-
-msgid "List environments per location"
-msgstr "列出各個位置的環境"
-
-msgid "List environments per organization"
-msgstr "列出各個組織的環境"
-
 msgid "List external authentication sources"
 msgstr ""
 
@@ -5165,6 +5124,9 @@ msgid "List external authentication sources per location"
 msgstr ""
 
 msgid "List external authentication sources per organization"
+msgstr ""
+
+msgid "List hosts forming the Foreman instance"
 msgstr ""
 
 msgid "List hosts per location"
@@ -5200,9 +5162,6 @@ msgstr ""
 msgid "List of compute profiles"
 msgstr "運算設定檔清單"
 
-msgid "List of config groups"
-msgstr "配置群組清單"
-
 msgid "List of domains"
 msgstr "區域清單"
 
@@ -5218,35 +5177,20 @@ msgstr "各個子網路中的區域之清單"
 msgid "List of email notifications"
 msgstr "電子郵件通知之清單"
 
+msgid "List of host statuses"
+msgstr ""
+
 msgid "List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output"
 msgstr ""
 
 msgid "List of hosts which answer to the provided query"
 msgstr "一列回應所提供之查詢的主機"
 
-msgid "List of override values for a specific smart class parameter"
-msgstr "特定智慧型類別參數的置換值之清單"
-
 msgid "List of realms"
 msgstr "領域清單"
 
 msgid "List of resources types that will be automatically associated"
 msgstr ""
-
-msgid "List of smart class parameters for a specific Puppet class"
-msgstr "特定 Puppet 類別的智慧型類別參數之清單"
-
-msgid "List of smart class parameters for a specific environment"
-msgstr "特定環境的智慧型類別參數之清單"
-
-msgid "List of smart class parameters for a specific environment/Puppet class combination"
-msgstr "特定環境/Puppet 類別組合的智慧型類別參數之清單"
-
-msgid "List of smart class parameters for a specific host"
-msgstr "特定主機的智慧型類別參數之清單"
-
-msgid "List of smart class parameters for a specific host group"
-msgstr "特定主機群組的智慧型類別參數之清單"
 
 msgid "List of subnets"
 msgstr "子網路清單"
@@ -5264,9 +5208,6 @@ msgid "List of table preferences for a user"
 msgstr ""
 
 msgid "List of timeouts (in seconds) for DNS lookup attempts such as the dns_lookup macro and DNS record conflict validation"
-msgstr ""
-
-msgid "List of trends counters"
 msgstr ""
 
 msgid "List of user selected columns"
@@ -5452,6 +5393,10 @@ msgid "LookupKey|Key type"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "LookupKey|Lookup values count"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "LookupKey|Merge default"
 msgstr ""
 
@@ -5500,6 +5445,9 @@ msgstr "MAC"
 
 msgid "MAC Address"
 msgstr "MAC 位址"
+
+msgid "MAC address"
+msgstr ""
 
 msgid "MAC address of interface. Required for managed interfaces on bare metal."
 msgstr "介面卡的 MAC 位址。在空機上的管理介面所需。"
@@ -5582,6 +5530,9 @@ msgstr "管理"
 msgid "Manage Bookmarks"
 msgstr "管理書籤"
 
+msgid "Manage Host's Statuses"
+msgstr ""
+
 msgid "Manage Locations"
 msgstr "管理位置"
 
@@ -5590,6 +5541,9 @@ msgstr "管理組織"
 
 msgid "Manage PuppetCA"
 msgstr "管理 PuppetCA"
+
+msgid "Manage all statuses"
+msgstr ""
 
 msgid "Manage host"
 msgstr "管理主機"
@@ -5690,10 +5644,6 @@ msgid "Message"
 msgstr "訊息"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Message|Digest"
-msgstr "摘要"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Message|Value"
 msgstr "值"
 
@@ -5711,6 +5661,9 @@ msgstr ""
 
 msgid "Metrics"
 msgstr "計量"
+
+msgid "Migrate Reports to new format"
+msgstr ""
 
 msgid "Minutes Ago"
 msgstr "幾分鐘前"
@@ -5789,6 +5742,9 @@ msgstr ""
 msgid "N/A"
 msgstr "N/A"
 
+msgid "N/A statuses"
+msgstr ""
+
 msgid "NA"
 msgstr "NA"
 
@@ -5810,7 +5766,7 @@ msgstr "媒介名稱"
 msgid "Name of the OpenID Connect Audience that is being used for Authentication. In case of Keycloak this is the Client ID."
 msgstr ""
 
-msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created (If you want to prevent the autocreation, keep unset)"
+msgid "Name of the external auth source where unknown externally authentication users (see authorize_login_delegation) should be created. Empty means no autocreation."
 msgstr ""
 
 msgid "Name of the host group"
@@ -5888,6 +5844,9 @@ msgstr "新增組織"
 msgid "New SSH key"
 msgstr ""
 
+msgid "New UI"
+msgstr ""
+
 msgid "New Virtual Machine"
 msgstr "新增虛擬機器"
 
@@ -5903,8 +5862,8 @@ msgstr ""
 msgid "New filter"
 msgstr "新增篩選器"
 
-msgid "New window"
-msgstr "新增視窗"
+msgid "New host details UI"
+msgstr ""
 
 msgid "Next"
 msgstr "下一步"
@@ -6031,6 +5990,9 @@ msgstr "沒有 TFTP 功能"
 msgid "No TFTP proxies defined, can't continue"
 msgstr "尚未定義 TFTP 協定，無法繼續"
 
+msgid "No VMs matched any host"
+msgstr ""
+
 msgid "No VMs matched any host."
 msgstr ""
 
@@ -6069,6 +6031,9 @@ msgstr "無電子郵件"
 
 msgid "No entries found"
 msgstr "找不到項目"
+
+msgid "No errors detected"
+msgstr ""
 
 msgid "No features found on this proxy, please make sure you enable at least one feature"
 msgstr "在此協定上找不到功能，請確認您啟用了至少一項功能"
@@ -6166,6 +6131,9 @@ msgstr "找不到智慧型代理伺服器。"
 msgid "No smart proxies to show"
 msgstr "沒有可顯示的智慧型代理伺服器"
 
+msgid "No statuses to show"
+msgstr ""
+
 msgid "No subnets"
 msgstr "無子網路"
 
@@ -6202,11 +6170,11 @@ msgstr "一般"
 msgid "Normally when setting up a Compute Resource, a key pair (private and public) is created for you automatically."
 msgstr ""
 
+msgid "Not Available"
+msgstr ""
+
 msgid "Not Installed"
 msgstr "未安裝"
-
-msgid "Not a valid URL for a HTTP proxy"
-msgstr ""
 
 msgid "Not implemented"
 msgstr "尚未實作"
@@ -6373,6 +6341,9 @@ msgstr ""
 msgid "OK"
 msgstr "確定"
 
+msgid "OK statuses"
+msgstr ""
+
 msgid "OS Image"
 msgstr "OS 映像檔"
 
@@ -6443,9 +6414,6 @@ msgstr "很抱歉發生了錯誤"
 
 msgid "Open"
 msgstr "開啟"
-
-msgid "Open Spice in a new window"
-msgstr "在新視窗中開啟 Spice"
 
 msgid "Open and read timeout for HTTP requests from Foreman to Smart Proxy (in seconds)"
 msgstr ""
@@ -6546,9 +6514,6 @@ msgstr ""
 msgid "Optional array of log hashes"
 msgstr "選用性的日誌雜湊陣列"
 
-msgid "Optional comma-delimited string containing either 'new', 'updated', or 'obsolete' that is used to limit the imported Puppet classes"
-msgstr "選用性的逗號分隔字串，包含了「new」、「updated」或是「obsolete」，以用來限制匯入的 Puppet 類別"
-
 msgid "Optional: Ending IP Address for IP auto suggestion"
 msgstr "選用性：IP 自動建議的結尾 IP 位址"
 
@@ -6612,9 +6577,6 @@ msgstr ""
 msgid "Override"
 msgstr "覆寫"
 
-msgid "Override Value"
-msgstr ""
-
 msgid "Override the default value of the Puppet class parameter."
 msgstr "覆寫 Puppet 類別參數的預設值。"
 
@@ -6627,8 +6589,17 @@ msgstr "概觀"
 msgid "Overwrite"
 msgstr "覆寫"
 
+msgid "Overwrite existing host (true by default)"
+msgstr ""
+
+msgid "Owned"
+msgstr ""
+
 msgid "Owned By"
 msgstr "擁有者："
+
+msgid "Owned: %s"
+msgstr ""
 
 msgid "Owner"
 msgstr "擁有者"
@@ -6712,6 +6683,10 @@ msgstr "名稱"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Parameter|Priority"
 msgstr "優先順序"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Parameter|Searchable value"
+msgstr ""
 
 msgid "Parameter|Type"
 msgstr ""
@@ -6948,9 +6923,6 @@ msgstr "請稍候，您的需求正被處理…"
 msgid "Plugins"
 msgstr "外掛"
 
-msgid "Port to connect to"
-msgstr ""
-
 msgid "Possible values"
 msgstr ""
 
@@ -6963,7 +6935,13 @@ msgstr "電源"
 msgid "Power ON this machine"
 msgstr "開啟這部機器的電源"
 
+msgid "Power Status"
+msgstr ""
+
 msgid "Power a Virtual Machine"
+msgstr ""
+
+msgid "Power has been set to \"%s\" successfully"
 msgstr ""
 
 msgid "Power operations are not enabled on this host."
@@ -7032,7 +7010,7 @@ msgstr ""
 msgid "Private"
 msgstr "私有的"
 
-msgid "Private key file that Foreman will use to encrypt websockets "
+msgid "Private key file path that Foreman will use to encrypt websockets"
 msgstr ""
 
 msgid "Proceed to Edit"
@@ -7130,6 +7108,9 @@ msgstr "代理伺服器"
 msgid "Proxy ID to use within this realm"
 msgstr ""
 
+msgid "Proxy lacks one of the following features: 'Registration', 'Templates'"
+msgstr ""
+
 msgid "Proxy reference should be { :relation => [:column_name, ...] }"
 msgstr ""
 
@@ -7178,9 +7159,6 @@ msgstr "Puppet 類別"
 msgid "Puppet error state"
 msgstr ""
 
-msgid "Puppet interval"
-msgstr "Puppet 間隔"
-
 msgid "Puppet parameter"
 msgstr "Puppet 參數"
 
@@ -7189,14 +7167,6 @@ msgstr "Puppet 代理 ID"
 
 msgid "Puppet summary"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass"
-msgstr "Puppetclass"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Puppetclass|Name"
-msgstr "名稱"
 
 msgid "Query"
 msgstr "查詢"
@@ -7272,6 +7242,9 @@ msgstr "名稱"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Realm|Realm type"
 msgstr "領域類型"
+
+msgid "Reboot"
+msgstr ""
 
 msgid "Reboot and build"
 msgstr "重新啟動與組建"
@@ -7373,12 +7346,6 @@ msgstr ""
 msgid "Remove Parameter"
 msgstr "移除參數"
 
-msgid "Remove a Puppet class from host"
-msgstr "從主機移除一個 Puppet 類別"
-
-msgid "Remove a Puppet class from host group"
-msgstr "從主機群組移除一個 Puppet 類別"
-
 msgid "Remove an email notification for a user"
 msgstr ""
 
@@ -7386,6 +7353,9 @@ msgid "Remove conflicting %{type} for %{host}"
 msgstr ""
 
 msgid "Remove tag"
+msgstr ""
+
+msgid "Remove widget"
 msgstr ""
 
 msgid "Removed %{from} to %{to}"
@@ -7470,6 +7440,9 @@ msgstr ""
 msgid "ReportTemplate|Snippet"
 msgstr ""
 
+msgid "Reported At"
+msgstr ""
+
 msgid "Reported at"
 msgstr "回報於"
 
@@ -7481,6 +7454,9 @@ msgstr ""
 
 msgid "Reports"
 msgstr "報告"
+
+msgid "Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Report|Metrics"
@@ -7523,6 +7499,9 @@ msgid "Required unless user is in an external authentication source"
 msgstr ""
 
 msgid "Required when user want to change own password"
+msgstr ""
+
+msgid "Reset"
 msgstr ""
 
 msgid "Reset PuppetCA certname for %s"
@@ -7568,6 +7547,9 @@ msgstr ""
 msgid "Resume"
 msgstr "復原"
 
+msgid "Return to last page"
+msgstr ""
+
 msgid "Returns string representing a host status of a given type"
 msgstr "傳回某個給定類型的主機狀態之字串"
 
@@ -7593,8 +7575,14 @@ msgstr ""
 msgid "Revert Local Changes"
 msgstr ""
 
+msgid "Revert template"
+msgstr ""
+
 msgid "Review"
 msgstr "檢視"
+
+msgid "Review before build"
+msgstr ""
 
 msgid "Review build status for %s"
 msgstr "檢視 %s 的組建狀態"
@@ -7603,6 +7591,9 @@ msgid "Revoke"
 msgstr "撤銷"
 
 msgid "Revoke a Personal Access Token for a user"
+msgstr ""
+
+msgid "Revoke personal access token"
 msgstr ""
 
 msgid "Revoked"
@@ -7685,6 +7676,9 @@ msgstr ""
 msgid "SMTP address"
 msgstr ""
 
+msgid "SMTP address to connect to"
+msgstr ""
+
 msgid "SMTP authentication"
 msgstr ""
 
@@ -7698,6 +7692,9 @@ msgid "SMTP password"
 msgstr ""
 
 msgid "SMTP port"
+msgstr ""
+
+msgid "SMTP port to connect to"
 msgstr ""
 
 msgid "SMTP username"
@@ -7718,14 +7715,20 @@ msgstr ""
 msgid "SSL CA file"
 msgstr "SSL CA 檔案"
 
-msgid "SSL CA file that Foreman will use to communicate with its proxies"
-msgstr "Foreman 將會使用來與其協定進行通訊的 SSL CA 檔案"
+msgid "SSL CA file not found, check the 'Server CA file' and 'SSL CA file' in Settings > Authentication"
+msgstr ""
+
+msgid "SSL CA file path that Foreman will use to communicate with its proxies"
+msgstr ""
+
+msgid "SSL CA file path that will be used in templates (to verify the connection to Foreman)"
+msgstr ""
 
 msgid "SSL Certificate path that Foreman would use to communicate with its proxies"
 msgstr "Foreman 將會使用來與其協定進行通訊的 SSL 憑證之路徑"
 
-msgid "SSL Private Key file that Foreman will use to communicate with its proxies"
-msgstr "Foreman 將會使用來與其協定進行通訊的 SSL 私密金鑰檔案"
+msgid "SSL Private Key path that Foreman will use to communicate with its proxies"
+msgstr ""
 
 msgid "SSL certificate"
 msgstr "SSL 憑證"
@@ -7773,6 +7776,9 @@ msgid "Save something and try again"
 msgstr "進行儲存並重新嘗試"
 
 msgid "Saved Bookmarks"
+msgstr ""
+
+msgid "Saved audits interval"
 msgstr ""
 
 msgid "Schedule generating of a report"
@@ -7951,6 +7957,9 @@ msgstr ""
 msgid "Sendmail location"
 msgstr ""
 
+msgid "Server CA file"
+msgstr ""
+
 msgid "Server group"
 msgstr ""
 
@@ -7981,6 +7990,9 @@ msgstr ""
 msgid "Set IP addresses for %s"
 msgstr ""
 
+msgid "Set a proxy for all outgoing HTTP(S) connections from Foreman. System-wide proxies must be configured at the operating system level."
+msgstr ""
+
 msgid "Set a randomly generated password on the VNC display connection"
 msgstr ""
 
@@ -8001,9 +8013,6 @@ msgstr "設定值解析的順序。"
 
 msgid "Set up compute instance %s"
 msgstr "設定運算事例 %s"
-
-msgid "Sets a proxy for all outgoing HTTP connections from Foreman. System-wide proxies must be configured at operating system level."
-msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Setting"
@@ -8071,6 +8080,12 @@ msgstr ""
 msgid "Setup REX"
 msgstr ""
 
+msgid "Share feedback"
+msgstr ""
+
+msgid "Share your feedback"
+msgstr ""
+
 msgid "Should the `foreman-rake db:seed` be executed on the next run of the installer modules?"
 msgstr "`foreman-rake db:seed` 是否應該在安裝程式模組下次運作時執行？"
 
@@ -8104,18 +8119,6 @@ msgstr ""
 msgid "Show a Personal Access Token for a user"
 msgstr ""
 
-msgid "Show a Puppet class"
-msgstr "顯示 Puppet 類別"
-
-msgid "Show a Puppet class for a host group"
-msgstr "顯示主機群組的 Puppet 類別"
-
-msgid "Show a Puppet class for an environment"
-msgstr "顯示環境的 Puppet 類別"
-
-msgid "Show a Puppet class for host"
-msgstr "顯示主機的 Puppet 類別"
-
 msgid "Show a bookmark"
 msgstr "顯示書籤"
 
@@ -8127,9 +8130,6 @@ msgstr "顯示運算設定檔"
 
 msgid "Show a compute resource"
 msgstr "顯示運算資源"
-
-msgid "Show a config group"
-msgstr "顯示配置群組"
 
 msgid "Show a default template combination for an operating system"
 msgstr "顯示一個作業系統的預設範本組合"
@@ -8197,17 +8197,11 @@ msgstr "顯示角色"
 msgid "Show a setting"
 msgstr "顯示設定"
 
-msgid "Show a smart class parameter"
-msgstr "顯示智慧類別參數"
-
 msgid "Show a smart proxy"
 msgstr "顯示智慧型代理伺服器"
 
 msgid "Show a subnet"
 msgstr "顯示子網路"
-
-msgid "Show a trend"
-msgstr ""
 
 msgid "Show a user"
 msgstr "顯示使用者"
@@ -8242,9 +8236,6 @@ msgstr "顯示稽核"
 msgid "Show an email notification"
 msgstr "顯示電子郵件通知"
 
-msgid "Show an environment"
-msgstr "顯示環境"
-
 msgid "Show an external authentication source"
 msgstr ""
 
@@ -8265,9 +8256,6 @@ msgstr ""
 
 msgid "Show an operating system"
 msgstr "顯示作業系統"
-
-msgid "Show an override value for a specific smart class parameter"
-msgstr "顯示特定智慧類別參數的置換值"
 
 msgid "Show available API links"
 msgstr "顯示可用的 API 連結"
@@ -8350,9 +8338,6 @@ msgstr "已跳過"
 msgid "Skipped|S"
 msgstr "S"
 
-msgid "Smart Class Parameter"
-msgstr "智慧類別參數"
-
 msgid "Smart Class Parameters"
 msgstr ""
 
@@ -8420,6 +8405,9 @@ msgstr "一些介面不合規定"
 msgid "Some of the interfaces are invalid. Please check the table below."
 msgstr "部分介面卡無法使用。請檢查下列表格。"
 
+msgid "Something went wrong"
+msgstr ""
+
 msgid "Something went wrong while changing host type - %s"
 msgstr "更改主機類型時發生了錯誤 - %s"
 
@@ -8443,10 +8431,6 @@ msgid "Source"
 msgstr "來源"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Source|Digest"
-msgstr "摘要"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Source|Value"
 msgstr "值"
 
@@ -8468,7 +8452,7 @@ msgstr ""
 msgid "Specify Matchers"
 msgstr ""
 
-msgid "Specify additional options to sendmail"
+msgid "Specify additional options to sendmail. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "Specify authentication type, if required"
@@ -8512,8 +8496,8 @@ msgstr "狀態"
 msgid "Status %s does not exist."
 msgstr ""
 
-msgid "Stop updating IP address and MAC values from Puppet facts (affects all interfaces)"
-msgstr "停止從 Puppet 詳情更新 IP 位址和 MAC 的值（影響所有介面）"
+msgid "Stop updating IP and MAC address values from facts (affects all interfaces)"
+msgstr ""
 
 msgid "Stop updating Operating System from facts"
 msgstr ""
@@ -8609,6 +8593,10 @@ msgid "Subnet|Dns secondary"
 msgstr "DNS 次要"
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Externalipam group"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|From"
 msgstr "從"
 
@@ -8635,6 +8623,10 @@ msgstr "名稱"
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Network"
 msgstr "網路"
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Subnet|Nic delay"
+msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Subnet|Priority"
@@ -8707,6 +8699,12 @@ msgstr ""
 
 msgid "Supported Formats"
 msgstr "格式"
+
+msgid "Switch to previous version"
+msgstr ""
+
+msgid "Switch to the new host details UI"
+msgstr ""
 
 msgid "Synchronize group from authentication source"
 msgstr "從認證來源同步群組"
@@ -8865,11 +8863,19 @@ msgid "TemplateInput|Advanced"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Default"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "TemplateInput|Fact name"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "TemplateInput|Hidden value"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
@@ -8939,6 +8945,10 @@ msgid "Template|Default"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "Template|Description"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "Template|Locked"
 msgstr ""
 
@@ -8989,7 +8999,7 @@ msgstr "測試電子郵件"
 msgid "Tester"
 msgstr ""
 
-msgid "Text to be shown in the login-page footer"
+msgid "Text to be shown in the login-page footer. Keyword $VERSION is replaced by current version."
 msgstr ""
 
 msgid "The %{proxy_type} proxy could not be set for host: %{host_names}."
@@ -9135,7 +9145,7 @@ msgstr ""
 msgid "The information from above can be used e.g. to create a NetworkManager configuration file for each interface in the provisioning template."
 msgstr ""
 
-msgid "The instance title is shown on the top navigation bar (requires reload of page)."
+msgid "The instance title is shown on the top navigation bar (requires a page reload)."
 msgstr ""
 
 msgid "The iss (issuer) claim identifies the principal that issued the JWT, which exists at a `/.well-known/openid-configuration` in case of most of the OpenID providers."
@@ -9152,7 +9162,7 @@ msgid_plural "The list is excluding %{count} %{link_start}physical hosts%{link_e
 msgstr[0] ""
 msgstr[1] ""
 
-msgid "The location of the sendmail executable"
+msgid "The location of the sendmail executable. Only used when the delivery method is set to sendmail."
 msgstr ""
 
 msgid "The marked fields will need reviewing"
@@ -9182,9 +9192,6 @@ msgstr ""
 
 msgid "The power state of the selected hosts will be set to %s"
 msgstr "所選主機的電源狀態會被設定為 %s"
-
-msgid "The puppetrun feature has been removed, however you can use the Remote Execution Plugin to run Puppet commands"
-msgstr ""
 
 msgid "The realm name, e.g. EXAMPLE.COM"
 msgstr "領域名稱，例如 EXAMPLE.COM"
@@ -9246,6 +9253,9 @@ msgid "There may be more information in the server's logs."
 msgstr ""
 
 msgid "There must be at least one Smart Proxy present with an External IPAM plugin installed and configured"
+msgstr ""
+
+msgid "There was a problem processing the request. Please try again."
 msgstr ""
 
 msgid "There was an error creating the PXE file: %s"
@@ -9373,7 +9383,7 @@ msgstr ""
 msgid "This value is used also as the host's primary interface name."
 msgstr "這個值也用於主機的主介面名稱。"
 
-msgid "This will be one of our coolest pages."
+msgid "This will change the host power status, are you sure?"
 msgstr ""
 
 msgid "This will generate a report %s. Based on its definition, it can take a long time to process."
@@ -9398,15 +9408,6 @@ msgid "Timezone to use for new users"
 msgstr ""
 
 msgid "To access %s API, you need to install the Foreman Puppet plugin"
-msgstr ""
-
-msgid "To access /statistics API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access /trends API you need to install Foreman Statistics plugin"
-msgstr ""
-
-msgid "To access import_puppetclasses API you need to install the Foreman Puppet plugin"
 msgstr ""
 
 msgid "To change the default behavior, modify the enclosing mark with <code>-&#37;></code>:"
@@ -9438,9 +9439,6 @@ msgstr "權杖"
 
 msgid "Token Expiry"
 msgstr ""
-
-msgid "Token duration"
-msgstr "權杖持續時間"
 
 msgid "Token expired"
 msgstr ""
@@ -9479,41 +9477,8 @@ msgid_plural "Total of %{hosts} hosts"
 msgstr[0] ""
 msgstr[1] ""
 
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend"
-msgstr "趨勢"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend counter"
-msgstr "趨勢計數器"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Count"
-msgstr "計數"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval end"
+msgid "Total: %s"
 msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "TrendCounter|Interval start"
-msgstr ""
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact name"
-msgstr "詳情名稱"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Fact value"
-msgstr "詳情值"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Name"
-msgstr "名稱"
-
-#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
-msgid "Trend|Trendable type"
-msgstr "趨勢類型"
 
 msgid "True/False flag whether a host is managed or unmanaged. Note: this value also determines whether several parameters are required or not"
 msgstr "True/False 標記代表主機是否受管理。請注意：這個值也能決定是否需要數個參數"
@@ -9794,6 +9759,12 @@ msgstr "websockets_encrypt 開啟時，無法取消設定 websockets_ssl_key"
 msgid "Unallowed template for dashboard widget: %s"
 msgstr "未經允許的面板小工具範本：%s"
 
+msgid "Unassign a given host from the Foreman instance"
+msgstr ""
+
+msgid "Unassign a given host from the smart proxy"
+msgstr ""
+
 msgid "Unattended URL"
 msgstr "無人看顧的 URL"
 
@@ -9851,6 +9822,9 @@ msgstr ""
 msgid "Unknown status: %s"
 msgstr ""
 
+msgid "Unkown '%{klass}' resource class"
+msgstr ""
+
 msgid "Unlock"
 msgstr "解鎖"
 
@@ -9878,9 +9852,6 @@ msgstr "更新一項資源(_R)"
 msgid "Update IP from built request"
 msgstr "從建立需求更新 IP"
 
-msgid "Update a Puppet class"
-msgstr "更新 Puppet 類別"
-
 msgid "Update a bookmark"
 msgstr "更新書籤"
 
@@ -9892,9 +9863,6 @@ msgstr "更新運算設定檔"
 
 msgid "Update a compute resource"
 msgstr "更新運算資源"
-
-msgid "Update a config group"
-msgstr "更新配置群組"
 
 msgid "Update a default template combination for an operating system"
 msgstr "更新作業系統的預設範本組合"
@@ -9962,9 +9930,6 @@ msgstr "更新角色"
 msgid "Update a setting"
 msgstr "更新設定"
 
-msgid "Update a smart class parameter"
-msgstr "更新智慧類別參數"
-
 msgid "Update a smart proxy"
 msgstr "更新智慧型代理伺服器"
 
@@ -9995,9 +9960,6 @@ msgstr "更新架構"
 msgid "Update an email notification for a user"
 msgstr ""
 
-msgid "Update an environment"
-msgstr "更新環境"
-
 msgid "Update an external authentication source"
 msgstr ""
 
@@ -10006,12 +9968,6 @@ msgstr "更新映像檔"
 
 msgid "Update an operating system"
 msgstr "更新作業系統"
-
-msgid "Update an override value for a specific smart class parameter"
-msgstr "更新特定智慧類別參數的置換值"
-
-msgid "Update environment from facts"
-msgstr "從詳情升級環境"
 
 msgid "Update external user group"
 msgstr "更新外部使用者群組"
@@ -10248,6 +10204,10 @@ msgid "User|Description"
 msgstr ""
 
 #. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
+msgid "User|Disabled"
+msgstr ""
+
+#. TRANSLATORS: "Table name" or "Table name|Column name" for error messages
 msgid "User|Firstname"
 msgstr "名"
 
@@ -10384,7 +10344,7 @@ msgstr "變數"
 msgid "Variables"
 msgstr "變數"
 
-msgid "Vendor Class"
+msgid "Vendor class"
 msgstr ""
 
 msgid "Verify"
@@ -10447,6 +10407,9 @@ msgstr "等待 %s 上線"
 msgid "Warning"
 msgstr "警告"
 
+msgid "Warning statuses"
+msgstr ""
+
 msgid "Warning!"
 msgstr "警告！"
 
@@ -10507,6 +10470,9 @@ msgid ""
 "When editing a template, you must assign a list \\\n"
 "of operating systems which this template can be used with. Optionally, you can \\\n"
 "restrict a template to a list of host groups."
+msgstr ""
+
+msgid "When enabled, Foreman will map users by username in request-header. If this is disabled, OAuth requests will have admin rights."
 msgstr ""
 
 msgid ""
@@ -10630,6 +10596,9 @@ msgstr ""
 
 msgid "You are about to change the default PXE menu on all configured TFTP servers - continue?"
 msgstr "您即將在所有已配置的 TFTP 伺服器上更改預設的 PXE 選單 - 是否繼續？"
+
+msgid "You are about to clear %s status. Are you sure?"
+msgstr ""
 
 msgid "You are about to delete %s. Are you sure?"
 msgstr ""
@@ -10784,6 +10753,9 @@ msgstr "全部"
 msgid "already exists"
 msgstr "已存在"
 
+msgid "an error occurred: %s"
+msgstr ""
+
 msgid "an organization"
 msgstr "組織"
 
@@ -10795,9 +10767,6 @@ msgstr "陣列"
 
 msgid "auxiliary field"
 msgstr ""
-
-msgid "belongs to config group"
-msgstr "屬於配置群組"
 
 msgid "boolean"
 msgstr "布林值"
@@ -10978,9 +10947,6 @@ msgstr ""
 
 msgid "enabled"
 msgstr ""
-
-msgid "environment id"
-msgstr "環境 ID"
 
 msgid "expected a value of type %s"
 msgstr ""
@@ -11230,8 +11196,7 @@ msgstr "將外部使用者群組連上這個使用者群組"
 msgid "list"
 msgstr "清單"
 
-#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead
-#. of German)
+#. TRANSLATORS: Provide locale name in native language (e.g. Deutsch instead of German)
 msgid "locale_name"
 msgstr "locale_name"
 
@@ -11411,12 +11376,6 @@ msgstr "實體 @ NAT %s"
 
 msgid "physical @ bridge %s"
 msgstr "實體 @ 橋接器 %s"
-
-msgid "plugin action 1"
-msgstr ""
-
-msgid "plugin action 2"
-msgstr ""
 
 msgid "power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)"
 msgstr "電源動作，有效的動作為（on/start）、（off/stop）、（soft/reboot）、（cycle/reset）、（state/status）"


### PR DESCRIPTION
```js
const test1 = __(
'test'
);
const test2 = __('test');
```
test1 won't be extracted test2 would be.
Only in JS.
There is a fix for it `gettext_i18n_rails_js` master, but no gem is published with this fix.