### PR TITLE
Fixes #35182 - Add Rocky Linux UEFI provisioning support

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
@@ -12,7 +12,7 @@ description: |
 <%
   # Grub1 only supports numeric default statement, this allows conversion to number. First define
   # array of directories we will search for EFI booloaders:
-  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  paths = ["fedora", "redhat", "centos", "rocky", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
   # Add remaining entries to it and use this to convert to number:
   items = paths.push("local_chain_hd0")
   # Read default setting but since "local" is missing, use the first path available.

--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
@@ -11,7 +11,7 @@ description: |
 <%
   # Grub1 only supports numeric default statement, this allows conversion to number. First define
   # array of directories we will search for EFI booloaders:
-  paths = ["fedora", "redhat", "centos", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  paths = ["fedora", "redhat", "centos", "rocky", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
   # Add remaining entries to it and use this to convert to number:
   items = paths.push("local_chain_hd0", "discovery")
   # Read default setting but since "local" is missing, use the first path available.

--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -16,6 +16,8 @@ description: |
     '/EFI/redhat/grubx64.efi',
     '/EFI/centos/shim.efi',
     '/EFI/centos/grubx64.efi',
+    '/EFI/rocky/shim.efi',
+    '/EFI/rocky/grubx64.efi',
     '/EFI/debian/grubx64.efi',
     '/EFI/ubuntu/grubx64.efi',
     '/EFI/sles/grubx64.efi',

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -56,6 +56,11 @@ Medium.without_auditing do
       :path => "https://github.com/rancher/os/releases/download/v$version",
     },
     {
+      :name => "Rocky Linux",
+      :os_family => "Redhat",
+      :path => "https://download.rockylinux.org/pub/rocky/$version/BaseOS/$arch/os",
+    },
+    {
       :name => "CoreOS mirror",
       :os_family => "Coreos",
       :path => "http://$release-temporary-archive.release.core-os.net",

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_default_local_boot.host4dhcp.snap.txt
@@ -2,7 +2,7 @@
 default=0
 timeout=20
 
-fallback=1 2 3 4 5 6 7 8 9 10
+fallback=1 2 3 4 5 6 7 8 9 10 11
   
 title Chainload Grub from /EFI/fedora or try next
   rootnoverify (hd0,0)
@@ -15,6 +15,10 @@ title Chainload Grub from /EFI/redhat or try next
 title Chainload Grub from /EFI/centos or try next
   rootnoverify (hd0,0)
   chainloader /EFI/centos/grubx64.efi
+  
+title Chainload Grub from /EFI/rocky or try next
+  rootnoverify (hd0,0)
+  chainloader /EFI/rocky/grubx64.efi
   
 title Chainload Grub from /EFI/debian or try next
   rootnoverify (hd0,0)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_global_default.host4dhcp.snap.txt
@@ -2,7 +2,7 @@
 default=0
 timeout=20
 
-fallback=1 2 3 4 5 6 7 8 9 10 11
+fallback=1 2 3 4 5 6 7 8 9 10 11 12
   
 title Chainload Grub from /EFI/fedora or try next
   rootnoverify (hd0,0)
@@ -15,6 +15,10 @@ title Chainload Grub from /EFI/redhat or try next
 title Chainload Grub from /EFI/centos or try next
   rootnoverify (hd0,0)
   chainloader /EFI/centos/grubx64.efi
+  
+title Chainload Grub from /EFI/rocky or try next
+  rootnoverify (hd0,0)
+  chainloader /EFI/rocky/grubx64.efi
   
 title Chainload Grub from /EFI/debian or try next
   rootnoverify (hd0,0)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -83,6 +83,26 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
+  echo "Trying /EFI/rocky/shim.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/rocky/shim.efi
+  if [ -f ($chroot)/EFI/rocky/shim.efi ]; then
+    chainloader ($chroot)/EFI/rocky/shim.efi
+    echo "Found /EFI/rocky/shim.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
+  echo "Trying /EFI/rocky/grubx64.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/rocky/grubx64.efi
+  if [ -f ($chroot)/EFI/rocky/grubx64.efi ]; then
+    chainloader ($chroot)/EFI/rocky/grubx64.efi
+    echo "Found /EFI/rocky/grubx64.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
   # add --efidisk-only when using Software RAID

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -99,6 +99,26 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
+  echo "Trying /EFI/rocky/shim.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/rocky/shim.efi
+  if [ -f ($chroot)/EFI/rocky/shim.efi ]; then
+    chainloader ($chroot)/EFI/rocky/shim.efi
+    echo "Found /EFI/rocky/shim.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
+  echo "Trying /EFI/rocky/grubx64.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/rocky/grubx64.efi
+  if [ -f ($chroot)/EFI/rocky/grubx64.efi ]; then
+    chainloader ($chroot)/EFI/rocky/grubx64.efi
+    echo "Found /EFI/rocky/grubx64.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
   # add --efidisk-only when using Software RAID

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -79,6 +79,26 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
+  echo "Trying /EFI/rocky/shim.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/rocky/shim.efi
+  if [ -f ($chroot)/EFI/rocky/shim.efi ]; then
+    chainloader ($chroot)/EFI/rocky/shim.efi
+    echo "Found /EFI/rocky/shim.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
+  echo "Trying /EFI/rocky/grubx64.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/rocky/grubx64.efi
+  if [ -f ($chroot)/EFI/rocky/grubx64.efi ]; then
+    chainloader ($chroot)/EFI/rocky/grubx64.efi
+    echo "Found /EFI/rocky/grubx64.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
   # add --efidisk-only when using Software RAID


### PR DESCRIPTION
In pxegrub2_chainload.erb various paths are tried, but the /EFI/rocky/grubx64.efi path is missing. This causes the server to refuse to boot.

To make it easier to use the Rocky Linux installation medium is added.