### PR TITLE
Fixes #34340 - Insights snippet - Remove connection test

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/insights.erb
+++ b/app/views/unattended/provisioning_templates/snippet/insights.erb
@@ -13,7 +13,6 @@ echo '# Installing Insights client'
 echo '#'
 
 yum install -y insights-client
-insights-client --test-connection
 insights-client --register
 
 <% end -%>


### PR DESCRIPTION
This reverts commit d5092649b241d5efef8fd4c034c36c2550948b6f.

Connectivity test for insights-client is not stable and reliable
and cause more harm than good.

Plus it's unnecessary because if there is an problem,
next command for insights client registration fails anyway.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
