### PR TITLE
Fixes #34360 - prepare for Host Reports migration

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -29,7 +29,11 @@ class Host::Managed < Host::Base
   has_many :all_reports, :foreign_key => :host_id
 
   belongs_to :image
-  has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
+  if defined? ForemanHostReports
+    has_many :host_statuses, -> { where("host_status.type != 'HostStatus::ConfigurationStatus' and host_status.type is not null") }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :delete_all
+  else
+    has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
+  end
   has_one :configuration_status_object, :class_name => 'HostStatus::ConfigurationStatus', :foreign_key => 'host_id'
   has_one :build_status_object, :class_name => 'HostStatus::BuildStatus', :foreign_key => 'host_id'
   before_destroy :remove_reports

--- a/script/reformat-fixtures
+++ b/script/reformat-fixtures
@@ -1,0 +1,8 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+trap 'rm -f "$TMPFILE"' EXIT
+TMPFILE=$(mktemp) || exit 1
+for FILE in $BASEDIR/../test/static_fixtures/reports/*.json; do
+  cp $FILE $TMPFILE
+  python -m json.tool --sort-keys $TMPFILE $FILE
+done

--- a/script/send-fixture-report
+++ b/script/send-fixture-report
@@ -1,0 +1,64 @@
+#!/bin/bash
+BASEDIR=$(dirname $0)
+URL=${URL:-http://localhost:5000}
+HOST=report.example.com
+TMP=/tmp/$(basename $0).tmp
+
+usage() {
+	echo "Usage:"
+	echo "  $0 -h               Display this help message"
+	echo "  $0 -u URL           Foreman URL ($URL)"
+	echo "  $0 -o HOSTNAME      Hostname ($HOST)"
+	echo "  $0 -f FILE          Fixture to upload"
+	echo "  $0 -a               Upload all fixtures"
+}
+
+while getopts "haf:u:o:" opt; do
+	case ${opt} in
+		u )
+			URL=$OPTARG
+			;;
+		f )
+			FILE=$OPTARG
+			;;
+		o )
+			HOST=$OPTARG
+			;;
+		a )
+			ALL=1
+			;;
+		h )
+			usage
+			exit 0
+			;;
+		\? )
+			echo "Invalid option: $OPTARG" 1>&2
+			usage
+			exit 1
+			;;
+		: )
+			echo "Invalid option: $OPTARG requires an argument" 1>&2
+			usage
+			exit 1
+			;;
+	esac
+done
+shift $((OPTIND -1))
+
+do_curl() {
+	cat "$1" | sed "s/\"reported_at\": *\"[^\"]*\"/\"reported_at\": \"$(date -Ru)\"/" | \
+		sed "s/\"host\": *\"[^\"]*\"/\"host\": \"$HOST\"/" > $TMP
+	curl -s -H "Content-Type: application/json" \
+		-X POST $URL/api/v2/config_reports \
+		--data-binary @$TMP -w " - $1: %{http_code}\n"
+	}
+
+if [[ -f "$FILE" ]]; then
+	do_curl "$FILE"
+elif [[ $ALL -eq 1 ]]; then
+	for FILE in $BASEDIR/test/static_fixtures/reports/skipped.json; do
+		do_curl "$FILE"
+	done
+else
+	usage
+fi

--- a/test/active_support_test_case_helper.rb
+++ b/test/active_support_test_case_helper.rb
@@ -184,7 +184,12 @@ class ActiveSupport::TestCase
 
   def read_json_fixture(file)
     json = File.expand_path(File.join('..', 'static_fixtures', file), __FILE__)
-    JSON.parse(File.read(json))
+    result = JSON.parse(File.read(json))
+    if file.start_with? "reports"
+      result["config_report"]
+    else
+      result
+    end
   end
 
   def assert_with_errors(condition, model)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -470,7 +470,7 @@ class HostTest < ActiveSupport::TestCase
     assert_difference 'Host.count' do
       Setting[:create_new_host_when_report_is_uploaded] = true
       ConfigReport.import read_json_fixture("reports/no-logs.json")
-      assert Host.find_by_name('builder.fm.example.net')
+      assert Host.find_by_name('report.example.com')
       Setting[:create_new_host_when_report_is_uploaded] =
         Setting.find_by_name("create_new_host_when_facts_are_uploaded").default
     end
@@ -480,7 +480,7 @@ class HostTest < ActiveSupport::TestCase
     Setting[:create_new_host_when_report_is_uploaded] = false
     assert_equal false, Setting[:create_new_host_when_report_is_uploaded]
     ConfigReport.import read_json_fixture("reports/no-logs.json")
-    host = Host.find_by_name('builder.fm.example.net')
+    host = Host.find_by_name('report.example.com')
     Setting[:create_new_host_when_report_is_uploaded] =
       Setting.find_by_name("create_new_host_when_facts_are_uploaded").default
     assert_nil host

--- a/test/static_fixtures/reports/applied.json
+++ b/test/static_fixtures/reports/applied.json
@@ -1,46 +1,45 @@
-// raw data from Foreman's old parsing of reports, with some readable formtting
 {
-  "host": "b.host.domain",
-  "reported_at": "2010-10-21 05:14:54 UTC",
-  "logs": [
-
-  ],
-  "status": {
-    "applied": 3,
-    "restarted": 0,
-    "failed": 0,
-    "failed_restarts": 0,
-    "skipped": 0,
-    "pending": 0
-  },
-  "metrics": {
-    "time": {
-      "config_retrieval": 13.6332910060883,
-      "cron": 0.0213279724121094,
-      "exec": 2.237300157547,
-      "file": 6.11497139930725,
-      "filebucket": 0.000134944915771484,
-      "host": 0.00245118141174316,
-      "mount": 0.141838073730469,
-      "package": 0.9647057056427,
-      "schedule": 0.000991106033325195,
-      "service": 3.46583986282349,
-      "total": 26.5871164798737,
-      "user": 0.00112104415893555,
-      "yumrepo": 0.0031440258026123
-    },
-    "resources": {
-      "applied": 3,
-      "failed": 0,
-      "failed_restarts": 0,
-      "out_of_sync": 0,
-      "restarted": 0,
-      "scheduled": 1368,
-      "skipped": 0,
-      "total": 1450
-    },
-    "changes": {
-      "total": 0
+    "config_report": {
+        "host": "report.example.com",
+        "logs": [],
+        "metrics": {
+            "changes": {
+                "total": 0
+            },
+            "resources": {
+                "applied": 3,
+                "failed": 0,
+                "failed_restarts": 0,
+                "out_of_sync": 0,
+                "restarted": 0,
+                "scheduled": 1368,
+                "skipped": 0,
+                "total": 1450
+            },
+            "time": {
+                "config_retrieval": 13.6332910060883,
+                "cron": 0.0213279724121094,
+                "exec": 2.237300157547,
+                "file": 6.11497139930725,
+                "filebucket": 0.000134944915771484,
+                "host": 0.00245118141174316,
+                "mount": 0.141838073730469,
+                "package": 0.9647057056427,
+                "schedule": 0.000991106033325195,
+                "service": 3.46583986282349,
+                "total": 26.5871164798737,
+                "user": 0.00112104415893555,
+                "yumrepo": 0.0031440258026123
+            }
+        },
+        "reported_at": "2010-10-21 05:14:54 UTC",
+        "status": {
+            "applied": 3,
+            "failed": 0,
+            "failed_restarts": 0,
+            "pending": 0,
+            "restarted": 0,
+            "skipped": 0
+        }
     }
-  }
 }

--- a/test/static_fixtures/reports/empty.json
+++ b/test/static_fixtures/reports/empty.json
@@ -1,50 +1,50 @@
-// raw data from Foreman's old parsing of reports, with some readable formtting
 {
-  "host": "rhel6n01.corp.com",
-  "reported_at": "2010-11-19 02:39:04 UTC",
-  "metrics": {
-  },
-  "status": {
-    "applied": 0,
-    "failed": 0,
-    "failed_restarts": 0,
-    "pending": 0,
-    "restarted": 0,
-    "skipped": 0
-  },
-  "logs": [
-    {
-      "log": {
-        "sources": {
-          "source": "Puppet"
-        },
-        "messages": {
-          "message": "Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find node 'rhel6n01.corp.com'; cannot compile"
-        },
-        "level": "err"
-      }
-    },
-    {
-      "log": {
-        "sources": {
-          "source": "Puppet"
-        },
-        "messages": {
-          "message": "Using cached catalog"
-        },
-        "level": "notice"
-      }
-    },
-    {
-      "log": {
-        "sources": {
-          "source": "Puppet"
-        },
-        "messages": {
-          "message": "Could not retrieve catalog; skipping run"
-        },
-        "level": "err"
-      }
+    "config_report": {
+        "host": "report.example.com",
+        "logs": [
+            {
+                "log": {
+                    "level": "err",
+                    "messages": {
+                        "message": "Could not retrieve catalog from remote server: Error 400 on SERVER: Could not find node 'rhel6n01.corp.com'; cannot compile"
+                    },
+                    "sources": {
+                        "source": "Puppet"
+                    }
+                }
+            },
+            {
+                "log": {
+                    "level": "notice",
+                    "messages": {
+                        "message": "Using cached catalog"
+                    },
+                    "sources": {
+                        "source": "Puppet"
+                    }
+                }
+            },
+            {
+                "log": {
+                    "level": "err",
+                    "messages": {
+                        "message": "Could not retrieve catalog; skipping run"
+                    },
+                    "sources": {
+                        "source": "Puppet"
+                    }
+                }
+            }
+        ],
+        "metrics": {},
+        "reported_at": "2010-11-19 02:39:04 UTC",
+        "status": {
+            "applied": 0,
+            "failed": 0,
+            "failed_restarts": 0,
+            "pending": 0,
+            "restarted": 0,
+            "skipped": 0
+        }
     }
-  ]
 }

--- a/test/static_fixtures/reports/errors.json
+++ b/test/static_fixtures/reports/errors.json
@@ -1,45 +1,46 @@
-// raw data from Foreman's old parsing of reports, with some readable formtting
 {
-  "host": "my.sol.client.com",
-  "reported_at": "2009-09-30 06:49:36 UTC",
-  "status": {
-    "applied": 0,
-    "restarted": 0,
-    "failed": 1,
-    "failed_restarts": 0,
-    "skipped": 0,
-    "pending": 0
-  },
-  "metrics": {
-    "time": {
-      "config_retrieval": 6.98906397819519,
-      "total": 13.8197405338287
-    },
-    "resources": {
-      "applied": 0,
-      "failed": 1,
-      "failed_restarts": 0,
-      "out_of_sync": 0,
-      "restarted": 0,
-      "scheduled": 67,
-      "skipped": 0,
-      "total": 68
-    },
-    "changes": {
-      "total": 0
-    }
-  },
-  "logs": [
-    {
-      "log": {
-        "sources": {
-          "source": "//Node[my.sol.client]/my_servers/minimal/time/Service[network/ntp]"
+    "config_report": {
+        "host": "report.example.com",
+        "logs": [
+            {
+                "log": {
+                    "level": "err",
+                    "messages": {
+                        "message": "Failed to retrieve current state of resource: Unmanageable state 'maintenance' on service network/ntp"
+                    },
+                    "sources": {
+                        "source": "//Node[my.sol.client]/my_servers/minimal/time/Service[network/ntp]"
+                    }
+                }
+            }
+        ],
+        "metrics": {
+            "changes": {
+                "total": 0
+            },
+            "resources": {
+                "applied": 0,
+                "failed": 1,
+                "failed_restarts": 0,
+                "out_of_sync": 0,
+                "restarted": 0,
+                "scheduled": 67,
+                "skipped": 0,
+                "total": 68
+            },
+            "time": {
+                "config_retrieval": 6.98906397819519,
+                "total": 13.8197405338287
+            }
         },
-        "messages": {
-          "message": "Failed to retrieve current state of resource: Unmanageable state 'maintenance' on service network/ntp"
-        },
-        "level": "err"
-      }
+        "reported_at": "2009-09-30 06:49:36 UTC",
+        "status": {
+            "applied": 0,
+            "failed": 1,
+            "failed_restarts": 0,
+            "pending": 0,
+            "restarted": 0,
+            "skipped": 0
+        }
     }
-  ]
 }

--- a/test/static_fixtures/reports/no-logs.json
+++ b/test/static_fixtures/reports/no-logs.json
@@ -1,44 +1,46 @@
 {
-  "host": "builder.fm.example.net",
-  "reported_at": "2013-09-06 16:55:23 UTC",
-  "logs": null,
-  "status": {
-    "failed_restarts": 0,
-    "skipped": 0,
-    "restarted": 0,
-    "pending": 0,
-    "failed": 0,
-    "applied": 1
-  },
-  "metrics": {
-    "resources": {
-      "skipped": 6,
-      "scheduled": 0,
-      "restarted": 0,
-      "out_of_sync": 1,
-      "failed_to_restart": 0,
-      "failed": 0,
-      "total": 52,
-      "changed": 1
-    },
-    "events": {
-      "success": 1,
-      "total": 1,
-      "failure": 0
-    },
-    "time": {
-      "kernel_parameter": 0.111702,
-      "filebucket": 0.000361,
-      "config_retrieval": 4.38487815856934,
-      "anchor": 0.001314,
-      "file": 1.536893,
-      "augeas": 0.381903,
-      "total": 6.63197715856934,
-      "package": 0.001708,
-      "service": 0.213218
-    },
-    "changes": {
-      "total": 1
+    "config_report": {
+        "host": "report.example.com",
+        "logs": null,
+        "metrics": {
+            "changes": {
+                "total": 1
+            },
+            "events": {
+                "failure": 0,
+                "success": 1,
+                "total": 1
+            },
+            "resources": {
+                "changed": 1,
+                "failed": 0,
+                "failed_to_restart": 0,
+                "out_of_sync": 1,
+                "restarted": 0,
+                "scheduled": 0,
+                "skipped": 6,
+                "total": 52
+            },
+            "time": {
+                "anchor": 0.001314,
+                "augeas": 0.381903,
+                "config_retrieval": 4.38487815856934,
+                "file": 1.536893,
+                "filebucket": 0.000361,
+                "kernel_parameter": 0.111702,
+                "package": 0.001708,
+                "service": 0.213218,
+                "total": 6.63197715856934
+            }
+        },
+        "reported_at": "2013-09-06 16:55:23 UTC",
+        "status": {
+            "applied": 1,
+            "failed": 0,
+            "failed_restarts": 0,
+            "pending": 0,
+            "restarted": 0,
+            "skipped": 0
+        }
     }
-  }
 }

--- a/test/static_fixtures/reports/skipped.json
+++ b/test/static_fixtures/reports/skipped.json
@@ -1,46 +1,45 @@
-// raw data from Foreman's old parsing of reports, with some readable formtting
 {
-  "host": "a.host.domain",
-  "reported_at": "2009-10-21 05:14:54 UTC",
-  "status": {
-    "applied": 0,
-    "restarted": 0,
-    "failed": 0,
-    "failed_restarts": 0,
-    "skipped": 0,
-    "pending": 0
-  },
-  "metrics": {
-    "time": {
-      "config_retrieval": 13.6332910060883,
-      "cron": 0.0213279724121094,
-      "exec": 2.237300157547,
-      "file": 6.11497139930725,
-      "filebucket": 0.000134944915771484,
-      "host": 0.00245118141174316,
-      "mount": 0.141838073730469,
-      "package": 0.9647057056427,
-      "schedule": 0.000991106033325195,
-      "service": 3.46583986282349,
-      "total": 26.5871164798737,
-      "user": 0.00112104415893555,
-      "yumrepo": 0.0031440258026123
-    },
-    "resources": {
-      "applied": 0,
-      "failed": 0,
-      "failed_restarts": 0,
-      "out_of_sync": 0,
-      "restarted": 0,
-      "scheduled": 1368,
-      "skipped": 1,
-      "total": 1450
-    },
-    "changes": {
-      "total": 0
+    "config_report": {
+        "host": "report.example.com",
+        "logs": [],
+        "metrics": {
+            "changes": {
+                "total": 0
+            },
+            "resources": {
+                "applied": 0,
+                "failed": 0,
+                "failed_restarts": 0,
+                "out_of_sync": 0,
+                "restarted": 0,
+                "scheduled": 1368,
+                "skipped": 1,
+                "total": 1450
+            },
+            "time": {
+                "config_retrieval": 13.6332910060883,
+                "cron": 0.0213279724121094,
+                "exec": 2.237300157547,
+                "file": 6.11497139930725,
+                "filebucket": 0.000134944915771484,
+                "host": 0.00245118141174316,
+                "mount": 0.141838073730469,
+                "package": 0.9647057056427,
+                "schedule": 0.000991106033325195,
+                "service": 3.46583986282349,
+                "total": 26.5871164798737,
+                "user": 0.00112104415893555,
+                "yumrepo": 0.0031440258026123
+            }
+        },
+        "reported_at": "2009-10-21 05:14:54 UTC",
+        "status": {
+            "applied": 0,
+            "failed": 0,
+            "failed_restarts": 0,
+            "pending": 0,
+            "restarted": 0,
+            "skipped": 0
+        }
     }
-  },
-  "logs": [
-
-  ]
 }


### PR DESCRIPTION
Some of the core features are not possible to override from Host Reports. This patch adds some if statements until we drop legacy reports from core.

The patch also improves test fixtures and creates a script that allows uploading of reports for easier testing and development of reports. It will be soon removed but it will be very useful in the transition period if we encounter any bugs.