### PR TITLE
Fixes #34500 - Add Rails 6.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,14 @@ require_relative 'config/boot_settings'
 
 source 'https://rubygems.org'
 
-case SETTINGS[:rails]
-when '6.0'
-  gem 'rails', '~> 6.0.3.1'
-else
-  raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"
-end
+gem 'rails', case SETTINGS[:rails]
+             when '6.0'
+               '~> 6.0.3.1'
+             when '6.1'
+               '~> 6.1.4.4'
+             else
+               raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"\
+             end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '>= 4.9.0', '< 5'

--- a/config/initializers/routing_hash_for.rb
+++ b/config/initializers/routing_hash_for.rb
@@ -2,17 +2,55 @@ module ActionDispatch
   module Routing
     class RouteSet
       class NamedRouteCollection
-        def define_url_helper(mod, route, name, opts, route_key, url_strategy)
-          helper = UrlHelper.create(route, opts, route_key, url_strategy)
-          mod.module_eval do
-            define_method(name) do |*args|
-              options = nil
-              options = args.pop if args.last.is_a? Hash
+        if Gem::Version.new(SETTINGS[:rails]) >= Gem::Version.new('6.1')
+          def define_url_helper(mod, name, helper, url_strategy)
+            mod.define_method(name) do |*args|
+              last = args.last
+              options = \
+                case last
+                when Hash
+                  args.pop
+                when ActionController::Parameters
+                  args.pop.to_h
+                end
+              helper.call(self, name, args, options, url_strategy)
+            end
+
+            # because we heavily rely on the removed hash_for method in routes, we must add this monkey patch.
+            mod.define_method("hash_for_#{name}") do |*args|
+              inner_options = \
+                case args.last
+                when Hash
+                  args.pop
+                when ActionController::Parameters
+                  args.pop.to_h
+                end
+              opts = helper.instance_variable_get(:@options)
+              helper.send(:handle_positional_args,
+                {},
+                inner_options || {},
+                args,
+                opts.merge(:use_route => helper.route_name),
+                helper.instance_variable_get(:@segment_keys))
+            end
+          end
+        else
+          def define_url_helper(mod, route, name, opts, route_key, url_strategy)
+            helper = UrlHelper.create(route, opts, route_key, url_strategy)
+            mod.define_method(name) do |*args|
+              last = args.last
+              options = \
+                case last
+                when Hash
+                  args.pop
+                when ActionController::Parameters
+                  args.pop.to_h
+                end
               helper.call self, args, options
             end
 
             # because we heavily rely on the removed hash_for method in routes, we must add this monkey patch.
-            define_method("hash_for_#{name}") do |*args|
+            mod.define_method("hash_for_#{name}") do |*args|
               inner_options = nil
               inner_options = args.pop if args.last.is_a? Hash
               helper.send(:handle_positional_args,

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -31,7 +31,7 @@
 # so only change this if you know what you're doing.
 :hsts_enabled: true
 
-# Ruby on Rails version (available: 5.2, 6.0)
+# Ruby on Rails version (available: 6.0, 6.1)
 # Defaults to 6.0
 #:rails: 6.0
 


### PR DESCRIPTION
### Routing hash_for
Rails 6.1 refactored the routing method responsible for definition of named routes.
We are overriding this method and thus we need to refactor it as well.
The switch for these is neccessary to support both Rails 6.0 and 6.1

### Support for Rails 6.1
Adds support for Rails 6.1 and allows it to be enabled from settings.
