### PR TITLE
fixes #34735 - Set defaults for Katello Tools (Red Hat Tools) install in redhat_register.erb

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -89,15 +89,24 @@ description: |
       subscription_manager_atomic_url = subscription_manager_configuration_url(@host, false)
       subscription_manager_org = @host.rhsm_organization_label
       activation_key = host_param('kt_activation_keys')
-      redhat_install_host_tools = host_param_true?('redhat_install_host_tools', true)
-      redhat_install_host_tracer_tools = host_param_true?('redhat_install_host_tracer_tools')
+      
     else
       subscription_manager_certpkg_url = host_param('subscription_manager_certpkg_url')
       subscription_manager_atomic_url = host_param('subscription_manager_atomic_url')
       subscription_manager_org = host_param('subscription_manager_org')
       activation_key = host_param('activation_key')
+    end
+    # use redhat_install_host_tools host param or default to true (was not sure if this could be a ternary)
+    if host_param('redhat_install_host_tools')
       redhat_install_host_tools = host_param_true?('redhat_install_host_tools')
+    else
+      redhat_install_host_tools = true
+    end
+    # use redhat_install_host_tracer_tools host param or default to false
+    if host_param('redhat_install_host_tracer_tools')
       redhat_install_host_tracer_tools = host_param_true?('redhat_install_host_tracer_tools')
+    else
+      redhat_install_host_tracer_tools = false
     end
   %>
 


### PR DESCRIPTION
Currently the tools are only installed if host parameter kt_activation_keys is set. Add check to see if the host parameter for redhat_install_host_tools (bool) is set use that if not default to true. If redhat_install_host_tracer_tools is set use that, else default to false.