### PR TITLE
Fixes #34234 - do not allow HTTP on SmartProxy Auth

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -13,22 +13,6 @@ module Foreman::Controller::SmartProxyAuth
       skip_before_action :session_expiry, :update_activity_time, :only => actions
       before_action(:only => actions) { require_smart_proxy_or_login(options[:features]) }
       attr_reader :detected_proxy
-
-      cattr_accessor :smart_proxy_filter_actions
-      self.smart_proxy_filter_actions ||= []
-      self.smart_proxy_filter_actions.push(*actions)
-
-      prepend SmartProxyRequireSsl
-    end
-  end
-
-  module SmartProxyRequireSsl
-    def require_ssl?
-      if [self.smart_proxy_filter_actions].flatten.map(&:to_s).include?(action_name)
-        false
-      else
-        super
-      end
     end
   end
 
@@ -82,6 +66,7 @@ module Foreman::Controller::SmartProxyAuth
         request_hosts = Resolv.new.getnames(request.remote_ip)
       end
     elsif SETTINGS[:require_ssl]
+      # This is theoretically unreachable branch since https://github.com/theforeman/foreman/pull/9020
       logger.warn "SSL is required - request from #{request.remote_ip}"
     else
       request_hosts = Resolv.new.getnames(request.remote_ip)

--- a/test/controllers/api/v2/config_reports_controller_test.rb
+++ b/test/controllers/api/v2/config_reports_controller_test.rb
@@ -106,7 +106,7 @@ class Api::V2::ConfigReportsControllerTest < ActionController::TestCase
 
       Resolv.any_instance.stubs(:getnames).returns(['else.where'])
       post :create, params: { :config_report => create_a_puppet_transaction_report }
-      assert_response :forbidden
+      assert_response :redirect
     end
 
     test 'when "require_ssl_smart_proxies" is true and "require_ssl" is false, HTTP requests should be able to create reports' do

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -792,7 +792,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
 
       Resolv.any_instance.stubs(:getnames).returns(['else.where'])
       post :facts, params: { :name => hostname, :facts => facts }
-      assert_response :forbidden
+      assert_response :redirect
     end
 
     test 'when "require_ssl_smart_proxies" is true and "require_ssl" is false, HTTP requests should be able to import facts' do


### PR DESCRIPTION
SmartProxyAuth enabled on its endpoints HTTP to log a message, that ssl is required.
This in not necessary and it is hard to keep for the future as Rails 6.1 will make that harder.

There is not too much benefit from this, so it's better to drop it.
