### PR TITLE
Fixes #35619 - Add kernel_version to reported data facet for use in new host UI OS card

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -81,6 +81,7 @@ module Hostext
       scoped_search :relation => :reported_data, :on => :sockets, :rename => 'reported.sockets', :only_explicit => true
       scoped_search :relation => :reported_data, :on => :cores, :rename => 'reported.cores', :only_explicit => true
       scoped_search :relation => :reported_data, :on => :disks_total, :rename => 'reported.disks_total', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :kernel_version, :rename => 'reported.kernel_version', :only_explicit => true
 
       scoped_search :relation => :location, :on => :title, :rename => :location, :complete_value => true, :only_explicit => true
       scoped_search :on => :location_id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER

--- a/app/models/host_facets/reported_data_facet.rb
+++ b/app/models/host_facets/reported_data_facet.rb
@@ -9,6 +9,7 @@ module HostFacets
         sockets: parser.sockets,
         cores: parser.cores,
         disks_total: parser.disks_total,
+        kernel_version: parser.kernel_version,
       }.compact
       facet.save if facet.changed?
     end

--- a/app/services/ansible_fact_parser.rb
+++ b/app/services/ansible_fact_parser.rb
@@ -90,6 +90,10 @@ class AnsibleFactParser < FactParser
     facts['ansible_processor_cores'].to_i
   end
 
+  def kernel_version
+    facts['ansible_kernel']
+  end
+
   private
 
   def ansible_interfaces

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -125,6 +125,10 @@ class FactParser
   def disks_total
   end
 
+  # Kernel version
+  def kernel_version
+  end
+
   private
 
   def find_interface_by_name(host_name)

--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -116,6 +116,10 @@ module Katello
       facts['cpu.core(s)_per_socket']
     end
 
+    def kernel_version
+      facts['uname.release']
+    end
+
     private
 
     def get_rhsm_ip(interface)

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -152,6 +152,11 @@ class PuppetFactParser < FactParser
     facts['disks']&.values&.sum { |disk| disk&.fetch('size_bytes', 0).to_i }
   end
 
+  def kernel_version
+    # Facter 3.0 introduced the os.kernel fact
+    facts.dig(:os, :kernel, :release).presence || facts[:kernelrelease].presence
+  end
+
   private
 
   # remove when dropping support for facter < 3.0

--- a/app/views/api/v2/hosts/reported_data.json.rabl
+++ b/app/views/api/v2/hosts/reported_data.json.rabl
@@ -3,5 +3,5 @@ glue(@facet) do
 end
 
 child(@facet => :reported_data) do
-  attributes :boot_time, :cores, :sockets, :disks_total
+  attributes :boot_time, :cores, :sockets, :disks_total, :kernel_version
 end

--- a/db/migrate/20221010174230_add_kernel_version_to_host_facets.rb
+++ b/db/migrate/20221010174230_add_kernel_version_to_host_facets.rb
@@ -1,0 +1,9 @@
+class AddKernelVersionToHostFacets < ActiveRecord::Migration[6.1]
+  def up
+    add_column :host_facets_reported_data_facets, :kernel_version, :string, :limit => 255
+  end
+
+  def down
+    remove_column :host_facets_reported_data_facets, :kernel_version
+  end
+end

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -510,6 +510,10 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
             assert_kind_of expected, subject.ram
           end
 
+          test "#kernel_version" do
+            assert_kind_of String, subject.kernel_version
+          end
+
           test "#disks_total" do
             if facterversion.to_i >= 3
               assert_kind_of Integer, subject.disks_total


### PR DESCRIPTION
Originally when I was going to start working on the host detail ui OS card, I was going to just use the facts which comes from RHSM but Marek suggested we gather the value from Puppet/Ansible for non Katello installs. This PR will add that