### PR TITLE
Split npm dependency resolution from module installation in React tests

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -28,8 +28,10 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Generate npm dependencies package-lock
+        run: npm install --package-lock-only --no-audit
       - name: Install npm dependencies
-        run: npm install
+        run: npm ci --no-audit
       - name: Run linter
         run: npm run lint
       - name: Run Spellcheck (only warnings)

--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -35,16 +35,22 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: ./projects/foreman
+      - name: Generate Foreman npm dependencies package-lock
+        run: npm install --package-lock-only --no-audit
+        working-directory: ${{ github.workspace }}/projects/foreman
       - name: Install Foreman npm dependencies
-        run: npm install
+        run: npm ci --no-audit
         working-directory: ${{ github.workspace }}/projects/foreman
       - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@v2
         with:
           repository: ${{ matrix.org }}/${{ matrix.repo }}
           path: ./projects/${{ matrix.repo }}
+      - name: Generate ${{ matrix.repo }} npm dependencies package-lock
+        run: npm install --package-lock-only --no-audit
+        working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}
       - name: Install ${{ matrix.repo }} npm dependencies
-        run: npm install
+        run: npm ci --no-audit
         working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}
       - name: Run ${{ matrix.plugin_repo }} tests
         run: npm test


### PR DESCRIPTION
The idea here is to give us more granularity in test output of the run time of each step. 