### PR TITLE
Fixes #32919 - Add Salt Autosign grain to minion configuration

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/saltstack_minion.erb
+++ b/app/views/unattended/provisioning_templates/snippet/saltstack_minion.erb
@@ -7,6 +7,9 @@ snippet: true
 master: <%= host_param('salt_master') %>
 log_level: warning
 
+autosign_grains:
+  - autosign_key
+
 <%#
 # Grains (http://docs.saltstack.com/en/latest/topics/targeting/grains.html#grains-in-the-minion-config)
 #
@@ -15,5 +18,9 @@ log_level: warning
 # * {'cluster': 'alpha'}
 # * {'roles': ['webserver', 'frontend']}
 #
-%>
-grains: <%= host_param('salt_grains') ? host_param('salt_grains') : '{}' %>
+-%>
+<% if plugin_present?('foreman_salt') -%>
+grains: <%= to_json(@host.derive_salt_grains(use_autosign: true)) %>
+<% else -%>
+grains: <%= host_param('salt_grains') ? to_json(host_param('salt_grains')) : '{}' %>
+<% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_minion.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_minion.host4dhcp.snap.txt
@@ -2,5 +2,7 @@
 master: 
 log_level: warning
 
+autosign_grains:
+  - autosign_key
 
 grains: {}

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/saltstack_setup.host4dhcp.snap.txt
@@ -12,6 +12,8 @@ cat > /etc/salt/minion.d/minion.conf << EOF
 master: 
 log_level: warning
 
+autosign_grains:
+  - autosign_key
 
 grains: {}
 


### PR DESCRIPTION
* Use host function .derive_salt_grains to get host_params['salt_grains'] and autosign key
* Makes foreman incompatible with previous foreman_salt versions

Co-authored-by: Evgeni Golov <evgeni@golov.de>
(cherry picked from commit ce2190057571ad3d9c3db3f6a80b9dcf52448426)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
