### PR TITLE
Fixes #35387 - Host details templates card

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -339,6 +339,20 @@ module Api
         end
       end
 
+      api :GET, "/hosts/:id/templates", N_("Get provisioning templates for the host")
+      param :id, :identifier_dottable, :required => true
+      def templates
+        edit_provisioning_templates = authorized_for(:controller => 'provisioning_templates', :action => 'edit')
+        templates = TemplateKind.order(:name).map do |kind|
+          @host.provisioning_template(:kind => kind.name)
+        end.compact
+        if templates.empty?
+          not_found(_("No templates found for %{host}") % {:host => @host.to_label})
+        else
+          render :json => { :templates => templates, :edit_provisioning_templates => edit_provisioning_templates }, :status => :ok
+        end
+      end
+
       private
 
       def apply_compute_profile(host)
@@ -381,7 +395,7 @@ module Api
             :console
           when 'disassociate', 'forget_status'
             :edit
-          when 'vm_compute_attributes', 'get_status', 'template', 'enc'
+          when 'vm_compute_attributes', 'get_status', 'template', 'enc', 'templates'
             :view
           when 'rebuild_config'
             :build

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -394,6 +394,7 @@ module ApplicationHelper
       perPage: Setting['entries_per_page'],
       destroyVmOnHostDelete: Setting['destroy_vm_on_host_delete'],
       labFeatures: Setting[:lab_features],
+      safeMode: Setting[:safemode_render],
     }
   end
 

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -235,7 +235,7 @@ Foreman::AccessControl.map do |permission_set|
                                                :templates, :overview, :nics, :get_power_state, :preview_host_collection, :welcome, :statuses],
                                     :dashboard => [:OutOfSync, :errors, :active],
                                     :unattended => [:host_template, :hostgroup_template],
-                                     :"api/v2/hosts" => [:index, :show, :get_status, :vm_compute_attributes, :template, :enc],
+                                     :"api/v2/hosts" => [:index, :show, :get_status, :vm_compute_attributes, :template, :templates, :enc],
                                      :"api/v2/interfaces" => [:index, :show],
                                      :"api/v2/host_statuses" => [:index],
                                      :locations =>  [:mismatches],

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -301,6 +301,7 @@ Foreman::Application.routes.draw do
           get 'status/:type', :on => :member, :action => :get_status
           get :vm_compute_attributes, :on => :member
           get 'template/:kind', :on => :member, :action => :template
+          get :templates, :on => :member
           put :disassociate, :on => :member
           delete 'status/:type', :on => :member, :action => :forget_status
           put :boot, :on => :member

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/CardRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/CardRegistry.js
@@ -2,10 +2,16 @@ import React from 'react';
 import { addGlobalFill } from '../../../common/Fill/GlobalFill';
 import Properties from '../Details/Cards/SystemProperties';
 import OperatingSystem from '../Details/Cards/OperatingSystem';
+import TemplatesCard from '../Details/Cards/TemplatesCard';
 
 const cards = [
   { key: '[core] System properties', Component: Properties, weight: 4000 },
   { key: '[core] Operating systems', Component: OperatingSystem, weight: 3000 },
+  {
+    key: '[core] Templates',
+    Component: TemplatesCard,
+    weight: 200,
+  },
 ];
 
 export const registerCoreCards = () => {

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/TemplatesCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/TemplatesCard/index.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button } from '@patternfly/react-core';
+import { PencilAltIcon } from '@patternfly/react-icons';
+import { TableComposable, Tr, Tbody, Td } from '@patternfly/react-table';
+import { translate as __ } from '../../../../../../common/I18n';
+import { foremanUrl } from '../../../../../../common/helpers';
+import { useAPI } from '../../../../../../common/hooks/API/APIHooks';
+import SkeletonLoader from '../../../../../common/SkeletonLoader';
+import DefaultLoaderEmptyState from '../../../../DetailsCard/DefaultLoaderEmptyState';
+import CardTemplate from '../../../../Templates/CardItem/CardTemplate';
+import { STATUS } from '../../../../../../constants';
+
+const TemplatesCard = ({ hostName }) => {
+  const templatesUrl = foremanUrl(`/api/hosts/${hostName}/templates`);
+  const TemplateTypeTitle = __('Template type');
+  const {
+    response: {
+      templates,
+      edit_provisioning_templates: editTemplatePermission,
+    },
+    status,
+  } = useAPI('get', templatesUrl);
+  const editTemplateUrl = id => `/templates/provisioning_templates/${id}/edit`;
+  if (!templates?.length) return null;
+  return (
+    <CardTemplate
+      header={__('Provisioning templates')}
+      expandable
+      masonryLayout
+    >
+      <SkeletonLoader
+        emptyState={<DefaultLoaderEmptyState />}
+        status={status || STATUS.PENDING}
+      >
+        <TableComposable aria-label="templates table" variant="compact">
+          <Tbody>
+            {templates?.map(template => (
+              <Tr key={template.name}>
+                <Td /* to remove padding */ />
+                <Td dataLabel={TemplateTypeTitle} noPadding>
+                  {template.name}
+                </Td>
+                {editTemplatePermission && (
+                  <Td>
+                    <Button
+                      component="a"
+                      key="edit"
+                      href={editTemplateUrl(template.id)}
+                      variant="plain"
+                      target="_blank"
+                    >
+                      <PencilAltIcon />
+                    </Button>
+                  </Td>
+                )}
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+      </SkeletonLoader>
+    </CardTemplate>
+  );
+};
+
+export default TemplatesCard;
+
+TemplatesCard.propTypes = {
+  hostName: PropTypes.string,
+};
+
+TemplatesCard.defaultProps = {
+  hostName: undefined,
+};


### PR DESCRIPTION
Currently looks like this:
![Screenshot from 2022-08-18 20-44-48](https://user-images.githubusercontent.com/30431079/185472225-771b1022-40e2-4960-9e2f-abd5300b6134.png)

Will add review buttons and preview in a new pr, will look like this:
![Screenshot from 2022-08-18 20-39-44](https://user-images.githubusercontent.com/30431079/185472229-c6ce8b86-8539-45f8-8a0b-7e8a731a38c0.png)

Possible "cleaner" designs:
![Screenshot from 2022-08-18 20-47-26](https://user-images.githubusercontent.com/30431079/185472468-9d39fd5d-bc3b-449b-9024-6ad5d2cb558a.png)
![Screenshot from 2022-08-18 20-47-48](https://user-images.githubusercontent.com/30431079/185472472-fc1d65ba-0b8b-4dde-b1ac-16e9c992c14b.png)
