### PR TITLE
Fixes #34553 - Use systemd for Ansible callback under newer Debian family OSes

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ansible_provisioning_callback.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_provisioning_callback.erb
@@ -15,7 +15,7 @@ description: |
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
-  has_systemd = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7)
+  has_systemd = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7) || (@host.operatingsystem.name == 'Ubuntu' && os_major >= 15) || (@host.operatingsystem.name == 'Debian' && os_major >= 8)
 -%>
 <% if has_systemd -%>
 <%= save_to_file('/etc/systemd/system/ansible-callback.service',


### PR DESCRIPTION
This PR tweaks the ansible_provisioning_callback snippit to use systemd for newer Debian type operating systems.  The snippit currently only really checks for RedHat family ones.