### PR TITLE
Fixes #31425 - Render statuses

### DIFF
--- a/app/controllers/api/v2/render_statuses_controller.rb
+++ b/app/controllers/api/v2/render_statuses_controller.rb
@@ -1,0 +1,19 @@
+module Api
+  module V2
+    class RenderStatusesController < V2::BaseController
+      api :GET, "/hosts/:host_id/render_statuses/", N_("List all render statuses for a given host")
+      api :GET, "/hostgroups/:host_id/render_statuses/", N_("List all render statuses for a given hostgroup")
+      api :GET, "/provisioning_templates/:provisioning_template_id/render_statuses/", N_("List all render statuses for a given provisioning template")
+
+      param :host_id, :identifier, desc: N_("ID of host")
+      param :hostgroup_id, :identifier, desc: N_("ID of hostgroup")
+      param :provisioning_template_id, :identifier, desc: N_("ID of provisioning template")
+      param_group :search_and_pagination, ::Api::V2::BaseController
+      add_scoped_search_description_for(RenderStatus)
+
+      def index
+        @render_statuses = resource_scope_for_index.includes(:host, :hostgroup, :provisioning_template)
+      end
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -33,6 +33,8 @@ class Host::Managed < Host::Base
   has_one :build_status_object, :class_name => 'HostStatus::BuildStatus', :foreign_key => 'host_id'
   before_destroy :remove_reports
 
+  has_many :render_statuses, foreign_key: :host_id, inverse_of: :host, dependent: :destroy, autosave: true
+
   def self.complete_for(query, opts = {})
     matcher = /(\s*(?:(?:user\.[a-z]+)|owner)\s*[=~])\s*(\S*)\s*\z/
     matches = matcher.match(query)

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -35,6 +35,8 @@ class Hostgroup < ApplicationRecord
   has_many :template_combinations, :dependent => :destroy
   has_many :provisioning_templates, :through => :template_combinations
 
+  has_many :render_statuses, inverse_of: :hostgroup, dependent: :destroy, autosave: true
+
   belongs_to :domain
   belongs_to :subnet
   belongs_to :subnet6, :class_name => "Subnet"

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -29,6 +29,9 @@ class ProvisioningTemplate < Template
     :reject_if => :reject_template_combination_attributes?
   has_and_belongs_to_many :operatingsystems, :join_table => :operatingsystems_provisioning_templates, :association_foreign_key => :operatingsystem_id, :foreign_key => :provisioning_template_id
   has_many :os_default_templates
+
+  has_many :render_statuses, foreign_key: :template_id, inverse_of: :provisioning_template, dependent: :destroy
+
   before_save :check_for_snippet_assoications
 
   validate :no_os_for_registration
@@ -231,6 +234,10 @@ class ProvisioningTemplate < Template
 
   def host_init_config_template?
     try(:template_kind)&.name == 'host_init_config'
+  end
+
+  def render_statuses_enabled?
+    !snippet?
   end
 
   private

--- a/app/models/render_status.rb
+++ b/app/models/render_status.rb
@@ -1,0 +1,24 @@
+class RenderStatus < ApplicationRecord
+  include Authorizable
+
+  belongs_to :host, class_name: 'Host::Managed'
+  belongs_to :hostgroup
+  belongs_to :provisioning_template, foreign_key: :template_id
+
+  validate :host_or_hostgroup_presence
+  validates :host, uniqueness: { scope: [:provisioning_template, :safemode] }
+  validates :hostgroup, uniqueness: { scope: [:provisioning_template, :safemode] }
+  validates :provisioning_template, presence: true
+  validates :safemode, inclusion: [true, false]
+  validates :success, inclusion: [true, false]
+
+  scoped_search on: :updated_at, default_order: :asc
+  scoped_search on: :safemode
+
+  private
+
+  def host_or_hostgroup_presence
+    errors.add(:base, "can only have host or hostgroup") if host.present? && hostgroup.present?
+    errors.add(:base, "host or hostgroup is required") if host.blank? && hostgroup.blank?
+  end
+end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -221,6 +221,10 @@ class Template < ApplicationRecord
     false
   end
 
+  def render_statuses_enabled?
+    false
+  end
+
   private
 
   # This method can be overridden in Template children classes to import additional attributes

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -635,6 +635,11 @@ Foreman::AccessControl.map do |permission_set|
       :"api/v2/personal_access_tokens" => [:destroy]
   end
 
+  permission_set.security_block :render_statuses do |map|
+    map.permission :view_render_statuses,
+      :"api/v2/render_statuses" => [:index]
+  end
+
   permission_set.security_block :settings do |map|
     map.permission :view_settings, { :settings => [:index, :show, :auto_complete_search],
                                      :'api/v2/settings' => [:index, :show] }

--- a/app/services/foreman/renderer/render_status_service.rb
+++ b/app/services/foreman/renderer/render_status_service.rb
@@ -1,0 +1,59 @@
+module Foreman
+  module Renderer
+    class RenderStatusService
+      def self.success(host:, provisioning_template:, safemode:)
+        call(host, provisioning_template, safemode, true)
+      end
+
+      def self.error(host:, provisioning_template:, safemode:)
+        call(host, provisioning_template, safemode, false)
+      end
+
+      def self.call(host, provisioning_template, safemode, success)
+        return unless host
+
+        klass = host.persisted? ? ExistingHostService : NewHostService
+        klass.new(host, provisioning_template, safemode, success).call
+      end
+
+      class BaseService
+        def initialize(host, provisioning_template, safemode, success)
+          @host = host
+          @provisioning_template = provisioning_template
+          @safemode = safemode
+          @success = success
+        end
+
+        private
+
+        attr_reader :host, :provisioning_template, :safemode, :success
+        delegate :render_statuses, to: :host
+        delegate :id, to: :provisioning_template, prefix: true
+      end
+
+      class ExistingHostService < BaseService
+        def call
+          render_statuses.find_or_initialize_by(provisioning_template: provisioning_template, safemode: safemode)
+                         .update(success: success)
+        end
+      end
+
+      class NewHostService < BaseService
+        def call
+          update || create
+        end
+
+        private
+
+        def update
+          render_statuses.find { |status| status.template_id == provisioning_template_id && status.safemode == safemode }
+                         .tap { |status| status&.assign_attributes(success: success) }
+        end
+
+        def create
+          render_statuses.new(provisioning_template: provisioning_template, safemode: safemode, success: success)
+        end
+      end
+    end
+  end
+end

--- a/app/services/foreman/renderer/safe_mode_renderer.rb
+++ b/app/services/foreman/renderer/safe_mode_renderer.rb
@@ -1,6 +1,8 @@
 module Foreman
   module Renderer
     class SafeModeRenderer < BaseRenderer
+      SAFEMODE = true
+
       def render
         box = Safemode::Box.new(scope, allowed_helpers, source_name)
         erb = ERB.new(source_content, trim_mode: '-')

--- a/app/services/foreman/renderer/unsafe_mode_renderer.rb
+++ b/app/services/foreman/renderer/unsafe_mode_renderer.rb
@@ -1,6 +1,8 @@
 module Foreman
   module Renderer
     class UnsafeModeRenderer < BaseRenderer
+      SAFEMODE = false
+
       def render
         erb = ERB.new(source_content, trim_mode: '-')
         erb.location = source_name, 0

--- a/app/views/api/v2/render_statuses/base.json.rabl
+++ b/app/views/api/v2/render_statuses/base.json.rabl
@@ -1,0 +1,3 @@
+object @render_status
+
+attributes :id

--- a/app/views/api/v2/render_statuses/index.json.rabl
+++ b/app/views/api/v2/render_statuses/index.json.rabl
@@ -1,0 +1,3 @@
+collection @render_statuses
+
+extends "api/v2/render_statuses/main"

--- a/app/views/api/v2/render_statuses/main.json.rabl
+++ b/app/views/api/v2/render_statuses/main.json.rabl
@@ -1,0 +1,29 @@
+object @render_status
+
+extends "api/v2/render_statuses/base"
+
+attributes :safemode, :success, :created_at, :updated_at
+
+child :host do
+  attributes :id, :name
+  node :path do |host|
+    path = host_details_page_path(host)
+    User.current.allowed_to?(path) ? path : nil
+  end
+end
+
+child :hostgroup do
+  attributes :id, :name
+  node :path do |hostgroup|
+    path = edit_hostgroup_path(hostgroup)
+    User.current.allowed_to?(path) ? path : nil
+  end
+end
+
+child :provisioning_template do
+  attributes :id, :name
+  node :path do |provisioning_template|
+    path = edit_provisioning_template_path(provisioning_template)
+    User.current.allowed_to?(path) ? path : nil
+  end
+end

--- a/app/views/provisioning_templates/_custom_tab_headers.html.erb
+++ b/app/views/provisioning_templates/_custom_tab_headers.html.erb
@@ -1,2 +1,5 @@
 <li><a href="#template_type" data-toggle="tab"><%= _("Type") %></a></li>
 <li><a href="#template_associations" data-toggle="tab"><%= _("Association") %></a></li>
+<% if @template.render_statuses_enabled? %>
+  <li><a href="#render_statuses" data-toggle="tab"><%= _("Render Statuses") %></a></li>
+<% end %>

--- a/app/views/provisioning_templates/_custom_tabs.html.erb
+++ b/app/views/provisioning_templates/_custom_tabs.html.erb
@@ -17,3 +17,9 @@
     <%= render "provisioning_templates/combinations", :f => f %>
   </div>
 </div>
+
+<% if @template.render_statuses_enabled? %>
+  <div class="tab-pane" id="render_statuses">
+    <%= render "provisioning_templates/render_statuses" %>
+  </div>
+<% end %>

--- a/app/views/provisioning_templates/_render_statuses.html.erb
+++ b/app/views/provisioning_templates/_render_statuses.html.erb
@@ -1,0 +1,1 @@
+<%= react_component('RenderStatuses', { path: api_provisioning_template_render_statuses_path(@template) }.to_json) %>

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -56,6 +56,7 @@ Foreman::Application.routes.draw do
         resources :template_combinations, :only => [:index, :create, :update, :show]
         resources :operatingsystems, :except => [:new, :edit]
         resources :os_default_templates, :except => [:new, :edit]
+        resources :render_statuses, :only => :index
       end
 
       resources :dashboard, :only => [:index]
@@ -74,6 +75,7 @@ Foreman::Application.routes.draw do
         end
         resources :hosts, :except => [:new, :edit]
         resources :template_combinations, :only => [:show, :index, :create, :update]
+        resources :render_statuses, :only => :index
       end
 
       resources :media, :except => [:new, :edit] do
@@ -316,6 +318,7 @@ Foreman::Application.routes.draw do
           post :facts, :on => :collection
           resources :audits, :only => :index
           resources :facts, :only => :index, :controller => :fact_values
+          resources :render_statuses, :only => :index
           resources :interfaces, :except => [:new, :edit]
           resources :parameters, :except => [:new, :edit] do
             collection do

--- a/db/migrate/20211116220221_create_render_statuses.rb
+++ b/db/migrate/20211116220221_create_render_statuses.rb
@@ -1,0 +1,33 @@
+class CreateRenderStatuses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :render_statuses do |t|
+      t.references :host, type: :integer, foreign_key: true, index: true
+      t.references :hostgroup, type: :integer, foreign_key: true, index: true
+      t.references :template, type: :integer, foreign_key: true, index: true, null: false
+      t.boolean :safemode, null: false
+      t.boolean :success, null: false
+      t.timestamps
+    end
+
+    add_index :render_statuses, [:host_id, :template_id, :safemode], unique: true, name: 'index_render_statuses_on_host_and_template_and_safemode'
+    add_index :render_statuses, [:hostgroup_id, :template_id, :safemode], unique: true, name: 'index_render_statuses_on_hostgroup_and_template_and_safemode'
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          ALTER TABLE render_statuses ADD CONSTRAINT host_or_hostgroup_check CHECK (
+            (
+              (host_id is not null)::integer +
+              (hostgroup_id is not null)::integer
+            ) = 1
+          );
+        SQL
+      end
+      dir.down do
+        execute <<-SQL
+          ALTER TABLE render_statuses DROP CONSTRAINT host_or_hostgroup_check;
+        SQL
+      end
+    end
+  end
+end

--- a/db/seeds.d/020-permissions_list.rb
+++ b/db/seeds.d/020-permissions_list.rb
@@ -161,6 +161,7 @@ class PermissionsList
         ['User', 'create_users'],
         ['User', 'edit_users'],
         ['User', 'destroy_users'],
+        ['RenderStatus', 'view_render_statuses'],
         [nil, 'view_statuses'],
       ]
     end

--- a/test/controllers/api/v2/render_statuses_controller_test.rb
+++ b/test/controllers/api/v2/render_statuses_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+class Api::V2::RenderStatusesControllerTest < ActionController::TestCase
+  let(:render_statuses) { as_admin { FactoryBot.create_list(:render_status, 2) } }
+  let(:hosts) { render_statuses.map(&:host) }
+  let(:provisioning_templates) do
+    render_statuses.map(&:provisioning_template).each do |provisioning_template|
+      provisioning_template.locations << Location.all
+      provisioning_template.organizations << Organization.all
+    end
+  end
+  let(:role) do
+    FactoryBot.create(:role, filters: permissions.map do |permission|
+      FactoryBot.create(:filter, permissions: Permission.where(name: [permission]))
+    end)
+  end
+  let(:user) { FactoryBot.create(:user, :with_mail, admin: false, roles: [role]) }
+
+  describe 'GET /api/v2/hosts/:host_id/render_statuses' do
+    let(:permissions) { [:view_hosts, :view_render_statuses] }
+
+    test 'should get render statuses for given host only' do
+      as_user user do
+        get :index, params: { host_id: hosts.first.to_param }
+      end
+
+      assert_response :success
+      assert_equal 1, ActiveSupport::JSON.decode(response.body)['total']
+    end
+  end
+
+  describe 'GET /api/v2/hostgroups/:hostgroup_id/render_statuses' do
+    let(:render_statuses) { as_admin { FactoryBot.create_list(:render_status, 2, :with_hostgroup) } }
+    let(:hostgroups) { render_statuses.map(&:hostgroup) }
+    let(:permissions) { [:view_hostgroups, :view_render_statuses] }
+
+    test 'should get render statuses for given hostgroup only' do
+      as_user user do
+        get :index, params: { hostgroup_id: hostgroups.first.id }
+      end
+
+      assert_response :success
+      assert_equal 1, ActiveSupport::JSON.decode(response.body)['total']
+    end
+  end
+
+  describe 'GET /api/v2/provisioning_templates/:provisioning_template_id/render_statuses' do
+    let(:permissions) { [:view_provisioning_templates, :view_render_statuses] }
+
+    test 'should get render statuses for given provisioning template only' do
+      as_user user do
+        get :index, params: { provisioning_template_id: provisioning_templates.first.to_param }
+      end
+
+      assert_response :success
+      assert_equal 1, ActiveSupport::JSON.decode(response.body)['total']
+    end
+  end
+end

--- a/test/factories/render_status.rb
+++ b/test/factories/render_status.rb
@@ -1,0 +1,29 @@
+FactoryBot.define do
+  factory :render_status do
+    host
+    provisioning_template
+    safemode { true }
+    success { true }
+
+    trait :with_hostgroup do
+      hostgroup
+      host { nil }
+    end
+
+    trait :safemode do
+      safemode { true }
+    end
+
+    trait :unsafemode do
+      safemode { false }
+    end
+
+    trait :success do
+      success { true }
+    end
+
+    trait :failure do
+      success { false }
+    end
+  end
+end

--- a/test/fixtures/filterings.yml
+++ b/test/fixtures/filterings.yml
@@ -329,6 +329,9 @@ viewer_24_0:
 viewer_25_0:
   filter: viewer_25
   permission: view_subnets
+viewer_26_0:
+  filter: viewer_26
+  permission: view_render_statuses
 default_role_1_0:
   filter: default_role_1
   permission: view_tasks

--- a/test/fixtures/filters.yml
+++ b/test/fixtures/filters.yml
@@ -95,6 +95,8 @@ viewer_24:
   role_id: 5
 viewer_25:
   role_id: 5
+viewer_26:
+  role_id: 5
 default_role_1:
   role_id: 7
 destroy_hosts_1:

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -724,6 +724,11 @@ destroy_lookup_values:
   resource_type: LookupValue
   created_at: "2023-10-31 15:43:36.594107"
   updated_at: "2023-10-31 15:43:36.594107"
+view_render_statuses:
+  name: view_render_statuses
+  resource_type: RenderStatus
+  created_at: "2014-01-07 15:09:32.783442"
+  updated_at: "2014-01-07 15:09:32.783442"
 
 <% Foreman::Plugin.all.map(&:permissions).inject({}, :merge).each do |permission,attrs| %>
 <%= permission %>:

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -126,6 +126,7 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
     image = images(:one)
     host = FactoryBot.build_stubbed(:host, :operatingsystem => image.operatingsystem, :image => image,
                              :compute_resource => image.compute_resource)
+    RenderStatus.any_instance.expects(:update).once.with(success: true)
     prov_temp = FactoryBot.create(:provisioning_template, :template_kind => TemplateKind.create(:name => "user_data"))
     host.stubs(:provisioning_template).returns(prov_temp)
     attrs = {}

--- a/test/models/orchestration/tftp_test.rb
+++ b/test/models/orchestration/tftp_test.rb
@@ -182,6 +182,7 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     h = FactoryBot.build_stubbed(:host, :managed, :build => true,
                           :operatingsystem => operatingsystems(:redhat),
                           :architecture => architectures(:x86_64))
+    RenderStatus.any_instance.expects(:update).once.with(success: true)
     h.organization.update_attribute :ignore_types, h.organization.ignore_types + ['ProvisioningTemplate']
     h.location.update_attribute :ignore_types, h.location.ignore_types + ['ProvisioningTemplate']
     Setting[:unattended_url] = "http://ahost.com:3000"
@@ -346,6 +347,7 @@ class TFTPOrchestrationTest < ActiveSupport::TestCase
     h = FactoryBot.build_stubbed(:host, :managed, :build => true,
                           :operatingsystem => operatingsystems(:opensuse),
                           :architecture => architectures(:x86_64))
+    RenderStatus.any_instance.expects(:update).once.with(success: true)
     Setting[:unattended_url] = "http://ahost.com:3000"
     h.organization.update_attribute :ignore_types, h.organization.ignore_types + ['ProvisioningTemplate']
     h.location.update_attribute :ignore_types, h.location.ignore_types + ['ProvisioningTemplate']

--- a/test/unit/foreman/renderer/render_status_service_test.rb
+++ b/test/unit/foreman/renderer/render_status_service_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class RenderStatusServiceTests < ActiveSupport::TestCase
+  let(:provisioning_template) { FactoryBot.create(:provisioning_template, template: '<%= @host.name %>') }
+
+  context 'for an existing host' do
+    let(:host) { FactoryBot.create(:host, :managed) }
+
+    it 'saves the render status' do
+      assert_difference('RenderStatus.count', 1) do
+        provisioning_template.render(host: host)
+      end
+    end
+
+    context 'when render status already exists' do
+      setup do
+        FactoryBot.create(:render_status, host: host, provisioning_template: provisioning_template, success: false)
+      end
+
+      it 'updates the render status' do
+        assert_not RenderStatus.find_by(host: host, provisioning_template: provisioning_template).success
+
+        provisioning_template.render(host: host)
+
+        assert RenderStatus.find_by(host: host, provisioning_template: provisioning_template).success
+      end
+    end
+  end
+
+  context 'for a new host' do
+    let(:host) { FactoryBot.build(:host, :managed) }
+
+    it 'saves the render status with the host' do
+      provisioning_template.render(host: host)
+
+      assert_difference('RenderStatus.count', 1) do
+        host.save!
+      end
+    end
+  end
+
+  context 'for an existing hostgroup' do
+    let(:hostgroup) { FactoryBot.create(:hostgroup) }
+
+    it 'saves the render status' do
+      assert_difference('RenderStatus.count', 1) do
+        provisioning_template.render(host: hostgroup)
+      end
+    end
+
+    context 'when render status already exists' do
+      setup do
+        FactoryBot.create(:render_status, :with_hostgroup, hostgroup: hostgroup, provisioning_template: provisioning_template, success: false)
+      end
+
+      it 'updates the render status' do
+        assert_not RenderStatus.find_by(hostgroup: hostgroup, provisioning_template: provisioning_template).success
+
+        provisioning_template.render(host: hostgroup)
+
+        assert RenderStatus.find_by(hostgroup: hostgroup, provisioning_template: provisioning_template).success
+      end
+    end
+  end
+
+  context 'for a new hostgroup' do
+    let(:hostgroup) { FactoryBot.build(:hostgroup) }
+
+    it 'saves the render status with the hostgroup' do
+      provisioning_template.render(host: hostgroup)
+
+      assert_difference('RenderStatus.count', 1) do
+        hostgroup.save!
+      end
+    end
+  end
+end

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -503,5 +503,31 @@ module RenderersSharedTests
         end
       end
     end
+
+    describe 'render statuses' do
+      let(:host) { FactoryBot.create(:host, :managed) }
+
+      context 'with valid template' do
+        let(:provisioning_template) { FactoryBot.create(:provisioning_template, template: '<%= @host.name %>') }
+
+        it 'calls render status service' do
+          Foreman::Renderer::RenderStatusService.expects(:success).once
+
+          provisioning_template.render(host: host, renderer: renderer)
+        end
+      end
+
+      context 'with invalid template' do
+        let(:provisioning_template) { FactoryBot.create(:provisioning_template, template: '<%- begin %>') }
+
+        it 'calls render status service' do
+          Foreman::Renderer::RenderStatusService.expects(:error).once
+
+          assert_raises(Foreman::Renderer::Errors::SyntaxError) do
+            provisioning_template.render(host: host, renderer: renderer)
+          end
+        end
+      end
+    end
   end
 end

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
@@ -6,6 +6,7 @@ import {
   selectAPIStatus,
 } from '../../../redux/API/APISelectors';
 import { APIActions } from '../../../redux/API';
+import { foremanUrl } from '../../../common/helpers';
 
 /**
  * A custom hook that creates an API request
@@ -45,3 +46,12 @@ export const useAPI = (method, url, options = {}) => {
 
   return { response, status, key: keyState, setAPIOptions };
 };
+
+/**
+ * A custom hook that creates a url with search parameters
+ * @param  {string} base path
+ * @param  {object} optional search params
+ * @return {string} returns url address
+ */
+export const useForemanUrl = (path, params = {}) =>
+  [foremanUrl(path), new URLSearchParams(params)].filter(Boolean).join('?');

--- a/webpack/assets/javascripts/react_app/components/RenderStatuses/Empty.js
+++ b/webpack/assets/javascripts/react_app/components/RenderStatuses/Empty.js
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {
+  Title,
+  EmptyState,
+  EmptyStateIcon,
+  Spinner,
+} from '@patternfly/react-core';
+import { BanIcon } from '@patternfly/react-icons';
+import { translate as __ } from '../../common/I18n';
+import { STATUS } from '../../constants';
+
+const Empty = ({ responseStatus }) => (
+  <EmptyState className="pf-u-mt-0" isFullHeight>
+    {responseStatus === STATUS.PENDING ? (
+      <Spinner isSVG />
+    ) : (
+      <EmptyStateIcon icon={BanIcon} />
+    )}
+    <Title size="lg" headingLevel="h4" ouiaId="render-statuses-empty-title">
+      {responseStatus === STATUS.PENDING
+        ? __('Loading...')
+        : __('No statuses to show')}
+    </Title>
+  </EmptyState>
+);
+
+Empty.propTypes = {
+  responseStatus: PropTypes.string,
+};
+
+Empty.defaultProps = {
+  responseStatus: STATUS.PENDING,
+};
+
+export default Empty;

--- a/webpack/assets/javascripts/react_app/components/RenderStatuses/RenderStatusesConstants.js
+++ b/webpack/assets/javascripts/react_app/components/RenderStatuses/RenderStatusesConstants.js
@@ -1,0 +1,2 @@
+export const RENDER_STATUSES_KEY = 'RENDER_STATUSES';
+export const API_OPTIONS = { key: RENDER_STATUSES_KEY };

--- a/webpack/assets/javascripts/react_app/components/RenderStatuses/RenderStatusesSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/RenderStatuses/RenderStatusesSelectors.js
@@ -1,0 +1,8 @@
+import { selectAPIResponse } from '../../redux/API/APISelectors';
+import { RENDER_STATUSES_KEY } from './RenderStatusesConstants';
+
+export const selectRenderStatuses = state =>
+  selectAPIResponse(state, RENDER_STATUSES_KEY)?.results || [];
+
+export const selectTotalRenderStatuses = state =>
+  selectAPIResponse(state, RENDER_STATUSES_KEY)?.subtotal || 0;

--- a/webpack/assets/javascripts/react_app/components/RenderStatuses/index.js
+++ b/webpack/assets/javascripts/react_app/components/RenderStatuses/index.js
@@ -1,0 +1,157 @@
+import React, { Fragment, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { asMutable } from 'seamless-immutable';
+import { Pagination, Tooltip } from '@patternfly/react-core';
+import { Table, TableHeader, TableBody } from '@patternfly/react-table';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  ExclamationCircleIcon,
+} from '@patternfly/react-icons';
+import { useAPI, useForemanUrl } from '../../common/hooks/API/APIHooks';
+import { useForemanSettings } from '../../Root/Context/ForemanContext';
+import RelativeDateTime from '../common/dates/RelativeDateTime';
+import { translate as __ } from '../../common/I18n';
+import { API_OPTIONS } from './RenderStatusesConstants';
+import {
+  selectRenderStatuses,
+  selectTotalRenderStatuses,
+} from './RenderStatusesSelectors';
+import Empty from './Empty';
+
+const RenderStatuses = ({ path }) => {
+  const {
+    perPage: perPageSetting,
+    safemode: safemodeRenderSetting,
+  } = useForemanSettings();
+  const [page, setPage] = useState(1);
+  const [perPage, setPerPage] = useState(perPageSetting);
+  const url = useForemanUrl(path, {
+    page,
+    per_page: perPage,
+    order: 'updated_at DESC',
+    ...(safemodeRenderSetting && { search: 'safemode = true' }),
+  });
+  const { status: responseStatus } = useAPI('get', url, API_OPTIONS);
+  const renderStatuses = useSelector(state => selectRenderStatuses(state));
+  const totalRenderStatuses = useSelector(state =>
+    selectTotalRenderStatuses(state)
+  );
+
+  const updatePerPage = newPerPage => {
+    setPerPage(newPerPage);
+    setPage(1);
+  };
+
+  const columnLabels = {
+    success: '',
+    safemode: '',
+    host_or_hostgroup: __('Host/Hostgroup'),
+    created_at: __('Created at'),
+    updated_at: __('Updated at'),
+  };
+
+  const columns = [
+    'success',
+    'host_or_hostgroup',
+    'created_at',
+    'updated_at',
+    ...(safemodeRenderSetting ? [] : ['safemode']),
+  ];
+  const cells = columns.map(name => [columnLabels[name]]);
+
+  const rows = renderStatuses.map(
+    ({
+      success,
+      safemode,
+      created_at: createdAt,
+      updated_at: updatedAt,
+      host,
+      hostgroup,
+      provisioning_template: {
+        name: provisioningTemplateName,
+        path: provisioningTemplatePath,
+      },
+    }) => {
+      const values = {
+        success: () =>
+          success ? (
+            <CheckCircleIcon
+              style={{ fill: 'var(--pf-global--success-color--100)' }}
+            />
+          ) : (
+            <ExclamationCircleIcon
+              style={{ fill: 'var(--pf-global--danger-color--100)' }}
+            />
+          ),
+        safemode: () =>
+          safemode ? (
+            <Fragment />
+          ) : (
+            <Tooltip position="right" content={__('Unsafe Mode')}>
+              <ExclamationTriangleIcon
+                style={{ fill: 'var(--pf-global--warning-color--100)' }}
+              />
+            </Tooltip>
+          ),
+        created_at: () => (
+          <RelativeDateTime date={createdAt} defaultValue="N/A" />
+        ),
+        updated_at: () => (
+          <RelativeDateTime date={updatedAt} defaultValue="N/A" />
+        ),
+        host_or_hostgroup: () => {
+          const { name: hName, path: hPath } = host || hostgroup;
+          return hPath ? <a href={hPath}>{hName}</a> : hName;
+        },
+        provisioning_template: () =>
+          provisioningTemplatePath ? (
+            <a href={provisioningTemplatePath}>{provisioningTemplateName}</a>
+          ) : (
+            <Fragment>provisioningTemplateName</Fragment>
+          ),
+      };
+
+      return columns.map(name => ({ title: values[name]() }));
+    }
+  );
+
+  return (
+    <Fragment>
+      {totalRenderStatuses ? (
+        <Fragment>
+          <Table
+            aria-label={__('Render Statuses')}
+            variant="compact"
+            cells={cells}
+            rows={asMutable(rows)}
+            ouiaId="render-statuses-table"
+          >
+            <TableHeader />
+            <TableBody />
+          </Table>
+
+          <Pagination
+            itemCount={totalRenderStatuses}
+            perPage={perPage}
+            page={page}
+            onSetPage={(_event, newPage) => setPage(newPage)}
+            onPerPageSelect={(_event, newPerPage) => updatePerPage(newPerPage)}
+            widgetId="pagination-options-menu-top"
+            isCompact
+            ouiaId="render-statuses-pagination"
+          />
+        </Fragment>
+      ) : (
+        <Empty responseStatus={responseStatus} />
+      )}
+    </Fragment>
+  );
+};
+
+RenderStatuses.propTypes = {
+  path: PropTypes.string.isRequired,
+};
+
+export default RenderStatuses;

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -45,6 +45,7 @@ import LabelIcon from './common/LabelIcon';
 import { WelcomeAuthSource } from './AuthSource/Welcome';
 import { WelcomeConfigReports } from './ConfigReports/Welcome';
 import { WelcomeArchitecture } from './Architectures/Welcome';
+import RenderStatuses from './RenderStatuses/';
 
 const componentRegistry = {
   registry: forceSingleton('component_registry', () => ({})),
@@ -180,6 +181,7 @@ const coreComponents = [
   { name: 'WelcomeAuthSource', type: WelcomeAuthSource },
   { name: 'WelcomeConfigReports', type: WelcomeConfigReports },
   { name: 'WelcomeArchitecture', type: WelcomeArchitecture },
+  { name: 'RenderStatuses', type: RenderStatuses },
 ];
 
 if (!componentRegistry.registry[coreComponents[0].name]) {


### PR DESCRIPTION
Reopened https://github.com/theforeman/foreman/pull/8377

I have a feeling the previous PR was overcomplicated and I wanted to keep this one as simple as possible. It includes saving the status after each render attempt and displaying that on the template and host pages. I think this is more about the template than the host (we want to make sure that the templates are not broken), so I'm not really sure if host status is suitable here. Once this is merged, we can think about some kind of monitoring/notifications.

Here are some screenshots:

![image](https://user-images.githubusercontent.com/37402924/145412575-86a5f194-1b43-446d-9a2c-fc646c4fec9c.png)
![image](https://user-images.githubusercontent.com/37402924/145412771-fb7f48ac-ae57-4c54-aacb-35062436f8af.png)
![image](https://user-images.githubusercontent.com/37402924/145412689-48098cc3-e62a-40b6-902a-a5a089e00862.png)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
