### PR TITLE
Fixes #32881 - Expose previous application record revision through safemode

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -59,7 +59,8 @@ module Foreman
         :join_with_line_break,
         :current_date,
         :truthy?,
-        :falsy?
+        :falsy?,
+        :previous_revision
       ]
 
       DEFAULT_ALLOWED_HOST_HELPERS = [

--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -404,6 +404,20 @@ module Foreman
             end
           end
 
+          apipie :method, 'Returns previous revision of a record as tracked in the audit' do
+            desc 'Returns the same object if there is no previous revision'
+            required :record, ApplicationRecord, desc: 'Record to get previous revision for'
+            returns ApplicationRecord
+            raises error: Foreman::Exception, desc: 'when the provided record is not auditable'
+            example 'previous_revision(host_with_new_name).name # => "previous-name"'
+          end
+          def previous_revision(record)
+            record.revision(:previous)
+          rescue NoMethodError => e
+            Foreman::Logging.logger('templates').error(e)
+            raise Foreman::Exception.new(_('%s is not auditable') % record.class)
+          end
+
           private
 
           def validate_subnet(subnet)

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -66,6 +66,17 @@ class BaseMacrosTest < ActiveSupport::TestCase
     assert_equal '', @scope.pxe_kernel_options
   end
 
+  describe '#previous_revision' do
+    test "should return previous revision of a host" do
+      host = FactoryBot.build(:host)
+      host.name = 'oldname'
+      host.save!
+      host.update(name: 'newname')
+      host.save!
+      assert_equal 'oldname', @scope.previous_revision(host).name
+    end
+  end
+
   describe '#host_uptime_seconds' do
     test 'should return host uptime in seconds' do
       host = FactoryBot.create(:host)


### PR DESCRIPTION
Replacement for https://github.com/theforeman/foreman/pull/8620. Instead of adding `previous_revision` to each model, this PR simply adds a new macro.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
