### PR TITLE
Fixes #34603 - deprecate non-DSL setting definitions

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -270,12 +270,12 @@ class Setting < ApplicationRecord
 
   def self.load_defaults
     return false unless table_exists?
-    dbcache = Hash[Setting.where(:category => name).map { |s| [s.name, s] }]
-    transaction do
-      default_settings.compact.each do |s|
-        val = s.update(:category => name).symbolize_keys
-        dbcache.key?(val[:name]) ? create_existing(dbcache[val[:name]], s) : create!(s)
-      end
+    Foreman::Deprecation.deprecation_warning('3.4', "subclassing Setting is deprecated '#{name}' should be migrated to setting DSL "\
+                                                    'see https://github.com/theforeman/foreman/blob/develop/developer_docs/how_to_create_a_plugin.asciidoc#settings for details')
+    default_settings.each do |s|
+      t = Setting.setting_type_from_value(s[:default]) || 'string'
+      kwargs = s.except(:name).merge(type: t.to_sym, category: name, context: :deprecated)
+      Foreman.settings._add(s[:name], **kwargs)
     end
     true
   end

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -11,14 +11,6 @@ require_dependency 'foreman/settings'
 require 'net'
 require 'foreman/provision'
 
-# in this phase, the classes are not fully loaded yet, load them
-Dir[
-  Rails.root.join('app', 'models', 'setting.rb'),
-  Rails.root.join('app', 'models', 'setting', '*.rb'),
-].each do |f|
-  require_dependency(f)
-end
-
 Rails.application.config.before_initialize do
   # load topbar
   Menu::Loader.load
@@ -28,6 +20,7 @@ Foreman.settings.load_definitions
 
 # We may be executing something like rake db:migrate:reset, which destroys this table
 # only continue if the table exists
+# TODO: remove this, and postpone loading values to to_prepare
 if (Setting.table_exists? rescue(false))
   Setting.descendants.each(&:load_defaults)
   Foreman.settings.load_values
@@ -47,17 +40,7 @@ Rails.application.config.to_prepare do
   # The users table may not be exist during initial migration of the database
   TopbarSweeper.expire_cache_all_users if (User.table_exists? rescue false)
 
-  if (Setting.table_exists? rescue(false))
-    # Force reload settings after all plugins have loaded and on code reload
-    Dir[
-      Rails.root.join('app', 'models', 'setting.rb'),
-      Rails.root.join('app', 'models', 'setting', '*.rb'),
-      *Foreman::Plugin.registered_plugins.map { |_n, p| p.engine&.root&.join('app', 'models', 'setting', '*.rb') }.compact
-    ].each do |f|
-      require_dependency(f)
-    end
-    Foreman.settings.load unless Foreman.in_setup_db_rake?
-  end
+  Foreman.settings.load if (Setting.table_exists? rescue(false)) && !Foreman.in_setup_db_rake?
 
   Foreman.input_types_registry.register(InputType::UserInput)
   Foreman.input_types_registry.register(InputType::FactInput)


### PR DESCRIPTION
Main gitst is that only Setting subclasses that implement `default_settings` are allowed, just deprecated.
Older classes (that no plugins I've seen use anymore) that created setting directly to database will no longer work.
Given this initialization is very simplified, I've moved it into `load_defaults` method and deprecated it at the same time.
This will stop the creation of the settings in database that previously happened in this method.
Tho `SettingRegistry#load` still create these database records to still keep the backward compatibility.

We no longer require the Setting classes manually.
If the plugins want to continue using the old way,
plugins need to require the Setting classes manually.