### PR TITLE
Fixes #35414 - Bump Sidekiq to 6.3.z

### DIFF
--- a/bundler.d/dynflow_sidekiq.rb
+++ b/bundler.d/dynflow_sidekiq.rb
@@ -1,5 +1,4 @@
 group :dynflow_sidekiq do
   gem 'sidekiq', '~> 6.3.0'
   gem 'gitlab-sidekiq-fetcher', require: false
-  gem 'sd_notify', '~> 0.1'
 end

--- a/bundler.d/dynflow_sidekiq.rb
+++ b/bundler.d/dynflow_sidekiq.rb
@@ -1,5 +1,5 @@
 group :dynflow_sidekiq do
-  gem 'sidekiq', '~> 5.0'
+  gem 'sidekiq', '~> 6.3.0'
   gem 'gitlab-sidekiq-fetcher', require: false
   gem 'sd_notify', '~> 0.1'
 end

--- a/bundler.d/redis.rb
+++ b/bundler.d/redis.rb
@@ -1,3 +1,3 @@
 group :redis do
-  gem 'redis', '~> 4.0'
+  gem 'redis', '~> 4.5.0'
 end

--- a/extras/dynflow-sidekiq.rb
+++ b/extras/dynflow-sidekiq.rb
@@ -1,5 +1,3 @@
-require 'sd_notify'
-
 rails_root = Dir.pwd
 
 app_file = File.expand_path('./config/application', rails_root)
@@ -7,10 +5,6 @@ require app_file
 
 ::Rails.application.dynflow.config.lazy_initialization = true
 ::Rails.application.dynflow.config.on_init(false) do |world|
-  world.before_termination do
-    SdNotify.stopping
-  end
-
   # Loading and initializing of all gettext languages takes about 100ms per language
   # in development environment and little less on production. Let's eager load languages
   # but only for production.
@@ -33,4 +27,3 @@ end
 
 ::Rails.application.dynflow.initialize!
 Rails.logger.info("Everything ready for world: #{::Rails.application.dynflow.world.id}")
-SdNotify.ready


### PR DESCRIPTION
As a side effect, gitlab-sidekiq-fetcher should get updated to >= 7.1.0.

Currently latest sidekiq is 6.5.5, but anything above 6.4.0 is rather
verbose about things being deprecated in sidekiq 7.0.0.

Fixing those deprecations is tracked as https://projects.theforeman.org/issues/35413

Similarly, latest redis is 4.8.0, but anything above 4.5.0 is rather
verbose about things being deprecated in redis 5.0.0. Note, those
deprecation warnings are triggered from inside of
gitlab-sidekiq-fetcher.

This issue has been reported as https://gitlab.com/gitlab-org/sidekiq-reliable-fetch/-/issues/32

To test these changes in development
```
# Prerequisite - have redis available
# podman run -p 6379:6379 --name redis1 -d redis:7-alpine

# cat >orchestrator.yaml <<EOF
:concurrency: 1
:queues:
    - dynflow_orchestrator
EOF

# cat >worker.yaml <<EOF
:concurrency: 10
:queues:
    - default
    - remote_execution
EOF

# cat >config/initializers/foreman_tasks.rb <<EOF
# config/initializers/foreman_tasks.rb
if defined?(ForemanTasks) && Rails.env != 'test'
  ForemanTasks.dynflow.config.remote = true
end
EOF

# bundle exec sidekiq -e development -r $PWD/extras/dynflow-sidekiq.rb -C orchestrator.yaml

# bundle exec sidekiq -e development -r $PWD/extras/dynflow-sidekiq.rb -C worker.yaml
```

There's also related issue https://projects.theforeman.org/issues/35415, but that can be fixed independently.
