### PR TITLE
Fixes #35439 - Add ouia-id to ConfirmModal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -53,6 +53,7 @@ const ConfirmModal = () => {
 
   return (
     <Modal
+      ouiaId="app-confirm-modal"
       id="app-confirm-modal"
       aria-label="application confirm modal"
       variant={ModalVariant.small}


### PR DESCRIPTION
edit:
For qe testing.
Bugzila description:
Need a static ouia-id for the close button on the Confirmation Modal. The current id is "OUIA-Generated-Modal-small-1-ModalBoxCloseButton". The number in this id changes every time you open the modal. We need an id that is just "ModalBoxCloseButton" or something else that is static.
More about the Open UI Automation: https://www.patternfly.org/v4/developer-resources/open-ui-automation/