### PR TITLE
Fixes #35376 - Allow additional entries in config.hosts

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,5 +58,9 @@ Foreman::Application.configure do
   # Allow disabling the webpack dev server from the settings
   config.webpack.dev_server.enabled = SETTINGS.fetch(:webpack_dev_server, true)
   config.webpack.dev_server.https = SETTINGS.fetch(:webpack_dev_server_https, false)
+
+  config.hosts += SETTINGS[:hosts]
   config.hosts << SETTINGS[:fqdn]
+  # Backporting from Rails 7.0
+  config.hosts += (ENV['RAILS_DEVELOPMENT_HOSTS'] || '').split(',')
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -77,4 +77,6 @@ Foreman::Application.configure do |app|
 
   # Log denied attributes into logger
   config.action_controller.action_on_unpermitted_parameters = :log
+
+  config.hosts += SETTINGS[:hosts]
 end

--- a/config/settings.rb
+++ b/config/settings.rb
@@ -26,6 +26,8 @@ unless SETTINGS[:domain] && SETTINGS[:fqdn]
   SETTINGS[:fqdn] ||= Facter.value(:fqdn)
 end
 
+SETTINGS[:hosts] ||= []
+
 # Load plugin config, if any
 Dir["#{__dir__}/settings.plugins.d/*.yaml"].each do |f|
   SETTINGS.merge! YAML.load(ERB.new(File.read(f)).result)

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -35,6 +35,12 @@
 :domain: 'localdomain.net'
 :fqdn: 'localhost.localdomain.net'
 
+# Configure hostnames for ActionDispatch::HostAuthorization
+# Only hostnames are supported. Regular expressions and IP addresses/ranges are not.
+# https://guides.rubyonrails.org/v6.1/configuring.html#configuring-middleware
+:hosts:
+# - host.example.com
+
 # List of Domains allowed for Cross-Origin Resource Sharing
 # :cors_domains:
 #   - https://foreman.example.com


### PR DESCRIPTION
`SETTINGS[:fqdn]` is added to Rails `config.hosts` automatically.

This change also allows additional entries in `config.hosts`.

for more information about this Rails feature, see https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization
