### PR TITLE
Fixes #35173 - Better distinguish autocompletion for index pages

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.test.js
@@ -21,7 +21,7 @@ const store = mockStore({
       },
     },
   },
-  autocomplete: { searchBar: { url: '/test/', searchQuery: 'name=test' } },
+  autocomplete: { 'searchBar-testController': { url: '/test/', searchQuery: 'name=test' } },
   foremanModals: {
     modal2: { isOpen: false },
   },
@@ -79,7 +79,7 @@ describe('TableIndexPage', () => {
     );
 
     expect(screen.queryAllByText('I am before the toolbar')).toHaveLength(1);
-    
+
     expect(screen.getByDisplayValue('name=test')).toBeInTheDocument();
     expect(screen.queryAllByText('Test Title')).toHaveLength(1);
     expect(screen.queryAllByText('Custom button')).toHaveLength(1);

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.js
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react';
-import { useDispatch } from 'react-redux';
+import React from 'react';
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
@@ -7,7 +6,6 @@ import { SearchIcon } from '@patternfly/react-icons';
 import AutoComplete from '../AutoComplete';
 import Bookmarks from '../PF4/Bookmarks';
 import { changeQuery } from '../../common/urlHelpers';
-import { updateController } from '../AutoComplete/AutoCompleteActions';
 import './search-bar.scss';
 
 const SearchBar = props => {
@@ -19,11 +17,6 @@ const SearchBar = props => {
     onBookmarkClick,
     setAutocompleteSearchQuery,
   } = props;
-  const dispatch = useDispatch();
-
-  useEffect(() => {
-    dispatch(updateController(controller, autocomplete.url, 'searchBar'));
-  }, [dispatch, controller, autocomplete.url]);
 
   return (
     <div className="pf-c-search-input">

--- a/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/__tests__/__snapshots__/integration.test.js.snap
@@ -79,31 +79,6 @@ Array [
     Object {
       "payload": Object {
         "controller": "models",
-        "id": "searchBar",
-        "trigger": "CONTROLLER_CHANGED",
-        "url": "model/auto_complete_search",
-      },
-      "type": "AUTO_COMPLETE_CONTROLLER_CHANGE",
-    },
-  ],
-  Array [
-    Object {
-      "payload": Object {
-        "controller": "models",
-        "error": null,
-        "id": "searchBar",
-        "searchQuery": "",
-        "status": "PENDING",
-        "trigger": "INPUT_CLEAR",
-        "url": "model/auto_complete_search",
-      },
-      "type": "AUTO_COMPLETE_REQUEST",
-    },
-  ],
-  Array [
-    Object {
-      "payload": Object {
-        "controller": "models",
         "error": null,
         "id": "searchBar",
         "searchQuery": "result",

--- a/webpack/assets/javascripts/react_app/constants.js
+++ b/webpack/assets/javascripts/react_app/constants.js
@@ -8,7 +8,7 @@ export const STATUS = {
 
 export const getControllerSearchProps = (
   controller,
-  id = 'searchBar',
+  id = `searchBar-${controller}`,
   canCreate = true
 ) => ({
   controller,

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -12,7 +12,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
         "useKeyShortcuts": true,
@@ -20,7 +20,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -84,7 +84,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
         "useKeyShortcuts": true,
@@ -92,7 +92,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -158,7 +158,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
         "useKeyShortcuts": true,
@@ -166,7 +166,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "url": "/api/bookmarks",
       },
       "controller": "audits",
@@ -232,7 +232,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
         "useKeyShortcuts": true,
@@ -240,7 +240,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
       "bookmarks": Object {
         "canCreate": true,
         "documentationUrl": "/links/manual/4.1.5Searching",
-        "id": "searchBar",
+        "id": "searchBar-audits",
         "url": "/api/bookmarks",
       },
       "controller": "audits",


### PR DESCRIPTION
Although https://github.com/theforeman/foreman/pull/9267 fixed the issue, the fix introduced some regressions our test suit revealed.

This fix uses a different approach which should be compatible (it reverts https://github.com/theforeman/foreman/pull/9267 though) and still fixes https://projects.theforeman.org/issues/35072 issue.