### PR TITLE
Fixes #35126 - Hide reports "Origin" col when table is already filtered by origin

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/ReportsTable.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/ReportsTable.js
@@ -15,8 +15,8 @@ import EmptyState from '../../../common/EmptyState';
 import { translate as __ } from '../../../../common/I18n';
 import { getColumns } from './helpers';
 
-const ReportsTable = ({ reports, status, fetchReports, error }) => {
-  const columns = getColumns(fetchReports);
+const ReportsTable = ({ reports, status, fetchReports, error, origin }) => {
+  const columns = getColumns(fetchReports, origin);
   let tableBody = null;
   let tableHead = null;
   let emptyState = null;
@@ -81,6 +81,7 @@ ReportsTable.propTypes = {
   reports: PropTypes.array,
   status: PropTypes.string,
   error: PropTypes.string,
+  origin: PropTypes.string,
   fetchReports: PropTypes.func.isRequired,
 };
 
@@ -88,6 +89,7 @@ ReportsTable.defaultProps = {
   reports: [],
   status: null,
   error: null,
+  origin: null,
 };
 
 export default ReportsTable;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/helpers.js
@@ -139,50 +139,51 @@ export const reportToShowFormatter = ({ reported_at, can_view, id }) => (
   </Button>
 );
 
-export const getColumns = fetchReports => [
-  {
-    title: __('Reported at'),
-    formatter: reportToShowFormatter,
-    width: 20,
-  },
-  {
-    title: __('Failed'),
-    formatter: response => statusFormatter('failed', response),
-    width: 10,
-  },
-  {
-    title: __('Failed restarts'),
-    formatter: response => statusFormatter('failed_restarts', response),
-    width: 10,
-  },
-  {
-    title: __('Restarted'),
-    formatter: response => statusFormatter('restarted', response),
-    width: 10,
-  },
-  {
-    title: __('Applied'),
-    formatter: response => statusFormatter('applied', response),
-    width: 10,
-  },
-  {
-    title: __('Skipped'),
-    formatter: response => statusFormatter('skipped', response),
-    width: 10,
-  },
-  {
-    title: __('Pending'),
-    formatter: response => statusFormatter('pending', response),
-    width: 10,
-  },
-  {
-    title: __('Origin'),
-    formatter: originFormatter,
-    width: 10,
-  },
-  {
-    title: null,
-    formatter: data => ActionFormatter(data, fetchReports),
-    width: 10,
-  },
-];
+export const getColumns = (fetchReports, origin) => {
+  const columns = [
+    {
+      title: __('Reported at'),
+      formatter: reportToShowFormatter,
+    },
+    {
+      title: __('Failed'),
+      formatter: response => statusFormatter('failed', response),
+    },
+    {
+      title: __('Failed restarts'),
+      formatter: response => statusFormatter('failed_restarts', response),
+    },
+    {
+      title: __('Restarted'),
+      formatter: response => statusFormatter('restarted', response),
+    },
+    {
+      title: __('Applied'),
+      formatter: response => statusFormatter('applied', response),
+    },
+    {
+      title: __('Skipped'),
+      formatter: response => statusFormatter('skipped', response),
+    },
+    {
+      title: __('Pending'),
+      formatter: response => statusFormatter('pending', response),
+    },
+    {
+      title: null,
+      formatter: data => ActionFormatter(data, fetchReports),
+    },
+  ];
+
+  /** if the table is being filtered already with a specific origin,
+   there is no need to show that origin column.
+  */
+  if (!origin) {
+    columns.splice(-2, 0, {
+      title: __('Origin'),
+      formatter: originFormatter,
+    });
+  }
+
+  return columns;
+};

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/index.js
@@ -124,6 +124,7 @@ const ReportsTab = ({ hostName, origin }) => {
           reports={reports}
           status={status}
           error={error}
+          origin={origin}
           fetchReports={fetchReports}
         />
       </GridItem>


### PR DESCRIPTION
if the table is being filtered already with a specific origin,
there is no need to show that origin column.

Fix https://github.com/theforeman/foreman_puppet/issues/292

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
