### PR TITLE
Fixes #35447 - Update apipie-rails to 0.8.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'will_paginate', '~> 3.3'
 gem 'ancestry', '~> 4.0'
 gem 'scoped_search', '>= 4.1.10', '< 5'
 gem 'ldap_fluff', '>= 0.5.0', '< 1.0'
-gem 'apipie-rails', '>= 0.5.17', '< 0.6.0'
+gem 'apipie-rails', '~> 0.8.0'
 gem 'apipie-dsl', '>= 2.2.6'
 # Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
 # Rails 6.0 is incompatible with Psych 4, Rails 6.1 should work


### PR DESCRIPTION
The [changelog](https://github.com/Apipie/apipie-rails/blob/master/CHANGELOG.md) says:

* 0.6.0 gives us Ruby 3 support
* 0.7.2 upgrades the vendored bootstrap and jquery for security reasons
* 0.8.0 gives us Rails 7 support

There are some warnings about `allow_blank` changing.