### PR TITLE
Fixes #34969 - Set up REX pull on client setup

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -22,6 +22,7 @@ description: |
   - ntp-server: string (default=undef)
   - package_upgrade: boolean (default=true)
   - salt_master: string (default=undef)
+  - enable-remote-execution-pull: boolean (default=false)
 -%>
 <%
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
@@ -70,6 +71,12 @@ fi
 <% end -%>
 
 <%= snippet('remote_execution_ssh_keys') %>
+
+<% if plugin_present?('katello') && host_param_true?('enable-remote-execution-pull') -%>
+<%= save_to_file('/root/remote_execution_pull_setup.sh', snippet('remote_execution_pull_setup')) %>
+chmod +x /root/remote_execution_pull_setup.sh
+/root/remote_execution_pull_setup.sh
+<% end -%>
 
 <%= snippet "blacklist_kernel_modules" %>
 

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -54,7 +54,10 @@ trap 'exit_and_cancel_build' ERR
 
 <% if host_param_true?('host_registration_remote_execution') -%>
 <%= snippet 'remote_execution_ssh_keys' %>
+<% end -%>
 
+<% if plugin_present?('katello') && host_param_true?('host_registration_remote_execution_pull') -%>
+<%= snippet 'remote_execution_pull_setup' %>
 <% end -%>
 
 <%= install_packages(host_param('host_packages')) -%>

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -23,6 +23,7 @@ description: |
 <%= "\n# Operating system: [#{@operatingsystem}]" if @operatingsystem -%>
 <%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
 <%= "\n# Setup remote execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
+<%= "\n# Setup remote execution pull: [#{@setup_remote_execution_pull}]" unless @setup_remote_execution_pull.nil? -%>
 <%= "\n# Remote execution interface: [#{@remote_execution_interface}]" if @remote_execution_interface.present? -%>
 <%= "\n# Packages: [#{@packages}]" if @packages.present? -%>
 <%= "\n# Update packages: [#{@update_packages}]" unless @update_packages.nil? -%>
@@ -121,6 +122,7 @@ if [ -f /etc/redhat-release ]; then
 <%= "          --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
 <%= "          --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
 <%= "          --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
+<%= "          --data 'setup_remote_execution_pull=#{@setup_remote_execution_pull}' \\\n" unless @setup_remote_execution_pull.nil? -%>
 <%= "          --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
 <%= "          --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
 

--- a/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
+++ b/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
@@ -1,0 +1,84 @@
+<%#
+kind: snippet
+name: remote_execution_pull_setup
+model: ProvisioningTemplate
+snippet: true
+description: |
+  Snippet for installing and setting up a client to be reachable by remote execution in pull mode
+-%>
+
+echo "Starting deployment of REX pull provider"
+# check if system is registered
+subscription-manager identity > /dev/null
+if [ $? -ne 0 ]; then
+    echo "Please register with subscription-manager first, then re-run '$0'."
+    exit 1
+fi
+
+set -e
+
+<%= install_packages('foreman_ygg_worker') %>
+
+echo "Getting configuration from subscription-manager..."
+KPPTEMPFILE=$(mktemp kpp_tempfile_XXXXXXXX)
+trap "rm -f $KPPTEMPFILE" ERR EXIT
+subscription-manager config --list > $KPPTEMPFILE
+CONSUMER_CERT_DIR=$(grep 'consumercertdir' $KPPTEMPFILE | cut -d= -f2 | xargs | sed 's/[][]//g')
+CERT_FILE=$CONSUMER_CERT_DIR/cert.pem
+KEY_FILE=$CONSUMER_CERT_DIR/key.pem
+CA_FILE=$(grep 'repo_ca_cert = ' $KPPTEMPFILE | cut -d= -f2 | xargs | cut -d ' ' -f1)
+SERVER_NAME=$(grep 'hostname = ' $KPPTEMPFILE | cut -d= -f2 | xargs | cut -d ' ' -f1)
+
+# fail if no server name, cert dir, or ca file
+if [ -z "$SERVER_NAME" ] || [ -z "$CONSUMER_CERT_DIR" ] || [ -z "$CA_FILE" ]; then
+    echo "Unable to determine config from 'subscription-manager config --list'; exiting"
+    exit 1
+fi
+
+# fail if client is not registered to a Katello
+if ! grep -q 'prefix = \/rhsm' $KPPTEMPFILE; then
+    echo "Client is registered to RHSM; exiting"
+    exit 1
+fi
+
+# set SYSCONFDIR to /etc if it is not set
+if [ -z "$SYSCONFDIR" ]; then
+    SYSCONFDIR=/etc
+fi
+
+# see if /etc/yggdrasil/config.toml exists
+CONFIGTOML=$SYSCONFDIR/yggdrasil/config.toml
+if [ -f $CONFIGTOML ]; then
+    # make a backup of CONFIGTOML
+    cp $CONFIGTOML $CONFIGTOML.bak
+    cat <<EOF > $CONFIGTOML
+# yggdrasil global configuration settings written by katello-pull-transport-migrate
+broker = ["mqtts://$SERVER_NAME:1883"]
+cert-file = "$CERT_FILE"
+key-file = "$KEY_FILE"
+ca-root = ["$CA_FILE"]
+log-level = "error"
+EOF
+
+else
+    echo "$SYSCONFDIR/yggdrasil/config.toml not found! Did 'yum install yggdrasil' succeed?"
+    exit 1
+fi
+
+# start the yggdrasild service
+echo "Starting yggdrasild..."
+systemctl enable --now yggdrasild
+
+# check status of yggdrasild and fail if it is not running
+# possible failure reason: incorrect protocol (should be tcp:// or mqtt://) or port (should be 1883)
+# also, cert-file and key-file must be valid
+# and broker must be running on the server
+yggdrasil status
+
+if ! systemctl is-active --quiet yggdrasild; then
+    echo ""
+    echo "yggdrasild failed to start! Check configuration in $CONFIGTOML and make sure the broker is running on the server."
+    exit $?
+fi
+
+echo "Remote execution pull provider successfully configured!"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -37,6 +37,7 @@ fi
 
 
 
+
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -268,6 +268,7 @@ const RegistrationCommandsPage = () => {
                   onChange={handlePluginValue}
                   handleInvalidField={handleInvalidField}
                   isLoading={isLoading}
+                  configParams={configParams}
                   multi
                 />
               </div>
@@ -315,6 +316,7 @@ const RegistrationCommandsPage = () => {
                   onChange={handlePluginValue}
                   handleInvalidField={handleInvalidField}
                   isLoading={isLoading}
+                  configParams={configParams}
                   multi
                 />
               </div>


### PR DESCRIPTION
- Import katello-pull-transport-migrate
- Setup rex pull on registration
- Setup rex pull during provisioning
- Pass config params to slots/fills in registration form

(cherry picked from commit 713a1878807671aa20394b0fd0aca8e99c537d6b)

The original PR was flagged  with "needs cherrypick" but noone really opened it up until now.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
