### PR TITLE
Fixes #34280 - Add `ip_include?` method to `IPAM::Base`

### DIFF
--- a/test/unit/ipam_test.rb
+++ b/test/unit/ipam_test.rb
@@ -112,6 +112,53 @@ class IPAMTest < ActiveSupport::TestCase
       ipam.excluded_ips.stubs(:include?).returns(true)
       assert_nil ipam.suggest_ip
     end
+
+    context 'subnet_range inclusion' do
+      test 'should return true for big ipv6 subnet' do
+        subnet = FactoryBot.build(
+          :subnet_ipv6, :name => 'my_subnet',
+          :network => '2001:db8::',
+          :mask => 'ffff:ffff:ffff:ffff::',
+          :ipam => IPAM::MODES[:random_db])
+
+        ipam = IPAM::RandomDb.new(:subnet => subnet)
+
+        assert_equal true, ipam.ip_include?('2001:db8::1')
+      end
+
+      test 'should return false for big ipv6 subnet' do
+        subnet = FactoryBot.build(
+          :subnet_ipv6, :name => 'my_subnet',
+          :network => '2001:db8::',
+          :mask => 'ffff:ffff:ffff:ffff::',
+          :ipam => IPAM::MODES[:random_db])
+        ipam = IPAM::RandomDb.new(:subnet => subnet)
+
+        assert_equal false, ipam.ip_include?('2001:db7::1')
+      end
+
+      test 'should return true for ipv4 subnet' do
+        subnet = FactoryBot.build(
+          :subnet_ipv4, :name => 'my_subnet',
+          :network => '10.0.0.1',
+          :mask => '255.255.255.0',
+          :ipam => IPAM::MODES[:random_db])
+        ipam = IPAM::RandomDb.new(:subnet => subnet)
+
+        assert_equal true, ipam.ip_include?('10.0.0.100')
+      end
+
+      test 'should return false for ipv4 subnet' do
+        subnet = FactoryBot.build(
+          :subnet_ipv4, :name => 'my_subnet',
+          :network => '10.0.0.1',
+          :mask => '255.255.255.0',
+          :ipam => IPAM::MODES[:random_db])
+        ipam = IPAM::RandomDb.new(:subnet => subnet)
+
+        assert_equal false, ipam.ip_include?('192.168.0.50')
+      end
+    end
   end
 
   context 'EUI-64 IPAM' do


### PR DESCRIPTION
Related to: https://github.com/theforeman/foreman_discovery/pull/545

https://projects.theforeman.org/issues/34280