### PR TITLE
Fixes #34093 - Don't eager load all authorized resources 

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -109,10 +109,11 @@ module HostStatus
     end
 
     def status_link
-      return nil if last_report.nil?
-      return nil unless User.current.can?(:view_config_reports, last_report)
+      return @config_status_link if defined?(@config_status_link)
+      return @config_status_link = nil if last_report.nil?
+      return @config_status_link = nil unless User.current.can?(:view_config_reports, last_report, false)
 
-      last_report && Rails.application.routes.url_helpers.config_report_path(last_report)
+      @config_status_link = last_report && Rails.application.routes.url_helpers.config_report_path(last_report)
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,6 +175,7 @@ class User < ApplicationRecord
     end
   end
 
+  # See Authorizer#can? for parameter documentation
   def can?(permission, subject = nil, cache = true)
     if admin?
       true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,12 +175,12 @@ class User < ApplicationRecord
     end
   end
 
-  def can?(permission, subject = nil)
+  def can?(permission, subject = nil, cache = true)
     if admin?
       true
     else
       @authorizer ||= Authorizer.new(self)
-      @authorizer.can?(permission, subject)
+      @authorizer.can?(permission, subject, cache)
     end
   end
 

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -10,6 +10,13 @@ class Authorizer
     @base_collection = options.delete(:collection)
   end
 
+  # Check if the current user has a specific permission on the subject.
+  # First parameter is the permission to check.
+  # Second parameter is the subject record which must have an id field.
+  # If subject is not passed, this method checks if the user has the given permission.
+  # Third parameter is if the allowed resources for the permission should be cached.
+  # This is useful if we need to check multiple subjects against the same permission.
+  # Caching increases memory load and should be avoided for resources that could have millions of records.
   def can?(permission, subject = nil, cache = true)
     return false if user.nil? || user.disabled?
     return true if user.admin?

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -15,12 +15,12 @@ class Authorizer
     return true if user.admin?
 
     if subject.nil?
-      user.permissions.where(:name => permission).present?
+      user.permissions.exists?(:name => permission)
     else
       return collection_cache_lookup(subject, permission) if cache
 
       find_collection(subject.class, :permission => permission).
-        where(:id => subject.id).any?
+        exists?(subject.id)
     end
   end
 

--- a/app/services/authorizer_cache.rb
+++ b/app/services/authorizer_cache.rb
@@ -7,8 +7,8 @@ module AuthorizerCache
 
   def collection_cache_lookup(subject, permission)
     collection = @cache[subject.class.to_s][permission] ||=
-      find_collection(subject.class, :permission => permission)
+      find_collection(subject.class, :permission => permission).pluck(:id)
 
-    collection.include?(subject)
+    collection.include?(subject.id)
   end
 end

--- a/app/services/authorizer_cache.rb
+++ b/app/services/authorizer_cache.rb
@@ -1,12 +1,12 @@
 module AuthorizerCache
   def initialize_cache
-    @cache = HashWithIndifferentAccess.new do |h, k|
-      h[k] = HashWithIndifferentAccess.new
+    @cache = Hash.new do |h, k|
+      h[k] = {}
     end
   end
 
   def collection_cache_lookup(subject, permission)
-    collection = @cache[subject.class.to_s][permission] ||=
+    collection = @cache[subject.class.to_s][permission.to_s] ||=
       find_collection(subject.class, :permission => permission).pluck(:id)
 
     collection.include?(subject.id)

--- a/app/services/authorizer_cache.rb
+++ b/app/services/authorizer_cache.rb
@@ -1,14 +1,23 @@
 module AuthorizerCache
   def initialize_cache
-    @cache = Hash.new do |h, k|
-      h[k] = {}
-    end
+    @cache = {}
   end
 
   def collection_cache_lookup(subject, permission)
-    collection = @cache[subject.class.to_s][permission.to_s] ||=
-      find_collection(subject.class, :permission => permission).pluck(:id)
+    collection = @cache[cache_key(subject, permission)] || fetch_collection(subject, permission)
 
     collection.include?(subject.id)
+  end
+
+  private
+
+  def fetch_collection(subject, permission)
+    collection = @cache[cache_key(subject, permission)] = find_collection(subject.class, :permission => permission).pluck(:id)
+    Rails.logger.info("Loaded #{collection.size} #{subject.class} records into authorization cache for permission #{permission}, consider skipping caching for this check.") if collection.size > 100000
+    collection
+  end
+
+  def cache_key(subject, permission)
+    "#{subject.class}/#{permission}"
   end
 end

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -177,14 +177,7 @@ class AuthorizerTest < ActiveSupport::TestCase
 
             auth = Authorizer.new(@user)
 
-            domains_collection = [domain1]
-            domains_collection.stubs(:where).
-              with(:id => domain1.id).returns([domain1])
-            domains_collection.stubs(:where).
-              with(:id => domain2.id).returns([])
-            domains_collection.stubs(:where).
-              with(:id => architecture.id).returns([])
-            auth.stubs(:find_collection).returns(domains_collection).
+            auth.stubs(:find_collection).returns(Domain.where(id: domain1.id)).
               times(cache ? 3 : 6)
             assert auth.can?(:view_domain, domain1, cache)
             refute auth.can?('view_domain', domain2, cache)


### PR DESCRIPTION
The authorizer cache currently loads all permitted resources to memory
when `.includes?` is called just to check if one resource is in the
list. This can get very heavy when authorizing resources that have many
records, for example ConfigReports.
Instead of loading the whole scope to memory, we use a fast SQL query
to check for the specific subject's inclusion in the authorized scope.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
