### PR TITLE
Fixes #35593 - Use CentOS 8 Stream for container

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Foreman::Application.configure do |app|
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', false) == 'true'
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       - POSTGRES_DATABASE=foreman
       - PGDATA=/var/lib/postgresql/data/pgdata
     hostname: db.example.com
-    image: postgres:10
+    image: postgres:12
     ports:
-      - 5432
+      - '5432'
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 5432 || exit 1"]


### PR DESCRIPTION
Currently the container image is based on Fedora 33, but that's long EOL. Current Fedora versions have Ruby 3.1, but we're unable to use that. Changing it to CentOS 8 Stream is the closest match and also close to what we run in production.

It also updates to PostgreSQL 12 which we use in production.

To make docker-compose.yml compatible with podman-compose the port is changed to a string.

It should be noted that since 36be84a1cfae3c207f05975ba4cac8f448495a6f no assets are served anymore so effectively the UI can no longer be used. Additionally, since 20f4804784c622851fd7beade233797c95b1304b websockify is unbundled and the container now no longer has it. Hence why it's a draft.