### PR TITLE
Fixes #35001 - adjust card weights

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Overview/CardsRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Overview/CardsRegistry.js
@@ -13,7 +13,7 @@ const cards = [
     weight: 3800,
   },
   { key: '[core]-detail-card', Component: DetailsCard, weight: 3400 },
-  { key: '[core]-audit-card', Component: AuditCard, weight: 3000 },
+  { key: '[core]-audit-card', Component: AuditCard, weight: 2400 },
 ];
 
 export const registerCoreCards = () => {


### PR DESCRIPTION
Per design discussion, these changes adjust Overview tab card order in Foreman & plugins.

### Required
* https://github.com/Katello/katello/pull/10145
* https://github.com/theforeman/foreman_rh_cloud/pull/738
* https://github.com/theforeman/foreman_remote_execution/pull/728
* to get Recent communication card, rebase on https://github.com/theforeman/foreman/pull/9239

### Using plugins from source
```rb
# bundler.d/some_file_name.local.rb

gemspec :path => '../katello', :development_group => 'katello_dev', :name => 'katello'
gemspec :path => '../foreman_rh_cloud', :development_group => 'foreman_rh_cloud_dev', :name => 'foreman_rh_cloud'
gemspec :path => '../foreman_remote_execution', :development_group => 'foreman_remote_execution_dev', :name => 'foreman_remote_execution'
```

After applying all 4 patches, card order should be like this:

4-card width:
![4-card-layout](https://user-images.githubusercontent.com/22042343/171881237-38837512-66e2-41ce-902a-f32481f05de4.png)

3-card width:
![3-card-layout](https://user-images.githubusercontent.com/22042343/171881239-6ba7263f-dca9-4bf6-b829-6f2ea1b74152.png)
