### PR TITLE
Fixes #34830 - Construct hostname for redirect each time

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -172,11 +172,9 @@ function submit_with_all_params() {
     success: function(response, _responseStatus, _jqXHR) {
       // workaround for redirecting to the new host details page
       if (!response.includes('id="main"')) {
-        var is_new_host = $('form').attr('id').startsWith('new');
-        var hostname = is_new_host ? construct_host_name() : $('#hidden-host-name').text() 
-        return tfm.nav.pushUrl(tfm.tools.foremanUrl('/new/hosts/' + hostname));
+        return tfm.nav.pushUrl(tfm.tools.foremanUrl('/new/hosts/' + construct_host_name()));
       }
-   
+
       $('#host-progress').hide();
       $('#content').replaceWith($('#content', response));
       $(document.body).trigger('ContentLoad');

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -391,7 +391,9 @@ $(document).on('change', '.virtual', function() {
 function construct_host_name() {
   var host_name_el = $('#host_name')
   var host_name = host_name_el.val();
-  if (host_name_el.data('appendDomainNameForHosts') === false) {
+  if (host_name_el.data('appendDomainNameForHosts') === false ||
+      host_name_el.data('managed') === false
+  ) {
     return host_name;
   }
   var domain_name = primary_nic_form()

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -32,7 +32,10 @@
         <%= text_f f, :name, :size => "col-md-4", :value => name_field(@host),
             :input_group_btn => randomize_mac_link,
             :help_inline => _("This value is used also as the host's primary interface name."),
-            :data => { 'append_domain_name_for_hosts' => Setting[:append_domain_name_for_hosts] } %>
+            :data => { 'append_domain_name_for_hosts' => Setting[:append_domain_name_for_hosts],
+              'managed' => @host.managed?
+            }
+        %>
 
         <% if show_organization_tab?  %>
           <%= host_taxonomy_select(f, Organization) %>

--- a/app/views/hosts/edit.html.erb
+++ b/app/views/hosts/edit.html.erb
@@ -10,6 +10,4 @@
                                {:class => 'btn btn-default', :method => :put}) if @host.compute?)
    )
 %>
-<%# The next hidden div is a workaround for host redirect after a submit %>
-<div class='hidden' id='hidden-host-name'><%= @host.name %></div>
 <%= render :partial => 'hosts/form' %>


### PR DESCRIPTION
https://github.com/theforeman/foreman/pull/9140 didn't solve the issue fully. This fix doesn't save the previous hostname for redirection after submit/cancel for host edit action, but builds it on the fly instead. Previous fix would fail if one changes host's name or it's domain.

UPD: This also needs to be cherry-picked into 3.2 and 3.1.