### PR TITLE
Fixes #35473 - Add extlogin API endpoint

### DIFF
--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -12,6 +12,8 @@ module Api
         ['compute_attributes']
 
       before_action :find_optional_nested_object
+      skip_before_action :authorize, :only => [:extlogin]
+      before_action :authenticate, :only => [:extlogin]
 
       api :GET, "/users/", N_("List all users")
       api :GET, "/auth_source_ldaps/:auth_source_ldap_id/users", N_("List all users for LDAP authentication source")
@@ -118,6 +120,10 @@ module Api
         else
           process_response @user.destroy
         end
+      end
+
+      api :GET, "/users/extlogin", N_("Use to authenticate against external authentication source")
+      def extlogin
       end
 
       private

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -212,6 +212,7 @@ Foreman::Application.routes.draw do
           resources :table_preferences, :only => [:index, :create, :destroy, :show, :update]
           resources :mail_notifications, :only => [:create, :destroy, :update]
           get 'mail_notifications', :to => 'mail_notifications#user_mail_notifications', :on => :member
+          get 'extlogin', :to => 'users#extlogin', :on => :collection
         end
       end
 

--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -53,7 +53,9 @@ class AccessPermissionsTest < ActiveSupport::TestCase
     "api/graphql/execute",
 
     # ping
-    "api/v2/ping/ping"
+    "api/v2/ping/ping",
+
+    "api/v2/users/extlogin"
   ]
 
   MAY_SKIP_AUTHORIZED = ["about/index", "react/index", "api/v2/ping/ping"]


### PR DESCRIPTION
/users/extlogin endpoint is designed for UI interaction, thus
using this endpoint to create a session to be used via API will
fail with "Can't verify CSRF token authenticity" for any method
except GET. We need to have a separate endpoint to create
a proper session to be used via API.

 - [x] Requires https://github.com/theforeman/puppet-foreman/pull/1083
 - [x] Required by https://github.com/theforeman/hammer-cli-foreman/pull/605
 
 I'd like to have it CPed into 3.3, but not sure if it's feasible...
 
 I've tested these (and deps) patches on production setup via:
 - curl -k -c cookies.txt -u : --negotiate https://foreman.ofedoren.example.com/api/users/extlogin [OK]
 - curl -b cookies.txt -H "Accept:application/json,version=2" -H "Content-Type:application/json" -X POST -d '{"architecture": { "name": "arch1" }}' -k https://foreman.ofedoren.example.com/api/architectures [OK]
 - hammer auth login negotiate [OK]
 - hammer architecture create --name arch2 [OK]
 
 P.S. This is a suggested solution. One of the possible solutions could be introduced here only. We would need to somehow make sure that
 https://github.com/theforeman/foreman/blob/develop/app/controllers/concerns/foreman/controller/authentication.rb#L88-L92 
 works with hitting `/users/extlogin` via API.