### PR TITLE
Refs #34602 - clear updated_plugins marker file on boot

### DIFF
--- a/config/initializers/remove_restart_required_changed_plugins_marker.rb
+++ b/config/initializers/remove_restart_required_changed_plugins_marker.rb
@@ -1,0 +1,3 @@
+Rails.application.config.after_initialize do
+  FileUtils.rm_f("#{Rails.root}/tmp/restart_required_changed_plugins")
+end


### PR DESCRIPTION
The file indicates that new plugins were installed and we need to
restart Rails.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
