### PR TITLE
Fixes #34643 - Do not use Apipie cache

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -18,7 +18,7 @@ module Api
 
       def_param_group :search_and_pagination do
         param :search, String, :desc => N_("filter results")
-        param :order, String, :desc => N_("Sort and order by a searchable field, e.g. '&lt;field&gt; DESC'")
+        param :order, String, :desc => N_("Sort and order by a searchable field, e.g. '<field> DESC'")
         param_group :pagination, ::Api::V2::BaseController
       end
 

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -39,7 +39,9 @@ Apipie.configure do |config|
   config.ignored = []
   config.ignored_by_recorder = %w[]
   config.doc_base_url = "/apidoc"
-  config.use_cache = Rails.env.production? || File.directory?(config.cache_dir)
+  # By default we disabled the cache, but if you need to speed the testing up, you can switch it to `true`.
+  # To speed up the generation of the cache, please use FOREMAN_APIPIE_LANGS=en bundle exec rake apipie:cache
+  config.use_cache = false
   # config.languages = [] # turn off localized API docs and CLI, useful for development
   config.languages = ENV['FOREMAN_APIPIE_LANGS'].try(:split, ' ') || FastGettext.available_locales
   config.default_locale = FastGettext.default_locale
@@ -47,8 +49,7 @@ Apipie.configure do |config|
 
   config.validate = false
   config.force_dsl = true
-  config.reload_controllers = Rails.env.development?
-  config.markup = Apipie::Markup::Markdown.new if Rails.env.development? && defined? Maruku
+  config.reload_controllers = false
   config.default_version = "v2"
   config.update_checksum = true
   config.checksum_path = ['/api/', '/apidoc/']
@@ -99,8 +100,6 @@ elsif Apipie.configuration.use_cache
   else
     warn "Apipie cache enabled but not present yet. Run apipie:cache rake task to speed up API calls."
   end
-else
-  warn "The Apipie cache is turned off. Enable it and run apipie:cache rake task to speed up API calls."
 end
 
 # special type of validator: we say that it's not specified


### PR DESCRIPTION
This makes a change in production away from using an Apipie cache,
and instead relying on HTML docs and JSON being generated on demand.
Testing has found that they are roughly equivalent in load times,
and solve a larger issue where the docs can present incorrect
information when cached. There are places inside the code where
docs are generated conditionally based on runtime configuration
that can lead to incorrect docs. By switching to on-demand, the Apipie
documentation can accurately reflect the state of the running machine
and the development and production environments get closer in alignment.

See [RFC](https://community.theforeman.org/t/generation-of-cached-api-doc-and-dynamic-content-types/26587) for detailed discussion.

This should be safe to merge and follow up with changes to packaging and the installer. Setting this to false simply means any already generated docs will get ignored. I can then follow up with packaging and installer changes to greatly speed up both of those areas across Foreman and plugins.

I did consider making this a configurable value at runtime, such as allowing for a environment variable. However, given that it would mean users now have to generate and manage the cache themselves, potentially leading to inconsistencies within their environment and with bug reports, I opted to make this a hard change across the board.