### PR TITLE
Fixes #35472 - Try restarting yggdrasild before enabling it

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
+++ b/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
@@ -67,6 +67,7 @@ fi
 
 # start the yggdrasild service
 echo "Starting yggdrasild..."
+systemctl try-restart yggdrasild
 systemctl enable --now yggdrasild
 
 # check status of yggdrasild and fail if it is not running


### PR DESCRIPTION
The way this was worked on a first run. If you ran the script again, it
might change the configuration, but the service never got restarted to
pick up the changes.

(cherry picked from commit e79cdce2dafb09a600f94fddf6ef7c5f71d21eaa)
