### PR TITLE
Refs #35300 - Pass arguments as keyword arguments

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -113,7 +113,7 @@ module Api
     def resource_scope_for_index(options = {})
       scope = resource_scope(options).search_for(*search_options)
       return scope if paginate_options[:per_page] == 'all'
-      scope.paginate(paginate_options)
+      scope.paginate(**paginate_options)
     end
 
     def api_request?

--- a/app/models/fact_value.rb
+++ b/app/models/fact_value.rb
@@ -2,7 +2,7 @@ class FactValue < ApplicationRecord
   include Authorizable
   include ScopedSearchExtensions
 
-  belongs_to :host, {:class_name => "Host::Base", :foreign_key => :host_id}
+  belongs_to :host, :class_name => "Host::Base", :foreign_key => :host_id
   belongs_to :fact_name
   delegate :name, :short_name, :compose, :origin, :icon_path, :to => :fact_name
   has_many :hostgroup, :through => :host


### PR DESCRIPTION
I'm not entirely sure about the `report_row` part. I'm pretty sure it's an API change with Ruby 3 but not with Ruby 2.7 I think.