### PR TITLE
Fixes #35244 - Pin Faraday to 1.x

### DIFF
--- a/bundler.d/gce.rb
+++ b/bundler.d/gce.rb
@@ -1,3 +1,7 @@
 group :gce do
   gem 'fog-google', '~> 1.14'
+
+  # https://projects.theforeman.org/issues/35244 Not a direct dependency, but
+  # indirect. The ecosystem is incompatible with 2.x so pin to 1.x
+  gem 'faraday', '< 2'
 end


### PR DESCRIPTION
While Foreman doesn't depend on Faraday directly, it is pulled in via fog-google which depends on google-cloud-env, googleauth and signet which all pull in Faraday. This is not a bad thing, but our ecosystem is largely incompatible with Faraday 2.x. Pinning to 1.x makes packaging easier.