### PR TITLE
Fixes #34941 - Reference smart proxy port for userdata

### DIFF
--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
@@ -34,6 +34,7 @@ test_on:
   end
   options << "locale=#{host_param('lang') || 'en_US'}"
   options = options.join(' ')
+  image_path = @preseed_path.sub(/\/?$/, '.iso')
 -%>
 #
 # WARNING
@@ -44,8 +45,8 @@ test_on:
 #
 DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
-    KERNEL ubuntu/focal/vmlinuz
-    INITRD ubuntu/focal/initrd
-    APPEND ip=dhcp url=http://<%= @preseed_server %><%= @preseed_path %> autoinstall ds=nocloud-net;s=http://<%= @preseed_server %>/pub/preseed/autoinstall/<%= @host.shortname %>/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
+    KERNEL <%= @kernel %>
+    INITRD <%= @initrd %>
+    APPEND ip=dhcp url=http://<%= @preseed_server %><%= image_path %> autoinstall ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -18,8 +18,8 @@
 #
 DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
-    KERNEL ubuntu/focal/vmlinuz
-    INITRD ubuntu/focal/initrd
-    APPEND ip=dhcp url=http://archive.ubuntu.com:80/ubuntu autoinstall ds=nocloud-net;s=http://archive.ubuntu.com:80/pub/preseed/autoinstall// root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
+    KERNEL boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz
+    INITRD boot/ubuntu-mirror-rf32u3HGTMZf-initrd
+    APPEND ip=dhcp url=http://archive.ubuntu.com:80/ubuntu.iso autoinstall ds=nocloud-net;s=http://foreman.example.com/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
 
 


### PR DESCRIPTION
When deploying an Ubuntu 22.04 host, the corresponding PXELinux template holds two addresses:

* `url` &rarr; the iso image url (`http://foreman.example.com:80/pub/path/to/image.iso`)
* `s` &rarr; the userdata interface url (`http://foreman.example.com:80/userdata/`)

In order to reference these addresses in the template, the `@preseed_server` variable is used which links to `http://foreman.example.com:80`. This works fine for direct Foreman-based deployments.

If we want to deploy from a Smart Proxy now, a problem arises with the userdata interface: The Smart Proxy itself does not provide the userdata interface directly, but it forwards the request to the Foreman. The port to forward this request is by default `smart.proxy.com:8000`. Unfortunately, the `@preseed_server` variable contains the port `:80` which is wrong in this scenario.

In order to reference the template server, which is supposed to be used here, we must use the correct port. A different variable than `@preseed_server` must be used which holds the corresponding Smart Proxy port (by default :8000). `foreman_url` can be used at this point.

Moreover, this PR introduces a default path to store the Ubuntu iso image: the media path with `.iso` attached. As a default procedure, I'd suggest putting the extracted iso and the iso itself in the pub directory like:
```
http://foreman.example.com/pub/installation_media/ubuntu/20.04-x86_64/<extracted iso files>
http://foreman.example.com/pub/installation_media/ubuntu/20.04-x86_64.iso
```
When using a Smart Proxy, the corresponding smart proxy address must be used and set up as an installation media.