### PR TITLE
Fixes #34409 - rename existing CentOS OSes to CentOS_Stream

### DIFF
--- a/db/migrate/20220208134539_rename_cent_os_stream_os.rb
+++ b/db/migrate/20220208134539_rename_cent_os_stream_os.rb
@@ -1,0 +1,18 @@
+class RenameCentOsStreamOs < ActiveRecord::Migration[6.0]
+  def up
+    User.without_auditing do
+      # When redhat-lsb-core package is installed, puppet creates
+      # description/title "CentOS Stream 8", however, when the package is not
+      # present description is unset and title is set to "CentOS_Stream 8" from
+      # the OS name and major by the ActiveRecord callback. Let's migrate both
+      # cases.
+      Operatingsystem.unscoped.where("type = 'Redhat' and name = 'CentOS' and (description like '%CentOS%Stream%' or title like '%CentOS%Stream%')").update_all(name: "CentOS_Stream")
+    end
+  end
+
+  def down
+    User.without_auditing do
+      Operatingsystem.unscoped.where("type = 'Redhat' and name = 'CentOS_Stream' and (description like '%CentOS%Stream%' or title like '%CentOS%Stream%')").update_all(name: "CentOS")
+    end
+  end
+end


### PR DESCRIPTION
Previously, Puppet facts coming out of CentOS Stream box were recognized as a OS with name "CentOS" and title "CentOS Stream 8". After the change 16701e6bc97c7 its recognized as "CentOS_Stream" and "CentOS Stream 8". That's all expected, however, the patch did not migrate the existing OSes because operating system model enforces the title to be unique.

The way we are parsing facts and create OS entries is bad from the moment we introduced another fact parsing other than Puppet. Foreman needs a proper operating system mapping that would various facter allow to co-exist. Or we could move the responsibility to the user creating a "reported OS name" table which users would need to associate with their operating systems which can now be created either manually or via Katello sync.

The purpose of this patch, however, is not to fix any of this. This introduces a simple migration that should have resolve the upgrade problem. It will help in the particular case mentioned in the RM issue.