### PR TITLE
Fixes #32991 - PageLayout to use PF4 components

### DIFF
--- a/test/integration/model_js_test.rb
+++ b/test/integration/model_js_test.rb
@@ -3,7 +3,7 @@ require 'integration_test_helper'
 class ModelIntegrationTest < IntegrationTestWithJavascript
   test "create new page" do
     visit models_path
-    click_on "Create model", class: 'pf-c-button'
+    click_on "Create new", class: 'pf-c-button'
     assert_current_path new_model_path
     fill_in "model_name", :with => "IBM 123"
     fill_in "model_hardware_model", :with => "IBMabcde"

--- a/webpack/assets/javascripts/react_app/common/urlHelpers.js
+++ b/webpack/assets/javascripts/react_app/common/urlHelpers.js
@@ -96,3 +96,13 @@ export const exportURL = () => {
   url.addQuery('format', 'csv');
   return `${url.pathname()}${url.search()}`;
 };
+
+export const createURL = () => {
+  const url = getURI();
+  return `${url.pathname()}/new`;
+};
+
+export const helpURL = () => {
+  const url = getURI();
+  return `${url.pathname()}/help`;
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/ActionButtons.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/ActionButtons.js
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  Dropdown,
+  KebabToggle,
+  DropdownItem,
+} from '@patternfly/react-core';
+
+/**
+ * Generate a button or a dropdown of buttons
+ * @param  {String} title The title of the button for the title and text inside the button
+ * @param  {Object} action action to preform when the button is click can be href with data-method or Onclick
+ * @return {Function} button component or splitbutton component
+ */
+export const ActionButtons = ({ buttons: originalButtons }) => {
+  const buttons = [...originalButtons];
+  const [isOpen, setIsOpen] = useState(false);
+  if (!buttons.length) return null;
+  const firstButton = buttons.shift();
+  return (
+    <>
+      <Button
+        component={firstButton.action?.href ? 'a' : null}
+        {...firstButton.action}
+      >
+        {firstButton.title}
+      </Button>
+      {buttons.length > 0 && (
+        <Dropdown
+          toggle={
+            <KebabToggle
+              aria-label="toggle action dropdown"
+              onToggle={setIsOpen}
+            />
+          }
+          isOpen={isOpen}
+          isPlain
+          dropdownItems={buttons.map(button => (
+            <DropdownItem
+              key={button.title}
+              title={button.title}
+              {...button.action}
+            >
+              {button.icon} {button.title}
+            </DropdownItem>
+          ))}
+        />
+      )}
+    </>
+  );
+};
+
+ActionButtons.propTypes = {
+  buttons: PropTypes.arrayOf(
+    PropTypes.shape({
+      action: PropTypes.object,
+      title: PropTypes.string,
+      icon: PropTypes.node,
+    })
+  ),
+};
+
+ActionButtons.defaultProps = {
+  buttons: [],
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -1,0 +1,233 @@
+import React, { useState, useMemo, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { QuestionCircleIcon } from '@patternfly/react-icons';
+import { useHistory } from 'react-router-dom';
+import URI from 'urijs';
+
+import {
+  Spinner,
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  PageSection,
+  PageSectionVariants,
+  TextContent,
+  Text,
+} from '@patternfly/react-core';
+import {
+  createURL,
+  exportURL,
+  helpURL,
+  changeQuery,
+  getURIsearch,
+} from '../../../common/urlHelpers';
+import { translate as __ } from '../../../common/I18n';
+
+import { useAPI } from '../../../common/hooks/API/APIHooks';
+import { getControllerSearchProps, STATUS } from '../../../constants';
+import BreadcrumbBar from '../../BreadcrumbBar';
+import SearchBar from '../../SearchBar';
+import Head from '../../Head';
+import { ActionButtons } from './ActionButtons';
+import './TableIndexPage.scss';
+
+const TableIndexPage = ({
+  apiUrl,
+  apiOptions,
+  header,
+  breadcrumbOptions,
+  beforeToolbarComponent,
+  controller,
+  searchable,
+  exportable,
+  creatable,
+  hasHelpPage,
+  customSearchProps,
+  customExportURL,
+  customCreateAction,
+  customHelpURL,
+  customActionButtons,
+  cutsomToolbarItems,
+  children,
+}) => {
+  const [params, setParams] = useState({});
+  const history = useHistory();
+  const { location: { search } = {} } = history || {};
+  const {
+    response: { search: apiSearchQuery, can_create: canCreate },
+    status = STATUS.PENDING,
+    setAPIOptions,
+  } = useAPI('get', apiUrl, { ...apiOptions, params });
+
+  const memoDefaultSearchProps = useMemo(
+    () => getControllerSearchProps(controller),
+    [controller]
+  );
+  const searchProps = customSearchProps || memoDefaultSearchProps;
+
+  useEffect(() => {
+    let newSearch;
+    if (search !== undefined) {
+      const urlParams = new URLSearchParams(search);
+      newSearch = urlParams.get('search');
+    } else {
+      newSearch = getURIsearch();
+    }
+    setParams({ search: newSearch });
+  }, [search, apiSearchQuery]);
+
+  const setSearch = newSearch => {
+    if (history) {
+      const uri = new URI();
+      uri.setSearch(newSearch);
+      history.push({ search: uri.search() });
+    } else {
+      changeQuery(params);
+    }
+  };
+  const onSearch = newSearch => {
+    setSearch({ search: newSearch, page: 1 });
+  };
+  useEffect(() => {
+    setAPIOptions({ ...apiOptions, params });
+    // Adding to the deps apiOptions creates an endless loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.search, params.page, params.perPage]);
+
+  const actionButtons = [
+    creatable &&
+      canCreate && {
+        title: __('Create new'),
+        action: customCreateAction
+          ? { onClick: customCreateAction() }
+          : { href: createURL() },
+      },
+    exportable && {
+      title: __('Export'),
+      action: { href: customExportURL || exportURL() },
+    },
+    hasHelpPage && {
+      title: __('Documentation'),
+      icon: <QuestionCircleIcon />,
+      action: { href: customHelpURL || helpURL() },
+    },
+    ...customActionButtons,
+  ].filter(item => item);
+
+  return (
+    <div className="pf-c-page foreman-page">
+      <Head>
+        <title>{header}</title>
+      </Head>
+      {breadcrumbOptions && (
+        <PageSection variant={PageSectionVariants.light} type="breadcrumb">
+          <BreadcrumbBar {...breadcrumbOptions} />
+        </PageSection>
+      )}
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text component="h1">{header}</Text>
+        </TextContent>
+      </PageSection>
+      {beforeToolbarComponent}
+      <PageSection variant={PageSectionVariants.light}>
+        <Toolbar className="table-toolbar">
+          <ToolbarContent>
+            {searchable && (
+              <ToolbarGroup>
+                <ToolbarItem>
+                  <SearchBar
+                    data={searchProps}
+                    initialQuery={apiSearchQuery}
+                    onSearch={onSearch}
+                    onBookmarkClick={onSearch}
+                  />
+                </ToolbarItem>
+                {status === STATUS.PENDING && (
+                  <ToolbarItem>
+                    <Spinner size="sm" />
+                  </ToolbarItem>
+                )}
+              </ToolbarGroup>
+            )}
+            {actionButtons.length > 0 && (
+              <ToolbarGroup>
+                <ToolbarItem>
+                  <ActionButtons buttons={actionButtons} />
+                </ToolbarItem>
+              </ToolbarGroup>
+            )}
+            {cutsomToolbarItems && (
+              <ToolbarGroup>{cutsomToolbarItems}</ToolbarGroup>
+            )}
+          </ToolbarContent>
+        </Toolbar>
+      </PageSection>
+      <PageSection variant={PageSectionVariants.light}>{children}</PageSection>
+    </div>
+  );
+};
+
+TableIndexPage.propTypes = {
+  apiUrl: PropTypes.string.isRequired,
+  header: PropTypes.string,
+  apiOptions: PropTypes.object,
+  breadcrumbOptions: PropTypes.shape({
+    isSwitchable: PropTypes.bool,
+    resource: PropTypes.shape({
+      nameField: PropTypes.string,
+      resourceUrl: PropTypes.string,
+      switcherItemUrl: PropTypes.string,
+      resourceFilter: PropTypes.string,
+    }),
+    breadcrumbItems: PropTypes.arrayOf(
+      PropTypes.shape({
+        caption: PropTypes.oneOfType([
+          PropTypes.string.isRequired,
+          PropTypes.shape({
+            icon: PropTypes.shape({
+              url: PropTypes.string,
+              alt: PropTypes.string,
+            }),
+            text: PropTypes.string,
+          }),
+        ]),
+        url: PropTypes.string,
+      })
+    ),
+  }),
+  beforeToolbarComponent: PropTypes.node,
+  controller: PropTypes.string,
+  searchable: PropTypes.bool,
+  exportable: PropTypes.bool,
+  creatable: PropTypes.bool,
+  hasHelpPage: PropTypes.bool,
+  customSearchProps: PropTypes.object,
+  customExportURL: PropTypes.string,
+  customCreateAction: PropTypes.func,
+  customHelpURL: PropTypes.string,
+  customActionButtons: PropTypes.array,
+  children: PropTypes.node.isRequired,
+  cutsomToolbarItems: PropTypes.node,
+};
+
+TableIndexPage.defaultProps = {
+  header: '',
+  apiOptions: null,
+  breadcrumbOptions: null,
+  beforeToolbarComponent: null,
+  controller: '',
+  searchable: true,
+  exportable: false,
+  creatable: true,
+  hasHelpPage: false,
+  customSearchProps: null,
+  customExportURL: '',
+  customCreateAction: null,
+  customHelpURL: '',
+  customActionButtons: [],
+  cutsomToolbarItems: null,
+};
+
+export default TableIndexPage;

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
@@ -1,0 +1,11 @@
+.pf-c-page.foreman-page {
+  display: block;
+  margin-right: -20px; // Overriding .container-fluid padding
+  margin-left: -20px; // Overriding .container-fluid padding
+  .table-toolbar {
+    padding: 0;
+    .pf-c-toolbar__content{
+      padding: 0;
+    }
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.test.js
@@ -1,0 +1,87 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import configureMockStore from 'redux-mock-store';
+import { fireEvent, screen, render, act } from '@testing-library/react';
+// import * as api from 'foremanReact/redux/API';
+// import * as routerSelectors from 'foremanReact/routes/RouterSelector';
+import TableIndexPage from './TableIndexPage';
+import { breadcrumbBar } from '../../../components/BreadcrumbBar/BreadcrumbBar.fixtures';
+import '@testing-library/jest-dom';
+
+const controller = 'testController';
+const mockStore = configureMockStore([thunk]);
+const apiKey = 'API_TEST';
+const store = mockStore({
+  API: {
+    [apiKey]: {
+      response: {
+        items: ['item1', 'item2'],
+        can_create: true,
+      },
+    },
+  },
+  autocomplete: { searchBar: { url: '/test/', searchQuery: 'name=test' } },
+  foremanModals: {
+    modal2: { isOpen: false },
+  },
+  breadcrumbBar: { resourceSwitcherItems: [{ name: 'a', id: '1' }] },
+});
+
+const props = {
+  apiUrl: '/api/test',
+  apiOptions: { key: apiKey },
+  header: 'Test Title',
+  breadcrumbOptions: breadcrumbBar,
+  beforeToolbarComponent: <span>I am before the toolbar</span>,
+  controller,
+  searchable: true,
+  exportable: true,
+  creatable: true,
+  hasHelpPage: true,
+  children: <div>Content</div>,
+  customActionButtons: [
+    {
+      title: 'Custom Action',
+      action: { href: '/custom' },
+    },
+  ],
+  cutsomToolbarItems: <button>Custom button</button>,
+};
+Object.defineProperty(window, 'location', {
+  value: { href: '/test?search=name=test' },
+});
+describe('TableIndexPage', () => {
+  it('All props are shown', async () => {
+    render(
+      <Provider store={store}>
+        <TableIndexPage {...props} />
+      </Provider>
+    );
+    expect(screen.getByText('Create new').closest('a')).toHaveAttribute(
+      'href',
+      '/test/new'
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('toggle action dropdown'));
+    });
+    expect(screen.getByText('Export').closest('a')).toHaveAttribute(
+      'href',
+      '/test?search=name%3Dtest&format=csv'
+    );
+    expect(screen.getByText('Documentation').closest('a')).toHaveAttribute(
+      'href',
+      '/test/help'
+    );
+    expect(screen.getByText('Custom Action').closest('a')).toHaveAttribute(
+      'href',
+      '/custom'
+    );
+
+    expect(screen.queryAllByText('I am before the toolbar')).toHaveLength(1);
+    
+    expect(screen.getByDisplayValue('name=test')).toBeInTheDocument();
+    expect(screen.queryAllByText('Test Title')).toHaveLength(1);
+    expect(screen.queryAllByText('Custom button')).toHaveLength(1);
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPage.js
@@ -1,16 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from '@patternfly/react-core';
-import { Link } from 'react-router-dom';
 
 import { translate as __ } from '../../../common/I18n';
-import PageLayout from '../../common/PageLayout/PageLayout';
+import TableIndexPage from '../../../components/PF4/TableIndexPage/TableIndexPage';
 import ModelsPageContent from './components/ModelsPageContent';
-import { MODELS_SEARCH_PROPS } from '../constants';
+import { MODELS_API_PATH, API_REQUEST_KEY } from '../constants';
 
 const ModelsPage = ({
   fetchAndPush,
-  search,
   isLoading,
   hasData,
   models,
@@ -18,45 +15,28 @@ const ModelsPage = ({
   hasError,
   itemCount,
   message,
-  canCreate,
-}) => {
-  const handleSearch = query => fetchAndPush({ searchQuery: query, page: 1 });
-
-  const createBtn = (
-    <Link to="/models/new">
-      <Button>{__('Create model')}</Button>
-    </Link>
-  );
-
-  return (
-    <PageLayout
-      header={__('Hardware models')}
-      searchable={!isLoading}
-      searchProps={MODELS_SEARCH_PROPS}
-      searchQuery={search}
-      isLoading={isLoading && hasData}
-      onSearch={handleSearch}
-      onBookmarkClick={handleSearch}
-      toolbarButtons={canCreate && createBtn}
-    >
-      <ModelsPageContent
-        models={models}
-        search={search}
-        sort={sort}
-        hasData={hasData}
-        hasError={hasError}
-        isLoading={isLoading}
-        itemCount={itemCount}
-        fetchAndPush={fetchAndPush}
-        message={message}
-      />
-    </PageLayout>
-  );
-};
+}) => (
+  <TableIndexPage
+    apiUrl={MODELS_API_PATH}
+    apiOptions={{ key: API_REQUEST_KEY }}
+    header={__('Hardware models')}
+    controller="models"
+  >
+    <ModelsPageContent
+      models={models}
+      sort={sort}
+      hasData={hasData}
+      hasError={hasError}
+      isLoading={isLoading}
+      itemCount={itemCount}
+      fetchAndPush={fetchAndPush}
+      message={message}
+    />
+  </TableIndexPage>
+);
 
 ModelsPage.propTypes = {
   fetchAndPush: PropTypes.func.isRequired,
-  search: PropTypes.string,
   isLoading: PropTypes.bool.isRequired,
   hasData: PropTypes.bool.isRequired,
   models: PropTypes.array.isRequired,
@@ -64,11 +44,9 @@ ModelsPage.propTypes = {
   hasError: PropTypes.bool.isRequired,
   itemCount: PropTypes.number.isRequired,
   message: PropTypes.object,
-  canCreate: PropTypes.bool.isRequired,
 };
 
 ModelsPage.defaultProps = {
-  search: '',
   message: {},
 };
 

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPageSelectors.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/ModelsPageSelectors.js
@@ -11,7 +11,6 @@ export const response = {
   perPage: 0,
   search: '',
   sort: {},
-  canCreate: false,
   subtotal: 0,
   message: {},
 };
@@ -59,7 +58,5 @@ export const selectSort = state => {
   return sort;
 };
 
-export const selectCanCreate = state =>
-  selectModelsPageResponse(state).canCreate;
 export const selectSubtotal = state => selectModelsPageResponse(state).subtotal;
 export const selectMessage = state => selectModelsPageResponse(state).message;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/ModelsPage.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/ModelsPage.test.js
@@ -6,7 +6,6 @@ const props = {
   fetchAndPush: () => {},
   models,
   itemCount: models.length,
-  canCreate: true,
 };
 
 const fixtures = {

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/__tests__/__snapshots__/ModelsPage.test.js.snap
@@ -1,42 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ModelsPage redering should render when loading 1`] = `
-<PageLayout
-  beforeToolbarComponent={null}
-  breadcrumbOptions={null}
-  customBreadcrumbs={null}
-  header="Hardware models"
-  isLoading={false}
-  onBookmarkClick={[Function]}
-  onSearch={[Function]}
-  searchProps={
+<TableIndexPage
+  apiOptions={
     Object {
-      "autocomplete": Object {
-        "id": "searchBar",
-        "searchQuery": "",
-        "url": "models/auto_complete_search",
-        "useKeyShortcuts": true,
-      },
-      "bookmarks": Object {
-        "canCreate": true,
-        "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
-        "url": "/api/bookmarks",
-      },
-      "controller": "models",
+      "key": "MODELS",
     }
   }
-  searchQuery="name=foo"
-  searchable={false}
-  toolbarButtons={
-    <Link
-      to="/models/new"
-    >
-      <Button>
-        Create model
-      </Button>
-    </Link>
-  }
+  apiUrl="/api/models?include_permissions=true"
+  beforeToolbarComponent={null}
+  breadcrumbOptions={null}
+  controller="models"
+  creatable={true}
+  customActionButtons={Array []}
+  customCreateAction={null}
+  customExportURL=""
+  customHelpURL=""
+  customSearchProps={null}
+  cutsomToolbarItems={null}
+  exportable={false}
+  hasHelpPage={false}
+  header="Hardware models"
+  searchable={true}
 >
   <Component
     fetchAndPush={[Function]}
@@ -65,7 +50,6 @@ exports[`ModelsPage redering should render when loading 1`] = `
         },
       ]
     }
-    search="name=foo"
     sort={
       Object {
         "by": "defaultName",
@@ -73,46 +57,31 @@ exports[`ModelsPage redering should render when loading 1`] = `
       }
     }
   />
-</PageLayout>
+</TableIndexPage>
 `;
 
 exports[`ModelsPage redering should render with error 1`] = `
-<PageLayout
-  beforeToolbarComponent={null}
-  breadcrumbOptions={null}
-  customBreadcrumbs={null}
-  header="Hardware models"
-  isLoading={false}
-  onBookmarkClick={[Function]}
-  onSearch={[Function]}
-  searchProps={
+<TableIndexPage
+  apiOptions={
     Object {
-      "autocomplete": Object {
-        "id": "searchBar",
-        "searchQuery": "",
-        "url": "models/auto_complete_search",
-        "useKeyShortcuts": true,
-      },
-      "bookmarks": Object {
-        "canCreate": true,
-        "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
-        "url": "/api/bookmarks",
-      },
-      "controller": "models",
+      "key": "MODELS",
     }
   }
-  searchQuery="name=foo"
+  apiUrl="/api/models?include_permissions=true"
+  beforeToolbarComponent={null}
+  breadcrumbOptions={null}
+  controller="models"
+  creatable={true}
+  customActionButtons={Array []}
+  customCreateAction={null}
+  customExportURL=""
+  customHelpURL=""
+  customSearchProps={null}
+  cutsomToolbarItems={null}
+  exportable={false}
+  hasHelpPage={false}
+  header="Hardware models"
   searchable={true}
-  toolbarButtons={
-    <Link
-      to="/models/new"
-    >
-      <Button>
-        Create model
-      </Button>
-    </Link>
-  }
 >
   <Component
     fetchAndPush={[Function]}
@@ -146,7 +115,6 @@ exports[`ModelsPage redering should render with error 1`] = `
         },
       ]
     }
-    search="name=foo"
     sort={
       Object {
         "by": "defaultName",
@@ -154,46 +122,31 @@ exports[`ModelsPage redering should render with error 1`] = `
       }
     }
   />
-</PageLayout>
+</TableIndexPage>
 `;
 
 exports[`ModelsPage redering should render with models 1`] = `
-<PageLayout
-  beforeToolbarComponent={null}
-  breadcrumbOptions={null}
-  customBreadcrumbs={null}
-  header="Hardware models"
-  isLoading={false}
-  onBookmarkClick={[Function]}
-  onSearch={[Function]}
-  searchProps={
+<TableIndexPage
+  apiOptions={
     Object {
-      "autocomplete": Object {
-        "id": "searchBar",
-        "searchQuery": "",
-        "url": "models/auto_complete_search",
-        "useKeyShortcuts": true,
-      },
-      "bookmarks": Object {
-        "canCreate": true,
-        "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
-        "url": "/api/bookmarks",
-      },
-      "controller": "models",
+      "key": "MODELS",
     }
   }
-  searchQuery="name=foo"
+  apiUrl="/api/models?include_permissions=true"
+  beforeToolbarComponent={null}
+  breadcrumbOptions={null}
+  controller="models"
+  creatable={true}
+  customActionButtons={Array []}
+  customCreateAction={null}
+  customExportURL=""
+  customHelpURL=""
+  customSearchProps={null}
+  cutsomToolbarItems={null}
+  exportable={false}
+  hasHelpPage={false}
+  header="Hardware models"
   searchable={true}
-  toolbarButtons={
-    <Link
-      to="/models/new"
-    >
-      <Button>
-        Create model
-      </Button>
-    </Link>
-  }
 >
   <Component
     fetchAndPush={[Function]}
@@ -222,7 +175,6 @@ exports[`ModelsPage redering should render with models 1`] = `
         },
       ]
     }
-    search="name=foo"
     sort={
       Object {
         "by": "defaultName",
@@ -230,46 +182,31 @@ exports[`ModelsPage redering should render with models 1`] = `
       }
     }
   />
-</PageLayout>
+</TableIndexPage>
 `;
 
 exports[`ModelsPage redering should render with no data 1`] = `
-<PageLayout
-  beforeToolbarComponent={null}
-  breadcrumbOptions={null}
-  customBreadcrumbs={null}
-  header="Hardware models"
-  isLoading={false}
-  onBookmarkClick={[Function]}
-  onSearch={[Function]}
-  searchProps={
+<TableIndexPage
+  apiOptions={
     Object {
-      "autocomplete": Object {
-        "id": "searchBar",
-        "searchQuery": "",
-        "url": "models/auto_complete_search",
-        "useKeyShortcuts": true,
-      },
-      "bookmarks": Object {
-        "canCreate": true,
-        "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
-        "url": "/api/bookmarks",
-      },
-      "controller": "models",
+      "key": "MODELS",
     }
   }
-  searchQuery="name=foo"
+  apiUrl="/api/models?include_permissions=true"
+  beforeToolbarComponent={null}
+  breadcrumbOptions={null}
+  controller="models"
+  creatable={true}
+  customActionButtons={Array []}
+  customCreateAction={null}
+  customExportURL=""
+  customHelpURL=""
+  customSearchProps={null}
+  cutsomToolbarItems={null}
+  exportable={false}
+  hasHelpPage={false}
+  header="Hardware models"
   searchable={true}
-  toolbarButtons={
-    <Link
-      to="/models/new"
-    >
-      <Button>
-        Create model
-      </Button>
-    </Link>
-  }
 >
   <Component
     fetchAndPush={[Function]}
@@ -298,7 +235,6 @@ exports[`ModelsPage redering should render with no data 1`] = `
         },
       ]
     }
-    search="name=foo"
     sort={
       Object {
         "by": "defaultName",
@@ -306,5 +242,5 @@ exports[`ModelsPage redering should render with no data 1`] = `
       }
     }
   />
-</PageLayout>
+</TableIndexPage>
 `;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/components/ModelsPageContent.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/components/ModelsPageContent.js
@@ -8,13 +8,7 @@ import ModelDeleteModal from './ModelDeleteModal';
 import LoadingPage from '../../../common/LoadingPage';
 import { withRenderHandler } from '../../../../common/HOC';
 
-const ModelsPageContent = ({
-  models,
-  search,
-  sort,
-  fetchAndPush,
-  itemCount,
-}) => {
+const ModelsPageContent = ({ models, sort, fetchAndPush, itemCount }) => {
   const [toDelete, setToDelete] = useState({});
 
   return (
@@ -22,7 +16,6 @@ const ModelsPageContent = ({
       <ModelDeleteModal toDelete={toDelete} fetchAndPush={fetchAndPush} />
       <ModelsTable
         results={models}
-        search={search}
         sortBy={sort.by}
         sortOrder={sort.order}
         getTableItems={fetchAndPush}
@@ -36,14 +29,9 @@ const ModelsPageContent = ({
 
 ModelsPageContent.propTypes = {
   models: PropTypes.array.isRequired,
-  search: PropTypes.string,
   sort: PropTypes.object.isRequired,
   fetchAndPush: PropTypes.func.isRequired,
   itemCount: PropTypes.number.isRequired,
-};
-
-ModelsPageContent.defaultProps = {
-  search: '',
 };
 
 export default withRenderHandler({

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
@@ -8,26 +8,22 @@ import { callOnMount, callOnPopState } from '../../../common/HOC';
 
 import {
   selectModels,
-  selectSearch,
   selectSort,
   selectHasData,
   selectHasError,
   selectIsLoading,
   selectSubtotal,
   selectMessage,
-  selectCanCreate,
 } from './ModelsPageSelectors';
 
 const mapStateToProps = state => ({
   models: selectModels(state),
-  search: selectSearch(state),
   sort: selectSort(state),
   isLoading: selectIsLoading(state),
   hasData: selectHasData(state),
   hasError: selectHasError(state),
   itemCount: selectSubtotal(state),
   message: selectMessage(state),
-  canCreate: selectCanCreate(state),
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);

--- a/webpack/assets/javascripts/react_app/routes/Models/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/constants.js
@@ -1,12 +1,9 @@
-import { getControllerSearchProps } from '../../constants';
-
 export const MODELS_PAGE_DATA_RESOLVED = 'MODELS_PAGE_DATA_RESOLVED';
 export const MODELS_PAGE_DATA_FAILED = 'MODELS_PAGE_DATA_FAILED';
 export const MODELS_PAGE_HIDE_LOADING = 'MODELS_PAGE_HIDE_LOADING';
 export const MODELS_PAGE_SHOW_LOADING = 'MODELS_PAGE_SHOW_LOADING';
 export const MODELS_PAGE_CLEAR_ERROR = 'MODELS_PAGE_CLEAR_ERROR';
 
-export const MODELS_SEARCH_PROPS = getControllerSearchProps('models');
 export const MODELS_API_PATH = '/api/models?include_permissions=true';
 export const MODELS_PATH = '/models';
 export const MODEL_DELETE_MODAL_ID = 'modelDeleteModal';


### PR DESCRIPTION
Starting to create an index page that would be used as a template for tables.
A screenshot that shows all the available buttons(create, export, documentation), models page doesn't have them all so its fake and the pr doesn't add them :)
Blocked by https://github.com/theforeman/foreman/pull/8990
![Screenshot from 2021-12-22 15-31-37](https://user-images.githubusercontent.com/30431079/147113382-b6b035c9-cf47-4a14-a5cc-4b62d322b9c9.png)
