### PR TITLE
Fixes #29590 - Katello report template for listing host packages

### DIFF
--- a/app/views/unattended/report_templates/host_-_all_installed_packages.erb
+++ b/app/views/unattended/report_templates/host_-_all_installed_packages.erb
@@ -1,0 +1,29 @@
+<%#
+name: Host - All Installed Packages
+snippet: false
+template_inputs:
+- name: Hosts filter
+  required: false
+  input_type: user
+  description: Limit the report to only hosts found by this search query. Keep empty
+    to report on all available hosts.
+  advanced: false
+  value_type: search
+  resource_type: Host
+model: ReportTemplate
+require:
+- plugin: katello
+  version: 4.7.0
+%>
+<%  load_hosts(search: input('Hosts filter')).each_record do |host| -%>
+<%    host.installed_packages.each do |pkg| -%>
+<%-   report_row(
+        'Host': host.name,
+        'Package Name': pkg.name,
+        'Package NVRA': pkg.nvra,
+        'Package NVREA': pkg.nvrea
+      )-%>
+<%    end -%>
+<%  end -%>
+<%= report_render -%>
+---


### PR DESCRIPTION
Adds a new Katello report template for listing a host's installed packages. Includes a search filter for limiting the targeted hosts.