### PR TITLE
Fixes #34302 - associate CentOS_Stream OS with the templates

### DIFF
--- a/app/views/unattended/partition_tables_templates/kickstart_custom.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_custom.erb
@@ -5,6 +5,7 @@ model: Ptable
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/partition_tables_templates/kickstart_default.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_default.erb
@@ -5,6 +5,7 @@ model: Ptable
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/partition_tables_templates/kickstart_default_thin.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_default_thin.erb
@@ -4,6 +4,7 @@ name: Kickstart default thin
 model: Ptable
 oses:
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - oVirt

--- a/app/views/unattended/partition_tables_templates/kickstart_dynamic.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_dynamic.erb
@@ -5,6 +5,7 @@ model: Ptable
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - Rocky
 description: |

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -6,6 +6,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - Rocky
 description: |

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/app/views/unattended/provisioning_templates/user_data/userdata_open_vm_tools.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_open_vm_tools.erb
@@ -5,6 +5,7 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
+- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/test/static_fixtures/templates/provision/one.erb
+++ b/test/static_fixtures/templates/provision/one.erb
@@ -4,5 +4,6 @@ name: One
 model: ProvisioningTemplate
 oses:
 - CentOS
+- CentOS_Stream
 %>
 1<%= snippet('two') -%>4


### PR DESCRIPTION
In https://github.com/theforeman/foreman/pull/8870 we have introduced a new OS name, but templates are not auto-associated. This was missed.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->