### PR TITLE
Fixes #32476 - 'No matches found' text is untranslated

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -485,7 +485,10 @@ function activate_select2(container, allowClear) {
     .find('select:not(.without_select2)')
     .not('.form_template select')
     .not('#interfaceForms select')
-    .select2({ allowClear: allowClear });
+    .select2({
+      allowClear: allowClear,
+      formatNoMatches: __('No matches found'),
+    });
 }
 
 function setError(field, text) {

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -105,6 +105,7 @@ export function activateTooltips(elParam = 'body') {
 
 export function initTypeAheadSelect(input) {
   input.select2({
+    formatNoMatches: __('No matches found'),
     ajax: {
       url: input.data('url'),
       dataType: 'json',

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -15,7 +15,10 @@ class Select extends React.Component {
     const { allowClear } = this.props;
 
     if ($.fn.select2) {
-      $(this.select).select2({ allowClear });
+      $(this.select).select2({
+        allowClear,
+        formatNoMatches: __('No matches found'),
+      });
     }
   }
 


### PR DESCRIPTION
(old) select2 docs: https://select2.github.io/select2/