### PR TITLE
Fixes #34223 - fix the missing username in audits

### DIFF
--- a/app/models/concerns/audit_extensions.rb
+++ b/app/models/concerns/audit_extensions.rb
@@ -1,6 +1,7 @@
 # The audit class is part of audited plugin
 module AuditExtensions
   extend ActiveSupport::Concern
+  include HasManyCommon
 
   REDACTED = N_('[redacted]')
 


### PR DESCRIPTION
The `user_name` attribute doesn't exist, probably due to some aliasing cleanup.