### PR TITLE
Fixes #34634 - fix order description syntax

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -18,7 +18,7 @@ module Api
 
       def_param_group :search_and_pagination do
         param :search, String, :desc => N_("filter results")
-        param :order, String, :desc => N_("Sort and order by a searchable field, e.g. '<field> DESC'")
+        param :order, String, :desc => N_("Sort and order by a searchable field, e.g. '&lt;field&gt; DESC'")
         param_group :pagination, ::Api::V2::BaseController
       end
 


### PR DESCRIPTION
In 25c24970695366727b1bc8b8747b40c74a388597 we have added description that does not comply with Maruku syntax.
We should have Maruku syntax compatible description even for a price of lower readability.

@ofedoren what do you think ? :)