### PR TITLE
Fixes #34987 - Force 1 call on first load for TableIndexPage

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/ActionButtons.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/ActionButtons.js
@@ -21,7 +21,7 @@ export const ActionButtons = ({ buttons: originalButtons }) => {
   return (
     <>
       <Button
-        component={firstButton.action?.href ? 'a' : null}
+        component={firstButton.action?.href ? 'a' : undefined}
         {...firstButton.action}
       >
         {firstButton.title}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { QuestionCircleIcon } from '@patternfly/react-icons';
 import { useHistory } from 'react-router-dom';
+import { isEqual } from 'lodash';
 import URI from 'urijs';
 
 import {
@@ -51,7 +52,8 @@ const TableIndexPage = ({
   cutsomToolbarItems,
   children,
 }) => {
-  const [params, setParams] = useState({});
+  const defaultParams = {};
+  const [params, setParams] = useState(defaultParams);
   const history = useHistory();
   const { location: { search } = {} } = history || {};
   const {
@@ -70,12 +72,12 @@ const TableIndexPage = ({
     let newSearch;
     if (search !== undefined) {
       const urlParams = new URLSearchParams(search);
-      newSearch = urlParams.get('search');
+      newSearch = urlParams.get('search') || '';
     } else {
       newSearch = getURIsearch();
     }
-    setParams({ search: newSearch });
-  }, [search, apiSearchQuery]);
+    if (!isEqual(newSearch, search)) setParams({ search: newSearch });
+  }, [search]);
 
   const setSearch = newSearch => {
     if (history) {
@@ -90,7 +92,9 @@ const TableIndexPage = ({
     setSearch({ search: newSearch, page: 1 });
   };
   useEffect(() => {
-    setAPIOptions({ ...apiOptions, params });
+    if (!isEqual(defaultParams, params)) {
+      setAPIOptions({ ...apiOptions, params });
+    }
     // Adding to the deps apiOptions creates an endless loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.search, params.page, params.perPage]);

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
@@ -4,7 +4,7 @@ import { compose, bindActionCreators } from 'redux';
 import ModelsPage from './ModelsPage';
 import * as actions from './ModelsPageActions';
 
-import { callOnMount, callOnPopState } from '../../../common/HOC';
+import { callOnPopState } from '../../../common/HOC';
 
 import {
   selectModels,
@@ -30,6 +30,5 @@ const mapDispatchToProps = dispatch => bindActionCreators(actions, dispatch);
 
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
-  callOnMount(({ initializeModels }) => initializeModels()),
   callOnPopState(({ initializeModels }) => initializeModels())
 )(ModelsPage);


### PR DESCRIPTION
There are two bugs: 
 - a really small one, so I've included the fix here. Action buttons in new TableIndexPage template didn't allow to pass a function as action instead of href.
 - TableIndexPage did 3 same API calls instead of 1 on first load.
 
 The current behaviour can be tested on /models page. I've tried to use the new template in foreman_webhooks, so this fix was mostly tested on https://github.com/theforeman/foreman_webhooks/pull/51.
 
 The bugs are also present in 3.3.