### PR TITLE
Fixes #35397 - Preseed Autoinstall incorporate host_params

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -41,8 +41,11 @@ autoinstall:
 <% else -%>
       ssh_authorized_keys: []
 <% end -%>
-  keyboard: {layout: us, toggle: null, variant: ''}
-  locale: en_US.UTF-8
+  keyboard:
+    layout: <%= host_param('keyboard', 'us') %>
+    toggle: null
+    variant: ''
+  locale: <%= host_param('lang', 'en_US') %>.UTF-8
 <%= snippet 'preseed_netplan_setup' -%>
   ssh:
     allow-pw: true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -18,7 +18,10 @@ autoinstall:
       lock-passwd: false
       hashed_passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
       ssh_authorized_keys: []
-  keyboard: {layout: us, toggle: null, variant: ''}
+  keyboard:
+    layout: us
+    toggle: null
+    variant: ''
   locale: en_US.UTF-8
   network:
     version: 2


### PR DESCRIPTION
Several host params exist to make the host creation more configurable ('keyboard' to set the layout, 'lang' to set the locale). The Ubuntu Autoinstall cloud-init template does not take any of these parameters into account.
This PR incorporates the following:

* Param 'ubuntu_mirror_uri' to set default mirror during upgrade
* Param 'keyboard' to set default layout
* Param 'lang' to set default locale



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
