### PR TITLE
Fixes #34329 - Allow permissions to be excluded from default roles

### DIFF
--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -407,11 +407,12 @@ module Foreman #:nodoc:
 
     # Add plugin permissions to Manager and Viewer roles. Use this method if there are no special cases that need to be taken care of.
     # Otherwise add_permissions_to_default_roles or add_resource_permissions_to_default_roles might be the methods you are looking for.
-    def add_all_permissions_to_default_roles
+    def add_all_permissions_to_default_roles(except: [])
       return if Foreman.in_setup_db_rake? || !permission_table_exists?
       Role.without_auditing do
         Filter.without_auditing do
-          Plugin::RbacSupport.new.add_all_permissions_to_default_roles(Permission.where(:name => @rbac_registry.permission_names))
+          permission_names = @rbac_registry.permission_names - except
+          Plugin::RbacSupport.new.add_all_permissions_to_default_roles(Permission.where(:name => permission_names))
         end
       end
     end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -288,6 +288,14 @@ end
 add_all_permissions_to_default_roles
 ----
 
+Alternatively, one can exclude specific permissions from being added to the
+default roles by using the following form instead
+
+[source, ruby]
+----
+add_all_permissions_to_default_roles(except: [:first_permission, :second_permission])
+----
+
 If you need more control over what needs to be added you can use the
 following:
 


### PR DESCRIPTION
(cherry picked from commit ef2ff06831ae7efcdab247b13c9ff642c6d56688)
