### PR TITLE
Fixes #34236 - Drop require_ssl_smart_proxies setting

### DIFF
--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -43,7 +43,7 @@ module Foreman::Controller::SmartProxyAuth
                               SmartProxy.unscoped.with_features(*features)
                             end
 
-    if !Setting[:restrict_registered_smart_proxies] || auth_smart_proxy(allowed_smart_proxies, Setting[:require_ssl_smart_proxies])
+    if !Setting[:restrict_registered_smart_proxies] || auth_smart_proxy(allowed_smart_proxies)
       set_admin_user
       return true
     end
@@ -57,8 +57,7 @@ module Foreman::Controller::SmartProxyAuth
   end
 
   # Filter requests to only permit from hosts with a registered smart proxy
-  # Uses rDNS of the request to match proxy hostnames
-  def auth_smart_proxy(proxies = SmartProxy.unscoped.all, require_cert = true)
+  def auth_smart_proxy(proxies = SmartProxy.unscoped.all)
     request_hosts = nil
     if request.ssl?
       # If we have the client certficate in the request environment we can extract the dn and sans from there
@@ -75,11 +74,8 @@ module Foreman::Controller::SmartProxyAuth
         else
           logger.warn "SSL cert has not been verified (#{client_certificate.verify}) - request from #{request.remote_ip}, #{client_certificate.subject}"
         end
-      elsif require_cert
-        logger.warn "No SSL cert with CN supplied - request from #{request.remote_ip}"
       else
-        logger.warn "No SSL cert supplied, falling back to reverse DNS for hostname lookup - request from #{request.remote_ip}"
-        request_hosts = Resolv.new.getnames(request.remote_ip)
+        logger.warn "No SSL cert with CN supplied - request from #{request.remote_ip}"
       end
     elsif SETTINGS[:require_ssl]
       logger.warn "SSL is required - request from #{request.remote_ip}"

--- a/app/registries/foreman/settings/auth.rb
+++ b/app/registries/foreman/settings/auth.rb
@@ -32,11 +32,6 @@ Foreman::SettingManager.define(:foreman) do
       description: N_('Only known Smart Proxies may access features that use Smart Proxy authentication'),
       default: true,
       full_name: N_('Restrict registered smart proxies'))
-    setting('require_ssl_smart_proxies',
-      type: :boolean,
-      description: N_('Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)'),
-      default: true,
-      full_name: N_('Require SSL for smart proxies'))
     setting('trusted_hosts',
       type: :array,
       description: N_('List of hostnames, IPv4, IPv6 addresses or subnets to be trusted in addition to Smart Proxies for access to fact/report importers and ENC output'),

--- a/db/migrate/20220111110149_drop_require_ssl_smart_proxies_setting.rb
+++ b/db/migrate/20220111110149_drop_require_ssl_smart_proxies_setting.rb
@@ -1,0 +1,5 @@
+class DropRequireSslSmartProxiesSetting < ActiveRecord::Migration[6.0]
+  def up
+    Setting.where(name: 'require_ssl_smart_proxies').delete_all
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -80,11 +80,6 @@ attribute27:
   category: Setting
   default: "true"
   description: "Only known Smart Proxies may access features that use Smart Proxy authentication"
-attribute28:
-  name: require_ssl_smart_proxies
-  category: Setting
-  default: "true"
-  description: "Client SSL certificates are used to identify Smart Proxies (:require_ssl should also be enabled)"
 attribute29:
   name: ssl_client_dn_env
   category: Setting


### PR DESCRIPTION
This defaults to true and setting it to false can create security problems. Mandating client SSL certificates creates a more secure environment.

Partial implementation of https://community.theforeman.org/t/drop-require-ssl-and-require-ssl-smart-proxies-settings/26772.