### PR TITLE
Fixes #34409 - Revert CentOS_Stream name

### DIFF
--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -6,8 +6,6 @@ module ForemanAnsible
     def operatingsystem
       args = { :name => os_name, :major => os_major, :minor => os_minor }
       args[:release_name] = os_release_name if os_name == 'Debian' || os_name == 'Ubuntu'
-      # for Ansible, the CentOS Stream can be identified by missing minor version only
-      args[:name] = "CentOS_Stream" if os_name == 'CentOS' && os_minor.blank?
       return @local_os if local_os(args).present?
       return @new_os if new_os(args).present?
       logger.debug do

--- a/app/services/foreman_chef/fact_parser.rb
+++ b/app/services/foreman_chef/fact_parser.rb
@@ -36,8 +36,7 @@ module ForemanChef
             minor = release[2..-1]
           end
         when 'centos'
-          # Centos Stream doesn't have minor version on need to replace blank spaces due to name restriction
-          os_name = facts.dig(:os_release, :name).tr(' ', '_') unless minor
+          os_name = 'CentOS'
       end
 
       begin

--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -88,17 +88,12 @@ module ForemanSalt
 
     def os_hash
       name = facts[:os]
-      (_, major, minor, sub) = /(\d+)\.?(\d+)?\.?(\d+)?/.match(facts[:osrelease]).to_a
-      minor = "" if minor.nil?
-      if name == 'CentOS Stream'
-        return { :name => name.tr(' ', '_'), :major => major, :minor => minor }
-      end
-      if name == 'CentOS' || name == 'CentOS Linux'
-        if sub
-          minor += '.' + sub
-        end
-        return { :name => 'CentOS', :major => major, :minor => minor }
-      end
+      name = 'CentOS' if ['CentOS', 'CentOS Stream', 'CentOS Linux'].include?(name)
+
+      match = /(?<major>\d+)(\.?(?<minor>\d+(\.\d+)?))?/.match(facts[:osrelease])
+      major = match[:major]
+      minor = match[:minor] || ""
+
       { :name => name, :major => major, :minor => minor }
     end
 

--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -69,7 +69,7 @@ module Katello
         end
 
         if facts['distribution.name'] == 'CentOS Stream'
-          os_attributes[:name] = "CentOS_Stream"
+          os_attributes[:name] = "CentOS"
         end
 
         if facts['distribution.name'] == 'CentOS Linux'

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -200,9 +200,6 @@ class PuppetFactParser < FactParser
   def os_name
     # Facter 2.2 introduced the os fact
     os_name = facts.dig(:os, :name).presence || facts[:operatingsystem].presence || raise(::Foreman::Exception.new("invalid facts, missing operating system value"))
-    # CentOS Stream doesn't have a minor version so it's good to check it at two places according to version of Facter that produced facts
-    has_no_minor = facts[:lsbdistrelease]&.exclude?('.') || (facts.dig(:os, :name).presence && facts.dig(:os, :release, :minor).nil?)
-    return 'CentOS_Stream' if os_name == 'CentOSStream' || (os_name == 'CentOS' && has_no_minor)
 
     if os_name == 'RedHat' && distro_id == 'RedHatEnterpriseWorkstation'
       os_name += '_Workstation'

--- a/app/views/unattended/partition_tables_templates/kickstart_custom.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_custom.erb
@@ -5,7 +5,6 @@ model: Ptable
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/partition_tables_templates/kickstart_default.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_default.erb
@@ -5,7 +5,6 @@ model: Ptable
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/partition_tables_templates/kickstart_default_thin.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_default_thin.erb
@@ -4,7 +4,6 @@ name: Kickstart default thin
 model: Ptable
 oses:
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - oVirt

--- a/app/views/unattended/partition_tables_templates/kickstart_dynamic.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_dynamic.erb
@@ -5,7 +5,6 @@ model: Ptable
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - Rocky
 description: |

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -6,7 +6,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - RedHat
 - Rocky

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - Rocky
 description: |

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/app/views/unattended/provisioning_templates/user_data/userdata_open_vm_tools.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_open_vm_tools.erb
@@ -5,7 +5,6 @@ model: ProvisioningTemplate
 oses:
 - AlmaLinux
 - CentOS
-- CentOS_Stream
 - Fedora
 - Rocky
 - Debian

--- a/test/static_fixtures/templates/provision/one.erb
+++ b/test/static_fixtures/templates/provision/one.erb
@@ -4,6 +4,5 @@ name: One
 model: ProvisioningTemplate
 oses:
 - CentOS
-- CentOS_Stream
 %>
 1<%= snippet('two') -%>4

--- a/test/unit/foreman_ansible/fact_parser_test.rb
+++ b/test/unit/foreman_ansible/fact_parser_test.rb
@@ -350,7 +350,7 @@ module ForemanAnsible
 
       test 'should identify CentOS Stream' do
         os = @fact_parser_stream.operatingsystem
-        assert_equal 'CentOS_Stream', os.name
+        assert_equal 'CentOS', os.name
         assert_equal '8', os.major
         assert_empty os.minor
       end

--- a/test/unit/foreman_chef/fact_parser_test.rb
+++ b/test/unit/foreman_chef/fact_parser_test.rb
@@ -9,7 +9,7 @@ module ForemanChef
       os = parser.operatingsystem
 
       assert os.present?
-      assert_equal 'CentOS_Stream', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '8', os.major
       assert_empty os.minor
     end
@@ -19,7 +19,7 @@ module ForemanChef
       os = parser.operatingsystem
 
       assert os.present?
-      assert_equal 'centos', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '7', os.major
       assert_equal '7', os.minor
     end
@@ -29,7 +29,7 @@ module ForemanChef
       os = parser.operatingsystem
 
       assert os.present?
-      assert_equal 'centos', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '8', os.major
       assert_equal '4', os.minor
     end

--- a/test/unit/foreman_salt/salt_fact_parser_test.rb
+++ b/test/unit/foreman_salt/salt_fact_parser_test.rb
@@ -29,7 +29,7 @@ module ForemanSalt
       os = parser.operatingsystem
 
       assert os.present?
-      assert_equal 'CentOS_Stream', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '8', os.major
       assert_empty os.minor
     end

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -193,7 +193,7 @@ module Katello
       @facts['distribution.version'] = '8'
       @facts['distribution.id'] = '8'
 
-      assert_equal parser.operatingsystem.name, 'CentOS_Stream'
+      assert_equal parser.operatingsystem.name, 'CentOS'
       assert_equal parser.operatingsystem.major, '8'
       assert_equal parser.operatingsystem.minor, ''
     end

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -208,7 +208,7 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     test "should correctly identify CentOS Stream" do
       parser = PuppetFactParser.new(centos_stream_facts)
       os = parser.operatingsystem
-      assert_equal 'CentOS_Stream', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '8', os.major
       assert_empty os.minor
     end
@@ -216,7 +216,7 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     test "should correctly identify CentOS Stream by facter 2.5" do
       parser = PuppetFactParser.new(centos_stream_facts_facter_2)
       os = parser.operatingsystem
-      assert_equal 'CentOS_Stream', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '8', os.major
       assert_empty os.minor
     end


### PR DESCRIPTION
In 16701e6bc97c716b7b316a0715285a6e6591e7b8 (and with a fixup in 7364916bd25512c2065892fab96c439648dbb6f1) Foreman started to identify CentOS Stream as CentOS_Stream. However, this is creating problems in upgrades because the description and title have been taken.

What Foreman 3.1 creates:

```
id | major |  name  | minor | nameindicator |         created_at         |         updated_at         | release_name |  type  |   description   | password_hash |      title
----+-------+--------+-------+---------------+----------------------------+----------------------------+--------------+--------+-----------------+---------------+-----------------
1 | 8     | CentOS |       |               | 2022-02-07 18:05:55.944924 | 2022-02-07 18:05:55.944924 |              | Redhat | CentOS Stream 8 | SHA256        | CentOS Stream 8
```

And Foreman Nightly:

```
id | major |     name      | minor | nameindicator |         created_at         |         updated_at         | release_name |  type  |   description   | password_hash |      title
----+-------+---------------+-------+---------------+----------------------------+----------------------------+--------------+--------+-----------------+---------------+-----------------
1 | 8     | CentOS_Stream |       |               | 2022-02-07 17:30:00.279439 | 2022-02-07 17:30:00.279439 |              | Redhat | CentOS Stream 8 | SHA256        | CentOS Stream 8
```

CentOS Linux 8 is End of Life and has been removed from the repositories. In order to minimize the risk for users it's safest to keep the name the same, especially now that Foreman 3.2 is about to branch. That means reverting the name change.

The various fact parser alignments should stay in. This is thus a manual revert instead of an automatic revert.

Related discussions:
* https://community.theforeman.org/t/katello-nightly-rpm-pipeline-1220-failed/27082/
* https://community.theforeman.org/t/luna-nightly-rpm-pipeline-332-failed/27195