### PR TITLE
Fixes #35289 - Add cali* interfaces to ignore list

### DIFF
--- a/app/registries/foreman/settings/facts.rb
+++ b/app/registries/foreman/settings/facts.rb
@@ -37,6 +37,7 @@ Foreman::SettingManager.define(:foreman) do
       'vovsbr*',
       'br-int',
       'vif*',
+      'cali*',
     ].freeze
 
     setting('create_new_host_when_facts_are_uploaded',


### PR DESCRIPTION
cali* interfaces are created by project calico (https://projectcalico.docs.tigera.io/reference/architecture/overview) and regenerated with a random name frequently. We need to ignore them the same way we ignore docker interfaces.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
