### PR TITLE
Fixes #34565 - fix installation media for new Ubuntu autoinstall (subiquity)

### DIFF
--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -59,6 +59,17 @@ class Debian < Operatingsystem
     s.presence || description
   end
 
+  def pxe_file_names(medium_provider)
+    if (guess_os == 'ubuntu' && (major.to_i > 20 || major.to_i == 20 && minor.to_i >= 3))
+      {
+        kernel: 'vmlinuz',
+        initrd: 'initrd',
+      }
+    else
+      super
+    end
+  end
+
   private
 
   # tries to guess if this an ubuntu or a debian os


### PR DESCRIPTION
The Installation Media doesn't work for the new Ubuntu installer, because the kernel file names changed:

The new Ubuntu autoinstall uses vmlinux and kernel initrd instead of linux and initrd.gz respectively.

* Adapt pxe_file_names to return (vmlinuz, initrd) if autoinstall subiquity is used

EDIT:
Wrong commit message when creating the PR, Issues: [#34565](https://projects.theforeman.org/issues/34565)