### PR TITLE
Fixes #34371 - correctly construct fqdn for redirct

### DIFF
--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -397,7 +397,7 @@ function construct_host_name() {
   var domain_name = primary_nic_form()
     .find('.interface_domain option:selected')
     .text();
-  return fqdn(host_name, domain_name);
+  return domain_name ? fqdn(host_name, domain_name) : host_name;
 }
 
 function update_fqdn() {


### PR DESCRIPTION
in 08a74cb we have fixed it for managed hosts, but it still doesn't work for unmanaged hosts

This is hacking the hack to get the redirect working with unmanaged hosts without interface.