### PR TITLE
Refs #34323 - explicit value for Rails 6.1

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -349,7 +349,7 @@ class Setting < ApplicationRecord
     return unless Foreman.settings.ready?
     Foreman.settings.find(name)&.tap do |definition|
       definition.updated_at = updated_at
-      definition.value = value
+      definition.value_from_db = value
     end
   end
 end

--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -27,8 +27,14 @@ class SettingPresenter
   end
 
   # Value set through setter can be explicit nil
-  def value=(*attr)
+  def value_from_db=(value)
     @explicit_value = true
+    self.value = value
+  end
+
+  # Mass assigned value is not relevant if it is a nil
+  def value=(value)
+    @explicit_value = !value.nil?
     super
   end
 
@@ -94,17 +100,5 @@ class SettingPresenter
 
   def select_values
     Setting.select_collection_registry.collection_for name
-  end
-
-  private
-
-  # explicit value from mass assignment can not be nil
-  def _assign_attribute(k, v)
-    if k.to_s == 'value'
-      @explicit_value = !v.nil?
-      write_attribute(k, v)
-    else
-      super
-    end
   end
 end

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -159,7 +159,7 @@ class SettingRegistry
         next
       end
       definition.updated_at = s.updated_at
-      definition.value = s.value
+      definition.value_from_db = s.value
       logger.debug("Updated cached value for setting=#{s.name}") unless ignore_cache
     end
     @values_loaded_at = Time.zone.now if settings.any?


### PR DESCRIPTION
In c693cd9 we have worked around an issue for distinguishing between value explicitly set by user and not set.
This workaround doesn't work properly in Rails 6.1 and we should improve it to work properly.