### PR TITLE
Fixes #35577 - Add a settings:reference rake task

### DIFF
--- a/lib/tasks/settings.rake
+++ b/lib/tasks/settings.rake
@@ -1,0 +1,15 @@
+namespace :settings do
+  desc 'Export a reference of all settings'
+  task :reference => :environment do
+    SettingRegistry.instance.sort_by(&:name).each do |setting|
+      puts <<~SETTING
+
+        ##### #{setting.name}
+
+        #{setting.description}
+
+        Default: `#{setting.default}`
+      SETTING
+    end
+  end
+end


### PR DESCRIPTION
This generates a reference that can be placed on the website. Today that's [3.5.2_configuration_options.md](https://github.com/theforeman/theforeman.org/blob/gh-pages/_includes/manuals/nightly/3.5.2_configuration_options.md).

Right now this isn't suitable for production use since some settings have a better description on the website. However, I have already used it to see which settings have been removed.