### PR TITLE
Fixes #31966 - Add warning for foreman-rake permissions:reset task

### DIFF
--- a/lib/tasks/reset_permissions.rake
+++ b/lib/tasks/reset_permissions.rake
@@ -22,6 +22,7 @@ namespace :permissions do
       user.password = password
       if user.save
         puts "Reset to user: #{user.login}, password: #{password}"
+        puts "WARNING: You need to change the password for hammer in ~/.hammer/cli.modules.d/foreman.yml manually!"
       else
         puts user.errors.full_messages.join(", ")
       end


### PR DESCRIPTION
Added warning to foreman-rake permissions:reset task.