### PR TITLE
Fix 35286 - New PXEGrub2 template for Ubuntu Autoinstall

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
@@ -1,0 +1,41 @@
+<%#
+kind: PXEGrub2
+name: Preseed default PXEGrub2 Autoinstall
+model: ProvisioningTemplate
+oses:
+- Ubuntu
+test_on:
+- ubuntu_autoinst4dhcp
+%>
+#
+# This file was deployed via '<%= template_name %>' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+# lang = en_US
+#   System locale
+#
+<%
+  efi_suffix = 'efi'
+  image_path = @preseed_path.sub(/\/?$/, '.iso')
+  options = []
+  options << 'ramdisk_size=1500000'
+  options << 'root=/dev/rd/0 rw auto'
+  options << "url=http://#{@preseed_server}#{image_path}"
+  options << 'cloud-config-url=/dev/null'
+  options << 'autoinstall'
+-%>
+
+set default=0
+set timeout=<%= host_param('loader_timeout') || 10 %>
+
+menuentry '<%= template_name %>' {
+  linux<%= efi_suffix %> <%= @kernel %> <%= options.compact.join(' ') %> "ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/" <%= snippet('preseed_kernel_options_autoinstall').strip %>
+  initrd<%= efi_suffix %> <%= @initrd %>
+}
+
+<%= snippet_if_exists(template_name + " custom menu") %>
+

--- a/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/preseed_default_pxelinux_autoinstall.erb
@@ -19,30 +19,19 @@ test_on:
 #   System locale
 #
 <%
-  iface = @host.provision_interface
-  hostname = @host.name
-  mac = @host.provision_interface.mac
-  subnet4 = iface.subnet
-  subnet6 = iface.subnet6
+  image_path = @preseed_path.sub(/\/?$/, '.iso')
   options = []
-
   if host_param('blacklist')
     options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
   end
-
-  if mac
-    # hardware type is always 01 (ethernet) unless specified otherwise
-    options << "BOOTIF=#{host_param("hardware_type", "01")}-#{mac.gsub(':', '-')}"
-  end
-  if subnet4 && subnet4.dhcp_boot_mode?
-    options << "ip=dhcp"
-  elsif subnet4 && !subnet4.dhcp_boot_mode?
-    options << "ip=#{iface.ip}::#{subnet4.gateway}:#{subnet4.mask}:#{hostname}:#{iface.identifier}:none:#{subnet4.dns_primary}:#{subnet4.dns_secondary}"
-  end
-
-  options << "locale=#{host_param('lang') || 'en_US'}"
+  options << 'root=/dev/ram0'
+  options << 'ramdisk_size=1500000'
+  options << 'fsck.mode=skip'
+  options << "url=http://#{@preseed_server}#{image_path}"
+  options << 'cloud-config-url=/dev/null'
+  options << "ds=nocloud-net;s=http://#{foreman_request_addr}/userdata/"
+  options << 'autoinstall'
   options = options.join(' ')
-  image_path = @preseed_path.sub(/\/?$/, '.iso')
 -%>
 #
 # WARNING
@@ -55,6 +44,6 @@ DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
     KERNEL <%= @kernel %>
     INITRD <%= @initrd %>
-    APPEND url=http://<%= @preseed_server %><%= image_path %> autoinstall ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip <%= options %>
+    APPEND <%= options %> <%= snippet('preseed_kernel_options_autoinstall').strip %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options_autoinstall.erb
@@ -1,0 +1,40 @@
+<%#
+kind: snippet
+name: preseed_kernel_options_autoinstall
+model: ProvisioningTemplate
+snippet: true
+description: options for the kernel / preseed startup initialization 
+-%>
+<%
+  hostname = @host.name
+  domain = @host.domain
+  iface = @host.provision_interface
+  mac = @host.provision_interface.mac
+  subnet4 = iface.subnet
+  subnet6 = iface.subnet6
+  options = []
+
+  if host_param('blacklist')
+    options << host_param('blacklist').split(',').collect{|x| "#{x.strip}.blacklist=yes"}.join(' ')
+  end
+  if @host.provision_interface.vlanid.present?
+    options << "netcfg/use_vlan=true netcfg/vlan_id=#{@host.provision_interface.vlanid}"
+  end
+  if subnet4 && subnet4.dhcp_boot_mode?
+    options << 'ip=dhcp'
+  elsif subnet4 && !subnet4.dhcp_boot_mode?
+    options << "ip=#{iface.ip}::#{subnet4.gateway}:#{subnet4.mask}:#{hostname}:#{iface.identifier}:none:#{subnet4.dns_servers.join(':')}"
+  elsif subnet6 && subnet6.dhcp_boot_mode?
+    options << 'ip=dhcp'
+  elsif subnet6 && !subnet6.dhcp_boot_mode?
+    options << "ip=[#{iface.ip6}]::[#{subnet6.gateway}]:[#{subnet6.mask}]:#{hostname}:#{iface.identifier}:none:[#{subnet6.dns_servers.join(']:[')}]"
+  end
+
+  options << 'console-setup/ask_detect=false'
+  options << 'localechooser/translation/warn-light=true'
+  options << 'localechooser/translation/warn-severe=true'
+  options << "hostname=#{hostname}"
+  options << "domain=#{domain}"
+%>
+<%# do not add newline after the next line %>
+<%= options.join(' ') -%>

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -57,6 +57,7 @@ files:
   - snippet/freeipa_register.erb
   - snippet/kickstart_rhsm.erb
   - snippet/preseed_networking_setup.erb
+  - snippet/preseed_kernel_options_autoinstall.erb
   - snippet/puppet.conf.erb
   - snippet/puppet_setup.erb
   - snippet/pxegrub2_chainload.erb
@@ -70,6 +71,7 @@ files:
   - snippet/saltstack_minion.erb
   - snippet/saltstack_setup.erb
   - PXELinux/preseed_default_pxelinux_autoinstall.erb
+  - PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
   - user_data/preseed_autoinstall_cloud_init.erb
   - iPXE/autoyast_default_ipxe.erb
   - iPXE/ipxe_default_local_boot.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -1,0 +1,23 @@
+
+#
+# This file was deployed via 'Preseed default PXEGrub2 Autoinstall' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+# lang = en_US
+#   System locale
+#
+
+set default=0
+set timeout=10
+
+menuentry 'Preseed default PXEGrub2 Autoinstall' {
+  linuxefi boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz ramdisk_size=1500000 root=/dev/rd/0 rw auto url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null autoinstall "ds=nocloud-net;s=http://foreman.example.com/userdata/" ip=dhcp console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
+  initrdefi boot/ubuntu-mirror-rf32u3HGTMZf-initrd
+}
+
+
+

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -20,6 +20,6 @@ DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
     KERNEL boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz
     INITRD boot/ubuntu-mirror-rf32u3HGTMZf-initrd
-    APPEND url=http://archive.ubuntu.com:80/ubuntu.iso autoinstall ds=nocloud-net;s=http://foreman.example.com/userdata/ root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip BOOTIF=01-00-f0-54-1a-7e-e0 ip=dhcp locale=en_US
+    APPEND root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null ds=nocloud-net;s=http://foreman.example.com/userdata/ autoinstall ip=dhcp console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options_autoinstall.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options_autoinstall.host4dhcp.snap.txt
@@ -1,0 +1,3 @@
+
+
+ip=dhcp console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-el7 domain=snap.example.com


### PR DESCRIPTION
This template is needed to deploy Ubuntu systems in EFI environments using Autoinstall

Additionally I moved the network configuration from the PXELinux Autoinstall template to a new kernel_options snippet so it can be shared between both Templates