### PR TITLE
Fix #34658 - Harmonize preseed templates

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -14,38 +14,10 @@ description: |
 -%>
 #
 # This file was deployed via '<%= template_name %>' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-# lang = en_US
-#   System locale
-#
+
 <%
   os_major = @host.operatingsystem.major.to_i
   os_name  = @host.operatingsystem.name
-
-  options = []
-  if host_param('blacklist')
-    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
-  end
-  if os_name == 'Debian'
-    options << "auto=true"
-    options << "domain=#{@host.domain}"
-  else
-    options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
-  end
-  options << "locale=#{host_param('lang') || 'en_US'}"
-  
-  # send PXELinux "IPAPPEND 2" option along
-  options.push("BOOTIF=01-$net_default_mac")
-  if host_param('pxe_kernel_options')
-    options << host_param('pxe_kernel_options')
-  end
-
-  options = options.join(' ')
 
   if (os_name == 'Ubuntu' && os_major > 12) || (os_name == 'Debian' && os_major > 8)
     efi_suffix = 'efi'
@@ -57,7 +29,7 @@ set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= options %>
+  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac <%= snippet("preseed_kernel_options").strip %>
   initrd<%= efi_suffix %> <%= @initrd %>
 }
 

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -14,39 +14,11 @@ description: |
 -%>
 #
 # This file was deployed via '<%= template_name %>' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-# lang = en_US
-#   System locale
-#
-<%
-  options = []
-  if host_param('blacklist')
-    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
-  end
-  if @host.operatingsystem.name == 'Debian'
-    options << "auto=true"
-    options << "domain=#{@host.domain}"
-  else
-    options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
-  end
-  if @host.provision_interface.vlanid.present?
-    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
-  end
-  options << "locale=#{host_param('lang') || 'en_US'}"
-  if host_param('pxe_kernel_options')
-    options << host_param('pxe_kernel_options')
-  end
-  options = options.join(' ')
--%>
+
 DEFAULT linux
 LABEL linux
     KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=<%= @host.name %> <%= options %>
+    APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options").strip %>
     IPAPPEND 2
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -14,21 +14,19 @@ description: |
   The output is deployed on the host's subnet TFTP proxy.
   See https://ipxe.org/scripting for more details
 -%>
-<% if @host.operatingsystem.name == 'Debian' -%>
-  <%- keyboard_params = "auto=true" -%>
-<% else -%>
-  <%- keyboard_params = 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us' -%>
-<% end -%>
+<%
+  iface = @host.provision_interface
+  subnet4 = iface.subnet
+  subnet6 = iface.subnet6
 
-<% subnet = @host.subnet -%>
-<% if subnet.nil? || subnet.dhcp_boot_mode? -%>
-  <%- provision_url_suffix = '' -%>
-  <%- netcfg_args = '' -%>
-<% else -%>
-  <%- provision_url_suffix = (@host.token.nil? ? '?' : '&') + 'static=yes' -%>
-  <%- netcfg_args = 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true' -%>
-<% end -%>
-
+  if subnet4 && !subnet4.dhcp_boot_mode?
+    url = foreman_url('provision', static: '1')
+  elsif subnet6 && !subnet6.dhcp_boot_mode?
+    url = foreman_url('provision', static6: '1')
+  else
+    url = foreman_url('provision')
+  end
+-%>
 echo Trying to ping Gateway: ${netX/gateway}
 ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
 echo Trying to ping DNS: ${netX/dns}
@@ -38,7 +36,10 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= foreman_url('provision')%><%= provision_url_suffix %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} hostname=<%= @host.name %> domain=<%= @host.domain %> <%= keyboard_params %> <%= pxe_kernel_options %> locale=<%= host_param('lang') || 'en_US' %> <%= netcfg_args %>
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} <%= snippet("preseed_kernel_options").strip %>
+
 initrd <%= initrd %>
 
+imgstat
+sleep 2
 boot

--- a/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options.erb
@@ -1,0 +1,51 @@
+<%#
+kind: snippet
+name: preseed_kernel_options
+model: ProvisioningTemplate
+snippet: true
+description: options for the kernel / preseed startup initialization
+-%>
+<%
+  is_debian = @host.operatingsystem.name == 'Debian'
+  hostname = @host.name
+  domain = @host.domain
+  iface = @host.provision_interface
+  subnet4 = iface.subnet
+  subnet6 = iface.subnet6
+  options = []
+
+  if host_param('blacklist')
+    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  end
+
+  if is_debian
+    options << "auto=true"
+  else
+    options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
+  end
+
+  if @host.provision_interface.vlanid.present?
+    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
+  end
+  options << "locale=#{host_param('lang') || 'en_US'}"
+
+  if subnet4 && subnet4.dhcp_boot_mode?
+    options << 'netcfg/disable_dhcp=false'
+  elsif subnet4 && !subnet4.dhcp_boot_mode?
+    options << 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true'
+  elsif subnet6 && subnet6.dhcp_boot_mode?
+    options << 'netcfg/disable_dhcp=false'
+  elsif subnet6 && !subnet6.dhcp_boot_mode?
+    options << 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true'
+  end
+
+  if host_param('pxe_kernel_options')
+    options << host_param('pxe_kernel_options')
+  end
+
+  options << "locale=#{host_param('lang') || 'en_US'}"
+  options << "hostname=#{hostname}"
+  options << "domain=#{domain}"
+%>
+<%# do not add newline after the next line %>
+<%= options.join(' ') -%>

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -48,7 +48,6 @@ files:
   - finish/xenserver_default_finish.erb
   - provision/xenserver_default_answerfile.erb
   - PXELinux/xenserver_default_pxelinux.erb
-  - iPXE/ipxe_intermediate_script.erb
   - snippet/ansible_tower_callback_script.erb
   - snippet/ansible_tower_callback_service.erb
   - snippet/chef_client.erb
@@ -71,3 +70,9 @@ files:
   - snippet/saltstack_setup.erb
   - PXELinux/preseed_default_pxelinux_autoinstall.erb
   - user_data/preseed_autoinstall_cloud_init.erb
+  - iPXE/autoyast_default_ipxe.erb
+  - iPXE/ipxe_default_local_boot.erb
+  - iPXE/ipxe_global_default.erb
+  - iPXE/ipxe_intermediate_script.erb
+  - iPXE/kickstart_default_ipxe.erb
+  - iPXE/preseed_default_ipxe.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
@@ -1,19 +1,11 @@
 #
 # This file was deployed via 'Preseed default PXEGrub2' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-# lang = en_US
-#   System locale
-#
+
 set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US BOOTIF=01-$net_default_mac
+  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac auto=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
   initrdefi boot/debian-mirror-RpV7E2zxrKHe-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -1,19 +1,11 @@
 #
 # This file was deployed via 'Preseed default PXEGrub2' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-# lang = en_US
-#   System locale
-#
+
 set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US BOOTIF=01-$net_default_mac
+  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
   initrdefi boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
@@ -1,18 +1,10 @@
 #
 # This file was deployed via 'Preseed default PXELinux' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-# lang = en_US
-#   System locale
-#
+
 DEFAULT linux
 LABEL linux
     KERNEL boot/debian-mirror-RpV7E2zxrKHe-linux
-    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-deb10 auto=true domain=snap.example.com locale=en_US
+    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto auto=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
@@ -1,18 +1,10 @@
 #
 # This file was deployed via 'Preseed default PXELinux' template
-#
-# Supported host/hostgroup parameters:
-#
-# blacklist = module1, module2
-#   Blacklisted kernel modules
-#
-# lang = en_US
-#   System locale
-#
+
 DEFAULT linux
 LABEL linux
     KERNEL boot/ubuntu-mirror-dBfjc2q1x3NM-linux
-    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto hostname=snapshot-ipv4-dhcp-ubuntu18 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US
+    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/AutoYaST_default_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/AutoYaST_default_iPXE.host4dhcp.snap.txt
@@ -1,0 +1,10 @@
+#!gpxe
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img splash=silent install=http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.example.com/unattended/provision text-mode=1 useDHCP=1 
+initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
@@ -1,0 +1,12 @@
+#!gpxe
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4dhcp.snap.txt
@@ -1,0 +1,12 @@
+#!gpxe
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4static.snap.txt
@@ -1,0 +1,12 @@
+#!gpxe
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision?static=1  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv4-static-el7:eth0:none nameserver=${dns} fips=1
+initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
@@ -1,0 +1,12 @@
+#!gpxe
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
@@ -1,0 +1,12 @@
+#!gpxe
+
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision?static=1  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv6-static-el7:eth0:none nameserver=${dns} fips=1
+initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.debian4dhcp.snap.txt
@@ -1,0 +1,14 @@
+#!gpxe
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+
+kernel http://ftp.debian.org/debian/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} auto=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
+
+initrd http://ftp.debian.org/debian/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz
+
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.ubuntu4dhcp.snap.txt
@@ -1,0 +1,14 @@
+#!gpxe
+echo Trying to ping Gateway: ${netX/gateway}
+ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
+echo Trying to ping DNS: ${netX/dns}
+ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
+
+
+kernel http://archive.ubuntu.com/ubuntu/dists/focal/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
+
+initrd http://archive.ubuntu.com/ubuntu/dists/focal/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz
+
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE_default_local_boot.host4dhcp.snap.txt
@@ -1,0 +1,4 @@
+#!ipxe
+
+# Skips booting from network and continues booting from next device
+exit 1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/iPXE_global_default.host4dhcp.snap.txt
@@ -1,0 +1,57 @@
+#!ipxe
+
+echo Opening global default menu in 15 seconds...
+sleep 15
+
+set menu-default local
+set menu-timeout 5000
+set port 8448
+
+:start
+menu iPXE global boot menu
+item --key l local     Local boot (next entry)
+item shell             Drop into iPXE shell
+item reboot            Reboot system
+item
+item --key d discovery Discovery from ${next-server}:8000 (httpboot module)
+item discovery_custom Discovery from ${next-server}:${port} (httpboot module)
+choose --timeout ${menu-timeout} --default ${menu-default} selected || goto cancel
+set menu-timeout 0
+goto ${selected}
+
+:cancel
+echo Menu canceled, dropping to shell
+
+:shell
+echo Use the command 'exit' to return to menu
+shell
+set menu-timeout 0
+goto start
+
+:failed
+echo Boot failed, dropping to shell
+goto shell
+
+:reboot
+reboot
+
+:local
+exit 1
+
+:discovery
+dhcp
+kernel http://${next-server}:8000/httpboot/boot/fdi-image/vmlinuz0 initrd=initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset nokaslr proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-${net0/mac}
+initrd http://${next-server}:8000/httpboot/boot/fdi-image/initrd0.img
+imgstat
+sleep 2
+boot || goto failed
+goto start
+
+:discovery_custom
+dhcp
+kernel http://${next-server}:${port}/httpboot/boot/fdi-image/vmlinuz0 initrd=initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset nokaslr proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-${net0/mac}
+initrd http://${next-server}:${port}/httpboot/boot/fdi-image/initrd0.img
+imgstat
+sleep 2
+boot || goto failed
+goto start


### PR DESCRIPTION
Use preseed kernel options and use it in preseed templates
Added iPXE snapshots
Updated snapshots

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
