### PR TITLE
Fixes #35578: preseed_netplan_generic_interface - proper IPv6

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -16,25 +16,36 @@ oses:
 <%- end -%>
         dhcp4: <%= @dhcp %>
         dhcp6: <%= @dhcp6 %>
-<%- if !@dhcp && !@subnet.nil? && !@interface.ip.nil? -%>
-        addresses: [ <%= @interface.ip %>/<%= @subnet.cidr %> ]
-<%-   if @subnet.gateway.present? -%>
+<%-
+static_v4 = !@dhcp && !@subnet.nil? && !@interface.ip.nil?
+static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?
+-%>
+<%- if static_v4 || static_v6 -%>
+        addresses:
+<%-   if static_v4 -%>
+          - <%= @interface.ip %>/<%= @subnet.cidr %>
+<%-   end -%>
+<%-   if static_v6 -%>
+          - <%= @interface.ip6 %>/<%= @subnet6.cidr %>
+<%-   end -%>
+<%-   if static_v4 && @subnet.gateway.present? -%>
         gateway4: <%= @subnet.gateway %>
 <%-   end -%>
-<%-   if @interface.primary -%>
+<%-   if static_v6 && @subnet6.gateway.present? -%>
+        gateway6: <%= @subnet6.gateway %>
+<%-   end -%>
+<%- if @interface.primary -%>
         nameservers:
           search: [ <%= @interface.domain %> ]
-          addresses: <%= @subnet.dns_servers %>
+          addresses:
+<%- if static_v4 -%>
+<%-   @subnet.dns_servers.each do |dns_server| -%>
+            - <%= dns_server %>
+<%-   end -%>
+<%-   end -%>
+<%- if static_v6 -%>
+<%-   @subnet6.dns_servers.each do |dns6_server| -%>
+            - <%= dns6_server %>
 <%-   end -%>
 <%- end -%>
-<%- if !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil? -%>
-        addresses: [ <%= @interface.ip6 %>/<%= @subnet6.cidr %> ]
-<%-   if @subnet6.gateway.present? -%>
-        gateway4: <%= @subnet6.gateway %>
-<%-   end -%>
-<%-   if @interface.primary -%>
-        nameservers:
-          search: [ <%= @interface.domain %> ]
-          addresses: <%= @subnet6.dns_servers %>
-<%-   end -%>
 <%- end -%>


### PR DESCRIPTION
If running a dual stack static network setup this fixes the netplan generation

1) gateway6 not gateway4 for the gateway (we should probably be moving to routes in future as gatewayN is deprecated 2) if you do separate addresses and nameservers blocks the LAST takes precedence so you end up having no ipv4 connectivity to complete builds etc

formatting looks screwy but its what stopped giving extra line breaks in the middle of the nameservers lines - there is probably a better way to do this... and perhaps the logic could be improved

This is a simple template change

to validate - try provisioning an Ubuntu 20.04 or 22.04 machine with static dual stack networking and validate the build completes successfully if you have a V4 only foreman setup


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
