### PR TITLE
Fixes #34462 - shorten DNS timeout for primary detection

### DIFF
--- a/lib/net/dns.rb
+++ b/lib/net/dns.rb
@@ -22,7 +22,7 @@ module Net
       proxy = options.fetch(:proxy, nil)
       resolver = options.fetch(:resolver, Resolv::DNS.new)
       ipfamily = options.fetch(:ipfamily, Socket::AF_INET)
-      resolver.timeouts = Setting[:dns_timeout]
+      resolver.timeouts = options.fetch(:timeout, Setting[:dns_timeout])
 
       ipquery = IPAddr.new(query) rescue nil
       if ipquery&.ipv4?


### PR DESCRIPTION
In facts parsing code we have a very old code bit that performs DNS reverse query for each IP address until it finds a PTR record matching the hostname of the host that sent facts. This works for all fact types which do not override the method in its implementation (e.g. Ansible, possibly others).

During testing today my fact queries were delayed to 75 seconds which turns out to be my OS default value. That is too much, hosts with many IP addresses can cause huge delays if DNS does not reply fast enough. This can easily overload the application server with unfinished requests.

I am proposing to shorten the DNS timeout to something sane like 250ms. If it does not return quickly, then the only drawback is that primary interface might not be detected correctly for unmanaged hosts.

We do have a dns_timeout setting which defaults to 5, 10, 15, 20 seconds (4 tries) but that is not suitable for this case - we simply want to quickly find if we are able to detect the primary interface using this heuristic techniuqe and then move on if not. Definitely not something we want to spend a minute on.