### PR TITLE
Fixes #34802 - Pin tabbable version

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -30,7 +30,8 @@
         "surge",
         "webpack-bundle-analyzer",
         "webpack-dev-server",
-        "webpack-dev-server-without-h2"
+        "webpack-dev-server-without-h2",
+        "tabbable"
     ],
     "EXCLUDE_NPM_PREFIXES": [
         "@babel/eslint-",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "webpack": "^3.4.1",
     "webpack-bundle-analyzer": ">=3.3.2",
     "webpack-dev-server-without-h2": "^2.11.8",
-    "webpack-stats-plugin": "^0.1.5"
+    "webpack-stats-plugin": "^0.1.5",
+    "tabbable": "~5.2.0"
   }
 }


### PR DESCRIPTION
We are getting some test failures in katello related to FocusTrap on modals and wizards..setting disableFocusTrap on Modal component to false fixes the test failures for us..We are still getting the "[Error: Your focus-trap must have at least one container with at least one tabbable node in it at all times]" on wizards..and modals without passing disableFocusTrap as false..

From my debugging and googling, the latest version of Tabbable that is 5.3.0 (and onwards) needs some changes to the Modal/Wizard components in Patternfly4 to be able to support tests.

Specifically this: https://github.com/focus-trap/tabbable#testing-in-jsdom

Modal currently has the prop disableFocusTrap that can be set to false and that lets us work around the issue without ever activating the trap. I spoke to folks on PF4 slack and they lock the version of FocusTrap but Focustrap brings in the latest 5.x.x tabbable causing the test failures.

There's an open PF4 issue around this: https://github.com/patternfly/patternfly-react/issues/7288