### PR TITLE
Fixes #34140 - remove reports warning

### DIFF
--- a/app/views/config_reports/index.html.erb
+++ b/app/views/config_reports/index.html.erb
@@ -14,11 +14,6 @@
     },
   ]
 ) if @host %>
-<%= alert class: 'alert-warning',
-  header: _('Migrate Reports to new format'),
-  text: "</br>".html_safe +
-        _("Reports can be stored in more efficient way, data will need to be upgraded to the new format. Read more details in") +
-        ' <a href="https://community.theforeman.org/t/migrating-reports-to-the-new-format-in-foreman-3-1/25846">our tutorial</a>.'.html_safe %>
 <% title _("Reports") %>
 <% title_actions csv_link, documentation_button('3.5.4PuppetReports') %>
 <%= render :partial => 'list' %>


### PR DESCRIPTION
Reverts theforeman/foreman#8862

We haven't finished the new report plugin for 3.1 and forgot to remove the warning.
Please let's do a 3.1 only patch and remove the warning from the page. Let's keep it in develop tho.

https://community.theforeman.org/t/migrating-reports-to-the-new-format-in-foreman-3-1/25846


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
