### PR TITLE
Fixes #35055 - Add permission to action_permission for bootfiles

### DIFF
--- a/app/controllers/api/v2/operatingsystems_controller.rb
+++ b/app/controllers/api/v2/operatingsystems_controller.rb
@@ -102,6 +102,15 @@ module Api
 
       private
 
+      def action_permission
+        case params[:action]
+        when 'bootfiles'
+          :view
+        else
+          super
+        end
+      end
+
       def allowed_nested_id
         %w(architecture_id medium_id ptable_id provisioning_template_id)
       end


### PR DESCRIPTION
Fixed a bug where calling API endpoint bootfiles resulted in error.