### PR TITLE
Refs #34495 - Katello erros from Breadcrumb switcher

### DIFF
--- a/app/services/breadcrumbs_options.rb
+++ b/app/services/breadcrumbs_options.rb
@@ -54,14 +54,12 @@ class BreadcrumbsOptions
   end
 
   def switcher_url_template
-    actual_action_name = (action_name == 'show') ? '' : action_name
     if respond_to?(resource_name + '_path')
       resource_path = try(resource_name + '_path', :id => ':id')
     else
       resource_path = "/#{controller_path}/:id"
     end
-
-    "#{resource_path}/#{actual_action_name}"
+    (action_name == 'show') ? resource_path : "#{resource_path}/#{action_name}"
   end
 
   def model_name_field

--- a/test/unit/breadcrumbs_options_test.rb
+++ b/test/unit/breadcrumbs_options_test.rb
@@ -45,7 +45,7 @@ class BreadcrumbsOptionsTest < ActiveSupport::TestCase
       ],
       resource:
       {
-        switcherItemUrl: "/strings/:id/",
+        switcherItemUrl: "/strings/:id",
         resourceUrl: "/api/v2/strings",
         nameField: "name",
         resourceFilter: "",

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/BreadcrumbBarActions.js
@@ -35,7 +35,11 @@ export const loadSwitcherResourcesByResource = (
   resource,
   { page = 1, searchQuery = '', perPage = 10 } = {}
 ) => async dispatch => {
-  const { resourceUrl, nameField, switcherItemUrl } = resource;
+  const { resourceUrl, nameField } = resource;
+  let { switcherItemUrl } = resource;
+  if (switcherItemUrl.endsWith('/')) {
+    switcherItemUrl = switcherItemUrl.slice(0, -1);
+  }
   const options = { page, searchQuery, perPage };
   const beforeRequest = () =>
     dispatch({


### PR DESCRIPTION
We can fix it in Katello instead but that would require finding where else this is broken :upside_down_face: 
Katellos angular part did match the id because the url had a `/` in the end.
https://github.com/Katello/katello/blob/d39e8b0d951004a00174dcc637e693b1a01f7e65/engines/bastion_katello/app/assets/javascripts/bastion_katello/pulp-primary/pulp-primary.controller.js#L18
`var urlMatcher = $urlMatcherFactory.compile("/smart_proxies/:capsuleId")`