### PR TITLE
Refs #34360 - allow host deleting with host_reports plugin (CP 3.2)

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -655,12 +655,17 @@ class HostsController < ApplicationController
   end
 
   def statuses
+    host_statuses = @host.host_statuses
+    # Do not show legacy configuration report when Host Report is installed.
+    if Foreman::Plugin.installed?('foreman_host_reports')
+      host_statuses = host_statuses.where("type != 'HostStatus::ConfigurationStatus'")
+    end
     statuses = {
       global: @host.global_status,
       captions: HostStatus.status_registry.map do |status_class|
         status_class.status_name
       end,
-      statuses: @host.host_statuses.map do |status|
+      statuses: host_statuses.map do |status|
         {
           id: status.id,
           name: status.name,

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -29,11 +29,7 @@ class Host::Managed < Host::Base
   has_many :all_reports, :foreign_key => :host_id
 
   belongs_to :image
-  if Foreman::Plugin.installed?('foreman_host_reports')
-    has_many :host_statuses, -> { where("host_status.type != 'HostStatus::ConfigurationStatus' and host_status.type is not null") }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :delete_all
-  else
-    has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
-  end
+  has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
   has_one :configuration_status_object, :class_name => 'HostStatus::ConfigurationStatus', :foreign_key => 'host_id'
   has_one :build_status_object, :class_name => 'HostStatus::BuildStatus', :foreign_key => 'host_id'
   before_destroy :remove_reports

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -93,6 +93,8 @@ module HostStatus
     end
 
     def relevant?(options = {})
+      # Do not calculate global status from legacy configuration when plugin is present.
+      return false if Foreman::Plugin.installed?('foreman_host_reports')
       handle_options(options)
 
       host.configuration? || last_report.present? || Setting[:always_show_configuration_status]

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -213,9 +213,9 @@ namespace :seed do
       Foreman::Logging.logger('permissions').level = Logger::ERROR
       Foreman::Logging.logger('audit').level = Logger::ERROR
       origin = ENV['origin'] || 'Puppet'
-      hosts = ENV['hosts'] || 10
-      reports = ENV['reports'] || 50
-      lines = ENV['lines'] || 100
+      hosts = (ENV['hosts'] || 10).to_i
+      reports = (ENV['reports'] || 50).to_i
+      lines = (ENV['lines'] || 100).to_i
       total_time = 0
       (1..reports).each do |i|
         host_id = i % hosts


### PR DESCRIPTION
Signed-off-by: Lukas Zapletal <lzap+git@redhat.com>
(cherry picked from commit c56db5d63bc6d147d15051baead436fa3ecf4722)

This is a blocker for Host Reports plugin - hosts cannot be deleted without this patch.

Apologies for the Refs commit message, it should have its own issue, we moved the issue back to New so we can keep any eye on it.