### PR TITLE
Fixes #34323 - use defaults from memory

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -22,6 +22,16 @@ class SettingPresenter
     Setting.model_name
   end
 
+  # Value set through setter can be explicit nil
+  def value=(*attr)
+    @explicit_value = true
+    super
+  end
+
+  def explicit_value?
+    @explicit_value
+  end
+
   def model_name
     self.class.model_name
   end
@@ -51,7 +61,7 @@ class SettingPresenter
   end
 
   def value
-    SETTINGS.fetch(name.to_sym) { super }
+    SETTINGS.fetch(name.to_sym) { explicit_value? ? super : default }
   end
 
   def settings_type
@@ -80,5 +90,17 @@ class SettingPresenter
 
   def select_values
     Setting.select_collection_registry.collection_for name
+  end
+
+  private
+
+  # explicit value from mass assignment can not be nil
+  def _assign_attribute(k, v)
+    if k.to_s == 'value'
+      @explicit_value = !v.nil?
+      write_attribute(k, v)
+    else
+      super
+    end
   end
 end

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -113,7 +113,6 @@ class SettingRegistry
       # Creating missing records as we operate over the DB model while updating the setting
       _new_db_record(definition).save(validate: false)
       definition.updated_at = nil
-      definition.value ||= definition.default
     end
   end
 
@@ -150,7 +149,7 @@ class SettingRegistry
 
   def load_values(ignore_cache: false)
     # we are loading only known STIs as we load settings fairly early the first time and plugin classes might not be loaded yet.
-    settings = Setting.unscoped.where(category: known_categories)
+    settings = Setting.unscoped.where(category: known_categories).where.not(value: nil)
     settings = settings.where('updated_at >= ?', @values_loaded_at) unless ignore_cache || @values_loaded_at.nil?
     settings.each do |s|
       unless (definition = find(s.name))

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -625,6 +625,11 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     let (:facts) { fact_json['facts'] }
     let (:hostname) { fact_json['name'] }
 
+    setup do
+      Setting[:default_location] = 'Location 1'
+      Setting[:default_organization] = 'Organization 1'
+    end
+
     test "create valid node from json facts object without certname" do
       User.current = nil
       post :facts, params: { :name => hostname, :facts => facts }, session: set_session_user

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -43,18 +43,38 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
     end
   end
 
-  test "should show individual record" do
-    get :show, params: { :id => settings(:attributes1).to_param }
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert !show_response.empty?
-  end
+  describe '#show' do
+    test "should show default value" do
+      get :show, params: { :id => 'foreman_url' }
+      assert_response :success
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert !show_response.empty?
+      assert_equal Setting['foreman_url'], show_response['value']
+    end
 
-  test "validate show attributes" do
-    get :show, params: { :id => settings(:attributes1).to_param }
-    assert_response :success
-    show_response = ActiveSupport::JSON.decode(@response.body)
-    assert_include show_response.keys, 'updated_at'
+    test "should show set value" do
+      Setting['foreman_url'] = value = 'http://cool-foreman.example.net'
+      get :show, params: { :id => 'foreman_url' }
+      assert_response :success
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert !show_response.empty?
+      assert_equal value, show_response['value']
+    end
+
+    test "properly show overriden false value" do
+      Setting['host_power_status'] = value = false
+      get :show, params: { :id => 'host_power_status' }
+      assert_response :success
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_equal value, show_response['value']
+    end
+
+    test "validate show attributes" do
+      get :show, params: { :id => 'foreman_url' }
+      assert_response :success
+      show_response = ActiveSupport::JSON.decode(@response.body)
+      assert_include show_response.keys, 'updated_at'
+    end
   end
 
   test "should not update setting" do

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -8,7 +8,8 @@ attributes1:
 attributes2:
   name: foreman_url
   category: Setting
-  default: http://foreman.some.host.fqdn
+  default: http://foreman.example.com
+  value: http://foreman.some.host.fqdn
   description: The URL Foreman should point to in emails etc
 attributes3:
   name: root_pass
@@ -129,7 +130,8 @@ attribute42:
 attributes43:
   name: unattended_url
   category: Setting
-  default: http://foreman.some.host.fqdn
+  default: http://foreman.example.com
+  value: http://foreman.some.host.fqdn
   description: The URL Foreman should point to in templates etc
 attributes44:
   name: default_organization

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -134,12 +134,16 @@ attributes43:
 attributes44:
   name: default_organization
   category: Setting
-  default: 'Organization 1'
+  settings_type: string
+  default: ''
+  value: 'Organization 1'
   description: 'Default organization when importing hosts'
 attributes45:
   name: default_location
   category: Setting
-  default: 'Location 1'
+  settings_type: string
+  default: ''
+  value: 'Location 1'
   description: 'Default location when importing hosts'
 attributes46:
   name: location_fact
@@ -159,12 +163,14 @@ attributes49:
 attributes50:
   name: oauth_consumer_key
   category: Setting
-  default: "oauth_key"
+  settings_type: string
+  default: ''
   description: "OAuth consumer key"
 attributes51:
   name: oauth_consumer_secret
   category: Setting
-  default: "oauth_secret"
+  settings_type: string
+  default: ''
   description: "OAuth consumer secret"
 attributes52:
   name: oauth_map_users
@@ -245,6 +251,7 @@ attributes66:
   name: delivery_method
   category: Setting
   default: :test
+  value: :test
   description: 'Method used to deliver e-mail'
 attributes67:
   name: smtp_address
@@ -390,7 +397,7 @@ attribute94:
 attribute95:
   name: default_host_init_config_template
   category: Setting
-  default: 'Linux host initial configuration'
+  default: 'Linux host_init_config default'
   description: "Default host initial configuration template"
 attribute96:
   name: server_ca_file

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -181,7 +181,7 @@ global_registration:
   type: ProvisioningTemplate
 
 host_init_config:
-  name: Linux host initial configuration
+  name: Linux host_init_config default
   template: 'echo "Linux host initial configuration"'
   template_kind: host_init_config
   operatingsystems: centos5_3, redhat

--- a/test/presenters/setting_presenter_test.rb
+++ b/test/presenters/setting_presenter_test.rb
@@ -2,14 +2,17 @@ require 'test_helper'
 
 class SettingPresenterTest < ActiveSupport::TestCase
   let(:encrypted) { false }
+  let(:initial_value) { nil }
+  let(:default) { 2 }
   let(:presenter) do
     SettingPresenter.new({ name: 'presenterfoo',
                            context: :test,
                            category: 'Test',
                            settings_type: 'integer',
-                           default: 2,
+                           default: default,
                            full_name: 'test foo',
                            description: 'test foo',
+                           value: initial_value,
                            encrypted: encrypted })
   end
 
@@ -21,6 +24,27 @@ class SettingPresenterTest < ActiveSupport::TestCase
   end
 
   describe '#value' do
+    context 'mass assigned nil value' do
+      it 'returns default' do
+        assert_equal presenter.value, default
+      end
+    end
+
+    context 'mass assigned non-nil value' do
+      let(:initial_value) { 30 }
+
+      it 'returns value' do
+        assert_equal presenter.value, initial_value
+      end
+    end
+
+    context 'set explicit nil value' do
+      it 'returns explicitly set nil value' do
+        presenter.value = nil
+        assert_equal presenter.value, nil
+      end
+    end
+
     context 'with global truth defined in SETTINGS' do
       setup { SETTINGS.merge!(presenterfoo: 42) }
       teardown { SETTINGS.delete(:presenterfoo) }

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -16,6 +16,7 @@ module RenderersSharedTests
         include Foreman::Renderer::Scope::Macros::Base
         include Foreman::Renderer::Scope::Macros::SnippetRendering
       end.send(:new, host: @host, source: source, variables: { x: 'test' })
+      Setting['foreman_url'] = 'http://foreman.example.net'
     end
 
     test "should evaluate template variables" do
@@ -31,12 +32,12 @@ module RenderersSharedTests
 
     test "foreman_server_fqdn helper method" do
       source = OpenStruct.new(content: '<%= foreman_server_fqdn %>')
-      assert_equal 'foreman.some.host.fqdn', renderer.render(source, @scope)
+      assert_equal 'foreman.example.net', renderer.render(source, @scope)
     end
 
     test "foreman_server_url helper method" do
       source = OpenStruct.new(content: '<%= foreman_server_url %>')
-      assert_equal 'http://foreman.some.host.fqdn', renderer.render(source, @scope)
+      assert_equal 'http://foreman.example.net', renderer.render(source, @scope)
     end
 
     test "plugin_present? finds existing plugin" do

--- a/test/unit/oidc_jwt_validate_test.rb
+++ b/test/unit/oidc_jwt_validate_test.rb
@@ -10,6 +10,10 @@ class OidcJwtValidateTest < ActiveSupport::TestCase
       exp = Time.now.to_i + 4 * 3600
       payload, headers = { "name": "jwt token", "iat": 1557224758, "exp": exp, "typ": "Bearer", "aud": "rest-client", "iss": "127.0.0.1"}, { kid: @jwk.kid }
 
+      Setting['oidc_jwks_url'] = 'https://keycloak.example.com/auth/realms/foreman/protocol/openid-connect/certs'
+      Setting['oidc_audience'] = 'rest-client'
+      Setting['oidc_issuer'] = '127.0.0.1'
+      Setting['oidc_algorithm'] = 'RS512'
       @token = JWT.encode(payload, @jwk.keypair, 'RS512', headers)
       @decoded_payload = payload.with_indifferent_access
     end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -39,7 +39,7 @@ class SettingRegistryTest < ActiveSupport::TestCase
     end
 
     it "can be forced to load all values" do
-      registry.expects(:find).times(Setting.count)
+      registry.expects(:find).times(Setting.where.not(value: nil).count)
 
       registry.load_values(ignore_cache: true)
     end
@@ -57,6 +57,14 @@ class SettingRegistryTest < ActiveSupport::TestCase
     it 'provides default if no value defined' do
       assert_equal 5, registry['foo']
       assert_equal 5, registry[:foo]
+    end
+
+    it 'returns updated default' do
+      assert_equal default, registry['foo']
+      registry.instance_variable_set(:@settings, {})
+      registry._add('foo', type: :integer, category: 'Setting', default: 10, full_name: 'test foo', description: 'test foo', context: :test)
+      registry.load_values
+      assert_equal 10, registry['foo']
     end
 
     it 'saves the value on assignment' do

--- a/test/unit/sso/oauth_test.rb
+++ b/test/unit/sso/oauth_test.rb
@@ -4,6 +4,8 @@ class OauthTest < ActiveSupport::TestCase
   setup do
     User.current = nil
     Setting[:oauth_active] = true
+    Setting['oauth_consumer_key'] = 'oauth_key'
+    Setting['oauth_consumer_secret'] = 'oauth_secret'
   end
 
   test 'oauth available in good conditions' do

--- a/test/unit/sso/openid_connect_test.rb
+++ b/test/unit/sso/openid_connect_test.rb
@@ -20,6 +20,10 @@ class OpenidConnectTest < ActiveSupport::TestCase
     payload.with_indifferent_access
   end
 
+  setup do
+    Setting['oidc_issuer'] = '127.0.0.1'
+  end
+
   describe '#available?' do
     test 'returns true if its a OpenID Connect session' do
       controller_with_session =


### PR DESCRIPTION
This loads values from database only if the values are in the database.
If there is no value populated for the Setting, we want to read the default from memory.