### PR TITLE
Fixes #35206 - more accurate messaging when host statuses are cleared

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
@@ -79,6 +79,8 @@ const AggregateStatusCard = ({
     warnStatus.length === 0 &&
     errorStatus.length === 0;
 
+  const allStatusesCleared = isOKState && okStatuses.length === 0;
+
   const hadleIconClick = type => {
     setChosenType(type);
     setOpenModal(true);
@@ -103,6 +105,7 @@ const AggregateStatusCard = ({
             cannotViewStatuses={!canViewStatuses}
             isOKState={isOKState}
             responseStatus={responseStatus}
+            allStatusesCleared={allStatusesCleared}
           >
             <Bullseye>
               <span className="card-pf-aggregate-status-notifications">

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalState.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/GlobalState.js
@@ -10,22 +10,26 @@ const GlobalState = ({
   responseStatus,
   isOKState,
   cannotViewStatuses,
+  allStatusesCleared,
   children,
 }) => {
-  if (responseStatus === STATUS.RESOLVED && (isOKState || cannotViewStatuses))
+  if (responseStatus === STATUS.RESOLVED && (isOKState || cannotViewStatuses)) {
+    const showBanIcon = cannotViewStatuses || allStatusesCleared;
+    const statusText = allStatusesCleared
+      ? __('All statuses cleared')
+      : __('All statuses OK');
     return (
       <EmptyState style={{ marginTop: '-1px' }} isFullHeight>
         <EmptyStateIcon
-          icon={cannotViewStatuses ? BanIcon : CheckCircleIcon}
-          color={cannotViewStatuses ? undefined : successColor.value}
+          icon={showBanIcon ? BanIcon : CheckCircleIcon}
+          color={showBanIcon ? undefined : successColor.value}
         />
         <Title ouiaId="global-state-title" size="lg" headingLevel="h4">
-          {cannotViewStatuses
-            ? __('No statuses to show')
-            : __('All statuses OK')}
+          {cannotViewStatuses ? __('No statuses to show') : statusText}
         </Title>
       </EmptyState>
     );
+  }
 
   return children;
 };
@@ -34,6 +38,7 @@ GlobalState.propTypes = {
   cannotViewStatuses: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
   isOKState: PropTypes.bool.isRequired,
+  allStatusesCleared: PropTypes.bool.isRequired,
   responseStatus: PropTypes.string,
 };
 


### PR DESCRIPTION
On Host Status card-

Per discussion with UX:

1) Use Patternfly 4 "BanIcon", not green CheckIcon.
2) Use the message wording "All statuses cleared"
(Leave "All statuses OK" unchanged for when they are actually OK and not cleared.)

![cleared-statuses](https://user-images.githubusercontent.com/22042343/189428354-60042dbf-b815-4110-aff2-e6c61e2801c1.png)

Quick way to test on a host with errata: Clear the Errata status, then Content > Errata > kebab > Recalculate to bring it back.