### PR TITLE
Fixes #34579 - fix the redirect after canceling host's form

### DIFF
--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -138,6 +138,6 @@
 
     <%= hidden_field_tag 'bare_metal_capabilities', @host.bare_metal_capabilities, :disabled => true %>
     <%= f.hidden_field :overwrite? %>
-    <%= submit_or_cancel f, @host.overwrite?, :cancel_path => resource_prev_url_with_search_filters || (@host.new_record? ? hosts_path : host_path(:id => @host.name_was)) %>
+    <%= submit_or_cancel f, @host.overwrite?, :cancel_path => resource_prev_url_with_search_filters || (@host.new_record? ? hosts_path : current_host_details_path(@host)) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
When the user clicks on the cancel button in the host's form, the user should be redirected to the new/legacy host UI corresponding to the setting.