### PR TITLE
Fixes #34908 - Set hostname for Ubuntu Autoinstall

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -31,6 +31,9 @@ description: |
 /bin/sed -i "s/^search.*$/search <%= @host.domain %>/g" /etc/resolv.conf
 /bin/sed -i "s/.*dns-search.*/\tdns-search <%= @host.domain %>/g" /etc/network/interfaces
 /bin/sed -i "s/^<%= @host.ip %>.*/<%= @host.ip %>\t<%= @host.shortname %>.<%= @host.domain %>\t<%= @host.shortname %>/g" /etc/hosts
+<% end -%>
+
+<% unless !(@host.operatingsystem.name == "Ubuntu" && @host.operatingsystem.major.to_i > 20 || (@host.operatingsystem.major.to_i == 20 && @host.operatingsystem.minor.to_i >= 3)) || dhcp -%>
 /bin/echo <%= @host.shortname %> > /etc/hostname
 /bin/hostname  <%= @host.shortname %>.<%= @host.domain %>
 <% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -4,6 +4,7 @@
 
 
 
+
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -4,6 +4,7 @@
 
 
 
+
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 


### PR DESCRIPTION
When deploying a new host with Ubuntu Autoinstall (new provisioning mechanism for Ubuntu 20.04.3+ hosts), the provisioning template itself doesn't set the hostname sufficiently such that it's available during the execution of the finish template (which is triggered at the end of the provisioning template) - it is only fully available after a reboot. In order to provide a successful execution of the finish template (especially the `subscription-manager register` part), the hostname must be set beforehand. Therefore, two option could be considered:
* Execute `hostnamectl` in the provisioning template, before the finish template is triggered
* Execute `hostnamectl` as first action in the finish template itself

I would argue that the finish template should consist all commands necessary to setup the host and prefer the second option accordingly. This PR gives an example on how to implement it.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
