### PR TITLE
fixes #31593 - included puppet7 param in kickstart_default header

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -31,6 +31,7 @@ description: |
   - enable-puppetlabs-repo: boolean (default=false)
   - enable-puppetlabs-puppet5-repo: boolean (default=false)
   - enable-puppetlabs-puppet6-repo: boolean (default=false)
+  - enable-official-puppet7-repo: boolean (default=false)
   - skip-puppet-setup: boolean (default=false)
   - salt_master: string (default=undef)
   - ntp-server: string (default=undef)


### PR DESCRIPTION
included missing enable-official-puppet7-repo from kickstart_default template to correctly document it's availability for use.