### PR TITLE
Fixes #35645 - install and use sub-man for SLES OS during host-reg

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -119,100 +119,96 @@ echo "#"
 echo "# Running registration"
 echo "#"
 
-<% if plugin_present?('katello') -%>
-if [ -f /etc/redhat-release ]; then
-    register_katello_host(){
-        UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
-        curl --silent --show-error --cacert $KATELLO_SERVER_CA_CERT --request POST "<%= @registration_url %>" \
-             --data "uuid=$UUID" \
-             <%= headers.join(' ') %> \
-<%= "          --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
-<%= "          --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
-<%= "          --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
-<%= "          --data 'host[lifecycle_environment_id]=#{@lifecycle_environment_id}' \\\n" if @lifecycle_environment_id.present? -%>
-<%= "          --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
-<%= "          --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
-<%= "          --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
-<%= "          --data 'setup_remote_execution_pull=#{@setup_remote_execution_pull}' \\\n" unless @setup_remote_execution_pull.nil? -%>
-<%= "          --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
-<%= "          --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
+<% if plugin_present?('katello') && activation_keys.present? -%>
+register_katello_host(){
+    UUID=$(subscription-manager identity | head -1 | awk '{print $3}')
+    curl --silent --show-error --cacert $KATELLO_SERVER_CA_CERT --request POST "<%= @registration_url %>" \
+         --data "uuid=$UUID" \
+         <%= headers.join(' ') %> \
+<%= "      --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
+<%= "      --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
+<%= "      --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
+<%= "      --data 'host[lifecycle_environment_id]=#{@lifecycle_environment_id}' \\\n" if @lifecycle_environment_id.present? -%>
+<%= "      --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
+<%= "      --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
+<%= "      --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
+<%= "      --data 'setup_remote_execution_pull=#{@setup_remote_execution_pull}' \\\n" unless @setup_remote_execution_pull.nil? -%>
+<%= "      --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
+<%= "      --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
 
-    }
+}
 
-    KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
-    RHSM_CFG=/etc/rhsm/rhsm.conf
+KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
-    # Backup rhsm.conf
-    if [ -f $RHSM_CFG ] ; then
-      test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-    fi
-
-    # rhn-client-tools conflicts with subscription-manager package
-    # since rhn tools replaces subscription-manager, we need to explicitly
-    # install subscription-manager after the rhn tools cleanup
-    if [ x$ID = xol ]; then
-      $PKG_MANAGER remove -y rhn-client-tools
-      $PKG_MANAGER install -y --setopt=obsoletes=0 subscription-manager
-    fi
-
-    # Prepare SSL certificate
-    mkdir -p /etc/rhsm/ca
-    cp -f $SSL_CA_CERT $KATELLO_SERVER_CA_CERT
-    chmod 644 $KATELLO_SERVER_CA_CERT
-
-    # Prepare subscription-manager
-    <% if truthy?(@force) -%>
-    if [ -x "$(command -v subscription-manager)" ] ; then
-      subscription-manager unregister || true
-      subscription-manager clean
-    fi
-
-    $PKG_MANAGER remove -y katello-ca-consumer\*
-    <% end -%>
-
-    if ! [ -x "$(command -v subscription-manager)" ] ; then
-      $PKG_MANAGER install -y subscription-manager
-    else
-      $PKG_MANAGER upgrade -y subscription-manager
-    fi
-
-    if ! [ -f $RHSM_CFG ] ; then
-      echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      cleanup_and_exit 1
-    fi
-
-    # Configure subscription-manager
-    test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-    subscription-manager config \
-      --server.hostname="<%= @rhsm_url.host if @rhsm_url %>" \
-      --server.port="<%= @rhsm_url.port if @rhsm_url %>" \
-      --server.prefix="<%= @rhsm_url.path if @rhsm_url %>" \
-      --rhsm.repo_ca_cert="$KATELLO_SERVER_CA_CERT" \
-      --rhsm.baseurl="<%= @pulp_content_url %>"
-
-    # Older versions of subscription manager may not recognize
-    # report_package_profile and package_profile_on_trans options.
-    # So set them separately and redirect out & error to /dev/null
-    # to fail silently.
-    subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-    subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-
-    # Configuration for EL6
-    if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-      sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-    else
-      full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-      sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-    fi
-
-    subscription-manager register <%= '--force' if truthy?(@force) %> \
-      --org='<%= @organization.label if @organization %>' \
-      --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
-
-    register_katello_host | bash
-else
-    register_host | bash
+# Backup rhsm.conf
+if [ -f $RHSM_CFG ] ; then
+  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
 fi
+
+# rhn-client-tools conflicts with subscription-manager package
+# since rhn tools replaces subscription-manager, we need to explicitly
+# install subscription-manager after the rhn tools cleanup
+if [ x$ID = xol ]; then
+  $PKG_MANAGER_REMOVE rhn-client-tools
+  $PKG_MANAGER_INSTALL --setopt=obsoletes=0 subscription-manager
+fi
+
+# Prepare SSL certificate
+mkdir -p /etc/rhsm/ca
+cp -f $SSL_CA_CERT $KATELLO_SERVER_CA_CERT
+chmod 644 $KATELLO_SERVER_CA_CERT
+
+# Prepare subscription-manager
+<% if truthy?(@force) -%>
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager unregister || true
+  subscription-manager clean
+fi
+
+$PKG_MANAGER_REMOVE katello-ca-consumer\*
+<% end -%>
+
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  $PKG_MANAGER_UPGRADE subscription-manager
+fi
+
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+  cleanup_and_exit 1
+fi
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="<%= @rhsm_url.host if @rhsm_url %>" \
+  --server.port="<%= @rhsm_url.port if @rhsm_url %>" \
+  --server.prefix="<%= @rhsm_url.path if @rhsm_url %>" \
+  --rhsm.repo_ca_cert="$KATELLO_SERVER_CA_CERT" \
+  --rhsm.baseurl="<%= @pulp_content_url %>"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+subscription-manager register <%= '--force' if truthy?(@force) %> \
+  --org='<%= @organization.label if @organization %>' \
+  --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
+
+register_katello_host | bash
 <% else -%>
 register_host | bash
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
@@ -13,22 +13,34 @@ if [ -f /etc/os-release ] ; then
   . /etc/os-release
 fi
 
-if [ -f /etc/fedora-release ]; then
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
   PKG_MANAGER='dnf'
-elif [ -f /etc/redhat-release ] ; then
-  if [ "${VERSION_ID%.*}" -gt 7 ]; then
-    PKG_MANAGER='dnf'
-  else
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
     PKG_MANAGER='yum'
   fi
-elif [ -f /etc/amazon-linux-release ]; then
-  PKG_MANAGER='dnf'
-elif [ -f /etc/system-release ]; then
-  PKG_MANAGER='yum'                                  
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
 elif [ -f /etc/debian_version ]; then
   PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
 elif [ -f /etc/arch-release ]; then
   PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
 elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
   PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
 fi


### PR DESCRIPTION
Idea regarding the pkg_manager snippet is, that we re-use these commands in other provisioning templates, like puppet_setup.