### PR TITLE
Fixes #34346 - support Openstack URI with paths

### DIFF
--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -262,7 +262,9 @@ module Foreman::Model
 
     def url_for_fog
       u = URI.parse(url)
-      "#{u.scheme}://#{u.host}:#{u.port}"
+      match_data = u.path.match(%r{(.*)\/v\d+.*})
+      path = match_data && (match_data[1] || '')
+      "#{u.scheme}://#{u.host}:#{u.port}#{path}"
     end
 
     def fog_credentials

--- a/test/models/compute_resources/openstack_test.rb
+++ b/test/models/compute_resources/openstack_test.rb
@@ -21,6 +21,26 @@ module Foreman
         Fog.unmock!
       end
 
+      describe "url_for_fog" do
+        it "parses the hostname and port" do
+          @compute_resource = FactoryBot.build_stubbed(:openstack_cr)
+          @compute_resource.url = 'http://stack.example.com:5000/v3/auth/tokens'
+          assert_equal 'http://stack.example.com:5000', @compute_resource.send(:url_for_fog)
+
+          @compute_resource.url = 'http://stack.example.com:5000/identity/v3/auth/tokens'
+          assert_equal 'http://stack.example.com:5000/identity', @compute_resource.send(:url_for_fog)
+
+          @compute_resource.url = 'http://stack.example.com:5000/identity/v2/auth/tokens'
+          assert_equal 'http://stack.example.com:5000/identity', @compute_resource.send(:url_for_fog)
+
+          @compute_resource.url = 'http://stack.example.com/identity/v3/auth/tokens'
+          assert_equal 'http://stack.example.com:80/identity', @compute_resource.send(:url_for_fog)
+
+          @compute_resource.url = 'http://stack.example.com/auth/tokens'
+          assert_equal 'http://stack.example.com:80', @compute_resource.send(:url_for_fog)
+        end
+      end
+
       test "#associated_host matches any NIC" do
         host = FactoryBot.create(:host, :ip => '10.0.0.154')
         iface = mock('iface1', :floating_ip_address => '10.0.0.154', :private_ip_address => "10.1.1.1")


### PR DESCRIPTION
The Keystone URI is processed before we pass it's base form to the fog.
If Keystone is deployed under a sub-uri e.g. /identity like Devstack
does, the path is always ommited. This preserves the path.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
