### PR TITLE
Refs #35300 - Pass options as keyword arguments

### DIFF
--- a/app/models/concerns/host_mix.rb
+++ b/app/models/concerns/host_mix.rb
@@ -3,11 +3,11 @@ module HostMix
 
   class_methods do
     def has_many_hosts(options = {})
-      has_many :hosts, {:class_name => "Host::Managed"}.merge(options)
+      has_many :hosts, **{:class_name => "Host::Managed"}.merge(options)
     end
 
     def belongs_to_host(options = {})
-      belongs_to :host, {:class_name => "Host::Managed", :foreign_key => :host_id}.merge(options)
+      belongs_to :host, **{:class_name => "Host::Managed", :foreign_key => :host_id}.merge(options)
     end
   end
 end


### PR DESCRIPTION
In 9089087ed7b2a7da33b73711aa5f457fe06adfc2 various keyword arguments were fixed, but some remained.

Fixes: 9089087ed7b2a7da33b73711aa5f457fe06adfc2