### PR TITLE
Fixes #35605 - host details tab can be too tall

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
@@ -1,5 +1,5 @@
 .details-tab-flex-container {
-  max-height: calc(100vh - 225px);
+  max-height: min(1000px, calc(100vh - 225px));
   width: 24rem;
   gap: 1.2rem;
 }


### PR DESCRIPTION
I messed around with this for a while.  Originally I thought that switching to a "row" style `Flex` `direction` would help, but the rows were spaced too far apart due to the varying card sizes.

I tried setting the max size to something static, but then the cards wouldn't wrap properly.  So, I chose to use the `min` function to keep the `Flex` height to a better range.

To test, try zooming in and out on the host details tab and check that the cards look proper.