### PR TITLE
Fixes #34330 - fix rhsm puppet parser for IPv6

### DIFF
--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -29,7 +29,7 @@ module Katello
         'macaddress' => get_rhsm_mac(interface),
         'ipaddress' => get_rhsm_ip(interface),
         'ipaddress6' => get_rhsm_ipv6(interface),
-      }
+      }.reject { |_, value| value.nil? }
     end
 
     def interfaces
@@ -124,7 +124,7 @@ module Katello
     end
 
     def get_rhsm_ipv6(interface)
-      ip = facts["net.interface.#{interface}.ipv6_address.link"] || facts["net.interface.#{interface}.ipv6_address.host"]
+      ip = facts["net.interface.#{interface}.ipv6_address.global"] || facts["net.interface.#{interface}.ipv6_address.host"]
       Net::Validations.validate_ip6(ip) ? ip : nil
     end
 

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -16,6 +16,14 @@ module Katello
         'net.interface.eth2.permanent_mac_address' => '52:54:00:D8:27:F7',
         'net.interface.eth3.ipv4_address' => 'Unknown',
         'net.interface.eth3.mac_address' => '00:00:00:00:00:14',
+        'net.interface.eno1.ipv6_address.global' => '2001:db8::1105',
+        'net.interface.eno1.ipv6_address.global_list' => '2001:db8::1105',
+        'net.interface.eno1.ipv6_address.link' => 'fe80::62bc:d32c:f0c6:af7a',
+        'net.interface.eno1.ipv6_address.link_list' => 'fe80::62bc:d32c:f0c6:af7a',
+        'net.interface.eno1.ipv6_netmask.global' => '64',
+        'net.interface.eno1.ipv6_netmask.global_list' => '64',
+        'net.interface.eno1.ipv6_netmask.link' => '64',
+        'net.interface.eno1.ipv6_netmask.link_list' => '64',
       }
     end
     let(:parser) { RhsmFactParser.new(@facts) }
@@ -33,21 +41,26 @@ module Katello
     end
 
     def test_get_facts_for_interface_with_ip
-      expected_eth0 = {
+      expected = {
         'link' => true,
         'macaddress' => @facts['net.interface.eth0.mac_address'],
         'ipaddress' => @facts['net.interface.eth0.ipv4_address'],
-        'ipaddress6' => @facts['net.interface.eth0.ipv6_address.link'],
       }
-      assert_equal expected_eth0, parser.get_facts_for_interface('eth0')
+      assert_equal expected, parser.get_facts_for_interface('eth0')
+    end
+
+    def test_get_facts_for_interface_with_ip6
+      expected = {
+        'link' => true,
+        'ipaddress6' => @facts['net.interface.eno1.ipv6_address.global'],
+      }
+      assert_equal expected, parser.get_facts_for_interface('eno1')
     end
 
     def test_get_facts_for_interface_without_ip
       expected_eth2 = {
         'link' => true,
         'macaddress' => @facts['net.interface.eth2.permanent_mac_address'],
-        'ipaddress' => nil,
-        'ipaddress6' => nil,
       }
       assert_equal expected_eth2, parser.get_facts_for_interface('eth2')
     end


### PR DESCRIPTION
This hopefully fixes IPv6 parsing, we did a fix for 3.1 but it ended up not working:

https://github.com/theforeman/foreman/pull/8871

The IPv6 appears to be reported as "global", I don't know where "host" comes from but I am keeping it.

Few changes"

* Removed local-link address, not sure how useful this can be and it can cause too many updates when private extension is turned on.
* Not returning `nil` values similarly how other parsers do.