### PR TITLE
Fixes #34998 - long breadcrumb switcher is out of view

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/breadcrumb-switcher.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/breadcrumb-switcher.scss
@@ -1,4 +1,11 @@
 .pf4-breadcrumb-switcher-popover {
+  .pf-c-pagination,
+  .pf-c-pagination.pf-m-bottom .pf-c-options-menu,
+  .pf-c-pagination.pf-m-bottom .pf-c-pagination__nav,
+  .pf-c-menu__list,
+  .pf-c-menu__list-item{
+    visibility: unset;
+  }
   .pf-c-menu__footer {
     padding: 0;
 

--- a/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/index.js
@@ -119,9 +119,10 @@ const BreadcrumbSwitcher = ({
         showClose={false}
         appendTo={() => document.querySelector('.pf4-breadcrumb-switcher')}
         position="bottom"
+        enableFlip={false}
         bodyContent={
           <div>
-            <Menu>
+            <Menu isScrollable>
               <MenuInput>
                 <SearchInput
                   value={searchValue}


### PR DESCRIPTION
Before: 
![Screenshot from 2022-06-01 19-11-48](https://user-images.githubusercontent.com/30431079/171467083-17829f07-9cd1-49c8-b935-bef14b723474.png)

After: 
![Screenshot from 2022-06-01 19-11-59](https://user-images.githubusercontent.com/30431079/171467079-6efc54d9-a990-4efa-b968-0a88ceb3e879.png)