### PR TITLE
Fixes #35641 - Add FOREMAN_PUMA_WORKER_TIMEOUT

### DIFF
--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -19,6 +19,13 @@ threads ENV.fetch('FOREMAN_PUMA_THREADS_MIN', 0).to_i, ENV.fetch('FOREMAN_PUMA_T
 #
 workers ENV.fetch('FOREMAN_PUMA_WORKERS', 2).to_i
 
+# Puma worker timeout.
+#
+# It's not recommended to change this, since it can mask real
+# bugs or incorrect tuning. This is not a request timeout.
+#
+worker_timeout ENV.fetch('FOREMAN_PUMA_WORKER_TIMEOUT').to_i if ENV.key?('FOREMAN_PUMA_WORKER_TIMEOUT')
+
 # In clustered mode, Puma can "preload" your application. This loads all the
 # application code prior to forking. Preloading reduces total memory usage of
 # your application via an operating system feature called copy-on-write


### PR DESCRIPTION
This allows configuring the Puma worker_timeout, which specifies the time before a worker process that has not checked in will be restarted. In some scenarios there were observations of worker timeouts which were not actually due to a hung process but could be resolved by tuning this value from the default of 60 seconds.

Thanks to @jpasqualetto , who is the author of this one; I simply rebased his branch on develop, added a descriptive commit message, and opened the PR in order to start on installer support for it
