### PR TITLE
Fixes #34328 - GraphQL uses SettingRegistry directly

### DIFF
--- a/app/graphql/mutations/settings/update.rb
+++ b/app/graphql/mutations/settings/update.rb
@@ -1,24 +1,59 @@
 module Mutations
   module Settings
-    class Update < UpdateMutation
+    class Update < BaseMutation
       graphql_name 'UpdateSettingMutation'
       description 'Updates a setting'
 
       # https://github.com/graphql/graphql-spec/blob/master/rfcs/InputUnion.md
+      argument :id, ID, required: false
+      argument :name, String, required: false
       argument :value, String, required: true
 
-      field :setting, Types::Setting, 'Setting', null: true
+      field :errors, [Types::AttributeError], null: false
+      field :setting, Types::Setting, description: 'Setting', null: true
 
-      def assign_attributes(object, params)
-        object.parse_string_value(params[:value])
+      def self.resource_class
+        SettingPresenter
       end
 
-      def self.save_object(resource)
-        return super resource unless resource.errors.any?
-        {
-          result_key => resource,
-          :errors => map_errors_to_path(resource),
-        }
+      def resolve(params)
+        authorize!
+
+        if params[:name]
+          name = params[:name]
+        else
+          _, _, name = Foreman::GlobalId.decode(params[:id])
+        end
+
+        definition = Foreman.settings.find(name)
+        validate_object(definition)
+
+        record = Foreman.settings.set_user_value(definition.name, params[:value])
+        save_object(definition, record)
+      end
+
+      def save_object(definition, record)
+        User.as(context[:current_user]) do
+          errors = if record.save
+                     []
+                   else
+                     map_errors_to_path(record)
+                   end
+          {
+            :setting => definition,
+            :errors => errors,
+          }
+        end
+      end
+
+      private
+
+      def authorize!
+        return if context[:current_user]&.can?(:edit_settings)
+
+        raise GraphQL::ExecutionError.new(
+          _('Unauthorized. You do not have the required permission %s.') % 'edit_settings'
+        )
       end
     end
   end

--- a/app/graphql/resolvers/setting_resolver.rb
+++ b/app/graphql/resolvers/setting_resolver.rb
@@ -1,0 +1,14 @@
+module Resolvers
+  class SettingResolver < BaseResolver
+    type Types::Setting, null: false
+
+    argument :id, String, 'Global ID for Record', required: true
+
+    def resolve(id:)
+      name = Foreman::GlobalId.decode(id).last
+      if ::User.current.can?(:view_settings)
+        Foreman.settings.find(name)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/settings_resolver.rb
+++ b/app/graphql/resolvers/settings_resolver.rb
@@ -1,0 +1,21 @@
+module Resolvers
+  class SettingsResolver < BaseResolver
+    type [Types::Setting], null: false
+
+    argument :search, String, 'Search query', required: false
+
+    def resolve(search: nil)
+      return [] unless user&.can?(:view_settings)
+
+      scope = Foreman.settings
+      scope = scope.search_for(search) if search
+      scope.to_a
+    end
+
+    private
+
+    def user
+      context[:current_user]
+    end
+  end
+end

--- a/app/graphql/types/query.rb
+++ b/app/graphql/types/query.rb
@@ -83,8 +83,8 @@ module Types
     record_field :bookmark, Types::Bookmark
     collection_field :bookmarks, Types::Bookmark
 
-    record_field :setting, Types::Setting
-    collection_field :settings, Types::Setting
+    field :setting, Types::Setting, resolver: Resolvers::SettingResolver
+    field :settings, Types::Setting.connection_type, resolver: Resolvers::SettingsResolver
 
     record_field :configReport, Types::ConfigReport
     collection_field :configReports, Types::ConfigReport

--- a/app/graphql/types/setting.rb
+++ b/app/graphql/types/setting.rb
@@ -2,8 +2,7 @@ module Types
   class Setting < BaseObject
     description 'An application-wide Setting'
 
-    global_id_field :id
-    timestamps
+    field :id, "ID", null: false
     field :name, String
     # https://github.com/graphql/graphql-spec/issues/215
     field :value, String
@@ -13,5 +12,20 @@ module Types
     field :default, String
     field :fullName, String
     field :encrypted, Boolean, method: :encrypted?
+    field :updated_at, GraphQL::Types::ISO8601DateTime
+
+    def id
+      context.schema.id_from_object(object, ::Setting, context)
+    end
+
+    private
+
+    def nullable?(attribute)
+      attribute.to_s == 'value'
+    end
+
+    def model_class
+      SettingPresenter
+    end
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -9,8 +9,6 @@ class Setting < ApplicationRecord
   include PermissionName
   self.inheritance_column = 'category'
 
-  graphql_type '::Types::Setting'
-
   TYPES = %w{integer boolean hash array string}
   FROZEN_ATTRS = %w{name category}
   NONZERO_ATTRS = %w{puppet_interval idle_timeout entries_per_page outofsync_interval}

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -18,6 +18,10 @@ class SettingPresenter
 
   attr_accessor :collection
 
+  def self.graphql_type
+    '::Types::Setting'
+  end
+
   def self.model_name
     Setting.model_name
   end

--- a/test/graphql/queries/setting_query_test.rb
+++ b/test/graphql/queries/setting_query_test.rb
@@ -20,7 +20,7 @@ module Queries
       GRAPHQL
     end
 
-    let(:setting) { Setting.find_by :name => 'access_unattended_without_build' }
+    let(:setting) { Foreman.settings.find('foreman_url') }
     let(:global_id) { Foreman::GlobalId.for(setting) }
     let(:variables) { { id: global_id } }
     let(:data) { result['data']['setting'] }

--- a/test/graphql/queries/settings_query_test.rb
+++ b/test/graphql/queries/settings_query_test.rb
@@ -18,6 +18,8 @@ module Queries
             node {
               id
               name
+              value
+              description
             }
           }
         }
@@ -30,7 +32,7 @@ module Queries
     test 'fetch settings' do
       assert_empty result['errors']
 
-      expected_count = Setting.count
+      expected_count = Foreman.settings.count
       assert_not_equal 0, expected_count
       assert_equal expected_count, data['totalCount']
       assert_equal expected_count, data['edges'].count


### PR DESCRIPTION
GraphQL was reading the settings from DB, but now we have the registry, it needs to read it from there instead.