### PR TITLE
Fixes #35717 - use caller_locations in deprecation warnings

### DIFF
--- a/app/services/foreman/deprecation.rb
+++ b/app/services/foreman/deprecation.rb
@@ -3,7 +3,7 @@ module Foreman
     # deadline_version - is the version the deprecation is going to be deleted, the format must be a major release e.g "1.8"
     def self.deprecation_warning(foreman_version_deadline, info)
       check_version_format foreman_version_deadline
-      ActiveSupport::Deprecation.warn("You are using a deprecated behavior, it will be removed in version #{foreman_version_deadline}, #{info}", caller(2))
+      ActiveSupport::Deprecation.warn("You are using a deprecated behavior, it will be removed in version #{foreman_version_deadline}, #{info}", caller_locations(2))
     end
 
     def self.check_version_format(foreman_version_deadline)


### PR DESCRIPTION
Rails prefers to have it that way for better reporting


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
