### PR TITLE
Fixes #35731 - update puppetlabs rpm path construction for EL9

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppetlabs_repo.erb
@@ -38,17 +38,21 @@ end
 
 if host_param_true?('enable-puppetlabs-repo')
   repo_name = 'puppet-release'
+  repo_subdir = ''
 elsif host_param_true?('enable-official-puppet7-repo')
   repo_name = 'puppet7-release'
+  repo_subdir = 'puppet7/'
 elsif host_param_true?('enable-puppetlabs-puppet6-repo')
   repo_name = 'puppet6-release'
+  repo_subdir = 'puppet6/'
 elsif host_param_true?('enable-puppetlabs-puppet5-repo')
   repo_name = 'puppet5-release'
+  repo_subdir = 'puppet5/'
 end
 -%>
 <% if repo_name -%>
 <% if os_family == 'Redhat' || os_name == 'SLES' -%>
-rpm -Uvh<%= http_proxy %><%= http_port %> https://<%= repo_host %>/<%= repo_name %>-<%= repo_os %>-<%= os_major %>.noarch.rpm
+rpm -Uvh<%= http_proxy %><%= http_port %> https://<%= repo_host %>/<%= repo_subdir %><%= repo_name %>-<%= repo_os %>-<%= os_major %>.noarch.rpm
 <% elsif os_family == 'Debian' -%>
 apt-get update
 apt-get -y install ca-certificates


### PR DESCRIPTION
The http://yum.puppet.com/puppet7 directory does not contain an rpm for EL9. In other words, this URL constructed using the current logic is a 404:

  https://yum.puppet.com/puppet7/puppet7-release-el-9.noarch.rpm

There are packages for EL5 through EL9 in the root of the repo. E.g.:

  http://yum.puppet.com/puppet7-release-el-9.noarch.rpm

This simple fix is to drop usage of a "puppet<ELX>" subdir for all major EL versions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
