### PR TITLE
Fixes #35491 - host details statuses clear button disabled

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalStatus.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalStatus.js
@@ -9,7 +9,7 @@ import { HOST_STATUSES_KEY } from './Constants';
 import { APIActions } from '../../../redux/API';
 import { selectAPIResponse } from '../../../redux/API/APISelectors';
 
-const GlobalStatus = ({ hostName }) => {
+const GlobalStatus = ({ hostName, canForgetStatuses }) => {
   const [modalStatus, setModalStatus] = useState(false);
   const dispatch = useDispatch();
 
@@ -41,6 +41,7 @@ const GlobalStatus = ({ hostName }) => {
         onClose={() => {
           setModalStatus(false);
         }}
+        canForgetStatuses={canForgetStatuses}
       />
     </>
   );
@@ -48,6 +49,7 @@ const GlobalStatus = ({ hostName }) => {
 
 GlobalStatus.propTypes = {
   hostName: PropTypes.string.isRequired,
+  canForgetStatuses: PropTypes.bool.isRequired,
 };
 
 export default GlobalStatus;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -141,7 +141,12 @@ const HostDetails = ({
                     </div>
                     <Split style={{ display: 'inline-flex' }} hasGutter>
                       <SplitItem>
-                        <HostGlobalStatus hostName={id} />
+                        <HostGlobalStatus
+                          hostName={id}
+                          canForgetStatuses={
+                            !!response?.permissions?.forget_status_hosts
+                          }
+                        />
                       </SplitItem>
                       <SplitItem>
                         <Label


### PR DESCRIPTION
When clicking on the host status icon next to the host title, in the host statuses modal the clear button is always disabled.
if a user clicks on "Manage all statuses" in the status card the clear button is not always disabled 