### PR TITLE
Refs #33968 - Fix the fix of Telemetry initializers

### DIFF
--- a/config/initializers/5_telemetry.rb
+++ b/config/initializers/5_telemetry.rb
@@ -1,4 +1,3 @@
-require 'foreman/telemetry'
 # Foreman telemetry metrics registration.
 #
 # There are three types of telemetry measurements: counter, gauge, histogram. Each measurement has unique name
@@ -8,6 +7,17 @@ require 'foreman/telemetry'
 # Plugins can add own metrics through add_counter_telemetry, add_gauge_telemetry and add_histogram_telemetry.
 #
 telemetry = Foreman::Telemetry.instance
+
+# Foreman telemetry global setup.
+if SETTINGS[:telemetry] && (Rails.env.production? || Rails.env.development?)
+  telemetry.setup(SETTINGS[:telemetry])
+end
+
+# Register Rails notifications metrics
+telemetry.register_rails
+
+# Register Ruby VM metrics
+telemetry.register_ruby
 
 telemetry.add_counter(:http_requests, 'A counter of HTTP requests made', [:controller, :action, :status])
 telemetry.add_histogram(:http_request_total_duration, 'Total duration of controller action', [:controller, :action])
@@ -103,14 +113,3 @@ allowed_labels = {
   ],
 }
 telemetry.add_allowed_tags!(allowed_labels)
-
-# Foreman telemetry global setup.
-if SETTINGS[:telemetry] && (Rails.env.production? || Rails.env.development?)
-  telemetry.setup(SETTINGS[:telemetry])
-end
-
-# Register Rails notifications metrics
-telemetry.register_rails
-
-# Register Ruby VM metrics
-telemetry.register_ruby

--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -1,11 +1,6 @@
 require 'singleton'
 require 'forwardable'
 
-require 'foreman/telemetry_sinks/metric_exporter_sink'
-require 'foreman/telemetry_sinks/prometheus_sink'
-require 'foreman/telemetry_sinks/rails_logger_sink'
-require 'foreman/telemetry_sinks/statsd_sink'
-
 module Foreman
   class Telemetry
     include Singleton


### PR DESCRIPTION
This fixes regression introduced by: https://github.com/theforeman/foreman/pull/8940

I think what was the culprit of the issue was `module Foreman::Telemetry`. The patch fixed this, but then it moved initializers around so it did not work actually. After I moved things into proper order, I got the very same constant warning. Only after I removed the explicit requires the RoR autoloader started picking those up correctly.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->