### PR TITLE
Fixes #35626 - Registration & proxy's registration_url

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration_commands.rb
+++ b/app/controllers/concerns/foreman/controller/registration_commands.rb
@@ -5,7 +5,7 @@ module Foreman::Controller::RegistrationCommands
 
   def command
     args_query = "?#{registration_args.to_query}"
-    "curl -sS #{insecure} '#{endpoint}#{args_query if args_query != '?'}' #{command_headers} | bash"
+    "curl -sS #{insecure} '#{registration_url(@smart_proxy)}#{args_query if args_query != '?'}' #{command_headers} | bash"
   end
 
   def registration_args
@@ -19,10 +19,12 @@ module Foreman::Controller::RegistrationCommands
     registration_params['insecure'] ? '--insecure' : ''
   end
 
-  def endpoint
-    return global_registration_url if registration_params['smart_proxy_id'].blank?
+  def registration_url(proxy = nil)
+    return global_registration_url unless proxy
 
-    "#{@smart_proxy.url}/register"
+    url = proxy.setting('Registration', 'registration_url').presence || proxy.url
+
+    "#{url}/register"
   end
 
   def command_headers

--- a/app/controllers/registration_commands_controller.rb
+++ b/app/controllers/registration_commands_controller.rb
@@ -52,7 +52,10 @@ class RegistrationCommandsController < ApplicationController
   end
 
   def smart_proxies
-    SmartProxy.with_features('Templates') & SmartProxy.with_features('Registration')
+    proxies = SmartProxy.with_features('Templates') & SmartProxy.with_features('Registration')
+    proxies.map do |proxy|
+      { id: proxy.id, name: proxy.name, url: registration_url(proxy) }
+    end
   end
 
   # Extension point for plugins

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/SmartProxy.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/SmartProxy.js
@@ -17,32 +17,42 @@ const SmartProxy = ({
   smartProxies,
   handleSmartProxy,
   isLoading,
-}) => (
-  <FormGroup
-    label={__('Smart proxy')}
-    fieldId="reg_smart_proxy"
-    labelIcon={
-      <LabelIcon
-        text={__(
-          'Only smart proxies with enabled `Templates` and `Registration` features are displayed.'
-        )}
-      />
-    }
-  >
-    <FormSelect
-      value={smartProxyId}
-      onChange={v => handleSmartProxy(v)}
-      className="without_select2"
-      id="reg_smart_proxy"
-      isDisabled={isLoading || smartProxies.length === 0}
+}) => {
+  const smartProxyUrl = () => {
+    if (!smartProxyId) return '';
+
+    const proxy = smartProxies.filter(p => `${p.id}` === smartProxyId)[0];
+    return proxy?.url;
+  };
+
+  return (
+    <FormGroup
+      label={__('Smart proxy')}
+      fieldId="reg_smart_proxy"
+      labelIcon={
+        <LabelIcon
+          text={__(
+            'Only smart proxies with enabled `Templates` and `Registration` features are displayed.'
+          )}
+        />
+      }
+      helperText={smartProxyUrl()}
     >
-      {emptyOption(smartProxies.length)}
-      {smartProxies.map((sp, i) => (
-        <FormSelectOption key={i} value={sp.id} label={sp.name} />
-      ))}
-    </FormSelect>
-  </FormGroup>
-);
+      <FormSelect
+        value={smartProxyId}
+        onChange={v => handleSmartProxy(v)}
+        className="without_select2"
+        id="reg_smart_proxy"
+        isDisabled={isLoading || smartProxies.length === 0}
+      >
+        {emptyOption(smartProxies.length)}
+        {smartProxies.map((sp, i) => (
+          <FormSelectOption key={i} value={sp.id} label={sp.name} />
+        ))}
+      </FormSelect>
+    </FormGroup>
+  );
+};
 
 SmartProxy.propTypes = {
   smartProxyId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),


### PR DESCRIPTION
Use registration_url from Registration SP module
for registration command.
    
RFC: https://community.theforeman.org/t/rfc-host-registration-and-load-balancers/30462
Katello: https://projects.theforeman.org/issues/35627
Smart Proxy: https://projects.theforeman.org/issues/35639
Installer: TODO