### PR TITLE
Fixes #34366 - skip GraphQL types enhancements in migrations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -317,7 +317,7 @@ module Foreman
         plugin.to_prepare_callbacks.each(&:call)
       end
 
-      Plugin.graphql_types_registry.realise_extensions
+      Plugin.graphql_types_registry.realise_extensions unless Foreman.in_setup_db_rake?
     end
 
     # Use the database for sessions instead of the cookie-based default


### PR DESCRIPTION
GraphQL types try to touch database, but that is not possible during the db migration.
These fields enhancements needs to be disabled during migrations.