### PR TITLE
Fixes #34949 - Do not set taxonomies during extlogin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,6 +9,7 @@ class UsersController < ApplicationController
   skip_before_action :require_mail, :only => [:edit, :update, :logout, :stop_impersonation]
   skip_before_action :require_login, :check_user_enabled, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogout]
   skip_before_action :authorize, :only => [:extlogin, :impersonate, :stop_impersonation]
+  skip_before_action :set_taxonomy, :only => :extlogin
   before_action      :require_admin, :only => :impersonate
   after_action       :update_activity_time, :only => :login
   before_action      :verify_active_session, :only => :login

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -227,6 +227,16 @@ class UsersControllerTest < ActionController::TestCase
     assert users(:admin).last_login_on.to_i >= time.to_i, 'User last login time was not updated'
   end
 
+  test "should not set taxonomies for external user" do
+    Setting['authorize_login_delegation'] = true
+    Setting['authorize_login_delegation_auth_source_user_autocreate'] = 'apache'
+    users(:admin).update(default_organization_id: Organization.first.id)
+    @request.env['HTTP_REMOTE_USER'] = users(:admin).login
+    get :extlogin, session: {:user => users(:admin).id }
+    assert session['location_id'] == ''
+    assert session['organization_id'] == Organization.first.id
+  end
+
   test "should logout external user" do
     @sso = mock('dummy_sso')
     @sso.stubs(:authenticated?).returns(true)


### PR DESCRIPTION
(cherry picked from commit a94dc8f06754939f44d54d0dd5314b7e91047225)
