### PR TITLE
Fixes #28571 - move away from record_tag_helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ gem 'net-ping', :require => false
 gem 'activerecord-session_store', '>= 2.0.0', '< 3'
 gem 'sprockets', '~> 4.0'
 gem 'sprockets-rails', '~> 3.0'
-gem 'record_tag_helper', '~> 1.0'
 gem 'responders', '~> 3.0'
 gem 'roadie-rails', '~> 2.0'
 gem 'deacon', '~> 1.0'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -239,20 +239,6 @@ module ApplicationHelper
     end
   end
 
-  def readonly_field(object, property, options = {})
-    name       = "#{type}[#{property}]"
-    helper     = options[:helper]
-    value      = helper.nil? ? object.send(property) : send(helper, object)
-    klass      = options[:type]
-    title      = options[:title]
-
-    opts = { :title => title, :class => klass.to_s, :name => name, :value => value}
-
-    content_tag_for :span, object, opts do
-      h(value)
-    end
-  end
-
   def show_parent?(obj)
     minimum_count = obj.new_record? ? 0 : 1
     base = obj.class.respond_to?(:completer_scope) ? obj.class.completer_scope(nil) : obj.class


### PR DESCRIPTION
Remove usage of `content_tag_for` & `div_for` helpers so we can drop `record_tag_helper` gem [0]

Checked plugins:
* Remote execution: _nothing found_
* Ansible: _nothing found_
* Katello: _nothing found_
* Discovery: _nothing found_
* Tasks: _nothing found_
* Openscap: _nothing found_
* Puppet: (https://github.com/theforeman/foreman_puppet/pull/236)
* Hooks: _nothing found_

[0] https://github.com/rails/record_tag_helper
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
