### PR TITLE
Fixes #34702 - use warning instead of halt for SCSI issues

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -27,23 +27,21 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Print warning and poweroff' --id local_chain_hd0 {
-  echo "This system was expected to boot from drive but it booted from network. While"
-  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
-  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
-  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
-  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
-  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
-  echo
-  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
-  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
-  echo
-  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
-  sleep -i 120
-  halt
-}
+echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
+echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
+echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
+echo "grub2_chainload template."
+echo
+echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
+echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
+echo "latest grub2 (*) and add "--efidisk-only" argument to the "search" command in"
+echo "the grub2_chainload template."
+echo
+echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
+echo
+#connectefi scsi
 
-menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
+menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
 <%
@@ -51,6 +49,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
 -%>
   echo "Trying <%= path %> "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot <%= path %>
   if [ -f ($chroot)<%= path %> ]; then
     chainloader ($chroot)<%= path %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -6,27 +6,26 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Print warning and poweroff' --id local_chain_hd0 {
-  echo "This system was expected to boot from drive but it booted from network. While"
-  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
-  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
-  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
-  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
-  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
-  echo
-  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
-  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
-  echo
-  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
-  sleep -i 120
-  halt
-}
+echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
+echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
+echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
+echo "grub2_chainload template."
+echo
+echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
+echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
+echo "latest grub2 (*) and add "--efidisk-only" argument to the "search" command in"
+echo "the grub2_chainload template."
+echo
+echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
+echo
+#connectefi scsi
 
-menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
+menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/fedora/shim.efi
   if [ -f ($chroot)/EFI/fedora/shim.efi ]; then
     chainloader ($chroot)/EFI/fedora/shim.efi
@@ -36,6 +35,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/fedora/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/fedora/grubx64.efi
   if [ -f ($chroot)/EFI/fedora/grubx64.efi ]; then
     chainloader ($chroot)/EFI/fedora/grubx64.efi
@@ -45,6 +45,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/redhat/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/redhat/shim.efi
   if [ -f ($chroot)/EFI/redhat/shim.efi ]; then
     chainloader ($chroot)/EFI/redhat/shim.efi
@@ -54,6 +55,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/redhat/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/redhat/grubx64.efi
   if [ -f ($chroot)/EFI/redhat/grubx64.efi ]; then
     chainloader ($chroot)/EFI/redhat/grubx64.efi
@@ -63,6 +65,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/centos/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/centos/shim.efi
   if [ -f ($chroot)/EFI/centos/shim.efi ]; then
     chainloader ($chroot)/EFI/centos/shim.efi
@@ -72,6 +75,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/centos/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/centos/grubx64.efi
   if [ -f ($chroot)/EFI/centos/grubx64.efi ]; then
     chainloader ($chroot)/EFI/centos/grubx64.efi
@@ -81,6 +85,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/debian/grubx64.efi
   if [ -f ($chroot)/EFI/debian/grubx64.efi ]; then
     chainloader ($chroot)/EFI/debian/grubx64.efi
@@ -90,6 +95,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/ubuntu/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/ubuntu/grubx64.efi
   if [ -f ($chroot)/EFI/ubuntu/grubx64.efi ]; then
     chainloader ($chroot)/EFI/ubuntu/grubx64.efi
@@ -99,6 +105,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/sles/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/sles/grubx64.efi
   if [ -f ($chroot)/EFI/sles/grubx64.efi ]; then
     chainloader ($chroot)/EFI/sles/grubx64.efi
@@ -108,6 +115,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/opensuse/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/opensuse/grubx64.efi
   if [ -f ($chroot)/EFI/opensuse/grubx64.efi ]; then
     chainloader ($chroot)/EFI/opensuse/grubx64.efi
@@ -117,6 +125,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/Microsoft/boot/bootmgfw.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/Microsoft/boot/bootmgfw.efi
   if [ -f ($chroot)/EFI/Microsoft/boot/bootmgfw.efi ]; then
     chainloader ($chroot)/EFI/Microsoft/boot/bootmgfw.efi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -22,27 +22,26 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Print warning and poweroff' --id local_chain_hd0 {
-  echo "This system was expected to boot from drive but it booted from network. While"
-  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
-  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
-  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
-  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
-  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
-  echo
-  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
-  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
-  echo
-  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
-  sleep -i 120
-  halt
-}
+echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
+echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
+echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
+echo "grub2_chainload template."
+echo
+echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
+echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
+echo "latest grub2 (*) and add "--efidisk-only" argument to the "search" command in"
+echo "the grub2_chainload template."
+echo
+echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
+echo
+#connectefi scsi
 
-menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
+menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/fedora/shim.efi
   if [ -f ($chroot)/EFI/fedora/shim.efi ]; then
     chainloader ($chroot)/EFI/fedora/shim.efi
@@ -52,6 +51,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/fedora/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/fedora/grubx64.efi
   if [ -f ($chroot)/EFI/fedora/grubx64.efi ]; then
     chainloader ($chroot)/EFI/fedora/grubx64.efi
@@ -61,6 +61,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/redhat/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/redhat/shim.efi
   if [ -f ($chroot)/EFI/redhat/shim.efi ]; then
     chainloader ($chroot)/EFI/redhat/shim.efi
@@ -70,6 +71,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/redhat/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/redhat/grubx64.efi
   if [ -f ($chroot)/EFI/redhat/grubx64.efi ]; then
     chainloader ($chroot)/EFI/redhat/grubx64.efi
@@ -79,6 +81,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/centos/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/centos/shim.efi
   if [ -f ($chroot)/EFI/centos/shim.efi ]; then
     chainloader ($chroot)/EFI/centos/shim.efi
@@ -88,6 +91,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/centos/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/centos/grubx64.efi
   if [ -f ($chroot)/EFI/centos/grubx64.efi ]; then
     chainloader ($chroot)/EFI/centos/grubx64.efi
@@ -97,6 +101,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/debian/grubx64.efi
   if [ -f ($chroot)/EFI/debian/grubx64.efi ]; then
     chainloader ($chroot)/EFI/debian/grubx64.efi
@@ -106,6 +111,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/ubuntu/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/ubuntu/grubx64.efi
   if [ -f ($chroot)/EFI/ubuntu/grubx64.efi ]; then
     chainloader ($chroot)/EFI/ubuntu/grubx64.efi
@@ -115,6 +121,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/sles/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/sles/grubx64.efi
   if [ -f ($chroot)/EFI/sles/grubx64.efi ]; then
     chainloader ($chroot)/EFI/sles/grubx64.efi
@@ -124,6 +131,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/opensuse/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/opensuse/grubx64.efi
   if [ -f ($chroot)/EFI/opensuse/grubx64.efi ]; then
     chainloader ($chroot)/EFI/opensuse/grubx64.efi
@@ -133,6 +141,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/Microsoft/boot/bootmgfw.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/Microsoft/boot/bootmgfw.efi
   if [ -f ($chroot)/EFI/Microsoft/boot/bootmgfw.efi ]; then
     chainloader ($chroot)/EFI/Microsoft/boot/bootmgfw.efi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -2,27 +2,26 @@ insmod part_gpt
 insmod fat
 insmod chain
 
-menuentry 'Print warning and poweroff' --id local_chain_hd0 {
-  echo "This system was expected to boot from drive but it booted from network. While"
-  echo "this workflow works in BIOS, it is not suitable for EFI systems where chainbooting"
-  echo "is not reliable. Change the boot order to boot from drive. Some platforms are known"
-  echo "to set EFI boot order incorrectly, in that case change EFI configuration or use"
-  echo "efibootmgr to ensure the correct boot order. There are provisioning template snippets"
-  echo "available to do this automatically during provisioning (e.g. in kistart or preseed)."
-  echo
-  echo "To perform chainboot anyway, use the next boot menu item. To set it as default,"
-  echo "change the 'Default PXE local template entry' to 'force_local_chain_hd0'."
-  echo
-  echo "The system will poweroff in 2 minutes or press ESC to poweroff immediately."
-  sleep -i 120
-  halt
-}
+echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
+echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
+echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
+echo "grub2_chainload template."
+echo
+echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
+echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
+echo "latest grub2 (*) and add "--efidisk-only" argument to the "search" command in"
+echo "the grub2_chainload template."
+echo
+echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
+echo
+#connectefi scsi
 
-menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
+menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls
   echo "Trying /EFI/fedora/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/fedora/shim.efi
   if [ -f ($chroot)/EFI/fedora/shim.efi ]; then
     chainloader ($chroot)/EFI/fedora/shim.efi
@@ -32,6 +31,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/fedora/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/fedora/grubx64.efi
   if [ -f ($chroot)/EFI/fedora/grubx64.efi ]; then
     chainloader ($chroot)/EFI/fedora/grubx64.efi
@@ -41,6 +41,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/redhat/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/redhat/shim.efi
   if [ -f ($chroot)/EFI/redhat/shim.efi ]; then
     chainloader ($chroot)/EFI/redhat/shim.efi
@@ -50,6 +51,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/redhat/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/redhat/grubx64.efi
   if [ -f ($chroot)/EFI/redhat/grubx64.efi ]; then
     chainloader ($chroot)/EFI/redhat/grubx64.efi
@@ -59,6 +61,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/centos/shim.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/centos/shim.efi
   if [ -f ($chroot)/EFI/centos/shim.efi ]; then
     chainloader ($chroot)/EFI/centos/shim.efi
@@ -68,6 +71,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/centos/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/centos/grubx64.efi
   if [ -f ($chroot)/EFI/centos/grubx64.efi ]; then
     chainloader ($chroot)/EFI/centos/grubx64.efi
@@ -77,6 +81,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/debian/grubx64.efi
   if [ -f ($chroot)/EFI/debian/grubx64.efi ]; then
     chainloader ($chroot)/EFI/debian/grubx64.efi
@@ -86,6 +91,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/ubuntu/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/ubuntu/grubx64.efi
   if [ -f ($chroot)/EFI/ubuntu/grubx64.efi ]; then
     chainloader ($chroot)/EFI/ubuntu/grubx64.efi
@@ -95,6 +101,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/sles/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/sles/grubx64.efi
   if [ -f ($chroot)/EFI/sles/grubx64.efi ]; then
     chainloader ($chroot)/EFI/sles/grubx64.efi
@@ -104,6 +111,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/opensuse/grubx64.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/opensuse/grubx64.efi
   if [ -f ($chroot)/EFI/opensuse/grubx64.efi ]; then
     chainloader ($chroot)/EFI/opensuse/grubx64.efi
@@ -113,6 +121,7 @@ menuentry 'Chainload Grub2 EFI from ESP' --id force_local_chain_hd0 {
   fi
   echo "Trying /EFI/Microsoft/boot/bootmgfw.efi "
   unset chroot
+  # add --efidisk-only when using Software RAID
   search --file --no-floppy --set=chroot /EFI/Microsoft/boot/bootmgfw.efi
   if [ -f ($chroot)/EFI/Microsoft/boot/bootmgfw.efi ]; then
     chainloader ($chroot)/EFI/Microsoft/boot/bootmgfw.efi


### PR DESCRIPTION
This is a heads-up related to 2 Grub2 BZs:

* BZ #2032294
* BZ #2048904

When network booting a system, there is grub.cfg file used to chainload to local disk upon system installation.
The template needs to be updated to make sure software raid systems and/or VMWare systems can chainload successfully.

The solution consists in:

* calling a new "connectefi scsi" command prior to searching for local disk boot loader (e.g. "search --file ... /EFI/BOOT/BOOTX64.EFI")
* modifying "search --file" commmand to restrict to EFI disks ("search --file --efidisk-only ... /EFI/BOOT/BOOTX64.EFI")

Fore more information see:

https://bugzilla.redhat.com/show_bug.cgi?id=2058037

This patch removes the default meny entry which was added few weeks ago because I could not figure out why VMWare suddently stopped working. Kudos to Renaud for the patches, the heads-up and assisting with this change as well! Thank you.