### PR TITLE
Fixes #34710 - Use foreman request address

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -9,6 +9,7 @@ module Foreman
         :snippet_if_exists,
         :indent,
         :foreman_server_fqdn, :foreman_server_url,
+        :foreman_request_addr,
         :log_debug, :log_info, :log_warn, :log_error, :log_fatal,
         :template_name,
         :dns_lookup,

--- a/app/views/unattended/provisioning_templates/iPXE/windows_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/windows_default_ipxe.erb
@@ -16,7 +16,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-set boot-url tftp://${next-server}/
+set boot-url tftp://<%= foreman_request_addr %>/
 kernel ${boot-url}<%= @host.operatingsystem.bootfile(medium_provider,:kernel) %>
 
 initrd <%= foreman_url('script') %> peSetup.cmd

--- a/test/unit/foreman_url_renderer_test.rb
+++ b/test/unit/foreman_url_renderer_test.rb
@@ -74,5 +74,17 @@ class ForemanUrlRendererTest < ActiveSupport::TestCase
       assert_equal "#{template_server_from_proxy}/unattended/#{action}?token=#{token}", renderer.foreman_url(action)
       assert_requested(:get, "https://template.proxy:8443/unattended/templateServer", times: 1)
     end
+
+    test "should render foreman request addr" do
+      Setting[:unattended_url] = 'http://www.example.com'
+      renderer.host = host
+      assert_equal "www.example.com", renderer.foreman_request_addr
+    end
+
+    test "should render template_url for foreman request addr" do
+      renderer.host = host
+      renderer.template_url = "http://www.example.com"
+      assert_equal "www.example.com", renderer.foreman_request_addr
+    end
   end
 end


### PR DESCRIPTION
1. Next-server in windows iPXE default template does only work in dhcp environments but not with static IPs
2. A method which only returns the request address (fqdn + port) of foreman or the related smart proxy is often useful