### PR TITLE
Fixes #34339 - sanitize fqdn in tests

### DIFF
--- a/lib/tasks/snapshots.rake
+++ b/lib/tasks/snapshots.rake
@@ -26,8 +26,8 @@ namespace :snapshots do
       ENV['FIXTURES'] = 'settings'
       Rake::Task['db:fixtures:load'].invoke
       Foreman.settings.load
-      Setting[:unattended_url] = "http://foreman.some.host.fqdn"
-      Setting[:foreman_url] = "http://foreman.some.host.fqdn"
+      Setting[:unattended_url] = "http://foreman.example.com"
+      Setting[:foreman_url] = "http://foreman.example.com"
 
       User.current = FactoryBot.build(:user, :admin)
       admin = FactoryBot.create(:user, :admin, password: 'password123', auth_source: FactoryBot.create(:auth_source_ldap))

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -9,7 +9,6 @@ attributes2:
   name: foreman_url
   category: Setting
   default: http://foreman.example.com
-  value: http://foreman.some.host.fqdn
   description: The URL Foreman should point to in emails etc
 attributes3:
   name: root_pass
@@ -131,7 +130,6 @@ attributes43:
   name: unattended_url
   category: Setting
   default: http://foreman.example.com
-  value: http://foreman.some.host.fqdn
   description: The URL Foreman should point to in templates etc
 attributes44:
   name: default_organization

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -33,7 +33,7 @@ class ApplicationMailerTest < ActiveSupport::TestCase
   end
 
   test 'foreman server header is set' do
-    assert_equal mail.header['X-Foreman-Server'].to_s, 'foreman.some.host.fqdn'
+    assert_equal mail.header['X-Foreman-Server'].to_s, 'foreman.example.com'
   end
 
   test 'application mailer can use external css' do

--- a/test/models/concerns/hostext/operating_system_test.rb
+++ b/test/models/concerns/hostext/operating_system_test.rb
@@ -50,7 +50,7 @@ module Hostext
       test "#render_template" do
         provision_template = @host.provisioning_template({:kind => "provision"})
         rendered_template = @host.render_template(template: provision_template)
-        assert(rendered_template.include?("http://foreman.some.host.fqdn/unattended/finish"), "rendred template should parse foreman_url")
+        assert(rendered_template.include?("http://foreman.example.com/unattended/finish"), "rendred template should parse foreman_url")
       end
     end
 

--- a/test/models/hosts/managed_test.rb
+++ b/test/models/hosts/managed_test.rb
@@ -236,7 +236,7 @@ module Host
       describe '#registration_url' do
         it 'generates a registration url' do
           ForemanRegister::RegistrationToken.stubs(:encode).returns('some-jwt-token')
-          assert_equal 'http://foreman.some.host.fqdn/foreman_register/hosts/register?token=some-jwt-token', host.registration_url
+          assert_equal 'http://foreman.example.com/foreman_register/hosts/register?token=some-jwt-token', host.registration_url
         end
       end
     end

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -354,12 +354,12 @@ class OperatingsystemTest < ActiveSupport::TestCase
   describe '#boot_filename' do
     test 'should be the ipxe unattended url for iPXE' do
       host = FactoryBot.build(:host, :managed, pxe_loader: 'iPXE Embedded')
-      assert_equal 'http://foreman.some.host.fqdn/unattended/iPXE', host.operatingsystem.boot_filename(host)
+      assert_equal 'http://foreman.example.com/unattended/iPXE', host.operatingsystem.boot_filename(host)
     end
 
     test 'should be the smart proxy ipxe unattended url for iPXE' do
       host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'iPXE Embedded')
-      assert_equal 'http://foreman.some.host.fqdn/unattended/iPXE', host.operatingsystem.boot_filename(host)
+      assert_equal 'http://foreman.example.com/unattended/iPXE', host.operatingsystem.boot_filename(host)
     end
 
     test 'should be the smart proxy and httpboot port for UEFI HTTP' do

--- a/test/models/ssh_key_test.rb
+++ b/test/models/ssh_key_test.rb
@@ -18,7 +18,7 @@ class SshKeyTest < ActiveSupport::TestCase
     let(:ssh_key) { FactoryBot.build_stubbed(:ssh_key, :key => key, :user => user) }
 
     test 'should clean up ssh key' do
-      assert_equal 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIhRoL6PfBRs9YwW3r2/pYeLrxRzEZSUO3Go8JivxMsguEKjJ3byHDPvPpMHhKKSZD/HJY/A+2Ndqp0ElB+t2qs= sshkeytestuser@foreman.some.host.fqdn', ssh_key.to_export
+      assert_equal 'ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBIhRoL6PfBRs9YwW3r2/pYeLrxRzEZSUO3Go8JivxMsguEKjJ3byHDPvPpMHhKKSZD/HJY/A+2Ndqp0ElB+t2qs= sshkeytestuser@foreman.example.com', ssh_key.to_export
     end
   end
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4and6dhcp.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6dhcp.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_global_default.host4dhcp.snap.txt
@@ -55,7 +55,7 @@ title Chainload into bootloader on first disk
 
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -152,7 +152,7 @@ menuentry 'Chainload into BIOS bootloader on second disk' --id local_chain_legac
   boot
 }
 
-common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac"
+common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac"
 
 if [ ${grub_platform} == "pc" ]; then
   menuentry 'Foreman Discovery Image' --id discovery {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -168,7 +168,7 @@ menuentry 'Chainload into BIOS bootloader on second disk' --id local_chain_legac
   boot
 }
 
-common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac"
+common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac"
 
 if [ ${grub_platform} == "pc" ]; then
   menuentry 'Foreman Discovery Image' --id discovery {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
@@ -13,7 +13,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US BOOTIF=01-$net_default_mac
+  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US BOOTIF=01-$net_default_mac
   initrdefi boot/debian-mirror-RpV7E2zxrKHe-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -13,7 +13,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
+  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
   initrdefi boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/AutoYaST_default_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/AutoYaST_default_PXELinux.host4dhcp.snap.txt
@@ -2,4 +2,4 @@ DEFAULT linux
 
 LABEL linux
     KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-    APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ramdisk_size=65536 install=url --url http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.some.host.fqdn/unattended/provision textmode=1 
+    APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img ramdisk_size=65536 install=url --url http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.example.com/unattended/provision textmode=1 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/CoreOS_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/CoreOS_PXELinux.host4dhcp.snap.txt
@@ -2,4 +2,4 @@ DEFAULT coreos
 
 LABEL coreos
     KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-    APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img cloud-config-url=http://foreman.some.host.fqdn/unattended/provision
+    APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img cloud-config-url=http://foreman.example.com/unattended/provision

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/FreeBSD_(mfsBSD)_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/FreeBSD_(mfsBSD)_PXELinux.host4dhcp.snap.txt
@@ -1,4 +1,4 @@
-# foreman_url=http://foreman.some.host.fqdn/unattended/provision
+# foreman_url=http://foreman.example.com/unattended/provision
 DEFAULT freebsd
 
 LABEL freebsd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.some.host.fqdn/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux_chain_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux_chain_iPXE.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 DEFAULT linux
 LABEL linux
 KERNEL ipxe.lkrn
-APPEND dhcp && chain http://foreman.some.host.fqdn/unattended/iPXE
+APPEND dhcp && chain http://foreman.example.com/unattended/iPXE
 IPAPPEND 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/PXELinux_global_default.host4dhcp.snap.txt
@@ -31,12 +31,12 @@ LABEL local_chain_hd1
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman
   IPAPPEND 2
 
 LABEL discovery_ipxe
   MENU LABEL Foreman Discovery Image - iPXE
   KERNEL ipxe.lkrn
-  APPEND dhcp && chain http://foreman.some.host.fqdn/pub/discovery.ipxe
+  APPEND dhcp && chain http://foreman.example.com/pub/discovery.ipxe
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
@@ -12,7 +12,7 @@
 DEFAULT linux
 LABEL linux
     KERNEL boot/debian-mirror-RpV7E2zxrKHe-linux
-    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US
+    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
@@ -12,7 +12,7 @@
 DEFAULT linux
 LABEL linux
     KERNEL boot/ubuntu-mirror-dBfjc2q1x3NM-linux
-    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
+    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/RancherOS_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/RancherOS_PXELinux.host4dhcp.snap.txt
@@ -2,5 +2,5 @@ DEFAULT rancheros
 
 LABEL rancheros
     KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-    APPEND rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda] rancher.cloud_init.datasources=['url:http://foreman.some.host.fqdn/unattended/provision']
+    APPEND rancher.state.dev=LABEL=RANCHER_STATE rancher.state.autoformat=[/dev/sda] rancher.cloud_init.datasources=['url:http://foreman.example.com/unattended/provision']
     INITRD boot/centos-mirror-nrm0GtSX1ZC5-initrd.img

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/XenServer_default_PXELinux.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/XenServer_default_PXELinux.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 default xenserver
 label xenserver
 kernel mboot.c32
-append  dom0_max_vcpus=1-2 dom0_mem=752M,max:752M com1=115200,8n1 console=com1,vga --- boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=http://foreman.some.host.fqdn/unattended/provision install --- boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
+append  dom0_max_vcpus=1-2 dom0_mem=752M,max:752M com1=115200,8n1 console=com1,vga --- boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz xencons=hvc console=hvc0 console=tty0 answerfile=http://foreman.example.com/unattended/provision install --- boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 IPAPPEND 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/ZTP/Junos_default_ZTP_config.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/ZTP/Junos_default_ZTP_config.host4dhcp.snap.txt
@@ -41,7 +41,7 @@ event-options {
         then {
             execute-commands {
                 commands {
-                    "op url http://foreman.some.host.fqdn/unattended/provision.slax";
+                    "op url http://foreman.example.com/unattended/provision.slax";
                 }
             }
         }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -75,6 +75,6 @@ runcmd:
   systemctl enable puppet
 
 phone_home:
-  url: http://foreman.some.host.fqdn/unattended/built
+  url: http://foreman.example.com/unattended/built
   post: []
   tries: 10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -76,6 +76,6 @@ runcmd:
   /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 phone_home:
-  url: http://foreman.some.host.fqdn/unattended/built
+  url: http://foreman.example.com/unattended/built
   post: []
   tries: 10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -75,6 +75,6 @@ runcmd:
   systemctl enable puppet
 
 phone_home:
-  url: http://foreman.some.host.fqdn/unattended/built
+  url: http://foreman.example.com/unattended/built
   post: []
   tries: 10

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -35,11 +35,11 @@ EOF
 /sbin/chkconfig puppetd on
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -55,10 +55,10 @@ iface $real inet dhcp
 EOF
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -55,10 +55,10 @@ iface $real inet dhcp
 EOF
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer_default_finish.host4dhcp.snap.txt
@@ -1,10 +1,10 @@
 #!/bin/bash
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE_intermediate_script.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE_intermediate_script.host4dhcp.snap.txt
@@ -4,167 +4,167 @@
 :net0
 isset ${net0/mac} || goto no_nic
 dhcp net0 || goto net1
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net0/mac} || goto net1
+chain http://foreman.example.com/unattended/iPXE?mac=${net0/mac} || goto net1
 
 :net1
 isset ${net1/mac} || goto no_nic
 dhcp net1 || goto net2
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net1/mac} || goto net2
+chain http://foreman.example.com/unattended/iPXE?mac=${net1/mac} || goto net2
 
 :net2
 isset ${net2/mac} || goto no_nic
 dhcp net2 || goto net3
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net2/mac} || goto net3
+chain http://foreman.example.com/unattended/iPXE?mac=${net2/mac} || goto net3
 
 :net3
 isset ${net3/mac} || goto no_nic
 dhcp net3 || goto net4
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net3/mac} || goto net4
+chain http://foreman.example.com/unattended/iPXE?mac=${net3/mac} || goto net4
 
 :net4
 isset ${net4/mac} || goto no_nic
 dhcp net4 || goto net5
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net4/mac} || goto net5
+chain http://foreman.example.com/unattended/iPXE?mac=${net4/mac} || goto net5
 
 :net5
 isset ${net5/mac} || goto no_nic
 dhcp net5 || goto net6
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net5/mac} || goto net6
+chain http://foreman.example.com/unattended/iPXE?mac=${net5/mac} || goto net6
 
 :net6
 isset ${net6/mac} || goto no_nic
 dhcp net6 || goto net7
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net6/mac} || goto net7
+chain http://foreman.example.com/unattended/iPXE?mac=${net6/mac} || goto net7
 
 :net7
 isset ${net7/mac} || goto no_nic
 dhcp net7 || goto net8
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net7/mac} || goto net8
+chain http://foreman.example.com/unattended/iPXE?mac=${net7/mac} || goto net8
 
 :net8
 isset ${net8/mac} || goto no_nic
 dhcp net8 || goto net9
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net8/mac} || goto net9
+chain http://foreman.example.com/unattended/iPXE?mac=${net8/mac} || goto net9
 
 :net9
 isset ${net9/mac} || goto no_nic
 dhcp net9 || goto net10
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net9/mac} || goto net10
+chain http://foreman.example.com/unattended/iPXE?mac=${net9/mac} || goto net10
 
 :net10
 isset ${net10/mac} || goto no_nic
 dhcp net10 || goto net11
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net10/mac} || goto net11
+chain http://foreman.example.com/unattended/iPXE?mac=${net10/mac} || goto net11
 
 :net11
 isset ${net11/mac} || goto no_nic
 dhcp net11 || goto net12
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net11/mac} || goto net12
+chain http://foreman.example.com/unattended/iPXE?mac=${net11/mac} || goto net12
 
 :net12
 isset ${net12/mac} || goto no_nic
 dhcp net12 || goto net13
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net12/mac} || goto net13
+chain http://foreman.example.com/unattended/iPXE?mac=${net12/mac} || goto net13
 
 :net13
 isset ${net13/mac} || goto no_nic
 dhcp net13 || goto net14
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net13/mac} || goto net14
+chain http://foreman.example.com/unattended/iPXE?mac=${net13/mac} || goto net14
 
 :net14
 isset ${net14/mac} || goto no_nic
 dhcp net14 || goto net15
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net14/mac} || goto net15
+chain http://foreman.example.com/unattended/iPXE?mac=${net14/mac} || goto net15
 
 :net15
 isset ${net15/mac} || goto no_nic
 dhcp net15 || goto net16
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net15/mac} || goto net16
+chain http://foreman.example.com/unattended/iPXE?mac=${net15/mac} || goto net16
 
 :net16
 isset ${net16/mac} || goto no_nic
 dhcp net16 || goto net17
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net16/mac} || goto net17
+chain http://foreman.example.com/unattended/iPXE?mac=${net16/mac} || goto net17
 
 :net17
 isset ${net17/mac} || goto no_nic
 dhcp net17 || goto net18
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net17/mac} || goto net18
+chain http://foreman.example.com/unattended/iPXE?mac=${net17/mac} || goto net18
 
 :net18
 isset ${net18/mac} || goto no_nic
 dhcp net18 || goto net19
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net18/mac} || goto net19
+chain http://foreman.example.com/unattended/iPXE?mac=${net18/mac} || goto net19
 
 :net19
 isset ${net19/mac} || goto no_nic
 dhcp net19 || goto net20
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net19/mac} || goto net20
+chain http://foreman.example.com/unattended/iPXE?mac=${net19/mac} || goto net20
 
 :net20
 isset ${net20/mac} || goto no_nic
 dhcp net20 || goto net21
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net20/mac} || goto net21
+chain http://foreman.example.com/unattended/iPXE?mac=${net20/mac} || goto net21
 
 :net21
 isset ${net21/mac} || goto no_nic
 dhcp net21 || goto net22
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net21/mac} || goto net22
+chain http://foreman.example.com/unattended/iPXE?mac=${net21/mac} || goto net22
 
 :net22
 isset ${net22/mac} || goto no_nic
 dhcp net22 || goto net23
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net22/mac} || goto net23
+chain http://foreman.example.com/unattended/iPXE?mac=${net22/mac} || goto net23
 
 :net23
 isset ${net23/mac} || goto no_nic
 dhcp net23 || goto net24
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net23/mac} || goto net24
+chain http://foreman.example.com/unattended/iPXE?mac=${net23/mac} || goto net24
 
 :net24
 isset ${net24/mac} || goto no_nic
 dhcp net24 || goto net25
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net24/mac} || goto net25
+chain http://foreman.example.com/unattended/iPXE?mac=${net24/mac} || goto net25
 
 :net25
 isset ${net25/mac} || goto no_nic
 dhcp net25 || goto net26
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net25/mac} || goto net26
+chain http://foreman.example.com/unattended/iPXE?mac=${net25/mac} || goto net26
 
 :net26
 isset ${net26/mac} || goto no_nic
 dhcp net26 || goto net27
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net26/mac} || goto net27
+chain http://foreman.example.com/unattended/iPXE?mac=${net26/mac} || goto net27
 
 :net27
 isset ${net27/mac} || goto no_nic
 dhcp net27 || goto net28
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net27/mac} || goto net28
+chain http://foreman.example.com/unattended/iPXE?mac=${net27/mac} || goto net28
 
 :net28
 isset ${net28/mac} || goto no_nic
 dhcp net28 || goto net29
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net28/mac} || goto net29
+chain http://foreman.example.com/unattended/iPXE?mac=${net28/mac} || goto net29
 
 :net29
 isset ${net29/mac} || goto no_nic
 dhcp net29 || goto net30
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net29/mac} || goto net30
+chain http://foreman.example.com/unattended/iPXE?mac=${net29/mac} || goto net30
 
 :net30
 isset ${net30/mac} || goto no_nic
 dhcp net30 || goto net31
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net30/mac} || goto net31
+chain http://foreman.example.com/unattended/iPXE?mac=${net30/mac} || goto net31
 
 :net31
 isset ${net31/mac} || goto no_nic
 dhcp net31 || goto net32
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net31/mac} || goto net32
+chain http://foreman.example.com/unattended/iPXE?mac=${net31/mac} || goto net32
 
 :net32
 isset ${net32/mac} || goto no_nic
 dhcp net32 || goto net33
-chain http://foreman.some.host.fqdn/unattended/iPXE?mac=${net32/mac} || goto net33
+chain http://foreman.example.com/unattended/iPXE?mac=${net32/mac} || goto net33
 
 :net33
 goto no_nic

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Alterator_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Alterator_default.host4dhcp.snap.txt
@@ -15,5 +15,5 @@
 ("/net-eth" action "add_iface_address" name "eth0" addip "192.168.42.42" addmask "255.255.255.0")
 ("/net-eth" action "write" commit #t)
 ("/root/change_password" language (en_US") passwd_2 "123" passwd_1 "123")
-("/postinstall/firsttime" action "write" method "url" url "http://foreman.some.host.fqdn/unattended/finish")
+("/postinstall/firsttime" action "write" method "url" url "http://foreman.example.com/unattended/finish")
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic_Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Atomic_Kickstart_default.host4dhcp.snap.txt
@@ -57,20 +57,20 @@ touch /tmp/foreman_built
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -127,11 +127,11 @@ export FACTER_is_installer=true
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 rm /etc/resolv.conf

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -129,11 +129,11 @@ export FACTER_is_installer=true
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
 rm /etc/resolv.conf

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/FreeBSD_(mfsBSD)_provision.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/FreeBSD_(mfsBSD)_provision.host4dhcp.snap.txt
@@ -10,10 +10,10 @@ test -z "$first_disk" || echo "First disk: $first_disk"
 
 cp /etc/resolv.conf /mnt/etc/resolv.conf
 mount -t devfs devfs /mnt/dev
-fetch -q --no-verify-hostname --no-verify-peer -o /mnt/tmp/finish.sh -d http://foreman.some.host.fqdn/unattended/finish
+fetch -q --no-verify-hostname --no-verify-peer -o /mnt/tmp/finish.sh -d http://foreman.example.com/unattended/finish
 chroot /mnt /bin/sh /tmp/finish.sh
 rm /mnt/tmp/finish.sh
 
-fetch -q --no-verify-hostname --no-verify-peer -o /dev/null -d http://foreman.some.host.fqdn/unattended/built
+fetch -q --no-verify-hostname --no-verify-peer -o /dev/null -d http://foreman.example.com/unattended/built
 sleep 5
 reboot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Junos_default_SLAX.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Junos_default_SLAX.host4dhcp.snap.txt
@@ -175,10 +175,10 @@ match / {
 <func:function name="fmztp:dl_junos_conf">
 {
   expr jcs:syslog( $SYSLOG, $APPNAME, ": downloading new Junos conf...");
-  expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", 'http://foreman.some.host.fqdn/unattended/finish');
+  expr jcs:syslog( $SYSLOG, $APPNAME, ": URL: ", 'http://foreman.example.com/unattended/finish');
 
   var $get = <file-copy> {
-    <source> 'http://foreman.some.host.fqdn/unattended/finish';
+    <source> 'http://foreman.example.com/unattended/finish';
     <destination> $JUNOS_CONF;
     <staging-directory> $TMPDIR;
   };
@@ -397,7 +397,7 @@ match / {
 
   expr jcs:syslog( $SYSLOG, $APPNAME, ": sending finish signal to foreman...");  
   var $do_foreman = <file-copy> {
-      <source> 'http://foreman.some.host.fqdn/unattended/provision';
+      <source> 'http://foreman.example.com/unattended/provision';
       <destination> "/tmp";
       <staging-directory> "/tmp";
   };

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -177,20 +177,20 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -177,20 +177,20 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -177,20 +177,20 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -177,20 +177,20 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -177,20 +177,20 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/built'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.some.host.fqdn/unattended/failed'
+    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/failed'
   else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/failed'
+    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
@@ -71,4 +71,4 @@ d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 
-d-i preseed/late_command string wget -Y off http://foreman.some.host.fqdn/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
@@ -71,4 +71,4 @@ d-i grub-installer/only_debian boolean true
 d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 
-d-i preseed/late_command string wget -Y off http://foreman.some.host.fqdn/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer_default_answerfile.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer_default_answerfile.host4dhcp.snap.txt
@@ -16,6 +16,6 @@ part swap  --recommended  <keymap>us</keymap>
   <timezone>UTC</timezone>
   <time-config-method>ntp</time-config-method>
   <script stage="installation-complete" type="url">
-    http://foreman.some.host.fqdn/unattended/finish
+    http://foreman.example.com/unattended/finish
   </script>
 </installation>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_discovery.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_discovery.host4dhcp.snap.txt
@@ -1,4 +1,4 @@
-common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac"
+common="rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac"
 
 if [ ${grub_platform} == "pc" ]; then
   menuentry 'Foreman Discovery Image' --id discovery {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub_discovery.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub_discovery.host4dhcp.snap.txt
@@ -1,4 +1,4 @@
 # http://projects.theforeman.org/issues/15997
 title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman BOOTIF=01-$net_default_mac
+  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac
   initrd boot/fdi-image/initrd0.img

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxelinux_discovery.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxelinux_discovery.host4dhcp.snap.txt
@@ -1,10 +1,10 @@
 LABEL discovery
   MENU LABEL Foreman Discovery Image
   KERNEL boot/fdi-image/vmlinuz0
-  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.some.host.fqdn proxy.type=foreman
+  APPEND initrd=boot/fdi-image/initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman
   IPAPPEND 2
 
 LABEL discovery_ipxe
   MENU LABEL Foreman Discovery Image - iPXE
   KERNEL ipxe.lkrn
-  APPEND dhcp && chain http://foreman.some.host.fqdn/pub/discovery.ipxe
+  APPEND dhcp && chain http://foreman.example.com/pub/discovery.ipxe

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -57,10 +57,10 @@ export FACTER_is_installer=true
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -95,10 +95,10 @@ EOF
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -28,6 +28,6 @@ autoinstall:
       name: lvm
   user-data:
     runcmd:
-      - wget -Y off http://foreman.some.host.fqdn/unattended/finish -O /tmp/finish.sh
+      - wget -Y off http://foreman.example.com/unattended/finish -O /tmp/finish.sh
       - chmod +x /tmp/finish.sh
       - /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -61,10 +61,10 @@ systemctl enable puppet
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -61,10 +61,10 @@ systemctl enable puppet
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
-  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 else
-  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.some.host.fqdn/unattended/built'
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -59,7 +59,7 @@ runcmd:
 
 
 phone_home:
-  url: http://foreman.some.host.fqdn/unattended/built
+  url: http://foreman.example.com/unattended/built
   post: []
   tries: 10
 


### PR DESCRIPTION
Tests were almost not using the fqdn defined in settings.yaml.test
That is quite confusing at first sight and we should not override this value by fixtures, only if overriden in the same test file.

Katello failure is fixed by https://github.com/Katello/katello/pull/9909, but I'd not consider it necessarily blocking