### PR TITLE
Fixes #35673 - Do not allow create empty table preference

### DIFF
--- a/app/controllers/api/v2/table_preferences_controller.rb
+++ b/app/controllers/api/v2/table_preferences_controller.rb
@@ -25,7 +25,7 @@ module Api
       def_param_group :table_preference do
         param :user_id, String, :desc => N_('ID of the user'), :required => true
         param :name, String, :desc => N_("Name of the table"), :required => true
-        param :columns, Array, :desc => N_("List of user selected columns")
+        param :columns, Array, :desc => N_("List of user selected columns"), :required => true
       end
 
       api :POST, "/users/:user_id/table_preferences/", N_("Creates a table preference for a given table")

--- a/app/models/table_preference.rb
+++ b/app/models/table_preference.rb
@@ -4,7 +4,7 @@ class TablePreference < ApplicationRecord
   include Parameterizable::ByIdName
 
   belongs_to :user
-  validates :user_id, :name, :presence => true
+  validates :user_id, :name, :columns, :presence => true
   serialize :columns
   validates_lengths_from_database
 end


### PR DESCRIPTION
User should not be able to create table preference for given table with empty columns.