### PR TITLE
Refs #35414 - Log an early message on dynflow startup

### DIFF
--- a/extras/dynflow-sidekiq.rb
+++ b/extras/dynflow-sidekiq.rb
@@ -34,8 +34,10 @@ end
 # To play nice with sd_notify, we need to mark the process as ready before it
 # attempts to acquire the lock.
 if Sidekiq.options[:dynflow_executor]
+  msg = 'orchestrator in passive mode'
+  Rails.logger.info(msg)
+  Sidekiq::SdNotify.status(msg)
   Sidekiq::SdNotify.ready
-  Sidekiq::SdNotify.status('orchestrator in passive mode')
 end
 ::Rails.application.dynflow.initialize!
 msg = "Everything ready for world: #{::Rails.application.dynflow.world.id}"


### PR DESCRIPTION
When the service is marked as ready, the verification starts. When puppet-foreman_proxy configures the service using journald logging it checks the journal. However, the application can take a while to really start while it's already signaled to systemd it has started up. This means verification fails.

By logging a message before sending ready we're guaranteed that there is something to verify.

Fixes: 0ab14da142c9539b0f8de34c32d929d2aa5de6d4