### PR TITLE
Fixes #35299 - Remove redundant mocha inclusion

### DIFF
--- a/test/unit/proxy_api/bmc_test.rb
+++ b/test/unit/proxy_api/bmc_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require "mocha/setup"
 
 class ProxyApiBmcTest < ActiveSupport::TestCase
   def setup


### PR DESCRIPTION
Mocha is already included in test_helper, using the non-deprecated version.