### PR TITLE
Fixes #35301 - minitest 5 deprecation fixes

### DIFF
--- a/test/helpers/compute_resources_helper_test.rb
+++ b/test/helpers/compute_resources_helper_test.rb
@@ -20,7 +20,7 @@ class ComputeResourcesHelperTest < ActionView::TestCase
       compute.stubs(:datacenters).raises(Foreman::FingerprintException, 'Wrong fingerprint')
       instance.controller.action_name = 'test_connection'
       instance.list_datacenters(compute)
-      _(compute.errors.messages[:pubkey_hash].first).must_include 'Wrong fingerprint'
+      assert_includes(compute.errors.messages[:pubkey_hash].first, 'Wrong fingerprint')
     end
   end
 end

--- a/test/models/compute_resources/ovirt_test.rb
+++ b/test/models/compute_resources/ovirt_test.rb
@@ -67,25 +67,25 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
 
     it 'maps operating system to ovirt operating systems' do
       @compute_resource.stubs(:available_operating_systems).returns(@os_hashes)
-      _(@compute_resource.determine_os_type(@host)).must_equal "other_linux"
+      assert_equal "other_linux", @compute_resource.determine_os_type(@host)
 
       @host.operatingsystem = operatingsystems(:redhat)
-      _(@compute_resource.determine_os_type(@host)).must_equal "rhel_6"
+      assert_equal "rhel_6", @compute_resource.determine_os_type(@host)
 
       @host.architecture = architectures(:x86_64)
-      _(@compute_resource.determine_os_type(@host)).must_equal "rhel_6x64"
+      assert_equal "rhel_6x64", @compute_resource.determine_os_type(@host)
 
       @host.operatingsystem = operatingsystems(:ubuntu1210)
-      _(@compute_resource.determine_os_type(@host)).must_equal "ubuntu_12_10"
+      assert_equal "ubuntu_12_10", @compute_resource.determine_os_type(@host)
 
       @host.operatingsystem = FactoryBot.create(:operatingsystem)
-      _(@compute_resource.determine_os_type(@host)).must_equal "other"
+      assert_equal "other", @compute_resource.determine_os_type(@host)
     end
 
     it 'respects host param ovirt_ostype' do
       @compute_resource.stubs(:available_operating_systems).returns(@os_hashes)
       @host.stubs(:params).returns({'ovirt_ostype' => 'some_os'})
-      _(@compute_resource.determine_os_type(@host)).must_equal "some_os"
+      assert_equal "some_os", @compute_resource.determine_os_type(@host)
     end
 
     it 'caches the operating systems in the compute resource' do
@@ -115,7 +115,7 @@ class Foreman::Model:: OvirtTest < ActiveSupport::TestCase
 
     it 'passes api_version v4 by default' do
       Fog::Compute.expects(:new).with do |options|
-        _(options[:api_version]).must_equal 'v4'
+        assert_equal 'v4', options[:api_version]
       end.returns(@client_mock)
       @compute_resource.send(:client)
     end

--- a/test/models/concerns/taxonomix_test.rb
+++ b/test/models/concerns/taxonomix_test.rb
@@ -313,7 +313,7 @@ class TaxonomixTest < ActiveSupport::TestCase
     original_org, Organization.current = Organization.current, org
     new_dom = Domain.new(:organization_ids => [org.id])
     Organization.current = original_org
-    _(new_dom.taxable_taxonomies).must_be :present?
+    assert_predicate(new_dom.taxable_taxonomies, :present?)
     assert new_dom.taxable_taxonomies.all?(&:valid?)
   end
 

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -28,12 +28,12 @@ class RoleTest < ActiveSupport::TestCase
 
   it "should strip leading space on name" do
     role = Role.new(:name => " a role name")
-    _(role).must_be :valid?
+    assert_predicate(role, :valid?)
   end
 
   it "should strip a trailing space on name" do
     role = Role.new(:name => "a role name ")
-    _(role).must_be :valid?
+    assert_predicate(role, :valid?)
   end
 
   it "should delete role who has users" do
@@ -204,8 +204,8 @@ class RoleTest < ActiveSupport::TestCase
       end
 
       subject { Role.for_current_user.to_a }
-      it { _(subject).must_include(first) }
-      it { _(subject).wont_include(second) }
+      it { assert_includes(subject, first) }
+      it { refute_includes(subject, second) }
     end
 
     context "when current user is admin for_current_user should return all givable roles" do

--- a/test/models/template_input_test.rb
+++ b/test/models/template_input_test.rb
@@ -10,11 +10,11 @@ class TemplateInputTest < ActiveSupport::TestCase
     end
 
     it 'exports type' do
-      _(template_input.to_export['input_type']).must_equal template_input.input_type
+      assert_equal(template_input.input_type, template_input.to_export['input_type'])
     end
 
     it 'exports options' do
-      _(template_input.to_export['options']).must_equal template_input.options
+      assert_equal(template_input.options, template_input.to_export['options'])
     end
   end
 

--- a/test/models/template_test.rb
+++ b/test/models/template_test.rb
@@ -480,15 +480,15 @@ data"
       end
 
       it 'exports name' do
-        _(erb).must_match(/^name: #{exportable_template.name}$/)
+        assert_match(/^name: #{exportable_template.name}$/, erb)
       end
 
       it 'includes template inputs' do
-        _(erb).must_match(/^template_inputs:$/)
+        assert_match(/^template_inputs:$/, erb)
       end
 
       it 'includes template contents' do
-        _(erb).must_include exportable_template.template
+        assert_includes(erb, exportable_template.template)
       end
 
       it 'is importable' do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1111,7 +1111,7 @@ class UserTest < ActiveSupport::TestCase
     user.timezone = ''
     assert user.valid?
     user.save
-    _(user.timezone).must_be_nil
+    assert_nil(user.timezone)
   end
 
   test "changing user password as admin without setting current password" do

--- a/test/unit/compute_resource_host_associator_test.rb
+++ b/test/unit/compute_resource_host_associator_test.rb
@@ -24,9 +24,9 @@ class ComputeResourceHostAssociatorTest < ActiveSupport::TestCase
 
     associator.associate_hosts
 
-    _(host_without_vm.uuid).must_equal(vm1.identity)
-    _(associator.hosts).must_equal([host_without_vm])
-    _(associator.fail_count).must_equal 0
+    assert_equal(vm1.identity, host_without_vm.uuid)
+    assert_equal([host_without_vm], associator.hosts)
+    assert_equal(0, associator.fail_count)
   end
 
   test 'rescues from errors occurred during the associated_host call ===' do
@@ -37,6 +37,6 @@ class ComputeResourceHostAssociatorTest < ActiveSupport::TestCase
 
     associator.associate_hosts
 
-    _(associator.fail_count).must_equal 1
+    assert_equal(1, associator.fail_count)
   end
 end

--- a/test/unit/foreman/force_ssl_test.rb
+++ b/test/unit/foreman/force_ssl_test.rb
@@ -8,7 +8,7 @@ class ForceSslTest < ActiveSupport::TestCase
 
   describe 'general urls' do
     it 'do not allow http' do
-      _(subject.allows_http?).must_equal false
+      refute subject.allows_http?
     end
   end
 
@@ -21,14 +21,14 @@ class ForceSslTest < ActiveSupport::TestCase
       end
 
       it 'allows http' do
-        _(subject.allows_http?).must_equal true
+        assert subject.allows_http?
       end
 
       context 'with preview params' do
         let(:params) { { 'spoof' => true } }
 
         it 'doesnt allow http for previews' do
-          _(subject.allows_http?).must_equal false
+          refute subject.allows_http?
         end
       end
     end
@@ -39,7 +39,7 @@ class ForceSslTest < ActiveSupport::TestCase
       end
 
       it 'does not allow http' do
-        _(subject.allows_http?).must_equal false
+        refute subject.allows_http?
       end
     end
   end

--- a/test/unit/net/validations_test.rb
+++ b/test/unit/net/validations_test.rb
@@ -4,21 +4,21 @@ require 'net'
 class ValidationsTest < ActiveSupport::TestCase
   describe "validate_mac" do
     test "nil is not valid" do
-      Net::Validations.validate_mac(nil).must_be_same_as false
+      refute Net::Validations.validate_mac(nil)
     end
 
     test "48-bit MAC address is valid" do
-      Net::Validations.validate_mac("aa:bb:cc:dd:ee:ff").must_be_same_as true
+      assert Net::Validations.validate_mac("aa:bb:cc:dd:ee:ff")
     end
 
     test "64-bit MAC address is valid" do
-      Net::Validations.validate_mac("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd").must_be_same_as true
+      assert Net::Validations.validate_mac("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd")
     end
 
     test "MAC address is not valid" do
-      Net::Validations.validate_mac("aa:bb:cc:dd:ee").must_be_same_as false
-      Net::Validations.validate_mac("aa:bb:cc:dd:ee:ff:gg:11").must_be_same_as false
-      Net::Validations.validate_mac("aa:bb:cc:dd:ee:zz").must_be_same_as false
+      refute Net::Validations.validate_mac("aa:bb:cc:dd:ee")
+      refute Net::Validations.validate_mac("aa:bb:cc:dd:ee:ff:gg:11")
+      refute Net::Validations.validate_mac("aa:bb:cc:dd:ee:zz")
     end
   end
 
@@ -119,7 +119,7 @@ class ValidationsTest < ActiveSupport::TestCase
     let(:hostname) { "this.is.an.example.com" }
 
     test "should normalize incorrect case" do
-      Net::Validations.normalize_hostname("ThIs.Is.An.eXaMPlE.CoM").must_equal(hostname)
+      assert_equal(hostname, Net::Validations.normalize_hostname("ThIs.Is.An.eXaMPlE.CoM"))
     end
   end
 
@@ -128,15 +128,15 @@ class ValidationsTest < ActiveSupport::TestCase
       let(:mac) { "aa:bb:cc:dd:ee:ff" }
 
       test "should normalize dash separated format" do
-        Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff").must_equal(mac)
+        assert_equal(mac, Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff"))
       end
 
       test "should normalize condensed format" do
-        Net::Validations.normalize_mac("aabbccddeeff").must_equal(mac)
+        assert_equal(mac, Net::Validations.normalize_mac("aabbccddeeff"))
       end
 
       test "should keep colon separated format" do
-        Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff").must_equal(mac)
+        assert_equal(mac, Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff"))
       end
     end
 
@@ -144,15 +144,15 @@ class ValidationsTest < ActiveSupport::TestCase
       let(:mac) { "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd" }
 
       test "should normalize dash separated format" do
-        Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff-00-11-22-33-44-55-66-77-88-99-aa-bb-cc-dd").must_equal(mac)
+        assert_equal(mac, Net::Validations.normalize_mac("aa-bb-cc-dd-ee-ff-00-11-22-33-44-55-66-77-88-99-aa-bb-cc-dd"))
       end
 
       test "should normalize condensed format" do
-        Net::Validations.normalize_mac("aabbccddeeff00112233445566778899aabbccdd").must_equal(mac)
+        assert_equal(mac, Net::Validations.normalize_mac("aabbccddeeff00112233445566778899aabbccdd"))
       end
 
       test "should keep colon separated format" do
-        Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd").must_equal(mac)
+        assert_equal(mac, Net::Validations.normalize_mac("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"))
       end
     end
 

--- a/test/unit/plugin_test.rb
+++ b/test/unit/plugin_test.rb
@@ -272,11 +272,11 @@ class PluginTest < ActiveSupport::TestCase
       name 'Awesome compute'
       compute_resource Awesome::Provider::MyAwesome
     end
-    assert _(ComputeResource.providers.keys).must_include 'MyAwesome'
-    assert _(ComputeResource.providers.values).must_include 'Awesome::Provider::MyAwesome'
+    assert_includes ComputeResource.providers.keys, 'MyAwesome'
+    assert_includes ComputeResource.providers.values, 'Awesome::Provider::MyAwesome'
     assert_equal ComputeResource.provider_class('MyAwesome'), 'Awesome::Provider::MyAwesome'
-    assert _(ComputeResource.registered_providers.keys).must_include 'MyAwesome'
-    assert _(ComputeResource.registered_providers.values).must_include 'Awesome::Provider::MyAwesome'
+    assert_includes ComputeResource.registered_providers.keys, 'MyAwesome'
+    assert_includes ComputeResource.registered_providers.values, 'Awesome::Provider::MyAwesome'
   end
 
   def test_invalid_compute_resource


### PR DESCRIPTION
This possibly overlaps with `_()` as a translation method. `value()` is also an alias that can be used but using the `assert*` methods is more consistent with the rest of the codebase