### PR TITLE
Fixes #34375 - allow passing empty attributes for facets

### DIFF
--- a/app/models/concerns/facets/model_extensions_base.rb
+++ b/app/models/concerns/facets/model_extensions_base.rb
@@ -126,6 +126,23 @@ module Facets
         end
         entries
       end
+
+      private
+
+      # Overrides ActiveRecord::NestedAttributes#call_reject_if
+      # we want to reject empty attributes only for new facets
+      # the existing record is already fetched so checking the record itself doesn't create overhead
+      # it is fetched in nested_attributes in:
+      # https://github.com/rails/rails/blob/6bfc637659248df5d6719a86d2981b52662d9b50/activerecord/lib/active_record/nested_attributes.rb#L411
+      def call_reject_if(association_name, attributes)
+        is_facet_assoc = facet_definitions.detect { |definition| definition.name.to_s == association_name.to_s }
+        if is_facet_assoc
+          # reject only if record doesn't exist yet
+          send(association_name).nil? && super
+        else
+          super
+        end
+      end
     end
 
     private

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -144,12 +144,20 @@ class FacetTest < ActiveSupport::TestCase
 
     test 'facets do not get created for nil attributes and viceversa' do
       saved_host = FactoryBot.build(:host)
-
       saved_host.update({'test_facet_attributes' => { 'my_attribute' => nil}})
       assert_nil saved_host.test_facet
 
-      saved_host.update({'test_facet_attributes' => { 'my_attribute' => "val"}})
+      saved_host.update({'test_facet_attributes' => { 'my_attribute' => 'val'}})
       assert_not_nil saved_host.test_facet
+    end
+
+    test 'facets do update with nil and empty attributes' do
+      saved_host = FactoryBot.build(:host)
+      saved_host.update({'test_facet_attributes' => { 'my_attribute' => 'val' }})
+
+      TestFacet.any_instance.expects(:my_attribute=).twice
+      saved_host.update({'test_facet_attributes' => { 'my_attribute' => nil }})
+      saved_host.update({'test_facet_attributes' => { 'my_attribute' => [] }})
     end
 
     test 'facet is not removed when associated host is deleted' do


### PR DESCRIPTION
Facets were rejecting empty attributes to not create empty facet.
Originally this was to fix an issue in 5d64eef2cba8e56ad39510c3bd1d724bd52762eb
Tho we want to pass empty attributes to facets that already exists.
We just don't want to create empty ones.

To see the usecase checkout https://github.com/theforeman/foreman_puppet/pull/254