### PR TITLE
Fixes #34997 - Fix expand/collapse all behavior in Details tab

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/CardRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/CardRegistry.js
@@ -4,8 +4,8 @@ import Properties from '../Details/Cards/SystemProperties';
 import OperatingSystem from '../Details/Cards/OperatingSystem';
 
 const cards = [
-  { key: '[core]-properties-card', Component: Properties, weight: 4000 },
-  { key: '[core]-os-card', Component: OperatingSystem, weight: 3000 },
+  { key: '[core] System properties', Component: Properties, weight: 4000 },
+  { key: '[core] Operating systems', Component: OperatingSystem, weight: 3000 },
 ];
 
 export const registerCoreCards = () => {

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/OperatingSystem/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/OperatingSystem/index.js
@@ -15,19 +15,14 @@ import DefaultLoaderEmptyState from '../../../../DetailsCard/DefaultLoaderEmptyS
 import { STATUS } from '../../../../../../constants';
 import RelativeDateTime from '../../../../../common/dates/RelativeDateTime';
 
-const OperatingSystemCard = ({ status, isExpandedGlobal, hostDetails }) => {
+const OperatingSystemCard = ({ status, hostDetails }) => {
   const {
     architecture_name: architectureName,
     operatingsystem_name: osName,
     reported_data: { boot_time: bootTime } = {},
   } = hostDetails;
   return (
-    <CardTemplate
-      header={__('Operating system')}
-      expandable
-      masonryLayout
-      isExpandedGlobal={isExpandedGlobal}
-    >
+    <CardTemplate header={__('Operating system')} expandable masonryLayout>
       <DescriptionList isCompact isHorizontal>
         <DescriptionListGroup>
           <DescriptionListTerm>{__('Architecture')}</DescriptionListTerm>
@@ -89,7 +84,6 @@ const OperatingSystemCard = ({ status, isExpandedGlobal, hostDetails }) => {
 
 OperatingSystemCard.propTypes = {
   status: PropTypes.string,
-  isExpandedGlobal: PropTypes.bool,
   hostDetails: PropTypes.shape({
     architecture_name: PropTypes.string,
     operatingsystem_name: PropTypes.string,
@@ -99,7 +93,6 @@ OperatingSystemCard.propTypes = {
 
 OperatingSystemCard.defaultProps = {
   status: STATUS.PENDING,
-  isExpandedGlobal: false,
   hostDetails: {
     architecture_name: undefined,
     operatingsystem_name: undefined,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
@@ -15,7 +15,7 @@ import SkeletonLoader from '../../../../../common/SkeletonLoader';
 import DefaultLoaderEmptyState from '../../../../DetailsCard/DefaultLoaderEmptyState';
 import { STATUS } from '../../../../../../constants';
 
-const SystemPropertiesCard = ({ status, isExpandedGlobal, hostDetails }) => {
+const SystemPropertiesCard = ({ status, hostDetails }) => {
   const {
     name,
     uuid,
@@ -33,7 +33,6 @@ const SystemPropertiesCard = ({ status, isExpandedGlobal, hostDetails }) => {
       header={__('System properties')}
       expandable
       masonryLayout
-      isExpandedGlobal={isExpandedGlobal}
     >
       <DescriptionList isCompact>
         <DescriptionListGroup>
@@ -154,7 +153,6 @@ const SystemPropertiesCard = ({ status, isExpandedGlobal, hostDetails }) => {
 
 SystemPropertiesCard.propTypes = {
   status: PropTypes.string,
-  isExpandedGlobal: PropTypes.bool,
   hostDetails: PropTypes.shape({
     hostgroup_name: PropTypes.string,
     model_name: PropTypes.string,
@@ -172,7 +170,6 @@ SystemPropertiesCard.propTypes = {
 
 SystemPropertiesCard.defaultProps = {
   status: STATUS.PENDING,
-  isExpandedGlobal: false,
   hostDetails: {
     name: undefined,
     model_name: undefined,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import { Flex, FlexItem, Button } from '@patternfly/react-core';
 import { registerCoreCards } from './CardRegistry';
 import Slot from '../../../common/Slot';
@@ -7,6 +7,43 @@ import { STATUS } from '../../../../constants';
 import '../Overview/styles.css';
 import './styles.css';
 import { translate as __ } from '../../../../common/I18n';
+
+export const CardExpansionContext = React.createContext({});
+
+const initialState = {
+  'System properties card expanded': true,
+  'Operating system card expanded': true,
+  'Registration details card expanded': true,
+  'HW properties card expanded': true,
+  'Installed products card expanded': true,
+};
+
+function cardExpansionReducer(state, action) {
+  // A React reducer, not a Redux one!
+  switch (action.type) {
+    case 'expand':
+      return {
+        ...state,
+        [action.key]: true,
+      };
+    case 'collapse':
+      return {
+        ...state,
+        [action.key]: false,
+      };
+    case 'expandAll':
+      return initialState;
+    case 'collapseAll': {
+      const collapsedState = {};
+      Object.keys(state).forEach(key => {
+        collapsedState[key] = false;
+      });
+      return collapsedState;
+    }
+    default:
+      throw new Error();
+  }
+}
 
 const DetailsTab = ({ response, status, hostName }) => {
   useEffect(() => {
@@ -16,7 +53,41 @@ const DetailsTab = ({ response, status, hostName }) => {
     registerCoreCards();
     return () => document.body.classList.remove('pf-gray-background');
   }, []);
-  const [isExpandedGlobal, setExpandedGlobal] = useState(true);
+
+  const [cardExpandStates, dispatch] = useReducer(
+    cardExpansionReducer,
+    initialState
+  );
+  const areAllCardsExpanded = Object.values(cardExpandStates).every(
+    value => value === true
+  );
+
+  const expandAllCards = () => dispatch({ type: 'expandAll' });
+
+  const collapseAllCards = () => dispatch({ type: 'collapseAll' });
+
+  // On mount, get values from localStorage and set them in state
+  useEffect(() => {
+    Object.keys(initialState).forEach(key => {
+      const value = localStorage.getItem(key);
+      if (value !== null) {
+        dispatch({ type: value === 'true' ? 'expand' : 'collapse', key });
+      }
+    });
+  }, []);
+
+  // On unmount, save the values to local storage
+  // eslint-disable-next-line arrow-body-style
+  useEffect(() => {
+    return () =>
+      Object.entries(cardExpandStates).forEach(([key, value]) =>
+        localStorage.setItem(key, value)
+      );
+  });
+
+  const buttonText = areAllCardsExpanded
+    ? __('Collapse all cards')
+    : __('Expand all cards');
 
   return (
     <div className="host-details-tab-item details-tab">
@@ -24,10 +95,10 @@ const DetailsTab = ({ response, status, hostName }) => {
         <FlexItem align={{ default: 'alignRight' }}>
           <Button
             ouiaId="expand-button"
-            onClick={() => setExpandedGlobal(prev => !prev)}
+            onClick={areAllCardsExpanded ? collapseAllCards : expandAllCards}
             variant="link"
           >
-            {__('Expand/Collapse all')}
+            {buttonText}
           </Button>
         </FlexItem>
       </Flex>
@@ -36,14 +107,15 @@ const DetailsTab = ({ response, status, hostName }) => {
         flexWrap={{ default: 'wrap' }}
         className="details-tab-flex-container"
       >
-        <Slot
-          hostDetails={response}
-          status={status}
-          hostName={hostName}
-          id="host-tab-details-cards"
-          isExpandedGlobal={isExpandedGlobal}
-          multi
-        />
+        <CardExpansionContext.Provider value={{ cardExpandStates, dispatch }}>
+          <Slot
+            hostDetails={response}
+            status={status}
+            hostName={hostName}
+            id="host-tab-details-cards"
+            multi
+          />
+        </CardExpansionContext.Provider>
       </Flex>
     </div>
   );

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
@@ -10,7 +10,7 @@ import { translate as __ } from '../../../../common/I18n';
 
 export const CardExpansionContext = React.createContext({});
 
-function cardExpansionReducer(state, action) {
+const cardExpansionReducer = (state, action) => {
   // A React reducer, not a Redux one!
   switch (action.type) {
     case 'expand':
@@ -46,9 +46,9 @@ function cardExpansionReducer(state, action) {
       return collapsedState;
     }
     default:
-      throw new Error();
+      throw new Error(`invalid card expansion type: ${action.type}`);
   }
-}
+};
 
 const DetailsTab = ({ response, status, hostName }) => {
   useEffect(() => {

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -24,16 +24,22 @@ const CardTemplate = ({
   overrideDropdownProps,
   masonryLayout,
 }) => {
-  const { cardExpandStates, dispatch } = useContext(CardExpansionContext);
+  const { cardExpandStates, dispatch, cardIds } = useContext(
+    CardExpansionContext
+  );
+  const cardId = cardIds?.find(id => id.includes(header));
+  if (cardIds && !cardId) {
+    throw new Error(
+      `Unable to find a fill for the card: ${header}. Please use the same name for the card header and the fill key.`
+    );
+  }
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
-  const isExpanded =
-    expandable && cardExpandStates[`${header} card expanded`] === true;
+  const isExpanded = expandable && cardExpandStates[`${cardId}`] === true;
   const onDropdownToggle = isOpen => setDropdownVisibility(isOpen);
-  // const onExpandCallback = () => setExpanded(!isExpanded);
   const onExpandCallback = () =>
     dispatch({
       type: isExpanded ? 'collapse' : 'expand',
-      key: `${header} card expanded`,
+      key: `${cardId}`,
     });
   const onDropdownSelect = event => {
     setDropdownVisibility(prevState => !prevState);

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState, useContext } from 'react';
+import React, { useState, useContext, useEffect } from 'react';
 import {
   Card,
   CardActions,
@@ -24,18 +24,16 @@ const CardTemplate = ({
   overrideDropdownProps,
   masonryLayout,
 }) => {
-  const { cardExpandStates, dispatch, cardIds } = useContext(
+  const { cardExpandStates, dispatch, registerCard } = useContext(
     CardExpansionContext
   );
-  const cardId = cardIds?.find(id => id.includes(header));
-  if (cardIds && !cardId) {
-    throw new Error(
-      `Unable to find a fill for the card: ${header}. Please use the same name for the card header and the fill key.`
-    );
-  }
+  const cardId = header;
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
   const isExpanded = expandable && cardExpandStates[`${cardId}`] === true;
   const onDropdownToggle = isOpen => setDropdownVisibility(isOpen);
+  useEffect(() => {
+    if (expandable) registerCard(cardId);
+  }, [cardId, registerCard, expandable]);
   const onExpandCallback = () =>
     dispatch({
       type: isExpanded ? 'collapse' : 'expand',

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useContext } from 'react';
 import {
   Card,
   CardActions,
@@ -13,36 +13,34 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 
-import { useLocalStorage } from '../../../../../common/hooks/Storage';
-import { useDidUpdateEffect } from '../../../../../common/hooks/Common';
+import { CardExpansionContext } from '../../../Tabs/Details';
 
 const CardTemplate = ({
   header,
   children,
   expandable,
-  isExpandedGlobal,
   dropdownItems,
   overrideGridProps,
   overrideDropdownProps,
   masonryLayout,
 }) => {
+  const { cardExpandStates, dispatch } = useContext(CardExpansionContext);
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
-  const [isExpanded, setExpanded] = useLocalStorage(
-    `${header} card expanded`,
-    true
-  );
+  const isExpanded =
+    expandable && cardExpandStates[`${header} card expanded`] === true;
   const onDropdownToggle = isOpen => setDropdownVisibility(isOpen);
-  const onExpandCallback = () => setExpanded(prevState => !prevState);
+  // const onExpandCallback = () => setExpanded(!isExpanded);
+  const onExpandCallback = () =>
+    dispatch({
+      type: isExpanded ? 'collapse' : 'expand',
+      key: `${header} card expanded`,
+    });
   const onDropdownSelect = event => {
     setDropdownVisibility(prevState => !prevState);
     // https://github.com/eslint/eslint/issues/12822
     // eslint-disable-next-line no-unused-expressions
     overrideDropdownProps?.onSelect?.(event);
   };
-  useDidUpdateEffect(
-    () => isExpandedGlobal !== undefined && setExpanded(isExpandedGlobal),
-    [isExpandedGlobal]
-  );
   const CardContainer = masonryLayout ? FlexItem : GridItem;
   const gridWidthProps = masonryLayout
     ? {}
@@ -93,7 +91,6 @@ const CardTemplate = ({
 
 CardTemplate.propTypes = {
   header: PropTypes.node.isRequired,
-  isExpandedGlobal: PropTypes.bool,
   children: PropTypes.node,
   overrideGridProps: PropTypes.object,
   dropdownItems: PropTypes.arrayOf(PropTypes.node),
@@ -108,7 +105,6 @@ CardTemplate.defaultProps = {
   dropdownItems: undefined,
   overrideDropdownProps: {},
   expandable: false,
-  isExpandedGlobal: false,
   masonryLayout: false,
 };
 


### PR DESCRIPTION
This is a refactor of the Expand/Collapse All behavior on the Details tab.

#### What hasn't changed:
* You can click to expand or collapse any individual card.
* Individual card states are saved in the browser's localStorage and loaded on page/tab load.

#### Before:
* There was an 'Expand / Collapse All' button which expands or collapses all cards.
* This state was kept in `isExpandedGlobal`, a React state independent of all individual card expansion states
* Clicking on 'Expand / Collapse All' would sometimes expand all and sometimes collapse all, depending on `isExpandedGlobal`
* Because of this, it was possible to get into states where 'Expand / Collapse All' does nothing, or does the opposite of what you expect

![expand-all](https://user-images.githubusercontent.com/22042343/189203997-102c3736-3688-4513-8d0c-5f0dbd2e0861.png)


#### After:
* The button text now changes as needed: When all cards are expanded, the button will be 'Collapse all cards.' Otherwise, it will be 'Expand all cards.' This behavior is much more clear and predictable.
* To accomplish this, the Details tab now knows the state of all its cards.
* I used React Context and useReducer to give the Details tab access to all card expansion states, and pass them directly to each card. This has several advantages: it avoids prop drilling through multiple components, and also through multiple code bases. The change is all in Foreman; I didn't have to change anything in Katello or other plugins. For more information on this pattern, see https://reactjs.org/docs/hooks-faq.html#how-to-avoid-passing-callbacks-down
* ~~In order for the Details tab to access all the card data, I load all the card names from the fill IDs in use for the slot.  To keep everything consistent I needed to have a consistent card ID string in both the fill ID and the card header. So I changed some fill IDs and added a (hopefully) helpful error message.~~
* The `isExpandedGlobal` prop is eliminated and you no longer need to pass it down in CardTemplate. Instead, `areAllCardsExpanded` is a computed value derived from all the individual card states.
* Instead of writing to localStorage on every state change, it now only writes on unmount / cleanup and reads on page / tab load
* This should work out of the box for any card that uses CardTemplate.

