### PR TITLE
preseed_cloud-init-autoinstall-user-data.erb

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/preseed_cloud-init-autoinstall-user-data.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/preseed_cloud-init-autoinstall-user-data.erb
@@ -1,0 +1,46 @@
+<%#
+kind: provision
+name: preseed_cloud-init-autoinstall-user-data
+model: ProvisioningTemplate
+oses:
+- Ubuntu 20.04 live-server and higher
+test_on:
+- ubuntu 20.04.3 live-server
+-%>
+<%-
+realname_to_create = host_param('realname_to_create')
+username_to_create = host_param('username_to_create')
+userpassword_to_create = host_param('userpassword_to_create')
+custom_sources_list = host_param('custom_sources_list')
+-%>
+#cloud-config
+autoinstall:
+<%= indent 2 do snippet_if_exists(template_name + " custom bootcmd") end -%>
+  apt:
+    geoip: false
+    preserve_sources_list: false
+<%- if custom_sources_list -%>
+<%= indent 4 do snippet 'preseed_cloud-init-autoinstall-user-data custom sources_list' end -%>
+<%- else -%>
+    primary:
+    - arches: [amd64, i386]
+      uri: http://archive.ubuntu.com/ubuntu
+    - arches: [default]
+      uri: http://ports.ubuntu.com/ubuntu-ports
+<%- end -%>
+  identity: {hostname: <%= @host.shortname %>, password: <%= userpassword_to_create %>,
+    realname: <%= realname_to_create %>, username: <%= username_to_create %>}
+  keyboard: {layout: us, toggle: null, variant: ''}
+  locale: en_US.UTF-8
+<%= snippet 'preseed_netplan_setup' -%>
+  ssh:
+    allow-pw: true
+    authorized-keys: []
+    install-server: true
+  user-data:
+    runcmd:
+      - wget -Y off <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /tmp/finish.sh
+      - chmod +x /tmp/finish.sh
+      - /tmp/finish.sh
+  version: 1
+<%= @host.diskLayout %>


### PR DESCRIPTION
Minor changes from the initial template provided in https://github.com/theforeman/foreman/pull/9056

* posibility to apply a custom bootcmd snippet in which might initialize some configuration in the beginnin g of the autoinstall, like for example:
  bootcmd:
    - echo < ip > < fqdn name > > /etc/hosts
* possibility to provide a custom sources_list in stead of the default block priority that refers to the ubuntu-uri (primary-block)
  This requires the boolean parameter custom_sources_list to be defined as true
* new user-data block containing runcmd which will perform the necessary actions at first boot in order to copy the final script from the foreman server on the host, and execute that script for the remaining actions like install/configure puppet-agent, install subscription manager from Atix, register the host in foreman, OS upgrade, ...


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
