### PR TITLE
Fixes #35388 - Drop unnecessary timestamps only if column exists

### DIFF
--- a/db/migrate/20220515130414_drop_unnecessary_timestamps.rb
+++ b/db/migrate/20220515130414_drop_unnecessary_timestamps.rb
@@ -1,6 +1,21 @@
 class DropUnnecessaryTimestamps < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :taxable_taxonomies, :created_at, :datetime
-    remove_column :taxable_taxonomies, :updated_at, :datetime
+  def up
+    if ActiveRecord::Base.connection.column_exists?(:taxable_taxonomies, :created_at)
+      remove_column :taxable_taxonomies, :created_at, :datetime
+    end
+
+    if ActiveRecord::Base.connection.column_exists?(:taxable_taxonomies, :updated_at)
+      remove_column :taxable_taxonomies, :updated_at, :datetime
+    end
+  end
+
+  def down
+    unless ActiveRecord::Base.connection.column_exists?(:taxable_taxonomies, :created_at)
+      add_column :taxable_taxonomies, :created_at, :datetime
+    end
+
+    unless ActiveRecord::Base.connection.column_exists?(:taxable_taxonomies, :updated_at)
+      add_column :taxable_taxonomies, :updated_at, :datetime
+    end
   end
 end


### PR DESCRIPTION
Fix for the issue when :remove_column tries to remove
column that does not exists.

Note: we can't use `if_exists` or `if_not_exists`, they've been added in Rails 6.1 and we need to CP this PR into the 3.3-stable (Sat 6.12)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
