### PR TITLE
Fixes #35416 - adding a disabled option to links in the dropdown menus

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -615,3 +615,7 @@ code.transparent {
   overflow-y: auto;
   max-width: 175px;
 }
+
+td .dropdown-menu > li > a.disabled:hover, td .dropdown-menu > li > a.disabled:focus {
+  cursor: pointer;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -225,9 +225,18 @@ module ApplicationHelper
 
     content_tag(:div, :class => "btn-group") do
       primary + link_to(content_tag(:span, '', :class => 'caret'), '#', :class => "btn btn-default #{'btn-sm' if primary =~ /btn-sm/} dropdown-toggle", :'data-toggle' => 'dropdown') +
-      content_tag(:ul, :class => "dropdown-menu pull-right") do
-        args.map { |option| content_tag(:li, option) }.join(" ").html_safe
-      end
+        content_tag(:ul, :class => "dropdown-menu pull-right") do
+          args.map do |option|
+            tag_options = nil
+            if option.is_a?(Hash)
+              content = option[:content]
+              tag_options = option[:options]
+            else
+              content = option
+            end
+            content_tag(:li, content, tag_options)
+          end.join(" ").html_safe
+        end
     end
   end
 

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1657,12 +1657,14 @@ end
 A plugin can add items to the `Actions` dropdown in the table on the hostgroups overview page.
 
 Adding an item to the actions dropdown requires adding a helper with a method that accepts a hostgroup as an argument and
-returns a list of hashes, where each hash will
-have two predefined fields: `:action` and `:priority`.
-The `:action`  item should be an HTML element (probably a link) that will be embedded as an item in the dropdown.
-The `:priority` value would be used by the
-system to define the order of the items to show. The lower the priority, the
-higher the item will show.
+returns a list of hashes, where each hash will have two predefined fields: `:action` and `:priority`.
+The `:action` item should be an HTML element (probably a link) that will be embedded as an item in the dropdown.
+The `:priority` value would be used by the system to define the order of the items to show.
+The lower the priority, the higher the item will show.
+
+There is also an option to add action with a disabled link by passing the `:action` as a hash.
+This hash has two values: `:content` which contains the HTML link as before, and `:options` which contains a hash with the HTML options to be added to the action’s `li` tag.
+See the second example below.
 
 In plugin helper (`my_plugin_helper.rb`):
 [source, ruby]
@@ -1670,6 +1672,7 @@ In plugin helper (`my_plugin_helper.rb`):
 def my_plugin_hostgroups_actions(hostgroup)
   [
     { :action => display_link_if_authorized('new_action', {other_properties}), :priority => 20 }
+    { :action => { :content => display_link_if_authorized('new_action', {other_properties}), :options => { :class => 'disabled' } }, :priority => 20 }
   ]
 end
 ----


### PR DESCRIPTION
This PR implements the functionality for adding disabled links to dropdown menus (which are created by the `action_buttons` method).
This PR comes to solve the issue that was raised in this [PR](https://github.com/theforeman/foreman_ansible/pull/554).
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
