### PR TITLE
Fixes #35528 - Remove i386 from seeded host architectures

### DIFF
--- a/db/seeds.d/060-architectures.rb
+++ b/db/seeds.d/060-architectures.rb
@@ -1,5 +1,4 @@
 # Architectures
 Architecture.without_auditing do
   Architecture.where(:name => "x86_64").first_or_create
-  Architecture.where(:name => "i386").first_or_create
 end


### PR DESCRIPTION
Remove the `i386` architecture from the new instances,
already installed instances are not affected.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
