### PR TITLE
Fixes #34592 - Remove max_trend setting fixture

### DIFF
--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -213,11 +213,6 @@ attributes59:
   category: Setting
   default: "false"
   description: 'All hosts will show a configuration status even when a Puppet smart proxy is not assigned'
-attributes60:
-  name: max_trend
-  category: Setting
-  default: 30
-  description: 'Max days for Trends graphs'
 attributes61:
   name: name_generator_type
   settings_type: string


### PR DESCRIPTION
In 7895751c25792bcff46ba2adc5ad1f240127c7c9 this was removed so there's no need for a fixture.

Fixes: 7895751c25792bcff46ba2adc5ad1f240127c7c9