### PR TITLE
Fixes #35708 - Fix various bad translations

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -161,7 +161,8 @@ class Setting < ApplicationRecord
 
     end
     if errors.present?
-      raise Foreman::SettingValueException.new(N_("Error parsing value for setting '%s': %s"), name, errors.full_messages.join(", "))
+      raise Foreman::SettingValueException.new(N_("Error parsing value for setting '%(name)s': %(error)s"),
+        { 'name' => name, 'error' => errors.full_messages.join(", ") })
     end
     true
   end

--- a/webpack/assets/javascripts/foreman_editor.js
+++ b/webpack/assets/javascripts/foreman_editor.js
@@ -2,7 +2,7 @@ import { API } from './react_app/redux/API';
 import store from './react_app/redux';
 
 import * as editorActions from './react_app/components/Editor/EditorActions';
-import { translate as __ } from './react_app/common/I18n';
+import { sprintf, translate as __ } from './react_app/common/I18n';
 import { openConfirmModal } from './foreman_tools';
 
 export const revertTemplate = ({ dataset: { version, url } }) => {
@@ -15,7 +15,7 @@ export const revertTemplate = ({ dataset: { version, url } }) => {
         document.getElementById('primary_tab').click();
         store.dispatch(editorActions.changeEditorValue(response.data));
       } catch (err) {
-        alert(__(`Revert Failed, ${err}`));
+        alert(sprintf(__('Revert Failed, %s'), err));
       }
     },
   });

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -39,12 +39,11 @@ export function activateDatatables() {
   const language = {
     searchPlaceholder: __('Filter...'),
     emptyTable: __('No data available in table'),
-    info: sprintf(
-      __('Showing %s to %s of %s entries'),
-      '_START_',
-      '_END_',
-      '_TOTAL_'
-    ),
+    info: sprintf(__('Showing %(start)s to %(end)s of %(total)s entries'), {
+      start: '_START_',
+      end: '_END_',
+      total: '_TOTAL_',
+    }),
     infoEmpty: __('Showing 0 to 0 of 0 entries'),
     infoFiltered: sprintf(__('(filtered from %s total entries)'), '_MAX_'),
     lengthMenu: sprintf(__('Show %s entries'), '_MENU_'),

--- a/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/EditorActions.js
@@ -1,6 +1,6 @@
 import { debounce, toString } from 'lodash';
 import { API } from '../../redux/API';
-import { translate as __ } from '../../common/I18n';
+import { sprintf, translate as __ } from '../../common/I18n';
 
 import {
   EDITOR_CHANGE_DIFF_VIEW,
@@ -183,7 +183,7 @@ const createHostAPIRequest = async (query, array, url, dispatch, getState) => {
       type: EDITOR_SHOW_ERROR,
       payload: {
         showError: true,
-        errorText: __(`Host Fetch ${response}`),
+        errorText: sprintf(__('Host Fetch %s'), response),
         previewResult: __('Error during rendering, Return to Editor tab.'),
       },
     });

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/ReportsTab/helpers.js
@@ -19,7 +19,7 @@ import {
 } from '@patternfly/react-icons';
 import { openConfirmModal } from '../../../ConfirmModal';
 import { APIActions } from '../../../../redux/API';
-import { translate as __ } from '../../../../common/I18n';
+import { sprintf, translate as __ } from '../../../../common/I18n';
 import RelativeDateTime from '../../../common/dates/RelativeDateTime';
 
 const statusMapper = {
@@ -92,7 +92,10 @@ export const ActionFormatter = ({ id, can_delete }, fetchReports) => {
               key: `report-${id}-DELETE`,
               successToast: success => __('Report was successfully deleted'),
               errorToast: error =>
-                __(`There was some issue deleting the report: ${error}`),
+                sprintf(
+                  __('There was some issue deleting the report: %s'),
+                  error
+                ),
               handleSuccess: fetchReports,
             })
           ),

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -217,7 +217,10 @@ const HostDetails = ({
               <Text ouiaId="date-text" component={TextVariants.span}>
                 <RelativeDateTime date={response.created_at} defaultValue="N/A">
                   {date =>
-                    sprintf(__('Created %s by %s'), date, response.owner_name)
+                    sprintf(__('Created %(date)s by %(owner)s'), {
+                      date,
+                      owner: response.owner_name,
+                    })
                   }
                 </RelativeDateTime>{' '}
                 <RelativeDateTime date={response.updated_at} defaultValue="N/A">

--- a/webpack/assets/javascripts/react_app/components/common/ModalProgressBar/ModalProgressBar.js
+++ b/webpack/assets/javascripts/react_app/components/common/ModalProgressBar/ModalProgressBar.js
@@ -18,7 +18,7 @@ const ModalProgressBar = ({ show, container, title, progress }) => (
       <ProgressBar
         active
         now={progress}
-        label={sprintf(__(`${progress}%% Complete`))}
+        label={sprintf(__('%s%% Complete'), progress)}
       />
     </Modal.Body>
   </Modal>

--- a/webpack/stories/docs/creating-a-form.stories.mdx
+++ b/webpack/stories/docs/creating-a-form.stories.mdx
@@ -68,8 +68,8 @@ You can override the default `successToast` or `errorToast` functions if needed:
     onSubmit={(values, actions) =>
       submitForm({
         ...otherProps,
-        successToast: response => __(`a custom success message with ${response.data.item}`),
-        errorToast: error => __(`a custom error message with ${error.response.data.error.item}`),
+        successToast: response => sprintf(__('a custom success message with %s'), response.data.item),
+        errorToast: error => sprintf(__('a custom error message with %s'), error.response.data.error.item),
       })
     }
   >


### PR DESCRIPTION
This was initially found by running `make -C locale tx-update` and that showed malformed strings. Many dating back to older releases. Then I also found the Javascript string interpolation by using ``rg '__\(`'``.

Each commit is there to fix another commit so it can be traced back to how long it was a problem. Initially it was part of https://github.com/theforeman/foreman/pull/9496 but that become too hard to review.