### PR TITLE
Fixes #35431 - Update spring to 4.x

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -20,7 +20,7 @@ group :development do
 
   gem 'bullet', '>= 6.1.0'
   gem "parallel_tests"
-  gem 'spring', '>= 1.0', '< 3'
+  gem 'spring', '~> 4.0'
   gem 'benchmark-ips', '>= 2.8.2'
   gem 'foreman'
   gem('bootsnap', :require => false)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,7 @@ Foreman::Application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+  config.cache_classes = false
 
   # Eager load currently cannot be set due to: https://projects.theforeman.org/issues/31977
   config.eager_load = false


### PR DESCRIPTION
Currently version 2 is used, but version 3 brings Ruby 3 support. Version 4 is the latest. The only backwards incompatible changes they [mention](https://github.com/rails/spring/blob/main/CHANGELOG.md) are requiring Ruby >= 2.7 and Rails >= 6.0, which is not a problem for Foreman.

Version 3 enforces that cache_classes is turned off, in particular for test environments.