### PR TITLE
Fixes #34646 - move initialization into initializer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -304,26 +304,6 @@ module Foreman
         end
         child.helper helpers
       end
-
-      Facets.register(HostFacets::ReportedDataFacet, :reported_data) do
-        api_view({ :list => 'api/v2/hosts/reported_data' })
-        set_dependent_action :destroy
-        template_compatibility_properties :cores, :virtual, :sockets, :ram, :uptime_seconds
-      end
-      Facets.register(HostFacets::InfrastructureFacet, :infrastructure_facet) do
-        api_view({ :list => 'api/v2/hosts/infrastructure_facet' })
-        set_dependent_action :destroy
-      end
-
-      Facets.register(ForemanRegister::RegistrationFacet, :registration_facet) do
-        set_dependent_action :destroy
-      end
-
-      Plugin.all.each do |plugin|
-        plugin.to_prepare_callbacks.each(&:call)
-      end
-
-      Plugin.graphql_types_registry.realise_extensions unless Foreman.in_setup_db_rake?
     end
 
     # Use the database for sessions instead of the cookie-based default

--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -59,6 +59,26 @@ Rails.application.config.to_prepare do
     Foreman.settings.load unless Foreman.in_setup_db_rake?
   end
 
+  Facets.register(HostFacets::ReportedDataFacet, :reported_data) do
+    api_view({ :list => 'api/v2/hosts/reported_data' })
+    set_dependent_action :destroy
+    template_compatibility_properties :cores, :virtual, :sockets, :ram, :uptime_seconds
+  end
+  Facets.register(HostFacets::InfrastructureFacet, :infrastructure_facet) do
+    api_view({ :list => 'api/v2/hosts/infrastructure_facet' })
+    set_dependent_action :destroy
+  end
+
+  Facets.register(ForemanRegister::RegistrationFacet, :registration_facet) do
+    set_dependent_action :destroy
+  end
+
+  Foreman::Plugin.all.each do |plugin|
+    plugin.to_prepare_callbacks.each(&:call)
+  end
+
+  Foreman::Plugin.graphql_types_registry.realise_extensions unless Foreman.in_setup_db_rake?
+
   Foreman.input_types_registry.register(InputType::UserInput)
   Foreman.input_types_registry.register(InputType::FactInput)
   Foreman.input_types_registry.register(InputType::VariableInput)


### PR DESCRIPTION
Tidies up application.rb by moving initialization steps into initializer.
This also makes sure that Facets are not the first subclass inheriting from ApplicationRecord.
Facets being first derails Rails initialization.
