### PR TITLE
Fixes #34489 - AutoYaST PXE http-proxy without http-proxy-port

### DIFF
--- a/app/views/unattended/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
@@ -9,11 +9,20 @@ description: |
   The template to render PXELinux bootloader configuration for SLES and OpenSUSE distributions.
   The output is deployed on the host's subnet TFTP proxy.
 -%>
-<% http_proxy_string = host_param('http-proxy') ? "proxy=http://" + host_param('http-proxy') + ":" + host_param('http-proxy-port') : '' -%>
+
+<% if host_param('http-proxy') -%>
+  <% if host_param('http-proxy-port') -%>
+    <% http_proxy_string = "proxy=http://" + host_param('http-proxy') + ":" + host_param('http-proxy-port') -%>
+  <% else -%>
+    <% http_proxy_string = "proxy=http://" + host_param('http-proxy') -%>
+  <% end -%>
+<% else -%>
+  <% http_proxy_string = '' -%>
+<% end -%>
 
 DEFAULT linux
 
 LABEL linux
     KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> ramdisk_size=65536 install=<%= @mediapath %> autoyast=<%= foreman_url('provision') %> textmode=1 <%= http_proxy_string -%>
+    APPEND initrd=<%= @initrd %> ramdisk_size=65536 install=<%= @mediapath %> autoyast=<%= foreman_url('provision') %> textmode=1 <%= http_proxy_string %>
 

--- a/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -11,7 +11,16 @@ description: |
   The output is deployed on the host's subnet TFTP proxy.
   See https://ipxe.org/scripting for more details
 -%>
-<% http_proxy_string = host_param('http-proxy') ? "proxy=http://" + host_param('http-proxy') + ":" + host_param('http-proxy-port') : '' -%>
+
+<% if host_param('http-proxy') -%>
+  <% if host_param('http-proxy-port') -%>
+    <% http_proxy_string = "proxy=http://" + host_param('http-proxy') + ":" + host_param('http-proxy-port') -%>
+  <% else -%>
+    <% http_proxy_string = "proxy=http://" + host_param('http-proxy') -%>
+  <% end -%>
+<% else -%>
+  <% http_proxy_string = '' -%>
+<% end -%>
 
 echo Trying to ping Gateway: ${netX/gateway}
 ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.


### PR DESCRIPTION
Catch cases where http-proxy parameter is set but http-proxy-port unset, e.g.
http-proxy=192.168.1.1:3128

