### PR TITLE
Fixes #34580 - Remove pagination deprecations

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/__snapshots__/TaxonomyDropdown.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/__snapshots__/TaxonomyDropdown.test.js.snap
@@ -4,6 +4,7 @@ exports[`TaxonomyDropdown Search items 1`] = `
 Array [
   <ContextSelectorItem
     className="organizations_clear"
+    href={null}
     isDisabled={false}
     key="0"
     onClick={[Function]}
@@ -13,6 +14,7 @@ Array [
   </ContextSelectorItem>,
   <ContextSelectorItem
     className="organization_menuitem"
+    href={null}
     id="select_taxonomy_org1"
     isDisabled={true}
     key="1"
@@ -29,6 +31,7 @@ Array [
   </ContextSelectorItem>,
   <ContextSelectorItem
     className="organization_menuitem"
+    href={null}
     id="select_taxonomy_org2"
     isDisabled={false}
     key="2"
@@ -44,6 +47,7 @@ exports[`TaxonomyDropdown Search items 2`] = `
 Array [
   <ContextSelectorItem
     className="organizations_clear"
+    href={null}
     isDisabled={false}
     key="0"
     onClick={[Function]}
@@ -53,6 +57,7 @@ Array [
   </ContextSelectorItem>,
   <ContextSelectorItem
     className="organization_menuitem"
+    href={null}
     id="select_taxonomy_org1"
     isDisabled={true}
     key="1"
@@ -73,6 +78,7 @@ Array [
 exports[`TaxonomyDropdown rendering rendering 1`] = `
 <ContextSelector
   className="context-selector"
+  disableFocusTrap={false}
   footer={
     <ContextSelectorFooter>
       <Button
@@ -104,6 +110,7 @@ exports[`TaxonomyDropdown rendering rendering 1`] = `
 >
   <ContextSelectorItem
     className="organizations_clear"
+    href={null}
     isDisabled={false}
     key="0"
     onClick={[Function]}
@@ -113,6 +120,7 @@ exports[`TaxonomyDropdown rendering rendering 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className="organization_menuitem"
+    href={null}
     id="select_taxonomy_org1"
     isDisabled={true}
     key="1"
@@ -129,6 +137,7 @@ exports[`TaxonomyDropdown rendering rendering 1`] = `
   </ContextSelectorItem>
   <ContextSelectorItem
     className="organization_menuitem"
+    href={null}
     id="select_taxonomy_org2"
     isDisabled={false}
     key="2"

--- a/webpack/assets/javascripts/react_app/components/Pagination/Pagination.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/Pagination.js
@@ -1,9 +1,0 @@
-import { deprecate } from '../../common/DeprecationService';
-
-export default () => {
-  deprecate(
-    'PF3 Pagination',
-    'PF4 pagination from "react_app/components/Pagination/index.js"',
-    3.2
-  );
-};

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationHooks.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationHooks.js
@@ -1,9 +1,0 @@
-import { deprecate } from '../../common/DeprecationService';
-
-export const usePaginationOptions = () => {
-  deprecate(
-    'usePaginationOptions',
-    'PF4 pagination which is already shipped with those options',
-    3.2
-  );
-};

--- a/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/PaginationWrapper.js
@@ -1,9 +1,0 @@
-import { deprecate } from '../../common/DeprecationService';
-
-export default () => {
-  deprecate(
-    'PaginationWrapper',
-    'PF4 pagination from "react_app/components/Pagination/index.js"',
-    3.2
-  );
-};


### PR DESCRIPTION
The pagination component was refactored in 3.2 and deprecation messages have been added,
now we can remove it in development (3.3)

The snapshot change is unrelated to this PR, but I fixed it
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
