### PR TITLE
Fixes #35264 - Unpin net-ssh dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,7 @@ gem 'i18n', '~> 1.1'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
 gem 'fog-core', '~> 2.1'
 gem 'net-scp'
-gem 'net-ssh', '4.2.0'
+gem 'net-ssh'
 gem 'net-ldap', '>= 0.16.0'
 gem 'net-ping', :require => false
 gem 'activerecord-session_store', '>= 2.0.0', '< 3'


### PR DESCRIPTION
Since 14e90094305a29440923a8fc21af1afde3173314 net-ssh is pinned to 4.2.0 but since f8ba14cb0a890ec62e44c9c887c008c48b9538a0 a newer fog-core is allowed. fog-core 2.2.1 can deal with a newer net-ssh so it can be unpinned.

net-ssh 7 can deal with the EL9's stronger crypto in sshd.

I must admit I haven't tested this out since I don't have SSH provisioning set up.