### PR TITLE
Fixes #35359 - Add cacert to http proxy

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/http_proxy.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/http_proxy.rb
@@ -5,7 +5,7 @@ module Foreman::Controller::Parameters::HttpProxy
   class_methods do
     def http_proxy_params_filter
       Foreman::ParameterFilter.new(::HttpProxy).tap do |filter|
-        filter.permit_by_context :id, :name, :url, :username, :password, :nested => true
+        filter.permit_by_context :id, :name, :url, :username, :password, :cacert, :nested => true
 
         add_taxonomix_params_filter(filter)
       end

--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -126,7 +126,7 @@ class ComputeResource < ApplicationRecord
   end
 
   def connection_options
-    http_proxy ? {:proxy => http_proxy.full_url} : {}
+    http_proxy ? {:proxy => http_proxy.full_url, :ssl_cert_store => http_proxy.ssl_cert_store} : {}
   end
 
   # Override this method to specify provider name

--- a/app/models/http_proxy.rb
+++ b/app/models/http_proxy.rb
@@ -41,13 +41,23 @@ class HttpProxy < ApplicationRecord
     uri.to_s
   end
 
+  def ssl_cert_store
+    cert_store = OpenSSL::X509::Store.new
+    cert_store.set_default_paths
+    if cacert.present?
+      Foreman::Util.add_ca_bundle_to_store(cacert, cert_store)
+    end
+    cert_store
+  end
+
   def test_connection(url)
     RestClient::Request.execute(
       method: :head,
       url: url,
       proxy: full_url,
       timeout: 5,
-      open_timeout: 5
+      open_timeout: 5,
+      ssl_cert_store: ssl_cert_store
     )
   rescue Excon::Error::Socket => e
     e.message

--- a/app/views/http_proxies/_form.html.erb
+++ b/app/views/http_proxies/_form.html.erb
@@ -21,7 +21,7 @@
       <%= text_f   f, :url, :help_inline => _("URL of the proxy including schema (https://proxy.example.com:8080)") %>
       <%= text_f   f, :username, :help_inline => _("Username to use if authentication is required.") %>
       <%= password_f   f, :password, :help_inline => _("Password to use if authentication is required."), :unset => true %>
-
+      <%= textarea_f f, :cacert, :rows=> 5,   :help_inline => _("SSL CA Certificate to use if authentication is required.") %>
       <%= text_f   f, :test_url, :value => "https://aws.amazon.com", :name => "test_url", :label => _("Test URL"),
                    :help_inline => spinner_button_f(f, _('Test Connection'), "tfm.httpProxies.testConnection(this, '#{test_connection_http_proxies_path}')",
                                                      :id => 'test_connection_button',

--- a/db/migrate/20220809191656_add_ssl_ca_to_http_proxy.rb
+++ b/db/migrate/20220809191656_add_ssl_ca_to_http_proxy.rb
@@ -1,0 +1,5 @@
+class AddSslCaToHttpProxy < ActiveRecord::Migration[6.1]
+  def change
+    add_column :http_proxies, :cacert, :text
+  end
+end

--- a/lib/foreman/util.rb
+++ b/lib/foreman/util.rb
@@ -27,5 +27,17 @@ module Foreman
     def secure_encryption_key
       SecureRandom.hex(ActiveSupport::MessageEncryptor.key_len / 2)
     end
+
+    # Adds a ca cert bundle with multiple ca certs to a
+    # OpenSSL::X509::Store certificate
+    def self.add_ca_bundle_to_store(ca_bundle, cert_store)
+      file = Tempfile.open('cert.pem', Rails.root.join('tmp')) do |f|
+        f.write(ca_bundle)
+        f.flush
+        f
+      end
+      cert_store.add_file(file.path)
+      file.unlink
+    end
   end
 end


### PR DESCRIPTION
This PR adds a cacert column to the http proxy and uses to this for
connecting to ec2 and other compute resources. This would also be used
by katello/other plugins when communicating to the CDN over a https
proxy
- run the `db:migration`
- Setup an https proxy externally that has its own ca cert
- On foreman go to -> Infrastructure -> Http Proxies 
- Add information about the proxy including the URL (leave cacert blank)
- Test Connection. Expect an SSL Failure because the Proxy cert is not in the trust store
- Paste the proxy's ca cert in the UI
- Test Connection. Should be successful.