### PR TITLE
Fixes #34558 - Trigger Ansible provisioning callback from Preseed Finish

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -65,6 +65,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
 <%= snippet 'preseed_networking_setup' -%>
+<%= snippet 'ansible_provisioning_callback' -%>
 <%= snippet 'efibootmgr_netboot' -%>
 <%= snippet 'eject_cdrom' -%>
 <%= snippet 'built' -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -54,6 +54,22 @@ allow-hotplug $real
 iface $real inet dhcp
 EOF
 
+cat << EOF > /etc/systemd/system/ansible-callback.service
+[Unit]
+Description=Provisioning callback to Ansible Tower
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStartPost=/usr/bin/systemctl disable ansible-callback
+
+[Install]
+WantedBy=multi-user.target
+EOF
+# Runs during first boot, removes itself
+systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then
   /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -54,6 +54,22 @@ allow-hotplug $real
 iface $real inet dhcp
 EOF
 
+cat << EOF > /etc/systemd/system/ansible-callback.service
+[Unit]
+Description=Provisioning callback to Ansible Tower
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStartPost=/usr/bin/systemctl disable ansible-callback
+
+[Install]
+WantedBy=multi-user.target
+EOF
+# Runs during first boot, removes itself
+systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then
   /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then


### PR DESCRIPTION
This PR may represent a **BREAKING CHANGE**.  The reason I say this is, if someone has set up the Ansible provisioning callback under RedHat and are just operating under the assumption that Ubuntu/Debian won't trigger it, this will cause it to 'suddenly' start triggering for Debian family hosts.

Anyway, this PR is a sister of #9133 and triggers the Preseed finishing template to kick off the ansible_provisioning_callback snippit, providing a means to trigger Ansible provisioning at install time of Debian family hosts.  Note that without it's sister PR, more modern Debian family OS's that use systemd will use the old init style handler, which I don't believe actually works.  (it may, but I seem to recall it not when I originally tested)