### PR TITLE
Fixes #35194 - add option for reboot --kexec to kickstart

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -230,7 +230,7 @@ key --skip
 <% end -%>
 
 text
-reboot<% if host_param_true?('install_reboot_kexec') %> --kexec<% endif %>
+reboot<% if host_param_true?('install_reboot_kexec') %> --kexec<% end %>
 
 %packages
 <%= snippet_if_exists(template_name + " custom packages") %>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -230,7 +230,7 @@ key --skip
 <% end -%>
 
 text
-reboot
+reboot<% if host_param_true?('install_reboot_kexec') %> --kexec<% endif %>
 
 %packages
 <%= snippet_if_exists(template_name + " custom packages") %>


### PR DESCRIPTION
When performing an installation of hosts with lots of disks that reboot multiple times, skipping one round of firmware initialization has meaningful time savings.