### PR TITLE
feature: Additional template inlcudes/if logic

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -7,6 +7,7 @@ module Foreman
         :foreman_url,
         :snippet, :snippets,
         :snippet_if_exists,
+        :snippet_exists,
         :indent,
         :foreman_server_fqdn, :foreman_server_url,
         :foreman_request_addr,

--- a/app/services/foreman/renderer/scope/macros/snippet_rendering.rb
+++ b/app/services/foreman/renderer/scope/macros/snippet_rendering.rb
@@ -10,6 +10,17 @@ module Foreman
             sections only: %w[all provisioning]
           end
 
+          apipie :method, 'Checks if a snippet exitsts in template source, e.g. database' do
+            desc 'Checks if a snippet exists, does not render template.'
+            required :name, String, desc: 'Name of the snippet template to check for'
+            returns [true, false], desc: 'presence of the snippet'
+            example "snippet_exist('motd') # => true"
+            see 'snippet', description: 'Snippet#snippet', scope: Foreman::Renderer::Scope::Macros::SnippetRendering
+          end
+          def snippet_exists(name)
+            source.find_snippet(name).present?
+          end
+
           apipie :method, 'Renders a snippet if it exists in template source, e.g. database' do
             desc 'Same to snippet but does not fail and continues the main rendering if the given snippet was not found'
             required :name, String, desc: 'Name of the snippet template to render'

--- a/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/kickstart_default_pxegrub.erb
@@ -27,7 +27,7 @@ timeout=<%= host_param('loader_timeout') || 10 %>
 
 title <%= template_name %>
   root (nd)
-  kernel (nd)/../<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  kernel (nd)/../<%= @kernel %> <%= pxe_kernel_options %> <%= snippet([['custom kickstart_kernel_options', 'kickstart_kernel_options']]).strip %>
   initrd (nd)/../<%= @initrd %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
@@ -23,4 +23,4 @@ description: |
 default=<%= default_item %>
 timeout=20
 
-<%= snippet "pxegrub_chainload", variables: {paths: paths} %>
+<%= snippet([['custom pxegrub_chainload', 'pxegrub_chainload']], variables: {paths: paths}) %>

--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
@@ -22,9 +22,9 @@ description: |
 default=<%= default_item %>
 timeout=20
 
-<%= snippet "pxegrub_chainload", variables: {paths: paths} %>
+<%= snippet([['custom pxegrub_chainload', 'pxegrub_chainload']], variables: {paths: paths}) %>
 
-<%= snippet "pxegrub_discovery" %>
+<%= snippet([['custom pxegrub_discovery', 'pxegrub_discovery']]) %>
 
 <% unless @profiles.nil? -%>
 <% for profile in @profiles

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -38,7 +38,7 @@ set default=<%= host_param('default_grub_install_entry') || 0 %>
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= linuxcmd %> <%= @kernel %> <%= pxe_kernel_options %> <%= snippet([['custom kickstart_kernel_options', 'kickstart_kernel_options']]).strip %>
   <%= initrdcmd %> <%= @initrd %>
 }
 
@@ -53,7 +53,7 @@ if subnet && subnet.httpboot
 -%>
 <% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
-  <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet([['custom kickstart_kernel_options', 'kickstart_kernel_options']]).strip %>
   <%= initrdcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>
@@ -62,7 +62,7 @@ menuentry '<%= template_name %> EFI HTTP' --id efi_http {
 
 <% if proxy_https_port -%>
 menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
-  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet([['custom kickstart_kernel_options', 'kickstart_kernel_options']]).strip %>
   <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -29,7 +29,7 @@ set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac <%= snippet("preseed_kernel_options").strip %>
+  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac <%= snippet([['custom preseed_kernel_options', 'preseed_kernel_options']]).strip %>
   initrd<%= efi_suffix %> <%= @initrd %>
 }
 

--- a/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_default_local_boot.erb
@@ -12,5 +12,5 @@ set default=<%= global_setting("default_pxe_item_local", "local") %>
 set timeout=20
 echo Default PXE local template entry is set to '<%= global_setting("default_pxe_item_local", "local") %>'
 
-<%= snippet "pxegrub2_chainload" %>
-<%= snippet "pxegrub2_discovery" %>
+<%= snippet([['custom pxegrub2_chainload', 'pxegrub2_chainload']]) %>
+<%= snippet([['custom pxegrub2_discovery', 'pxegrub2_discovery']]) %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
@@ -11,9 +11,9 @@ default=<%= global_setting("default_pxe_item_global", "local") %>
 timeout=20
 echo Default PXE global template entry is set to '<%= global_setting("default_pxe_item_global", "local") %>'
 
-<%= snippet "pxegrub2_mac" %>
-<%= snippet "pxegrub2_chainload" %>
-<%= snippet "pxegrub2_discovery" %>
+<%= snippet([['custom pxegrub2_mac', 'pxegrub2_mac']]) %>
+<%= snippet([['custom pxegrub2_chainload', 'pxegrub2_chainload']]) %>
+<%= snippet([['custom pxegrub2_discovery', 'pxegrub2_discovery']]) %>
 
 <% unless @profiles.nil? -%>
 <% for profile in @profiles

--- a/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/kickstart_default_pxelinux.erb
@@ -35,7 +35,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL <%= template_name %>
 KERNEL <%= @kernel %>
-APPEND initrd=<%= @initrd %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+APPEND initrd=<%= @initrd %> <%= pxe_kernel_options %> <%= snippet([['custom kickstart_kernel_options', 'kickstart_kernel_options']]).strip %>
 <% if @host.architecture.to_s.match(/s390x?/i) %>
 INITRD <%= @initrd %>
 <% end %>

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux.erb
@@ -18,7 +18,7 @@ description: |
 DEFAULT linux
 LABEL linux
     KERNEL <%= @kernel %>
-    APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options").strip %>
+    APPEND initrd=<%= @initrd %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet([['custom preseed_kernel_options', 'preseed_kernel_options']]).strip %>
     IPAPPEND 2
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/pxelinux_default_local_boot.erb
@@ -25,5 +25,5 @@ TIMEOUT 200
 ONTIMEOUT <%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
 DEFAULT <%= global_setting("default_pxe_item_local", "local_chain_hd0") %>
 
-<%= snippet "pxelinux_chainload" %>
+<%= snippet([['custom pxelinux_chainload', 'pxelinux_chainload']]) %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/PXELinux/pxelinux_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/pxelinux_global_default.erb
@@ -14,9 +14,9 @@ TIMEOUT 200
 ONTIMEOUT <%= global_setting("default_pxe_item_global", "local") %>
 DEFAULT <%= global_setting("default_pxe_item_global", "local") %>
 
-<%= snippet "pxelinux_chainload" %>
+<%= snippet([['custom pxelinux_chainload', 'pxelinux_chainload']]) %>
 
-<%= snippet "pxelinux_discovery" %>
+<%= snippet([['custom pxelinux_discovery', 'pxelinux_discovery']]) %>
 
 <% unless @profiles.nil? -%>
 <% for profile in @profiles

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -40,35 +40,35 @@ manage_etc_hosts: true
 users: {}
 runcmd:
 - |
-<%= indent(2) { snippet 'fix_hosts' } -%>
+<%= indent(2) { snippet([['custom fix_hosts', 'fix_hosts']]) } -%>
 - |
-<%= indent(2) { snippet 'yum_proxy' } -%>
+<%= indent(2) { snippet([['custom yum_proxy', 'yum_proxy']]) } -%>
 - |
-<%= indent(2) { snippet 'ntp' } -%>
+<%= indent(2) { snippet([['custom ntp', 'ntp']]) } -%>
 - |
 <% if rhel_compatible && host_param_true?('enable-epel') -%>
-<%= indent(2) { snippet 'epel' } -%>
+<%= indent(2) { snippet([['cusom epel', 'epel']]) } -%>
 <% end -%>
 - |
-<%= indent(2) { snippet 'redhat_register' } -%>
+<%= indent(2) { snippet([['custom redhat_register', 'redhat_register']]) } -%>
 - |
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
-<%= indent(2) { snippet 'freeipa_register' } %>
+<%= indent(2) { snippet([['custom freeipa_register', 'freeipa_register']]) } %>
 <% end -%>
 - |
-<%= indent(2) { snippet 'remote_execution_ssh_keys' } %>
+<%= indent(2) { snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) } %>
 - |
-<%= indent(2) { snippet 'blacklist_kernel_modules' } %>
+<%= indent(2) { snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) } %>
 - |
 <% if chef_enabled %>
-<%= indent(2) { snippet 'chef_client' } %>
+<%= indent(2) { snippet([['custom chef_client', 'chef_client']]) } %>
 <% end -%>
 - |
 <% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= indent(2) { snippet 'puppetlabs_repo' } %>
+<%= indent(2) { snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) } %>
 <% end -%>
-<%= indent(2) { snippet 'puppet_setup' } %>
+<%= indent(2) { snippet([['custom puppet_setup', 'puppet_setup']]) } %>
 <% end -%>
 phone_home:
   url: <%= foreman_url('built') %>

--- a/app/views/unattended/provisioning_templates/finish/alterator_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/alterator_default_finish.erb
@@ -13,20 +13,20 @@ description: |
 -%>
 #!/bin/sh
 
-<%= snippet 'fix_hosts' %>
+<%= snippet([['custom fix_hosts', 'fix_hosts']]) %>
 
 apt-get update >/dev/null 2>/dev/null
 apt-get -y install puppet >/dev/null 2>/dev/null
 
 
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet 'puppet.conf' -%>
+<%= snippet([['custom puppet.conf', 'puppet.conf']]) -%>
 EOF
 
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf -o --tags no_such_tag --server <%= host_puppet_server %> --no-daemonize
 /sbin/chkconfig puppetd on
 
-<%= snippet 'built' %>
-<%= snippet 'schedule_reboot' -%>
+<%= snippet([['custom built', 'built']]) %>
+<%= snippet([['custom schedule_reboot', 'schedule_reboot']]) -%>
 
 exit 0

--- a/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
@@ -44,14 +44,14 @@ pkg update > /root/install/pkg_update.txt
 pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 <% if puppet_enabled %>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet 'schedule_reboot' -%>
+<%= snippet([['custom schedule_reboot', 'schedule_reboot']]) -%>
 
 exit 0

--- a/app/views/unattended/provisioning_templates/finish/jumpstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/jumpstart_default_finish.erb
@@ -48,7 +48,7 @@ EOF
 
 /usr/bin/echo "Configuring puppet"
 cat > /etc/puppet/puppet.conf << EOF
-<%= snippet 'puppet.conf' -%>
+<%= snippet([['custom puppet.conf', 'puppet.conf']]) -%>
 EOF
 # The x86 version of the puppet package ignores the --config parameter. This should fix that and not hurt other installations
 if [ -f /etc/opt/csw/puppet/puppetd.conf ]
@@ -61,6 +61,6 @@ fi
 echo "Informing Foreman that we are built"
 /opt/csw/bin/wget --no-check-certificate -O /dev/null <%= foreman_url('built') %>
 
-<%= snippet 'schedule_reboot' -%>
+<%= snippet([['custom schedule_reboot', 'schedule_reboot']]) -%>
 
 exit 0

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -34,7 +34,7 @@ description: |
 
 <%= snippet_if_exists(template_name + " custom pre") -%>
 <% if @host.subnet.respond_to?(:dhcp_boot_mode?) -%>
-<%= snippet 'kickstart_networking_setup' %>
+<%= snippet([['custom kickstart_networking_setup', 'kickstart_networking_setup']]) %>
 <% if (rhel_compatible && os_major >= 8) -%>
 systemctl restart NetworkManager
 <% else -%>
@@ -47,18 +47,18 @@ service network restart
 echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
-<%= snippet 'yum_proxy' %>
+<%= snippet([['custom yum_proxy', 'yum_proxy']]) %>
 
-<%= snippet 'ntp' %>
+<%= snippet([['custom ntp', 'ntp']]) %>
 
 <% if rhel_compatible && host_param_true?('enable-epel') -%>
-<%= snippet 'epel' -%>
+<%= snippet([['custom epel', 'epel']]) -%>
 <% end -%>
 
-<%= snippet 'redhat_register' %>
+<%= snippet([['custom redhat_register', 'redhat_register']]) %>
 
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
-<%= snippet 'freeipa_register' %>
+<%= snippet([['custom freeipa_register', 'freeipa_register']]) %>
 <% end -%>
 
 <% unless host_param_false?('package_upgrade') -%>
@@ -70,40 +70,40 @@ else
 fi
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
 <% if plugin_present?('katello') && host_param_true?('enable-remote-execution-pull') -%>
-<%= save_to_file('/root/remote_execution_pull_setup.sh', snippet('remote_execution_pull_setup'), verbatim: true) %>
+<%= save_to_file('/root/remote_execution_pull_setup.sh', snippet([['custom remote_execution_pull_setup', 'remote_execution_pull_setup']]), verbatim: true) %>
 chmod +x /root/remote_execution_pull_setup.sh
 /root/remote_execution_pull_setup.sh
 <% end -%>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <%= snippet_if_exists(template_name + " custom post") -%>
 <% if chef_enabled %>
-<%= snippet 'chef_client' %>
+<%= snippet([['custom chef_client', 'chef_client']]) %>
 <% end -%>
 
 <% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
 <% end -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 <% if host_param_true?('ansible_tower_provisioning') -%>
-<%= save_to_file('/root/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+<%= save_to_file('/root/ansible_provisioning_call.sh', snippet([['custom ansible_tower_callback_script', 'ansible_tower_callback_script']])) %>
 chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh
 <% end -%>
 
 sync
 
-<%= snippet 'schedule_reboot' -%>
+<%= snippet([['custom schedule_reboot', 'schedule_reboot']]) -%>
 
 exit 0

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -46,12 +46,12 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 <%= snippet_if_exists(template_name + " custom snippet") %>
 <% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
-<%= snippet 'freeipa_register' %>
+<%= snippet([['custom freeipa_register', 'freeipa_register']]) %>
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <%= snippet_if_exists(template_name + " custom post") -%>
 <% unless host_param('kernel_parameters').nil? -%>
@@ -61,23 +61,23 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 <% if chef_enabled -%>
 
-<%= snippet 'chef_client' %>
+<%= snippet([['custom chef_client', 'chef_client']]) %>
 <% end -%>
 <% if puppet_enabled -%>
 
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
 <% end -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 <% if salt_enabled -%>
 
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
-<%= snippet 'preseed_networking_setup' -%>
-<%= snippet 'ansible_provisioning_callback' -%>
-<%= snippet 'efibootmgr_netboot' -%>
-<%= snippet 'eject_cdrom' -%>
-<%= snippet 'built' -%>
-<%= snippet 'schedule_reboot' -%>
+<%= snippet([['custom preseed_networking_setup', 'preseed_networking_setup']]) -%>
+<%= snippet([['custom ansible_provisioning_callback', 'ansible_provisioning_callback']]) -%>
+<%= snippet([['custom efibootmgr_netboot', 'efibootmgr_netboot']]) -%>
+<%= snippet([['custom eject_cdrom', 'eject_cdrom']]) -%>
+<%= snippet([['custom built', 'built']]) -%>
+<%= snippet([['custom schedule_reboot', 'schedule_reboot']]) -%>

--- a/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/windows_default_finish.erb
@@ -95,7 +95,7 @@ description: |
     cmd /c winrm set winrm/config/service/auth @{Certificate="true"}
   <% end %>
 
-  <%= snippet 'Windows network' %>
+  <%= snippet([['custom Windows network', 'Windows network']]) %>
 
   <% if foreman_url('user_data') %>
     echo execute user data script

--- a/app/views/unattended/provisioning_templates/finish/xenserver_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/xenserver_default_finish.erb
@@ -9,5 +9,5 @@ description: |
   is complete. It reboots the machine afterwards. Meant for use with XenServer or Citrix Hypervisor
 -%>
 #!/bin/bash
-<%= snippet 'built' %>
-<%= snippet 'schedule_reboot' -%>
+<%= snippet([['custom built', 'built']]) %>
+<%= snippet([['custom schedule_reboot', 'schedule_reboot']]) -%>

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -51,22 +51,22 @@ set +e
 trap 'exit_and_cancel_build' ERR
 
 <% if !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet')) -%>
-<%= snippet 'puppetlabs_repo' %>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if host_param_true?('host_registration_remote_execution') -%>
-<%= snippet 'remote_execution_ssh_keys' %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 <% end -%>
 
 <% if plugin_present?('katello') && host_param_true?('host_registration_remote_execution_pull') -%>
-<%= snippet 'remote_execution_pull_setup' %>
+<%= snippet([['custom remote_execution_pull_setup', 'remote_execution_pull_setup']]) %>
 <% end -%>
 
 <%= install_packages(host_param('host_packages')) -%>
 
 <% if host_param_true?('host_registration_insights') -%>
-<%= snippet 'insights' %>
+<%= snippet([['custom insights', 'insights']]) %>
 
 <% end -%>
 
@@ -87,7 +87,7 @@ fi
 <% end -%>
 <%= update_packages if host_param_true?('host_update_packages') -%>
 
-<%= snippet_if_exists('host_init_config_post') -%>
+<%= snippet_if_exists([['custom host_init_config_post', 'host_init_config_post']]) -%>
 
 # Call home to exit build mode
 

--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -27,7 +27,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
+kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img <%= pxe_kernel_options %> <%= snippet([['custom kickstart_kernel_options', 'kickstart_kernel_options']], variables: {ipxe_net: true}).strip %>
 initrd <%= "#{@host.url_for_boot(:initrd)}" %>
 imgstat
 sleep 2

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -36,7 +36,7 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} <%= snippet("preseed_kernel_options").strip %>
+kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} <%= snippet([['custom preseed_kernel_options', 'preseed_kernel_options']]).strip %>
 
 initrd <%= initrd %>
 

--- a/app/views/unattended/provisioning_templates/provision/alterator_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/alterator_default.erb
@@ -12,7 +12,7 @@ description: |
 <% if @metadata.to_s == '/vm-profile.scm' -%>
 <%= @host.diskLayout %>
 <% elsif @metadata.to_s == '/pkg-groups.tar' -%>
-<%= snippet 'alterator_pkglist' %>
+<%= snippet([['custom alterator_pkglist', 'alterator_pkglist']]) %>
 <% else -%>
 ("/sysconfig-base/language" action "write" lang ("<%= host_param('lang') || 'en_US' %>"))
 ("/sysconfig-base/kbd" action "write" layout "ctrl_shift_toggle")

--- a/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/atomic_kickstart_default.erb
@@ -69,10 +69,11 @@ cp -vf /tmp/*pre*log /mnt/sysimage/root/
 %end
 
 %post
-<%= snippet 'redhat_register' %>
+<%= snippet_if_exists(template_name + " custom post early") -%>
+<%= snippet([['custom redhat_register', 'redhat_register']]) %>
 rm -f /etc/ostree/remotes.d/*.conf
-<%= snippet('remote_execution_ssh_keys') %>
-<%= snippet 'efibootmgr_netboot' %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
+<%= snippet([['custom efibootmgr_netboot', 'efibootmgr_netboot']]) %>
 touch /tmp/foreman_built
 %end
 
@@ -91,10 +92,10 @@ The last post section halts Anaconda to prevent endless loop in case HTTP reques
 <% end -%>
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
+  <%= indent(2, skip1: true) { snippet([['custom built', 'built']], :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 else
   echo "calling home: build failed!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
+  <%= indent(2, skip1: true) { snippet([['custom built', 'built']], :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 fi
 
 sync

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -189,22 +189,22 @@ cp /etc/resolv.conf /mnt/etc
 
 <%= snippet_if_exists(template_name + " custom pre") -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <% if puppet_enabled -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 <%= snippet_if_exists(template_name + " custom post") -%>
 
-<%= snippet 'eject_cdrom' -%>
-<%= snippet 'built' -%>
+<%= snippet([['custom eject_cdrom', 'eject_cdrom']]) -%>
+<%= snippet([['custom built', 'built']]) -%>
 
 rm /etc/resolv.conf
 ]]>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -219,26 +219,26 @@ cp /etc/resolv.conf /mnt/etc
 
 <%= snippet_if_exists(template_name + " custom pre") -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <% if spacewalk_enabled -%>
-<%= snippet 'redhat_register' %>
+<%= snippet([['custom redhat_register', 'redhat_register']]) %>
 <% end -%>
 
 <% if puppet_enabled -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 <%= snippet_if_exists(template_name + " custom post") -%>
 
-<%= snippet 'eject_cdrom' -%>
-<%= snippet 'built' -%>
+<%= snippet([['custom eject_cdrom', 'eject_cdrom']]) -%>
+<%= snippet([['custom built', 'built']]) -%>
 
 rm /etc/resolv.conf
 ]]>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -259,7 +259,7 @@ wget
 <% end -%>
 @Core
 <% if host_param_true?('fips_enabled') -%>
-<%=   snippet 'fips_packages' %>
+<%=   snippet([['custom fips_packages', 'fips_packages']]) %>
 <% end -%>
 <%= section_end %>
 
@@ -293,20 +293,22 @@ exec < /dev/tty3 > /dev/tty3
 chvt 3
 (
 logger "Starting anaconda <%= @host %> postinstall"
-<%= snippet 'kickstart_networking_setup' %>
+<%= snippet_if_exists(template_name + " custom post early") -%>
 
-<%= snippet 'ntp' %>
+<%= snippet([['custom kickstart_networking_setup', 'kickstart_networking_setup']]) %>
 
-<%= snippet 'yum_proxy' %>
+<%= snippet([['custom ntp', 'ntp']]) %>
+
+<%= snippet([['custom yum_proxy', 'yum_proxy']]) %>
 
 <% if rhel_compatible && host_param_true?('enable-epel') -%>
-<%= snippet 'epel' -%>
+<%= snippet([['custom epel', 'epel']]) -%>
 <% end -%>
 
-<%= snippet 'redhat_register' if rhel_compatible && os_major < 9 -%>
+<%= snippet([['custom redhat_register', 'redhat_register']]) if rhel_compatible && os_major < 9 -%>
 
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
-<%= snippet 'freeipa_register' %>
+<%= snippet([['custom freeipa_register', 'freeipa_register']]) %>
 <% end -%>
 
 <% unless host_param_false?('package_upgrade') -%>
@@ -318,29 +320,29 @@ else
 fi
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
 <% if plugin_present?('katello') && host_param_true?('enable-remote-execution-pull') -%>
-<%= save_to_file('/root/remote_execution_pull_setup.sh', snippet('remote_execution_pull_setup'), verbatim: true) %>
+<%= save_to_file('/root/remote_execution_pull_setup.sh', snippet([['custom remote_execution_pull_setup', 'remote_execution_pull_setup']]), verbatim: true) %>
 chmod +x /root/remote_execution_pull_setup.sh
 /root/remote_execution_pull_setup.sh
 <% end -%>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <% if chef_enabled %>
-<%= snippet 'chef_client' %>
+<%= snippet([['custom chef_client', 'chef_client']]) %>
 <% end -%>
 
 <% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo')|| host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
 <% end -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 <% if @host.operatingsystem.name == 'OracleLinux' && host_param_true?('disable-uek') -%>
@@ -349,13 +351,13 @@ yum -t -y remove kernel-uek*
 sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/kernel
 <% end -%>
 
-<%= snippet('ansible_provisioning_callback') %>
+<%= snippet([['custom ansible_provisioning_callback', 'ansible_provisioning_callback']]) %>
 
-<%= snippet 'efibootmgr_netboot' %>
+<%= snippet([['custom efibootmgr_netboot', 'efibootmgr_netboot']]) %>
 
 <%= snippet_if_exists(template_name + " custom post") %>
 
-<%= snippet 'insights' if host_param_true?('host_registration_insights') && os_major < 9 -%>
+<%= snippet([['custom insights', 'insights']]) if host_param_true?('host_registration_insights') && os_major < 9 -%>
 
 touch /tmp/foreman_built
 
@@ -377,14 +379,14 @@ The last post section halts Anaconda to prevent endless loop in case HTTP reques
 %post --erroronfail --log=/root/install-callhome.post.log
 <% end -%>
 
-<%= snippet 'eject_cdrom' -%>
+<%= snippet([['custom eject_cdrom', 'eject_cdrom']]) -%>
 
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
+  <%= indent(2, skip1: true) { snippet([['custom built', 'built']], :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 else
   echo "calling home: build failed!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
+  <%= indent(2, skip1: true) { snippet([['custom built', 'built']], :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 fi
 
 sync

--- a/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
@@ -76,11 +76,11 @@ reboot
 
 %post --log=/root/ks.post.log --erroronfail
 nodectl init
-<%= snippet 'redhat_register' %>
-<%= snippet 'kickstart_networking_setup' %>
-<%= snippet 'efibootmgr_netboot' %>
+<%= snippet([['custom redhat_register', 'redhat_register']]) %>
+<%= snippet([['custom kickstart_networking_setup', 'kickstart_networking_setup']]) %>
+<%= snippet([['custom efibootmgr_netboot', 'efibootmgr_netboot']]) %>
 <% if host_param_true?('host_registration_insights') -%>
-<%= snippet 'insights' -%>
+<%= snippet([['custom insights', 'insights']]) -%>
 <% end -%>
 
 /usr/sbin/ntpdate -sub <%= host_param('ntp-server') || '0.fedora.pool.ntp.org' %>

--- a/app/views/unattended/provisioning_templates/provision/rancheros_provision.erb
+++ b/app/views/unattended/provisioning_templates/provision/rancheros_provision.erb
@@ -8,4 +8,4 @@ description: |
   The provisioning template for the RancherOS. The output is the cloud config data.
   This does not work with k3os, a successor of the RancherOS 1.x and 2.x
 -%>
-<%= snippet 'rancheros_cloudconfig' -%>
+<%= snippet([['custom rancheros_cloudconfig', 'rancheros_cloudconfig']]) -%>

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -43,7 +43,7 @@ if ! [ $(id -u) = 0 ]; then
   exit 1
 fi
 
-<%= snippet 'pkg_manager' %>
+<%= snippet([['custom pkg_manager', 'pkg_manager']]) %>
 
 SSL_CA_CERT=$(mktemp)
 cat << EOF > $SSL_CA_CERT

--- a/app/views/unattended/provisioning_templates/snippet/ansible_provisioning_callback.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_provisioning_callback.erb
@@ -19,12 +19,12 @@ description: |
 -%>
 <% if has_systemd -%>
 <%= save_to_file('/etc/systemd/system/ansible-callback.service',
-                 snippet('ansible_tower_callback_service')) %>
+                 snippet([['custom ansible_tower_callback_service', 'ansible_tower_callback_service']])) %>
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 <% else -%>
 # Assume systemd is not available
-<%= save_to_file('/root/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+<%= save_to_file('/root/ansible_provisioning_call.sh', snippet([['custom ansible_tower_callback_script', 'ansible_tower_callback_script']])) %>
 (chmod +x /root/ansible_provisioning_call.sh; crontab -u root -l 2>/dev/null; echo "@reboot /root/ansible_provisioning_call.sh" ) | crontab -u root -
 <% end -%>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_bond_interface.erb
@@ -9,7 +9,7 @@ description: |
   This is typically used by other templates and snippets that pass interface
   object to be configured. It is not expected to be used directly.
 -%>
-<%= snippet('kickstart_ifcfg_generic_interface', :variables => {
+<%= snippet([['custom kickstart_ifcfg_generic_interface', 'kickstart_ifcfg_generic_interface']], :variables => {
                   :interface => @interface,
                   :subnet => @subnet,
                   :subnet6 => @subnet6,

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_bonded_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_bonded_interface.erb
@@ -9,7 +9,7 @@ description: |
   This is typically used by other templates and snippets that pass interface
   object to be configured. It is not expected to be used directly.
 -%>
-<%= snippet('kickstart_ifcfg_generic_interface', :variables => {
+<%= snippet([['custom kickstart_ifcfg_generic_interface', 'kickstart_ifcfg_generic_interface']], :variables => {
                   :interface => @interface,
                   :subnet => @subnet,
                   :subnet6 => @subnet6,

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_networking_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_networking_setup.erb
@@ -12,8 +12,8 @@ description: |
 <%- @host.bond_interfaces.each do |bond| -%>
 <%-   bonding_interfaces.push(bond.identifier) -%>
 <%=   "# #{bond.identifier} interface" %>
-<%=   snippet('kickstart_ifcfg_get_identifier_names', :variables => { :identifier => bond.identifier }) %>
-<%-   ifcfg = snippet('kickstart_ifcfg_bond_interface', :variables => {
+<%=   snippet([['custom kickstart_ifcfg_get_identifier_names', 'kickstart_ifcfg_get_identifier_names']], :variables => { :identifier => bond.identifier }) %>
+<%-   ifcfg = snippet([['custom kickstart_ifcfg_bond_interface', 'kickstart_ifcfg_bond_interface']], :variables => {
                         :interface => bond,
                         :subnet => bond.subnet,
                         :subnet6 => bond.subnet6,
@@ -23,8 +23,8 @@ description: |
 <%-   @host.interfaces_with_identifier(bond.attached_devices_identifiers).each do |interface| -%>
 <%-     next if !interface.managed? -%>
 <%=     "# #{interface.identifier} interface" %>
-<%=     snippet('kickstart_ifcfg_get_identifier_names', :variables => { :interface => interface }) -%>
-<%-     ifcfg = snippet('kickstart_ifcfg_bonded_interface', :variables => {
+<%=     snippet([['custom kickstart_ifcfg_get_identifier_names', 'kickstart_ifcfg_get_identifier_names']], :variables => { :interface => interface }) -%>
+<%-     ifcfg = snippet([['custom kickstart_ifcfg_bonded_interface', 'kickstart_ifcfg_bonded_interface']], :variables => {
                           :interface => interface,
                           :subnet => interface.subnet,
                           :subnet6 => interface.subnet6,
@@ -41,8 +41,8 @@ description: |
 
 <%-   interface_identifier = @host.bond_interfaces.map { |i| i.identifier }.include?(interface.attached_to) ? interface.identifier : nil %>
 <%=   "# #{interface.identifier} interface" %>
-<%=   snippet('kickstart_ifcfg_get_identifier_names', :variables => { :interface => interface, :identifier => interface_identifier }) -%>
-<%-   ifcfg = snippet('kickstart_ifcfg_generic_interface', :variables => {
+<%=   snippet([['custom kickstart_ifcfg_get_identifier_names', 'kickstart_ifcfg_get_identifier_names']], :variables => { :interface => interface, :identifier => interface_identifier }) -%>
+<%-   ifcfg = snippet([['custom kickstart_ifcfg_generic_interface', 'kickstart_ifcfg_generic_interface']], :variables => {
                         :interface => interface,
                         :subnet => interface.subnet,
                         :subnet6 => interface.subnet6,

--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -30,7 +30,7 @@ oses:
   <%- found = true -%>
     bonds:
   <%- end -%>
-<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+<%- result= snippet([['custom preseed_netplan_generic_interface', 'preseed_netplan_generic_interface']], :variables => {
                   :interface => bond,
                   :subnet => bond.subnet,
                   :subnet6 => bond.subnet6,
@@ -56,7 +56,7 @@ oses:
   <%- found = true -%>
     bridges:
   <%- end -%>
-<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+<%- result= snippet([['custom preseed_netplan_generic_interface', 'preseed_netplan_generic_interface']], :variables => {
                   :interface => bridge,
                   :subnet => bridge.subnet,
                   :subnet6 => bridge.subnet6,
@@ -77,7 +77,7 @@ oses:
   <%- found = true -%>
     vlans:
   <%- end -%>
-<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+<%- result= snippet([['custom preseed_netplan_generic_interface', 'preseed_netplan_generic_interface']], :variables => {
                   :interface => vlan,
                   :subnet => vlan.subnet,
                   :subnet6 => vlan.subnet6,
@@ -100,7 +100,7 @@ oses:
   <%- found = true -%>
     ethernets:
   <%- end -%>
-<%- result= snippet('preseed_netplan_generic_interface', :variables => {
+<%- result= snippet([['custom preseed_netplan_generic_interface', 'preseed_netplan_generic_interface']], :variables => {
                   :interface => interface,
                   :subnet => interface.subnet,
                   :subnet6 => interface.subnet6,

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -80,21 +80,21 @@ Start-Process 'msiexec.exe' -ArgumentList $puppet_install_args -Wait -NoNewWindo
 <% end -%>
 
 <% if os_family == 'Windows' -%>
-$puppet_conf = @("<%= snippet 'puppet.conf' %>".Replace("`n","`r`n"))
+$puppet_conf = @("<%= snippet([['custom puppet.conf', 'puppet.conf']]) %>".Replace("`n","`r`n"))
 Out-File -FilePath <%= etc_path %>\puppet.conf -InputObject $puppet_conf
 <% else -%>
 cat > <%= etc_path %>/puppet.conf << EOF
-<%= snippet 'puppet.conf' %>
+<%= snippet([['custom puppet.conf', 'puppet.conf']]) %>
 EOF
 <% end -%>
 
 <% if @host.puppetca_token.present? -%>
 <% if os_family == 'Windows' -%>
-$csr_attributes = @("<%= snippet 'csr_attributes.yaml' %>".Replace("`n","`r`n"))
+$csr_attributes = @("<%= snippet([['custom csr_attributes.yaml', 'csr_attributes.yaml']]) %>".Replace("`n","`r`n"))
 Out-File -FilePath <%= etc_path %>\csr_attributes.yaml -InputObject $csr_attributes
 <% else -%>
 cat > <%= etc_path %>/csr_attributes.yaml << EOF
-<%= snippet 'csr_attributes.yaml' %>
+<%= snippet([['custom csr_attributes.yaml', 'csr_attributes.yaml']]) %>
 EOF
 <% end -%>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/saltstack_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/saltstack_setup.erb
@@ -26,7 +26,7 @@ fi
 <% end -%>
 
 cat > <%= etc_path %>/minion.d/minion.conf << EOF
-<%= snippet 'saltstack_minion' %>
+<%= snippet([['custom saltstack_minion', 'saltstack_minion']]) %>
 EOF
 
 echo <%= @host.name %> > <%= etc_path %>/minion_id

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -19,27 +19,27 @@ description: |
 #!/bin/bash
 
 <%# Cloud instances frequently have incorrect hosts data %>
-<%= snippet 'fix_hosts' %>
+<%= snippet([['custom fix_hosts', 'fix_hosts']]) %>
 
 <% if @host.provision_method == 'image' && root_pass.present? -%>
 # Install the root password
 echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <% if puppet_enabled %>
 <% if host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
 <% end -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 # UserData still needs to mark the build as finished
-<%= snippet 'built' %>
+<%= snippet([['custom built', 'built' ]])%>

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -24,25 +24,25 @@ description: |
 #!/bin/bash
 
 <%# Cloud instances frequently have incorrect hosts data %>
-<%= snippet 'fix_hosts' %>
+<%= snippet([['custom fix_hosts', 'fix_hosts']]) %>
 
 <% if @host.provision_method == 'image' && root_pass.present? -%>
 # Install the root password
 echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <% end -%>
 
-<%= snippet 'yum_proxy' %>
+<%= snippet([['custom yum_proxy', 'yum_proxy']]) %>
 
-<%= snippet 'ntp' %>
+<%= snippet([['custom ntp', 'ntp']]) %>
 
 <% if rhel_compatible && host_param_true?('enable-epel') -%>
-<%= snippet 'epel' -%>
+<%= snippet([['custom epel', 'epel']]) -%>
 <% end -%>
 
-<%= snippet 'redhat_register' %>
+<%= snippet([['custom redhat_register', 'redhat_register']]) %>
 
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
-<%= snippet 'freeipa_register' %>
+<%= snippet([['custom freeipa_register', 'freeipa_register']]) %>
 <% end -%>
 
 <% unless host_param_false?('package_upgrade') -%>
@@ -54,29 +54,29 @@ else
 fi
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <% if chef_enabled %>
-<%= snippet 'chef_client' %>
+<%= snippet([['custom chef_client', 'chef_client']]) %>
 <% end -%>
 
 <% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
 <% end -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 <% if host_param_true?('ansible_tower_provisioning') -%>
-    <%= save_to_file('/tmp/ansible_provisioning_call.sh', snippet('ansible_tower_callback_script')) %>
+    <%= save_to_file('/tmp/ansible_provisioning_call.sh', snippet([['custom ansible_tower_callback_script', 'ansible_tower_callback_script']])) %>
     /bin/sh /tmp/ansible_provisioning_call.sh
 <% end -%>
 
 # UserData still needs to mark the build as finished
-<%= snippet 'built' %>
+<%= snippet([['custom built', 'built']]) %>

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -46,7 +46,7 @@ autoinstall:
     toggle: null
     variant: ''
   locale: <%= host_param('lang', 'en_US') %>.UTF-8
-<%= snippet 'preseed_netplan_setup' -%>
+<%= snippet([['custom preseed_netplan_setup', 'preseed_netplan_setup']]) -%>
   ssh:
     allow-pw: true
     install-server: true

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -17,7 +17,7 @@ description: |
 #!/bin/bash
 
 <%# Cloud instances frequently have incorrect hosts data %>
-<%= snippet 'fix_hosts' %>
+<%= snippet([['custom fix_hosts', 'fix_hosts']]) %>
 
 <%
   # safemode renderer does not support unary negation
@@ -32,27 +32,27 @@ echo 'Acquire::http::Proxy "<%= proxy_uri %>";' >> /etc/apt/apt.conf
 <% end -%>
 
 <% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
-<%= snippet 'freeipa_register' %>
+<%= snippet([['custom freeipa_register', 'freeipa_register']]) %>
 <% end -%>
 
-<%= snippet('remote_execution_ssh_keys') %>
+<%= snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) %>
 
-<%= snippet "blacklist_kernel_modules" %>
+<%= snippet([['custom blacklist_kernel_modules', 'blacklist_kernel_modules']]) %>
 
 <% if chef_enabled %>
-<%= snippet 'chef_client' %>
+<%= snippet([['custom chef_client', 'chef_client']]) %>
 <% end -%>
 
 <% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-<%= snippet 'puppetlabs_repo' %>
+<%= snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) %>
 <% end -%>
-<%= snippet 'puppet_setup' %>
+<%= snippet([['custom puppet_setup', 'puppet_setup']]) %>
 <% end -%>
 
 <% if salt_enabled %>
-<%= snippet 'saltstack_setup' %>
+<%= snippet([['custom saltstack_setup', 'saltstack_setup']]) %>
 <% end -%>
 
 # UserData still needs wget to mark as finished
-<%= snippet 'built' %>
+<%= snippet([['custom built', 'built']]) %>

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -64,23 +64,23 @@ package_upgrade: true
 runcmd:
 <% if rhel_compatible -%>
 - |
-<%= indent(2) { snippet('epel') } %>
+<%= indent(2) { snippet([['custom epel', 'epel']]) } %>
 <% end -%>
 - |
-<%= indent(2) { snippet('remote_execution_ssh_keys') } %>
+<%= indent(2) { snippet([['custom remote_execution_ssh_keys', 'remote_execution_ssh_keys']]) } %>
 <% if chef_enabled -%>
 - |
-<%= indent(2) { snippet('chef_client') } %>
+<%= indent(2) { snippet([['custom chef_client', 'chef_client']]) } %>
 <% end -%>
 <% if puppet_enabled -%>
 - |
-<%= indent(2) { snippet('puppetlabs_repo') } %>
+<%= indent(2) { snippet([['custom puppetlabs_repo', 'puppetlabs_repo']]) } %>
 - |
-<%= indent(2) { snippet('puppet_setup') } %>
+<%= indent(2) { snippet([['custom puppet_setup', 'puppet_setup']]) } %>
 <% end -%>
 <% if salt_enabled -%>
 - |
-<%= indent(2) { snippet('saltstack_setup') } %>
+<%= indent(2) { snippet([['custom saltstack_setup', 'saltstack_setup']]) } %>
 <% end -%>
 
 <%# Contact Foreman to confirm instance is built -%>


### PR DESCRIPTION
This work is based on the RFC discussion found https://community.theforeman.org/t/rfc-additional-template-includes-if-logic/29225 .  It is probable that there are additional items that need updating that I am just not aware of/thinking about, but I believe this is a ~95+% solution.

This change introduces additional template includes and easier overrides for snippets.  As designed today, if I wanted to override a snippet, I also need to override the template it is used in so that the name can be changed.  With this change set there can now be an array of templates/snippets to try allowing you to only override the template/snippet you need to make adjustments to.  This should make updating easier as you can just inherit the newer base template and not need to spend time diffing and pulling changes back into your copy.