### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -8,8 +8,14 @@ on:
       - '.eslintrc'
       - '.eslintignore'
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      checks: write  # for coverallsapp/github-action to create new checks
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:

--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -9,6 +9,9 @@ on:
       - 'config/webpack.config.js'
       - '.github/workflows/plugins_react_tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -2,6 +2,9 @@ name: RuboCop
 on: [pull_request]
 env:
   BUNDLE_WITHOUT: assets:console:development:dynflow_sidekiq:ec2:gce:journald:jsonp:libvirt:openid:openstack:ovirt:redis:service:telemetry:vmware
+permissions:
+  contents: read
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest

--- a/.github/workflows/single_commit.yml
+++ b/.github/workflows/single_commit.yml
@@ -2,6 +2,9 @@ name: Assert Single Commit (non-blocking)
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   build:
     steps:

--- a/.github/workflows/storybook_deploy_main.yml
+++ b/.github/workflows/storybook_deploy_main.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - 'webpack/**'
 
+permissions:
+  contents: read
+
 jobs:
   deploy_main_storybook:
 


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
