### PR TITLE
Fixes #34881 - Clean up MountingService

### DIFF
--- a/webpack/assets/javascripts/bundle.js
+++ b/webpack/assets/javascripts/bundle.js
@@ -13,7 +13,6 @@ import * as users from './foreman_users';
 import * as sshKeys from './foreman_ssh_keys';
 import * as httpProxies from './foreman_http_proxies';
 import * as toastNotifications from './foreman_toast_notifications';
-import * as reactMounter from './react_app/common/MountingService';
 import * as editor from './foreman_editor';
 import * as nav from './foreman_navigation';
 import * as medium from './foreman_medium';
@@ -26,6 +25,7 @@ import * as spice from './spice';
 import * as autocomplete from './foreman_autocomplete';
 import * as typeAheadSelect from './foreman_type_ahead_select';
 import * as lookupKeys from './foreman_lookup_keys';
+import './react_app/common/MountingService';
 import './foreman_overrides';
 import './bundle_novnc';
 
@@ -44,7 +44,6 @@ window.tfm = Object.assign(window.tfm || {}, {
   hosts,
   httpProxies,
   toastNotifications,
-  reactMounter,
   editor,
   nav,
   medium,

--- a/webpack/assets/javascripts/react_app/common/MountingService.js
+++ b/webpack/assets/javascripts/react_app/common/MountingService.js
@@ -4,20 +4,6 @@ import componentRegistry from '../components/componentRegistry';
 
 export { default as registerReducer } from '../redux/reducers/registerReducer';
 
-export function mount(component, selector, data, flattenData = false) {
-  const reactNode = document.querySelector(selector);
-  if (reactNode) {
-    ReactDOM.unmountComponentAtNode(reactNode);
-
-    mountNode(component, reactNode, data, flattenData);
-  } else {
-    // eslint-disable-next-line no-console
-    console.log(
-      `Cannot find '${selector}' element for mounting the '${component}'`
-    );
-  }
-}
-
 function mountNode(component, reactNode, data, flattenData) {
   ReactDOM.render(
     componentRegistry.markup(component, {
@@ -67,18 +53,6 @@ class ReactComponentElement extends HTMLElement {
 
   connectedCallback() {
     this._render();
-  }
-
-  disconnectedCallback() {
-    try {
-      ReactDOM.unmountComponentAtNode(this.mountPoint);
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(
-        `Unable to unmount foreman-react-component: ${this.componentName}`,
-        error
-      );
-    }
   }
 
   _render() {


### PR DESCRIPTION
`mount` is not used anymore, and the unmounting was a workaround for turbolinks and they are no longer used.
Relevent prs for context:
https://github.com/theforeman/foreman/pull/5083
https://github.com/theforeman/foreman/pull/7874

