### PR TITLE
Fixes #35719 - Preseed Autoinstall auto updates

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -6,11 +6,24 @@ oses:
 - ubuntu
 test_on:
 - ubuntu_autoinst4dhcp
+description: |
+  The provisioning template for Autoinstall based distributions. To customize the installation,
+  modify the host parameters
+
+  This template accepts the following parameters:
+  - lang: string (default="en_US.UTF-8")
+  - keyboard: string (default="us")
+  - package_upgrade: boolean (default=true)
+  - remote_execution_ssh_keys: string (default="")
+  - username_to_create: string (default="root")
+  - realname_to_create: string (default=username_to_create)
+  - password_to_create: string (default=@host.root_pass)
 -%>
 <%-
 username_to_create = host_param('username_to_create', 'root')
 realname_to_create = host_param('realname_to_create') || username_to_create
 password_to_create = host_param('password_to_create') || @host.root_pass
+enable_auto_update = (host_param_true?('package_upgrade') && !host_param('kt_activation_keys'))
 -%>
 #cloud-config
 autoinstall:
@@ -23,6 +36,10 @@ autoinstall:
         uri: http://archive.ubuntu.com/ubuntu
       - arches: [default]
         uri: http://ports.ubuntu.com/ubuntu-ports
+<% unless enable_auto_update -%>
+    disable_components: [multiverse]
+    disable_suites: [backports,security,updates] 
+<% end -%>
 <%= indent(4) { snippet_if_exists(template_name + " custom apt") } -%>
   user-data:
     disable_root: false


### PR DESCRIPTION
Follow-up issue of #9363 
As discussed [here](https://github.com/theforeman/foreman/pull/9363#issuecomment-1302004432), auto updates of the installer can lead to sync problems or installing the same package twice during the execution of the finish scripts. Therefore, we want to limit the auto update functionality to a specific use case: 

- [x] `package_upgrade` is set in general
- [x] must be a _non-katello_ environment since we assume that updates are handled by the finish script (and sub-man) otherwise

A more detailled description can be found in the issue.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
