### PR TITLE
Fixes #35492 - Update Operating Systems card to use masonry layout

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/OperatingSystem/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/OperatingSystem/index.js
@@ -26,6 +26,7 @@ const OperatingSystemCard = ({ status, isExpandedGlobal, hostDetails }) => {
       header={__('Operating system')}
       expandable
       isExpandedGlobal={isExpandedGlobal}
+      masonryLayout
     >
       <DescriptionList isCompact isHorizontal>
         <DescriptionListGroup>


### PR DESCRIPTION
Cards in the Details tab need to have the `masonryLayout` prop or they show up misaligned like this:

![operating-system-card-alignment](https://user-images.githubusercontent.com/22042343/188730847-a8ccf41d-2c1f-4676-a024-a62dd6dfe1f5.png)
