### PR TITLE
Fixes #34557 - improve association resolver

### DIFF
--- a/app/graphql/resolvers/concerns/association.rb
+++ b/app/graphql/resolvers/concerns/association.rb
@@ -1,0 +1,24 @@
+module Resolvers
+  module Concerns
+    module Association
+      extend ActiveSupport::Concern
+
+      # In future versions of graphql-ruby (>1.9) we should have easier access through `field.owner`
+      def owner_type
+        object.class.graphql_type&.safe_constantize
+      end
+
+      def record
+        if owner_type
+          owner_type.record_for(object)
+        else
+          object
+        end
+      end
+
+      def resolve
+        CollectionLoader.for(self.class::MODEL_CLASS, self.class::ASSOC_NAME).load(record)
+      end
+    end
+  end
+end

--- a/app/graphql/resolvers/generic.rb
+++ b/app/graphql/resolvers/generic.rb
@@ -18,6 +18,13 @@ module Resolvers
       base_class.include(Resolvers::Concerns::Collection)
     end
 
+    def association(association_name)
+      return unless model_class
+      base_class.tap do |c|
+        c.const_set('ASSOC_NAME', association_name)
+      end.include(Resolvers::Concerns::Association)
+    end
+
     private
 
     attr_reader :type

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -16,13 +16,8 @@ module Types
       end
 
       def has_many(name, type, resolver: nil, **kwargs)
-        if resolver
-          field name, type.connection_type, resolver: resolver, **kwargs.except(:resolver)
-        else
-          field name, type.connection_type,
-            resolve: proc { |object| CollectionLoader.for(object.class, name).load(object) },
-            **kwargs.except(:resolver)
-        end
+        resolver ||= Resolvers::Generic.for(self).association(name)
+        field name, type.connection_type, resolver: resolver, **kwargs.except(:resolver)
       end
 
       def belongs_to(name, type, resolver: nil, foreign_key: nil, **kwargs)
@@ -46,6 +41,11 @@ module Types
         else
           @model_class ||= "::#{to_s.demodulize}".safe_constantize
         end
+      end
+
+      # Some objects are wrappers around models
+      def record_for(object)
+        object
       end
 
       private


### PR DESCRIPTION
Why: resolve proc is deprecated and not dynamic enough as if we inherit the type it fails to recognize that.

I've come up with `record_for` on Type and Resolver goes through that method, to enable wrappers.
