### PR TITLE
Fixes #34315 - adds Oracle VIF hypervisor NIC filter

### DIFF
--- a/app/registries/foreman/settings/facts.rb
+++ b/app/registries/foreman/settings/facts.rb
@@ -36,6 +36,7 @@ Foreman::SettingManager.define(:foreman) do
       'vlinuxbr*',
       'vovsbr*',
       'br-int',
+      'vif*',
     ].freeze
 
     setting('create_new_host_when_facts_are_uploaded',


### PR DESCRIPTION
SSIA

https://community.theforeman.org/t/puma-cluster-worker-using-huge-amounts-of-memory/26978