### PR TITLE
Fixes #35421 - Pin will_paginate to at least 3.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'rails', case SETTINGS[:rails]
 
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
 gem 'audited', '>= 4.9.0', '< 5'
-gem 'will_paginate', '>= 3.1.7', '< 4'
+gem 'will_paginate', '~> 3.3'
 gem 'ancestry', '>= 3.0.7', '< 4', '!= 3.2.0'
 gem 'scoped_search', '>= 4.1.8', '< 5'
 gem 'ldap_fluff', '>= 0.5.0', '< 1.0'


### PR DESCRIPTION
Version 3.3.0 fixes Ruby 2.7 warnings. Note we already package 3.3.1 in RPMs. This just enforces a correct lower bound.