### PR TITLE
Fixes #35330 - Add support for ActiveStorage and PostgreSQL adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'jwt', '>= 2.2.2', '< 3.0'
 gem 'graphql', '~> 1.13.0'
 gem 'graphql-batch'
 
+gem 'active_storage-postgresql', '~> 0.3.0'
+
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   instance_eval(Bundler.read_file(bundle))
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -18,6 +18,18 @@ Foreman::AccessControl.map do |permission_set|
       :bookmarks => [:index, :show, :auto_complete_search, :welcome],
       :"api/v2/bookmarks" => [:index, :show],
     }, :public => true
+    # file URLs are short-lived, hence can be public
+    map.permission :files,
+      {
+        :"active_storage/postgresql" => [:show, :update],
+        :"active_storage/representations/proxy" => [:show],
+        :"active_storage/direct_uploads" => [:create],
+        :"active_storage/representations/redirect" => [:show],
+        :"active_storage/disk" => [:show, :update],
+        :"active_storage/blobs/redirect" => [:show],
+        :"active_storage/blobs/proxy" => [:show],
+      },
+      :public => true
   end
 
   permission_set.security_block :architectures do |map|

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ require "rails"
 
 [
   'active_record/railtie',
-  # 'active_storage/engine',
+  'active_storage/engine',
   'action_controller/railtie',
   'action_view/railtie',
   'action_mailer/railtie',

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -44,6 +44,9 @@ Foreman::Application.configure do
   # include query source line when sql logging is enabled
   config.active_record.verbose_query_logs = Foreman::Logging.logger('sql')
 
+  # Use :local ActiveStorage provider
+  config.active_storage.service = :local
+
   if defined?(Bullet)
     config.after_initialize do
       Bullet.enable = true

--- a/config/environments/production.rb.orig
+++ b/config/environments/production.rb.orig
@@ -78,8 +78,10 @@ Foreman::Application.configure do |app|
   # Log denied attributes into logger
   config.action_controller.action_on_unpermitted_parameters = :log
 
+<<<<<<< HEAD
+  config.hosts += SETTINGS[:hosts]
+=======
   # Use :local ActiveStorage provider
   config.active_storage.service = :local
-
-  config.hosts += SETTINGS[:hosts]
+>>>>>>> fcc3986bf (Fixes #35330 - Add support for ActiveStorage and PostgreSQL adapter)
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,6 +66,13 @@ Foreman::Application.configure do
 
   config.webpack.dev_server.enabled = false
 
+  # Use :temp_folder ActiveStorage provider
+  config.active_storage.service = :temp_folder
+
+  Minitest.after_run do
+    FileUtils.rm_rf(ActiveStorage::Blob.service.root) if ActiveStorage::Blob.service&.root
+  end
+
   # Whitelist all plugin engines by default from raising errors on deprecation warnings for
   # compatibility, allow them to override it by adding an ASDT configuration file.
   config.after_initialize do

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,0 +1,10 @@
+filesystem:
+  service: Disk
+  root: <%= Rails.root.join("storage") %>
+
+local:
+  service: PostgreSQL
+
+temp_folder:
+  service: Disk
+  root: <%= Dir.mktmpdir('test_active_storage') %>

--- a/db/migrate/20220804072553_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20220804072553_create_active_storage_tables.active_storage.rb
@@ -1,0 +1,36 @@
+# This migration comes from active_storage (originally 20170806125915)
+class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_blobs do |t|
+      t.string   :key,          null: false
+      t.string   :filename,     null: false
+      t.string   :content_type
+      t.text     :metadata
+      t.string   :service_name, null: false
+      t.bigint   :byte_size,    null: false
+      t.string   :checksum,     null: false
+      t.datetime :created_at,   null: false
+
+      t.index [:key], unique: true
+    end
+
+    create_table :active_storage_attachments do |t|
+      t.string     :name,     null: false
+      t.references :record,   null: false, polymorphic: true, index: false
+      t.references :blob,     null: false
+
+      t.datetime :created_at, null: false
+
+      t.index [:record_type, :record_id, :name, :blob_id], name: "index_active_storage_attachments_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+
+    create_table :active_storage_variant_records do |t|
+      t.belongs_to :blob, null: false, index: false
+      t.string :variation_digest, null: false
+
+      t.index [:blob_id, :variation_digest], name: "index_active_storage_variant_records_uniqueness", unique: true
+      t.foreign_key :active_storage_blobs, column: :blob_id
+    end
+  end
+end

--- a/db/migrate/20220804072622_create_active_storage_postgresql_tables.active_storage_postgresql.rb
+++ b/db/migrate/20220804072622_create_active_storage_postgresql_tables.active_storage_postgresql.rb
@@ -1,0 +1,11 @@
+# This migration comes from active_storage_postgresql (originally 20180530020601)
+class CreateActiveStoragePostgresqlTables < ActiveRecord::Migration[5.2]
+  def change
+    create_table :active_storage_postgresql_files do |t|
+      t.oid :oid
+      t.string :key
+
+      t.index :key, unique: true
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for ActiveStorage in Foreman with PostgreSQL blob adapter.

By default postgresql would be used for development and production. For testing a local temp directory would be used to prevent database bloat in case of forgotten objects.