### PR TITLE
Fixes #35179 - Use Ruby 2.7 for Rubocop action

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop -P


### PR DESCRIPTION
All the other actions are running on Ruby 2.7 and we're moving away from Ruby 2.5.