### PR TITLE
Fixes #35196 - Use assert_equal to match rendered templates

### DIFF
--- a/test/unit/foreman/renderer_test.rb
+++ b/test/unit/foreman/renderer_test.rb
@@ -47,12 +47,7 @@ class RendererTest < ActiveSupport::TestCase
     Foreman::Renderer::Source::Snapshot.hosts(template).each do |host|
       snapshot_path = Foreman::Renderer::Source::Snapshot.snapshot_path(template, host)
       rendered = Foreman::TemplateSnapshotService.render_template(template, host)
-      unless rendered == File.read(snapshot_path)
-        puts "Diff for #{snapshot_path}:"
-        puts diff(File.read(snapshot_path), rendered)
-
-        assert false, "Rendered template #{template.name} did not match the snapshot."
-      end
+      assert_equal File.read(snapshot_path), rendered, "Rendered template #{template.name} did not match the snapshot."
     end
   end
 end


### PR DESCRIPTION
This allows the report to properly show up in Jenkins, rather than the unhelpful message that it didn't match.