### PR TITLE
Fixes #34887 - userdata controller should be able to look up host by MAC address

### DIFF
--- a/app/controllers/userdata_controller.rb
+++ b/app/controllers/userdata_controller.rb
@@ -55,6 +55,8 @@ class UserdataController < ApplicationController
       ip: request.remote_ip,
     }
 
+    query_params[:mac_list] = Foreman::UnattendedInstallation::MacListExtractor.new.extract_from_env(request.env, params: params)
+
     @host = Foreman::UnattendedInstallation::HostFinder.new(query_params: query_params).search
 
     return true if @host

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -463,8 +463,8 @@ Foreman::Application.routes.draw do
   # get for all unattended scripts
   get 'unattended/(:kind/(:id(:format)))', controller: 'unattended', action: 'host_template', format: 'text'
 
-  get 'userdata/meta-data', controller: 'userdata', action: 'metadata', format: 'text'
-  get 'userdata/user-data', controller: 'userdata', action: 'userdata', format: 'text'
+  get 'userdata/(:mac)/user-data', controller: 'userdata', action: 'userdata', format: 'text'
+  get 'userdata/(:mac)/meta-data', controller: 'userdata', action: 'metadata', format: 'text'
 
   resources :tasks, only: [:show]
 


### PR DESCRIPTION
This patch adds an optional route parameter "mac=_mac address_" to the userdata/(user|meta)-data URLs to be able to look up a host requesting cloud-init/subiquity-style provisioning template by MAC address. The MAC address is expected as optional URI path component, e.g. `http://<foreman-server>/userdata/52:54:00:9f:47:08/meta-data`. 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
