### PR TITLE
Fixes #35305 - make host details labels clickable

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -2,6 +2,7 @@
 import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { useSelector, shallowEqual } from 'react-redux';
+import { Link } from 'react-router-dom';
 import {
   Flex,
   FlexItem,
@@ -9,7 +10,7 @@ import {
   Tab,
   Tabs,
   GridItem,
-  Badge,
+  Label,
   Title,
   Text,
   TextVariants,
@@ -143,10 +144,42 @@ const HostDetails = ({
                         <HostGlobalStatus hostName={id} />
                       </SplitItem>
                       <SplitItem>
-                        <Badge> {response?.operatingsystem_name}</Badge>
+                        <Label
+                          isCompact
+                          color="blue"
+                          render={({ className, content, componentRef }) => (
+                            <Link
+                              to={`/hosts?search=os_title="${response?.operatingsystem_name}"`}
+                              className={className}
+                              innerRef={componentRef}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {content}
+                            </Link>
+                          )}
+                        >
+                          {response?.operatingsystem_name}
+                        </Label>
                       </SplitItem>
                       <SplitItem>
-                        <Badge>{response?.architecture_name}</Badge>
+                        <Label
+                          isCompact
+                          color="blue"
+                          render={({ className, content, componentRef }) => (
+                            <Link
+                              to={`/hosts?search=architecture=${response?.architecture_name}`}
+                              className={className}
+                              innerRef={componentRef}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {content}
+                            </Link>
+                          )}
+                        >
+                          {response?.architecture_name}
+                        </Label>
                       </SplitItem>
                     </Split>
                   </>


### PR DESCRIPTION
Needed to change the `Badge` to `Label` so it would be clickable and have `onHover` behavior.
The links lead to host search with the same os/architecture which is what clicking on os/architecture would do in the old ui (in the properties section)

New look (left is hovered on):
![Screenshot from 2022-08-29 13-08-56](https://user-images.githubusercontent.com/30431079/187214957-19b0e845-4eb6-4e54-b539-6338a637431c.png)

old look:
![Screenshot from 2022-08-29 11-07-52](https://user-images.githubusercontent.com/30431079/187214962-273fcb6d-9b97-466d-b8e4-41a06cfd681d.png)
