### PR TITLE
Fixes #4007 - updating users email to be optional

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -83,7 +83,7 @@ class User < ApplicationRecord
 
   validates :mail, :email => true, :allow_blank => true
   validates :mail, :presence => true, :on => :update,
-                   :if => proc { |u| !AuthSourceHidden.where(:id => u.auth_source_id).any? && (u.mail_was.present? || (User.current == u && !User.current.hidden?)) }
+            :if => proc { |u| !AuthSourceHidden.where(:id => u.auth_source_id).any? && (u.mail_enabled || (User.current == u && !User.current.hidden?)) }
 
   validates :locale, :format => { :with => /\A\w{2}([_-]\w{2})?\Z/ }, :allow_blank => true, :if => proc { |user| user.respond_to?(:locale) }
   before_validation :normalize_locale

--- a/db/migrate/20220628083024_change_default_value_for_mail_enabled_to_user.rb
+++ b/db/migrate/20220628083024_change_default_value_for_mail_enabled_to_user.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultValueForMailEnabledToUser < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :users, :mail_enabled, from: true, to: false
+  end
+end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -62,6 +62,7 @@ admin:
   firstname: Admin
   lastname: User
   mail: admin@someware.com
+  mail_enabled: true
   admin: true
   last_login_on: 2009-10-12 21:50:04
   auth_source: internal

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -145,16 +145,16 @@ class UserTest < ActiveSupport::TestCase
     assert_valid FactoryBot.build_stubbed(:user, :mail => nil)
   end
 
-  test "mail is optional if mail is currently nil" do
-    u = FactoryBot.create(:user, :mail => nil)
+  test "mail is optional if mail is not enabled" do
+    u = FactoryBot.create(:user, :mail => nil, :mail_enabled => false)
     u.firstname = 'Bob'
     assert_valid u
   end
 
-  test "mail is require when mail isn't currently nil" do
-    u = FactoryBot.create(:user, :mail => "foo@bar.com")
-    u.mail = nil
-    refute_valid u, :mail
+  test "mail address is required if mail is enabled" do
+    u = FactoryBot.create(:user, :mail => nil, :mail_enabled => true)
+    u.firstname = 'Bob'
+    refute u.valid?
   end
 
   test "mail is required for own user" do

--- a/test/models/usergroup_test.rb
+++ b/test/models/usergroup_test.rb
@@ -201,7 +201,7 @@ class UsergroupTest < ActiveSupport::TestCase
   end
 
   test "receipients_for provides subscribers of notification recipients" do
-    users = [FactoryBot.create(:user, :with_mail_notification), FactoryBot.create(:user)]
+    users = [FactoryBot.create(:user, :with_mail_notification, :mail_enabled => true), FactoryBot.create(:user)]
     notification = users[0].mail_notifications.first.name
     usergroup = FactoryBot.create(:usergroup)
     usergroup.users << users

--- a/test/unit/report_importer_test.rb
+++ b/test/unit/report_importer_test.rb
@@ -47,7 +47,7 @@ class ReportImporterTest < ActiveSupport::TestCase
 
   context 'with user owner' do
     setup do
-      @owner = as_admin { FactoryBot.create(:user, :admin, :with_mail) }
+      @owner = as_admin { FactoryBot.create(:user, :admin, :with_mail, :mail_enabled => true) }
       @host = FactoryBot.create(:host, :owner => @owner)
     end
 
@@ -64,6 +64,21 @@ class ReportImporterTest < ActiveSupport::TestCase
 
     test 'when owner is not subscribed to notifications, no mail should be sent on error' do
       @owner.mail_notifications = []
+      assert_no_difference 'ActionMailer::Base.deliveries.size' do
+        report = read_json_fixture('reports/errors.json')
+        report["host"] = @host.name
+        TestReportImporter.import report
+      end
+    end
+  end
+
+  context 'with user owner with mail disabled' do
+    setup do
+      @owner = as_admin { FactoryBot.create(:user, :admin, :with_mail, :mail_enabled => false) }
+      @host = FactoryBot.create(:host, :owner => @owner)
+    end
+
+    test 'when owner has mail disabled, no mail should be sent on error' do
       assert_no_difference 'ActionMailer::Base.deliveries.size' do
         report = read_json_fixture('reports/errors.json')
         report["host"] = @host.name

--- a/test/unit/tasks/reports_test.rb
+++ b/test/unit/tasks/reports_test.rb
@@ -10,7 +10,7 @@ class ReportsTest < ActiveSupport::TestCase
 
     as_admin do
       ActionMailer::Base.deliveries = []
-      @owner = FactoryBot.create(:user, :admin, :with_mail)
+      @owner = FactoryBot.create(:user, :admin, :with_mail, :mail_enabled => true)
       @owner.mail_notifications << MailNotification[:config_summary]
       @owner.user_mail_notifications.all.each { |notification| notification.update_attribute(:interval, 'Daily') }
       @host = FactoryBot.create(:host, :owner => @owner)


### PR DESCRIPTION
Updating users' emails to be optional, except for when the email notifications are enabled (in this case the email is required).

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
