### PR TITLE
Fixes #34569 - postpone LookupValue#match validations

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -58,7 +58,7 @@ module HostCommon
             lookup_value.mark_for_destruction if mark_for_destruction
           end
         elsif !Foreman::Cast.to_bool(attr.delete(:_destroy))
-          lookup_values.build(attr.merge(:match => lookup_value_match, :host_or_hostgroup => self))
+          lookup_values.build(attr.merge(:host_or_hostgroup => self))
         end
       end
     end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -280,7 +280,7 @@ class HostTest < ActiveSupport::TestCase
         :subnet => subnets(:two), :architecture => architectures(:x86_64), :medium => media(:one),
         :organization => users(:one).organizations.first, :location => users(:one).locations.first,
         :disk => "empty partition",
-        :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lookup_key.id, "value" => "some_value", "match" => "fqdn=abc.mydomain.net"}}
+        :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lookup_key.id, "value" => "some_value"}}
       end
     end
 
@@ -298,9 +298,8 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryBot.create(:host)
       lookup_key = FactoryBot.create(:lookup_key, override: true, path: 'fqdn')
       assert_difference('LookupValue.count') do
-        assert host.update!(:lookup_values_attributes => {:new_123456 =>
-                                                                     {:lookup_key_id => lookup_key.id, :value => true, :match => "fqdn=#{host.fqdn}",
-                                                                      :_destroy => 'false'}})
+        assert host.update!(:lookup_values_attributes => { :new_123456 => { :lookup_key_id => lookup_key.id, :value => true,
+                                                                            :_destroy => 'false'}})
       end
     end
 
@@ -311,9 +310,8 @@ class HostTest < ActiveSupport::TestCase
                                         :match => "fqdn=#{host.fqdn}", :value => '8080')
       host.reload
       assert_difference('LookupValue.count', -1) do
-        assert host.update!(:lookup_values_attributes => {'0' =>
-                                                                     {:lookup_key_id => lookup_key.id, :value => '8080', :match => "fqdn=#{host.fqdn}",
-                                                                      :id => lookup_value.id, :_destroy => 'true'}})
+        assert host.update!(:lookup_values_attributes => { '0' => { :lookup_key_id => lookup_key.id, :value => '8080',
+                                                                    :id => lookup_value.id, :_destroy => 'true' }})
       end
     end
 
@@ -324,9 +322,8 @@ class HostTest < ActiveSupport::TestCase
                                         :match => "fqdn=#{host.fqdn}", :value => '8080')
       host.reload
       assert_difference('LookupValue.count', 0) do
-        assert host.update!(:lookup_values_attributes => {'0' =>
-                                                                     {:lookup_key_id => lookup_key.id, :value => '80', :match => "fqdn=#{host.fqdn}",
-                                                                      :id => lookup_value.id, :_destroy => 'false'}})
+        assert host.update!(:lookup_values_attributes => { '0' => { :lookup_key_id => lookup_key.id, :value => '80',
+                                                                    :id => lookup_value.id, :_destroy => 'false'}})
       end
       assert_equal '80', lookup_value.reload.value
     end
@@ -338,10 +335,8 @@ class HostTest < ActiveSupport::TestCase
                                         :match => host.lookup_value_matcher, :value => YAML.dump(:foo => :bar))
       host.reload
       assert_difference('LookupValue.count', 0) do
-        assert host.update!(:lookup_values_attributes => {'0' =>
-                                                                     {:lookup_key_id => lookup_key.id.to_s, :value => YAML.dump(:updated => :value),
-                                                                      :match => host.lookup_value_matcher,
-                                                                      :id => lookup_value.id.to_s, :_destroy => 'false'}})
+        assert host.update!(:lookup_values_attributes => { '0' => { :lookup_key_id => lookup_key.id.to_s, :value => YAML.dump(:updated => :value),
+                                                                    :id => lookup_value.id.to_s, :_destroy => 'false'}})
       end
       assert_equal({:updated => :value}, lookup_value.reload.value)
     end
@@ -351,7 +346,6 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryBot.build(:host)
       host.attributes = {:lookup_values_attributes => {'0' =>
                                                        {:lookup_key_id => lookup_key.id.to_s, :value => '{"a":',
-                                                        :match => host.lookup_value_matcher,
                                                         :_destroy => 'false'}}}
       assert host.lookup_values.first.present?
       refute_valid host, :'lookup_values.value', /invalid hash/
@@ -2668,7 +2662,7 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryBot.create(:host)
       lkey = FactoryBot.create(:lookup_key, override: true, path: 'fqdn')
       assert_no_difference('LookupValue.count') do
-        host.lookup_values_attributes = {"new_123456" => {"lookup_key_id" => lkey.id, "value" => "some_value", "match" => "fqdn=abc.mydomain.net"}}
+        host.lookup_values_attributes = {"new_123456" => {"lookup_key_id" => lkey.id, "value" => "some_value"}}
       end
 
       assert_difference('LookupValue.count', 1) do
@@ -2690,7 +2684,7 @@ class HostTest < ActiveSupport::TestCase
 
     test "destroy existing lookup values on host save" do
       lkey = FactoryBot.create(:lookup_key, override: true, path: 'fqdn')
-      host = FactoryBot.create(:host, :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lkey.id, "value" => "some_value", "match" => "fqdn=abc.mydomain.net"}})
+      host = FactoryBot.create(:host, :lookup_values_attributes => {"new_123456" => {"lookup_key_id" => lkey.id, "value" => "some_value"}})
       lookup_value = host.lookup_values.first
       assert_no_difference('LookupValue.count') do
         host.lookup_values_attributes = {'0' => {'lookup_key_id' => lkey.id.to_s, 'id' => lookup_value.id.to_s, '_destroy' => '1'}}.with_indifferent_access

--- a/test/models/lookup_value_test.rb
+++ b/test/models/lookup_value_test.rb
@@ -145,9 +145,14 @@ class LookupValueTest < ActiveSupport::TestCase
     assert_valid value
   end
 
-  test "lookup value should not allow for nil key" do
+  test "lookup value should not allow for blank key" do
     value = LookupValue.new(:value => true, :match => "", :lookup_key_id => boolean_lookup_key.id)
     refute_valid value
+  end
+
+  test "lookup value should not allow for nil key" do
+    value = LookupValue.new(:value => true, :match => nil, :lookup_key_id => boolean_lookup_key.id)
+    refute value.save
   end
 
   test "lookup value will be rejected for invalid key" do


### PR DESCRIPTION
Validation for presence of foreign_key has to be postponed because of Rails internals.

association.build() filters out foreign_key for given association because it assigns the value for that key after the main record gets saved.
This filtering did not work properly until Rails 6.1, thus we did not notice and thought it works.

Since Rails 6.1 https://github.com/rails/rails/blob/13cdd7a6aef86b23c3410adff1d4f6eeefc72c67/activerecord/lib/active_record/associations/association.rb#L196 works properly
and returns `foreing_key` in string format and thus filters out attributes from hashes where those passed as string keys.

All other validations can be run during validation if those allow nil value as the Rails assigned key should not need validation.