### PR TITLE
Fixes #34450 - Normalize CentOS casing from facts

### DIFF
--- a/app/services/foreman_chef/fact_parser.rb
+++ b/app/services/foreman_chef/fact_parser.rb
@@ -37,7 +37,8 @@ module ForemanChef
           end
         when 'centos'
           # Centos Stream doesn't have minor version on need to replace blank spaces due to name restriction
-          os_name = facts.dig(:os_release, :name).tr(' ', '_') unless minor
+          # Also normalize CentOS / CentOS Linux
+          os_name = minor ? 'CentOS' : facts.dig(:os_release, :name).tr(' ', '_')
       end
 
       begin

--- a/app/services/foreman_salt/fact_parser.rb
+++ b/app/services/foreman_salt/fact_parser.rb
@@ -87,17 +87,19 @@ module ForemanSalt
     private
 
     def os_hash
-      name = facts[:os]
+      name = case facts[:os]
+             when 'CentOS', 'CentOS Linux'
+               'CentOS'
+             when 'CentOS Stream'
+               'CentOS_Stream'
+             else
+               facts[:os]
+             end
+
       (_, major, minor, sub) = /(\d+)\.?(\d+)?\.?(\d+)?/.match(facts[:osrelease]).to_a
       minor = "" if minor.nil?
-      if name == 'CentOS Stream'
-        return { :name => name.tr(' ', '_'), :major => major, :minor => minor }
-      end
-      if name == 'CentOS' || name == 'CentOS Linux'
-        if sub
-          minor += '.' + sub
-        end
-        return { :name => 'CentOS', :major => major, :minor => minor }
+      if name == 'CentOS' && sub
+        minor += '.' + sub
       end
       { :name => name, :major => major, :minor => minor }
     end

--- a/test/unit/foreman_chef/fact_parser_test.rb
+++ b/test/unit/foreman_chef/fact_parser_test.rb
@@ -19,7 +19,7 @@ module ForemanChef
       os = parser.operatingsystem
 
       assert os.present?
-      assert_equal 'centos', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '7', os.major
       assert_equal '7', os.minor
     end
@@ -29,7 +29,7 @@ module ForemanChef
       os = parser.operatingsystem
 
       assert os.present?
-      assert_equal 'centos', os.name
+      assert_equal 'CentOS', os.name
       assert_equal '8', os.major
       assert_equal '4', os.minor
     end


### PR DESCRIPTION
This aligns Chef and Salt with the other fact parsers. The Salt fact parser logic is changed so it's easier to read.