### PR TITLE
Fixes #21758 - Customizable landing page

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/user.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/user.rb
@@ -19,6 +19,7 @@ module Foreman::Controller::Parameters::User
           :password_confirmation,
           :timezone,
           :disabled,
+          :homepage,
           :user_mail_notifications_attributes => [user_mail_notification_params_filter]
 
         filter.permit do |ctx|

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -48,4 +48,9 @@ module UsersHelper
   def mail_notification_query_builder(mail_notification, f)
     render :partial => "#{mail_notification}_query_builder", :locals => {:f => f, :mailer => mail_notification.name } if mail_notification.queryable?
   end
+
+  def homepages
+    items = Menu::Manager.to_hash(:top_menu).map { |item| item[:children] }.flatten.keep_if { |item| item[:homepage] }
+    items.map { |item| [item[:name], item[:url]] }
+  end
 end

--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -1,6 +1,6 @@
 module Menu
   class Item < Node
-    attr_reader :name, :condition, :parent, :child_menus, :last, :html_options
+    attr_reader :name, :condition, :parent, :child_menus, :last, :html_options, :homepage
 
     def initialize(name, options)
       raise ArgumentError, "Invalid option :if for menu item '#{name}'" if options[:if] && !options[:if].respond_to?(:call)
@@ -19,6 +19,7 @@ module Menu
       @last = options[:last] || false
       @context =  options[:engine] || Rails.application
       @exact = options[:exact] || false
+      @homepage = options[:homepage] || false
       super @name.to_sym
     end
 
@@ -26,7 +27,7 @@ module Menu
       if @condition.present?
         return unless @condition.call
       end
-      {type: :item, exact: @exact, html_options: @html_options, name: @caption || @name, url: url} if authorized?
+      { type: :item, exact: @exact, html_options: @html_options, name: @caption || @name, url: url, homepage: @homepage } if authorized?
     end
 
     def url

--- a/app/registries/menu/loader.rb
+++ b/app/registries/menu/loader.rb
@@ -52,12 +52,12 @@ module Menu
         end
 
         menu.sub_menu :hosts_menu,      :caption => N_('Hosts'), :icon => 'fa fa-server' do
-          menu.item :hosts,             :caption => N_('All Hosts')
+          menu.item :hosts,             :caption => N_('All Hosts'), :homepage => true
           menu.item :newhost,           :caption => N_('Create Host'),
-                    :url_hash => {:controller => '/hosts', :action => 'new'}
+                    :url_hash => {:controller => '/hosts', :action => 'new'}, :homepage => true
           menu.item :register_hosts,    :caption => N_('Register Host'),
                     :url => '/hosts/register',
-                    :url_hash => { :controller => 'hosts', :action => 'create' }
+                    :url_hash => { :controller => 'hosts', :action => 'create' }, :homepage => true
           menu.divider                :caption => N_('Provisioning Setup')
           menu.item :architectures,   :caption => N_('Architectures')
           menu.item :models,
@@ -70,7 +70,7 @@ module Menu
           menu.item :ptables, :caption => N_('Partition Tables'),
                     :url_hash => { :controller => 'ptables', :action => 'index' }
           menu.item :provisioning_templates, :caption => N_('Provisioning Templates'),
-                    :url_hash => { :controller => 'provisioning_templates', :action => 'index' }
+                    :url_hash => { :controller => 'provisioning_templates', :action => 'index' }, :homepage => true
         end
 
         menu.sub_menu :configure_menu,  :caption => N_('Configure'), :icon => 'fa fa-wrench' do

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -37,6 +37,9 @@
       <%= selectable_f(f, :locale, FastGettext.human_available_locales,
                         { :include_blank => _('Browser locale') } , { :label => _('Language') } ) %>
 
+      <%= selectable_f(f, :homepage, homepages,
+                        { :include_blank => _('Default') } , { :label => _('Home page') } ) %>
+
       <%= time_zone_select_f(f, :timezone, Time.find_zone(@user.timezone) || Time.find_zone!('UTC'), { :include_blank => _('Browser timezone') }) %>
 
       <%= select_f(f, :auth_source_id, AuthSource.except_hidden.to_a.delete_if { |a| a.to_label.nil? } , :id,

--- a/db/migrate/20220708082310_user_homepage.rb
+++ b/db/migrate/20220708082310_user_homepage.rb
@@ -1,0 +1,5 @@
+class UserHomepage < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :homepage, :string, default: '/'
+  end
+end

--- a/public/404.html
+++ b/public/404.html
@@ -60,6 +60,7 @@
     <div>
       <h1>The page you were looking for doesn't exist.</h1>
       <p>You may have mistyped the address or the page may have moved.</p>
+      <p><a href="/">Click here</a> to return to home page.</p>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>

--- a/public/422.html
+++ b/public/422.html
@@ -60,6 +60,7 @@
     <div>
       <h1>The change you wanted was rejected.</h1>
       <p>Maybe you tried to change something you didn't have access to.</p>
+      <p><a href="/">Click here</a> to return to home page.</p>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>

--- a/public/500.html
+++ b/public/500.html
@@ -59,6 +59,7 @@
   <div class="dialog">
     <div>
       <h1>We're sorry, but something went wrong.</h1>
+      <p><a href="/">Click here</a> to return to home page.</p>
     </div>
     <p>If you are the application owner check the logs for more information.</p>
   </div>

--- a/test/helpers/users_helper_test.rb
+++ b/test/helpers/users_helper_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class UsersHelperTest < ActionView::TestCase
+  include UsersHelper
+
+  describe 'homepages' do
+    test 'with permission' do
+      assert_not_empty homepages
+    end
+
+    test 'without permission' do
+      as_user(:one) do
+        assert_equal homepages, []
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Allow user to configure landing page after login
* Update 404, 422 and 500 pages with link to '/'
* New :homepage attribute for Menu::Item

RFC: https://community.theforeman.org/t/rfc-customizable-landing-page-after-user-login/29429