### PR TITLE
Fixes #35490 - Registration - Changing proxy cause an error

### DIFF
--- a/app/controllers/registration_commands_controller.rb
+++ b/app/controllers/registration_commands_controller.rb
@@ -1,7 +1,7 @@
 class RegistrationCommandsController < ApplicationController
   include Foreman::Controller::RegistrationCommands
 
-  before_action :find_smart_proxy, if: -> { registration_params['smart_proxy_id'] }, only: [:create]
+  before_action :find_smart_proxy, if: -> { registration_params['smart_proxy_id'].presence }, only: [:create]
 
   def form_data
     render json: {


### PR DESCRIPTION
**Steps to reproduce**
* Go to registration form
* generate command with proxy
* Unselect proxy and generate command again

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
