### PR TITLE
Fixes #35536 - Template input_resource macro & preview error

### DIFF
--- a/app/services/foreman/renderer/scope/macros/inputs.rb
+++ b/app/services/foreman/renderer/scope/macros/inputs.rb
@@ -39,8 +39,7 @@ module Foreman
             raise UndefinedInput.new(s: name) unless @input
             raise WrongInputValueType.new(name: name, type: @input.value_type) if @input.value_type != 'resource'
 
-            return @input.preview(self) if preview?
-
+            return resource_klass.new if preview?
             find_resource
           end
 

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -383,7 +383,7 @@ module RenderersSharedTests
     end
 
     describe 'input_resource macro' do
-      let(:template) { FactoryBot.build(:provisioning_template, template: 'resource: <%= input_resource("ress") -%>') }
+      let(:template) { FactoryBot.build(:provisioning_template, template: "resource_id: '<%= input_resource('ress').id -%>'") }
       let(:template_inputs) { [FactoryBot.build(:template_input, name: 'ress', value_type: 'resource', resource_type: 'Hostgroup')] }
       let(:source) { Foreman::Renderer::Source::Database.new(template) }
 
@@ -398,14 +398,14 @@ module RenderersSharedTests
         test "preview" do
           assert_nothing_raised do
             result = renderer.render(source, preview_scope)
-            assert_equal "resource: #{hostgroups(:common).id}", result
+            assert_equal "resource_id: ''", result
           end
         end
 
         test "render" do
           assert_nothing_raised do
             result = renderer.render(source, real_scope)
-            assert_equal "resource: #{hostgroups(:common)}", result
+            assert_equal "resource_id: '#{hostgroups(:common).id}'", result
           end
         end
       end
@@ -416,7 +416,7 @@ module RenderersSharedTests
         test "preview" do
           assert_nothing_raised do
             result = renderer.render(source, preview_scope)
-            assert_equal 'resource: 0', result
+            assert_equal "resource_id: ''", result
           end
         end
 
@@ -432,10 +432,10 @@ module RenderersSharedTests
         let(:scope_args) { { host: @host, source: source, template_input_values: { 'ress' => 0 } } }
 
         test "preview" do
-          assert_nothing_raised do
-            result = renderer.render(source, preview_scope)
-            assert_equal 'resource: 0', result
+          e = assert_raises Foreman::Renderer::Errors::UnknownResource do
+            renderer.render(source, preview_scope)
           end
+          assert_includes e.message, "Unkown 'NotExistingResource' resource class"
         end
 
         test "render" do
@@ -454,7 +454,7 @@ module RenderersSharedTests
           as_user(users(:one)) do
             assert_nothing_raised do
               result = renderer.render(source, preview_scope)
-              assert_equal "resource: #{images(:one).id}", result
+              assert_equal "resource_id: ''", result
             end
           end
         end
@@ -474,7 +474,7 @@ module RenderersSharedTests
         test "preview" do
           assert_nothing_raised do
             result = renderer.render(source, preview_scope)
-            assert_equal "resource: $USER_INPUT[ress]", result
+            assert_equal "resource_id: ''", result
           end
         end
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
