### PR TITLE
Fixes #34122 - Report disallowed metric labels as other

### DIFF
--- a/app/services/authorizer_cache.rb
+++ b/app/services/authorizer_cache.rb
@@ -1,4 +1,6 @@
 module AuthorizerCache
+  include Foreman::TelemetryHelper
+
   def initialize_cache
     @cache = {}
   end
@@ -13,6 +15,7 @@ module AuthorizerCache
 
   def fetch_collection(subject, permission)
     collection = @cache[cache_key(subject, permission)] = find_collection(subject.class, :permission => permission).pluck(:id)
+    telemetry_increment_counter(:authorizer_cache_records_fetched, collection.count, class: subject&.class || :Other)
     Rails.logger.info("Loaded #{collection.size} #{subject.class} records into authorization cache for permission #{permission}, consider skipping caching for this check.") if collection.size > 100000
     collection
   end

--- a/config/initializers/5_telemetry.rb
+++ b/config/initializers/5_telemetry.rb
@@ -41,6 +41,7 @@ telemetry.add_histogram(:report_importer_refresh, 'Total duration of report stat
 telemetry.add_counter(:audit_records_created, 'Number of audit records created in the DB', [:type])
 telemetry.add_counter(:audit_records_logged, 'Number of audit records sent into logger', [:type])
 telemetry.add_counter(:config_report_metric_count, 'Number of config report status metrics', [:metric])
+telemetry.add_counter(:authorizer_cache_records_fetched, 'Number of records fetched by authorizer cache', [:class])
 
 # To decrease amount of metrics, labels must be allowed explicitly
 allowed_labels = {
@@ -54,6 +55,16 @@ allowed_labels = {
     'hostgroups_controller',
     'hosts_controller',
     'notification_recipients_controller',
+  ],
+  action: [
+    'index',
+    'show',
+    'create',
+    'update',
+    'destroy',
+    'export',
+    'generate',
+    'facts',
   ],
   class: [
     'Architecture',

--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -117,29 +117,27 @@ module Foreman
     end
 
     def increment_counter(name, value = 1, tags = {})
-      return unless allowed?(tags)
+      rename_disallowed!(tags)
       @sinks.each { |x| x.increment_counter("#{prefix}_#{name}", value, tags) }
     end
 
     def set_gauge(name, value, tags = {})
-      return unless allowed?(tags)
+      rename_disallowed!(tags)
       @sinks.each { |x| x.set_gauge("#{prefix}_#{name}", value, tags) }
     end
 
     def observe_histogram(name, value, tags = {})
-      return unless allowed?(tags)
+      rename_disallowed!(tags)
       @sinks.each { |x| x.observe_histogram("#{prefix}_#{name}", value, tags) }
     end
 
     private
 
-    def allowed?(tags)
-      result = true
+    def rename_disallowed!(tags)
       tags.each do |label, value|
         regexp = @allowed_tags[label]
-        result &&= !!regexp.match(value) if regexp
+        tags[label] = 'other' if regexp && !regexp.match(value&.to_s)
       end
-      result
     end
   end
 end

--- a/lib/foreman/telemetry_sinks/statsd_sink.rb
+++ b/lib/foreman/telemetry_sinks/statsd_sink.rb
@@ -26,7 +26,12 @@ module Foreman
 
       def increment_counter(name, value, tags)
         if @protocol == :datadog
-          StatsD.increment(name, value, tags: tags_in_statsd(tags))
+          if tags&.any?
+            # https://github.com/Shopify/statsd-instrument/issues/298
+            StatsD.increment(name, value, tags: tags_in_statsd(tags))
+          else
+            StatsD.increment(name, value)
+          end
         else
           StatsD.increment(name_tag_mapping(name, tags), value)
         end
@@ -34,7 +39,12 @@ module Foreman
 
       def set_gauge(name, value, tags)
         if @protocol == :datadog
-          StatsD.gauge(name, value, tags: tags_in_statsd(tags))
+          if tags&.any?
+            # https://github.com/Shopify/statsd-instrument/issues/298
+            StatsD.gauge(name, value, tags: tags_in_statsd(tags))
+          else
+            StatsD.gauge(name, value)
+          end
         else
           StatsD.gauge(name_tag_mapping(name, tags), value)
         end
@@ -42,7 +52,12 @@ module Foreman
 
       def observe_histogram(name, value, tags)
         if @protocol == :datadog
-          StatsD.measure(name, value, tags: tags_in_statsd(tags))
+          if tags&.any?
+            # https://github.com/Shopify/statsd-instrument/issues/298
+            StatsD.measure(name, value, tags: tags_in_statsd(tags))
+          else
+            StatsD.measure(name, value)
+          end
         else
           StatsD.measure(name_tag_mapping(name, tags), value)
         end


### PR DESCRIPTION
To keep amount of metric labels small, we deny unwanted labels and only keep those which are interesting to have in the telemetry data. However, previously when metric had a label that was not allowed, it was simply dropped.

This is skewing the data, when presenting total numbers as sum of all measurements (or duration histogram) those dropped measurements must be included. This patch changes the behavior, it is now measured with label value of "Other".

The patch also adds one more metric which is amount of loaded record ids into authorizer cache so we can keep an eye on the rate.

To test this:

Enable telemetry (logs or prometheus).
Visit any controller that is not allowed.
The controller should be reported with label Other.
To test the authorizer, login as a regular user, visit any page that has authorization.

I would like to ask for 3.1.x backport as telemetry will be big theme of the 7.0 release and I am preparing big documentation changes and demo. This patch is needed to make numbers more useful.

During testing, I have found out that datadog format actually sends slightly incorrect packets when an empty array is passed into the tags argument. This breaks the PCP PMDA Statsd agent, it drops the packet as invalid. I am reporting this to the project, however, that might be actually a bug in the PMDA itself, the format is vague. So this patch includes a workaround - when no tags are present do not send the argument:

https://github.com/Shopify/statsd-instrument/issues/298