### PR TITLE
Fixes #35187 - puppet params for non-integrated

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -47,10 +47,14 @@ pluginsync      = true
 report          = true
 <%- if host_puppet_ca_server.present? -%>
 ca_server       = <%= host_puppet_ca_server %>
+<%- elsif host_param('puppet_ca_server').present? -%>
+ca_server       = <%= host_param('puppet_ca_server') %>
 <%- end -%>
 certname        = <%= @host.certname %>
 <%- if host_puppet_server.present? -%>
 server          = <%= host_puppet_server %>
+<%- elsif host_param('puppet_server').present? -%>
+server       = <%= host_param('puppet_server') %>
 <%- end -%>
 <%- if host_puppet_environment.present? -%>
 environment     = <%= host_puppet_environment %>


### PR DESCRIPTION
This gives me a clean way to specify a fully disconnected puppet server while still taking advantage of the builtin snippets.