### PR TITLE
Fixes #35298 - Pass trim_mode as a keyword argument

### DIFF
--- a/app/services/foreman/renderer/safe_mode_renderer.rb
+++ b/app/services/foreman/renderer/safe_mode_renderer.rb
@@ -3,7 +3,7 @@ module Foreman
     class SafeModeRenderer < BaseRenderer
       def render
         box = Safemode::Box.new(scope, allowed_helpers, source_name)
-        erb = ERB.new(source_content, nil, '-')
+        erb = ERB.new(source_content, trim_mode: '-')
         box.eval(erb.src, allowed_variables)
       rescue ::Racc::ParseError => e
         new_e = SyntaxError.new(name: source_name, message: e.message)

--- a/app/services/foreman/renderer/unsafe_mode_renderer.rb
+++ b/app/services/foreman/renderer/unsafe_mode_renderer.rb
@@ -2,7 +2,7 @@ module Foreman
   module Renderer
     class UnsafeModeRenderer < BaseRenderer
       def render
-        erb = ERB.new(source_content, nil, '-')
+        erb = ERB.new(source_content, trim_mode: '-')
         erb.location = source_name, 0
         erb.result(get_binding)
       rescue ::SyntaxError => e


### PR DESCRIPTION
Ruby 2.6 introduced the keyword argument and Ruby 3.1 raises deprecation warnings about this.