### PR TITLE
Fixes #34495 - Breadcrumb switcher doesn't work with katello

### DIFF
--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBar.js
@@ -53,7 +53,11 @@ class BreadcrumbBar extends React.Component {
     const isTitle = breadcrumbItems.length === 1;
     const handleSwitcherItemClick = (e, href) => {
       closeSwitcher();
-      onSwitcherItemClick(e, href);
+      if (onSwitcherItemClick) {
+        onSwitcherItemClick(e, href);
+      } else {
+        window.location.href = href;
+      }
     };
 
     return (
@@ -157,7 +161,7 @@ BreadcrumbBar.defaultProps = {
   openSwitcher: noop,
   closeSwitcher: noop,
   loadSwitcherResourcesByResource: noop,
-  onSwitcherItemClick: noop,
+  onSwitcherItemClick: null,
   removeSearchQuery: noop,
   perPage: BREADCRUMB_SWITCHER_PER_PAGE,
 };


### PR DESCRIPTION
for example smart_proxies with katello plugin will not change the page after switcher click