### PR TITLE
Fixes #3421 - Typos in provisioning templates broke Puppet aio detection

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -12,7 +12,7 @@ description: |
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+  aio_enabled = host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -16,7 +16,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+aio_enabled = host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
 
 if os_family == 'Freebsd'
   freebsd_package = host_param_true?('enable-puppet6') ? 'puppet6' : 'puppet5'
@@ -48,7 +48,7 @@ else
   yum -t -y install <%= linux_package %>
 fi
 <% elsif os_family == 'Suse' -%>
-<% if host_param_true?('enable-official-puppet7-repo') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 rpmkeys --import http://yum.puppet.com/RPM-GPG-KEY-puppetlabs
 rpmkeys --import http://yum.puppet.com/RPM-GPG-KEY-puppet
 <% end -%>

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -31,7 +31,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet "blacklist_kernel_modules" %>
 
 <% if puppet_enabled %>
-<% if host_param_true?('enable-official-puppet7-repo') || ('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
+<% if host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -43,12 +43,15 @@ runcmd:
 
 - |
 - |
-
   apt-get update
-  apt-get install -y puppet-agent
+  apt-get install -y puppet
   
-  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+  cat > /etc/puppet/puppet.conf << EOF
   [main]
+  vardir = /var/lib/puppet
+  logdir = /var/log/puppet
+  rundir = /var/run/puppet
+  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -58,13 +61,17 @@ runcmd:
   EOF
   
   
+  if [ -f "/etc/default/puppet" ]
+  then
+  /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+  fi
+  /usr/bin/puppet agent --enable
   
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
   systemctl enable puppet
-
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built
   post: []

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -44,15 +44,18 @@ runcmd:
 
 - |
 - |
-
   if [ -f /usr/bin/dnf ]; then
-    dnf -y install puppet-agent
+    dnf -y install puppet
   else
-    yum -t -y install puppet-agent
+    yum -t -y install puppet
   fi
   
-  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+  cat > /etc/puppet/puppet.conf << EOF
   [main]
+  vardir = /var/lib/puppet
+  logdir = /var/log/puppet
+  rundir = /var/run/puppet
+  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -69,8 +72,7 @@ runcmd:
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
-
+  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built
   post: []

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -43,12 +43,15 @@ runcmd:
 
 - |
 - |
-
   apt-get update
-  apt-get install -y puppet-agent
+  apt-get install -y puppet
   
-  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+  cat > /etc/puppet/puppet.conf << EOF
   [main]
+  vardir = /var/lib/puppet
+  logdir = /var/log/puppet
+  rundir = /var/run/puppet
+  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -58,13 +61,17 @@ runcmd:
   EOF
   
   
+  if [ -f "/etc/default/puppet" ]
+  then
+  /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+  fi
+  /usr/bin/puppet agent --enable
   
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime   --no-daemonize
   systemctl enable puppet
-
 phone_home:
   url: http://foreman.some.host.fqdn/unattended/built
   post: []

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -20,6 +20,10 @@ apt-get -y install puppet >/dev/null 2>/dev/null
 
 cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
@@ -25,13 +25,17 @@ pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -48,7 +52,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -43,13 +43,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -66,7 +70,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -10,10 +10,14 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet-agent
+apt-get install -y puppet
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -23,11 +27,16 @@ certname        = snapshot-ipv4-dhcp-deb10
 EOF
 
 
+if [ -f "/etc/default/puppet" ]
+then
+/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+fi
+/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -10,10 +10,14 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet-agent
+apt-get install -y puppet
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -23,11 +27,16 @@ certname        = snapshot-ipv4-dhcp-ubuntu20
 EOF
 
 
+if [ -f "/etc/default/puppet" ]
+then
+/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+fi
+/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -95,13 +95,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -118,7 +122,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -97,13 +97,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -120,7 +124,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -105,13 +105,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -128,7 +132,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -105,13 +105,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -128,7 +132,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -105,13 +105,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -128,7 +132,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -105,13 +105,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -128,7 +132,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -105,13 +105,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -128,7 +132,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
@@ -1,4 +1,8 @@
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
@@ -1,11 +1,15 @@
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -22,4 +26,4 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -23,15 +23,18 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 
-
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -48,7 +51,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -53,13 +53,17 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet-agent
+  dnf -y install puppet
 else
-  yum -t -y install puppet-agent
+  yum -t -y install puppet
 fi
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -76,7 +80,7 @@ puppet_unit=puppet
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -28,10 +28,14 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet-agent
+apt-get install -y puppet
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -41,11 +45,16 @@ certname        = snapshot-ipv4-dhcp-deb10
 EOF
 
 
+if [ -f "/etc/default/puppet" ]
+then
+/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+fi
+/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -28,10 +28,14 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet-agent
+apt-get install -y puppet
 
-cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+cat > /etc/puppet/puppet.conf << EOF
 [main]
+vardir = /var/lib/puppet
+logdir = /var/log/puppet
+rundir = /var/run/puppet
+ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -41,11 +45,16 @@ certname        = snapshot-ipv4-dhcp-ubuntu20
 EOF
 
 
+if [ -f "/etc/default/puppet" ]
+then
+/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
+fi
+/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
 # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -28,13 +28,17 @@ runcmd:
 
 - |
   if [ -f /usr/bin/dnf ]; then
-    dnf -y install puppet-agent
+    dnf -y install puppet
   else
-    yum -t -y install puppet-agent
+    yum -t -y install puppet
   fi
   
-  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
+  cat > /etc/puppet/puppet.conf << EOF
   [main]
+  vardir = /var/lib/puppet
+  logdir = /var/log/puppet
+  rundir = /var/run/puppet
+  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -51,7 +55,7 @@ runcmd:
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
   # passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 phone_home:


### PR DESCRIPTION
Hello,

Please attached a patch fixing PR #8899 that broke Puppet aio detection in provisionning because of missing `host_param_true?`.
I also reverted all unittests changes because these are obviously related to unexpected switch from distribution puppet package to puppetlabs ones.

Regards, Adam.