### PR TITLE
Refs #10413 - Deprecate setting unattended: false

### DIFF
--- a/config/initializers/deprecations.rb
+++ b/config/initializers/deprecations.rb
@@ -1,1 +1,28 @@
 ActiveSupport::Deprecation.behavior = :silence if Rails.env.production?
+
+Foreman::Application.configure do |app|
+  config.after_initialize do
+    next if Foreman.in_rake?
+    next unless Rails.env.production?
+    next if SETTINGS[:unattended]
+    blueprint = NotificationBlueprint.find_by_name('feature_deprecation')
+    next unless blueprint
+    message = UINotifications::StringParser.new(blueprint.message, {feature: 'Setting ":unattended: false" in settings.yaml', version: '3.3'}).to_s
+    next if blueprint.notifications.where(message: message).any?
+    Notification.create!(
+      audience: Notification::AUDIENCE_ADMIN,
+      message: message,
+      notification_blueprint: blueprint,
+      initiator: User.anonymous_admin,
+      actions: {
+        links: [
+          {
+            href: 'https://community.theforeman.org/t/rfc-remove-unattended-setting/10035',
+            title: _('Further Information'),
+            external: true,
+          },
+        ],
+      }
+    )
+  end
+end


### PR DESCRIPTION
This setting is rarely used and complicates the code quite a lot. With
the introduction of host registration, there is a path for any remaining
users who had been using Foreman only for inventory to add their hosts.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
