### PR TITLE
Settings - Issues with search

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -3,5 +3,8 @@ class SettingsController < ApplicationController
 
   def index
     @settings = Foreman.settings.search_for(params[:search])
+  rescue ::Foreman::Exception => e
+    @settings = Foreman.settings
+    @search_error = e
   end
 end

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -63,7 +63,7 @@ class Setting < ApplicationRecord
   scope :order_by, ->(attr) { except(:order).order(attr) }
 
   scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
-  scoped_search on: :name, complete_value: :true, operators: ['=']
+  scoped_search on: :name, complete_value: :true, operators: ['=', '~']
   scoped_search on: :description, complete_value: :true, operators: ['~']
 
   def self.config_file

--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -3,6 +3,12 @@
 
 <%= react_component('SettingRecords', { settings: grouped_settings(@settings) }) %>
 
+<% if @search_error %>
+<%= alert(class: 'alert-danger',
+        header: _('Search error'),
+        text: @search_error) %>
+<% end %>
+
 <ul class="nav nav-tabs" data-tabs="tabs">
   <% @settings.categories.each do |category, label| %>
     <li class="<%= 'active' if category == @settings.categories.keys.first %>">

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -173,6 +173,18 @@ class SettingRegistryTest < ActiveSupport::TestCase
       assert_equal 'foo', result.first.name
     end
 
+    it 'can find setting by "name ~ value"' do
+      result = registry.search_for('name ~ c_set_t').to_a
+      assert_equal 1, result.size
+      assert_equal 'desc_set_test', result.first.name
+    end
+
+    it 'can find setting by "name ~ value" in full_name' do
+      result = registry.search_for('name ~ "c_set_t"').to_a
+      assert_equal 1, result.size
+      assert_equal 'desc_set_test', result.first.name
+    end
+
     it 'can find setting by description' do
       result = registry.search_for('test f').to_a
       assert_equal 1, result.size


### PR DESCRIPTION
* Allow ~ operator for `name` (and `full_name`)
* Fix issue with double quote in search
* Raise exception for unsupported operators :and / :or

**Note**
`:and` / `:or` still doesn't work, but that's going to be handled in [redmine#34864](https://projects.theforeman.org/issues/34864)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
