### PR TITLE
Fixes #35530 - Make save_to_file macro safer

### DIFF
--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -112,10 +112,11 @@ module Foreman
             example "save_to_file('/etc/motd', \"hello\\nworld\\n\") # => 'cat << EOF > /etc/motd\\nhello\\nworld\\nEOF'"
           end
           def save_to_file(filename, content)
+            content = content.lines.map { |line| ' ' + line }.join()
             if !content || content.ends_with?("\n")
-              "cat << EOF > #{filename}\n#{content}EOF"
+              "cat << EOF | sed 's/^ //' > #{filename}\n#{content}EOF"
             else
-              "cat << EOF > #{filename}\n#{content}\nEOF"
+              "cat << EOF | sed 's/^ //' > #{filename}\n#{content}\nEOF"
             end
           end
 

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -138,7 +138,7 @@ module RenderersSharedTests
     test "should render a save_to_file macro" do
       source = OpenStruct.new(content: '<%= save_to_file("/etc/puppet/puppet.conf", "[main]\nserver=example.com\n") %>')
       assert_nothing_raised do
-        assert_equal("cat << EOF > /etc/puppet/puppet.conf\n[main]\nserver=example.com\nEOF", renderer.render(source, @scope))
+        assert_equal("cat << EOF | sed 's/^ //' > /etc/puppet/puppet.conf\n [main]\n server=example.com\nEOF", renderer.render(source, @scope))
       end
     end
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -78,12 +78,12 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /root/ansible_provisioning_call.sh
-#!/bin/sh
-
-echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-echo "DONE"
+cat << EOF | sed 's/^ //' > /root/ansible_provisioning_call.sh
+ #!/bin/sh
+ 
+ echo "Calling Ansible AWX/Tower provisioning callback..."
+ /usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ echo "DONE"
 EOF
 chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -58,19 +58,19 @@ allow-hotplug $real
 iface $real inet dhcp
 EOF
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -58,19 +58,19 @@ allow-hotplug $real
 iface $real inet dhcp
 EOF
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -141,19 +141,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -141,19 +141,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -141,19 +141,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -141,19 +141,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -141,19 +141,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -135,19 +135,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
+cat << EOF | sed 's/^ //' > /etc/systemd/system/ansible-callback.service
+ [Unit]
+ Description=Provisioning callback to Ansible Tower
+ Wants=network-online.target
+ After=network-online.target
+ 
+ [Service]
+ Type=oneshot
+ ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ ExecStartPost=/usr/bin/systemctl disable ansible-callback
+ 
+ [Install]
+ WantedBy=multi-user.target
 EOF
 # Runs during first boot, removes itself
 systemctl enable ansible-callback

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -87,12 +87,12 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-    cat << EOF > /tmp/ansible_provisioning_call.sh
-#!/bin/sh
-
-echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-echo "DONE"
+    cat << EOF | sed 's/^ //' > /tmp/ansible_provisioning_call.sh
+ #!/bin/sh
+ 
+ echo "Calling Ansible AWX/Tower provisioning callback..."
+ /usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ echo "DONE"
 EOF
     /bin/sh /tmp/ansible_provisioning_call.sh
 


### PR DESCRIPTION
End to end example:

Use this job template
```
<%#
name: eof
snippet: false
template_inputs:
- name: script
  required: false
  input_type: user
  advanced: false
  value_type: plain
  resource_type: AnsibleRole
  hidden_value: false
model: JobTemplate
job_category: Miscellaneous
provider_type: script
kind: job_template
organizations:
- Default Organization
locations:
- Default Location
%>

<%= save_to_file('/tmp/test', input('script')) %>
cat /tmp/test
echo

echo "====="
chmod +x /tmp/test
/tmp/test
```

Run it on a host with script input using a heredoc
```
cat <<EOF
hello heredoc
EOF
```

Actual job output:
```
   1: /var/tmp/foreman-ssh-cmd-c252e59a-05dd-4247-96d6-8473e2a9c872/script: line 5: EOF: not found
   2: cat <<EOF
   3: hello heredoc
   4: 
   5: =====
   6: hello heredoc
   7: »Exit status: 0«
```

Expected job output:
```
   1: cat <<EOF
   2: hello heredoc
   3: EOF
   4: 
   5: =====
   6: hello heredoc
   7: »Exit status: 0«
```