### PR TITLE
Fixes #34857 - show error when using node 16+

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "license": "GPL-3.0",
   "description": "Foreman isn't really a node module, these are just dependencies needed to build the webpack bundle. 'dependencies' are the asset libraries in use and 'devDependencies' are used for the build process.",
   "private": true,
+  "engines": {
+    "node": "<16.0.0"
+  },
   "scripts": {
     "lint": "tfm-lint",
     "lint:spelling": "eslint ./webpack",


### PR DESCRIPTION
When running `npm i` this error will show up:
```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: TheForemanDevDeps@3.3.0
npm ERR! notsup Not compatible with your version of node/npm: TheForemanDevDeps@3.3.0
npm ERR! notsup Required: {"node":"<16.0.0"}
npm ERR! notsup Actual:   {"npm":"8.1.0","node":"v16.13.0"}
```

https://community.theforeman.org/t/which-node-versions-do-we-support/22778