### PR TITLE
Refs #33418 - Make last_report.origin interval parametrizable

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -22,15 +22,17 @@ module HostStatus
     end
 
     def expected_report_interval
-      (reported_origin_interval + default_report_interval).minutes
+      (reported_origin_interval || default_report_interval).minutes
     end
 
     def reported_origin_interval
-      if last_report.origin &&
-         (interval = Setting[:"#{last_report.origin.downcase}_interval"])
-        interval.to_i
-      else
-        default_report_interval
+      if last_report.origin
+        if host.params.has_key? "#{last_report.origin.downcase}_interval"
+          interval = host.params["#{last_report.origin.downcase}_interval"]
+        else
+          interval = Setting[:"#{last_report.origin.downcase}_interval"]
+        end
+        interval
       end
     end
 
@@ -134,11 +136,7 @@ module HostStatus
     end
 
     def default_report_interval
-      if host.params.has_key? 'outofsync_interval'
-        host.params['outofsync_interval']
-      else
-        Setting[:outofsync_interval]
-      end
+      Setting[:outofsync_interval]
     end
 
     def out_of_sync_disabled?

--- a/app/registries/foreman/settings/general.rb
+++ b/app/registries/foreman/settings/general.rb
@@ -63,7 +63,8 @@ Foreman::SettingManager.define(:foreman) do
       full_name: N_('Append domain names to the host'))
     setting('outofsync_interval',
       type: :integer,
-      description: N_('Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter "outofsync_interval".'),
+      description: N_('Duration in minutes after servers are classed as out of sync. ' \
+                      'This setting is overridden by specific settings from config management tools (e.g. puppet_inteval, ansible_interval).'),
       default: 30,
       full_name: N_('Out of sync interval'))
     setting('instance_id',


### PR DESCRIPTION
This PR is an effort to split https://github.com/theforeman/foreman/pull/8761 up into multiple chunks. 
This PR 
1) cleans up the `expected_report_interval` to be consistent with what the dashboard shows
2) makes "last_report.origin"_interval parametrizable instead of global outofsync_interval setting
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
