### PR TITLE
fixes #35377 - allow upper case letter in device identifiers"

### DIFF
--- a/app/models/nic/with_attached_devices.rb
+++ b/app/models/nic/with_attached_devices.rb
@@ -4,7 +4,7 @@ module Nic::WithAttachedDevices
 
   SEPARATOR = ','
   included do
-    validates :attached_devices, :format => { :with => /\A[a-z0-9#{SEPARATOR}.:_-]+\Z/ }, :allow_blank => true
+    validates :attached_devices, :format => { :with => /\A[A-Za-z0-9#{SEPARATOR}.:_-]+\Z/ }, :allow_blank => true
     validates :identifier, :presence => true, :if => :managed?
 
     before_validation :ensure_virtual
@@ -18,7 +18,7 @@ module Nic::WithAttachedDevices
 
   def attached_devices=(devices)
     devices = devices.split(SEPARATOR) if devices.is_a?(String)
-    super(devices.map { |i| i.downcase.strip }.join(SEPARATOR))
+    super(devices.map { |i| i.strip }.join(SEPARATOR))
   end
 
   def attached_devices_identifiers

--- a/test/models/nics/bond_test.rb
+++ b/test/models/nics/bond_test.rb
@@ -15,14 +15,14 @@ class BondTest < ActiveSupport::TestCase
     assert bond.virtual
   end
 
-  test 'attached devices are stripped and downcased' do
+  test 'attached devices are stripped, case is preserved due to identifiers like on HPE Superdome Flex 280' do
     bond = FactoryBot.build_stubbed(:nic_bond, :attached_devices => 'Eth0, ETH1 ,   eth2    ')
-    assert_equal "eth0,eth1,eth2", bond.attached_devices
+    assert_equal "Eth0,ETH1,eth2", bond.attached_devices
   end
 
   test 'attached devices can be also specified as an array' do
     bond = FactoryBot.build_stubbed(:nic_bond, :attached_devices => ['Eth0', 'ETH1 ', '   eth2    '])
-    assert_equal "eth0,eth1,eth2", bond.attached_devices
+    assert_equal "Eth0,ETH1,eth2", bond.attached_devices
   end
 
   test 'attached devices interfaces can be accessed as an array' do


### PR DESCRIPTION
This fixes issue https://projects.theforeman.org/issues/35377 where if there is nic with capital letter provided by udev, satellite chages it and provisioning fails as result