### PR TITLE
Fixes #35630 - remove translated string in layout html

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Layout.fixtures.js
@@ -42,12 +42,14 @@ const monitorChildren = [
   {
     type: 'item',
     name: 'Dashboard',
+    title: 'Dashboard',
     exact: true,
     url: '/',
   },
   {
     type: 'item',
     name: 'Facts',
+    title: 'Facts',
     url: '/fact_values',
   },
 ];
@@ -56,6 +58,7 @@ const hostsChildren = [
   {
     type: 'item',
     name: 'All Hosts',
+    title: 'All Hosts',
     url: '/hosts/new',
   },
 ];

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -44,7 +44,7 @@ export const combineMenuItems = data => {
   data.menu.forEach(item => {
     const translatedChildren = item.children.map(child => ({
       ...child,
-      name: isEmpty(child.name) ? child.name : __(child.name),
+      title: isEmpty(child.name) ? child.name : __(child.name),
     }));
 
     const translatedItem = {
@@ -65,7 +65,8 @@ export const combineMenuItems = data => {
 
 const createOrgItem = orgs => {
   const anyOrg = {
-    name: __('Any Organization'),
+    name: 'Any Organization',
+    title: __('Any Organization'),
     onClick: () => {
       window.location.assign(foremanUrl('/organizations/clear'));
     },
@@ -76,6 +77,7 @@ const createOrgItem = orgs => {
     const childObject = {
       type: org.type,
       name: org.title,
+      title: org.title,
       onClick: () => {
         window.location.assign(org.href);
       },
@@ -96,7 +98,8 @@ const createOrgItem = orgs => {
 
 const createLocationItem = locations => {
   const anyLoc = {
-    name: __('Any Location'),
+    name: 'Any Location',
+    title: __('Any Location'),
     onClick: () => {
       window.location.assign(foremanUrl('/locations/clear'));
     },
@@ -107,6 +110,7 @@ const createLocationItem = locations => {
     const childObject = {
       type: loc.type,
       name: loc.title,
+      title: loc.title,
       onClick: () => {
         window.location.assign(loc.href);
       },

--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutSelectors.js
@@ -32,10 +32,10 @@ export const patternflyMenuItemsSelector = (
 
 const childToMenuItem = (child, currentLocation, currentOrganization) => ({
   id: `menu_item_${snakeCase(child.name)}`,
-  title: child.name,
+  title: child.title,
   isDivider: child.type === 'divider',
   className:
-    child.name === currentLocation || child.name === currentOrganization
+    child.title === currentLocation || child.title === currentOrganization
       ? 'mobile-active'
       : '',
   href: child.url || '#',

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/Layout.test.js.snap
@@ -92,11 +92,13 @@ exports[`Layout rendering renders layout 1`] = `
                   Object {
                     "exact": true,
                     "name": "Dashboard",
+                    "title": "Dashboard",
                     "type": "item",
                     "url": "/",
                   },
                   Object {
                     "name": "Facts",
+                    "title": "Facts",
                     "type": "item",
                     "url": "/fact_values",
                   },
@@ -109,6 +111,7 @@ exports[`Layout rendering renders layout 1`] = `
                 "children": Array [
                   Object {
                     "name": "All Hosts",
+                    "title": "All Hosts",
                     "type": "item",
                     "url": "/hosts/new",
                   },

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutHelper.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutHelper.test.js.snap
@@ -7,11 +7,13 @@ Array [
       Object {
         "exact": true,
         "name": "Dashboard",
+        "title": "Dashboard",
         "type": "item",
         "url": "/",
       },
       Object {
         "name": "Facts",
+        "title": "Facts",
         "type": "item",
         "url": "/fact_values",
       },
@@ -25,6 +27,7 @@ Array [
     "children": Array [
       Object {
         "name": "All Hosts",
+        "title": "All Hosts",
         "type": "item",
         "url": "/hosts/new",
       },
@@ -37,12 +40,12 @@ Array [
   Object {
     "children": Array [
       Object {
-        "name": undefined,
+        "title": undefined,
         "type": "item",
         "url": "/nameless",
       },
       Object {
-        "name": undefined,
+        "title": undefined,
         "type": "divider",
       },
     ],
@@ -56,15 +59,18 @@ Array [
       Object {
         "name": "Any Organization",
         "onClick": [Function],
+        "title": "Any Organization",
       },
       Object {
         "name": "org1",
         "onClick": [Function],
+        "title": "org1",
         "type": undefined,
       },
       Object {
         "name": "org2",
         "onClick": [Function],
+        "title": "org2",
         "type": undefined,
       },
     ],
@@ -78,20 +84,24 @@ Array [
       Object {
         "name": "Any Location",
         "onClick": [Function],
+        "title": "Any Location",
       },
       Object {
         "name": "yaml",
         "onClick": [Function],
+        "title": "yaml",
         "type": undefined,
       },
       Object {
         "name": "london",
         "onClick": [Function],
+        "title": "london",
         "type": undefined,
       },
       Object {
         "name": "norway",
         "onClick": [Function],
+        "title": "norway",
         "type": undefined,
       },
     ],

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/LayoutSelectors.test.js.snap
@@ -24,11 +24,13 @@ Object {
         Object {
           "exact": true,
           "name": "Dashboard",
+          "title": "Dashboard",
           "type": "item",
           "url": "/",
         },
         Object {
           "name": "Facts",
+          "title": "Facts",
           "type": "item",
           "url": "/fact_values",
         },
@@ -41,6 +43,7 @@ Object {
       "children": Array [
         Object {
           "name": "All Hosts",
+          "title": "All Hosts",
           "type": "item",
           "url": "/hosts/new",
         },

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/__snapshots__/integration.test.js.snap
@@ -25,11 +25,13 @@ Object {
             Object {
               "exact": true,
               "name": "Dashboard",
+              "title": "Dashboard",
               "type": "item",
               "url": "/",
             },
             Object {
               "name": "Facts",
+              "title": "Facts",
               "type": "item",
               "url": "/fact_values",
             },
@@ -43,6 +45,7 @@ Object {
           "children": Array [
             Object {
               "name": "All Hosts",
+              "title": "All Hosts",
               "type": "item",
               "url": "/hosts/new",
             },
@@ -55,12 +58,12 @@ Object {
         Object {
           "children": Array [
             Object {
-              "name": undefined,
+              "title": undefined,
               "type": "item",
               "url": "/nameless",
             },
             Object {
-              "name": undefined,
+              "title": undefined,
               "type": "divider",
             },
           ],
@@ -74,15 +77,18 @@ Object {
             Object {
               "name": "Any Organization",
               "onClick": [Function],
+              "title": "Any Organization",
             },
             Object {
               "name": "org1",
               "onClick": [Function],
+              "title": "org1",
               "type": undefined,
             },
             Object {
               "name": "org2",
               "onClick": [Function],
+              "title": "org2",
               "type": undefined,
             },
           ],
@@ -96,20 +102,24 @@ Object {
             Object {
               "name": "Any Location",
               "onClick": [Function],
+              "title": "Any Location",
             },
             Object {
               "name": "yaml",
               "onClick": [Function],
+              "title": "yaml",
               "type": undefined,
             },
             Object {
               "name": "london",
               "onClick": [Function],
+              "title": "london",
               "type": undefined,
             },
             Object {
               "name": "norway",
               "onClick": [Function],
+              "title": "norway",
               "type": undefined,
             },
           ],
@@ -138,11 +148,13 @@ Object {
           Object {
             "exact": true,
             "name": "Dashboard",
+            "title": "Dashboard",
             "type": "item",
             "url": "/",
           },
           Object {
             "name": "Facts",
+            "title": "Facts",
             "type": "item",
             "url": "/fact_values",
           },
@@ -156,6 +168,7 @@ Object {
         "children": Array [
           Object {
             "name": "All Hosts",
+            "title": "All Hosts",
             "type": "item",
             "url": "/hosts/new",
           },
@@ -168,12 +181,12 @@ Object {
       Object {
         "children": Array [
           Object {
-            "name": undefined,
+            "title": undefined,
             "type": "item",
             "url": "/nameless",
           },
           Object {
-            "name": undefined,
+            "title": undefined,
             "type": "divider",
           },
         ],
@@ -187,15 +200,18 @@ Object {
           Object {
             "name": "Any Organization",
             "onClick": [Function],
+            "title": "Any Organization",
           },
           Object {
             "name": "org1",
             "onClick": [Function],
+            "title": "org1",
             "type": undefined,
           },
           Object {
             "name": "org2",
             "onClick": [Function],
+            "title": "org2",
             "type": undefined,
           },
         ],
@@ -209,20 +225,24 @@ Object {
           Object {
             "name": "Any Location",
             "onClick": [Function],
+            "title": "Any Location",
           },
           Object {
             "name": "yaml",
             "onClick": [Function],
+            "title": "yaml",
             "type": undefined,
           },
           Object {
             "name": "london",
             "onClick": [Function],
+            "title": "london",
             "type": undefined,
           },
           Object {
             "name": "norway",
             "onClick": [Function],
+            "title": "norway",
             "type": undefined,
           },
         ],


### PR DESCRIPTION
html ids should be English only, when they are not it breaks i18n automation.