### PR TITLE
Fixes #34981 - Add 'Recent communication' card to overview

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
           "checkbox",
           "clearbutton",
           "clearfix",
+          "comms",
           "consts",
           "cpu",
           "csrf",

--- a/webpack/assets/javascripts/react_app/components/HostDetails/RecentCommunicationCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/RecentCommunicationCard/index.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { DescriptionList } from '@patternfly/react-core';
+import { translate as __ } from '../../../common/I18n';
+import Slot from '../../common/Slot';
+import CardTemplate from '../Templates/CardItem/CardTemplate';
+import { selectFillsAmount } from '../../common/Slot/SlotSelectors';
+
+const RecentCommunicationCard = ({ hostDetails }) => {
+  const itemCount = useSelector(state =>
+    selectFillsAmount(state, 'recent-communication-card-item')
+  );
+  if (!itemCount) return null;
+  return (
+    <CardTemplate header={__('Recent communication')}>
+      <DescriptionList isHorizontal>
+        <Slot
+          hostDetails={hostDetails}
+          id="recent-communication-card-item"
+          multi
+        />
+      </DescriptionList>
+    </CardTemplate>
+  );
+};
+
+export default RecentCommunicationCard;
+
+RecentCommunicationCard.propTypes = {
+  hostDetails: PropTypes.shape({}),
+};
+
+RecentCommunicationCard.defaultProps = {
+  hostDetails: {},
+};

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Overview/CardsRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Overview/CardsRegistry.js
@@ -2,11 +2,17 @@ import React from 'react';
 import { addGlobalFill } from '../../../common/Fill/GlobalFill';
 import AuditCard from '../../Audits';
 import DetailsCard from '../../DetailsCard';
+import RecentCommunicationCard from '../../RecentCommunicationCard';
 import AggregateStatus from '../../Status/AggregateStatusCard';
 
 const cards = [
-  { key: '[core]-detail-card', Component: DetailsCard, weight: 4000 },
-  { key: '[core]-status-card', Component: AggregateStatus, weight: 3500 },
+  { key: '[core]-status-card', Component: AggregateStatus, weight: 4000 },
+  {
+    key: '[core]-recent-comms-card',
+    Component: RecentCommunicationCard,
+    weight: 3800,
+  },
+  { key: '[core]-detail-card', Component: DetailsCard, weight: 3400 },
   { key: '[core]-audit-card', Component: AuditCard, weight: 3000 },
 ];
 


### PR DESCRIPTION
Adds a 'Recent communication' card to the Overview tab of the new host details page, per design.

* Card itself will be supplied by Foreman
* 'Last checkin' supplied by Katello - https://github.com/Katello/katello/pull/10135
* 'Last configuration report' supplied by another plugin

If no plugins provide fills, the card is not displayed.

![new-card-order](https://user-images.githubusercontent.com/22042343/170776483-3c290596-6ff1-481b-bf58-6ebea36b3c39.png)
