### PR TITLE
Fixes #34271 - Ignore url query params when setting active tab

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -72,7 +72,12 @@ const HostDetails = ({
     registerCoreTabs();
   }, []);
 
-  const activeTab = decodeURI(hash.slice(2).split('/')[0]);
+  const activeTab = decodeURI(
+    hash
+      .slice(2)
+      .split('/')[0]
+      .split('?')[0] // Remove query params
+  );
 
   return (
     <>


### PR DESCRIPTION
The new host details page sets the active tab by looking at the url hash, such as

```js
"#/Repository%20sets" // sets active tab to 'Repository sets'
```

When there is a search query param, such as the following, it doesn't work:

```js
"#/Repository%20sets?search=myReposet" // attempts to set active tab to 'Repository sets?search=myReposet'
// no match, so no tab is shown as selected
```

To test this: You don't need to check out the Katello PR; you should be able to see the issue simply by adding a URL param to your URL.