### PR TITLE
Fixes #35726 - adding mountpoints for templates form

### DIFF
--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -12,6 +12,8 @@
     <li class="active"><a id="primary_tab" href="#primary" data-toggle="tab"><%= _("Template") %></a></li>
     <li><a href="#template_inputs" data-toggle="tab"><%= _("Inputs") %></a></li>
     <%= render "#{@type_name_plural}/custom_tab_headers" unless type == 'ptable'%>
+    <%= render_pagelets_for(:tab_headers, :subject => @template) %>
+
     <li><a id='history_tab' href="#history" data-toggle="tab"><%= _("History") %></a></li>
     <% if show_location_tab? %>
       <li><a href="#locations" data-toggle="tab"><%= _("Locations") %></a></li>
@@ -191,6 +193,7 @@
     </div>
 
     <%= render "custom_tabs", :f => f unless type == 'ptable'%>
+    <%= render_pagelets_for(:tab_content, :subject => @template, :f => f) %>
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @template %>
 
     <%= submit_or_cancel f, false, :cancel_path => template_path_for(@template.class) %>

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -464,6 +464,8 @@ Possible mount points:
 * main_tabs
 * hosts_table_column_header
 * hosts_table_column_content
+* tab_headers
+* tab_content
 
 [[using-react-in-plugins]]
 === Using React in plugins


### PR DESCRIPTION
Added the `ansible_callback_enabled` property to the template's params, so we can set it from the UI. And added a new mount point in the template's form, for the Pagelet created in `foreman_ansible` plugin.

Related to:
- https://github.com/theforeman/foreman_ansible/pull/572
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
