### PR TITLE
Fixes #35650 - write correct form of deb repo

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -83,9 +83,7 @@ EOF
     zypper --quiet --non-interactive addrepo /tmp/foreman_registration.repo
   fi
 elif [ -f /etc/debian_version ]; then
-  cat << EOF > /etc/apt/sources.list.d/foreman_registration.list
-<%= shell_escape @repo %>
-EOF
+<%= save_to_file('/etc/apt/sources.list.d/foreman_registration.list', @repo) %>
 <% if @repo_gpg_key_url.present? -%>
   apt-get -y install ca-certificates gpg
   curl --silent --show-error <%= shell_escape @repo_gpg_key_url %> | apt-key add -

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -83,7 +83,7 @@ EOF
     zypper --quiet --non-interactive addrepo /tmp/foreman_registration.repo
   fi
 elif [ -f /etc/debian_version ]; then
-<%= save_to_file('/etc/apt/sources.list.d/foreman_registration.list', @repo) %>
+  <%= save_to_file('/etc/apt/sources.list.d/foreman_registration.list', @repo) %>
 <% if @repo_gpg_key_url.present? -%>
   apt-get -y install ca-certificates gpg
   curl --silent --show-error <%= shell_escape @repo_gpg_key_url %> | apt-key add -


### PR DESCRIPTION
In Host registration -> advanced its possible to enter a debian
repository which will then be written to
/etc/apt/sources.list.d/foreman_registration.list

If you enter a debian repo like "deb https://example.com buster stable",
shell_escape method would rewrite the string so that it looks like:
    
deb\ https://example.com\ buster\ stable
    
This repo config can not work. Use save_to_file to write the file.
