### PR TITLE
Fixes #35124 - Fix preseed_kernel_options for bootdisk-deployments

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -29,7 +29,7 @@ set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac <%= snippet("preseed_kernel_options").strip %>
+  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options").strip %>
   initrd<%= efi_suffix %> <%= @initrd %>
 }
 

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -36,7 +36,7 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} <%= snippet("preseed_kernel_options").strip %>
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options", variables: {ipxe_net: true}).strip %>
 
 initrd <%= initrd %>
 

--- a/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options.erb
@@ -10,12 +10,22 @@ description: options for the kernel / preseed startup initialization
   hostname = @host.name
   domain = @host.domain
   iface = @host.provision_interface
+  mac = @host.provision_interface.mac
   subnet4 = iface.subnet
   subnet6 = iface.subnet6
   options = []
 
   if host_param('blacklist')
     options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  end
+
+  if mac
+    # hardware type is always 01 (ethernet) unless specified otherwise
+    if @ipxe_net
+      options << "BOOTIF=01-${netX/mac:hexhyp}"
+    else
+      options << "BOOTIF=#{host_param("hardware_type", "01")}-#{mac.gsub(':', '-')}"
+    end
   end
 
   if is_debian
@@ -27,16 +37,25 @@ description: options for the kernel / preseed startup initialization
   if @host.provision_interface.vlanid.present?
     options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
   end
-  options << "locale=#{host_param('lang') || 'en_US'}"
 
   if subnet4 && subnet4.dhcp_boot_mode?
     options << 'netcfg/disable_dhcp=false'
   elsif subnet4 && !subnet4.dhcp_boot_mode?
-    options << 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true'
+    if @ipxe_net
+      options << 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true'
+    else
+      dns_servers = subnet4.dns_servers.join(' ')
+      options << "netcfg/disable_dhcp=true netcfg/get_ipaddress=#{iface.ip} netcfg/get_netmask=#{subnet4.mask} netcfg/get_gateway=#{subnet4.gateway} netcfg/get_nameservers=\"#{dns_servers}\" netcfg/confirm_static=true"
+    end
   elsif subnet6 && subnet6.dhcp_boot_mode?
     options << 'netcfg/disable_dhcp=false'
   elsif subnet6 && !subnet6.dhcp_boot_mode?
-    options << 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true'
+    if @ipxe_net
+      options << 'netcfg/disable_dhcp=true netcfg/get_ipaddress=${netX/ip} netcfg/get_netmask=${netX/netmask} netcfg/get_gateway=${netX/gateway} netcfg/get_nameservers=${dns} netcfg/confirm_static=true'
+    else
+      dns_servers = subnet6.dns_servers.join(' ')
+      options << "netcfg/disable_dhcp=true netcfg/get_ipaddress=#{iface.ip6} netcfg/get_netmask=#{subnet6.mask} netcfg/get_gateway=#{subnet6.gateway} netcfg/get_nameservers=\"#{dns_servers}\" netcfg/confirm_static=true"
+    end
   end
 
   if host_param('pxe_kernel_options')

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
@@ -5,7 +5,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac auto=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
+  linuxefi  boot/debian-mirror-RpV7E2zxrKHe-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-00-f0-54-1a-7e-e0 auto=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
   initrdefi boot/debian-mirror-RpV7E2zxrKHe-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -5,7 +5,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2' {
-  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
+  linuxefi  boot/ubuntu-mirror-dBfjc2q1x3NM-linux interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-00-f0-54-1a-7e-e0 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
   initrdefi boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.debian4dhcp.snap.txt
@@ -4,7 +4,7 @@
 DEFAULT linux
 LABEL linux
     KERNEL boot/debian-mirror-RpV7E2zxrKHe-linux
-    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto auto=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
+    APPEND initrd=boot/debian-mirror-RpV7E2zxrKHe-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-00-f0-54-1a-7e-e0 auto=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux.ubuntu4dhcp.snap.txt
@@ -4,7 +4,7 @@
 DEFAULT linux
 LABEL linux
     KERNEL boot/ubuntu-mirror-dBfjc2q1x3NM-linux
-    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
+    APPEND initrd=boot/ubuntu-mirror-dBfjc2q1x3NM-initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-00-f0-54-1a-7e-e0 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
     IPAPPEND 2
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.debian4dhcp.snap.txt
@@ -5,7 +5,7 @@ echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
 
-kernel http://ftp.debian.org/debian/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} auto=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
+kernel http://ftp.debian.org/debian/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} auto=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
 
 initrd http://ftp.debian.org/debian/dists/wheezy/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.ubuntu4dhcp.snap.txt
@@ -5,7 +5,7 @@ echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
 
-kernel http://archive.ubuntu.com/ubuntu/dists/focal/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true locale=en_US netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
+kernel http://archive.ubuntu.com/ubuntu/dists/focal/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
 
 initrd http://archive.ubuntu.com/ubuntu/dists/focal/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options.host4dhcp.snap.txt
@@ -1,0 +1,3 @@
+
+
+BOOTIF=01-00-f0-54-1a-7e-e0 console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-el7 domain=snap.example.com


### PR DESCRIPTION
To make it possible to use full-host ISO with static network configurations for Debian/Ubuntu it is needed to add the network configuration in the templates.
This is build similar to the kickstart_kernel_options snippet.