### PR TITLE
Fixes #32632 - initial verison of Ubuntu autoinstall templates

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -34,6 +34,10 @@ module Foreman
       new.ubuntu4dhcp
     end
 
+    def self.ubuntu_autoinst4dhcp
+      new.ubuntu_autoinst4dhcp
+    end
+
     def self.render_template(template, host_name = :host4dhcp)
       host_stub = send(host_name.to_sym)
       source = Foreman::Renderer::Source::Snapshot.new(template)
@@ -135,6 +139,14 @@ module Foreman
     end
 
     def ubuntu4dhcp
+      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_ubuntu18,
+        name: 'snapshot-ipv4-dhcp-ubuntu18',
+        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
+        interfaces: [ipv4_interface])
+      define_host_params(host)
+    end
+
+    def ubuntu_autoinst4dhcp
       host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_ubuntu20,
         name: 'snapshot-ipv4-dhcp-ubuntu20',
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),

--- a/app/views/unattended/partition_tables_templates/preseed_default_autoinstall.erb
+++ b/app/views/unattended/partition_tables_templates/preseed_default_autoinstall.erb
@@ -1,0 +1,14 @@
+<%#
+kind: ptable
+name: Preseed default autoinstall
+model: Ptable
+description: |
+  Preseed Autoinstall default storage snippet configures drives automatically
+  with LVM. The snippet is automatically indented by 2 spaces. For reference:
+  https://ubuntu.com/server/docs/install/autoinstall-reference
+oses:
+- Ubuntu
+%>
+storage:
+  layout:
+    name: lvm

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
@@ -1,0 +1,51 @@
+<%#
+kind: PXELinux
+name: Preseed default PXELinux Autoinstall
+model: ProvisioningTemplate
+oses:
+- ubuntu
+test_on:
+- ubuntu_autoinst4dhcp
+-%>
+#
+# This file was deployed via '<%= template_name %>' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+# lang = en_US
+#   System locale
+#
+<%
+  options = []
+  if host_param('blacklist')
+    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  end
+  if @host.operatingsystem.name == 'Debian'
+    options << "auto=true"
+    options << "domain=#{@host.domain}"
+  else
+    options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
+  end
+  if @host.provision_interface.vlanid.present?
+    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
+  end
+  options << "locale=#{host_param('lang') || 'en_US'}"
+  options = options.join(' ')
+-%>
+#
+# WARNING
+#
+# Foreman will not download the kernel/initramdisk to PXE automatically. Please follow
+# the official Ubuntu documentation and extract the files from the LiveCD (DVD) manually
+# and optionally update the KERNEL and INITRD lines in this template.
+#
+DEFAULT linux cloud-init autoinstall
+LABEL linux cloud-init autoinstall
+    KERNEL ubuntu/focal/vmlinuz
+    INITRD ubuntu/focal/initrd
+    APPEND ip=dhcp url=http://<%= @preseed_server %><%= @preseed_path %> autoinstall ds=nocloud-net;s=http://<%= @preseed_server %>/pub/preseed/autoinstall/<%= @host.shortname %>/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
+
+<%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -1,0 +1,34 @@
+<%#
+name: preseed_netplan_generic_interface
+model: ProvisioningTemplate
+snippet: true
+model: ProvisioningTemplate
+kind: snippet
+oses:
+- Ubuntu
+-%>
+    <%= @interface.identifier %>:
+        dhcp4: <%= @dhcp %>
+        dhcp6: <%= @dhcp6 %>
+<%- if !@dhcp && !@subnet.nil? && !@interface.ip.nil? -%>
+        addresses: [ <%= @interface.ip %>/<%= @subnet.cidr %> ]
+<%-   if @subnet.gateway.present? -%>
+        gateway4: <%= @subnet.gateway %>
+<%-   end -%>
+<%-   if @interface.primary -%>
+        nameservers:
+          search: [ <%= @interface.domain %> ]
+          addresses: <%= @subnet.dns_servers %>
+<%-   end -%>
+<%- end -%>
+<%- if !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil? -%>
+        addresses: [ <%= @interface.ip6 %>/<%= @subnet6.cidr %> ]
+<%-   if @subnet6.gateway.present? -%>
+        gateway4: <%= @subnet6.gateway %>
+<%-   end -%>
+<%-   if @interface.primary -%>
+        nameservers:
+          search: [ <%= @interface.domain %> ]
+          addresses: <%= @subnet6.dns_servers %>
+<%-   end -%>
+<%- end -%>

--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -1,0 +1,111 @@
+<%#
+kind: snippet
+name: preseed_netplan_setup
+model: ProvisioningTemplate
+snippet: true
+description: |
+  This will configure your host networking, it configures your
+  primary interface as well as other NICs like BOND, BRIDGE, VLAN and Alias
+  interfaces.
+oses:
+- Ubuntu
+-%>
+<% os_major = @host.operatingsystem.major.to_i -%>
+<% os_minor = @host.operatingsystem.minor.to_i -%>
+<%- -%>
+<%# Begin Ubuntu 18.04 and newer uses netplan instead of /etc/network/interfaces -%>
+<%- if os_major >= 20 -%>
+<%- bonding_interfaces = [] -%>
+<%- bridged_interfaces = [] -%>
+<%- vlans_interfaces = [] -%>
+  network:
+    version: 2
+<%#
+##### Processing bond-interfaces #####
+-%>
+<%- found = false -%>
+<%- @host.bond_interfaces.each do | bond | -%>
+  <%- bonding_interfaces.push(bond.identifier) -%>
+  <%- if !found -%>
+  <%- found = true -%>
+    bonds:
+  <%- end -%>
+<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+                  :interface => bond,
+                  :subnet => bond.subnet,
+                  :subnet6 => bond.subnet6,
+                  :dhcp => bond.subnet.nil? ? false : bond.subnet.dhcp_boot_mode?,
+                  :dhcp6 => bond.subnet6.nil? ? false : bond.subnet.dhcp_boot_mode? }) -%>
+  <%= result -%>
+        interfaces: <%= bond.attached_devices_identifiers %>
+        parameters:
+          mode: <%= bond.mode %>
+          <%- options = bond.bond_options.split() -%>
+          <%- options.each do | option | -%>
+          <%= option.gsub('=',': ') %>
+          <%- end -%>
+<% end -%>
+<%#
+##### Processing bridge interfaces #####
+-%>
+<%- found = false -%>
+<%- @host.bridge_interfaces.each do | bridge | -%>
+<%- next if bonding_interfaces.include?(bridge.identifier) -%>
+  <%- bridged_interfaces.push(bridge.identifier) -%>
+  <%- if !found -%>
+  <%- found = true -%>
+    bridges:
+  <%- end -%>
+<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+                  :interface => bridge,
+                  :subnet => bridge.subnet,
+                  :subnet6 => bridge.subnet6,
+                  :dhcp => bridge.subnet.nil? ? false : bridge.subnet.dhcp_boot_mode?,
+                  :dhcp6 => bridge.subnet6.nil? ? false : bridge.subnet.dhcp_boot_mode? }) -%>
+  <%= result -%>
+<%- end -%>
+<%#
+##### Processing vlan interfaces #####
+-%>
+<%- found = false -%>
+<%- @host.managed_interfaces.each do | vlan | -%>
+<%- next if bonding_interfaces.include?(vlan.identifier) -%>
+<%- next if bridged_interfaces.include?(vlan.identifier) -%>
+<%- next if !vlan.virtual? -%>
+  <%- vlans_interfaces.push(vlan.identifier) -%>
+  <%- if !found -%>
+  <%- found = true -%>
+    vlans:
+  <%- end -%>
+<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+                  :interface => vlan,
+                  :subnet => vlan.subnet,
+                  :subnet6 => vlan.subnet6,
+                  :dhcp => vlan.subnet.nil? ? false : vlan.subnet.dhcp_boot_mode?,
+                  :dhcp6 => vlan.subnet6.nil? ? false : vlan.subnet.dhcp_boot_mode? }) -%>
+  <%= result -%>
+        id: <%= vlan.tag %>
+        link: <%= vlan.attached_to %>
+<%- end -%>
+<%#
+##### Processing remaining interfaces (ethernets) #####
+-%>
+<%- found = false -%>
+<%- @host.managed_interfaces.each do | interface | -%>
+<%- next if bonding_interfaces.include?(interface.identifier) -%>
+<%- next if bridged_interfaces.include?(interface.identifier) -%>
+<%- next if vlans_interfaces.include?(interface.identifier) -%>
+  <%- interface_subnet = interface.subnet -%>
+  <%- if !found -%>
+  <%- found = true -%>
+    ethernets:
+  <%- end -%>
+<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+                  :interface => interface,
+                  :subnet => interface.subnet,
+                  :subnet6 => interface.subnet6,
+                  :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode?,
+                  :dhcp6 => interface.subnet6.nil? ? false : interface.subnet.dhcp_boot_mode? }) -%>
+  <%= result -%>
+<%- end -%>
+<%- end -%>

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -1,0 +1,46 @@
+<%#
+kind: user_data
+name: Preseed Autoinstall cloud-init user data
+model: ProvisioningTemplate
+oses:
+- ubuntu
+test_on:
+- ubuntu_autoinst4dhcp
+-%>
+<%-
+username_to_create = host_param('username_to_create', 'root')
+realname_to_create = host_param('realname_to_create') || username_to_create
+password_to_create = host_param('password_to_create') || @host.root_pass
+-%>
+#cloud-config
+autoinstall:
+  version: 1
+  apt:
+    geoip: false
+    preserve_sources_list: false
+    primary:
+      - arches: [amd64, i386]
+        uri: http://archive.ubuntu.com/ubuntu
+      - arches: [default]
+        uri: http://ports.ubuntu.com/ubuntu-ports
+<%= indent(4) { snippet_if_exists(template_name + " custom apt") } -%>
+  identity:
+    hostname: <%= @host.name %>
+    realname: <%= realname_to_create %>
+    username: <%= username_to_create %>
+    password: "<%= password_to_create %>"
+  keyboard: {layout: us, toggle: null, variant: ''}
+  locale: en_US.UTF-8
+<%= snippet 'preseed_netplan_setup' -%>
+  ssh:
+    allow-pw: true
+    authorized-keys: []
+    install-server: true
+  updates: security
+<%= indent(2) { @host.diskLayout } -%>
+<%= indent(2) { snippet_if_exists(template_name + " custom root") } -%>
+  user-data:
+    runcmd:
+      - wget -Y off <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /tmp/finish.sh
+      - chmod +x /tmp/finish.sh
+      - /tmp/finish.sh

--- a/lib/tasks/snapshots.rake
+++ b/lib/tasks/snapshots.rake
@@ -40,6 +40,11 @@ namespace :snapshots do
             FileUtils.mkdir_p(dir) unless File.directory?(dir)
 
             snapshot = Foreman::TemplateSnapshotService.render_template(template, host)
+            if snapshot =~ /^#cloud-config/
+              puts "Validating YAML #{snapshot_path}"
+              YAML.safe_load(snapshot)
+            end
+            puts "Writing #{snapshot_path}"
             File.write(snapshot_path, snapshot)
           end
         end

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -26,6 +26,12 @@ FactoryBot.define do
       os_family { 'Debian' }
     end
 
+    trait :ubuntu_autoinstall do
+      sequence(:name) { |n| "ubuntu default autoinstall#{n}" }
+      layout { "storage:\n  layout:\n    name: lvm\n" }
+      os_family { 'Debian' }
+    end
+
     trait :suse do
       sequence(:name) { |n| "suse default#{n}" }
       layout { "<partitioning  config:type=\"list\">\n  <drive>\n    <device>/dev/hda</device>\n    <use>all</use>\n  </drive>\n</partitioning>" }
@@ -309,7 +315,12 @@ FactoryBot.define do
         operatingsystem { FactoryBot.build(:for_snapshots_debian_10) }
       end
 
+      factory :host_for_snapshots_ipv4_dhcp_ubuntu18 do
+        operatingsystem { FactoryBot.build(:for_snapshots_ubuntu_18) }
+      end
+
       factory :host_for_snapshots_ipv4_dhcp_ubuntu20 do
+        ptable { FactoryBot.build(:ptable, :ubuntu_autoinstall) }
         operatingsystem { FactoryBot.build(:for_snapshots_ubuntu_20) }
       end
     end

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -165,6 +165,20 @@ FactoryBot.define do
       ptables { [FactoryBot.build(:ptable, name: 'ptable')] }
     end
 
+    # pre-netinstall release
+    factory :for_snapshots_ubuntu_18, class: Debian do
+      name { 'Ubuntu' }
+      major { '18' }
+      minor { '04' }
+      type { 'Debian' }
+      release_name { 'focal' }
+      title { 'Ubuntu Focal' }
+      architectures { [FactoryBot.build(:architecture, :for_snapshots_x86_64)] }
+      media { [FactoryBot.build(:ubuntu_for_snapshots)] }
+      ptables { [FactoryBot.build(:ptable, name: 'ptable')] }
+    end
+
+    # post-netinstall release
     factory :for_snapshots_ubuntu_20, class: Debian do
       name { 'Ubuntu' }
       major { '20' }

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -69,3 +69,5 @@ files:
   - snippet/remote_execution_ssh_keys.erb
   - snippet/saltstack_minion.erb
   - snippet/saltstack_setup.erb
+  - PXELinux/preseed_default_pxelinux_autoinstall.erb
+  - user_data/preseed_autoinstall_cloud_init.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -13,8 +13,8 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/ubuntu-mirror-c5UKFnM0aX6y-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu20 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
-  initrdefi boot/ubuntu-mirror-c5UKFnM0aX6y-initrd.gz
+  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
+  initrdefi boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz
 }
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
@@ -11,8 +11,8 @@
 #
 DEFAULT linux
 LABEL linux
-    KERNEL boot/ubuntu-mirror-c5UKFnM0aX6y-linux
-    APPEND initrd=boot/ubuntu-mirror-c5UKFnM0aX6y-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu20 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
+    KERNEL boot/ubuntu-mirror-dBfjc2q1x3NM-linux
+    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.some.host.fqdn/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -1,0 +1,25 @@
+#
+# This file was deployed via 'Preseed default PXELinux Autoinstall' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+# lang = en_US
+#   System locale
+#
+#
+# WARNING
+#
+# Foreman will not download the kernel/initramdisk to PXE automatically. Please follow
+# the official Ubuntu documentation and extract the files from the LiveCD (DVD) manually
+# and optionally update the KERNEL and INITRD lines in this template.
+#
+DEFAULT linux cloud-init autoinstall
+LABEL linux cloud-init autoinstall
+    KERNEL ubuntu/focal/vmlinuz
+    INITRD ubuntu/focal/initrd
+    APPEND ip=dhcp url=http://archive.ubuntu.com:80/ubuntu autoinstall ds=nocloud-net;s=http://archive.ubuntu.com:80/pub/preseed/autoinstall// root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
+
+

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -1,7 +1,7 @@
 
 #cloud-config
-hostname: snapshot-ipv4-dhcp-ubuntu20
-fqdn: snapshot-ipv4-dhcp-ubuntu20
+hostname: snapshot-ipv4-dhcp-ubuntu18
+fqdn: snapshot-ipv4-dhcp-ubuntu18
 manage_etc_hosts: true
 users: {}
 runcmd:
@@ -11,7 +11,7 @@ runcmd:
   hostname 
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-ubuntu20  localhost localhost.localdomain
+  127.0.0.1   snapshot-ipv4-dhcp-ubuntu18  localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix
@@ -57,7 +57,7 @@ runcmd:
   [agent]
   pluginsync      = true
   report          = true
-  certname        = snapshot-ipv4-dhcp-ubuntu20
+  certname        = snapshot-ipv4-dhcp-ubuntu18
   
   EOF
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -22,7 +22,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-ubuntu20
+certname        = snapshot-ipv4-dhcp-ubuntu18
 
 EOF
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
@@ -8,7 +8,7 @@ d-i keyboard-configuration/xkb-keymap seen true
 
 # Network configuration
 d-i netcfg/choose_interface select auto
-d-i netcfg/get_hostname string snapshot-ipv4-dhcp-ubuntu20
+d-i netcfg/get_hostname string snapshot-ipv4-dhcp-ubuntu18
 d-i netcfg/get_domain string snap.example.com
 d-i netcfg/wireless_wep string
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -1,0 +1,33 @@
+#cloud-config
+autoinstall:
+  version: 1
+  apt:
+    geoip: false
+    preserve_sources_list: false
+    primary:
+      - arches: [amd64, i386]
+        uri: http://archive.ubuntu.com/ubuntu
+      - arches: [default]
+        uri: http://ports.ubuntu.com/ubuntu-ports
+  identity:
+    hostname: snapshot-ipv4-dhcp-ubuntu20
+    realname: root
+    username: root
+    password: "$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0"
+  keyboard: {layout: us, toggle: null, variant: ''}
+  locale: en_US.UTF-8
+  network:
+    version: 2
+  ssh:
+    allow-pw: true
+    authorized-keys: []
+    install-server: true
+  updates: security
+  storage:
+    layout:
+      name: lvm
+  user-data:
+    runcmd:
+      - wget -Y off http://foreman.some.host.fqdn/unattended/finish -O /tmp/finish.sh
+      - chmod +x /tmp/finish.sh
+      - /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -6,7 +6,7 @@ echo "" > /etc/hostname
 hostname 
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-ubuntu20  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-ubuntu18  localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix
@@ -40,7 +40,7 @@ ssldir = \$vardir/ssl
 [agent]
 pluginsync      = true
 report          = true
-certname        = snapshot-ipv4-dhcp-ubuntu20
+certname        = snapshot-ipv4-dhcp-ubuntu18
 
 EOF
 


### PR DESCRIPTION
This adds slightly modified and corrected templates which were contributed by @langesmalle

I have cleaned them up, added partitioning scheme, updated some indentation and few issues. I have not tested them yet as I am busy with 3.2 features. Feel free to merge this so we can gradually improve them. I have updated snapshot mocks and there are now two ubuntu versions: 18 (with traditional installer) and 20 (with autoinstall cloud-init based installer). Both have snapshots and I also added YAML validation when generating snapshots to avoid syntax errors in YAML.

More context:

https://community.theforeman.org/t/autoinstalling-ubuntu-server-20-04-3-from-the-live-iso/27050