### PR TITLE
Fixes #35527 - Include the remote IP in status

### DIFF
--- a/app/controllers/api/v2/home_controller.rb
+++ b/app/controllers/api/v2/home_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class HomeController < V2::BaseController
+      include Foreman::Controller::SmartProxyAuth
+
       before_action :require_admin, :only => [:index]
       layout false
 
@@ -11,9 +13,11 @@ module Api
         Apipie.reload_documentation if Apipie.configuration.reload_controllers?
       end
 
+      add_smart_proxy_filters :status
       api :GET, "/status/", N_("Show status")
 
       def status
+        @remote_ip = request.remote_ip if detected_proxy
       end
     end
   end

--- a/app/views/api/v2/home/status.json.rabl
+++ b/app/views/api/v2/home/status.json.rabl
@@ -3,3 +3,4 @@ node(:result) { "ok" }
 node(:status) { 200 }
 node(:version) { SETTINGS[:version].full }
 node(:api_version) { 2 }
+node(:remote_ip) { @remote_ip } if @remote_ip


### PR DESCRIPTION
To verify everything is correctly configured for a Smart Proxy, the remote IP is useful. This is because Foreman can be configured to respect the X-Forwarded-For header from a Smart Proxy. The best way to check this is to send it from a Smart Proxy and check the response.

One possible implementation is for the Smart Proxy to send a request to /api/status with X-Forwarded-For: 192.0.2.42 as a header. Then if the remote_ip is not set to that value, there is a misconfiguration. This could be exposed on the Smart Proxy as a /verify endpoint. The registration protocol can then be enhanced to call /verify. This makes it harder to misconfigure a setup.