### PR TITLE
Fixes #34532 - disable EFI local chainloading by default

### DIFF
--- a/app/registries/foreman/settings/provisioning.rb
+++ b/app/registries/foreman/settings/provisioning.rb
@@ -86,7 +86,7 @@ Foreman::SettingManager.define(:foreman) do
       full_name: N_("Default PXE global template entry"))
     setting('default_pxe_item_local',
       type: :string,
-      description: N_("Default PXE menu item in local template - 'local', 'local_chain_hd0' or custom, use blank for template default"),
+      description: N_("Default PXE menu item in local template - 'local', 'force_local_chain_hd0' or custom, use blank for template default"),
       default: nil,
       full_name: N_("Default PXE local template entry"))
     setting('intermediate_ipxe_script',

--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -27,7 +27,23 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
+menuentry 'Print warning and poweroff' --id local_chain_hd0 {
+  echo "This system was expected to boot from drive but it booted from network. While"
+  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
+  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
+  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
+  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
+  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
+  echo
+  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
+  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
+  echo
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
+  sleep -i 120
+  halt
+}
+
+menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
 <%
@@ -56,9 +72,9 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "1) NETWORK"
   echo "2) HDD"
   echo
-  echo "The system will halt in 2 minutes or press ESC to halt immediately."
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
   sleep -i 120
-  halt --no-apm
+  halt
 }
 
 menuentry 'Chainload into BIOS bootloader on first disk' --id local_chain_legacy_hd0 {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -6,7 +6,23 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
+menuentry 'Print warning and poweroff' --id local_chain_hd0 {
+  echo "This system was expected to boot from drive but it booted from network. While"
+  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
+  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
+  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
+  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
+  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
+  echo
+  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
+  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
+  echo
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
+  sleep -i 120
+  halt
+}
+
+menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
@@ -119,9 +135,9 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "1) NETWORK"
   echo "2) HDD"
   echo
-  echo "The system will halt in 2 minutes or press ESC to halt immediately."
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
   sleep -i 120
-  halt --no-apm
+  halt
 }
 
 menuentry 'Chainload into BIOS bootloader on first disk' --id local_chain_legacy_hd0 {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -22,7 +22,23 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
+menuentry 'Print warning and poweroff' --id local_chain_hd0 {
+  echo "This system was expected to boot from drive but it booted from network. While"
+  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
+  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
+  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
+  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
+  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
+  echo
+  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
+  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
+  echo
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
+  sleep -i 120
+  halt
+}
+
+menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
@@ -135,9 +151,9 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "1) NETWORK"
   echo "2) HDD"
   echo
-  echo "The system will halt in 2 minutes or press ESC to halt immediately."
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
   sleep -i 120
-  halt --no-apm
+  halt
 }
 
 menuentry 'Chainload into BIOS bootloader on first disk' --id local_chain_legacy_hd0 {

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -2,7 +2,23 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
+menuentry 'Print warning and poweroff' --id local_chain_hd0 {
+  echo "This system was expected to boot from drive but it booted from network. While"
+  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
+  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
+  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
+  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
+  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
+  echo
+  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
+  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
+  echo
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
+  sleep -i 120
+  halt
+}
+
+menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
@@ -115,9 +131,9 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "1) NETWORK"
   echo "2) HDD"
   echo
-  echo "The system will halt in 2 minutes or press ESC to halt immediately."
+  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
   sleep -i 120
-  halt --no-apm
+  halt
 }
 
 menuentry 'Chainload into BIOS bootloader on first disk' --id local_chain_legacy_hd0 {


### PR DESCRIPTION
We see increasing number of problems with EFI chainloading grub script, it is also not supported on SecureBoot. What worked well for BIOS never worked for EFI, therefore I propose to enforce the normal workflow for EFI systems: when EFI host is installed it should boot from local drive. Booting from network will result a warning message and system halt. Users who still want to continue this BIOS-like "always boot from network" workflow will have instructions how to change the configuration value to achieve it.

On some systems, Anaconda fails to configure first boot entry correctly. For this reason, Foreman (and Satellite) ships with efibootmgr_netboot snippet which is enabled by default in kickstart. It can be controlled by efi_bootentry host parameter - when set Anaconda will perform efibootmgr command to override boot entry. Unfortunately full name of boot entry must be entered, this is different for each linux OS (e.g. "CentOS Linux" for CentOS or "Fedora") so there cannot be a single default value for all users.