### PR TITLE
Fixes #35306 - host_puppet_* template macros ignores host_param

### DIFF
--- a/app/services/foreman/renderer/scope/macros/host_template.rb
+++ b/app/services/foreman/renderer/scope/macros/host_template.rb
@@ -57,7 +57,7 @@ module Foreman
           end
           def host_puppet_server
             check_host
-            host.try(:puppet_server) || host_param('puppet_server')
+            host.try(:puppet_server).presence || host_param('puppet_server')
           end
 
           apipie :method, 'Returns Puppet CA server\'s hostname configured through the ENC or the puppet_ca_server host parameter' do
@@ -65,7 +65,7 @@ module Foreman
           end
           def host_puppet_ca_server
             check_host
-            host.try(:puppet_ca_server) || host_param('puppet_ca_server')
+            host.try(:puppet_ca_server).presence || host_param('puppet_ca_server')
           end
 
           apipie :method, 'Returns the Puppet environment configured configured through the ENC or the puppet_environment host parameter' do

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -100,10 +100,10 @@ class HostTemplateTest < ActiveSupport::TestCase
     end
 
     test 'should render puppet_server parameter when puppet_server not defined' do
-      host = stub()
+      host = stub(puppet_server: '')
       @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_server').returns('myserver.example.com')
-      assert_equal @scope.host_puppet_server, 'myserver.example.com'
+      @scope.expects(:host_param).with('puppet_server').returns('from_param.example.com')
+      assert_equal @scope.host_puppet_server, 'from_param.example.com'
     end
   end
 
@@ -115,10 +115,10 @@ class HostTemplateTest < ActiveSupport::TestCase
     end
 
     test 'should render puppet_ca_server parameter when puppet_ca_server not defined' do
-      host = stub()
+      host = stub(puppet_ca_server: '')
       @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server').returns('myserver.example.com')
-      assert_equal @scope.host_puppet_ca_server, 'myserver.example.com'
+      @scope.expects(:host_param).with('puppet_ca_server').returns('from_param.example.com')
+      assert_equal @scope.host_puppet_ca_server, 'from_param.example.com'
     end
   end
 


### PR DESCRIPTION
When host.puppet_server or host.puppet_ca_server returns
empty string we don't load the values from host parameters.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
