### PR TITLE
Fixes #35069 - ApplicationRecord.<=> undefined method 'name'

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -40,7 +40,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   def <=>(other)
-    name <=> other.name
+    name <=> other.try(:name)
   end
 
   def id_and_type


### PR DESCRIPTION
After 6.1 upgrade some tests (eg. Foreman Discovery)
are failing with following error:
```
NoMethodError: undefined method `name' for 0:Integer
    app/models/application_record.rb:43:in `<=>'
```

How to verify the fix:
* Enable `foreman_discovery` plugin
* Run `bundle exec rails test:discovery TEST=~/your-path-to-foreman_discovery/test/unit/host_discovered_test.rb`
(There are some other tests that are failing but that's not the problem of this PR)
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

