### PR TITLE
Fixes #34661 - Registration migration with nil template

### DIFF
--- a/db/migrate/20210115124508_template_kind_registration.rb
+++ b/db/migrate/20210115124508_template_kind_registration.rb
@@ -23,15 +23,16 @@ class TemplateKindRegistration < ActiveRecord::Migration[6.0]
     # and change registration association to the host_init_config
     template = ProvisioningTemplate.unscoped.find_by_name(Setting[:default_host_init_config_template])
     Operatingsystem.all.each do |os|
-      template.operatingsystems << os unless template.operatingsystems.include?(os)
+      template.operatingsystems << os if template && !template.operatingsystems.include?(os)
 
       os_default_registration = OsDefaultTemplate.find_by(template_kind: registration_kind, operatingsystem: os)
-      if os_default_registration
-        os_default_registration.update(template_kind_id: host_init_config_kind.id)
-      else
-        OsDefaultTemplate.create template_kind: host_init_config_kind,
+
+      os_default_registration&.update(template_kind_id: host_init_config_kind.id)
+
+      if template && !os_default_registration
+        OsDefaultTemplate.create(template_kind: host_init_config_kind,
                                  provisioning_template: template,
-                                 operatingsystem: os
+                                 operatingsystem: os)
       end
     end
   end


### PR DESCRIPTION
Fix for the issue in registration migration,
when template might not exist while migrating the db.

See https://github.com/theforeman/foreman/pull/8256#discussion_r824099694

(cherry picked from commit 73101ef97e7fbb1b34a04b00e2a2d005b97e27d7)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
