### PR TITLE
Fixes #34573 - encrypt DSL setting values

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -105,7 +105,7 @@ class Setting < ApplicationRecord
   def value=(v)
     v = v.to_yaml unless v.nil?
     # the has_attribute is for enabling DB migrations on older versions
-    if has_attribute?(:encrypted) && encrypted
+    if setting_definition&.encrypted?
       # Don't re-write the attribute if the current encrypted value is identical to the new one
       current_value = self[:value]
       unless is_decryptable?(current_value) && decrypt_field(current_value) == v
@@ -345,9 +345,13 @@ class Setting < ApplicationRecord
     readonly! if !new_record? && has_readonly_value?
   end
 
-  def refresh_registry_value
+  def setting_definition
     return unless Foreman.settings.ready?
-    Foreman.settings.find(name)&.tap do |definition|
+    Foreman.settings.find(name)
+  end
+
+  def refresh_registry_value
+    setting_definition&.tap do |definition|
       definition.updated_at = updated_at
       definition.value_from_db = value
     end

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -15,9 +15,8 @@ class AuditExtensionsTest < ActiveSupport::TestCase
   end
 
   test "audit's change is filtered when data is encrypted" do
-    setting = settings(:attributes63)
-    setting.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
-    setting.value = '654321'
+    Setting.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+    setting = Foreman.settings.set_user_value('root_pass', '654321')
     as_admin do
       assert setting.save
     end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -102,28 +102,51 @@ class SettingRegistryTest < ActiveSupport::TestCase
   end
 
   describe '#set_user_value' do
-    setup do
-      registry._add('test',
-        category: 'Setting',
-        default: default,
-        type: :integer,
-        full_name: 'Test Foo',
-        description: 'test update',
-        context: :test)
+    context 'integer setting' do
+      setup do
+        registry._add('test',
+          category: 'Setting',
+          default: default,
+          type: :integer,
+          full_name: 'Test Foo',
+          description: 'test update',
+          context: :test)
+      end
+
+      it 'initiates the DB model if none exists yet' do
+        model = registry.set_user_value('test', '10')
+        assert_not_nil model
+        assert model.valid?
+        assert model.save
+        assert_equal 10, model.reload.value
+      end
+
+      it 'updates the DB model if already exists' do
+        model = Setting.create(registry.find('test').attributes.merge(value: setting_value))
+        registry.set_user_value('test', '10').save
+        assert_equal 10, model.reload.value
+      end
     end
 
-    it 'initiates the DB model if none exists yet' do
-      model = registry.set_user_value('test', '10')
-      assert_not_nil model
-      assert model.valid?
-      assert model.save
-      assert_equal 10, model.reload.value
-    end
+    context 'encrypted setting' do
+      setup do
+        registry._add('test',
+          category: 'Setting',
+          default: 'foo',
+          type: :string,
+          full_name: 'Test Encrypted Foo',
+          description: 'test update',
+          encrypted: true,
+          context: :test)
+        Setting.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+      end
 
-    it 'updates the DB model if already exists' do
-      model = Setting.create(registry.find('test').attributes.merge(value: setting_value))
-      registry.set_user_value('test', '10').save
-      assert_equal 10, model.reload.value
+      it 'encrypts the value' do
+        Setting.any_instance.stubs(:setting_definition).returns(registry.find('test'))
+        model = registry.set_user_value('test', 'foobar')
+        model.save
+        assert_includes model.read_attribute(:value), EncryptValue::ENCRYPTION_PREFIX
+      end
     end
   end
 


### PR DESCRIPTION
DSL setting values were not properly encrypted as the encryption flag has not been propagated into DB model.
