### PR TITLE
Fixes #34410 - add missing variant prop to pagination 

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Pagination/index.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/index.js
@@ -111,6 +111,7 @@ const Pagination = ({
       isCompact={variant === PaginationVariant.top}
       {...props}
       page={page}
+      variant={variant}
       perPage={perPage}
       onSetPage={_onSetPage}
       onPerPageSelect={_onPerPageSelect}


### PR DESCRIPTION
The `variant` prop is initialized but doesn't propagate.

before:

https://user-images.githubusercontent.com/11807069/152873468-04025971-9b74-472e-b69b-f551e2163903.mov

after:

https://user-images.githubusercontent.com/11807069/152873552-82b12816-31af-4efd-bbd1-69e07ecb90f4.mov



