### PR TITLE
Fixes #34843 - load SSL key using OpenSSL::PKey.read

### DIFF
--- a/app/services/proxy_api/resource.rb
+++ b/app/services/proxy_api/resource.rb
@@ -137,7 +137,7 @@ module ProxyAPI
 
       {
         :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(File.read(cert)),
-        :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read(hostprivkey)),
+        :ssl_client_key   =>  OpenSSL::PKey.read(File.read(hostprivkey)),
         :ssl_ca_file      =>  ca_cert,
         :verify_ssl       =>  OpenSSL::SSL::VERIFY_PEER,
       }


### PR DESCRIPTION
This allows using non-RSA keys as PKey.read can figure out the type of key automatically


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
