### PR TITLE
Fixes #34596 - sanitize default template names

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -121,21 +121,11 @@ class ProvisioningTemplate < Template
   end
 
   def self.local_boot_name(kind)
-    return Setting["local_boot_#{kind}"] if Setting["local_boot_#{kind}"].present?
-    local_boot_template_name = "#{kind} default local boot"
-    Rails.logger.info "Could not find user defined local_boot template from Settings for #{kind}, falling back to #{local_boot_template_name}"
-    local_boot_template_name
-  end
-
-  def self.global_default_name(kind)
-    "#{kind} global default"
+    Setting["local_boot_#{kind}"]
   end
 
   def self.global_template_name_for(kind)
-    return Setting["global_#{kind}"] if Setting["global_#{kind}"].present?
-    global_template_name = global_default_name(kind)
-    Rails.logger.info "Could not find user defined global template from Settings for #{kind}, falling back to #{global_template_name}"
-    global_template_name
+    Setting["global_#{kind}"]
   end
 
   def self.build_pxe_default

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -8,7 +8,7 @@ class TemplateKind < ApplicationRecord
   scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name
 
-  PXE = ["PXEGrub2", "PXELinux", "PXEGrub", "iPXE"]
+  PXE = Foreman::Provision::PXE_TEMPLATE_KINDS
 
   def self.default_template_labels
     {

--- a/app/registries/foreman/settings/provisioning.rb
+++ b/app/registries/foreman/settings/provisioning.rb
@@ -1,3 +1,5 @@
+require 'foreman/provision'
+
 Foreman::SettingManager.define(:foreman) do
   category(:provisioning, N_('Provisioning')) do
     owner_select = proc do
@@ -128,20 +130,20 @@ Foreman::SettingManager.define(:foreman) do
 
     # We have following loop twice to keep the historical order.
     # TODO: First resolve the correct order and then optimize this loop.
-    TemplateKind::PXE.each do |pxe_kind|
+    Foreman::Provision::PXE_TEMPLATE_KINDS.each do |pxe_kind|
       setting("global_#{pxe_kind}",
         type: :string,
         description: N_("Global default %s template. This template gets deployed to all configured TFTP servers. It will not be affected by upgrades.") % pxe_kind,
-        default: ProvisioningTemplate.global_default_name(pxe_kind),
+        default: Foreman::Provision.global_default_name(pxe_kind),
         full_name: N_("Global default %s template") % pxe_kind,
         collection: proc { Hash[ProvisioningTemplate.unscoped.of_kind(pxe_kind).pluck(:name).map { |name| [name, name] }] },
         validate: :pxe_template_name)
     end
-    TemplateKind::PXE.each do |pxe_kind|
+    Foreman::Provision::PXE_TEMPLATE_KINDS.each do |pxe_kind|
       setting("local_boot_#{pxe_kind}",
         type: :string,
         description: N_("Template that will be selected as %s default for local boot.") % pxe_kind,
-        default: ProvisioningTemplate.local_boot_name(pxe_kind),
+        default: Foreman::Provision.local_boot_default_name(pxe_kind),
         full_name: N_("Local boot %s template") % pxe_kind,
         collection: proc { Hash[ProvisioningTemplate.unscoped.of_kind(pxe_kind).pluck(:name).map { |name| [name, name] }] },
         validate: :pxe_template_name)

--- a/app/validators/pxe_template_name_validator.rb
+++ b/app/validators/pxe_template_name_validator.rb
@@ -12,11 +12,11 @@ class PxeTemplateNameValidator < ActiveModel::EachValidator
   end
 
   def local_boot_templates
-    TemplateKind::PXE.map { |kind| ProvisioningTemplate.local_boot_name kind }
+    TemplateKind::PXE.map { |kind| Foreman::Provision.local_boot_default_name kind }
   end
 
   def global_default_templates
-    TemplateKind::PXE.map { |kind| ProvisioningTemplate.global_default_name kind }
+    TemplateKind::PXE.map { |kind| Foreman::Provision.global_default_name kind }
   end
 
   def exempt_templates

--- a/lib/foreman/provision.rb
+++ b/lib/foreman/provision.rb
@@ -1,3 +1,13 @@
 module Foreman::Provision
+  PXE_TEMPLATE_KINDS = ["PXEGrub2", "PXELinux", "PXEGrub", "iPXE"]
+
+  def self.local_boot_default_name(kind)
+    "#{kind} default local boot"
+  end
+
+  def self.global_default_name(kind)
+    "#{kind} global default"
+  end
+
   autoload :SSH, 'foreman/provision/ssh'
 end


### PR DESCRIPTION
Default boot templates are weirdly interconnected with its settings.
