### PR TITLE
Refs #34305 - forgotten category for new settings

### DIFF
--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -179,6 +179,8 @@ class SettingRegistry
   end
 
   def _new_db_record(definition)
-    Setting.new(name: definition.name, value: definition.value)
+    Setting.new(name: definition.name,
+                value: definition.value,
+                category: definition.category.safe_constantize&.name || 'Setting')
   end
 end


### PR DESCRIPTION
We have accidently removed category for new records, but we have left 
the category wiring, so we need to keep it for now.
