### PR TITLE
Refs #35420 - Remove unused settings.yaml.dist file

### DIFF
--- a/config/settings.yaml.dist
+++ b/config/settings.yaml.dist
@@ -1,5 +1,0 @@
----
-# Distribution settings file
-#
-# Allows distributors to set default boot settings. User settings should be
-# added to settings.yaml, which takes precedence.


### PR DESCRIPTION
Just after the PR was merged I noticed this was in a later commit that I didn't include.

Fixes: afd0518243e3e478195c92cc16cd5f809d170032