### PR TITLE
Fixes #35047 - improve copy to clipboard react component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/ClipboardCopy/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/ClipboardCopy/index.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'patternfly-react';
+import { Button, Icon } from 'patternfly-react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
 import { translate as __ } from '../../../common/I18n';
 import './clipboard-copy.scss';
@@ -11,16 +11,23 @@ const ClipboardCopy = ({
   buttonText,
   textareaProps,
   buttonProps,
+  hideTextarea,
+  withCopyIcon,
 }) => {
   const [text, setText] = useState(defaultText);
 
+  const clipboardClass = hideTextarea === false ? 'clipboard-copy' : '';
+  const iconMarginLeft = buttonText === '' ? '0px' : '5px';
+
   return (
-    <div className="clipboard-copy">
-      <textarea
-        defaultValue={text}
-        onChange={({ target: { value } }) => setText(value)}
-        {...textareaProps}
-      />
+    <div className={clipboardClass}>
+      {hideTextarea === false ? (
+        <textarea
+          defaultValue={text}
+          onChange={({ target: { value } }) => setText(value)}
+          {...textareaProps}
+        />
+      ) : null}
       <Tooltip
         content={successMessage}
         position={TooltipPosition.right}
@@ -32,6 +39,13 @@ const ClipboardCopy = ({
           {...buttonProps}
         >
           {buttonText}
+          {withCopyIcon && (
+            <Icon
+              style={{ marginLeft: iconMarginLeft }}
+              type="fa"
+              name="copy"
+            />
+          )}
         </Button>
       </Tooltip>
     </div>
@@ -44,6 +58,8 @@ ClipboardCopy.propTypes = {
   successMessage: PropTypes.string,
   textareaProps: PropTypes.object,
   buttonProps: PropTypes.object,
+  hideTextarea: PropTypes.bool,
+  withCopyIcon: PropTypes.bool,
 };
 
 ClipboardCopy.defaultProps = {
@@ -51,6 +67,8 @@ ClipboardCopy.defaultProps = {
   successMessage: __('Copied!'),
   textareaProps: {},
   buttonProps: {},
+  hideTextarea: false,
+  withCopyIcon: false,
 };
 
 export default ClipboardCopy;


### PR DESCRIPTION
Usage:

This would only show the copy Icon. The textarea is hidden.
```
<%= react_component('ClipboardCopy', {
           text: "My data to copy",
           textareaProps: { disabled: true, readOnly: true, rows: '1' },
           hideTextarea: true,
           withCopyIcon: true,
           buttonText: '' %>
```
![copy1](https://user-images.githubusercontent.com/25485845/173566594-55978057-cf76-4b0c-bad8-86b8c4bc2be3.png)
(possible usage: a hard-coded text should be able to be copied)



This would show the text "Copy Me" and additonally the copy Icon. The textarea is show, too.
```
<%= react_component('ClipboardCopy', {
           text: "My data to copy",
           textareaProps: { disabled: true, readOnly: true, rows: '1' },
           withCopyIcon: true,
           buttonText: 'Copy' %>
```
![copy3](https://user-images.githubusercontent.com/25485845/173566611-31e2e686-958c-433a-aee5-c80b30a51dfb.png)
(possible use case: a hard-coded text should be able to be copied)

Copy Text + Icon but without textarea.
![copy2](https://user-images.githubusercontent.com/25485845/173566625-59afcc3c-a8ad-43a2-b0c7-4b8303b2acf7.png)
(use case: show the text which should be copied, maybe text would be adjustable. text should be possible to be copied)

