### PR TITLE
Support of almalinux8 config file style

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -181,8 +181,9 @@ description: |
     for subman_config_file in /etc/yum/pluginconf.d/subscription-manager.conf /etc/dnf/plugins/subscription-manager.conf; do
       if [ -f $subman_config_file ]; then
         egrep -q "^disable_system_repos=" $subman_config_file
+        egrep -q "^disable_system_repos\s?=" $subman_config_file
         if [ "$?" -eq 0 ]; then
-          sed s/^disable_system_repos=.*/disable_system_repos=1/ $subman_config_file >"${subman_config_file}.new"
+          sed s/^disable_system_repos\s?=.*/disable_system_repos=1/ $subman_config_file >"${subman_config_file}.new"
           mv -f "${subman_config_file}.new" $subman_config_file
         else
           echo "disable_system_repos=1" >>$subman_config_file


### PR DESCRIPTION
In Almalinux the configuraiton file uses whitespaces to separate the configuration

Exaple config file: 

[root@test]$ cat /etc/dnf/plugins/subscription-manager.conf 
[main]
enabled = 1
disable_system_repos = 0


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
