### PR TITLE
Fixes #34350 - Require 'foreman/telemetry' in ldap initializer

### DIFF
--- a/config/initializers/ldap_instrumentation.rb
+++ b/config/initializers/ldap_instrumentation.rb
@@ -1,45 +1,9 @@
+require 'foreman/ldap/ldap_subscriber.rb'
+require 'foreman/ldap/ldap_fluff_subscriber.rb'
+require 'foreman/ldap/net_ldap_subscriber.rb'
+
 # Debug logging from net-ldap and ldap_fluff events sent via ActiveSupport::Notifications
-module Foreman
-  class LdapSubscriber < ActiveSupport::LogSubscriber
-    include Foreman::TelemetryHelper
-
-    def logger
-      ::Foreman::Logging.logger('ldap')
-    end
-
-    def self.define_log(action, log_name, color)
-      define_method(action) do |event|
-        telemetry_observe_histogram(:ldap_request_duration, event.duration)
-        return unless logger.debug?
-        name = '%s (%.1fms)' % [log_name, event.duration]
-        debug "  #{color(name, color, true)}  [ #{yield(event.payload)} ]"
-      end
-    end
-  end
-
-  class NetLdapSubscriber < LdapSubscriber
-    define_log(:bind, 'op bind', YELLOW) do |payload|
-      if payload[:bind].try(:status)
-        "result=#{payload[:bind].status}"
-      else
-        "result=#{payload[:bind]}"
-      end
-    end
-    define_log(:search, 'op search', YELLOW) { |payload| "filter=#{payload[:filter]}, base=#{payload[:base]}" }
-  end
-
-  class LdapFluffSubscriber < LdapSubscriber
-    define_log(:authenticate, 'authenticate', GREEN) { |payload| "user=#{payload[:uid]}" }
-    define_log(:test, 'test', GREEN) {}
-    define_log(:user_list, 'user_list', GREEN) { |payload| "group=#{payload[:gid]}" }
-    define_log(:valid_group?, 'valid_group?', GREEN) { |payload| "group=#{payload[:gid]}" }
-    define_log(:find_group, 'find_group', GREEN) { |payload| "group=#{payload[:gid]}" }
-    define_log(:group_list, 'group_list', GREEN) { |payload| "user=#{payload[:uid]}" }
-    define_log(:valid_user?, 'valid_user?', GREEN) { |payload| "user=#{payload[:uid]}" }
-    define_log(:find_user, 'find_user', GREEN) { |payload| "user=#{payload[:uid]}" }
-    define_log(:is_in_groups?, 'is_in_groups?', GREEN) { |payload| "user=#{payload[:uid]}, grouplist=#{payload[:grouplist].inspect}" }
-  end
+Rails.application.config.after_initialize do
+  Foreman::Ldap::NetLdapSubscriber.attach_to :net_ldap
+  Foreman::Ldap::LdapFluffSubscriber.attach_to :ldap_fluff
 end
-
-Foreman::NetLdapSubscriber.attach_to :net_ldap
-Foreman::LdapFluffSubscriber.attach_to :ldap_fluff

--- a/lib/foreman/ldap/ldap_fluff_subscriber.rb
+++ b/lib/foreman/ldap/ldap_fluff_subscriber.rb
@@ -1,0 +1,15 @@
+module Foreman
+  module Ldap
+    class LdapFluffSubscriber < Foreman::Ldap::LdapSubscriber
+      define_log(:authenticate, 'authenticate', GREEN) { |payload| "user=#{payload[:uid]}" }
+      define_log(:test, 'test', GREEN) {}
+      define_log(:user_list, 'user_list', GREEN) { |payload| "group=#{payload[:gid]}" }
+      define_log(:valid_group?, 'valid_group?', GREEN) { |payload| "group=#{payload[:gid]}" }
+      define_log(:find_group, 'find_group', GREEN) { |payload| "group=#{payload[:gid]}" }
+      define_log(:group_list, 'group_list', GREEN) { |payload| "user=#{payload[:uid]}" }
+      define_log(:valid_user?, 'valid_user?', GREEN) { |payload| "user=#{payload[:uid]}" }
+      define_log(:find_user, 'find_user', GREEN) { |payload| "user=#{payload[:uid]}" }
+      define_log(:is_in_groups?, 'is_in_groups?', GREEN) { |payload| "user=#{payload[:uid]}, grouplist=#{payload[:grouplist].inspect}" }
+    end
+  end
+end

--- a/lib/foreman/ldap/ldap_subscriber.rb
+++ b/lib/foreman/ldap/ldap_subscriber.rb
@@ -1,0 +1,20 @@
+module Foreman
+  module Ldap
+    class LdapSubscriber < ActiveSupport::LogSubscriber
+      include Foreman::TelemetryHelper
+
+      def logger
+        ::Foreman::Logging.logger('ldap')
+      end
+
+      def self.define_log(action, log_name, color)
+        define_method(action) do |event|
+          telemetry_observe_histogram(:ldap_request_duration, event.duration)
+          return unless logger.debug?
+          name = '%s (%.1fms)' % [log_name, event.duration]
+          debug "  #{color(name, color, true)}  [ #{yield(event.payload)} ]"
+        end
+      end
+    end
+  end
+end

--- a/lib/foreman/ldap/net_ldap_subscriber.rb
+++ b/lib/foreman/ldap/net_ldap_subscriber.rb
@@ -1,0 +1,14 @@
+module Foreman
+  module Ldap
+    class NetLdapSubscriber < Foreman::Ldap::LdapSubscriber
+      define_log(:bind, 'op bind', YELLOW) do |payload|
+        if payload[:bind].try(:status)
+          "result=#{payload[:bind].status}"
+        else
+          "result=#{payload[:bind]}"
+        end
+      end
+      define_log(:search, 'op search', YELLOW) { |payload| "filter=#{payload[:filter]}, base=#{payload[:base]}" }
+    end
+  end
+end


### PR DESCRIPTION
Fix for:
```
DEPRECATION WARNING: Initialization autoloaded the constants ...
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
