### PR TITLE
Fixes #34265 - change more deprecated ks/sendmac Anaconda options

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
@@ -31,7 +31,7 @@ timeout=20
   url = default_template_url(profile[:template], profile[:hostgroup])
   case profile[:pxe_type]
   when 'kickstart'
-    append = "ks=#{url} ksdevice=bootif network kssendmac ks.sendmac inst.ks.sendmac"
+    append = "inst.ks=#{url} ksdevice=bootif network inst.ks.sendmac"
   when 'preseed'
     locale = profile[:hostgroup].params['lang'] || 'en_US'
     append = "interface=auto url=#{url} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=#{locale} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA"

--- a/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
@@ -20,7 +20,7 @@ echo Default PXE global template entry is set to '<%= global_setting("default_px
   url = default_template_url(profile[:template], profile[:hostgroup])
   case profile[:pxe_type]
   when 'kickstart'
-    append = "ks=#{url} ksdevice=bootif network kssendmac ks.sendmac inst.ks.sendmac"
+    append = "inst.ks=#{url} ksdevice=bootif network inst.ks.sendmac"
   when 'preseed'
     locale = profile[:hostgroup].params['lang'] || 'en_US'
     append = "interface=auto url=#{url} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=#{locale} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA"

--- a/app/views/unattended/provisioning_templates/PXELinux/pxelinux_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/pxelinux_global_default.erb
@@ -23,7 +23,7 @@ DEFAULT <%= global_setting("default_pxe_item_global", "local") %>
   url = default_template_url(profile[:template], profile[:hostgroup])
   case profile[:pxe_type]
   when 'kickstart'
-    append = "ks=#{url} ksdevice=bootif network kssendmac ks.sendmac inst.ks.sendmac"
+    append = "inst.ks=#{url} ksdevice=bootif network inst.ks.sendmac"
   when 'preseed'
     locale = profile[:hostgroup].params['lang'] || 'en_US'
     append = "interface=auto url=#{url} ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=unassigned-hostname locale=#{locale} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA"

--- a/app/views/unattended/provisioning_templates/script/grubby_default.erb
+++ b/app/views/unattended/provisioning_templates/script/grubby_default.erb
@@ -7,7 +7,7 @@ description: |
   Script that can be manually downloaded to a server to reprovision it without booting from network.
   Grubby compatibility package must be installed. WARNING: It will immediately reconfigure
   bootloader and reprovision the node.
-    
+  
   Usage:
   curl https://foreman/unattended/script -o reprovision.sh
   bash reprovision.sh
@@ -20,4 +20,4 @@ INITRD="/boot/initrd.img"
 wget -O "$KERNEL" "<%= @host.url_for_boot(:kernel) %>"
 wget -O "$INITRD" "<%= @host.url_for_boot(:initrd) %>"
 
-grubby --add-kernel=$KERNEL --initrd=$INITRD  --copy-default --title "<%= @host.operatingsystem %>" --make-default  --args="ks=<%= foreman_url('provision')%>"
+grubby --add-kernel=$KERNEL --initrd=$INITRD  --copy-default --title "<%= @host.operatingsystem %>" --make-default  --args="inst.ks=<%= foreman_url('provision')%>"

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -6,7 +6,7 @@ snippet: true
 description: |
   The list of kernel options for initrd appended to the bootloader kernel line on Red Hat compatible distributions.
   Typically renders to a string with the url where to fetch the OS installer answer files, e.g.
-    network ksdevice=bootif ks.device=bootif BOOTIF=01-52-54-00-8b-a3-86 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.122.1
+    network ksdevice=bootif ks.device=bootif BOOTIF=01-52-54-00-8b-a3-86 inst.ks=http://foreman.example.com/unattended/provision inst.ks.sendmac ip=dhcp nameserver=192.168.122.1
 -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -36,7 +36,7 @@ description: |
   if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
     options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
   else
-    options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")  
+    options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
   end
 
   # networking credentials


### PR DESCRIPTION
Anaconda in RHEL9 removed the deprecated `ks=` option in favour of `inst.ks=` one. We changed some templates in

https://projects.theforeman.org/issues/32486

but not all. This hopefully resolves all the places.

I would like to request 3.1 too.