### PR TITLE
Fixes #34391 - use facets to expose reported data in API

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -16,7 +16,7 @@ attributes :ip, :ip6, :last_report, :mac, :realm_id, :realm_name,
   :compute_resource_id, :compute_resource_name,
   :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
   :certname, :image_id, :image_name, :created_at, :updated_at,
-  :last_compile, :global_status, :global_status_label, :uptime_seconds, :tags, :bmc_available
+  :last_compile, :global_status, :global_status_label, :tags, :bmc_available
 attributes :organization_id, :organization_name
 attributes :location_id, :location_name
 

--- a/app/views/api/v2/hosts/reported_data.json.rabl
+++ b/app/views/api/v2/hosts/reported_data.json.rabl
@@ -1,0 +1,7 @@
+glue(@facet) do
+  attributes :uptime_seconds
+end
+
+child(@facet => :reported_data) do
+  attributes :boot_time, :cores, :sockets, :disks_total
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -301,6 +301,7 @@ module Foreman
       end
 
       Facets.register(HostFacets::ReportedDataFacet, :reported_data) do
+        api_view({ :list => 'api/v2/hosts/reported_data' })
         set_dependent_action :destroy
         template_compatibility_properties :cores, :virtual, :sockets, :ram, :uptime_seconds
       end


### PR DESCRIPTION
We use only uptime_seconds in the API and not even properly.
Facets should have its own view to separate its data from the main host attributes.