### PR TITLE
Refs #33968 - Telemetry is not autoloadable

### DIFF
--- a/config/initializers/5_telemetry.rb
+++ b/config/initializers/5_telemetry.rb
@@ -1,3 +1,5 @@
+require 'foreman/telemetry'
+
 # Foreman telemetry metrics registration.
 #
 # There are three types of telemetry measurements: counter, gauge, histogram. Each measurement has unique name

--- a/lib/foreman/telemetry.rb
+++ b/lib/foreman/telemetry.rb
@@ -1,6 +1,11 @@
 require 'singleton'
 require 'forwardable'
 
+require 'foreman/telemetry_sinks/metric_exporter_sink'
+require 'foreman/telemetry_sinks/prometheus_sink'
+require 'foreman/telemetry_sinks/rails_logger_sink'
+require 'foreman/telemetry_sinks/statsd_sink'
+
 module Foreman
   class Telemetry
     include Singleton


### PR DESCRIPTION
We need to require Telemetry, because it will not be autoloadable with Zeitwerk (it is too early).