### PR TITLE
refs #28571 - Remove record_tag helpers in .erb files

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -45,11 +45,9 @@ module ComputeResourcesVmsHelper
   end
 
   def spice_data_attributes(console)
-    {
-      :encrypt  => console[:encrypt],
-      :port     => console[:port],
-      :password => console[:password],
-    }
+    ["data-encrypt='#{console[:encrypt]}'",
+     "data-port='#{console[:port]}'",
+     "data-password='#{console[:password]}'"].join(' ').html_safe
   end
 
   def libvirt_networks(compute_resource)

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -37,8 +37,11 @@ module DashboardHelper
   end
 
   def widget_data(widget)
-    { :data => { :id    => widget.id,    :name  => _(widget.name), :row => widget.row, :col => widget.col,
-                 :sizex => widget.sizex, :sizey =>  widget.sizey } }
+    data = ["data-id='#{widget.id}'", "data-name='#{widget.name}'",
+            "data-row='#{widget.row}'", "data-col='#{widget.col}'",
+            "data-sizex='#{widget.sizex}'", "data-sizey='#{widget.sizey}'"]
+
+    data.join(' ').html_safe
   end
 
   def count_reports(hosts, options = {})

--- a/app/views/common/403.html.erb
+++ b/app/views/common/403.html.erb
@@ -1,5 +1,3 @@
-<% permissions = @missing_permissions.map { |permission| content_tag(:li, content_tag(:strong, permission.name)) } %>
-
 <% content_for(:title, _("Permission denied")) %>
 <div class="blank-slate-pf">
   <div class="blank-slate-pf-icon">
@@ -9,7 +7,11 @@
   <p>
     <%= _("You are not authorized to perform this action.") %></br>
     <%= _("Please request one of the required permissions listed below from a Foreman administrator:") %></br>
-    <%= content_tag(:ul, permissions.join.html_safe, class: 'list-unstyled') %>
+    <ul class="list-unstyled">
+      <% @missing_permissions.each do |permission| %>
+        <li><strong><%= permission.name %></strong></li>
+      <% end %>
+    </ul>
   </p>
   <p><%= link_to(_('Back'), main_app.root_path, :class => 'btn btn-default') %></p>
 </div>

--- a/app/views/common_parameters/_inherited_parameters.html.erb
+++ b/app/views/common_parameters/_inherited_parameters.html.erb
@@ -15,9 +15,11 @@
            param_obj = inherited_parameters[name]
         %>
         <tr class="<%="override-param" if overriden %>">
-          <td class="ellipsis"><%= content_tag :span, name, :id => "name_#{name}"%>
+          <td class="ellipsis">
+            <span id="<%= "name_#{name}" %>"><%= name %></span>
           </td>
-          <td class="ellipsis"><%= content_tag :span, param_obj[:parameter_type], :id => "parameter_type_#{param_obj[:parameter_type]}"%>
+          <td class="ellipsis">
+            <span id="<%= "parameter_type_#{param_obj[:parameter_type]}"%>"></span>
           </td>
           <td><%= parameter_value_field param_obj %></td>
           <td>

--- a/app/views/compute_profiles/show.html.erb
+++ b/app/views/compute_profiles/show.html.erb
@@ -23,7 +23,7 @@
         <td><%= link_to(compute_resource.to_label, which_path) %></td>
         <td>
           <% set = compute_resource.compute_attributes.where(:compute_profile_id => @compute_profile.id).first %>
-          <%= set ? set.name : content_tag(:span, _("unspecified"), :class => 'gray') %>
+          <%= set ? set.name : "<span class='gray'>#{_("unspecified")}</span>".html_safe %>
         </td>
       </tr>
     <% end %>

--- a/app/views/compute_resources/show.html.erb
+++ b/app/views/compute_resources/show.html.erb
@@ -81,7 +81,7 @@
             <td class="ellipsis"><%= link_to(compute_profile.name, which_path) %></td>
             <td>
               <% set = @compute_resource.compute_attributes.where(:compute_profile_id => compute_profile.id).first %>
-              <%= set ? set.name : content_tag(:span, _("unspecified"), :class => 'gray') %>
+              <%= set ? set.name : "<span class='gray'>#{_("unspecified")}</span>".html_safe %>
             </td>
           </tr>
         <% end %>

--- a/app/views/compute_resources_vms/_details.html.erb
+++ b/app/views/compute_resources_vms/_details.html.erb
@@ -1,3 +1,5 @@
 <%= render "compute_resources_vms/show/#{@compute_resource.provider.downcase}" %>
 
-<%= content_tag(:div, vm_power_actions(@host, @vm) + vm_console(@host, @vm) , :id=>'power_actions') %>
+<div id="power_actions">
+  <%= vm_power_actions(@host, @vm) + vm_console(@host, @vm) %>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -10,7 +10,7 @@
     <div id='dashboard' class="dashboard gridster col-md-12">
       <ul>
         <% User.current.widgets.available.order(:id).each do |widget| %>
-          <%= content_tag(:li, widget_data(widget)) do %>
+          <li <%= widget_data(widget) %>>
             <div class='widget_control'>
               <a class='remove' data-url='<%= widget_path(widget) %>' onclick='tfm.dashboard.removeWidget(this)' >&times;</a>
             </div>
@@ -19,7 +19,7 @@
                 <%= spinner(_("%s widget loading...") % widget.name) %>
               </div>
             </div>
-          <% end %>
+          </li>
         <% end %>
       </ul>
     </div>

--- a/app/views/fact_values/_fact.html.erb
+++ b/app/views/fact_values/_fact.html.erb
@@ -10,7 +10,7 @@
   <% end %>
   <td>
     <%= popover("", escaped_warning_context, {:data => {:title => escaped_warning_title, :placement => "top"}, :icon => "warning-triangle-o", :class => "pull-right" }) if is_escaped_value(fact.name) %>
-    <%= content_tag(:ol, fact_name(fact, parent), :class => "breadcrumb") %>
+    <ol class="breadcrumb"><%= fact_name(fact, parent) %></ol>
   </td>
   <td class="fact-col">
     <% unless fact.compose %>

--- a/app/views/filters/index.html.erb
+++ b/app/views/filters/index.html.erb
@@ -38,8 +38,10 @@ end %>
       <tr>
         <% unless params[:role_id] %>
           <td>
-            <%= content_tag('span', link_to_if_authorized(filter.role.name, hash_for_roles_path(:search => "name = #{filter.role.name}").
-                  merge(:auth_object => filter.role, :authorizer => @roles_authorizer))) %>
+            <span>
+            <%= link_to_if_authorized(filter.role.name, hash_for_roles_path(:search => "name = #{filter.role.name}").
+                  merge(:auth_object => filter.role, :authorizer => @roles_authorizer)) %>
+            </span>
           </td>
         <% end %>
         <td>
@@ -49,9 +51,11 @@ end %>
         <td><%= checked_icon filter.unlimited? %></td>
         <td><%= checked_icon filter.override? %></td>
         <td>
-          <%= content_tag('span', link_to_unless_locked(filter.search || _('N/A'), @role,
-                                                      hash_for_edit_filter_path(:id => filter, :role_id => @role).
-                                                              merge(:auth_object => filter, :authorizer => authorizer))) %>
+          <span>
+            <%= link_to_unless_locked(filter.search || _('N/A'), @role,
+                                      hash_for_edit_filter_path(:id => filter, :role_id => @role).
+                                      merge(:auth_object => filter, :authorizer => authorizer)) %>
+          </span>
         </td>
         <% if @role && !@role.locked? %>
           <td>

--- a/app/views/hosts/_assign_hosts.html.erb
+++ b/app/views/hosts/_assign_hosts.html.erb
@@ -32,8 +32,8 @@
       <%= will_paginate_with_info hosts, :more => " - "+_("<b class='select_count'>0</b> selected") %>
     </div>
   </div>
-  <%= content_tag(:div, :class => "form-actions") do %>
+  <div class="form-actions">
     <%= link_to(_("Cancel"), :back, :class => "btn btn-default") %>
     <%= f.submit(_("Assign to %s") % @taxonomy_type, :class => "btn btn-success") %>
-  <% end %>
+  </div>
 <% end %>

--- a/app/views/hosts/console/spice.html.erb
+++ b/app/views/hosts/console/spice.html.erb
@@ -8,11 +8,11 @@
         documentation_button("7.1NoVNC",
           {:id => "troubleshootingButton", :class => "btn btn-default"})
         ) %>
-<%= content_tag(:div, :id =>'spice-area', :data => spice_data_attributes(@console)) do %>
+<div id="spice-area" <%= spice_data_attributes(@console) %>>
   <div class="console-status">
     <div id="spice-status" class="col-md-12 label" data-host="<%= @console[:name] %>"><%= _("Connecting (unencrypted) to: %s") % @console[:name] %></div>
   </div>
   <div id="spice-screen" class="console-screen"> </div>
-<% end %>
+</div>
 
 <script type="text/javascript"> tfm.spice.startSpice() </script>

--- a/app/views/nic/bmcs/_bmc.html.erb
+++ b/app/views/nic/bmcs/_bmc.html.erb
@@ -1,6 +1,6 @@
 <%= render 'nic/base_form', :f => f %>
 
-<%= content_tag :span, :id => 'bmc_fields' do %>
+<span id="<%= 'bmc_fields' %>">
   <%= text_f f, :username, :size => "col-md-8", :label_size => "col-md-3" %>
   <%= password_f f, :password, :unset => action_name == "edit", :size => "col-md-8", :label_size => "col-md-3",
                     :label_help => _("The BMC password will be used by Foreman to access the host's BMC controller via a BMC-enabled smart proxy, if available.<br/>").html_safe +
@@ -12,8 +12,8 @@
                         :rel => 'popover-modal',
                         :'data-placement' => "top"
                      }
- %>
+  %>
   <%= selectable_f f, :provider, Nic::BMC::PROVIDERS, {}, :size => "col-md-8", :label_size => "col-md-3" %>
-<% end %>
+</span>
 
 <%= render 'nic/provider_specific_form', :f => f %>

--- a/app/views/nic/bonds/_bond.html.erb
+++ b/app/views/nic/bonds/_bond.html.erb
@@ -1,11 +1,11 @@
 <%= render 'nic/base_form', :f => f %>
 
-<%= content_tag :span, :class => 'bond_fields' do %>
+<span class="<%='bond_fields' %>">
   <%= selectable_f f, :mode, Nic::Bond::MODES, {}, :size => "col-md-8", :label_size => "col-md-3" %>
   <%= text_f f, :attached_devices, :label_help => _('comma separated interface identifiers'),
              :label_help_options => { :rel => 'popover-modal' }, :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>
   <%= text_f f, :bond_options, :label_help => _('space separated options, e.g. miimon=100'),
              :label_help_options => { :rel => 'popover-modal' }, :size => "col-md-8", :label_size => "col-md-3" %>
-<% end %>
+</span>
 
 <%= render 'nic/provider_specific_form', :f => f %>

--- a/app/views/nic/bridges/_bridge.html.erb
+++ b/app/views/nic/bridges/_bridge.html.erb
@@ -1,8 +1,8 @@
 <%= render 'nic/base_form', :f => f %>
 
-<%= content_tag :span, :class => 'bridge_fields' do %>
+<span class="<%= 'bridge_fields' %>">
   <%= text_f f, :attached_devices, :label_help => _('comma separated interface identifiers'),
              :label_help_options => { :rel => 'popover-modal' }, :class => 'attached', :size => "col-md-8", :label_size => "col-md-3" %>
-<% end %>
+</span>
 
 <%= render 'nic/provider_specific_form', :f => f %>

--- a/app/views/nic/manageds/_managed.html.erb
+++ b/app/views/nic/manageds/_managed.html.erb
@@ -9,8 +9,8 @@
                :size => "col-md-8", :label_size => "col-md-3" %>
 
 <% hidden_class = f.object.virtual ? '' : 'hidden' %>
-<%= content_tag :div, :class => "virtual_form #{hidden_class}" do %>
+<div class="<%= "virtual_form #{hidden_class}" %>">
   <%= render 'nic/virtual_form', :f => f, :attached_to_required => true %>
-<% end %>
+</div>
 
 <%= render 'nic/provider_specific_form', :f => f %>

--- a/app/views/settings/category/_email.html.erb
+++ b/app/views/settings/category/_email.html.erb
@@ -1,3 +1,3 @@
 <%= link_to_function(_("Test email"), "tfm.users.testMail(this, '#{test_mail_user_url(User.current)}')",
                      :title => _("Send a test message to the current user's email address to confirm the configuration is working."), :id => "test_mail_button", :class =>"btn btn-success") + hidden_spinner('', :id => 'test_indicator').html_safe %>
-<%= content_tag(:br) %>
+<br>

--- a/app/views/templates/_help_accordion.html.erb
+++ b/app/views/templates/_help_accordion.html.erb
@@ -9,7 +9,7 @@
   <div id="<%= title.parameterize %>" class="panel-collapse collapse">
     <div class="panel-body">
       <% if !local_assigns.key?(:wrap_in_code) || wrap_in_code %>
-        <%= content_tag :code, contents %>
+        <code><%= contents %></code>
       <% else %>
         <%= contents %>
       <% end %>


### PR DESCRIPTION
Replace 'content_tag_for' and 'div_for' helpers in '.erb'
templates so we can later drop record_tag_helper gem [0].

[0] https://github.com/rails/record_tag_helper


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
