### PR TITLE
Refs #34442 - Allow plugins to hide tabs on new host detail page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -79,6 +79,11 @@ const HostDetails = ({
       .split('?')[0] // Remove query params
   );
 
+  const filteredTabs =
+    tabs?.filter(
+      tab => !slotMetadata?.[tab]?.hideTab?.({ hostDetails: response })
+    ) ?? [];
+
   if (status === STATUS.ERROR) return <RedirectToEmptyHostPage hostname={id} />;
   return (
     <>
@@ -173,7 +178,7 @@ const HostDetails = ({
                 isNavCollapsed ? '138' : '263'
               }`}
             >
-              {tabs.map(tab => (
+              {filteredTabs.map(tab => (
                 <Tab
                   key={tab}
                   eventKey={tab}


### PR DESCRIPTION
We need to allow Katello to hide its tabs and cards from the new host detail page.

Hiding cards I can do from Katello, but I found that changing Foreman code is the only clean way to hide an entire tab. 

* Looks for a new attribute `hideTab` in the fill metadata
* If present, calls the `hideTab` function and if it returns a truthy value, the tab is not displayed.

