### PR TITLE
Fixes #34748 - Taxonomies api to accept per_page all

### DIFF
--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -45,7 +45,10 @@ module Api::V2::TaxonomiesController
                      else
                        taxonomy_class
                      end
-    @taxonomies = taxonomy_scope.send("my_#{taxonomies_plural}").search_for(*search_options).paginate(paginate_options)
+    @taxonomies = taxonomy_scope.send("my_#{taxonomies_plural}").search_for(*search_options)
+    if (paginate_options[:per_page] != 'all')
+      @taxonomies = @taxonomies.paginate(paginate_options)
+    end
     @total = taxonomy_scope.send("my_#{taxonomies_plural}").count
     instance_variable_set("@#{taxonomies_plural}", @taxonomies)
 


### PR DESCRIPTION
locations and organizations show 0 results when sending per_page=all
`api/organizations?per_page=all`
`api/locations?per_page=all`

