### PR TITLE
Fixes #33948 - Present network info in single columns

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js
@@ -49,12 +49,7 @@ const DetailsCard = ({
         </CardActions>
       </CardHeader>
       <CardBody>
-        <DescriptionList
-          isAutoColumnWidths
-          columnModifier={{
-            default: '2Col',
-          }}
-        >
+        <DescriptionList>
           <DescriptionListGroup>
             <DescriptionListTerm>{__('IPv6 address')}</DescriptionListTerm>
             <DescriptionListDescription>


### PR DESCRIPTION
This avoids line wrapping on smaller screens and with long IPs, such as IPv6. Similar to what 95c237bb731b3ca3cb24625ad59b80246fec2f0f did with the owner fields.

I don't have a development setup to test this right now, it's still spinning up.