### PR TITLE
Fixes #35642 - updated the message in the new UI to show the host's creator

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -42,6 +42,9 @@ module Host
 
     include PxeLoaderSuggestion
 
+    belongs_to :creator, :class_name => 'User'
+    before_create :set_creator_id
+
     default_scope -> { where(taxonomy_conditions) }
 
     def self.taxonomy_conditions
@@ -611,6 +614,10 @@ module Host
       else
         true
       end
+    end
+
+    def set_creator_id
+      self.creator_id = User.current.id if User&.current&.id
     end
   end
 end

--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -11,7 +11,7 @@ extends "api/v2/smart_proxies/children_nodes"
 attributes :ip, :ip6, :last_report, :mac, :realm_id, :realm_name,
   :sp_mac, :sp_ip, :sp_name, :domain_id, :domain_name, :architecture_id, :architecture_name, :operatingsystem_id, :operatingsystem_name,
   :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :sp_subnet_id, :ptable_id, :ptable_name, :medium_id, :medium_name, :pxe_loader,
-  :build, :comment, :disk, :initiated_at, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_name, :owner_type,
+  :build, :comment, :disk, :initiated_at, :installed_at, :model_id, :hostgroup_id, :owner_id, :owner_name, :owner_type, :creator_id, :creator,
   :enabled, :managed, :use_image, :image_file, :uuid,
   :compute_resource_id, :compute_resource_name,
   :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,

--- a/db/migrate/20221025151600_add_creator_id_to_hosts.rb
+++ b/db/migrate/20221025151600_add_creator_id_to_hosts.rb
@@ -1,0 +1,5 @@
+class AddCreatorIdToHosts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :hosts, :creator, foreign_key: { to_table: :users, on_delete: :nullify }
+  end
+end

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -216,13 +216,11 @@ const HostDetails = ({
             {response && (
               <Text ouiaId="date-text" component={TextVariants.span}>
                 <RelativeDateTime date={response.created_at} defaultValue="N/A">
-                  {date =>
-                    sprintf(__('Created %(date)s by %(owner)s'), {
-                      date,
-                      owner: response.owner_name,
-                    })
-                  }
+                  {date => sprintf(__('Created %s'), date)}
                 </RelativeDateTime>{' '}
+                {response.creator
+                  ? `${sprintf(__('by %s'), response.creator)}`
+                  : ''}{' '}
                 <RelativeDateTime date={response.updated_at} defaultValue="N/A">
                   {date => sprintf(__('(updated %s)'), date)}
                 </RelativeDateTime>


### PR DESCRIPTION
Updated the message in the new UI to show the owner of the host. 
The new message will show (for example): "Created 3 minutes ago owned by Nofar Alfassi (updated 3 minutes ago)".
Any suggestions regarding this change / the new syntax are welcome.

Before screenshot:
![image](https://user-images.githubusercontent.com/38184193/198251732-cba27897-ea21-41bf-96c3-786c61bba754.png)

After screenshot:
![image](https://user-images.githubusercontent.com/38184193/198253274-c2b2e549-a7e5-4f76-bf16-e236a5c3846f.png)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
