### PR TITLE
Fixes #34129 - HostDetails - UX Review - Spacing

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
@@ -9,8 +9,9 @@
 }
 
 .host-details-tab-item {
-  padding: 18px;
+  padding: 16px 24px;
   background: #f0f0f0;
+
   .pf-c-card {
     height: 100%;
   }
@@ -31,5 +32,5 @@
 }
 
 .host-details-header-section .pf-c-alert {
-  margin: 15px 24px;
+  margin: 16px 24px;
 }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -27,7 +27,6 @@ import {
   selectSlotMetadata,
 } from '../common/Slot/SlotSelectors';
 
-import { selectIsCollapsed } from '../Layout/LayoutSelectors';
 import ActionsBar from './ActionsBar';
 import { registerCoreTabs } from './Tabs';
 import { HOST_DETAILS_API_OPTIONS, TABS_SLOT_ID } from './consts';
@@ -54,7 +53,6 @@ const HostDetails = ({
     HOST_DETAILS_API_OPTIONS
   );
 
-  const isNavCollapsed = useSelector(selectIsCollapsed);
   const tabs = useSelector(
     state => selectFillsIDs(state, TABS_SLOT_ID),
     shallowEqual
@@ -82,17 +80,14 @@ const HostDetails = ({
         isFilled
         variant="light"
       >
-        <div style={{ marginLeft: '18px', marginRight: '18px' }}>
-          <Breadcrumb style={{ marginTop: '15px' }}>
+        <div style={{ margin: ' 0px 24px 16px', paddingTop: '16px' }}>
+          <Breadcrumb style={{ margin: '0 0 24px' }}>
             <BreadcrumbItem to="/hosts">{__('Hosts')}</BreadcrumbItem>
             <BreadcrumbItem isActive>
               {response.name || <Skeleton />}
             </BreadcrumbItem>
           </Breadcrumb>
-          {/* TODO: Replace all br with css */}
-          <br />
-          <br />
-          <Grid>
+          <Grid style={{ marginBottom: '8px' }}>
             <GridItem span={9}>
               <SkeletonLoader status={status || STATUS.PENDING}>
                 {response && (
@@ -166,12 +161,7 @@ const HostDetails = ({
             tabs={tabs}
             router={history}
           >
-            <Tabs
-              style={{
-                width: window.innerWidth - (isNavCollapsed ? 95 : 220),
-              }}
-              activeKey={activeTab}
-            >
+            <Tabs style={{ margin: '0 24px' }} activeKey={activeTab}>
               {tabs.map(tab => (
                 <Tab
                   key={tab}


### PR DESCRIPTION
The related Katello task is [here](https://github.com/Katello/katello/pull/9843)

This is adjusting spacing issues seen on the new host details UI.

Excerpt from the above task below: 

#### What are the changes introduced in this pull request?

- Adjusted spacing/placement on all pages across the new CV UI, as well as a few changes on the new Hosts UI.
 
#### Considerations taken when implementing this change?

- "Consistency" - Maria 

#### What are the testing steps for this pull request?

- Navigate through all new  CV/Hosts pages, using [this](https://marvelapp.com/prototype/8813483/screen/80289005)  design template as an outline for spacing.

- Note any pages that look off or don't follow a similar pattern.
