### PR TITLE
Fixes #35166 - Enable DHCP and static IP deployment for Ubuntu Autoinstall

### DIFF
--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
@@ -19,19 +19,27 @@ test_on:
 #   System locale
 #
 <%
+  iface = @host.provision_interface
+  hostname = @host.name
+  mac = @host.provision_interface.mac
+  subnet4 = iface.subnet
+  subnet6 = iface.subnet6
   options = []
+
   if host_param('blacklist')
     options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
   end
-  if @host.operatingsystem.name == 'Debian'
-    options << "auto=true"
-    options << "domain=#{@host.domain}"
-  else
-    options << 'console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true'
+
+  if mac
+    # hardware type is always 01 (ethernet) unless specified otherwise
+    options << "BOOTIF=#{host_param("hardware_type", "01")}-#{mac.gsub(':', '-')}"
   end
-  if @host.provision_interface.vlanid.present?
-    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
+  if subnet4 && subnet4.dhcp_boot_mode?
+    options << "ip=dhcp"
+  elsif subnet4 && !subnet4.dhcp_boot_mode?
+    options << "ip=#{iface.ip}::#{subnet4.gateway}:#{subnet4.mask}:#{hostname}:#{iface.identifier}:none:#{subnet4.dns_primary}:#{subnet4.dns_secondary}"
   end
+
   options << "locale=#{host_param('lang') || 'en_US'}"
   options = options.join(' ')
   image_path = @preseed_path.sub(/\/?$/, '.iso')
@@ -47,6 +55,6 @@ DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
     KERNEL <%= @kernel %>
     INITRD <%= @initrd %>
-    APPEND ip=dhcp url=http://<%= @preseed_server %><%= image_path %> autoinstall ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
+    APPEND url=http://<%= @preseed_server %><%= image_path %> autoinstall ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip <%= options %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -20,6 +20,6 @@ DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
     KERNEL boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz
     INITRD boot/ubuntu-mirror-rf32u3HGTMZf-initrd
-    APPEND ip=dhcp url=http://archive.ubuntu.com:80/ubuntu.iso autoinstall ds=nocloud-net;s=http://foreman.example.com/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip
+    APPEND url=http://archive.ubuntu.com:80/ubuntu.iso autoinstall ds=nocloud-net;s=http://foreman.example.com/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip BOOTIF=01-00-f0-54-1a-7e-e0 ip=dhcp locale=en_US
 
 


### PR DESCRIPTION
* Add `options` variable to the `APPEND` statement (make actually use of the options)
* Enable flexible network configuration (switch between DHCP and static IP)
* Make BOOTIF default for multi-network device setup
* Remove unused parameters from options
* Adapt snapshot accordingly

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
