### PR TITLE
Fixes #35658 - don't fail parsing Windows facts without os_name

### DIFF
--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -79,8 +79,7 @@ module ForemanAnsible
 
     def os_name
       if facts[:ansible_os_family] == 'Windows'
-        facts[:ansible_os_name].tr(" \n\t", '') ||
-            facts[:ansible_distribution].tr(" \n\t", '')
+        windows_os_name.tr(" \n\t", '')
       else
         # RHEL 7 is marked as either RedHatEnterpriseServer or RedHatEnterpriseWorkstation, RHEL 8 is lsb id is RedHatEnterprise
         # but we always consider it just RHEL on this level, workstation is differentiated below
@@ -99,10 +98,14 @@ module ForemanAnsible
 
     def os_description
       if facts[:ansible_os_family] == 'Windows'
-        facts[:ansible_os_name].strip || facts[:ansible_distribution].strip
+        windows_os_name
       else
         facts[:ansible_lsb] && facts[:ansible_lsb]['description']
       end
+    end
+
+    def windows_os_name
+      (facts[:ansible_os_name] || facts[:ansible_distribution] || 'Microsoft Windows').strip
     end
   end
 end

--- a/test/unit/foreman_ansible/fact_parser_test.rb
+++ b/test/unit/foreman_ansible/fact_parser_test.rb
@@ -337,6 +337,37 @@ module ForemanAnsible
         assert os.valid?
       end
     end
+
+    context 'Windows Server 2016 without admin privileges' do
+      setup do
+        @facts_parser = AnsibleFactParser.new(
+          HashWithIndifferentAccess.new(
+            '_type' => 'ansible',
+            '_timestamp' => '2015-10-29 20:01:51 +0100',
+            'ansible_facts' => {
+              'ansible_architecture' => '64-Bit',
+              'ansible_distribution_major_version' => '10',
+              'ansible_distribution_version' => '10.0.14393.0',
+              'ansible_os_family' => 'Windows',
+              'ansible_system' => 'Win32NT',
+              'ansible_win_rm_certificate_expires' => '2021-01-23 15:08:48',
+              'ansible_windows_domain' => 'example.com',
+            }
+          )
+        )
+      end
+
+      test 'parses Windows Server correctly' do
+        os = @facts_parser.operatingsystem
+        assert_equal '10', os.major
+        assert_equal '10.0.143930', os.release
+        assert_equal '0.143930', os.minor
+        assert_equal 'Windows', os.family
+        assert_equal 'Microsoft Windows', os.description
+        assert_equal 'MicrosoftWindows', os.name
+        assert os.valid?
+      end
+    end
   end
 
   class CentOSStreamFactParserTest < ActiveSupport::TestCase


### PR DESCRIPTION
When Ansible runs on Windows without Admin privileges, it will not report `ansible_os_name` and `ansible_distribution` facts, as those can't be read without being Admin. Don't fail to parse facts in this case and fall back to a generic "Microsoft Windows" name.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
