### PR TITLE
Fixes #35072 - Save search props into store

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
@@ -6,6 +7,7 @@ import { SearchIcon } from '@patternfly/react-icons';
 import AutoComplete from '../AutoComplete';
 import Bookmarks from '../PF4/Bookmarks';
 import { changeQuery } from '../../common/urlHelpers';
+import { updateController } from '../AutoComplete/AutoCompleteActions';
 import './search-bar.scss';
 
 const SearchBar = props => {
@@ -17,6 +19,11 @@ const SearchBar = props => {
     onBookmarkClick,
     setAutocompleteSearchQuery,
   } = props;
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    dispatch(updateController(controller, autocomplete.url, 'searchBar'));
+  }, [dispatch, controller, autocomplete.url]);
 
   return (
     <div className="pf-c-search-input">

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/SearchBar.test.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/SearchBar.test.js
@@ -1,4 +1,7 @@
+import React from 'react';
 import SearchBar from '../SearchBar';
+import { Provider } from 'react-redux';
+import store from '../../../redux';
 import { SearchBarProps } from '../SearchBar.fixtures';
 import { testComponentSnapshotsWithFixtures } from '../../../common/testHelpers';
 
@@ -7,6 +10,11 @@ const fixtures = {
 };
 describe('AutoComplete', () => {
   describe('rendering', () => {
-    testComponentSnapshotsWithFixtures(SearchBar, fixtures);
+    const searchBar = () => (
+      <Provider store={store}>
+        <SearchBar {...SearchBarProps} />
+      </Provider>
+    );
+    testComponentSnapshotsWithFixtures(searchBar, fixtures);
   });
 });

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/SearchBar.test.js.snap
@@ -1,43 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AutoComplete rendering renders AutoComplete 1`] = `
-<div
-  className="pf-c-search-input"
+<Provider
+  store={
+    Object {
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(Symbol.observable): [Function],
+    }
+  }
 >
-  <div
-    className="search-bar pf-c-input-group"
-    id="search-bar"
-  >
-    <Connect(AutoComplete)
-      controller="models"
-      handleSearch={[Function]}
-      id="searchBar"
-      searchQuery=""
-      url="model/auto_complete_search"
-      useKeyShortcuts={true}
-    />
-    <Button
-      aria-label="search button for search input"
-      className="autocomplete-search-btn"
-      id="btn-search"
-      onClick={[Function]}
-      variant="control"
-    >
-      <SearchIcon
-        color="currentColor"
-        noVerticalAlign={false}
-        size="sm"
-      />
-    </Button>
-    <ConnectedBookmarks
-      canCreate={true}
-      controller="models"
-      documentationUrl="/doc/url"
-      id="searchBar"
-      onBookmarkClick={[Function]}
-      searchQuery=""
-      url="/api/bookmarks"
-    />
-  </div>
-</div>
+  <SearchBar
+    data={
+      Object {
+        "autocomplete": Object {
+          "id": "searchBar",
+          "searchQuery": null,
+          "url": "model/auto_complete_search",
+          "useKeyShortcuts": true,
+        },
+        "bookmarks": Object {
+          "canCreate": true,
+          "documentationUrl": "/doc/url",
+          "id": "searchBar",
+          "url": "/api/bookmarks",
+        },
+        "controller": "models",
+      }
+    }
+    initialQuery=""
+    onBookmarkClick={[Function]}
+    onSearch={[Function]}
+    searchQuery=""
+    setAutocompleteSearchQuery={[MockFunction]}
+  />
+</Provider>
 `;

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -79,6 +79,31 @@ Array [
     Object {
       "payload": Object {
         "controller": "models",
+        "id": "searchBar",
+        "trigger": "CONTROLLER_CHANGED",
+        "url": "model/auto_complete_search",
+      },
+      "type": "AUTO_COMPLETE_CONTROLLER_CHANGE",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "controller": "models",
+        "error": null,
+        "id": "searchBar",
+        "searchQuery": "",
+        "status": "PENDING",
+        "trigger": "INPUT_CLEAR",
+        "url": "model/auto_complete_search",
+      },
+      "type": "AUTO_COMPLETE_REQUEST",
+    },
+  ],
+  Array [
+    Object {
+      "payload": Object {
+        "controller": "models",
         "error": null,
         "id": "searchBar",
         "searchQuery": "result",


### PR DESCRIPTION
Someone with stronger React/Redux knowledge, please tell me if it can be solved in a "proper" way, since this looks more like a workaround.

Nevertheless, it fixes the described issue. Tested with https://github.com/theforeman/foreman_webhooks/pull/51 as well.