### PR TITLE
Refs #26968 - don't disable Katellos MeantimeReporter

### DIFF
--- a/lib/tasks/jenkins.rake
+++ b/lib/tasks/jenkins.rake
@@ -9,10 +9,7 @@ begin
     task :units => ["jenkins:setup:minitest", 'rake:test:units']
 
     namespace :setup do
-      task :pre_ci do
-        ENV['USE_MEAN_TIME_REPORTER'] = '0'
-      end
-      minitest_plugins = [:pre_ci]
+      minitest_plugins = []
       minitest_plugins << 'robottelo:setup:minitest' if ENV['GENERATE_ROBOTTELO_REPORT'] == 'true'
       task :minitest => minitest_plugins
     end


### PR DESCRIPTION
katello dropped the relevant code, relying on our implementation now

look @ezr-ondrej, I DIDN'T FORGET ;)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
