### PR TITLE
Fixes #34506 - infer correct permisson name in authorized_for

### DIFF
--- a/app/helpers/authorize_helper.rb
+++ b/app/helpers/authorize_helper.rb
@@ -16,7 +16,7 @@ module AuthorizeHelper
     controller_name = controller.to_s.gsub(/::/, "_").underscore
     id              = options[:id]
     user_id         = options[:user_id].to_param
-    permission      = options.delete(:permission) || [action, controller_name].join('_')
+    permission      = options.delete(:permission) || [action, controller_name.split('/').last].join('_')
 
     if object.nil?
       user.allowed_to?({ :controller => controller_name, :action => action, :id => id, :user_id => user_id }) rescue false

--- a/test/helpers/authorize_helper_test.rb
+++ b/test/helpers/authorize_helper_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class AuthorizeHelperTest < ActionView::TestCase
+  HelperTestDummy = Class.new { include AuthorizeHelper }
+  subject { HelperTestDummy.new }
+  let(:authorizer) { mock('Authorizer') }
+
+  describe '#authorized_for' do
+    describe 'permission inference' do
+      it 'infer permission for core controllers' do
+        host = mock('Host')
+        authorizer.expects(:can?).with('edit_hosts', host)
+        subject.authorized_for(authorizer: authorizer, auth_object: host, controller: 'hosts', action: 'edit')
+      end
+
+      it 'infer permission for isolated engine controllers' do
+        plugin_resource = mock('PluginResource')
+        authorizer.expects(:can?).with('edit_plugin_resource', plugin_resource)
+        subject.authorized_for(authorizer: authorizer, auth_object: plugin_resource, controller: 'plugin_name/plugin_resource', action: 'edit')
+      end
+    end
+  end
+end


### PR DESCRIPTION
authorized_for doesn't work for isolated namespace engines.
That is ATM only ForemanPuppet, but there might come more of those.
