### PR TITLE
Fixes #34240 - do not read undefined setting

### DIFF
--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -97,7 +97,7 @@ module Dashboard
     end
 
     def out_of_sync_enabled?
-      return true unless settings[:origin]
+      return true if !settings[:origin] || settings[:origin] == 'All'
       setting = Setting[:"#{settings[:origin].downcase}_out_of_sync_disabled"]
       setting.nil? ? true : !setting
     end


### PR DESCRIPTION
We read undefined setting in the Dashboard, we didn't catch that until we introduced warning messages about that.

It was harmless, but it's better to not do such things :)
