### PR TITLE
Add Safemode Jail for ActiveSupport::TimeWithZone

### DIFF
--- a/config/initializers/safemode_jail.rb
+++ b/config/initializers/safemode_jail.rb
@@ -21,5 +21,5 @@ class URI::Generic::Jail < Safemode::Jail
 end
 
 class ActiveSupport::TimeWithZone::Jail < Safemode::Jail
-  allow *Safemode.core_jail_methods(Time).uniq
+  allow(*Safemode.core_jail_methods(Time).uniq)
 end

--- a/config/initializers/safemode_jail.rb
+++ b/config/initializers/safemode_jail.rb
@@ -19,3 +19,7 @@ end
 class URI::Generic::Jail < Safemode::Jail
   allow :host, :path, :port, :query, :scheme
 end
+
+class ActiveSupport::TimeWithZone::Jail < Safemode::Jail
+  allow *Safemode.core_jail_methods(Time).uniq
+end


### PR DESCRIPTION
Adding Safemode Jail to ActiveSupport::TimeWithZone to allow it's use in templates and parameters.