### PR TITLE
Fixes #34213 - 'truthy?' and 'falsy?' template helpers

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -54,7 +54,9 @@ module Foreman
         :format_time,
         :shell_escape,
         :join_with_line_break,
-        :current_date
+        :current_date,
+        :truthy?,
+        :falsy?
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/app/services/foreman/renderer/scope/macros/helpers.rb
+++ b/app/services/foreman/renderer/scope/macros/helpers.rb
@@ -108,6 +108,26 @@ module Foreman
           def current_date(format: '%F')
             Time.zone.today.strftime(format)
           end
+
+          apipie :method, 'Checks whether a value is truthy or not' do
+            optional :value, Object, desc: 'Value to check'
+            returns one_of: [true, false], desc: 'Returns true if the value can be considered as truthy, false otherwise'
+            example "truthy?('1') #=> true"
+            example "truthy?('0') #=> false"
+          end
+          def truthy?(value = nil)
+            Foreman::Cast.to_bool(value) == true
+          end
+
+          apipie :method, 'Checks whether a value is falsy or not' do
+            optional :value, Object, desc: 'Value to check'
+            returns one_of: [true, false], desc: 'Returns true if the value can be considered as falsy, false otherwise'
+            example "falsy?('1') #=> false"
+            example "falsy?('0') #=> true"
+          end
+          def falsy?(value = nil)
+            Foreman::Cast.to_bool(value) == false
+          end
         end
       end
     end

--- a/test/unit/foreman/renderer/scope/macros/helpers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/helpers_test.rb
@@ -99,4 +99,14 @@ class HelpersTest < ActiveSupport::TestCase
 
     it { assert_equal escaped, scope.shell_escape(string) }
   end
+
+  describe '#truthy?' do
+    it { assert scope.truthy?('true') }
+    it { refute scope.truthy?('false') }
+  end
+
+  describe '#falsy?' do
+    it { assert scope.falsy?('false') }
+    it { refute scope.falsy?('true') }
+  end
 end


### PR DESCRIPTION
Template helpers for checking if a value is truthly or falsy

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
