### PR TITLE
Fixes #35702 - Move Card Context to apply all host tabs

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/CardExpansionContext.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/CardExpansionContext.js
@@ -1,0 +1,80 @@
+import PropTypes from 'prop-types';
+import React, { useEffect, useReducer, useCallback } from 'react';
+
+export const CardExpansionContext = React.createContext({});
+
+const cardExpansionReducer = (state, action) => {
+  // A React reducer, not a Redux one!
+  switch (action.type) {
+    case 'expand':
+      return {
+        ...state,
+        [action.key]: true,
+      };
+    case 'collapse':
+      return {
+        ...state,
+        [action.key]: false,
+      };
+    case 'add':
+      if (state[action.key] === undefined) {
+        return {
+          ...state,
+          [action.key]: true,
+        };
+      }
+      return state;
+    case 'expandAll': {
+      const expandedState = {};
+      Object.keys(state).forEach(key => {
+        expandedState[key] = true;
+      });
+      return expandedState;
+    }
+    case 'collapseAll': {
+      const collapsedState = {};
+      Object.keys(state).forEach(key => {
+        collapsedState[key] = false;
+      });
+      return collapsedState;
+    }
+    default:
+      throw new Error(`invalid card expansion type: ${action.type}`);
+  }
+};
+
+export const CardExpansionContextWrapper = ({ children }) => {
+  const [cardExpandStates, dispatch] = useReducer(cardExpansionReducer, {});
+  // On mount, get values from localStorage and set them in state
+  const initializeCardFromLocalStorage = useCallback(key => {
+    const value = localStorage.getItem(`${key} card expanded`);
+    if (value !== null && value !== undefined) {
+      dispatch({ type: value === 'true' ? 'expand' : 'collapse', key });
+    } else {
+      dispatch({ type: 'add', key });
+    }
+  }, []);
+  // On unmount, save the values to local storage
+  // eslint-disable-next-line arrow-body-style
+  useEffect(() => {
+    return () =>
+      Object.entries(cardExpandStates).forEach(([key, value]) =>
+        localStorage.setItem(`${key} card expanded`, value)
+      );
+  });
+  return (
+    <CardExpansionContext.Provider
+      value={{
+        cardExpandStates,
+        dispatch,
+        registerCard: initializeCardFromLocalStorage,
+      }}
+    >
+      {children}
+    </CardExpansionContext.Provider>
+  );
+};
+
+CardExpansionContextWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -13,7 +13,7 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 
-import { CardExpansionContext } from '../../../Tabs/Details';
+import { CardExpansionContext } from '../../../CardExpansionContext';
 
 const CardTemplate = ({
   header,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -41,6 +41,7 @@ import RedirectToEmptyHostPage from './EmptyState';
 import BreadcrumbBar from '../BreadcrumbBar';
 import { foremanUrl } from '../../common/helpers';
 import { useForemanSettings } from '../../Root/Context/ForemanContext';
+import { CardExpansionContextWrapper } from './CardExpansionContext';
 
 const HostDetails = ({
   match: {
@@ -227,29 +228,31 @@ const HostDetails = ({
           </SkeletonLoader>
         </div>
         {tabs && (
-          <TabRouter
-            response={response}
-            hostName={id}
-            status={status}
-            tabs={tabs}
-            router={history}
-          >
-            <Tabs
-              ouiaId="host-details-tabs"
-              activeKey={activeTab}
-              className={`host-details-tabs tab-width-${
-                isNavCollapsed ? '138' : '263'
-              }`}
+          <CardExpansionContextWrapper>
+            <TabRouter
+              response={response}
+              hostName={id}
+              status={status}
+              tabs={tabs}
+              router={history}
             >
-              {filteredTabs.map(tab => (
-                <Tab
-                  key={tab}
-                  eventKey={tab}
-                  title={slotMetadata?.[tab]?.title || tab}
-                />
-              ))}
-            </Tabs>
-          </TabRouter>
+              <Tabs
+                ouiaId="host-details-tabs"
+                activeKey={activeTab}
+                className={`host-details-tabs tab-width-${
+                  isNavCollapsed ? '138' : '263'
+                }`}
+              >
+                {filteredTabs.map(tab => (
+                  <Tab
+                    key={tab}
+                    eventKey={tab}
+                    title={slotMetadata?.[tab]?.title || tab}
+                  />
+                ))}
+              </Tabs>
+            </TabRouter>
+          </CardExpansionContextWrapper>
         )}
       </PageSection>
     </>


### PR DESCRIPTION
`CardTemplate` expand functionality requires `CardExpansionContext`, so it should be available for all tabs and not just the Details tab