### PR TITLE
Fixes #34228 - close bookmarks after selecting a bookmark

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
@@ -68,6 +68,7 @@ const Bookmarks = ({
       />
       <Dropdown
         isOpen={isDropdownOpen}
+        onSelect={() => setIsDropdownOpen(false)}
         toggle={
           <DropdownToggle
             onToggle={onToggle}

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/Bookmarks.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/__tests__/Bookmarks.test.js
@@ -46,9 +46,11 @@ describe('Bookmarks', () => {
       pathname: '/bookmarks',
       search: '?page=1&per_page=25&search=controller%3Darchitectures',
     });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('bookmarks dropdown toggle'));
+    });
     fireEvent.click(screen.getByText('Documentation'));
     expect(helpersNewWindow).toHaveBeenCalledWith('https://test-docs.com');
-    expect(screen.queryAllByText('Documentation')).toHaveLength(1);
   });
   it('success load with no bookmarks has all base items', async () => {
     render(
@@ -67,9 +69,11 @@ describe('Bookmarks', () => {
       pathname: '/bookmarks',
       search: '?page=1&per_page=25&search=controller%3Darchitectures',
     });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('bookmarks dropdown toggle'));
+    });
     fireEvent.click(screen.getByText('Documentation'));
     expect(helpersNewWindow).toHaveBeenCalledWith('https://test-docs.com');
-    expect(screen.queryAllByText('Documentation')).toHaveLength(1);
   });
 
   it('bookmark click', async () => {
@@ -121,10 +125,15 @@ describe('Bookmarks', () => {
       pathname: '/bookmarks',
       search: '?page=1&per_page=25&search=controller%3Darchitectures',
     });
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('bookmarks dropdown toggle'));
+    });
     fireEvent.click(screen.getByText('Documentation'));
     expect(helpersNewWindow).toHaveBeenCalledWith('https://test-docs.com');
-    expect(screen.queryAllByText('Documentation')).toHaveLength(1);
     expect(screen.queryAllByLabelText('loading bookmarks')).toHaveLength(0);
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('bookmarks dropdown toggle'));
+    });
     expect(
       screen.queryAllByText('Failed to load bookmarks: Random test error')
     ).toHaveLength(1);


### PR DESCRIPTION
After selecting a bookmark some page don't reload and just replace the data so the dropdown should close on select