### PR TITLE
Fixes #32925 - added validation for root_pass on provisioning settings

### DIFF
--- a/app/registries/foreman/settings/provisioning.rb
+++ b/app/registries/foreman/settings/provisioning.rb
@@ -20,6 +20,8 @@ Foreman::SettingManager.define(:foreman) do
       default: nil,
       full_name: N_('Root password'),
       encrypted: true)
+    validates 'root_pass', length: { minimum: 8 }, allow_blank: true
+
     setting('unattended_url',
       type: :string,
       description: N_("URL hosts will retrieve templates from during build, when it starts with https unattended/userdata controllers cannot be accessed via HTTP"),

--- a/test/models/concerns/audit_extensions_test.rb
+++ b/test/models/concerns/audit_extensions_test.rb
@@ -16,7 +16,7 @@ class AuditExtensionsTest < ActiveSupport::TestCase
 
   test "audit's change is filtered when data is encrypted" do
     Setting.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
-    setting = Foreman.settings.set_user_value('root_pass', '654321')
+    setting = Foreman.settings.set_user_value('root_pass', '87654321')
     as_admin do
       assert setting.save
     end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -30,7 +30,7 @@ class SettingTest < ActiveSupport::TestCase
 
   test "encrypted value is saved encrypted when created" do
     Setting.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
-    setting = Foreman.settings.set_user_value('root_pass', '123456')
+    setting = Foreman.settings.set_user_value('root_pass', '12345678')
     as_admin do
       assert setting.save
     end
@@ -72,6 +72,12 @@ class SettingTest < ActiveSupport::TestCase
       setting.save!
     end
     assert_equal db_value, setting.read_attribute(:value)
+  end
+
+  test "root_pass should be at least 8 characters long" do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      Setting[:root_pass] = "1234567"
+    end
   end
 
   test 'proxy the value get to the registry' do


### PR DESCRIPTION
Link to the redmine issue - [here](https://projects.theforeman.org/issues/32925)

I added validation for the root_pass (Satellite settings > Provisioning > root_pass), which requires an 8 characters minimum length password.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
