### PR TITLE
Refs #32685 - Keep modulized model name in Global ID

### DIFF
--- a/app/graphql/foreman_graphql_schema.rb
+++ b/app/graphql/foreman_graphql_schema.rb
@@ -16,7 +16,7 @@ class ForemanGraphqlSchema < GraphQL::Schema
 
   def self.id_from_object(object, type_definition, query_ctx)
     name = if type_definition.respond_to?(:graphql_name)
-             type_definition.graphql_name
+             type_definition.graphql_name.gsub('_', '::')
            else
              type_definition.name
            end
@@ -27,7 +27,7 @@ class ForemanGraphqlSchema < GraphQL::Schema
     return unless id.present?
 
     _, model_class_name, item_id = Foreman::GlobalId.decode(id)
-    model_class = ForemanGraphqlSchema.types.fetch(model_class_name)&.model_class
+    model_class = ForemanGraphqlSchema.types.fetch(model_class_name.gsub('::', '_'))&.model_class
 
     return unless model_class
 

--- a/app/services/foreman/global_id.rb
+++ b/app/services/foreman/global_id.rb
@@ -28,12 +28,7 @@ module Foreman
 
     def self.for(obj)
       type_definition = ForemanGraphqlSchema.resolve_type(nil, obj, nil)
-      name = if type_definition.respond_to?(:graphql_name)
-               type_definition.graphql_name
-             else
-               type_definition.name
-             end
-      encode(name, obj.id)
+      ForemanGraphqlSchema.id_from_object(obj, type_definition, nil)
     end
 
     def self.base64_encoded?(string)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -188,18 +188,14 @@ class GraphQLQueryTestCase < ActiveSupport::TestCase
 
   def assert_record(expected, actual, type_name: nil)
     assert_not_nil expected
-    type_name ||= ForemanGraphqlSchema.resolve_type(nil, expected, nil)&.graphql_name || expected.class.name
-    assert_equal Foreman::GlobalId.encode(type_name, expected.id), actual['id']
+    assert_equal Foreman::GlobalId.for(expected), actual['id']
   end
 
   def assert_collection(expected, actual, type_name: nil)
     assert expected.any?, 'The expected records array can not be empty to assert_collection'
     assert_equal expected.count, actual['totalCount']
 
-    expected_global_ids = expected.map do |r|
-      t_name = type_name || ForemanGraphqlSchema.resolve_type(nil, r, nil)&.graphql_name || r.class.name
-      Foreman::GlobalId.encode(t_name, r.id)
-    end
+    expected_global_ids = expected.map { |r| Foreman::GlobalId.for(r) }
     actual_global_ids = actual['edges'].map { |e| e['node']['id'] }
 
     assert_same_elements expected_global_ids, actual_global_ids


### PR DESCRIPTION
This is to properly handle model names that are scoped by plugin name. Because the graphql type name can't contain `::` we could use `_` instead

```ruby
 module ForemanPuppet
   module Types
     class Environment < ::Types::BaseObject
       graphql_name 'ForemanPuppet_Environment'
```

however, the Global ID should contain the correct model name, with `::`.

```ruby
[1] pry(main)> Foreman::GlobalId.decode("MDE6Rm9yZW1hblB1cHBldDo6RW52aXJvbm1lbnQtMjgz")
=> [1, "ForemanPuppet::Environment", "283"]
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
