### PR TITLE
Preview of registration and host_init_config templates

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -87,11 +87,15 @@ class TemplatesController < ApplicationController
     else
       @template = resource_class.new(params[type_name_plural])
     end
-    base = @template.class.preview_host_collection
-    @host = params[:preview_host_id].present? ? base.find(params[:preview_host_id]) : base.first
-    if @host.nil?
-      render :plain => _('No host could be found for rendering the template'), :status => :not_found
-      return
+    scope = @template.host_init_config_template? ? Template : @template.class
+    base = scope.preview_host_collection
+
+    unless @template.registration_template?
+      @host = params[:preview_host_id].present? ? base.find(params[:preview_host_id]) : base.first
+      if @host.nil?
+        render :plain => _('No host could be found for rendering the template'), :status => :not_found
+        return
+      end
     end
     @template.template = params[:template]
 

--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -103,4 +103,10 @@ module TemplatesHelper
   def resource_permission(resource_type)
     "view_#{resource_type.demodulize.underscore.pluralize}".to_sym
   end
+
+  def template_class(template)
+    return 'Template' if template.registration_template? || template.host_init_config_template?
+
+    template.class.to_s
+  end
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -206,11 +206,19 @@ class Template < ApplicationRecord
   end
 
   def support_single_host_render?
-    true
+    !registration_template?
   end
 
   def support_preview?
     true
+  end
+
+  def registration_template?
+    try(:template_kind)&.name == "registration"
+  end
+
+  def host_init_config_template?
+    try(:template_kind)&.name == "host_init_config"
   end
 
   private

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -51,7 +51,7 @@
             id: @template.id,
             type: 'templates',
             name: template_name_attribute(@template.class),
-            templateClass: @template.class.to_s,
+            templateClass: template_class(@template),
             title: @template.name,
             showImport: !@template.locked,
             showPreview: @template.support_preview?,

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -16,7 +16,7 @@ description: |
 -%>
 
 # Rendered with following template parameters:
-<%= "# User: [#{@user.login}]" -%>
+<%= "# User: [#{@user.login}]" if @user -%>
 <%= "\n# Organization: [#{@organization.name}]" if @organization -%>
 <%= "\n# Location: [#{@location.name}]" if @location -%>
 <%= "\n# Host group: [#{@hostgroup.title}]" if @hostgroup -%>
@@ -171,9 +171,9 @@ if [ -f /etc/redhat-release ]; then
     # Configure subscription-manager
     test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
     subscription-manager config \
-      --server.hostname="<%= @rhsm_url.host %>" \
-      --server.port="<%= @rhsm_url.port %>" \
-      --server.prefix="<%= @rhsm_url.path %>" \
+      --server.hostname="<%= @rhsm_url.host if @rhsm_url %>" \
+      --server.port="<%= @rhsm_url.port if @rhsm_url %>" \
+      --server.prefix="<%= @rhsm_url.path if @rhsm_url %>" \
       --rhsm.repo_ca_cert="$KATELLO_SERVER_CA_CERT" \
       --rhsm.baseurl="<%= @pulp_content_url %>"
 
@@ -193,7 +193,7 @@ if [ -f /etc/redhat-release ]; then
     fi
 
     subscription-manager register <%= '--force' if @force %> \
-      --org='<%= @organization.label %>' \
+      --org='<%= @organization.label if @organization %>' \
       --activationkey='<%= activation_keys %>' || <%= @ignore_subman_errors ? 'true' : 'cleanup_and_exit 1' %>
 
     register_katello_host | bash

--- a/test/controllers/provisioning_templates_controller_test.rb
+++ b/test/controllers/provisioning_templates_controller_test.rb
@@ -211,6 +211,26 @@ class ProvisioningTemplatesControllerTest < ActionController::TestCase
     assert_includes @response.body, 'parse error on value'
   end
 
+  test 'preview - registration' do
+    template = FactoryBot.create(:provisioning_template, template_kind: template_kinds(:registration))
+
+    post :preview, params: { :template => '<%= 1+1 -%>', :id => template }, session: set_session_user
+    assert_equal '2'.to_json, @response.body
+  end
+
+  test 'preview - host_init_config' do
+    template = FactoryBot.create(:provisioning_template, template_kind: template_kinds(:host_init_config))
+    host = FactoryBot.create(:host, managed: false)
+
+    # works for given host
+    post :preview, params: { :preview_host_id => host.id, :template => '<%= @host.name -%>', :id => template }, session: set_session_user
+    assert_equal host.hostname.to_s.to_json, @response.body
+
+    # without host specified it uses first one
+    post :preview, params: { :template => '<%= 1+1 -%>', :id => template }, session: set_session_user
+    assert_equal '2'.to_json, @response.body
+  end
+
   context 'templates combinations' do
     test 'can be added on template creation' do
       provisioning_template = {

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -502,4 +502,16 @@ data"
       end
     end
   end
+
+  test 'registration_template?' do
+    template = FactoryBot.build(:provisioning_template, template_kind: template_kinds(:registration))
+
+    assert template.registration_template?
+  end
+
+  test 'host_init_config_template?' do
+    template = FactoryBot.build(:provisioning_template, template_kind: template_kinds(:host_init_config))
+
+    assert template.host_init_config_template?
+  end
 end


### PR DESCRIPTION
* Allow preview of registration templates without selecting hosts
* List all hosts (managed & un-managed) for preview of host_init_config template

From community post: https://community.theforeman.org/t/provisioning-template-preview-is-blank-and-no-hosts-listed/26588

**TODO**
* Fix issue of preview when registration template is not saved (for example while cloning)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
