### PR TITLE
Fixes #35472 - Try restarting yggdrasild before enabling it

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
+++ b/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
@@ -67,6 +67,7 @@ fi
 
 # start the yggdrasild service
 echo "Starting yggdrasild..."
+systemctl try-restart yggdrasild
 systemctl enable --now yggdrasild
 
 # check status of yggdrasild and fail if it is not running


### PR DESCRIPTION
The way this was worked on a first run. If you ran the script again, it
might change the configuration, but the service never got restarted to
pick up the changes.

"Backport" of https://github.com/theforeman/katello-pull-transport-migrate/pull/6

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
