### PR TITLE
Fixes #34326 - improve test clarity

### DIFF
--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -724,9 +724,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       Setting[:restrict_registered_smart_proxies] = false
       SETTINGS[:require_ssl] = false
 
-      Resolv.any_instance.stubs(:getnames).returns(['else.where'])
+      @controller.expects(:auth_smart_proxy).never
       post :facts, params: { :name => hostname, :facts => facts }
-      assert_nil @controller.detected_proxy
       assert_response :success
     end
 


### PR DESCRIPTION
The test is supposed to test, that the proxy auth is never executed, but it is bit unclear to unexperienced developer.
