### PR TITLE
Fixes #34423 - Ubuntu 21.10 netboot files from Foreman site

### DIFF
--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -2,8 +2,7 @@ class Debian < Operatingsystem
   PXEFILES = {:kernel => "linux", :initrd => "initrd.gz"}
 
   def pxedir(medium_provider = nil)
-    # support ubuntu focal(20), which moved pxe files to legacy_image
-    if (guess_os == 'ubuntu' && major.to_i >= 20)
+    if (guess_os == 'ubuntu' && major.to_i >= 20 && major.to_i <= 21)
       'dists/$release/main/installer-$arch/current/legacy-images/netboot/' + guess_os + '-installer/$arch'
     else
       'dists/$release/main/installer-$arch/current/images/netboot/' + guess_os + '-installer/$arch'
@@ -19,10 +18,17 @@ class Debian < Operatingsystem
   end
 
   def boot_file_sources(medium_provider, &block)
-    super do |vars|
-      vars = yield(vars) if block_given?
+    if (guess_os == 'ubuntu' && major.to_i == 21 && minor.to_i == 10)
+      {
+        kernel: medium_provider.interpolate_vars("http://downloads.theforeman.org/netboot-files/ubuntu-21.10-$arch-linux").to_s,
+        initrd: medium_provider.interpolate_vars("http://downloads.theforeman.org/netboot-files/ubuntu-21.10-$arch-initrd.gz").to_s,
+      }
+    else
+      super do |vars|
+        vars = yield(vars) if block_given?
 
-      transform_vars(vars)
+        transform_vars(vars)
+      end
     end
   end
 

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -126,6 +126,33 @@ FactoryBot.define do
       title { 'Debian Wheezy' }
     end
 
+    factory :ubuntu18_04, class: Debian do
+      sequence(:name) { 'Ubuntu' }
+      major { '18' }
+      minor { '04' }
+      type { 'Debian' }
+      release_name { 'bionic' }
+      title { 'Ubuntu 18.04' }
+    end
+
+    factory :ubuntu20_04, class: Debian do
+      sequence(:name) { 'Ubuntu' }
+      major { '20' }
+      minor { '04' }
+      type { 'Debian' }
+      release_name { 'focal' }
+      title { 'Ubuntu 20.04' }
+    end
+
+    factory :ubuntu21_10, class: Debian do
+      sequence(:name) { 'Ubuntu' }
+      major { '21' }
+      minor { '10' }
+      type { 'Debian' }
+      release_name { 'impish' }
+      title { 'Ubuntu 21.10' }
+    end
+
     factory :suse, class: Suse do
       sequence(:name) { 'OpenSuse' }
       major { '11' }

--- a/test/models/operatingsystems/debian_test.rb
+++ b/test/models/operatingsystems/debian_test.rb
@@ -1,0 +1,126 @@
+require 'test_helper'
+
+class DebianTest < ActiveSupport::TestCase
+  let(:medium) { FactoryBot.create(:medium, path: "http://mirror.example.com/debian/$major.$minor") }
+  let(:mock_entity) do
+    OpenStruct.new(
+      operatingsystem: operatingsystem,
+      architecture: architecture,
+      medium: medium
+    )
+  end
+  let(:medium_provider) { MediumProviders::Default.new(mock_entity) }
+  let(:architecture) { architectures(:x86_64) }
+
+  context 'Debian 7.1' do
+    let(:operatingsystem) { FactoryBot.create(:debian7_1) }
+
+    test 'returns the bootfile' do
+      assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'linux'
+      assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.gz'
+    end
+
+    test 'generates medium path url' do
+      assert_equal 'http://mirror.example.com/debian/7.1', operatingsystem.mediumpath(medium_provider)
+    end
+
+    test 'returns all boot file sources' do
+      expected = {
+        kernel: 'http://mirror.example.com/debian/7.1/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux',
+        initrd: 'http://mirror.example.com/debian/7.1/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz',
+      }
+      assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+    end
+
+    test 'returns url for boot' do
+      kernel = 'http://mirror.example.com/debian/7.1/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux'
+      initrd = 'http://mirror.example.com/debian/7.1/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz'
+      assert_equal kernel, operatingsystem.url_for_boot(medium_provider, :kernel)
+      assert_equal initrd, operatingsystem.url_for_boot(medium_provider, :initrd)
+    end
+  end
+
+  context 'Ubuntu 18.04' do
+    let(:operatingsystem) { FactoryBot.create(:ubuntu18_04) }
+
+    test 'returns the bootfile' do
+      assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'linux'
+      assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.gz'
+    end
+
+    test 'generates medium path url' do
+      assert_equal 'http://mirror.example.com/debian/18.04', operatingsystem.mediumpath(medium_provider)
+    end
+
+    test 'returns all boot file sources' do
+      expected = {
+        kernel: 'http://mirror.example.com/debian/18.04/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux',
+        initrd: 'http://mirror.example.com/debian/18.04/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz',
+      }
+      assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+    end
+
+    test 'returns url for boot' do
+      kernel = 'http://mirror.example.com/debian/18.04/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux'
+      initrd = 'http://mirror.example.com/debian/18.04/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz'
+      assert_equal kernel, operatingsystem.url_for_boot(medium_provider, :kernel)
+      assert_equal initrd, operatingsystem.url_for_boot(medium_provider, :initrd)
+    end
+  end
+
+  context 'Ubuntu 20.04' do
+    let(:operatingsystem) { FactoryBot.create(:ubuntu20_04) }
+
+    test 'returns the bootfile' do
+      assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'linux'
+      assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.gz'
+    end
+
+    test 'generates medium path url' do
+      assert_equal 'http://mirror.example.com/debian/20.04', operatingsystem.mediumpath(medium_provider)
+    end
+
+    test 'returns all boot file sources' do
+      expected = {
+        kernel: 'http://mirror.example.com/debian/20.04/dists/focal/main/installer-amd64/current/legacy-images/netboot/ubuntu-installer/amd64/linux',
+        initrd: 'http://mirror.example.com/debian/20.04/dists/focal/main/installer-amd64/current/legacy-images/netboot/ubuntu-installer/amd64/initrd.gz',
+      }
+      assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+    end
+
+    test 'returns url for boot' do
+      kernel = 'http://mirror.example.com/debian/20.04/dists/focal/main/installer-amd64/current/legacy-images/netboot/ubuntu-installer/amd64/linux'
+      initrd = 'http://mirror.example.com/debian/20.04/dists/focal/main/installer-amd64/current/legacy-images/netboot/ubuntu-installer/amd64/initrd.gz'
+      assert_equal kernel, operatingsystem.url_for_boot(medium_provider, :kernel)
+      assert_equal initrd, operatingsystem.url_for_boot(medium_provider, :initrd)
+    end
+  end
+
+  context 'Ubuntu 21.10' do
+    let(:operatingsystem) { FactoryBot.create(:ubuntu21_10) }
+
+    test 'returns the bootfile' do
+      assert_includes operatingsystem.bootfile(medium_provider, :kernel), 'linux'
+      assert_includes operatingsystem.bootfile(medium_provider, :initrd), 'initrd.gz'
+    end
+
+    test 'generates medium path url' do
+      assert_equal 'http://mirror.example.com/debian/21.10', operatingsystem.mediumpath(medium_provider)
+    end
+
+    test 'returns all boot file sources' do
+      expected = {
+        kernel: 'http://downloads.theforeman.org/netboot-files/ubuntu-21.10-x86_64-linux',
+        initrd: 'http://downloads.theforeman.org/netboot-files/ubuntu-21.10-x86_64-initrd.gz',
+      }
+      assert_equal expected, operatingsystem.boot_file_sources(medium_provider)
+    end
+
+    test 'returns url for boot' do
+      kernel = 'http://downloads.theforeman.org/netboot-files/ubuntu-21.10-x86_64-linux'
+      initrd = 'http://downloads.theforeman.org/netboot-files/ubuntu-21.10-x86_64-initrd.gz'
+      assert_equal kernel, operatingsystem.url_for_boot(medium_provider, :kernel)
+      assert_equal initrd, operatingsystem.url_for_boot(medium_provider, :initrd)
+    end
+  end
+end


### PR DESCRIPTION
Canonical made a breaking change in Ubuntu 20.04 and 21.10: debian-installer is no longer used for installations and LiveCD must be booted instead with cloud-init used to do the provisioning.

This alone would not be a huge issue for Foreman, but there is a change that comes with it. Boot files which are required to boot such LiveCD (kernel/initramdisk) are not published via HTTP protocol directly, instead, users are asked to download the whole LiveCD ISO (1.2GB), mount it and extract it into the TFTP/HTTP directories.

https://community.theforeman.org/t/rfc-rearchitecting-how-pxe-files-are-deployed/27021

There was a confirmation that this should be fixed for the next release, but for the two releases to keep a good and consistent Foreman experience I propose to make a special exception and download these files from our very own downloads.theforeman.org:

https://discourse.ubuntu.com/t/netbooting-the-live-server-installer/14510/159

This would help to mitigate the problems users will run into. There is one concern about Foreman connecting to an unexpected hostname/IP, however, if that's blocked it does not introduce any bug since without this change the request would end up as HTTP 404. It could be a timeout but that is a little concern - timeout will occur in curl on smart proxy which is a asynchronous operation anyway and the end result will be the same - PXE files being zero size.

Things to do before merge:

* put PXE files for all supported architectures to http://downloads.theforeman.org/netboot-files/