### PR TITLE
Fixes #34525 - Honor host_registration_insights param in provisioning templates

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -328,7 +328,10 @@ sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/ker
 
 <%= snippet_if_exists(template_name + " custom post") %>
 
+<% if host_param_true?('host_registration_insights') -%>
 <%= snippet 'insights' -%>
+<% end -%>
+
 touch /tmp/foreman_built
 
 chvt 1

--- a/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
@@ -79,7 +79,10 @@ nodectl init
 <%= snippet 'redhat_register' %>
 <%= snippet 'kickstart_networking_setup' %>
 <%= snippet 'efibootmgr_netboot' %>
+<% if host_param_true?('host_registration_insights') -%>
 <%= snippet 'insights' -%>
+<% end -%>
+
 /usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>
 /usr/sbin/hwclock --systohc
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -159,6 +159,7 @@ systemctl enable ansible-callback
 
 
 
+
 touch /tmp/foreman_built
 
 chvt 1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -159,6 +159,7 @@ systemctl enable ansible-callback
 
 
 
+
 touch /tmp/foreman_built
 
 chvt 1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -159,6 +159,7 @@ systemctl enable ansible-callback
 
 
 
+
 touch /tmp/foreman_built
 
 chvt 1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -159,6 +159,7 @@ systemctl enable ansible-callback
 
 
 
+
 touch /tmp/foreman_built
 
 chvt 1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -159,6 +159,7 @@ systemctl enable ansible-callback
 
 
 
+
 touch /tmp/foreman_built
 
 chvt 1


### PR DESCRIPTION
Adding an if conditional so that insights snippet will only be called inside kickstart_ovirt.erb and kickstart_default.erb when the host_registration_insights param is set to true