### PR TITLE
Fixes #34091 - logging helper method how_duration

### DIFF
--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -117,6 +117,20 @@ module Foreman
       contents
     end
 
+    # Helper method useful for investigation when some code portions are slow.
+    # Logs a message into WARN app logger with log_duration tag for easier
+    # grepping. Only use for ad-hoc code investigation. For long-term
+    # performance metrics, use the Telemetry API. On Rails 7+ consider
+    # using Rails.benchmark instead of this method.
+    def log_duration(message)
+      before = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+    ensure
+      after = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      duration = ((after - before) * 1000).round(4)
+      Rails.logger.warn("log_duration: #{message}: #{duration} ms")
+    end
+
     private
 
     def load_config(environment, overrides = {})


### PR DESCRIPTION
Finding out when something is slow is error-prone. We should have a helper available to easily log how long a block took for ad-hoc investigations. This is not meant for long-term use, use Telemetry API for that.

The context: https://community.theforeman.org/t/high-memory-usage-of-foreman-2-5-4/26410

Please test it before merging.