### PR TITLE
Fixes #34838 - Add errors when setting values are invalid

### DIFF
--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -53,6 +53,8 @@ module Api
         end
         @setting = Foreman.settings.set_user_value(@setting.name, value)
         process_response @setting.save
+      rescue Foreman::SettingValueException => e
+        render_error :custom_error, :locals => { :message => e.message }, :status => :unprocessable_entity
       end
 
       def resource_scope(_options = {})

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -90,7 +90,7 @@ class SettingRegistry
     when db_record.settings_type
       db_record.value = value
     else
-      raise ::Foreman::Exception.new(N_('expected a value of type %s'), @setting.settings_type)
+      raise ::Foreman::SettingValueException.new(N_('expected a value of type %s'), @setting.settings_type)
     end
     db_record
   end

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -97,6 +97,9 @@ module Foreman
   class PermissionMissingException < Foreman::Exception
   end
 
+  class SettingValueException < Foreman::Exception
+  end
+
   class LdapException < Foreman::WrappedException
   end
 

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -23,7 +23,7 @@ class SettingTest < ActiveSupport::TestCase
   end
 
   test 'should not strip setting value when parsing if we do not want to' do
-    setting = Setting.create(:name => 'not_stripped_test', :value => 'whatever', :setting_type => 'string')
+    setting = Setting.create(:name => 'not_stripped_test', :default => '', :description => 'not_stripped_test', :value => 'whatever', :setting_type => 'string')
     trailing_space_val = 'Local '
     setting.parse_string_value(trailing_space_val)
     assert_equal setting.value, trailing_space_val
@@ -423,8 +423,9 @@ class SettingTest < ActiveSupport::TestCase
 
   def check_parsed_value_failure(settings_type, string_value)
     setting = Setting.new(:name => "foo", :default => "default", :settings_type => settings_type)
-    setting.parse_string_value(string_value)
-
+    assert_raises Foreman::SettingValueException do
+      setting.parse_string_value(string_value)
+    end
     assert_equal "default", setting.value
     assert setting.errors[:value].join(";").include?("is invalid")
   end

--- a/webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingForm/SettingForm.js
+++ b/webpack/assets/javascripts/react_app/components/SettingUpdateModal/components/SettingForm/SettingForm.js
@@ -25,9 +25,12 @@ const SettingForm = ({
       url: SETTING_UPDATE_PATH.replace(':id', setting.id),
       values: submitValues,
       item: 'Settings',
-      message: __('Setting was successfully updated.'),
+      message: __('Setting updated.'),
       method: 'put',
       successCallback: setModalClosed,
+      errorToast: error =>
+        `${__('Error updating setting')}: ${error.response?.data?.error
+          ?.message ?? error.message}`,
       actions,
     });
   };


### PR DESCRIPTION
In the `parse_string_value` method of `setting.rb` the values were being checked, but not actually set on the database object. This caused a 200 response when it should have been an error. The reason is because the value was never actually changed, so it was just saving the same data.

The bug was filed originally for the "Sync Connect Timeout" content setting, but I discovered that the same issue exists for all numeric settings when you try to set an invalid value.

This fixes it by adding a `SettingValueException` error class and explicitly raising it when `parse_string_value` has encountered errors.

To test, try to set any integer setting to a string or negative value.