### PR TITLE
Fixes #3073 - send the correct command on reboot and reset

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -253,7 +253,7 @@ module Api
 
       api :PUT, "/hosts/:id/power", N_("Run a power operation on host")
       param :id, :identifier_dottable, :required => true
-      param :power_action, String, :required => true, :desc => N_("power action, valid actions are (on/start), (off/stop), (soft/reboot), (cycle/reset), (state/status)")
+      param :power_action, String, :required => true, :desc => N_("power action, valid actions are (on), (stop), (shutdown), (cycle), (status)")
 
       def power
         unless @host.supports_power?

--- a/app/services/power_manager.rb
+++ b/app/services/power_manager.rb
@@ -1,4 +1,4 @@
 module PowerManager
-  REAL_ACTIONS = [N_('start'), N_('stop'), N_('poweroff'), N_('reboot'), N_('reset'), N_('soft'), N_('cycle')]
-  SUPPORTED_ACTIONS = REAL_ACTIONS + [N_('state'), N_('on'), N_('off'), N_('status'), N_('ready?')]
+  REAL_ACTIONS = [N_('start'), N_('stop'), N_('poweroff'), N_('reboot'), N_('reset')]
+  SUPPORTED_ACTIONS = REAL_ACTIONS + [N_('state'), N_('status'), N_('ready?')]
 end

--- a/app/services/power_manager.rb
+++ b/app/services/power_manager.rb
@@ -1,4 +1,4 @@
 module PowerManager
-  REAL_ACTIONS = [N_('start'), N_('stop'), N_('poweroff'), N_('reboot'), N_('reset')]
-  SUPPORTED_ACTIONS = REAL_ACTIONS + [N_('state'), N_('status'), N_('ready?')]
+  REAL_ACTIONS = [N_('on'), N_('stop'), N_('shutdown'), N_('reset'), N_('mgmt_warm_reset'), N_('mgmt_cold_reset')]
+  SUPPORTED_ACTIONS = REAL_ACTIONS + [N_('status'), N_('ready?')]
 end

--- a/app/services/power_manager/base.rb
+++ b/app/services/power_manager/base.rb
@@ -18,13 +18,11 @@ module PowerManager
     SUPPORTED_ACTIONS.each do |method|
       define_method method do # def start
         action_entry = find_action_entry(method)
-        method_to_call = action_entry[:action]
-        if method_to_call
-          result = send(method_to_call)
-        else
-          result = default_action(method.to_sym)
-        end
+
+        result = send(action_entry[:action]) if action_entry[:action]
+        result = default_action(action_entry[:default]) if action_entry[:default]
         result = send(action_entry[:output], result) if action_entry[:output]
+
         result
       end
     end
@@ -41,7 +39,7 @@ module PowerManager
 
     def action_map
       {
-        :status => { :output => :translate_status },
+        :status => { :default => 'status', :output => :translate_status },
       }
     end
 
@@ -58,9 +56,9 @@ module PowerManager
     attr_reader :host
 
     def find_action_entry(method)
-      action_entry = action_map[method.to_sym] || {} # create a valid entry
+      action_entry = action_map[method.to_sym] || method # create a valid entry
       # if action_map is in simple format (:key => 'method'), transform it to entry
-      action_entry = {:action => action_entry.to_sym} unless action_entry.is_a?(Hash)
+      action_entry = {:default => action_entry.to_sym} unless action_entry.is_a?(Hash)
       action_entry
     end
   end

--- a/app/services/power_manager/bmc.rb
+++ b/app/services/power_manager/bmc.rb
@@ -16,11 +16,13 @@ module PowerManager
     # TODO: consider moving this to the proxy code, so we can just delegate like as with Virt.
     def action_map
       super.deep_merge({
-                         :start    => 'on',
+                         :on       => 'on',
                          :stop     => 'off',
-                         :poweroff => 'soft',
-                         :reboot   => 'cycle',
-                         :state    => { :action => 'status' },
+                         :shutdown => 'soft',
+                         :reset    => 'cycle',
+                         :mgmt_warm_reset => "reset_warm",
+                         :mgmt_cold_reset => "reset_cold",
+                         :ready?   => { :action => 'ready?' },
                        })
     end
 

--- a/app/services/power_manager/bmc.rb
+++ b/app/services/power_manager/bmc.rb
@@ -18,11 +18,9 @@ module PowerManager
       super.deep_merge({
                          :start    => 'on',
                          :stop     => 'off',
-                         :poweroff => 'off',
-                         :reboot   => 'soft',
-                         :reset    => 'cycle',
-                         :state    => 'status',
-                         :ready?   => 'ready?',
+                         :poweroff => 'soft',
+                         :reboot   => 'cycle',
+                         :state    => { :action => 'status' },
                        })
     end
 

--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -35,12 +35,9 @@ module PowerManager
 
     def action_map
       super.deep_merge({
-                         :on       => 'start',
-                         :off      => 'stop',
-                         :soft     => 'reboot',
-                         :cycle    => 'reset',
-                         :status   => {:action => :virt_state, :output => :state_output},
-                         :state    => {:action => :virt_state, :output => :state_output},
+                         :poweroff => 'soft',
+                         :status   => {:action => :virt_state, :output => :state_output, :default => nil},
+                         :state    => {:action => :virt_state, :output => :state_output, :default => nil},
                        })
     end
 

--- a/app/services/power_manager/virt.rb
+++ b/app/services/power_manager/virt.rb
@@ -29,15 +29,24 @@ module PowerManager
       translate_status(result) # unknown output
     end
 
+    def noop
+      vm
+    end
+
     def default_action(action)
       vm.send(action)
     end
 
     def action_map
       super.deep_merge({
-                         :poweroff => 'soft',
-                         :status   => {:action => :virt_state, :output => :state_output, :default => nil},
-                         :state    => {:action => :virt_state, :output => :state_output, :default => nil},
+                         :on => 'start',
+                         :shutdown => 'shutdown',
+                         :stop => 'destroy',
+                         :reset => 'reset',
+                         :mgmt_warm_reset  => { :action => :noop },
+                         :mgmt_cold_reset  => { :action => :noop },
+                         :status    => { :action => :virt_state, :output => :state_output, :default => nil },
+                         :ready?   => 'ready?',
                        })
     end
 

--- a/app/views/hosts/review_before_build.html.erb
+++ b/app/views/hosts/review_before_build.html.erb
@@ -24,7 +24,7 @@
              :url    => hash_for_setBuild_host_path(:id => @host).merge(:auth_object => @host, :permission => 'build_hosts'),
              :html   => { :id => 'build_form' } do |form|
 %>
-  <%= checkbox_f(form, :build, :help_text => _('Reboot now') % @host) if @host.supports_power_and_running? %>
+  <%= checkbox_f(form, :build, :help_text => _('Cycle now') % @host) if @host.supports_power_and_running? %>
   <div class="modal-footer">
     <%= modal_close %>
     <%= review_build_button(form, build_state(@build)) %>

--- a/test/unit/power_manager_test.rb
+++ b/test/unit/power_manager_test.rb
@@ -73,6 +73,7 @@ class PowerManagerTest < ActiveSupport::TestCase
   def actions_list(host)
     action_map = host.power.send(:action_map)
     actions = PowerManager::SUPPORTED_ACTIONS - action_map.keys.map { |k| k.to_s }
+
     action_map.each do |key, value|
       action_entry = value
       action_entry = {:action => value.to_sym} unless value.is_a?(Hash)

--- a/test/unit/power_manager_test.rb
+++ b/test/unit/power_manager_test.rb
@@ -11,7 +11,7 @@ class PowerManagerTest < ActiveSupport::TestCase
     host.unstub(:queue_compute)
     host.stubs(:compute_resource).returns(compute_resource_mock)
 
-    (actions_list(host) - ['virt_state']).each do |action|
+    (actions_list(host) - ['virt_state', 'noop']).each do |action|
       vm_mock.expects(action.to_sym).at_least_once.returns(true)
     end
     vm_mock.expects('state').at_least_once.returns('On')
@@ -65,7 +65,7 @@ class PowerManagerTest < ActiveSupport::TestCase
 
     test "should respond correctly to status when compute resource is paused" do
       @vm_mock.expects(:state).at_least_once.returns('Paused')
-      result = @host.power.state
+      result = @host.power.status
       assert_equal 'off', result
     end
   end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Currently pressing "Reboot" on the UI soft-shutdowns the server. See the referenced issue (https://projects.theforeman.org/issues/3073) for details. PR changes so that reboot reboots the server, and reset actually resets the server.