### PR TITLE
Fixes #35462 - Depend on the rss gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,9 @@ gem 'jwt', '~> 2.2.2'
 gem 'graphql', '~> 1.13.0'
 gem 'graphql-batch'
 
+# A bundled gem since Ruby 3.0
+gem 'rss' if RUBY_VERSION >= '3.0'
+
 Dir["#{File.dirname(FOREMAN_GEMFILE)}/bundler.d/*.rb"].each do |bundle|
   instance_eval(Bundler.read_file(bundle))
 end


### PR DESCRIPTION
Ruby 3.0 has moved rss from a default gem to a bundled gem. This means it must be specified as a dependency. See https://community.theforeman.org/t/path-to-ruby-3-0-3-1-el9-and-ubuntu-22-04/30295#ruby-30-4 for more details.