### PR TITLE
Fixes #34515, #34516 - Add host owner and comment on host list page

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -85,6 +85,14 @@ module HostsHelper
     opts
   end
 
+  def host_owner_column(host)
+    if host.owner_type == 'User'
+      icon_text('user', host.owner, :kind => 'fa')
+    elsif host.owner_type == 'Usergroup'
+      icon_text('users', host.owner, :kind => 'fa')
+    end
+  end
+
   # method that reformat the hostname column by adding the status icons
   def name_column(host)
     style = host_global_status_icon_class_for_host(host)

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -10,6 +10,7 @@
       <th width="25%"><%= sort :name, :as => _('Name') %></th>
       <th class="hidden-xs" width="17%"><%= sort :os_title, :as => _("Operating system") %></th>
       <th class="hidden-tablet hidden-xs" width="10%"><%= sort :model, :as => _('Model') %></th>
+      <th class="hidden-tablet hidden-xs" width="8%"><%= sort :owner, :as => _('Owner') %></th>
       <th class="hidden-tablet hidden-xs" width="15%"><%= sort :hostgroup, :as => _("Host group") %></th>
       <th class="hidden-tablet hidden-xs" width="10%"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
       <%= render_pagelets_for(:hosts_table_column_header) %>
@@ -31,6 +32,7 @@
         </td>
         <td class="hidden-xs ellipsis"><%= (icon(host.operatingsystem, :size => "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= host.compute_resource_or_model %></td>
+        <td class="hidden-tablet hidden-xs ellipsis"><%= host_owner_column(host) %></td>
         <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 23, @hostgroup_authorizer %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= last_report_column(host) %></td>
         <%= render_pagelets_for(:hosts_table_column_content, :subject => host) %>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -14,6 +14,7 @@
       <th class="hidden-tablet hidden-xs" width="15%"><%= sort :hostgroup, :as => _("Host group") %></th>
       <th class="hidden-tablet hidden-xs" width="10%"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
       <%= render_pagelets_for(:hosts_table_column_header) %>
+      <th class="hidden-tablet hidden-xs" width="7%"><%= sort :comment, :as => _('Comment') %></th>
       <th width="100px"><%= _('Actions') %></th>
     </tr>
   </thead>
@@ -36,6 +37,7 @@
         <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 23, @hostgroup_authorizer %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= last_report_column(host) %></td>
         <%= render_pagelets_for(:hosts_table_column_content, :subject => host) %>
+        <td class="hidden-tablet hidden-xs ca" title="<%= host.comment&.truncate(255) %>"><%= icon_text('comment', '') unless host.comment.empty? %></td>
         <td>
           <%= action_buttons(
                       display_link_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),


### PR DESCRIPTION
Add two columns in host list page - owner of the host and host comment