### PR TITLE
Fixes #34511 - add breadcrumb's switcher to the new host page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -11,8 +11,6 @@ import {
   GridItem,
   Badge,
   Title,
-  Breadcrumb,
-  BreadcrumbItem,
   Text,
   TextVariants,
   PageSection,
@@ -20,7 +18,6 @@ import {
   SplitItem,
 } from '@patternfly/react-core';
 
-import Skeleton from 'react-loading-skeleton';
 import RelativeDateTime from '../../components/common/dates/RelativeDateTime';
 import {
   selectFillsIDs,
@@ -40,6 +37,8 @@ import './HostDetails.scss';
 import { useAPI } from '../../common/hooks/API/APIHooks';
 import TabRouter from './Tabs/TabRouter';
 import RedirectToEmptyHostPage from './EmptyState';
+import BreadcrumbBar from '../BreadcrumbBar';
+import { foremanUrl } from '../../common/helpers';
 
 const HostDetails = ({
   match: {
@@ -88,12 +87,29 @@ const HostDetails = ({
         variant="light"
       >
         <div className="header-top">
-          <Breadcrumb className="host-details-breadcrumb">
-            <BreadcrumbItem to="/hosts">{__('Hosts')}</BreadcrumbItem>
-            <BreadcrumbItem isActive>
-              {response.name || <Skeleton />}
-            </BreadcrumbItem>
-          </Breadcrumb>
+          <SkeletonLoader
+            skeletonProps={{ width: 300 }}
+            status={status || STATUS.PENDING}
+          >
+            {response.name && (
+              <BreadcrumbBar
+                isSwitchable
+                onSwitcherItemClick={(e, href) => {
+                  e.preventDefault();
+                  history.push(href);
+                }}
+                resource={{
+                  nameField: 'name',
+                  resourceUrl: '/api/v2/hosts?thin=true',
+                  switcherItemUrl: '/new/hosts/:name',
+                }}
+                breadcrumbItems={[
+                  { caption: __('Hosts'), url: foremanUrl('/hosts') },
+                  { caption: response.name },
+                ]}
+              />
+            )}
+          </SkeletonLoader>
           <Grid className="hostname-skeleton-rapper">
             <GridItem span={8}>
               <SkeletonLoader status={status || STATUS.PENDING}>

--- a/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/index.js
@@ -83,7 +83,7 @@ const BreadcrumbSwitcher = ({
         key={id}
         itemId={id}
         to={href}
-        onClick={onResourceClick}
+        onClick={e => onResourceClick(e, href)}
         className={
           isActive(href, id, name) ? 'breadcrumb-switcher-current-item' : ''
         }


### PR DESCRIPTION
Following https://github.com/theforeman/foreman/pull/9039 (thanks to @MariaAga) we have this new PF4 breadcrumb's switcher :)
This PR adds it to the new host page, so switching between hosts is super fast!



https://user-images.githubusercontent.com/11807069/155400634-87b5a1f8-5a33-4a65-8fa5-9817dea34085.mov





