### PR TITLE
Fixes #35294 - Switch to masonry card layout for Details tab

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
@@ -32,6 +32,7 @@ const SystemPropertiesCard = ({ status, isExpandedGlobal, hostDetails }) => {
       overrideGridProps={{ rowSpan: 2 }}
       header={__('System properties')}
       expandable
+      masonryLayout
       isExpandedGlobal={isExpandedGlobal}
     >
       <DescriptionList isCompact>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
@@ -1,10 +1,11 @@
 import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
-import { Grid, Flex, FlexItem, Button } from '@patternfly/react-core';
+import { Flex, FlexItem, Button } from '@patternfly/react-core';
 import { registerCoreCards } from './CardRegistry';
 import Slot from '../../../common/Slot';
 import { STATUS } from '../../../../constants';
 import '../Overview/styles.css';
+import './styles.css';
 import { translate as __ } from '../../../../common/I18n';
 
 const DetailsTab = ({ response, status, hostName }) => {
@@ -19,17 +20,21 @@ const DetailsTab = ({ response, status, hostName }) => {
 
   return (
     <div className="host-details-tab-item details-tab">
-      <Flex>
+      <Flex style={{ marginBottom: '1rem' }}>
         <FlexItem align={{ default: 'alignRight' }}>
           <Button
             onClick={() => setExpandedGlobal(prev => !prev)}
             variant="link"
           >
-            {__('Expand/Collapse  all')}
+            {__('Expand/Collapse all')}
           </Button>
         </FlexItem>
       </Flex>
-      <Grid hasGutter>
+      <Flex
+        direction={{ default: 'column' }}
+        flexWrap={{ default: 'wrap' }}
+        className="details-tab-flex-container"
+      >
         <Slot
           hostDetails={response}
           status={status}
@@ -38,7 +43,7 @@ const DetailsTab = ({ response, status, hostName }) => {
           isExpandedGlobal={isExpandedGlobal}
           multi
         />
-      </Grid>
+      </Flex>
     </div>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
@@ -1,0 +1,5 @@
+.details-tab-flex-container {
+  max-height: 66rem;
+  width: 24rem;
+  gap: 1.2rem;
+}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
@@ -1,5 +1,5 @@
 .details-tab-flex-container {
-  max-height: 66rem;
+  max-height: calc(100vh - 225px);
   width: 24rem;
   gap: 1.2rem;
 }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -10,6 +10,7 @@ import {
   CardTitle,
   CardBody,
   GridItem,
+  FlexItem,
 } from '@patternfly/react-core';
 
 import { useLocalStorage } from '../../../../../common/hooks/Storage';
@@ -23,6 +24,7 @@ const CardTemplate = ({
   dropdownItems,
   overrideGridProps,
   overrideDropdownProps,
+  masonryLayout,
 }) => {
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
   const [isExpanded, setExpanded] = useLocalStorage(
@@ -41,10 +43,22 @@ const CardTemplate = ({
     () => isExpandedGlobal !== undefined && setExpanded(isExpandedGlobal),
     [isExpandedGlobal]
   );
+  const CardContainer = masonryLayout ? FlexItem : GridItem;
+  const gridWidthProps = masonryLayout
+    ? {}
+    : {
+        xl2: 3,
+        xl: 4,
+        md: 6,
+        lg: 4,
+      };
+  const cardProps = masonryLayout
+    ? { style: { width: '24rem', marginTop: '-0.8rem' } }
+    : {};
 
   return (
-    <GridItem xl2={3} xl={4} md={6} lg={4} {...overrideGridProps}>
-      <Card isExpanded={isExpanded} isSelectable>
+    <CardContainer {...gridWidthProps} {...overrideGridProps}>
+      <Card isExpanded={isExpanded} {...cardProps} isSelectable>
         <CardHeader
           onExpand={expandable && onExpandCallback}
           isToggleRightAligned
@@ -72,7 +86,7 @@ const CardTemplate = ({
           <CardBody>{children}</CardBody>
         )}
       </Card>
-    </GridItem>
+    </CardContainer>
   );
 };
 
@@ -84,6 +98,7 @@ CardTemplate.propTypes = {
   dropdownItems: PropTypes.arrayOf(PropTypes.node),
   overrideDropdownProps: PropTypes.object,
   expandable: PropTypes.bool,
+  masonryLayout: PropTypes.bool,
 };
 
 CardTemplate.defaultProps = {
@@ -93,6 +108,7 @@ CardTemplate.defaultProps = {
   overrideDropdownProps: {},
   expandable: false,
   isExpandedGlobal: false,
+  masonryLayout: false,
 };
 
 export default CardTemplate;


### PR DESCRIPTION
Our implementation of the Details tab didn't look like the original mockups because we used Patternfly's Grid layout, which means cards must be a uniform height across columns.

This PR changes to a vertical flex layout for Details tab cards, which brings several advantages:
* cards don't have to be uniform heights
* smaller cards take up less vertical space
* the height of a card is independent from the height of the cards in adjacent columns

The flex layout has a maximum height and wraps cards to the next column as needed.
With this change, cards will fill in from top to bottom first, then left to right.

![masonry-Details](https://user-images.githubusercontent.com/22042343/181847437-f11b0da1-152d-48dd-89c3-a8e114d97c10.png)
