### PR TITLE
Fixes #34292 - support pxe_kernel_options in Preseed templates

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -41,6 +41,9 @@ description: |
   
   # send PXELinux "IPAPPEND 2" option along
   options.push("BOOTIF=01-$net_default_mac")
+  if host_param('pxe_kernel_options')
+    options << host_param('pxe_kernel_options')
+  end
 
   options = options.join(' ')
 

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -38,6 +38,9 @@ description: |
     options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
   end
   options << "locale=#{host_param('lang') || 'en_US'}"
+  if host_param('pxe_kernel_options')
+    options << host_param('pxe_kernel_options')
+  end
   options = options.join(' ')
 -%>
 DEFAULT linux

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -38,7 +38,7 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> domain=<%= @host.domain %> <%= keyboard_params %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> domain=<%= @host.domain %> <%= keyboard_params %> <%= pxe_kernel_options %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
 initrd <%= initrd %>
 
 boot


### PR DESCRIPTION
I tested the PXELinux and PXEGrub2 modifications with real hardware, the change in the iPXE template is not tested on real hardware, but seems a straightfoward extrapolation. 