### PR TITLE
Remove duplicate puma gem declaration

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,3 +1,1 @@
-group :service do
-  gem 'puma', '~> 5.1'
-end
+gem 'puma', '~> 5.1', groups: [:test, :service], require: false

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -6,7 +6,6 @@ group :test do
   gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 6.0'
   gem 'capybara', '~> 3.33', :require => false
-  gem 'puma', '~> 5.1', :require => false
   gem 'show_me_the_cookies', '~> 5.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false
   gem 'launchy', '~> 2.4'


### PR DESCRIPTION
This duplication doesn't show up in production, but in development and testing it does. By declaring it in service.rb for both groups it will still be included in both production setups and testing.

According to 36d17b1743569158e1a68d323e7222fa04168c0f puma is needed in testing to run Capybara tests.