### PR TITLE
Fixes #33937 - Use local boot template setting

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -111,7 +111,7 @@ class UnattendedController < ApplicationController
 
     return safe_render(template) if template
 
-    render_ipxe_message(message: _("iPXE default local boot template '%s' not found") % name)
+    render_ipxe_message(message: _("iPXE local boot template '%s' not found") % name)
   end
 
   def render_provisioning_template(type)

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -121,7 +121,11 @@ class ProvisioningTemplate < Template
   end
 
   def self.local_boot_name(kind)
-    "#{kind} default local boot"
+    local_boot_setting = Setting.find_by(:name => "local_boot_#{kind}")
+    return local_boot_setting.value if local_boot_setting && local_boot_setting.value.present?
+    local_boot_template_name = "#{kind} default local boot"
+    Rails.logger.info "Could not find user defined local_boot template from Settings for #{kind}, falling back to #{local_boot_template_name}"
+    local_boot_template_name
   end
 
   def self.global_default_name(kind)

--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -121,8 +121,7 @@ class ProvisioningTemplate < Template
   end
 
   def self.local_boot_name(kind)
-    local_boot_setting = Setting.find_by(:name => "local_boot_#{kind}")
-    return local_boot_setting.value if local_boot_setting && local_boot_setting.value.present?
+    return Setting["local_boot_#{kind}"] if Setting["local_boot_#{kind}"].present?
     local_boot_template_name = "#{kind} default local boot"
     Rails.logger.info "Could not find user defined local_boot template from Settings for #{kind}, falling back to #{local_boot_template_name}"
     local_boot_template_name
@@ -133,8 +132,7 @@ class ProvisioningTemplate < Template
   end
 
   def self.global_template_name_for(kind)
-    global_setting = Setting.find_by(:name => "global_#{kind}")
-    return global_setting.value if global_setting && global_setting.value.present?
+    return Setting["global_#{kind}"] if Setting["global_#{kind}"].present?
     global_template_name = global_default_name(kind)
     Rails.logger.info "Could not find user defined global template from Settings for #{kind}, falling back to #{global_template_name}"
     global_template_name

--- a/app/registries/foreman/settings/provisioning.rb
+++ b/app/registries/foreman/settings/provisioning.rb
@@ -135,7 +135,7 @@ Foreman::SettingManager.define(:foreman) do
         default: ProvisioningTemplate.global_default_name(pxe_kind),
         full_name: N_("Global default %s template") % pxe_kind,
         collection: proc { Hash[ProvisioningTemplate.unscoped.of_kind(pxe_kind).pluck(:name).map { |name| [name, name] }] },
-        validates: :pxe_template_name)
+        validate: :pxe_template_name)
     end
     TemplateKind::PXE.each do |pxe_kind|
       setting("local_boot_#{pxe_kind}",
@@ -144,7 +144,7 @@ Foreman::SettingManager.define(:foreman) do
         default: ProvisioningTemplate.local_boot_name(pxe_kind),
         full_name: N_("Local boot %s template") % pxe_kind,
         collection: proc { Hash[ProvisioningTemplate.unscoped.of_kind(pxe_kind).pluck(:name).map { |name| [name, name] }] },
-        validates: :pxe_template_name)
+        validate: :pxe_template_name)
     end
 
     validates 'safemode_render', ->(value) { value || Setting[:bmc_credentials_accessible] }, message: N_("Unable to disable safemode_render when bmc_credentials_accessible is disabled")


### PR DESCRIPTION
Currently when booting with iPXE, the `iPXE default local boot`
regardless of the configured option in settings.  This shifts to looking
up the configured template and falling back to the default if not found.

Signed-off-by: Ben Magistro <koncept1@gmail.com>

