### PR TITLE
Fixes #35035 - set VNC password length to 8 chars.

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -424,9 +424,10 @@ class ComputeResource < ApplicationRecord
     self.url = url.chomp("/") unless url.empty?
   end
 
-  def random_password
+  def random_password(characters = 16)
     return nil unless set_console_password?
-    SecureRandom.hex(8)
+    # characters returned by base64 are 4/3 of size, so limit to size
+    SecureRandom.base64(characters)[0..characters - 1]
   end
 
   def nested_attributes_for(type, opts)

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -170,10 +170,15 @@ module Foreman::Model
       raise e
     end
 
+    def console_password_length(type)
+      # use an 8 character password for vnc (which is the allowed maximum) and 16 for everything else
+      type == 'vnc' ? 8 : 16
+    end
+
     def console(uuid)
       vm = find_vm_by_uuid(uuid)
       raise Foreman::Exception.new(N_("VM is not running!")) unless vm.ready?
-      password = random_password
+      password = random_password(console_password_length(vm.display[:type]))
       # Listen address cannot be updated while the guest is running
       # When we update the display password, we pass the existing listen address
       vm.update_display(:password => password, :listen => vm.display[:listen], :type => vm.display[:type])
@@ -285,7 +290,7 @@ module Foreman::Model
         :volumes    => [new_volume].compact,
         :display    => { :type     => display_type,
                          :listen   => Setting[:libvirt_default_console_address],
-                         :password => random_password,
+                         :password => random_password(console_password_length(display_type)),
                          :port     => '-1' }
       )
     end

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -586,7 +586,7 @@ module Foreman::Model
     end
 
     def vnc_console(vm)
-      values = { :port => unused_vnc_port(vm.hypervisor), :password => random_password, :enabled => true }
+      values = { :port => unused_vnc_port(vm.hypervisor), :password => random_password(8), :enabled => true }
       vm.config_vnc(values)
       WsProxy.start(:host => vm.hypervisor, :host_port => values[:port], :password => values[:password]).merge(:type => 'vnc')
     end

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -45,7 +45,7 @@ class ComputeResourceTest < ActiveSupport::TestCase
   test "random_password should return a string when set_console_password is true" do
     cr = compute_resources(:mycompute)
     cr.set_console_password = 1
-    assert_match /^[[:alnum:]]+$/, cr.send(:random_password) # Can't call protected methods directly
+    assert_match /^[[[:alnum:]]+=\/]+$/, cr.send(:random_password) # Can't call protected methods directly
   end
 
   test "attrs[:setpw] is set to nil if compute resource is not Libvirt or VMWare" do


### PR DESCRIPTION
VNC passwords have a maximum length of 8 characters, Foreman uses 16.
Newer versions of libvirt enforce the 8 character limit.