### PR TITLE
Fixes #35733 - Add network category to selectable columns

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -68,6 +68,8 @@ module Hostext
 
       scoped_search :relation => :primary_interface, :on => :ip, :complete_value => true
       scoped_search :relation => :interfaces, :on => :ip, :complete_value => true, :rename => :has_ip, :only_explicit => true
+      scoped_search :relation => :primary_interface, :on => :ip6, :complete_value => true
+      scoped_search :relation => :interfaces, :on => :ip6, :complete_value => true, :rename => :has_ip6, :only_explicit => true
       scoped_search :relation => :interfaces, :on => :mac, :complete_value => true, :rename => :has_mac, :only_explicit => true
 
       scoped_search :relation => :fact_values, :on => :value, :in_key => :fact_names, :on_key => :name, :rename => :facts, :complete_value => true, :only_explicit => true, :ext_method => :search_cast_facts

--- a/config/initializers/foreman_register.rb
+++ b/config/initializers/foreman_register.rb
@@ -26,6 +26,16 @@ Pagelets::Manager.with_key 'hosts/_list' do |ctx|
     add_pagelet :hosts_table_column_header, key: :comment, label: _('Comment'), sortable: true, width: '7%', class: common_th_class
     add_pagelet :hosts_table_column_content, key: :comment, class: common_th_class + ' ca', attr_callbacks: { title: ->(host) { host.comment&.truncate(255) } }, callback: ->(host) { icon_text('comment', '') unless host.comment.empty? }
   end
+  ctx.with_profile :network_data, _('Network'), default: false do
+    common_th_class = 'hidden-tablet hidden-xs'
+    common_td_class = common_th_class + ' ellipsis'
+    add_pagelet :hosts_table_column_header, key: :ip, label: _('IPv4 address'), sortable: true, width: '10%', class: common_th_class, priority: 200
+    add_pagelet :hosts_table_column_content, key: :ip, callback: ->(host) { host.ip }, class: common_td_class, priority: 200
+    add_pagelet :hosts_table_column_header, key: :ip6, label: _('IPv6 address'), sortable: true, width: '13%', class: common_th_class, priority: 200
+    add_pagelet :hosts_table_column_content, key: :ip6, callback: ->(host) { host.ip6 }, class: common_td_class, priority: 200
+    add_pagelet :hosts_table_column_header, key: :mac, label: _('MAC address'), sortable: true, width: '10%', class: common_th_class, priority: 200
+    add_pagelet :hosts_table_column_content, key: :mac, callback: ->(host) { host.mac }, class: common_td_class, priority: 200
+  end
   ctx.with_profile :reported_data, _('Reported data'), default: false do
     common_th_class = 'hidden-tablet hidden-xs'
     common_td_class = common_th_class + ' ellipsis'


### PR DESCRIPTION
Adding network category to the selectable columns. Columns in this category should show basic network information about host - IPv4 address, IPv6 address and MAC address.

![selectable-columns-with-network-info](https://user-images.githubusercontent.com/47797196/200602398-2f80badb-45d5-4db2-94a2-46576c4498e8.png)
