### PR TITLE
Fixes #34718 - Ubuntu netplan use ens160 as default interface name

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -7,7 +7,7 @@ kind: snippet
 oses:
 - Ubuntu
 -%>
-    <%= @interface.identifier %>:
+    <%= @interface.identifier.blank? ? 'ens160' : @interface.identifier %>:
         dhcp4: <%= @dhcp %>
         dhcp6: <%= @dhcp6 %>
 <%- if !@dhcp && !@subnet.nil? && !@interface.ip.nil? -%>


### PR DESCRIPTION
The `preseed_netplan_generic_interface` snippet creates an invalid YAML if no network identifier is set explicitly.
Moreover, if the network identifier is different from "ens160", the corresponding netplan setup cannot be applied. The network identifier must fit the device name during installation.
Accordingly, a default network identifier is introduced here if the identifier is not set.

During a conversation on [discourse](https://community.theforeman.org/t/autoinstalling-ubuntu-server-20-04-3-from-the-live-iso/27050/27?u=bastian-src), an alternative approach has been suggested. Thereby, the `match` operator is used which identifies the interface by giving a MAC address (see [here](https://netplan.io/reference/#common-properties-for-physical-device-types)). AFAIK we cannot rely on having the host's MAC in every scenario beforehand. Therefore, I'd choose the default identifier. 

If one can verify, that the host MAC is always given during provisioning, I'd also favor the `match` approach.


REDMINE ISSUE: [#34718](https://projects.theforeman.org/issues/34718)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
