### PR TITLE
Fixes #35520 - Unattended - Invalid remote_ip on production setup

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -147,7 +147,7 @@ class UnattendedController < ApplicationController
 
   def load_host_details
     query_params = params
-    query_params[:ip] = request.remote_ip
+    query_params[:ip] = ipxe_request? ? request.forwarded_for&.first || request.remote_ip : request.remote_ip
     query_params[:mac_list] = Foreman::UnattendedInstallation::MacListExtractor.new.extract_from_env(request.env, params: params)
     query_params[:built] = ['built', 'failed'].include? action_name
 


### PR DESCRIPTION
When rendering template through Smart Proxy in production setup, 'load_host_details' method is loading 'remote_ip' for the Smart Proxy, not for the provisioned host.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
