### PR TITLE
Fixes #34985 - Extend windows templates

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
@@ -8,31 +8,28 @@ oses:
 - Windows Server 2012
 - Windows Server 2012 R2
 - Windows
-description: |
-  A finish template executed at the end of Windows provisioning. For more information, please
-  see https://community.theforeman.org/t/windows-provisioning-made-easy/16756
-
-  This template accepts the following parameters:
-  - windowsLicenseKey: ABCDE-ABCDE-ABCDE-ABCDE-ABCDE # Valid Windows license key
-  - windowsLicenseOwner: Company, INC # Legal owner of the Windows license key
-  - localAdminAccountDisabled: false
-  - ntpServer: time.windows.com,other.time.server
-  - domainAdminAccount: joinuser@domain.com # please do not use the domain administrator
-  - domainAdminAccountPasswd: Password for the domain Admin account
-  - computerOU: OU=Computers,CN=domain,CN=com # Place the computer account in specified Organizational Unit
-  - computerDomain: domain.com # domain to join
-  - machinePassword: used for unsecure domain join. needs precrated computer object (New-ADComputer)
-  - foremanDebug: false
-  - skip-puppet-setup: boolean (default=false)
-
-  Information about unsecure domain join
-  https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/add-computer?view=powershell-5.1#example-9--add-a-computer-to-a-domain-using-predefined-computer-credentials
--%>
+# Parameters are expected to be set in Foreman (globally or per group/host)
+params:
+- windowsLicenseKey: ABCDE-ABCDE-ABCDE-ABCDE-ABCDE # Valid Windows license key
+- windowsLicenseOwner: Company, INC # Legal owner of the Windows license key
+- localAdminAccountDisabled: false
+- ntpServer: time.windows.com,other.time.server
+- domainAdminAccount: joinuser@domain.com # please do not use the domain administrator
+- domainAdminAccountPasswd: Password for the domain Admin account
+- computerOU: OU=Computers,CN=domain,CN=com # Place the computer account in specified Organizational Unit
+- computerDomain: domain.com # domain to join
+- machinePassword: used for unsecure domain join. needs precrated computer object (New-ADComputer)
+%>
+<%#
+# Information about unsecure domain join
+# https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.management/add-computer?view=powershell-5.1#example-9--add-a-computer-to-a-domain-using-predefined-computer-credentials
+%>
 <%
   # safemode renderer does not support unary negation
-  puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
-  salt_enabled = host_param('salt_master') ? true : false
-  chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
+  pm_set = @host.puppetmaster.empty? ? false : true
+  puppet_enabled = pm_set || host_param('force-puppet') && host_param('force-puppet') == 'true'
+  network_location = host_param('networklocation') ? host_param('networklocation') : 'Private'
+  foreman_Debug = host_param('foremanDebug') ? host_param('foremanDebug') : 'false'
 %>
 
 @echo off
@@ -44,12 +41,10 @@ description: |
 <% if @host.pxe_build? %>
   set ctr=0
   set nettimeout=10
+<% end -%>
 
-  (echo Updating time)
-  (sc config w32time start= auto)
-  sc start w32time
-  ::ipconfig /renew
-
+  <%= snippet 'Windows network simon' %>
+  
   <% if host_param('ntpServer') %>
     echo setting time server
     w32tm /config /manualpeerlist:<%= host_param('ntpServer') %> /syncfromflags:manual /update
@@ -70,63 +65,75 @@ description: |
       <% end %>
     <% end %>
   <% end %>
+  
+  powershell /c "powercfg /setactive 8c5e7fda-e8bf-4a96-9a85-a6e23a8c635c"
 
   <% if host_param('localAdminAccountDisabled') %>
     echo Disabling %tempAdminUser%
     net user %tempAdminUser% %tempAdminUser% /active:no
   <% end %>
 
-  <% if host_param('ansible_port') == 5985 or host_param('ansible_winrm_scheme') == 'http' %>
-    cmd /c winrm set winrm/config/service @{AllowUnencrypted="true"}
+  <% if host_param('http-proxy').present? -%>
+    cmd /C "netsh winhttp set proxy <%= host_param('http-proxy') %>:<%= host_param('http-proxy-port') %>"
+  <% end %>
+  
+  <% unless host_param('computerDomain') %>
+    powershell /c "Get-NetConnectionProfile -InterfaceAlias \"Ethernet0\" | Set-NetConnectionProfile -NetworkCategory <%= network_location %>"
   <% end %>
 
-  <% if host_param('ansible_winrm_transport') == 'basic' %>
-    cmd /c winrm set winrm/config/client/auth @{Basic="true"}
-    cmd /c winrm set winrm/config/service/auth @{Basic="true"}
+  <% if host_param('ansible_user').present? %>
+    <%= snippet("Windows configure ansible simon") %>
   <% end %>
 
-  <% if host_param('ansible_winrm_transport') == 'credssp' %>
-    cmd /c winrm set winrm/config/client/auth @{CredSSP="true"}
-    cmd /c winrm set winrm/config/service/auth @{CredSSP="true"}
+  <% if host_param('ping') %>
+    cmd /c "netsh advfirewall firewall add rule name=\"Enable IPv4 ICMP\" dir=in protocol=icmpv4 action=allow"
   <% end %>
-
-  <% if host_param('ansible_winrm_transport') == 'certificate' %>
-    cmd /c winrm set winrm/config/client/auth @{Certificate="true"}
-    cmd /c winrm set winrm/config/service/auth @{Certificate="true"}
+  
+  <% if host_param('remote_desktop') %>
+    cmd /c "netsh advfirewall firewall set rule group=\"remote desktop\" new enable=Yes"
+    cmd /c "netsh advfirewall firewall set rule group=\"remotedesktop\" new enable=Yes"
   <% end %>
-
-  <%= snippet 'Windows network' %>
-
-  <% if foreman_url('user_data') %>
-    echo execute user data script
-    IF EXIST c:\deploy\user_data.ps1 powershell.exe -OutputFormat text -command c:\deploy\user_data.ps1
-  <% end -%>
 
   <% if puppet_enabled %>
+    echo get puppet installer 
+    powershell /c "wget <%= host_param('win_puppet_source') %> -O C:\puppet-agent-x64-latest.msi"
+    echo configure puppet
+    powershell /c "md C:\ProgramData\PuppetLabs\puppet\etc"
+    powershell /c "echo \"[main]\" | out-file C:\ProgramData\PuppetLabs\puppet\etc\puppet.conf -encoding utf8"
+    powershell /c "echo \"server=http://<%= foreman_server_fqdn %>" | add-content C:\ProgramData\PuppetLabs\puppet\etc\puppet.conf -encoding utf8"
+    powershell /c "echo \"autoflush=true\" | add-content C:\ProgramData\PuppetLabs\puppet\etc\puppet.conf -encoding utf8"
     echo Installing puppet
-    start /w "" msiexec /qn /i C:\extras\puppet.msi PUPPET_AGENT_STARTUP_MODE=Manual PUPPET_MASTER_SERVER=<%= host_puppet_server -%> PUPPET_AGENT_ACCOUNT_DOMAIN=<%= @host.domain -%> PUPPET_AGENT_ACCOUNT_USER=administrator PUPPET_AGENT_ACCOUNT_PASSWORD="<%= host_param('domainAdminAccountPasswd') -%>"
-    echo set puppet to auto start
-    sc config puppet start= auto
-    sc query puppet
-  <% end%>
+    start /wait "" msiexec /qn /i C:\puppet-agent-x64-latest.msi PUPPET_MASTER_SERVER=<%= @host.puppetmaster -%> PUPPET_AGENT_ENVIRONMENT=<%= @host.environment -%>
+  <% end %>
 
-  <% if host_param('foremanDebug') != true %>
+  <% unless host_param('noupdates') %>
+    echo Updating System
+    powershell /c "& {$Updates = (Start-WUScan); Install-WUUpdates -Updates $Updates}"
+    powershell /c "& {$Updates = (Start-WUScan); Install-WUUpdates -Updates $Updates}"
+    powershell /c "wuauclt.exe /updatenow"
+  <% end %>
 
-    echo reboot in 15sec
-    start /b shutdown /r /t 15
+  <% unless foreman_Debug %>
+    echo rebooting in 60 sec
+    shutdown /r /t 60
 
     echo Safely remove wimaging files
-    sdelete.exe -accepteula -p 2 -r c:\wimaging
-    sdelete.exe -accepteula -p 2 -r c:\minint
+    rd /s /q c:\wimaging
     sdelete.exe -accepteula -p 2 c:\Windows\Panther\unattend.xml
     sdelete.exe -accepteula -p 2 C:\Windows\Setup\Scripts\SetupComplete.cmd
+    
+    echo remove leftover directories
+    rd /s /q c:\MININT
+    rd /s /q c:\drivers
+    rd /s /q c:\updates
 
-    echo Safely remove leftover directories
-    sdelete.exe -accepteula -p 2 -r c:\drivers
-    sdelete.exe -accepteula -p 2 -r c:\updates
-
-    echo Safely removing c:\deploy
-    cd /
-    sdelete.exe -accepteula -p 2 -r c:\deploy
+    <% if puppet_enabled %>
+        echo Safely remove Puppet installer
+        sdelete.exe -accepteula -p 2 C:\puppet-agent-x64-latest.msi
+    <% end %>    
+  
+    echo remove deploy directory
+    cd c:\
+    rd /s /q c:\deploy
+    
   <% end -%>
-<% end -%>

--- a/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
@@ -43,7 +43,7 @@ params:
   set nettimeout=10
 <% end -%>
 
-  <%= snippet 'Windows network simon' %>
+  <%= snippet 'Windows network' %>
   
   <% if host_param('ntpServer') %>
     echo setting time server

--- a/app/views/unattended/provisioning_templates/script/windows_default_script.erb
+++ b/app/views/unattended/provisioning_templates/script/windows_default_script.erb
@@ -4,16 +4,17 @@ name: Windows peSetup.cmd
 model: ProvisioningTemplate
 oses:
 - Windows
-description: |
-  The provisioning template used for Windows
-  You can create and assign a "user_data" ProvisioningTemplate as powershell to execute some custom code
-  See https://community.theforeman.org/t/windows-provisioning-made-easy/16756/
-  params:
-  - wimImageName: Windows 8.1 Pro # name of wim image to apply
--%>
+# Parameters are expected to be set in Foreman (globally or per group/host)
+params:
+- wimImageName: Windows 8.1 Pro # name of wim image to apply
+- windowsLicenseKey: ABCDE-ABCDE-ABCDE-ABCDE-ABCDE # Valid Windows license key
+- windowsLicenseOwner: Company, INC # Legal owner of the Windows license key
+%>
 <%
-  proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port') || 3128}" : nil
+  iface = @host.provision_interface
+  proxy_uri = host_param('http-proxy') ? "#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   proxy_string = proxy_uri ? "-e http_proxy=#{proxy_uri}" : ''
+  foreman_Debug = host_param('foremanDebug') ? host_param('foremanDebug') : 'false'
 %>
 @setlocal enableextensions enabledelayedexpansion
 @echo off
@@ -21,13 +22,25 @@ set WGET=wget64.exe
 
 <%= @host.diskLayout %>
 
+
+<% if iface.subnet && !iface.subnet.dhcp_boot_mode? %>
+echo set network config for static interfaces
+    netsh interface ip set address name="Ethernet0" static "<%= iface.ip %>" "<%= iface.subnet.mask %>" "<%= iface.subnet.gateway %>"
+    net stop "DHCP-Client"
+    net stop "DHCP Client"
+    net start "DNS-Client"
+    net start "DNS Client"
+    ping -n "<%= iface.subnet.gateway %>"
+    netsh interface ip set dns name="Ethernet0" static "<%= iface.subnet.dns_primary %>"
+<% end %>
+
 echo Started downloading main WIM
 
-%WGET% <%= proxy_string %> "<%= medium_uri %>/sources/images.ini" -O X:\images.ini
+%WGET% <%= proxy_string %> "<%= medium_uri %>sources/images.ini" -O X:\images.ini
 if %ERRORLEVEL% == 0 goto :lookup_image
 
 echo WARNING: Couldn't download the images.ini, falling back to legacy mode!
-%WGET% <%= proxy_string %> "<%= medium_uri %>/sources/install.wim" -O C:\install.wim
+%WGET% <%= proxy_string %> "<%= medium_uri %>sources/install.wim" -O C:\install.wim
 goto :install
 
 :lookup_image
@@ -39,14 +52,15 @@ for /f "usebackq delims=" %%a in ("!file!") do (
             set currkey=%%b
             set currval=%%c
             if "x!key!"=="x!currkey!" (
-                %WGET% <%= proxy_string %> "<%= medium_uri %>/sources/!currval!" -O C:\install.wim
+                %WGET% <%= proxy_string %> <%= medium_uri %>sources/!currval! -O C:\install.wim
             )
         )
     )
 )
 
 :install
-echo Writing install image to partition while downloading additional files
+echo Writing install image to partition while downloading additional files,
+echo this will take some time
 
 (
    start /min cmd /C "echo Write the install image to the partition
@@ -62,7 +76,7 @@ echo Writing install image to partition while downloading additional files
    start /min cmd /C "echo Downloading finsh script and activating SetupComplete.cmd
                 md c:\deploy
                 %WGET% --no-verbose <%= foreman_url("finish") -%> -O C:\deploy\foreman-finish.bat"
-) | pause
+) | pause >nul
 
 echo Creating a temp staging folder for DISM
 md c:\MININT\Scratch
@@ -74,7 +88,7 @@ IF not exist %PantherDirectory% (mkdir %PantherDirectory%)
 echo Finalizing installation...
 
 echo Downloading custom theme
-%WGET%  -P C:\Windows\Web\ -r -np -nH --cut-dirs=3 -R index.html -q --level=0 <%= medium_uri %>/theme/
+%WGET% <%= proxy_string %> -P C:\Windows\Web\ -r -np -nH --cut-dirs=3 -R index.html -q --level=0 "<%= medium_uri %>/theme/"
 
 echo Stage the Unattend.xml file for dism to apply
 echo Downloading unattend.xml
@@ -89,9 +103,8 @@ copy x:\windows\system32\sdelete.exe C:\Windows\
 IF not exist C:\Windows\Setup\Scripts (md C:\Windows\Setup\Scripts)
 echo call C:\deploy\foreman-finish.bat ^> c:\foreman.log 2^>^&1 > C:\Windows\Setup\Scripts\SetupComplete.cmd
 
-<% if foreman_url('user_data') %>
-echo Downloading user data script
-%WGET% <%= foreman_url('user_data') %> -O c:\deploy\user_data.ps1
+<% unless foreman_Debug %>
+sdelete.exe -accepteula -p 2 c:\foreman.log
 <% end -%>
 
 echo Apply Drivers

--- a/app/views/unattended/provisioning_templates/snippet/windows_configure_ansible.erb
+++ b/app/views/unattended/provisioning_templates/snippet/windows_configure_ansible.erb
@@ -1,0 +1,35 @@
+<%#
+name: Windows configure ansible
+snippet: true
+model: ProvisioningTemplate
+-%>
+
+ <% if host_param('create_ansible_user') %>
+   powershell /c "set-localuser -name <%= host_param('ansible_user') %> -passwordneverexpires 1"
+ <% end %>
+ powershell /c "Enable-PSRemoting"
+ <% if host_param('ansible_port') == 5985 %>
+   netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=yes
+   cmd /c "winrm set winrm/config/service @{AllowUnencrypted=\"true \"}"
+   cmd /c "winrm set winrm/config/client/auth @{Basic=\"true\"}"
+   cmd /c "winrm set winrm/config/service/auth @{Basic=\"true\"}"
+ <% end %>
+ <% if host_param('ansible_port') == '5986' %>
+   netsh advfirewall firewall add rule name="Windows Remote Management (HTTPs-In)" dir=in localport=5986 protocol=TCP action=allow
+   powershell /C "$thumbprint = New-SelfSignedCertificate -certstorelocation cert:\localmachine\my -dnsname <%= @host -%> -KeyLength 4096; New-WSManInstance -ResourceURI winrm/config/Listener -SelectorSet @{Address='*';Transport='HTTPS'} -ValueSet @{CertificateThumbprint=$thumbprint.Thumbprint;Hostname='<%= @host -%>'}"
+
+   <% if host_param('ansible_winrm_transport')  == 'credssp' %>
+   powershell /c "Enable-WSManCredSSP -Role Server -Force"
+   <% end %>
+
+   <% unless host_param('ansible_winrm_enable_http') %>
+   netsh advfirewall firewall set rule name="Windows Remote Management (HTTP-In)" new enable=no
+   <% end %>
+   <% unless host_param('ansible_winrm_enable_unencrypted') %>
+   cmd /c "winrm set winrm/config/service @{AllowUnencrypted=\"false\"}"
+   <% end %>
+   <% unless host_param('ansible_winrm_transport')  == 'basic' %>
+   cmd /c "winrm set winrm/config/client/auth @{Basic=\"false\"}"
+   cmd /c "winrm set winrm/config/service/auth @{Basic=\"false\"}"
+   <% end %>
+<% end %>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

To test this changes, deploy windows hosts with ansible and/or puppet enabled. Use puppet with a separate puppet environment, not production. The new hosts should be fully updated, if they have internet connection.