### PR TITLE
Fixes #34745 - Error on API actions if no key is passed

### DIFF
--- a/webpack/assets/javascripts/react_app/redux/API/APIMiddleware.js
+++ b/webpack/assets/javascripts/react_app/redux/API/APIMiddleware.js
@@ -3,6 +3,11 @@ import { isAPIAction } from './APIHelpers';
 
 export const APIMiddleware = store => next => action => {
   if (isAPIAction(action)) {
+    if (!action?.payload?.key) {
+      throw new Error(
+        `API action ${action?.type} was dispatched without a key. API action payloads must have a key. Did you confuse default and named exports?`
+      );
+    }
     apiRequest(action, store);
   }
   return next(action);

--- a/webpack/assets/javascripts/react_app/redux/API/__tests__/APIMiddleware.test.js
+++ b/webpack/assets/javascripts/react_app/redux/API/__tests__/APIMiddleware.test.js
@@ -12,7 +12,7 @@ describe('APIMiddleware', () => {
 
   it('should call apiRequest when action type is relevant', async () => {
     apiRequest.mockImplementation(jest.fn());
-    APIMiddleware()(jest.fn())({ type: API_OPERATIONS.GET });
+    APIMiddleware()(jest.fn())({ type: API_OPERATIONS.GET, payload: { key: 'TEST_KEY' } });
     expect(apiRequest).toBeCalled();
   });
 
@@ -20,7 +20,7 @@ describe('APIMiddleware', () => {
     const fakeStore = {};
     const fakeNext = jest.fn();
 
-    const action = { type: API_OPERATIONS.GET };
+    const action = { type: API_OPERATIONS.GET, payload: { key: 'TEST_KEY' } };
     APIMiddleware(fakeStore)(fakeNext)(action);
     expect(fakeNext).toHaveBeenCalledWith(action);
   });


### PR DESCRIPTION
When API middleware receives an action payload with no `key`, it results in dispatching actions such as `undefined_REQUEST` and `undefined_SUCCESS`. This can cause lots of developer frustration (developer = me) because the API request goes through, but doesn't update the Redux store for status, response, etc.

Turned out I was mixing up named and default exports, e.g. `import { MY_KEY } from '../file_path` when it should instead be `import MY_KEY from '../file_path`.  This PR adds the error message that would have saved me an hour or two.