### PR TITLE
Fixes #35167 - move hostgroups dropdown actions to extendable helper

### DIFF
--- a/app/helpers/hostgroup_description_helper.rb
+++ b/app/helpers/hostgroup_description_helper.rb
@@ -1,0 +1,14 @@
+module HostgroupDescriptionHelper
+  UI.register_hostgroup_description do
+    hostgroup_actions_provider :base_hostgroup_actions
+  end
+
+  def base_hostgroup_actions(hostgroup)
+    [
+      { action: display_link_if_authorized(_('Nest'), hash_for_nest_hostgroup_path(id: hostgroup)), priority: 10 },
+      { action: display_link_if_authorized(_('Create Host'), hash_for_new_host_path(hostgroup_id: hostgroup.id)), priority: 20 },
+      { action: display_link_if_authorized(_('Clone'), hash_for_clone_hostgroup_path(id: hostgroup)), priority: 30 },
+      { action: display_delete_if_authorized(hash_for_hostgroup_path(id: hostgroup).merge(auth_object: hostgroup, authorizer: authorizer), data: { confirm: warning_message(hostgroup) }), priority: 40 },
+    ]
+  end
+end

--- a/app/helpers/hostgroups_helper.rb
+++ b/app/helpers/hostgroups_helper.rb
@@ -19,4 +19,22 @@ module HostgroupsHelper
       accessible_hostgroups - @hostgroup.descendants - [@hostgroup]
     end
   end
+
+  def hostgroup_actions(hostgroup)
+    actions = []
+    UI::HostgroupDescription.reduce_provider(:hostgroup_actions).each do |provider|
+      actions += send(provider, hostgroup)
+    end
+    prioritized_members(actions, :action)
+  end
+
+  def hostgroup_actions_dropdown(hostgroup)
+    action_buttons(hostgroup_actions(hostgroup))
+  end
+
+  def prioritized_members(list, value_key)
+    list.
+      sort_by { |member| member[:priority] }.
+      map { |member_hash| member_hash[value_key] }
+  end
 end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -158,7 +158,7 @@ module Foreman #:nodoc:
     def_field :name, :description, :url, :author, :author_url, :version, :path
     attr_reader :id, :logging, :provision_methods, :compute_resources, :to_prepare_callbacks,
       :facets, :rbac_registry, :dashboard_widgets, :info_providers, :smart_proxy_references,
-      :renderer_variable_loaders, :host_ui_description, :ping_extension, :status_extension,
+      :renderer_variable_loaders, :host_ui_description, :hostgroup_ui_description, :ping_extension, :status_extension,
       :allowed_registration_vars, :observable_events
 
     delegate :fact_importer_registry, :fact_parser_registry, :graphql_types_registry, :medium_providers_registry, :report_scanner_registry, :report_origin_registry, to: :class
@@ -581,6 +581,10 @@ module Foreman #:nodoc:
 
     def describe_host(&block)
       @host_ui_description = UI.describe_host(&block)
+    end
+
+    def describe_hostgroup(&block)
+      @hostgroup_ui_description = UI.describe_hostgroup(&block)
     end
 
     def extend_allowed_registration_vars(var)

--- a/app/services/ui.rb
+++ b/app/services/ui.rb
@@ -16,11 +16,30 @@ module UI
     host_descriptions_from_plugins + (@local_host_descriptions || [])
   end
 
+  def describe_hostgroup(&block)
+    description = HostgroupDescription.new
+    description.instance_eval(&block)
+    description
+  end
+
+  def register_hostgroup_description(&block)
+    @local_hostgroup_descriptions ||= []
+    @local_hostgroup_descriptions << describe_hostgroup(&block)
+  end
+
+  def hostgroup_descriptions
+    hostgroup_descriptions_from_plugins + (@local_hostgroup_descriptions || [])
+  end
+
   class << self
     private
 
     def host_descriptions_from_plugins
       Foreman::Plugin.all.map { |plugin| plugin.host_ui_description }.compact
+    end
+
+    def hostgroup_descriptions_from_plugins
+      Foreman::Plugin.all.map { |plugin| plugin.hostgroup_ui_description }.compact
     end
   end
 end

--- a/app/services/ui/hostgroup_description.rb
+++ b/app/services/ui/hostgroup_description.rb
@@ -1,0 +1,17 @@
+module UI
+  class HostgroupDescription
+    CUSTOMIZATION_POINT = [:hostgroup_actions]
+
+    def self.reduce_provider(customization_point)
+      UI.hostgroup_descriptions.map(&customization_point).flatten.compact
+    end
+
+    attr_reader(*CUSTOMIZATION_POINT)
+
+    define_method "hostgroup_actions_provider" do |method_sym|
+      value = instance_variable_get("@hostgroup_actions") || []
+      value << method_sym
+      instance_variable_set("@hostgroup_actions", value)
+    end
+  end
+end

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -12,26 +12,22 @@
     </tr>
   </thead>
   <tbody>
-    <% @hostgroups.each do |hostgroup| %>
-      <tr>
-        <td>
-          <%= label_with_link(hostgroup, 150, authorizer) %>
-        </td>
-        <td>
-          <%= link_to hosts_count[hostgroup], hosts_path(:search => %Q[hostgroup_fullname = "#{hostgroup.title}"]) %>
-        </td>
-        <td>
-          <%= link_to hostgroup.children_hosts_count, hosts_path(:search => %Q[parent_hostgroup = "#{hostgroup.title}"]) %>
-        </td>
-        <td>
-          <%= action_buttons(
-                      display_link_if_authorized(_('Nest'),    hash_for_nest_hostgroup_path(:id => hostgroup)),
-                      display_link_if_authorized((link_to _('Create Host'), new_host_path(hostgroup_id: hostgroup.id))),
-                      display_link_if_authorized(_('Clone'),   hash_for_clone_hostgroup_path(:id => hostgroup)),
-                      display_delete_if_authorized(hash_for_hostgroup_path(:id => hostgroup).merge(:auth_object => hostgroup, :authorizer => authorizer), :data => { :confirm => warning_message(hostgroup) })) %>
-        </td>
-      </tr>
-    <% end %>
+  <% @hostgroups.each do |hostgroup| %>
+    <tr>
+      <td>
+        <%= label_with_link(hostgroup, 150, authorizer) %>
+      </td>
+      <td>
+        <%= link_to hosts_count[hostgroup], hosts_path(:search => %Q[hostgroup_fullname = "#{hostgroup.title}"]) %>
+      </td>
+      <td>
+        <%= link_to hostgroup.children_hosts_count, hosts_path(:search => %Q[parent_hostgroup = "#{hostgroup.title}"]) %>
+      </td>
+      <td>
+        <%= hostgroup_actions_dropdown(hostgroup) %>
+      </td>
+    </tr>
+  <% end %>
   </tbody>
 </table>
 

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1649,6 +1649,42 @@ end
 ----
 
 
+[[extending-hostgroup-ui]]
+=== Extending hostgroup UI
+
+[[extending-hostgroup-ui-index-actions]]
+==== Adding actions to the index page
+A plugin can add items to the `Actions` dropdown in the table on the hostgroups overview page.
+
+Adding an item to the actions dropdown requires adding a helper with a method that accepts a hostgroup as an argument and
+returns a list of hashes, where each hash will
+have two predefined fields: `:action` and `:priority`.
+The `:action`  item should be an HTML element (probably a link) that will be embedded as an item in the dropdown.
+The `:priority` value would be used by the
+system to define the order of the items to show. The lower the priority, the
+higher the item will show.
+
+In plugin helper (`my_plugin_helper.rb`):
+[source, ruby]
+----
+def my_plugin_hostgroups_actions(hostgroup)
+  [
+    { :action => display_link_if_authorized('new_action', {other_properties}), :priority => 20 }
+  ]
+end
+----
+
+Now we have to register our new helper in `register.rb`:
+[source, ruby]
+----
+Foreman::Plugin.register :my_plugin do
+  describe_hostgroup do
+    hostgroup_actions_provider :my_plugin_hostgroups_actions
+  end
+end
+----
+
+
 [[settings]]
 === Settings
 


### PR DESCRIPTION
Added ansible action to the actions' dropdown on the Hostgroups page without overriding the existing ones.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
