### PR TITLE
Demonstrate native RHSM registration support

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -229,6 +229,9 @@ key --skip
 <%= @host.diskLayout %>
 <% end -%>
 
+<# TODO conditionals whether rhsm kickstart is supported #>
+<%= snippet('redhat_kickstart_rhsm') %>
+
 text
 reboot
 
@@ -292,6 +295,7 @@ logger "Starting anaconda <%= @host %> postinstall"
 <%= snippet 'epel' -%>
 <% end -%>
 
+<# TODO only if rhsm is unsupported #>
 <%= snippet 'redhat_register' %>
 
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>

--- a/app/views/unattended/provisioning_templates/snippet/redhat_kickstart_rhsm.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_kickstart_rhsm.erb
@@ -1,0 +1,49 @@
+<%- if host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla') || host_param('syspurpose_addons') %>
+<%-
+  syspurpose_args = []
+  ['role', 'usage', 'sla'].each do |arg|
+    if (value = host_param("syspurpose_#{arg}")
+      syspurpose_args << "--#{arg}=\"#{value}\""
+    end
+  end
+  if syspurpose_args.any?
+-%>
+syspurpose <%= syspurpose_args.join(' ') %>
+<% end -%>
+<%-
+  rhsm_args = []
+  if host_param('kt_activation_keys')
+    subscription_manager_certpkg_url = subscription_manager_configuration_url(@host)
+    subscription_manager_org = @host.rhsm_organization_label
+    activation_key = host_param('kt_activation_keys')
+  else
+    subscription_manager_certpkg_url = host_param('subscription_manager_certpkg_url')
+    subscription_manager_org = host_param('subscription_manager_org')
+    activation_key = host_param('activation_key')
+  end
+
+  # kickstart only supports activation keys
+  if activation_key
+    rhsm_args << "--organization=\"#{subscription_manager_org}\""
+    rhsm_args << "--activation-key=\"#{activation_key}\""
+    # TODO add --connect-to-insights if desired
+
+    if (http_proxy = host_param('http-proxy'))
+      if (http_proxy_user = host_param('http-proxy-user'))
+        if (http_proxy_password = host_param('http-proxy-password'))
+          http_proxy = "#{http_proxy_user}:#{http_proxy_password}@#{http_proxy}"
+        else
+          # TODO: is no password valid?
+          http_proxy = "#{http_proxy_user}:@#{http_proxy}"
+        end
+      end
+      if (http_proxy_port = host_param('http-proxy-port'))
+        http_proxy += ":#{http_proxy_port}"
+      end
+    end
+  end
+
+  if rhsm_args.any?
+-%>
+rhsm <%= rhsm_args.join(' ') %>
+<% end -%>


### PR DESCRIPTION
The goal of this PR now is to show an alternative solution to https://community.theforeman.org/t/rfc-systemd-first-boot-service-for-host-provisioning/29892.

This uses the native support in Anaconda to configure RHSM. Having RHSM configured allows using all repositories in %packages, which avoids the need to do everything in %post. That makes the progress bar accurate and also avoids the need to run dnf update in %post. That also speeds up provisioning since you're not installing certain packages twice.

This brings RHEL provisioning much closer to kickstarting Fedora or CentOS.

There are still many TODOs, like setting the correct server for Candlepin and Pulp in case of Katello. It also hasn't been tested.

[1]: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_8_installation/index#register-and-install-from-cdn-using-kickstart_register-and-install-from-cdn