### PR TITLE
Fixes #35180 - Remove default network identifier

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -7,7 +7,13 @@ kind: snippet
 oses:
 - Ubuntu
 -%>
-    <%= @interface.identifier.blank? ? 'ens160' : @interface.identifier %>:
+<%- if @interface.identifier.blank? -%>
+    id0:
+        match:
+          macaddress: "<%= @host.mac %>"
+<%- else -%>
+    <%= @interface.identifier %>:
+<%- end -%>
         dhcp4: <%= @dhcp %>
         dhcp6: <%= @dhcp6 %>
 <%- if !@dhcp && !@subnet.nil? && !@interface.ip.nil? -%>


### PR DESCRIPTION
The Ubuntu Autoinstall cloud-init provisioning template relies on a network identifier name for its network setup. Currently, the default name `ens160` is used (if none is given explicitly). Unfortunately, we figured out that this one works only for a specific hardware type. Instead of using a default identifier name, we propose making use of the MAC-matching field.

It allows us to use the MAC instead of the system-generated network identifier (which relies on the compute resource hardware) for matching the network configuration with the corresponding hardware device.

This is a follow-up issue of #9228. Have a look there for more information.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
