### PR TITLE
Refs #34997 - prevent CardTemplate from crashing

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -29,10 +29,10 @@ const CardTemplate = ({
   );
   const cardId = header;
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
-  const isExpanded = expandable && cardExpandStates[`${cardId}`] === true;
+  const isExpanded = expandable && cardExpandStates?.[`${cardId}`] === true;
   const onDropdownToggle = isOpen => setDropdownVisibility(isOpen);
   useEffect(() => {
-    if (expandable) registerCard(cardId);
+    if (expandable && registerCard) registerCard(cardId);
   }, [cardId, registerCard, expandable]);
   const onExpandCallback = () =>
     dispatch({


### PR DESCRIPTION
At the moment, the `CardExpansionContext` which was introduced in #9416
fails on plugins that don't use that functionality yet. Added more conditions in order to prevent it from crashing entire tabs in the new host details page.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
