### PR TITLE
Fixes #34975 - Removed ks=. is supplied by kernel options snippet

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -21,26 +21,13 @@ test_on:
 - host4static
 - host6static
 -%>
-<%
-  iface = @host.provision_interface
-  subnet4 = iface.subnet
-  subnet6 = iface.subnet6
-
-  if subnet4 && !subnet4.dhcp_boot_mode?
-    ks = foreman_url('provision', static: '1')
-  elsif subnet6 && !subnet6.dhcp_boot_mode?
-    ks = foreman_url('provision', static6: '1')
-  else
-    ks = foreman_url('provision')
-  end
--%>
 
 echo Trying to ping Gateway: ${netX/gateway}
 ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= ks %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 imgstat
 sleep 2

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -34,9 +34,21 @@ description: |
   # tell Anaconda what to pass off to kickstart server
   # both current and legacy syntax provided
   if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
-    options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+    if subnet4 && !subnet4.dhcp_boot_mode?
+      options.push("inst.ks=#{foreman_url('provision', static: '1')}")
+    elsif subnet6 && !subnet6.dhcp_boot_mode?
+      options.push("inst.ks=#{foreman_url('provision', static6: '1')}")
+    else
+      options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+    end
   else
-    options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
+    if subnet4 && !subnet4.dhcp_boot_mode?
+      options.push("ks=#{foreman_url('provision', static: '1')}")
+    elsif subnet6 && !subnet6.dhcp_boot_mode?
+      options.push("ks=#{foreman_url('provision', static6: '1')}")
+    else
+      options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
+    end  
   end
 
   # networking credentials

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4static.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision?static=1  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv4-static-el7:eth0:none nameserver=${dns} fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv4-static-el7:eth0:none nameserver=${dns} fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision?static=1  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv6-static-el7:eth0:none nameserver=${dns} fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv6-static-el7:eth0:none nameserver=${dns} fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2


### PR DESCRIPTION
Fixes [#34975](https://projects.theforeman.org/issues/34975)

Issue encountered with Satellite 6.10.5.1 and RedHat Enterprise Linux 9.0.  RHEL9 does not begin installation as ks= kernel boot parameter is being passed instead of inst.ks=.

This bug is similar to the work done on https://projects.theforeman.org/issues/32486 the kickstart_default_ipxe template renders the following currently.

```
#!gpxe


echo Trying to ping Gateway: ${netX/gateway}
ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
echo Trying to ping DNS: ${netX/dns}
ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.

kernel http://satellite.fqdn/pulp/repos/Default_Organization/Library/Red_Hat_Enterprise_Linux_9_Kickstart/content/dist/rhel9/9.0/x86_64/baseos/kickstart//images/pxeboot/vmlinuz initrd=initrd.img ks=http://satellite.fqdn:8000/unattended/provision?token=d79a2f7d-cfdc-49cc-ac81-88f9761d572c  BOOTIF=01-00-50-56-ac-10-13 kssendmac ks.sendmac inst.ks.sendmac ip=dhcp
initrd http://satellite.fqdn/pulp/repos/Default_Organization/Library/Red_Hat_Enterprise_Linux_9_Kickstart/content/dist/rhel9/9.0/x86_64/baseos/kickstart//images/pxeboot/initrd.img
imgstat
sleep 2
boot
```

By removing `ks=<%= ks %>` the desired `inst.ks=` segment is rendered from the kickstart_kernel_options snippet.
```
#!gpxe


echo Trying to ping Gateway: ${netX/gateway}
ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
echo Trying to ping DNS: ${netX/dns}
ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.

kernel http://satellite.fqdn/pulp/repos/Default_Organization/Library/Red_Hat_Enterprise_Linux_9_Kickstart/content/dist/rhel9/9.0/x86_64/baseos/kickstart//images/pxeboot/vmlinuz initrd=initrd.img  BOOTIF=01-00-50-56-ac-10-13 inst.ks=http://satellite.fqdn:8000/unattended/provision?token=d79a2f7d-cfdc-49cc-ac81-88f9761d572c inst.ks.sendmac ip=dhcp
initrd http://satellite.fqdn/pulp/repos/Default_Organization/Library/Red_Hat_Enterprise_Linux_9_Kickstart/content/dist/rhel9/9.0/x86_64/baseos/kickstart//images/pxeboot/initrd.img
imgstat
sleep 2
boot
```

Side note: I attempted to regenerate the tests with `RAILS_ENV=test bundle exec rake snapshots:generate`, but there may be an error in a CoreOS template that is causing it to fail half way through.

edit: fixed copy/paste problem for accurate description of the request.