### PR TITLE
Fixes #33310 - Remove epoch shifting, as AreaChart already does this

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -202,7 +202,7 @@ module HostsHelper
     failed_restarts = [_("Skipped")]
     skipped = [_("Restarted")]
     @host.reports.recent(timerange).each do |r|
-      time            << r.reported_at.to_i * 1000
+      time            << r.reported_at.to_i
       applied         << r.applied
       failed          << r.failed
       restarted       << r.restarted
@@ -217,7 +217,7 @@ module HostsHelper
     config = [_("Config Retrieval")]
     runtime = [_("Runtime")]
     @host.reports.recent(timerange).each do |r|
-      time << r.reported_at.to_i * 1000
+      time << r.reported_at.to_i
       config  << r.config_retrieval
       runtime << r.runtime
     end


### PR DESCRIPTION
The epoch time is getting multiplied twice for the runtime/resources charts leading to dates to be randomly shifted many years in the future. This PR removes the multiplication before the data is sent to AreaChart.

![image](https://user-images.githubusercontent.com/174320/148407852-f477dc00-1ef0-49e1-9314-4ffdc58983e7.png)
