### PR TITLE
experimental - use pnpm

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -34,16 +34,34 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Generate npm dependencies package-lock
-        run: npm install --package-lock-only --no-audit
-      - name: Install npm dependencies
-        run: npm ci --no-audit
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 6
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm recursive install
       - name: Run linter
-        run: npm run lint
+        run: pnpm run lint
       - name: Run Spellcheck (only warnings)
-        run: npm run lint:spelling
+        run: pnpm run lint:spelling
       - name: Run tests
-        run: npm run test
+        run: pnpm run test
       - name: Publish Coveralls (node v14)
         if: ${{ matrix.node-version == 14 }}
         uses: coverallsapp/github-action@master

--- a/.github/workflows/plugins_react_tests.yml
+++ b/.github/workflows/plugins_react_tests.yml
@@ -29,8 +29,25 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: '12.x'
-      # We could update the postinstall action for foreman to look for an environment variable for plugin webpack dirs
-      # before kicking off the ruby script to find them, this would eliminate the ruby dep and running `npm install` in plugins.
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 6
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: |
+          echo "::set-output name=pnpm_cache_dir::$(pnpm store path)"
+
+      - uses: actions/cache@v3
+        name: Setup pnpm cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
@@ -38,23 +55,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: ./projects/foreman
-      - name: Generate Foreman npm dependencies package-lock
-        run: npm install --package-lock-only --no-audit
-        working-directory: ${{ github.workspace }}/projects/foreman
-      - name: Install Foreman npm dependencies
-        run: npm ci --no-audit
+      - name: Install dependencies
+        run: pnpm recursive install
         working-directory: ${{ github.workspace }}/projects/foreman
       - name: Checkout ${{ matrix.repo }}
         uses: actions/checkout@v3
         with:
           repository: ${{ matrix.org }}/${{ matrix.repo }}
           path: ./projects/${{ matrix.repo }}
-      - name: Generate ${{ matrix.repo }} npm dependencies package-lock
-        run: npm install --package-lock-only --no-audit
-        working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}
       - name: Install ${{ matrix.repo }} npm dependencies
-        run: npm ci --no-audit
+        run: pnpm recursive install
         working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}
       - name: Run ${{ matrix.plugin_repo }} tests
-        run: npm test
+        run: pnpm test
         working-directory: ${{ github.workspace }}/projects/${{ matrix.repo }}

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ npm-debug.log
 .solargraph.yml
 .nvmrc
 mkmf.log
+pnpm-lock.yaml

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+auto-install-peers=true

--- a/script/npm_install_plugins.js
+++ b/script/npm_install_plugins.js
@@ -3,7 +3,7 @@ const childProcess = require('child_process');
 const { packageJsonDirs } = require('./plugin_webpack_directories');
 
 packageJsonDirs('pipe').forEach(pluginPath => {
-  childProcess.spawn('npm', ['install', '--no-optional', '--no-audit'], {
+  childProcess.spawn('pnpm', ['install'], {
     env: process.env,
     cwd: pluginPath,
     stdio: 'inherit',

--- a/script/npm_lint_plugins.js
+++ b/script/npm_lint_plugins.js
@@ -14,7 +14,7 @@ function pluginDefinesLint(pluginPath) {
 
 packageJsonDirs().forEach(pluginPath => {
   if (pluginDefinesLint(pluginPath)) {
-    childProcess.spawn('npm', ['run', 'lint'], {
+    childProcess.spawn('pnpm', ['run', 'lint'], {
       env: process.env,
       cwd: pluginPath,
       stdio: 'inherit',


### PR DESCRIPTION
When using npm or Yarn, if you have 100 projects using a dependency, you will have 100 copies of that dependency saved on disk. With pnpm, the dependency will be stored in a content-addressable store, so:

- If you depend on different versions of the dependency, only the files that differ are added to the store. For instance, if it has 100 files, and a new version has a change in only one of those files, pnpm update will only add 1 new file to the store, instead of cloning the entire dependency just for the singular change.
- All the files are saved in a single place on the disk. When packages are installed, their files are hard-linked from that single place, consuming no additional disk space. This allows you to share dependencies of the same version across projects.
As a result, you save a lot of space on your disk proportional to the number of projects and dependencies, and you have a lot faster installations!

Read more about pnpm on https://pnpm.io/motivation