### PR TITLE
Fixes #34396 - job report tweaks

### DIFF
--- a/app/services/foreman/renderer/scope/macros/helpers.rb
+++ b/app/services/foreman/renderer/scope/macros/helpers.rb
@@ -80,7 +80,7 @@ module Foreman
             optional :zone, String, desc: 'This parameter can be used for specify timezone of time, for example Europe/Prague', default: 'Default local timezone'
             returns String
           end
-          def format_time(time, format: '%Y-%-m-%-d %k:%M:%S %z', zone: Time.zone)
+          def format_time(time, format: '%Y-%m-%d %k:%M:%S %z', zone: Time.zone)
             # if time is in float, we need to understand it as UNIX timestamp that is in UTC
             time_to_format = if (time.is_a? Float) || (time.is_a? Integer)
                                Time.zone.at(time).utc

--- a/app/views/unattended/report_templates/job_-_invocation_report.erb
+++ b/app/views/unattended/report_templates/job_-_invocation_report.erb
@@ -1,5 +1,5 @@
 <%#
-name: Job invocation - report template
+name: Job - Invocation Report
 snippet: false
 template_inputs:
 - name: job_id
@@ -23,11 +23,11 @@ require:
 - plugin: foreman_remote_execution
 ￼ version: 4.4.0
 -%>
-<%- report_headers 'Host', 'stdout', 'stderr', 'debug', 'Result', 'Finished' %>
+<%- report_headers 'Host', 'stdout', 'stderr', 'debug', 'Result', 'Finished' -%>
 <%- invocation = find_job_invocation_by_id(input('job_id')) -%>
-<%- parts = ["job_invocation.id = #{input('job_id')}"] %>
-<%- parts << input('hosts') unless input('hosts').blank? %>
-<%- search = parts.map { |part| '(' + part + ')' }.join(' AND ') %>
+<%- parts = ["job_invocation.id = #{input('job_id')}"] -%>
+<%- parts << input('hosts') unless input('hosts').blank? -%>
+<%- search = parts.map { |part| '(' + part + ')' }.join(' AND ') -%>
 <%- load_hosts(search: search).each do |batch| -%>
 <%-   batch.each do |host|  -%>
 <%-     task = invocation.sub_task_for_host(host) -%>
@@ -41,7 +41,7 @@ require:
             'stderr': join_with_line_break(outputs['stderr']),
             'debug': join_with_line_break(outputs['debug']),
             'Result': task.result,
-            'Finished': format_time(task.ended_at),
+            'Finished': task.ended_at.blank? ? nil : format_time(task.ended_at),
         ) -%>
 <%-   end -%>
 <%- end -%>

--- a/db/migrate/20220204155632_rename_job_report_template.rb
+++ b/db/migrate/20220204155632_rename_job_report_template.rb
@@ -1,0 +1,20 @@
+class RenameJobReportTemplate < ActiveRecord::Migration[5.2]
+  TEMPLATE_NAMES = {
+    "Job invocation - report template" => "Job - Invocation Report",
+  }
+
+  def up
+    TEMPLATE_NAMES.each do |from, to|
+      token = SecureRandom.base64(5)
+      ReportTemplate.unscoped.find_by(name: to)&.update_columns(:name => "#{to} Backup #{token}")
+      ReportTemplate.unscoped.find_by(name: from)&.update_columns(:name => to)
+    end
+  end
+
+  def down
+    TEMPLATE_NAMES.each do |from, to|
+      ReportTemplate.unscoped.find_by(name: from)&.delete
+      ReportTemplate.unscoped.find_by(name: to)&.update_columns(:name => from)
+    end
+  end
+end


### PR DESCRIPTION
This change adds few enhancements to the existing Job report. The report
is used with REX plugin, which has a button "Create Report" in job
detail page. Clicking that button takes user to the render report form
and fills in the job id input.

The enhancements:
1) rename the template to Job - Invocation Report to be more consistent
   with other report templates
2) Add missing `-` to closing `%>` erb tags to avoid empty lines in the
   output
3) don't fail on ended_at being nil, meaning on jobs that are still
   running, instead use empty value in such case

The follow up is necessary in the REX plugin so the setting default
value reflects the new name.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
