### PR TITLE
Fixes #35300 - Pass keyword arguments correctly

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -161,7 +161,7 @@ module ApplicationHelper
 
   def sort(field, permitted: [], **kwargs)
     kwargs[:url_options] ||= current_url_params(permitted: permitted)
-    super(field, kwargs)
+    super(field, **kwargs)
   end
 
   def help_button

--- a/app/models/concerns/foreman/sti.rb
+++ b/app/models/concerns/foreman/sti.rb
@@ -20,7 +20,7 @@ module Foreman
       end
     end
 
-    def save(*args)
+    def save(*args, **kwargs)
       type_changed = type_changed?
       self.class.instance_variable_set("@finder_needs_type_condition", :false) if type_changed
       super

--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -42,18 +42,17 @@ module HasManyCommon
     end
 
     #### has_many ####
-    def has_many(*args)
-      options = args.last.is_a?(Hash) ? args.last : {}
-      has_many_names_for(args.first, options)
+    def has_many(name, scope = nil, **kwargs, &extension)
+      has_many_names_for(name)
       super
     end
 
-    def has_and_belongs_to_many(association, options = {})
-      has_many_names_for(association, options)
+    def has_and_belongs_to_many(name, scope = nil, **kwargs, &extension)
+      has_many_names_for(name)
       super
     end
 
-    def has_many_names_for(association, options)
+    def has_many_names_for(association)
       assoc = association.to_s.tableize.singularize
 
       # SETTER _names= method
@@ -71,15 +70,14 @@ module HasManyCommon
     end
 
     #### belongs_to ####
-    def belongs_to(*args)
-      options = args.last.is_a?(Hash) ? args.last : {}
-      belongs_to_name_for(args.first, options)
-      super
+    def belongs_to(name, scope = nil, name_accessor: nil, **kwargs)
+      belongs_to_name_for(name, name_accessor)
+      super(name, scope, **kwargs)
     end
 
-    def belongs_to_name_for(association, options)
+    def belongs_to_name_for(association, name_accessor)
       assoc = association.to_s.tableize.singularize
-      assoc_name = options.delete(:name_accessor) || "#{assoc}_name"
+      assoc_name = name_accessor || "#{assoc}_name"
 
       # SETTER _name= method
       define_method "#{assoc_name}=" do |name_value|

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -8,7 +8,7 @@ module CsvExporter
     context = Foreman::ThreadSession::Context.get
 
     Enumerator.new do |csv|
-      Foreman::ThreadSession::Context.set(context)
+      Foreman::ThreadSession::Context.set(**context)
       csv << CSV.generate_line(header)
       cols = columns.map { |c| c.to_s.split('.').map(&:to_sym) }
       resources.uncached do

--- a/app/services/foreman/renderer/scope/template.rb
+++ b/app/services/foreman/renderer/scope/template.rb
@@ -6,7 +6,7 @@ module Foreman
         attr_reader :template_input_values
 
         def initialize(template_input_values: {}, **params)
-          super(params)
+          super(**params)
           @template_input_values = template_input_values
         end
       end


### PR DESCRIPTION
In Ruby 3.0 keyword arguments are [handled separate from positional arguments](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). This uses kwargs and passes it along.

It is likely very incomplete, but this is what I found easily when I started Rails 7.0 on Ruby 3.1 and clicked through the UI. I believe these changes are all Ruby 2.7 compatible.