### PR TITLE
Fixes #34085 - fix 'all audits' link in host page

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -110,7 +110,7 @@ class HostJSTest < IntegrationTestWithJavascript
     test "all audit redirect to audit page" do
       visit host_details_page_path(@host)
       find('a', :text => /All audits/).click
-      assert_current_path audits_path
+      assert_current_path audits_path(search: "host=#{@host.fqdn}")
     end
 
     test "manage host statuses modal" do

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Audits/index.js
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useDispatch } from 'react-redux';
 import {
   Bullseye,
   DataList,
@@ -16,6 +17,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import URI from 'urijs';
+import { push } from 'connected-react-router';
 
 import { foremanUrl } from '../../../common/helpers';
 import { translate as __ } from '../../../common/I18n';
@@ -23,19 +25,18 @@ import { useAPI } from '../../../common/hooks/API/APIHooks';
 import RelativeDateTime from '../../common/dates/RelativeDateTime';
 import SkeletonLoader from '../../common/SkeletonLoader';
 import { STATUS } from '../../../constants';
-import { pushUrl } from '../../../../foreman_navigation';
 
 const NUMBER_OF_RECORDS = 3;
-const BASE_URL = '/audits';
 
 const AuditCard = ({ hostName }) => {
+  const dispatch = useDispatch();
   const hostSearch = `host=${hostName}`;
   const apiUrl = new URI({
-    path: foremanUrl(`/api/${BASE_URL}`),
+    path: foremanUrl('/api/audits'),
     query: { search: hostSearch, per_page: NUMBER_OF_RECORDS },
   }).toString();
   const uiUrl = new URI({
-    path: foremanUrl(BASE_URL),
+    path: foremanUrl('/audits'),
     query: { search: hostSearch },
   }).toString();
   const {
@@ -47,7 +48,7 @@ const AuditCard = ({ hostName }) => {
       <CardHeader>
         <CardTitle>{__('Recent Audits')}</CardTitle>
         <CardActions>
-          <a onClick={() => pushUrl(uiUrl)}> {__('All audits')}</a>
+          <a onClick={() => dispatch(push(uiUrl))}> {__('All audits')}</a>
         </CardActions>
       </CardHeader>
       <CardBody>


### PR DESCRIPTION
the "All audits" link redirects to the audits index page without hostname in the search query