### PR TITLE
Add custom late snippit for Preseed default finish.

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -65,6 +65,9 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
 <%= snippet 'preseed_networking_setup' -%>
+
+<%= snippet_if_exists(template_name + " custom late snippet") %>
+
 <%= snippet 'efibootmgr_netboot' -%>
 <%= snippet 'eject_cdrom' -%>
 <%= snippet 'built' -%>


### PR DESCRIPTION
Fixes #34389

This PR adds a hook that occurs after almost everything else to the Preseed default finish template. (Preseed default finish custom late snippit)  So that you can do some post-chef/puppet/salt/whatever tweaks.
