### PR TITLE
Refs #34526 - Drop Rails 6.0 support code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,10 @@ require_relative 'config/boot_settings'
 source 'https://rubygems.org'
 
 gem 'rails', case SETTINGS[:rails]
-             when '6.0'
-               '~> 6.0.4.7'
              when '6.1'
                '~> 6.1.6.1'
              else
-               raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"\
+               raise "Unsupported Ruby on Rails version configured in settings.yaml: #{SETTINGS[:rails]}"
              end
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'

--- a/config/initializers/routing_hash_for.rb
+++ b/config/initializers/routing_hash_for.rb
@@ -2,64 +2,35 @@ module ActionDispatch
   module Routing
     class RouteSet
       class NamedRouteCollection
-        if Gem::Version.new(SETTINGS[:rails]) >= Gem::Version.new('6.1')
-          def define_url_helper(mod, name, helper, url_strategy)
-            mod.define_method(name) do |*args|
-              last = args.last
-              options = \
-                case last
-                when Hash
-                  args.pop
-                when ActionController::Parameters
-                  args.pop.to_h
-                end
-              helper.call(self, name, args, options, url_strategy)
-            end
-
-            # because we heavily rely on the removed hash_for method in routes, we must add this monkey patch.
-            mod.define_method("hash_for_#{name}") do |*args|
-              inner_options = \
-                case args.last
-                when Hash
-                  args.pop
-                when ActionController::Parameters
-                  args.pop.to_h
-                end
-              opts = helper.instance_variable_get(:@options)
-              helper.send(:handle_positional_args,
-                {},
-                inner_options || {},
-                args,
-                opts.merge(:use_route => helper.route_name),
-                helper.instance_variable_get(:@segment_keys))
-            end
+        def define_url_helper(mod, name, helper, url_strategy)
+          mod.define_method(name) do |*args|
+            last = args.last
+            options = \
+              case last
+              when Hash
+                args.pop
+              when ActionController::Parameters
+                args.pop.to_h
+              end
+            helper.call(self, name, args, options, url_strategy)
           end
-        else
-          def define_url_helper(mod, route, name, opts, route_key, url_strategy)
-            helper = UrlHelper.create(route, opts, route_key, url_strategy)
-            mod.define_method(name) do |*args|
-              last = args.last
-              options = \
-                case last
-                when Hash
-                  args.pop
-                when ActionController::Parameters
-                  args.pop.to_h
-                end
-              helper.call self, args, options
-            end
 
-            # because we heavily rely on the removed hash_for method in routes, we must add this monkey patch.
-            mod.define_method("hash_for_#{name}") do |*args|
-              inner_options = nil
-              inner_options = args.pop if args.last.is_a? Hash
-              helper.send(:handle_positional_args,
-                {},
-                inner_options || {},
-                args,
-                opts.merge(:use_route => route_key),
-                route.segment_keys.uniq)
-            end
+          # because we heavily rely on the removed hash_for method in routes, we must add this monkey patch.
+          mod.define_method("hash_for_#{name}") do |*args|
+            inner_options = \
+              case args.last
+              when Hash
+                args.pop
+              when ActionController::Parameters
+                args.pop.to_h
+              end
+            opts = helper.instance_variable_get(:@options)
+            helper.send(:handle_positional_args,
+              {},
+              inner_options || {},
+              args,
+              opts.merge(:use_route => helper.route_name),
+              helper.instance_variable_get(:@segment_keys))
           end
         end
       end


### PR DESCRIPTION
When Foreman switched to Rails 6.1, Rails 6.0 compatibility was dropped. This makes it fail hard when it is attempted to be used. it also removes a stray backslash.

Fixes: 1cf4147a06420842d3818f4edb6e22892f40a939
Fixes: f95e36928306637843fdfb39ed5ffe1d5f5af782