### PR TITLE
Fixes #35432 - Use Rails 6.1 defaults

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -161,7 +161,7 @@ module ApplicationHelper
 
   def sort(field, permitted: [], **kwargs)
     kwargs[:url_options] ||= current_url_params(permitted: permitted)
-    super(field, kwargs)
+    super(field, **kwargs)
   end
 
   def help_button

--- a/app/models/concerns/foreman/sti.rb
+++ b/app/models/concerns/foreman/sti.rb
@@ -20,7 +20,7 @@ module Foreman
       end
     end
 
-    def save(*args)
+    def save(*args, **kwargs)
       type_changed = type_changed?
       self.class.instance_variable_set("@finder_needs_type_condition", :false) if type_changed
       super

--- a/app/models/concerns/has_many_common.rb
+++ b/app/models/concerns/has_many_common.rb
@@ -42,18 +42,17 @@ module HasManyCommon
     end
 
     #### has_many ####
-    def has_many(*args)
-      options = args.last.is_a?(Hash) ? args.last : {}
-      has_many_names_for(args.first, options)
+    def has_many(name, scope = nil, **kwargs, &extension)
+      has_many_names_for(name)
       super
     end
 
-    def has_and_belongs_to_many(association, options = {})
-      has_many_names_for(association, options)
+    def has_and_belongs_to_many(name, scope = nil, **kwargs, &extension)
+      has_many_names_for(name)
       super
     end
 
-    def has_many_names_for(association, options)
+    def has_many_names_for(association)
       assoc = association.to_s.tableize.singularize
 
       # SETTER _names= method
@@ -71,15 +70,14 @@ module HasManyCommon
     end
 
     #### belongs_to ####
-    def belongs_to(*args)
-      options = args.last.is_a?(Hash) ? args.last : {}
-      belongs_to_name_for(args.first, options)
-      super
+    def belongs_to(name, scope = nil, name_accessor: nil, **kwargs)
+      belongs_to_name_for(name, name_accessor)
+      super(name, scope, **kwargs)
     end
 
-    def belongs_to_name_for(association, options)
+    def belongs_to_name_for(association, name_accessor)
       assoc = association.to_s.tableize.singularize
-      assoc_name = options.delete(:name_accessor) || "#{assoc}_name"
+      assoc_name = name_accessor || "#{assoc}_name"
 
       # SETTER _name= method
       define_method "#{assoc_name}=" do |name_value|

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -8,7 +8,7 @@ module CsvExporter
     context = Foreman::ThreadSession::Context.get
 
     Enumerator.new do |csv|
-      Foreman::ThreadSession::Context.set(context)
+      Foreman::ThreadSession::Context.set(**context)
       csv << CSV.generate_line(header)
       cols = columns.map { |c| c.to_s.split('.').map(&:to_sym) }
       resources.uncached do

--- a/app/services/foreman/renderer/scope/template.rb
+++ b/app/services/foreman/renderer/scope/template.rb
@@ -6,7 +6,7 @@ module Foreman
         attr_reader :template_input_values
 
         def initialize(template_input_values: {}, **params)
-          super(params)
+          super(**params)
           @template_input_values = template_input_values
         end
       end

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,7 +100,7 @@ end
 
 module Foreman
   class Application < Rails::Application
-    config.load_defaults 6.0
+    config.load_defaults 6.1
 
     # Rails 5.0 changed this to true, but a lot of code depends on this
     config.active_record.belongs_to_required_by_default = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,7 +100,7 @@ end
 
 module Foreman
   class Application < Rails::Application
-    config.load_defaults 5.0
+    config.load_defaults 5.1
 
     # Rails 5.0 changed this to true, but a lot of code depends on this
     config.active_record.belongs_to_required_by_default = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,7 +100,7 @@ end
 
 module Foreman
   class Application < Rails::Application
-    config.load_defaults 5.1
+    config.load_defaults 5.2
 
     # Rails 5.0 changed this to true, but a lot of code depends on this
     config.active_record.belongs_to_required_by_default = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,10 +100,13 @@ end
 
 module Foreman
   class Application < Rails::Application
-    config.load_defaults 5.2
+    config.load_defaults 6.0
 
     # Rails 5.0 changed this to true, but a lot of code depends on this
     config.active_record.belongs_to_required_by_default = false
+
+    # Rails 6.0 changed this to :zeitwerk
+    config.autoloader = :classic
 
     # Setup additional routes by loading all routes file from routes directory
     Dir["#{Rails.root}/config/routes/**/*.rb"].each do |route_file|

--- a/config/application.rb
+++ b/config/application.rb
@@ -100,6 +100,11 @@ end
 
 module Foreman
   class Application < Rails::Application
+    config.load_defaults 5.0
+
+    # Rails 5.0 changed this to true, but a lot of code depends on this
+    config.active_record.belongs_to_required_by_default = false
+
     # Setup additional routes by loading all routes file from routes directory
     Dir["#{Rails.root}/config/routes/**/*.rb"].each do |route_file|
       config.paths['config/routes.rb'] << route_file

--- a/test/models/external_usergroup_test.rb
+++ b/test/models/external_usergroup_test.rb
@@ -18,7 +18,7 @@ class ExternalUsergroupTest < ActiveSupport::TestCase
   test 'update_usergroups matches LDAP gids with external user groups case insensitively' do
     setup_ldap_stubs
 
-    @auth_source_ldap.expects(:valid_group?).with('IPAUSERS').returns(true)
+    @auth_source_ldap.expects(:valid_group?).with('IPAUSERS').returns(true).twice
     external = FactoryBot.create(:external_usergroup, :auth_source => @auth_source_ldap, :name => 'IPAUSERS')
     ldap_user = FactoryBot.create(:user, :login => 'JohnSmith', :mail => 'a@b.com', :auth_source => @auth_source_ldap)
     AuthSourceLdap.any_instance.expects(:users_in_group).with('IPAUSERS').returns(['JohnSmith'])

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2500,8 +2500,8 @@ class HostTest < ActiveSupport::TestCase
     refute_nil host.provision_interface
     primary = host.primary_interface
 
-    nic = FactoryBot.build_stubbed(:nic_managed, :host => host, :mac => '00:00:00:AA:BB:CC', :ip => '192.168.0.1',
-                            :name => 'host2', :domain => host.domain)
+    nic = FactoryBot.build(:nic_managed, :host => host, :mac => '00:00:00:AA:BB:CC', :ip => '192.168.0.1',
+                           :name => 'host2', :domain => host.domain)
     nic.primary = true
     nic.provision = true
 


### PR DESCRIPTION
Rails has introduced [config.load_defaults](https://guides.rubyonrails.org/configuring.html#versioned-default-values) to load the defaults of a certain version. Currently this is not called at all, which means using Rails < 5.0 defaults. Changing this brings Foreman more in line with the Rails recommended defaults.

Right now this is a draft since I'm a bit uncertain of all the implications.