### PR TITLE
Refs #34949 - Do not set taxonomies during extlogin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,6 @@ class UsersController < ApplicationController
   skip_before_action :require_mail, :only => [:edit, :update, :logout, :stop_impersonation]
   skip_before_action :require_login, :check_user_enabled, :authorize, :session_expiry, :update_activity_time, :set_taxonomy, :set_gettext_locale_db, :only => [:login, :logout, :extlogout]
   skip_before_action :authorize, :only => [:extlogin, :impersonate, :stop_impersonation]
-  skip_before_action :set_taxonomy, :only => :extlogin
   before_action      :require_admin, :only => :impersonate
   after_action       :update_activity_time, :only => :login
   before_action      :verify_active_session, :only => :login
@@ -154,6 +153,8 @@ class UsersController < ApplicationController
 
   def extlogin
     if session[:user]
+      session.delete('organization_id')
+      session.delete('location_id')
       user = User.find_by_id(session[:user])
       login_user(user)
       user.post_successful_login


### PR DESCRIPTION
This partially reverts commit a94dc8f06754939f44d54d0dd5314b7e91047225.

The previous iteration of this fix seemed to work only sometimes, possibly depending on which plugins were enabled and load order? This solution is much less elegant, but should be more reliable.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
