### PR TITLE
Fixes #34978: Do not use Apipie DSL cache

### DIFF
--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -5,7 +5,6 @@ ApipieDSL.configure do |config|
   config.app_name = 'Foreman'
   config.app_info = 'The Foreman is aimed to be a single address for all machines life cycle management.'
   config.doc_base_url = '/templates_doc'
-  config.markup = ApipieDSL::Markup::Markdown.new if Rails.env.development? && defined? Maruku
   config.dsl_classes_matchers = [
     "#{Rails.root}/app/models/**/*.rb",
     "#{Rails.root}/lib/foreman/renderer/**/*.rb",
@@ -14,7 +13,7 @@ ApipieDSL.configure do |config|
   # TODO enable?
   config.validate = false
 
-  config.use_cache = Rails.env.production? || File.directory?(config.cache_dir)
+  config.use_cache = false
   # config.languages = [] # turn off localized DSL docs, useful for development
   config.languages = ENV['FOREMAN_APIPIE_LANGS'].try(:split, ' ') || FastGettext.available_locales
   config.default_locale = FastGettext.default_locale

--- a/test/integration/apipie_test.rb
+++ b/test/integration/apipie_test.rb
@@ -1,0 +1,13 @@
+require 'integration_test_helper'
+
+class ApipieIntegrationTest < ActionDispatch::IntegrationTest
+  test "Apipie docs URL should be successful" do
+    get "/apidoc"
+    assert_equal 200, status
+  end
+
+  test "Apipie DSL docs URL should be successful" do
+    get "/templates_doc"
+    assert_equal 200, status
+  end
+end


### PR DESCRIPTION
This makes a change in production away from using an Apipie DSL cache,
and instead relying on HTML docs and JSON being generated on demand.
Testing has found that they are roughly equivalent in load times.
By switching to on-demand, the Apipie DSL documentation can accurately
reflect the state of the running machine and the development and
production environments get closer in alignment. Additionally, this
speeds up installations runs by shaving off around 2 minutes every time
the cache must be generated.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
