### PR TITLE
[CP 3.2] Fixes #34747 - override_param should consider direction

### DIFF
--- a/app/assets/javascripts/parameter_override.js
+++ b/app/assets/javascripts/parameter_override.js
@@ -7,12 +7,15 @@ function override_param(item) {
   var param_value = param.find('[id^=value_]');
   var v = param_value.val();
 
-  $('#parameters')
-    .find('.btn-primary')
-    .click();
-  var new_param = $('#parameters')
-    .find('.fields')
-    .last();
+  var addParameterButton = $('#parameters').find('.btn-primary');
+  addParameterButton.click();
+  var directionOfAddedItems = addParameterButton.attr('direction');
+  var new_param = $('#parameters').find('.fields');
+  if(directionOfAddedItems === 'append'){
+    new_param = new_param.last();
+  } else {
+    new_param = new_param.first();
+  }
   new_param.find('[id$=_name]').val(n);
   new_param.find('[id$=_parameter_type]').val(parameter_type_val);
   new_param


### PR DESCRIPTION
after #8667 (RM32013) improved the UX with the ability to prepend items,
the `override_param` function should have been also updated
to consider the direction of the added items.

(cherry picked from commit 99d67b1745b17815edd2822b2584b475bb708bac)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
