### PR TITLE
Fixes #34994 - require ApplicationRecord early for migrations

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -81,6 +81,15 @@ require File.expand_path('../lib/foreman/middleware/logging_context_session', __
 require File.expand_path('../lib/foreman/middleware/telemetry', __dir__)
 require File.expand_path('../lib/foreman/middleware/libvirt_connection_cleaner', __dir__)
 
+# Ensure ApplicationRecord is loaded early and can be used inside migrations.
+# Can probably be removed once we migrate to Zeitwerk.
+require File.expand_path('../app/models/concerns/host_mix', __dir__)
+require File.expand_path('../app/models/concerns/has_many_common', __dir__)
+require File.expand_path('../app/models/concerns/strip_whitespace', __dir__)
+require File.expand_path('../app/models/concerns/parameterizable', __dir__)
+require File.expand_path('../app/models/concerns/audit_associations', __dir__)
+require File.expand_path('../app/models/application_record', __dir__)
+
 if SETTINGS[:support_jsonp]
   if File.exist?(File.expand_path('../Gemfile.in', __dir__))
     BundlerExt.system_require(File.expand_path('../Gemfile.in', __dir__), :jsonp)


### PR DESCRIPTION
Without this migrations that use models fail with

    PG::UndefinedTable: ERROR:  relation "application_records" does not exist


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
