### PR TITLE
Fixes #34289 - remove workaround for encoding root_pass

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -139,9 +139,6 @@ module Api
         else
           @host = Host.new(host_attributes(host_params))
           @host.managed = true if (params[:host] && params[:host][:managed].nil?)
-
-          # Workaround to fix #33732 (do base64 encoding while creating a host via API)
-          @host.root_pass = @host.root_pass
         end
         apply_compute_profile(@host)
         @host.suggest_default_pxe_loader if params[:host] && params[:host][:pxe_loader].nil?

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -272,6 +272,14 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal true, JSON.parse(@response.body)['build']
   end
 
+  test 'root_pass from setting is encrypted if no password is passed' do
+    Setting[:root_pass] = 'password'
+    post :create, params: { :host => valid_attrs }
+    host = Host.find(JSON.parse(@response.body)['id'])
+    assert_not_equal host.root_pass, 'password'
+    assert host.root_pass.starts_with?('$5$')
+  end
+
   test "should create host with host_parameters_attributes" do
     disable_orchestration
     attrs = [{"name" => "compute_resource_id", "value" => "1"}]


### PR DESCRIPTION
Remove workaround indtroduced in 6f076d5d6dcad5b89875c5a291ce8d0d014e386e.
The proper fix for this has been introduced in 60d53c2621b3537e61e9082428ebb585f02fd3bc.
