### PR TITLE
Update pkg_manager.erb to include support/detection for AmazonLinux 2 and AmazonLinux 2022

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
@@ -31,6 +31,10 @@ elif [ -f /etc/redhat-release ] ; then
   else
     PKG_MANAGER='yum'
   fi
+elif [ -f /etc/amazon-linux-release ]; then
+  PKG_MANAGER='dnf'
+elif [ -f /etc/system-release ]; then
+  PKG_MANAGER='yum'                                  
 elif [ -f /etc/debian_version ]; then
   PKG_MANAGER='apt-get'
 elif [ -f /etc/arch-release ]; then

--- a/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
@@ -13,16 +13,6 @@ if [ -f /etc/os-release ] ; then
   . /etc/os-release
 fi
 
-# Get OS package manager
-# ---
-# apt-get   Debian
-#           Ubuntu
-# dnf       Fedora
-#           RHEL family version > 7
-# yum       RHEL family version < 8
-# pacman    Arch
-# zypper    openSUSE Tumbleweed
-
 if [ -f /etc/fedora-release ]; then
   PKG_MANAGER='dnf'
 elif [ -f /etc/redhat-release ] ; then


### PR DESCRIPTION
This provides detection for AmazonLinux 2022 (dnf) and fallback 'yum' support for Amazon Linux 2, as well as other RHEL'ish clones which use /etc/system-release.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
