### PR TITLE
[CP 3.3] Fixes #35083 - add power status timeout param

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -270,9 +270,10 @@ module Api
 
       api :GET, '/hosts/:id/power', N_('Fetch the status of whether the host is powered on or not. Supported hosts are VMs and physical hosts with BMCs.')
       param :id, :identifier_dottable, required: true
+      param :timeout, String, required: false, desc: N_("Timeout to retrieve the power status of the host in seconds. Default is 3 seconds.")
 
       def power_status
-        render json: PowerManager::PowerStatus.new(host: @host).power_state
+        render json: PowerManager::PowerStatus.new(host: @host).power_state(params[:timeout])
       rescue => e
         Foreman::Logging.exception("Failed to fetch power status", e)
 

--- a/app/services/power_manager/power_status.rb
+++ b/app/services/power_manager/power_status.rb
@@ -6,11 +6,13 @@ module PowerManager
       na:  { state: 'na', title: N_('N/A') },
     }.freeze
 
-    def power_state
+    DEFAULT_TIMEOUT = 3
+
+    def power_state(timeout = DEFAULT_TIMEOUT)
       result = { id: host.id }.merge(HOST_POWER[:na])
 
       if host.supports_power?
-        result = host_power_ping(result)
+        result = host_power_ping(result, timeout)
       else
         result[:statusText] = _('Power operations are not enabled on this host.')
       end
@@ -20,20 +22,19 @@ module PowerManager
 
     private
 
-    def host_power_ping(result)
-      timeout = 3
-
-      Timeout.timeout(timeout) do
+    def host_power_ping(result, timeout = DEFAULT_TIMEOUT)
+      req_timeout = timeout.nil? || timeout.to_i == 0 ? DEFAULT_TIMEOUT : timeout.to_i
+      Timeout.timeout(req_timeout) do
         result.merge!(HOST_POWER[host.supports_power_and_running? ? :on : :off])
       end
 
       result
     rescue Timeout::Error
-      logger.debug("Failed to retrieve power status for #{host} within #{timeout} seconds.")
+      logger.debug("Failed to retrieve power status for #{host} within #{req_timeout} seconds.")
 
-      result[:statusText] = n_("Failed to retrieve power status for %{host} within %{timeout} second.",
-        "Failed to retrieve power status for %{host} within %{timeout} seconds.", timeout) %
-                              {host: host, timeout: timeout}
+      result[:statusText] = n_("Failed to retrieve power status for %{host} within %{req_timeout} second.",
+        "Failed to retrieve power status for %{host} within %{req_timeout} seconds.", req_timeout) %
+                              {host: host, req_timeout: req_timeout}
       result
     end
   end

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/constants.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/constants.js
@@ -1,7 +1,7 @@
 import { translate as __ } from '../../../../common/I18n';
 
 export const POWER_REQURST_KEY = 'HOST_TOGGLE_POWER';
-export const POWER_REQUEST_OPTIONS = { key: POWER_REQURST_KEY };
+export const POWER_REQUEST_OPTIONS = { key: POWER_REQURST_KEY, params: { timeout: 30 } };
 export const BASE_POWER_STATES = { off: __('Off'), on: __('On') };
 export const BMC_POWER_STATES = { soft: __('Reboot'), cycle: __('Reset') };
 export const SUPPORTED_POWER_STATES = {


### PR DESCRIPTION
When checking for the host's power status, the request stops after 3 seconds by default,
Therefore in cases where it takes longer for the host to respond, the timeout fails the request.

discussion: https://community.theforeman.org/t/bmc-timeout-setting-in-foreman-ui/29016
(cherry picked from commit 884b4d88201ba09d8b68d57f82a76b844a8da7ae)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
