### PR TITLE
Refs #34360 - allow host deleting with host_reports plugin

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -655,12 +655,17 @@ class HostsController < ApplicationController
   end
 
   def statuses
+    host_statuses = @host.host_statuses
+    # Do not show legacy configuration report when Host Report is installed.
+    if Foreman::Plugin.installed?('foreman_host_reports')
+      host_statuses = host_statuses.where("type != 'HostStatus::ConfigurationStatus'")
+    end
     statuses = {
       global: @host.global_status,
       captions: HostStatus.status_registry.map do |status_class|
         status_class.status_name
       end,
-      statuses: @host.host_statuses.map do |status|
+      statuses: host_statuses.map do |status|
         {
           id: status.id,
           name: status.name,

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -29,11 +29,7 @@ class Host::Managed < Host::Base
   has_many :all_reports, :foreign_key => :host_id
 
   belongs_to :image
-  if Foreman::Plugin.installed?('foreman_host_reports')
-    has_many :host_statuses, -> { where("host_status.type != 'HostStatus::ConfigurationStatus' and host_status.type is not null") }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :delete_all
-  else
-    has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
-  end
+  has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
   has_one :configuration_status_object, :class_name => 'HostStatus::ConfigurationStatus', :foreign_key => 'host_id'
   has_one :build_status_object, :class_name => 'HostStatus::BuildStatus', :foreign_key => 'host_id'
   before_destroy :remove_reports

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -93,6 +93,8 @@ module HostStatus
     end
 
     def relevant?(options = {})
+      # Do not calculate global status from legacy configuration when plugin is present.
+      return false if Foreman::Plugin.installed?('foreman_host_reports')
       handle_options(options)
 
       host.configuration? || last_report.present? || Setting[:always_show_configuration_status]

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -213,9 +213,9 @@ namespace :seed do
       Foreman::Logging.logger('permissions').level = Logger::ERROR
       Foreman::Logging.logger('audit').level = Logger::ERROR
       origin = ENV['origin'] || 'Puppet'
-      hosts = ENV['hosts'] || 10
-      reports = ENV['reports'] || 50
-      lines = ENV['lines'] || 100
+      hosts = (ENV['hosts'] || 10).to_i
+      reports = (ENV['reports'] || 50).to_i
+      lines = (ENV['lines'] || 100).to_i
       total_time = 0
       (1..reports).each do |i|
         host_id = i % hosts


### PR DESCRIPTION
When host_reports plugin is installed, there is a workaround for 3.2-3.3 version of Foreman to override the host status association. However, it turns out it breaks host deletion - when a host with legacy (configuration) reports (thus status records) is deleted, the association does not match (because of the scope - where condition) and therefore cascade deletion is not happening leading to the foreign key SQL error.

It also breaks uploading of legacy reports. Therefore the approach was not viable.

Since the reason why we introduced this workaround was only to hide the legacy configuration status from the UI/API/CLI when the new plugin is installed, I am taking a different approach - I will keep the association as-is, however, it will be removed from the UI/API/CLI.

How to test:

Without the plugin, import some reports:

```
bundle exec rake seed:reports origin=Ansible hosts=1 reports=1 lines=10
bundle exec rake seed:reports origin=Puppet hosts=1 reports=1 lines=10
```

Check configuration status of the new host, check reports. Do the same with the plugin installed.

Import new reports too: enable foreman_host_reports and smart_proxy_reports plugins and in the latter git repository use the following script to upload snapshot fixtures from tests: `contrib/upload-fixture -a` (smart proxy must be running in order to upload new reports, override_hostname setting must be set to an existing hostname). Check the new host reports, check the hosts and their host statuses in UI and CLI.

I was unable to verify if Hammer works, whatever I do hammer always shows me only Global and Build statuses although my host don't have any build status:

```
[lzap@nuc cli]$ hammer host info --name host9.example.com
Type application/netcdf is already registered as a variant of application/netcdf.
Id:                 75
Name:               host9.example.com
Cert name:          host9.example.com
Managed:            no
Installed at:
Last report:        2022/03/10 13:29:54
Status:
    Global Status: Error
    Build Status:  Installed
...
```

@ofedoren maybe you can comment, it's not clear how this is supposed to work. But the patch works for the UI just fine.