### PR TITLE
Fixes #35316 - enhance template-seed error-report

### DIFF
--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -102,6 +102,7 @@ class SeedHelper
 
     def import_raw_template(contents, vendor = 'Foreman')
       metadata = Template.parse_metadata(contents)
+      raise "Metadata could not be parsed, it seems to be empty" if metadata.empty?
       raise "Attribute 'name' is required in metadata in order to seed the template" if metadata['name'].nil?
       raise "Attribute 'model' is required in metadata in order to seed the template" if metadata['model'].nil?
 
@@ -138,6 +139,9 @@ class SeedHelper
     def import_templates(template_paths, vendor = 'Foreman')
       template_paths.each do |path|
         import_raw_template(File.read(path), vendor)
+      rescue RuntimeError => e
+        Foreman::Logging.exception("Error in seeding the template #{path.inspect} metadata #{e.message}", e)
+        raise e
       end
     end
 


### PR DESCRIPTION
I had the problem, that a template could not be seeded, because the Metadata was not valid YAML and therefore could not be parsed `metadata` therefore being empty, the seed reported that `name` was missing.
Having `name:` in all templates I was pretty puzzled.

This fix will:
* report empty parsed `metadata` as 'Metadata could not be parsed'
* log the path of a template that produces errors during it's seeding
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
