### PR TITLE
Fixes #35622 - Add kernel release to new host UI OS card

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/OperatingSystem/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/OperatingSystem/index.js
@@ -19,7 +19,7 @@ const OperatingSystemCard = ({ status, isExpandedGlobal, hostDetails }) => {
   const {
     architecture_name: architectureName,
     operatingsystem_name: osName,
-    reported_data: { boot_time: bootTime } = {},
+    reported_data: { boot_time: bootTime, kernel_version: kernelVersion } = {},
   } = hostDetails;
   return (
     <CardTemplate
@@ -79,6 +79,17 @@ const OperatingSystemCard = ({ status, isExpandedGlobal, hostDetails }) => {
               emptyState={<DefaultLoaderEmptyState />}
             >
               {bootTime && <RelativeDateTime date={bootTime} />}
+            </SkeletonLoader>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+        <DescriptionListGroup>
+          <DescriptionListTerm>{__('Kernel release')}</DescriptionListTerm>
+          <DescriptionListDescription>
+            <SkeletonLoader
+              status={status}
+              emptyState={<DefaultLoaderEmptyState />}
+            >
+              {kernelVersion}
             </SkeletonLoader>
           </DescriptionListDescription>
         </DescriptionListGroup>


### PR DESCRIPTION
Requires this backend change:

https://github.com/theforeman/foreman/pull/9460

![screenshot-192 168 121 2-2022 10 11-10_11_10](https://user-images.githubusercontent.com/1518655/195119692-2a224de4-730f-458d-bc90-4c493d1912d7.png)
