### PR TITLE
Fixes #34921 - Fix SettingValueException error message

### DIFF
--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -54,7 +54,7 @@ module Api
         @setting = Foreman.settings.set_user_value(@setting.name, value)
         process_response @setting.save
       rescue Foreman::SettingValueException => e
-        render_error :custom_error, :locals => { :message => e.message }, :status => :unprocessable_entity
+        render_error :custom_error, :locals => { :message => e.bare_message }, :status => :unprocessable_entity
       end
 
       def resource_scope(_options = {})

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -167,14 +167,14 @@ class Setting < ApplicationRecord
       self.value = NOT_STRIPPED.include?(name) ? val : val.to_s.strip
 
     when "hash"
-      raise Foreman::SettingValueException, N_("parsing hash from string is not supported")
+      raise Foreman::SettingValueException, N_("Parsing a hash from a string is not supported")
 
     else
-      raise Foreman::SettingValueException.new(N_("parsing settings type '%s' from string is not defined"), settings_type)
+      raise Foreman::SettingValueException.new(N_("Parsing settings type '%s' from a string is not defined"), settings_type)
 
     end
     if errors.present?
-      raise Foreman::SettingValueException.new(N_("error parsing value for setting '%s': %s"), name, errors.full_messages.join(", "))
+      raise Foreman::SettingValueException.new(N_("Error parsing value for setting '%s': %s"), name, errors.full_messages.join(", "))
     end
     true
   end

--- a/lib/foreman/exception.rb
+++ b/lib/foreman/exception.rb
@@ -22,15 +22,22 @@ module Foreman
       @message
     end
 
-    def message
+    def message_translated
       # make sure it works without gettext too
       if Kernel.respond_to? :_
-        translated_msg = _(@message) % @params
+        _(@message) % @params
       else
         # use plain ruby interpolation
-        translated_msg = @message % @params
+        @message % @params
       end
-      "#{code} [#{self.class.name}]: #{translated_msg}"
+    end
+
+    def message
+      "#{code} [#{self.class.name}]: #{message_translated}"
+    end
+
+    def bare_message
+      message_translated
     end
 
     def to_s


### PR DESCRIPTION
The error message returned for SettingValueExceptions was something like

`ERF07-1096 [Foreman::SettingValueException]: error parsing value for setting 'sync_connect_timeout_v2': Value is invalid: must be integer`

which gets displayed in the toast. Instead it should just be

`Error parsing value for setting 'sync_connect_timeout_v2': Value is invalid: must be integer`

Changes here:
* fix the above
* add a `bare_message` method to `Foreman::Exception` so it can be reused, without affecting translation
