### PR TITLE
Fixes #34086 - explicitly depend on graphql-tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@theforeman/vendor": "^8.16.0",
+    "graphql-tag": "^2.11.0",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "react-intl": "^2.8.0"
@@ -47,6 +48,7 @@
     "expose-loader": "~0.6.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.9.0",
+    "graphql": "^15.5.0",
     "highlight.js": "~9.14.0",
     "node-sass": "^4.5.0",
     "optimize-css-assets-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
We configure the graphql-tag loader in webpack, but didn't depend on it
in the past, which made builds using the loader (like REX plugin) fail.

Also adding `graphql` itself, as this is needed *by* the loader when
building stuff.

(cherry picked from commit 4f0ced0e7966a416f02aedc2f46e2a8a36ea9236)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
