### PR TITLE
Fixes #34300 - correctly construct the fqdn for redirect

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -159,7 +159,7 @@ function update_capabilities(capabilities) {
 var stop_pooling;
 
 function submit_with_all_params() {
-  var fqdn = $('.fqdn')[0].textContent;
+  var host_unique_name = construct_host_name();
   $('form.hostresource-form input[type="submit"]').attr('disabled', true);
   stop_pooling = false;
   $('body').css('cursor', 'progress');
@@ -170,10 +170,10 @@ function submit_with_all_params() {
     type: 'POST',
     url: $('form').attr('action'),
     data: serializeForm(),
-    success: function(response) {
+    success: function(response, _responseStatus, _jqXHR) {
       // workaround for redirecting to the new host details page
       if (!response.includes('id="main"')) {
-        return tfm.nav.pushUrl('/new/hosts/' + fqdn);
+        return tfm.nav.pushUrl(tfm.tools.foremanUrl('/new/hosts/' + host_unique_name));
       }
    
       $('#host-progress').hide();

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -388,13 +388,21 @@ $(document).on('change', '.virtual', function() {
     .toggle(!is_virtual);
 });
 
-function update_fqdn() {
-  var host_name = $('#host_name').val();
+function construct_host_name() {
+  var host_name_el = $('#host_name')
+  var host_name = host_name_el.val();
+  if (host_name_el.data('appendDomainNameForHosts') === false) {
+    return host_name;
+  }
   var domain_name = primary_nic_form()
     .find('.interface_domain option:selected')
     .text();
+  return fqdn(host_name, domain_name);
+}
+
+function update_fqdn() {
+  var name = construct_host_name();
   var pathname = window.location.pathname;
-  var name = fqdn(host_name, domain_name);
   if (name.length > 0 && pathname === tfm.tools.foremanUrl('/hosts/new')) {
     name = __('Create Host') + ' | ' + name;
     tfm.store.dispatch('updateBreadcrumbTitle', name);

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -31,7 +31,8 @@
       <div class="tab-pane active" id="primary">
         <%= text_f f, :name, :size => "col-md-4", :value => name_field(@host),
             :input_group_btn => randomize_mac_link,
-            :help_inline => _("This value is used also as the host's primary interface name.") %>
+            :help_inline => _("This value is used also as the host's primary interface name."),
+            :data => { 'append_domain_name_for_hosts' => Setting[:append_domain_name_for_hosts] } %>
 
         <% if show_organization_tab?  %>
           <%= host_taxonomy_select(f, Organization) %>

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -123,35 +123,79 @@ class HostJSTest < IntegrationTestWithJavascript
       find('h1', :text => /Manage Host's Statuses/)
     end
 
-    test "create new host and redirect to the new host details page" do
-      compute_resource = FactoryBot.create(:compute_resource, :libvirt)
-      os = FactoryBot.create(:ubuntu14_10, :with_associations)
-      Nic::Managed.any_instance.stubs(:dns_conflict_detected?).returns(true)
-      visit new_host_path
+    describe 'create and redirect' do
+      test 'redirects correctly with second nic being primary' do
+        compute_resource = FactoryBot.create(:compute_resource, :libvirt)
+        os = FactoryBot.create(:ubuntu14_10, :with_associations)
+        Nic::Managed.any_instance.stubs(:dns_conflict_detected?).returns(true)
+        visit new_host_path
 
-      fill_in 'host_name', :with => 'newhost1'
-      select2 'Organization 1', :from => 'host_organization_id'
-      wait_for_ajax
-      select2 'Location 1', :from => 'host_location_id'
-      wait_for_ajax
-      select2 compute_resource.name, :from => 'host_compute_resource_id'
+        fill_in 'host_name', :with => 'newhost1'
+        select2 'Organization 1', :from => 'host_organization_id'
+        wait_for_ajax
+        select2 'Location 1', :from => 'host_location_id'
+        wait_for_ajax
+        select2 compute_resource.name, :from => 'host_compute_resource_id'
 
-      click_link 'Operating System'
-      wait_for_ajax
-      select2 os.architectures.first.name, :from => 'host_architecture_id'
-      select2 os.title, :from => 'host_operatingsystem_id'
-      uncheck('host_build')
-      select2 os.media.first.name, :from => 'host_medium_id'
-      select2 os.ptables.first.name, :from => 'host_ptable_id'
-      fill_in 'host_root_pass', :with => '12345678'
+        click_link 'Operating System'
+        wait_for_ajax
+        select2 os.architectures.first.name, :from => 'host_architecture_id'
+        select2 os.title, :from => 'host_operatingsystem_id'
+        uncheck('host_build')
+        select2 os.media.first.name, :from => 'host_medium_id'
+        select2 os.ptables.first.name, :from => 'host_ptable_id'
+        fill_in 'host_root_pass', :with => '12345678'
 
-      switch_form_tab_to_interfaces
-      click_button 'Edit'
-      select2 domains(:mydomain).name, :from => 'host_interfaces_attributes_0_domain_id'
-      fill_in 'host_interfaces_attributes_0_ip', :with => '1.1.1.1'
-      close_interfaces_modal
-      click_button('Submit')
-      find('h5', :text => /newhost1.*/) # wait for the new host details page
+        switch_form_tab_to_interfaces
+        page.find(:button, 'Edit').click
+        select2 domains(:mydomain).name, :from => "host_interfaces_attributes_0_domain_id"
+        fill_in "host_interfaces_attributes_0_ip", :with => '1.1.1.1'
+        close_interfaces_modal
+
+        page.find(:button, '+ Add Interface').click
+        interface_id = page.evaluate_script("$('#interfaceModal').data('current-id');")
+        fill_in "host_interfaces_attributes_#{interface_id}_name", :with => 'newhost2'
+        select2 domains(:mydomain).name, :from => "host_interfaces_attributes_#{interface_id}_domain_id"
+        fill_in "host_interfaces_attributes_#{interface_id}_ip", :with => '1.1.1.2'
+        accept_confirm do
+          find("#host_interfaces_attributes_#{interface_id}_primary").check
+        end
+        close_interfaces_modal
+        click_button('Submit')
+        find('h5', :text => /newhost2.*/) # wait for the new host details page
+      end
+
+      test "redirects correctly with append_domain_name_for_hosts turned off" do
+        Setting['append_domain_name_for_hosts'] = false
+        compute_resource = FactoryBot.create(:compute_resource, :libvirt)
+        os = FactoryBot.create(:ubuntu14_10, :with_associations)
+        Nic::Managed.any_instance.stubs(:dns_conflict_detected?).returns(true)
+        visit new_host_path
+
+        fill_in 'host_name', :with => 'newhost1'
+        select2 'Organization 1', :from => 'host_organization_id'
+        wait_for_ajax
+        select2 'Location 1', :from => 'host_location_id'
+        wait_for_ajax
+        select2 compute_resource.name, :from => 'host_compute_resource_id'
+
+        click_link 'Operating System'
+        wait_for_ajax
+        select2 os.architectures.first.name, :from => 'host_architecture_id'
+        select2 os.title, :from => 'host_operatingsystem_id'
+        uncheck('host_build')
+        select2 os.media.first.name, :from => 'host_medium_id'
+        select2 os.ptables.first.name, :from => 'host_ptable_id'
+        fill_in 'host_root_pass', :with => '12345678'
+
+        switch_form_tab_to_interfaces
+        page.find(:button, 'Edit').click
+        select2 domains(:mydomain).name, :from => "host_interfaces_attributes_0_domain_id"
+        fill_in "host_interfaces_attributes_0_ip", :with => '1.1.1.1'
+        close_interfaces_modal
+        click_button('Submit')
+        find('h5', :text => /newhost1/) # wait for the new host details page
+      end
     end
   end
 


### PR DESCRIPTION
In host form we've used a hack in 28765788dc to redirect to the new Host details page.
It relied on the primary interface being the first interface in the table.

This fixes it to always incur the correct fqdn.
