### PR TITLE
[CP] Fixes #34975 - Removed ks=. is supplied by kernel options snippet (#9238)

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -21,26 +21,13 @@ test_on:
 - host4static
 - host6static
 -%>
-<%
-  iface = @host.provision_interface
-  subnet4 = iface.subnet
-  subnet6 = iface.subnet6
-
-  if subnet4 && !subnet4.dhcp_boot_mode?
-    ks = foreman_url('provision', static: '1')
-  elsif subnet6 && !subnet6.dhcp_boot_mode?
-    ks = foreman_url('provision', static6: '1')
-  else
-    ks = foreman_url('provision')
-  end
--%>
 
 echo Trying to ping Gateway: ${netX/gateway}
 ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img ks=<%= ks %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 imgstat
 sleep 2

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -34,9 +34,21 @@ description: |
   # tell Anaconda what to pass off to kickstart server
   # both current and legacy syntax provided
   if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
-    options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+    if subnet4 && !subnet4.dhcp_boot_mode?
+      options.push("inst.ks=#{foreman_url('provision', static: '1')}")
+    elsif subnet6 && !subnet6.dhcp_boot_mode?
+      options.push("inst.ks=#{foreman_url('provision', static6: '1')}")
+    else
+      options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+    end
   else
-    options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
+    if subnet4 && !subnet4.dhcp_boot_mode?
+      options.push("ks=#{foreman_url('provision', static: '1')}")
+    elsif subnet6 && !subnet6.dhcp_boot_mode?
+      options.push("ks=#{foreman_url('provision', static6: '1')}")
+    else
+      options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
+    end  
   end
 
   # networking credentials

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host4static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/Kickstart_default_PXEGrub.host6static.snap.txt
@@ -5,7 +5,7 @@ timeout=10
 
 title Kickstart default PXEGrub
   root (nd)
-  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  kernel (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd (nd)/../boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=192.168.42.42::192.168.42.1:255.255.255.0:snapshot-ipv4-static-el7:eth0:none nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4static.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision?static=1  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv4-static-el7:eth0:none nameserver=${dns} fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv4-static-el7:eth0:none nameserver=${dns} fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=dhcp fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img ks=http://foreman.example.com/unattended/provision?static=1  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv6-static-el7:eth0:none nameserver=${dns} fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv6-static-el7:eth0:none nameserver=${dns} fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2


### PR DESCRIPTION
* Fixes #34975 - Removed ks= from template.  It is supplied by kernel options snippet.

* Refs #34975 - Update snapshots

Co-authored-by: garret <garret@foreman8.rumohr.me>
Co-authored-by: Oleh Fedorenko <ofedoren@redhat.com>
(cherry picked from commit 0c1f404149973899fd458bd47d14f8db2101918c)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
