### PR TITLE
Fixes #34086 - explicitly configure the resolveLoader

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -147,6 +147,10 @@ module.exports = env => {
       ),
     },
 
+    resolveLoader: {
+      modules: resolveModules,
+    },
+
     module: {
       rules: [
         {


### PR DESCRIPTION
The webpack documentation says:

> This set of options is identical to the resolve property set above,
> but is used only to resolve webpack's loader packages.

So one might assume, it inherits stuff from the `resolve` config, but it
doesn't. And if we don't configure the plugins `node_modules` here,
webpack will fail to find loaders that are only present in module
dependencies, breaking production builds.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
