### PR TITLE
Fixes #34961 - Move expansion carat to right side for Details tab cards

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -45,7 +45,10 @@ const CardTemplate = ({
   return (
     <GridItem xl2={3} xl={4} md={6} lg={4} {...overrideGridProps}>
       <Card isExpanded={isExpanded} isSelectable>
-        <CardHeader onExpand={expandable && onExpandCallback}>
+        <CardHeader
+          onExpand={expandable && onExpandCallback}
+          isToggleRightAligned
+        >
           {dropdownItems && (
             <CardActions>
               <Dropdown


### PR DESCRIPTION
Moved the expansion carat from left to right side for Details tab cards.
