### PR TITLE
Fixes #34798 - New host detail page sentence case fixes

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -128,7 +128,7 @@ class HostJSTest < IntegrationTestWithJavascript
     test "manage host statuses modal" do
       visit host_details_page_path(@host)
       find('a', :text => /Manage all statuses/).click
-      find('h1', :text => /Manage Host's Statuses/)
+      find('h1', :text => /Manage host statuses/)
     end
 
     describe 'create and redirect' do

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
@@ -89,7 +89,7 @@ const AggregateStatusCard = ({
       <Card className="card-pf-aggregate-status" isHoverable>
         <CardTitle>
           <span>
-            <span style={{ marginRight: '0.5rem' }}>{__('Host Status')}</span>
+            <span style={{ marginRight: '0.5rem' }}>{__('Host status')}</span>
             {!isOKState && (
               <StatusIcon
                 statusNumber={global}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalState.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalState.js
@@ -18,7 +18,7 @@ const GlobalState = ({
         <Title size="lg" headingLevel="h4">
           {cannotViewStatuses
             ? __('No statuses to show')
-            : __('All Statuses are OK')}
+            : __('All statuses are OK')}
         </Title>
       </EmptyState>
     );

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusTable.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusTable.js
@@ -15,9 +15,9 @@ const StatusTable = ({ hostName, statuses, canForgetStatuses }) => {
     const statusName = rowData[0]?.title?.props?.children || rowData[0];
     dispatch(
       openConfirmModal({
-        title: __("Clear Host's Status"),
+        title: __('Clear host status'),
         message: sprintf(
-          __('You are about to clear %s status. Are you sure?'),
+          __('You are about to clear the %s status. Are you sure?'),
           statusName
         ),
         isWarning: true,
@@ -30,7 +30,7 @@ const StatusTable = ({ hostName, statuses, canForgetStatuses }) => {
       })
     );
   };
-  const columns = [__('Name'), __('Status'), __('Reported At')];
+  const columns = [__('Name'), __('Status'), __('Reported at')];
   const rows = statuses?.map(
     ({ name, label, link, global, reported_at: reportedAt }) => [
       link ? { title: <a href={link}>{name}</a> } : name,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusesModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusesModal.js
@@ -19,7 +19,7 @@ const StatusModal = ({
         headingLevel="h1"
         size={TitleSizes['2xl']}
       >
-        {__("Manage Host's Statuses")}
+        {__('Manage host statuses')}
       </Title>
     </>
   );


### PR DESCRIPTION
Fixes Overview tab - Host detail page - incorrect use of sentence case.

Correct card names
“Host status”

Manage all statuses - modal (from status card)
Column header: “Reported at”
Header: “Manage host statuses”

Status card - empty state
"All statuses are OK"
