### PR TITLE
Fixes #34416 - taxonomy title in ForemanContext

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -432,8 +432,8 @@ module ApplicationHelper
   def app_metadata
     {
       UISettings: ui_settings, version: SETTINGS[:version].short, docUrl: documentation_url,
-      location: Location.current&.attributes&.slice('id', 'title'),
-      organization: Organization.current&.attributes&.slice('id', 'title'),
+      location: Location.current && { id: Location.current.id, title: Location.current.title },
+      organization: Organization.current && { id: Organization.current.id, title: Organization.current.title },
       user: User.current&.attributes&.slice('id', 'login', 'firstname', 'lastname', 'admin')
     }.compact
   end

--- a/app/models/concerns/nested_ancestry_common.rb
+++ b/app/models/concerns/nested_ancestry_common.rb
@@ -80,7 +80,7 @@ module NestedAncestryCommon
   private
 
   def set_title
-    self.title = get_title if (name_changed? || ancestry_changed? || title.blank?)
+    self.title = get_title if (name_changed? || ancestry_changed? || self[:title].blank?)
   end
 
   def set_other_titles


### PR DESCRIPTION
When creating new org/loc we did not save the title there.
In the app_metadata for the frontend we were taking these directly from db, so it disallowed the calculation on runtime.

This was wrong from b0d5a6c9b882fa078379ed90f8610ff021978e6b, but only when we switched to using these in the TaxonomySwitcher it started to exhibit in this bug.
Probably 299c2976888bce605d29bbecbc5e4cab4cfb9fc5 was where this actually broke, but only for new orgs, so it was not discovered.

This resolves firstly the issue of empty title in the database and secondly the issue not using methods to retrieve data, which we always should.

(cherry picked from commit 32f0977d22f4e6c9f44de490a50d2fa18a469e8a)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
