### PR TITLE
Fixes #35361 - Make columns on host index page selectable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,7 +22,7 @@ class ApplicationController < ActionController::Base
   before_action :session_expiry, :update_activity_time, :unless => proc { |c| c.remote_user_provided? || c.api_request? }
   before_action :set_taxonomy, :require_mail, :check_empty_taxonomy
   before_action :authorize
-  before_action :welcome, :only => :index, :unless => :api_request?
+  before_action :welcome, :find_selected_columns, :only => :index, :unless => :api_request?
   prepend_before_action :allow_webpack, if: -> { Rails.configuration.webpack.dev_server.enabled }
   around_action :set_timezone
 

--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -140,4 +140,8 @@ module ApplicationShared
     end
     determined_taxonomy
   end
+
+  def find_selected_columns
+    @selected_columns = User.current.table_preferences.find_by(name: controller_name)&.columns&.sort
+  end
 end

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -33,6 +33,8 @@ class HostsController < ApplicationController
   before_action :set_host_type, :only => [:update]
   before_action :find_multiple, :only => MULTIPLE_ACTIONS
   before_action :validate_power_action, :only => :update_multiple_power_state
+  # index action is already included in ApplicationController
+  before_action(:only => SEARCHABLE_ACTIONS.without('index')) { find_selected_columns }
 
   helper :hosts, :reports, :interfaces
 

--- a/app/helpers/pagelets_helper.rb
+++ b/app/helpers/pagelets_helper.rb
@@ -5,7 +5,7 @@ module PageletsHelper
 
   def pagelets_for(mountpoint)
     result = ["#{controller_name}/#{action_name}", virtual_path].uniq.map do |key|
-      Pagelets::Manager.pagelets_at(key, mountpoint)
+      Pagelets::Manager.pagelets_at(key, mountpoint, filter: filter_opts)
     end
     result.flatten.sort
   end
@@ -40,9 +40,40 @@ module PageletsHelper
 
   def render_pagelet(pagelet, opts = {})
     if pagelet.onlyif.call(opts[:subject], self)
-      render(pagelet.partial, opts.merge!({ :pagelet => pagelet, controller_name.singularize.to_sym => opts[:subject] })).html_safe
+      render(pagelet.partial, opts.merge!(
+        {
+          :pagelet => pagelet,
+          controller_name.singularize.to_sym => opts[:subject],
+          :subject => opts[:subject],
+        }
+      )).html_safe
     else
       "".html_safe
     end
+  end
+
+  def html_attributes(th_or_td, subject)
+    #                      Allowed HTML attributes
+    attrs = th_or_td.slice(:width, :class)
+                    .map { |(k, v)| "#{k}=\"#{v}\"" }
+    attrs_from_callbacks = (th_or_td[:attr_callbacks] || {}).map { |(k, v)| "#{k}=\"#{instance_exec(subject, &v)}\"" }
+    (attrs + attrs_from_callbacks).join(' ').html_safe
+  end
+
+  def th_content(col)
+    return if col[:callback]
+    return col[:label] unless col[:sortable]
+
+    sort col[:key], as: col[:label], default: col[:default_sort] || 'ASC'
+  end
+
+  private
+
+  def filter_opts(opts = {})
+    opts.merge(
+      {
+        selected: @selected_columns,
+      }
+    )
   end
 end

--- a/app/registries/pagelets/filter.rb
+++ b/app/registries/pagelets/filter.rb
@@ -1,0 +1,20 @@
+module Pagelets
+  class Filter
+    attr_reader :items
+
+    def initialize(items)
+      @items = Array(items)
+    end
+
+    def filter(opts = {})
+      result = if opts[:selected]
+                 items.select { |pagelet| opts[:selected].include?(pagelet.key.to_s) }
+               else
+                 items.select do |pagelet|
+                   pagelet.profiles.empty? ? true : pagelet.profiles.any? { |profile| profile.default? }
+                 end
+               end
+      result.uniq
+    end
+  end
+end

--- a/app/registries/pagelets/manager.rb
+++ b/app/registries/pagelets/manager.rb
@@ -1,5 +1,10 @@
 module Pagelets
   class Manager
+    DEFAULT_PARTIALS = {
+      hosts_table_column_header: 'common/selectable_column_th',
+      hosts_table_column_content: 'common/selectable_column_td',
+    }.freeze
+
     class << self
       delegate :add_pagelet, :pagelets_at, :with_key, to: :instance
 
@@ -20,10 +25,11 @@ module Pagelets
 
     def add_pagelet(key, mountpoint, opts)
       handle_empty_keys_for key, mountpoint
-      raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without partial"), key) unless opts[:partial]
+      partial = opts.delete(:partial) || default_pagelet_partial(mountpoint)
+      raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without partial"), key) unless partial
       raise ::Foreman::Exception.new(N_("Cannot add pagelet with key %s and without mountpoint"), key) if mountpoint.nil?
       priority = opts[:priority] || default_pagelet_priority(key, mountpoint)
-      pagelet = Pagelets::Pagelet.new(opts.delete(:name), opts.delete(:partial), priority, opts)
+      pagelet = Pagelets::Pagelet.new(opts.delete(:name), partial, priority, opts)
       @pagelets[key][mountpoint] << pagelet
       pagelet
     end
@@ -32,9 +38,12 @@ module Pagelets
       @pagelets.clear
     end
 
-    def pagelets_at(key, mountpoint)
+    def pagelets_at(key, mountpoint, opts = {})
       handle_empty_keys_for key, mountpoint
-      @pagelets[key][mountpoint]
+      pagelets = @pagelets[key][mountpoint]
+      return pagelets unless opts[:filter]
+
+      Pagelets::Filter.new(pagelets).filter(opts[:filter])
     end
 
     # Yields a simpler interface for add_pagelet to avoid re-stating the key
@@ -55,6 +64,42 @@ module Pagelets
       def pagelets_at(*args)
         @manager.pagelets_at(*args.unshift(@key))
       end
+
+      def with_profile(id, label, opts, &block)
+        profile = Profile.new(id, label, self, opts)
+        profile.instance_exec(&block)
+        profile.pagelets.each do |pagelet|
+          add_pagelet(*pagelet)
+        end
+      end
+    end
+
+    class Profile
+      attr_reader :id, :label, :opts, :pagelets
+
+      def initialize(id, label, context, opts)
+        @id = id
+        @label = label
+        @context = context
+        @opts = opts
+        @pagelets = []
+      end
+
+      def default?
+        @opts[:default]
+      end
+
+      def add_pagelet(mountpoint, opts)
+        opts = opts.merge(profiles: [self])
+        @pagelets << [mountpoint, opts]
+      end
+
+      def use_pagelet(mountpoint, key)
+        pagelet = @context.pagelets_at(mountpoint).find { |pt| pt.key == key }
+        raise ::Foreman::Exception.new(N_("Pagelet with %s key is not found"), key) unless pagelet
+
+        pagelet.profiles.push(self)
+      end
     end
 
     private
@@ -67,6 +112,10 @@ module Pagelets
     def default_pagelet_priority(key, mountpoint)
       # We need a default priority value for the first pagelet if it is not specified
       @pagelets[key][mountpoint].map(&:priority).push(0).max + 100
+    end
+
+    def default_pagelet_partial(mountpoint)
+      DEFAULT_PARTIALS[mountpoint]
     end
   end
 end

--- a/app/registries/pagelets/pagelet.rb
+++ b/app/registries/pagelets/pagelet.rb
@@ -8,6 +8,7 @@ module Pagelets
       @priority = priority
       @opts = opts
       @opts[:onlyif] ||= proc { true }
+      @opts[:profiles] ||= []
     end
 
     def <=>(other)

--- a/app/views/common/_selectable_column_td.html.erb
+++ b/app/views/common/_selectable_column_td.html.erb
@@ -1,0 +1,1 @@
+<td <%= html_attributes(pagelet.opts, subject) %>><%= instance_exec(subject, &pagelet.opts[:callback]) %></td>

--- a/app/views/common/_selectable_column_th.html.erb
+++ b/app/views/common/_selectable_column_th.html.erb
@@ -1,0 +1,1 @@
+<th <%= html_attributes(pagelet.opts, subject) %>><%= th_content(pagelet.opts) || instance_eval(pagelet.opts[:callback]) %></th>

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -8,6 +8,13 @@
         <th class="ca" width="80px"><%= _('Power') %></th>
       <% end %>
       <%= render_pagelets_for(:hosts_table_column_header) %>
+      <th hidden="true" width="25%"><%= sort :name, :as => _('Name') %></th>
+      <th hidden="true" class="hidden-xs" width="17%"><%= sort :os_title, :as => _("Operating system") %></th>
+      <th hidden="true" class="hidden-tablet hidden-xs" width="10%"><%= sort :model, :as => _('Model') %></th>
+      <th hidden="true" class="hidden-tablet hidden-xs" width="8%"><%= sort :owner, :as => _('Owner') %></th>
+      <th hidden="true" class="hidden-tablet hidden-xs" width="15%"><%= sort :hostgroup, :as => _("Host group") %></th>
+      <th hidden="true" class="hidden-tablet hidden-xs" width="10%"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
+      <th hidden="true" class="hidden-tablet hidden-xs" width="7%"><%= sort :comment, :as => _('Comment') %></th>
       <th width="100px"><%= _('Actions') %></th>
     </tr>
   </thead>
@@ -23,7 +30,14 @@
           </td>
         <% end %>
         <%= render_pagelets_for(:hosts_table_column_content, :subject => host) %>
-        <td>
+        <td hidden="true" class="ellipsis"><%= name_column(host) %></td>
+        <td hidden="true" class="hidden-xs ellipsis"><%= (icon(host.operatingsystem, :size => "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem %></td>
+        <td hidden="true" class="hidden-tablet hidden-xs ellipsis"><%= host.compute_resource_or_model %></td>
+        <td hidden="true" class="hidden-tablet hidden-xs ellipsis"><%= host_owner_column(host) %></td>
+        <td hidden="true" class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 23, @hostgroup_authorizer %></td>
+        <td hidden="true" class="hidden-tablet hidden-xs ellipsis"><%= last_report_column(host) %></td>
+        <td hidden="true" class="hidden-tablet hidden-xs ca" title="<%= host.comment&.truncate(255) %>"><%= icon_text('comment', '') unless host.comment.empty? %></td>
+	<td>
           <%= action_buttons(
                       display_link_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),
                       display_link_if_authorized(_("Clone"), hash_for_clone_host_path(:id => host)),

--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -7,14 +7,7 @@
       <% if power_status_visible? %>
         <th class="ca" width="80px"><%= _('Power') %></th>
       <% end %>
-      <th width="25%"><%= sort :name, :as => _('Name') %></th>
-      <th class="hidden-xs" width="17%"><%= sort :os_title, :as => _("Operating system") %></th>
-      <th class="hidden-tablet hidden-xs" width="10%"><%= sort :model, :as => _('Model') %></th>
-      <th class="hidden-tablet hidden-xs" width="8%"><%= sort :owner, :as => _('Owner') %></th>
-      <th class="hidden-tablet hidden-xs" width="15%"><%= sort :hostgroup, :as => _("Host group") %></th>
-      <th class="hidden-tablet hidden-xs" width="10%"><%= sort :last_report, :as => _('Last report'), :default => 'DESC' %></th>
       <%= render_pagelets_for(:hosts_table_column_header) %>
-      <th class="hidden-tablet hidden-xs" width="7%"><%= sort :comment, :as => _('Comment') %></th>
       <th width="100px"><%= _('Actions') %></th>
     </tr>
   </thead>
@@ -29,15 +22,7 @@
             <%= react_component('PowerStatus', id: host.id, url: power_api_host_path(host)) %>
           </td>
         <% end %>
-        <td class="ellipsis"><%= name_column(host) %>
-        </td>
-        <td class="hidden-xs ellipsis"><%= (icon(host.operatingsystem, :size => "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem %></td>
-        <td class="hidden-tablet hidden-xs ellipsis"><%= host.compute_resource_or_model %></td>
-        <td class="hidden-tablet hidden-xs ellipsis"><%= host_owner_column(host) %></td>
-        <td class="hidden-tablet hidden-xs"><%= label_with_link host.hostgroup, 23, @hostgroup_authorizer %></td>
-        <td class="hidden-tablet hidden-xs ellipsis"><%= last_report_column(host) %></td>
         <%= render_pagelets_for(:hosts_table_column_content, :subject => host) %>
-        <td class="hidden-tablet hidden-xs ca" title="<%= host.comment&.truncate(255) %>"><%= icon_text('comment', '') unless host.comment.empty? %></td>
         <td>
           <%= action_buttons(
                       display_link_if_authorized(_("Edit"), hash_for_edit_host_path(:id => host).merge(:auth_object => host, :authorizer => authorizer)),

--- a/config/initializers/foreman_register.rb
+++ b/config/initializers/foreman_register.rb
@@ -4,3 +4,24 @@ Pagelets::Manager.with_key 'hosts/show' do |mgr|
     partial: 'hosts/init_config_tab',
     priority: 100
 end
+
+Pagelets::Manager.with_key 'hosts/_list' do |ctx|
+  ctx.with_profile :general, _('General'), default: true do
+    common_th_class = 'hidden-tablet hidden-xs'
+    common_td_class = common_th_class + ' ellipsis'
+    add_pagelet :hosts_table_column_header, key: :name, label: _('Name'), sortable: true, width: '25%'
+    add_pagelet :hosts_table_column_content, key: :name, class: 'ellipsis', callback: ->(host) { name_column(host) }
+    add_pagelet :hosts_table_column_header, key: :os_title, label: _('Operating system'), sortable: true, width: '17%', class: 'hidden-xs'
+    add_pagelet :hosts_table_column_content, key: :os_title, class: 'hidden-xs ellipsis', callback: ->(host) { (icon(host.operatingsystem, size: "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem }
+    add_pagelet :hosts_table_column_header, key: :model, label: _('Model'), sortable: true, width: '10%', class: common_th_class
+    add_pagelet :hosts_table_column_content, key: :model, class: common_td_class, callback: ->(host) { host.compute_resource_or_model }
+    add_pagelet :hosts_table_column_header, key: :owner, label: _('Owner'), sortable: true, width: '8%', class: common_th_class
+    add_pagelet :hosts_table_column_content, key: :owner, class: common_td_class, callback: ->(host) { host_owner_column(host) }
+    add_pagelet :hosts_table_column_header, key: :hostgroup, label: _('Host group'), sortable: true, width: '15%', class: common_th_class
+    add_pagelet :hosts_table_column_content, key: :hostgroup, class: common_th_class, callback: ->(host) { label_with_link host.hostgroup, 23, @hostgroup_authorizer }
+    add_pagelet :hosts_table_column_header, key: :last_report, label: _('Last report'), sortable: true, default_sort: 'DESC', width: '10%', class: common_th_class
+    add_pagelet :hosts_table_column_content, key: :last_report, class: common_td_class, callback: ->(host) { last_report_column(host) }
+    add_pagelet :hosts_table_column_header, key: :comment, label: _('Comment'), sortable: true, width: '7%', class: common_th_class
+    add_pagelet :hosts_table_column_content, key: :comment, class: common_th_class + ' ca', attr_callbacks: { title: ->(host) { host.comment&.truncate(255) } }, callback: ->(host) { icon_text('comment', '') unless host.comment.empty? }
+  end
+end


### PR DESCRIPTION
Replaces #9319. @ShimShtein is that better?

 - tried to make it as much compatible with current usage of pagelets for columns, but without `key: :col_name` it won't be displayed if a user has preferences, thus plugins should be updated.
 - Deface solution seems to be not working anymore with these changes, thus plugins should be updated in favor of pagelets.