### PR TITLE
Fixes #35587 - Updating Contributing file with a few links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,3 +4,7 @@ Before submitting a pull request, please verify that:
 * Any strings are extracted for [translation](http://projects.theforeman.org/projects/foreman/wiki/Translating).
 
 For more information regarding contributions, plese read the [Foreman Handbook](http://theforeman.org/handbook.html) and [Foreman contributions](http://theforeman.org/contribute.html).
+
+Looking for a good starting issue to work on? have a look at: [Easy Fix Issues](https://projects.theforeman.org/projects/foreman/issues?utf8=%E2%9C%93&set_filter=1&sort=id%3Adesc&f%5B%5D=status_id&op%5Bstatus_id%5D=%3D&v%5Bstatus_id%5D%5B%5D=1&f%5B%5D=cf_3&op%5Bcf_3%5D=%3D&v%5Bcf_3%5D%5B%5D=trivial&v%5Bcf_3%5D%5B%5D=easy&f%5B%5D=assigned_to_id&op%5Bassigned_to_id%5D=%21*&f%5B%5D=&c%5B%5D=tracker&c%5B%5D=status&c%5B%5D=priority&c%5B%5D=subject&c%5B%5D=author&c%5B%5D=assigned_to&c%5B%5D=updated_on&c%5B%5D=category&c%5B%5D=fixed_version&group_by=)
+
+Developers, Need help installing Foreman? have a look at: [Foreman_Dev_Setup](https://github.com/theforeman/foreman/blob/develop/developer_docs/foreman_dev_setup.asciidoc)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ Generally, follow the [Foreman guidelines](https://theforeman.org/contribute.htm
 * [Follow the rules](https://theforeman.org/contribute.html#SubmitPatches) about commit message style and create a Redmine issue. Doing this right will help reviewers to get your contribution merged faster.
 * We have a [development handbook](https://theforeman.org/handbook.html) to help developers understand how Foreman developers code.
 * [Rubocop](https://github.com/bbatsov/rubocop) will analyze your code, you can run it locally with `rake rubocop`.
-* All of our pull requests run the full test suite in our [Jenkins CI system](https://ci.theforeman.org/). Please include tests in your pull requests for any additions or changes in functionality
+* All of our pull requests run the full test suite in our [Jenkins CI system](https://ci.theforeman.org/). Please include tests in your pull requests for any additions or changes in functionality.
+* Please have a look at [Contributing.md](https://github.com/theforeman/foreman/blob/develop/CONTRIBUTING.md) for more information.
 
 # Media
 We keep a repository of talks, tutorials, articles about everything in the Foreman ecosystem in the [media section](https://theforeman.org/media.html) of our web. If you want to get yours published, just submit a pull request to [theforeman.org repository](https://github.com/theforeman/theforeman.org)


### PR DESCRIPTION
- Adding a link to the Foreman_Dev_Setup
- Adding a link to easy fixes in RedMine for easier contribution, especially for newcomers to developing in Open Source 
(using filters: difficulty: trivial & easy, status: new, assignee: none)
- Adding a link on the main ReadMe to the Contributing file