### PR TITLE
Fixes #35583 - Skip dhclient installation

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -243,7 +243,9 @@ reboot<% if host_param_true?('install_reboot_kexec') %> --kexec<% end %>
 %packages
 <%= snippet_if_exists(template_name + " custom packages") %>
 yum
+<% if os_major < 8 -%>
 dhclient
+<% end -%>
 <% if use_ntp -%>
 ntp
 -chrony

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -39,7 +39,6 @@ reboot
 %packages
 
 yum
-dhclient
 chrony
 -ntp
 @Core


### PR DESCRIPTION
During installation with the minimal ISO image I found out, that dhclient is no longer part of the minimal ISO image. Therefore, installation with this medium fails because it tries to install the dhclient package. 