### PR TITLE
Fixes #35017 - Add Tracer installation status to System properties card

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
@@ -125,6 +125,11 @@ const SystemPropertiesCard = ({ status, isExpandedGlobal, hostDetails }) => {
             </SkeletonLoader>
           </DescriptionListDescription>
         </DescriptionListGroup>
+        <Slot
+          id="host-details-tab-properties-2"
+          multi
+          hostDetails={hostDetails}
+        />
         <DescriptionListGroup>
           <DescriptionListTerm>{__('Owner')}</DescriptionListTerm>
           <DescriptionListDescription>


### PR DESCRIPTION
Add Tracer installation status to System properties card in Details tab.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
