### PR TITLE
Fixes #34755 - Fix text/icon alignment on host status card

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
@@ -89,8 +89,13 @@ const AggregateStatusCard = ({
       <Card className="card-pf-aggregate-status" isHoverable>
         <CardTitle>
           <span>
-            {__('Host Status')}
-            {!isOKState && <StatusIcon statusNumber={global} />}
+            <span style={{ marginRight: '0.5rem' }}>{__('Host Status')}</span>
+            {!isOKState && (
+              <StatusIcon
+                statusNumber={global}
+                style={{ position: 'relative', top: '2px' }}
+              />
+            )}
           </span>
         </CardTitle>
         <CardBody style={{ height: '129px' }}>
@@ -100,7 +105,7 @@ const AggregateStatusCard = ({
             responseStatus={responseStatus}
           >
             <Bullseye>
-              <p className="card-pf-aggregate-status-notifications">
+              <span className="card-pf-aggregate-status-notifications">
                 {SUPPORTED_STATUSES.map(({ label, status }) => (
                   <AggregateStatusItem
                     key={`status-${label}`}
@@ -111,7 +116,7 @@ const AggregateStatusCard = ({
                     amount={statusesMapper(status).length}
                   />
                 ))}
-              </p>
+              </span>
             </Bullseye>
           </GlobalState>
         </CardBody>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusItem.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusItem.js
@@ -16,9 +16,13 @@ const StatusItem = ({ status, amount, responseStatus, label, onClick }) => (
       >
         <SkeletonLoader skeletonProps={{ width: 30 }} status={responseStatus}>
           {status !== undefined && (
-            <span>
-              <StatusIcon statusNumber={status} /> {amount}
-            </span>
+            <>
+              <StatusIcon
+                statusNumber={status}
+                style={{ marginRight: '3px', position: 'relative', top: '4px' }}
+              />
+              <span style={{ marginRight: '0.5rem' }}>{amount}</span>
+            </>
           )}
         </SkeletonLoader>
       </a>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusIcon.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusIcon.js
@@ -14,30 +14,30 @@ import {
   WARNING_STATUS_STATE,
 } from './Constants';
 
-const StatusIcon = ({ statusNumber, label }) => {
+const StatusIcon = ({ statusNumber, label, style }) => {
   switch (statusNumber) {
     case OK_STATUS_STATE:
       return (
-        <span className="status-success">
+        <span className="status-success" style={style}>
           <CheckCircleIcon noVerticalAlign /> {label}
         </span>
       );
     case WARNING_STATUS_STATE:
       return (
-        <span className="status-warning">
+        <span className="status-warning" style={style}>
           <ExclamationTriangleIcon noVerticalAlign /> {label}
         </span>
       );
 
     case ERROR_STATUS_STATE:
       return (
-        <span className="status-error">
+        <span className="status-error" style={style}>
           <ExclamationCircleIcon noVerticalAlign /> {label}
         </span>
       );
     case NA_STATUS_STATE:
       return (
-        <span className="disabled">
+        <span className="disabled" style={style}>
           <BanIcon noVerticalAlign /> {label}
         </span>
       );
@@ -49,11 +49,13 @@ const StatusIcon = ({ statusNumber, label }) => {
 StatusIcon.propTypes = {
   label: PropTypes.string,
   statusNumber: PropTypes.number,
+  style: PropTypes.shape({}),
 };
 
 StatusIcon.defaultProps = {
   label: '',
   statusNumber: undefined,
+  style: undefined,
 };
 
 export default StatusIcon;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/styles.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/styles.scss
@@ -1,5 +1,11 @@
-.card-pf-aggregate-status-notifications .aggregate-text {
+.card-pf-aggregate-status-notifications a.aggregate-text {
   font-size: 16px;
+  &:hover {
+    text-decoration: none;
+    span:last-child {
+      text-decoration: underline;
+    }
+  }
 }
 
 .disabled {


### PR DESCRIPTION
This is an attempt to improve the alignment and spacing of the text and icons on the AggregateStatusCard.

Before:
![host_status_bad_alignment](https://user-images.githubusercontent.com/22042343/162473571-8c3caa00-abe2-40d3-8af8-094d8d379b47.png)

After:
![host_status_new_alignment](https://user-images.githubusercontent.com/22042343/162473590-0c364369-74cb-4fcb-bbd6-18f1e5fb8202.png)

let me know your thoughts