### PR TITLE
Refs #35414 - Add sd_notify dependency to service

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,1 +1,5 @@
 gem 'puma', '~> 5.1', groups: [:test, :service], require: false
+group :service do
+  # Puma has a soft dependency on this
+  gem 'sd_notify', '~> 0.1.0'
+end


### PR DESCRIPTION
Puma has a soft dependency on sd_notify when systemd is used. In our service we use this so we should make sure it's pulled in. Prior to 9b0652fed9f86fd429e237ce359422a1dba14a2a the dynflow_sidekiq group pulled it in, which technically wasn't entirely correct but in practice it worked. Sidekiq 6 has essentially vendored sd_notify so it was removed.

Fixes: 9b0652fed9f86fd429e237ce359422a1dba14a2a