### PR TITLE
Fixes #34700 - autoinstall template enable root user

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -24,23 +24,33 @@ autoinstall:
       - arches: [default]
         uri: http://ports.ubuntu.com/ubuntu-ports
 <%= indent(4) { snippet_if_exists(template_name + " custom apt") } -%>
-  identity:
-    hostname: <%= @host.name %>
-    realname: <%= realname_to_create %>
-    username: <%= username_to_create %>
-    password: "<%= password_to_create %>"
+  user-data:
+    disable_root: false
+    fqdn: <%= @host.name %>
+    users:
+    - name: <%= username_to_create %>
+      gecos: <%= realname_to_create %>
+      lock-passwd: false
+      hashed_passwd: <%= password_to_create %>
+<% if !host_param('remote_execution_ssh_keys').blank? -%>
+<%   if host_param('remote_execution_ssh_keys').is_a?(String) -%>
+      ssh_authorized_keys: [<%= host_param('remote_execution_ssh_keys') %>]
+<%   else -%>
+      ssh_authorized_keys: <%= host_param('remote_execution_ssh_keys') %>
+<%   end -%>
+<% else -%>
+      ssh_authorized_keys: []
+<% end -%>
   keyboard: {layout: us, toggle: null, variant: ''}
   locale: en_US.UTF-8
 <%= snippet 'preseed_netplan_setup' -%>
   ssh:
     allow-pw: true
-    authorized-keys: []
     install-server: true
   updates: security
 <%= indent(2) { @host.diskLayout } -%>
 <%= indent(2) { snippet_if_exists(template_name + " custom root") } -%>
-  user-data:
-    runcmd:
-      - wget -Y off <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /tmp/finish.sh
-      - chmod +x /tmp/finish.sh
-      - /tmp/finish.sh
+  late-commands:
+  - wget -Y off <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /target/tmp/finish.sh
+  - curtin in-target -- chmod +x /tmp/finish.sh
+  - curtin in-target -- /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -9,25 +9,27 @@ autoinstall:
         uri: http://archive.ubuntu.com/ubuntu
       - arches: [default]
         uri: http://ports.ubuntu.com/ubuntu-ports
-  identity:
-    hostname: snapshot-ipv4-dhcp-ubuntu20
-    realname: root
-    username: root
-    password: "$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0"
+  user-data:
+    disable_root: false
+    fqdn: snapshot-ipv4-dhcp-ubuntu20
+    users:
+    - name: root
+      gecos: root
+      lock-passwd: false
+      hashed_passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
+      ssh_authorized_keys: []
   keyboard: {layout: us, toggle: null, variant: ''}
   locale: en_US.UTF-8
   network:
     version: 2
   ssh:
     allow-pw: true
-    authorized-keys: []
     install-server: true
   updates: security
   storage:
     layout:
       name: lvm
-  user-data:
-    runcmd:
-      - wget -Y off http://foreman.example.com/unattended/finish -O /tmp/finish.sh
-      - chmod +x /tmp/finish.sh
-      - /tmp/finish.sh
+  late-commands:
+  - wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh
+  - curtin in-target -- chmod +x /tmp/finish.sh
+  - curtin in-target -- /tmp/finish.sh


### PR DESCRIPTION
During provisioning of Ubuntu 20.04.3 > hosts, the new Ubuntu Autoinstall mechanism is used. Therefore, new templates have been created.

The `identitiy` field of the user-data template doesn't allow to add/edit the `root` user. Accordingly, one cannot use password authentication for a newly provisioned Ubuntu hosts when using `root`.
Therefore, the user-data field must be used. Compare the [Ubuntu Autoinstall documentation](https://ubuntu.com/server/docs/install/autoinstall-reference#identity) and the [cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/topics/modules.html#users-and-groups)

* Switch finish template to late-commands
* Replace identitiy with user-data


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
