### PR TITLE
Fixes #35438 - Unescape cluster on compute resource controller

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -144,7 +144,7 @@ module Api
       param :id, :identifier, :required => true
       param :cluster_id, String
       def available_networks
-        @available_networks = @compute_resource.available_networks(params[:cluster_id].presence)
+        @available_networks = @compute_resource.available_networks(cluster_id)
         @total = @available_networks&.size
         render :available_networks, :layout => 'api/v2/layouts/index_layout'
       end
@@ -160,7 +160,7 @@ module Api
       param :id, :identifier, :required => true
       param :cluster_id, String, :required => true
       def available_resource_pools
-        @available_resource_pools = @compute_resource.available_resource_pools({ :cluster_id => params[:cluster_id] })
+        @available_resource_pools = @compute_resource.available_resource_pools({ :cluster_id => cluster_id })
         @total = @available_resource_pools&.size
         render :available_resource_pools, :layout => 'api/v2/layouts/index_layout'
       end
@@ -183,7 +183,7 @@ module Api
           Foreman::Deprecation.api_deprecation_warning("use /compute_resources/:id/storage_domain/:storage_domain_id endpoind instead")
           @available_storage_domains = [@compute_resource.storage_domain(params[:storage_domain])]
         else
-          @available_storage_domains = @compute_resource.available_storage_domains(params[:cluster_id].presence)
+          @available_storage_domains = @compute_resource.available_storage_domains(cluster_id)
         end
         @total = @available_storage_domains&.size
         render :available_storage_domains, :layout => 'api/v2/layouts/index_layout'
@@ -207,7 +207,7 @@ module Api
           Foreman::Deprecation.api_deprecation_warning("use /compute_resources/:id/storage_pod/:storage_pod_id endpoind instead")
           @available_storage_pods = [@compute_resource.storage_pod(params[:storage_pod])]
         else
-          @available_storage_pods = @compute_resource.available_storage_pods(params[:cluster_id].presence)
+          @available_storage_pods = @compute_resource.available_storage_pods(cluster_id)
         end
         @total = @available_storage_pods&.size
         render :available_storage_pods, :layout => 'api/v2/layouts/index_layout'
@@ -294,6 +294,10 @@ module Api
       end
 
       private
+
+      def cluster_id
+        params[:cluster_id].present? && CGI.unescape(params[:cluster_id])
+      end
 
       def action_permission
         case params[:action]

--- a/app/views/api/v2/compute_resources/available_clusters.rabl
+++ b/app/views/api/v2/compute_resources/available_clusters.rabl
@@ -1,3 +1,3 @@
 collection @available_clusters
 
-attribute :name, :id, :full_path
+attribute :name, :id, :full_path, :datacenter, :num_host

--- a/app/views/api/v2/compute_resources/available_images.json.rabl
+++ b/app/views/api/v2/compute_resources/available_images.json.rabl
@@ -3,4 +3,4 @@ collection @available_images
 node :uuid do |img|
   img.id
 end
-attribute :name
+attribute :name, :path

--- a/app/views/api/v2/compute_resources/available_networks.rabl
+++ b/app/views/api/v2/compute_resources/available_networks.rabl
@@ -1,3 +1,3 @@
 collection @available_networks
 
-attribute :name, :id
+attribute :name, :id, :datacenter, :virtualswitch, :vlanid

--- a/app/views/api/v2/compute_resources/available_resource_pools.rabl
+++ b/app/views/api/v2/compute_resources/available_resource_pools.rabl
@@ -1,3 +1,3 @@
 collection @available_resource_pools
 
-attribute :name, :id
+attribute :name, :id, :cluster, :datacenter

--- a/app/views/api/v2/compute_resources/available_storage_pods.rabl
+++ b/app/views/api/v2/compute_resources/available_storage_pods.rabl
@@ -1,3 +1,3 @@
 collection @available_storage_pods
 
-attribute :name, :id, :capacity, :freespace
+attribute :name, :id, :capacity, :freespace, :datacenter

--- a/app/views/api/v2/compute_resources/available_virtual_machines.rabl
+++ b/app/views/api/v2/compute_resources/available_virtual_machines.rabl
@@ -1,3 +1,3 @@
 collection @available_virtual_machines
 
-attribute :name, :id
+attribute :name, :id, :path, :state


### PR DESCRIPTION
* The webui uses a different controller than hammer does, we don't allow slashes in [Apache](https://httpd.apache.org/docs/current/mod/core.html#allowencodedslashes) so this allows nested clusters to be found when using hammer. Also updated various rabl files for better user experience in hammer list commands(seperate pr to that repo)

* This allows the cluster to be passed in with `hammer -d compute-resource resource-pools --id 1 --cluster-id "Test-Folder%2FTest-Cluster"` where before you would get a  `Fog::Vsphere::Compute::NotFound`

* And for the other endpoint to find the cluster: `hammer -d compute-profile values create --compute-profile-id 6 --compute-resource-id 6 '--compute-attributes={"cpus":2,"corespersocket":2,"memory_mb":4096,"firmware":"efi","resource_pool":"Resources","cluster":"Test-Folder/Test-Cluster","guest_id":"rhel8_64Guest","path":"/Datacenters/Toledo-Test/vm","hardware_version":"Default","memoryHotAddEnabled":0,"cpuHotAddEnabled":0,"add_cdrom":0,"boot_order":["disk","network"],"scsi_controllers":[{"type":"ParaVirtualSCSIController","key":1000},{"type":"ParaVirtualSCSIController","key":1001}]}'`

Hammer PR for enhanced listing commands:

https://github.com/theforeman/hammer-cli-foreman/pull/604