### PR TITLE
Fixes #34690 - rake printing auditable attributes

### DIFF
--- a/lib/tasks/audits.rake
+++ b/lib/tasks/audits.rake
@@ -31,6 +31,28 @@ namespace :audits do
     puts "Successfully anonymized #{count} audits!"
   end
 
+  task :list_attributes => :environment do
+    Foreman::Application.eager_load!
+
+    # Only direct subclasses of ApplicationRecord, so we do not get all the STI like GroupParameter
+    # Host is a different case as always, we want all the STI classes there.
+    Host::Base.subclasses.concat(ApplicationRecord.subclasses).each do |ar|
+      next unless ar.respond_to?(:non_audited_columns)
+      docs = ApipieDSL.get_class_description(ar)&.docs || {}
+      props_docs = docs[:properties] || []
+
+      puts "=== #{docs[:name] || ar.name}"
+      puts '|==='
+      puts "| Attribute | Description\n\n"
+
+      (ar.column_names - ar.non_audited_columns).each do |col|
+        col_docs = props_docs.detect { |doc| doc[:name] == col.sub(/_id$/, '') } || {}
+        puts "| #{col.humanize} | #{col_docs[:short_description].to_s.sub('|', '_')}"
+      end
+      puts "|===\n\n"
+    end
+  end
+
   def get_audits_without_templates
     User.as_anonymous_admin do
       Audited::Audit.up_until(before_date).where.not(auditable_type: %w(ReportTemplate Ptable ProvisioningTemplate JobTemplate))


### PR DESCRIPTION
Add a rake task that prints out all auditable attributes available in the APP.

Excerpt output:
```
=== Host Managed
|===
| Attribute | Description

| Name | Host FQDN, e.g. my-host.example.com
| Root pass | Returns host's encrypted password hash
| Architecture | Returns architecture assigned to the host or nil if no architecture is assigned (unmanaged host)
| Operatingsystem | alias of os property
| Ptable | Returns a partition table object assigned to the host, returns nil if none is found
| Medium | Returns installation medium associated with the host
| Build | 
| Comment | Returns comment/description of this host
| Disk | 
| Installed at | 
| Model | Returns a hardware model object of the host
| Hostgroup | Returns a host group object the host is assigned to, nil if no host group is assigned
| Owner | Returns host's owner
| Owner type | Returns host owner's type
| Enabled | 
| Puppet ca proxy | 
| Managed | 
| Use image | Returns whether provisioning is image based
| Image file | 
| Uuid | 
| Compute resource | Returns a compute resource object the host exists in, nil if no compute resource is assigned (e.g. baremetal host)
| Puppet proxy | 
| Certname | Returns a name used in puppet certificate, this is usually either equal to FQDN or random UUID if `use_uuid_for_certificates` setting is enabled
| Image | 
| Organization | Returns an organization object of the host, returns nil if is assigned
| Location | Returns a location object of the host, returns nil if is assigned
| Otp | One time password obtained from IPA, used for realm enrollment during provisioning
| Realm | Returns a realm object assigned to the host primary interface, returns nil if none is found
| Compute profile | 
| Provision method | Returns a provisioning method used for this host, one of "build", "image". Plugins can add additional methods.
| Grub pass | 
| Pxe loader | Returns name of PXE loader, e.g. PXELinux BIOS
| Initiated at | 
| Build errors | 
| Discovery rule | 
| Openscap proxy | 
|===

=== Setting
|===
| Attribute | Description

| Value | 
| Default | 
|===
```