### PR TITLE
Fixes #35075 - Out of sync translation of outofsync parameter

### DIFF
--- a/app/registries/foreman/settings/general.rb
+++ b/app/registries/foreman/settings/general.rb
@@ -63,8 +63,8 @@ Foreman::SettingManager.define(:foreman) do
       full_name: N_('Append domain names to the host'))
     setting('outofsync_interval',
       type: :integer,
-      description: N_('Duration in minutes after servers are classed as out of sync. ' \
-                      'This setting is overridden by specific settings from config management tools (e.g. puppet_inteval, ansible_interval).'),
+      description: N_('Duration in minutes after servers are classed as out of sync.' \
+                      'You can override this on hosts by adding a parameter `outofsync_interval`.'),
       default: 30,
       full_name: N_('Out of sync interval'))
     setting('instance_id',

--- a/locale/en/foreman.po
+++ b/locale/en/foreman.po
@@ -2633,7 +2633,7 @@ msgstr ""
 msgid "Duration in days to preserve audits for. Leave empty to disable the audits cleanup."
 msgstr ""
 
-msgid "Duration in minutes after servers are classed as out of sync. This setting is overridden by specific settings from config management tools (e.g. puppet_inteval, ansible_interval)."
+msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"."
 msgstr ""
 
 msgid "EC2"


### PR DESCRIPTION
Hi,

I may be wrong, but it seems that the en locale is not in sync with other languages.

In all locales the file `foreman.po` reads:

```
msgid "Duration in minutes after servers are classed as out of sync. You can override this on hosts by adding a parameter \"outofsync_interval\"." 
```

but in the `locale/en/foreman.po`, it reads:

```
msgid "Duration in minutes after servers are classed as out of sync. This setting is overridden by specific settings from config management tools (e.g. puppet_inteval, ansible_interval)." 
```

It seems also to be the case in the `app/registries/foreman/settings/general.rb` file.

Here is a tiny PR to fix that.

Regards,

--
Nicolas