### PR TITLE
Fixes #35738 - Add a git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,77 @@
+Adam Cécile <acecile@letz-it.lu>
+Adam Cécile <acecile@letz-it.lu> <acecile@le-vert.net>
+Adam Růžička <aruzicka@redhat.com> <a.ruzicka@outlook.com>
+Adam Růžička <aruzicka@redhat.com> <adamruzicka@users.noreply.github.com>
+Adam Růžička <aruzicka@redhat.com> <aruzicka@redhat.com>
+Adi Abramovich <aabramov@redhat.com>
+Adi Abramovich <aabramov@redhat.com> <57755873+adiabramovitch@users.noreply.github.com>
+Alexander Olofsson <ace@haxalot.com>
+Alexander Olofsson <ace@haxalot.com> Alexander Olofsson <alexander.olofsson@liu.se>
+Amir Fefer <amirfefer@gmail.com>
+Amir Fefer <amirfefer@gmail.com> <afeferku@dhcp-4-115.tlv.redhat.com>
+Amit Karsale <akarsale@redhat.com> <karsale.amit@gmail.com>
+Amit Upadhye <upadhyeammit@gmail.com> <amitupadhye@foreman.example.com>
+Andrew Dewar <andrewgdewar@gmail.com>
+Andrew Kofink <akofink@redhat.com> <ajkofink@gmail.com>
+Arend Lapere <arend.lapere@gmail.com> <test@foreman-develop.televic-test.com>
+Avi Sharvit <asharvit@redhat.com> <sharvita@gmail.com>
+Bernhard Suttner <suttner@atix.de> <BernhardAtix@users.noreply.github.com>
+Bernhard Suttner <suttner@atix.de> <sbernhard@users.noreply.github.com>
+Boaz Shuster <ripcurld.github@gmail.com>
+Boaz Shuster <ripcurld.github@gmail.com> <2453279+boaz1337@users.noreply.github.com>
+Boaz Shuster <ripcurld.github@gmail.com> <boaz.shuster.github@gmail.com>
+Boaz Shuster <ripcurld.github@gmail.com> <bshuster@fedora-work.mynet>
+Boaz Shuster <ripcurld.github@gmail.com> <ripcurld.github@gmail.com>
+Daniel Lobato García <elobatocs@gmail.com>
+Daniel Lobato García <elobatocs@gmail.com> <me@daniellobato.me>
+Dominik Hlavac Duran <dhlavacd@redhat.com>
+Dominik Hlavac Duran <dhlavacd@redhat.com> <xhlava42@stud.fit.vutbr.cz>
+Dominik Hlavac Duran <dhlavacd@redhat.com> <xhlava42@vutbr.cz>
+Dominik Matoulek <domitea@gmail.com> <domitea@users.noreply.github.com>
+Eric Helms <ericdhelms@gmail.com> <eric.d.helms@gmail.com>
+Eric Helms <ericdhelms@gmail.com> Eric D. Helms <ericdhelms@gmail.com>
+Ian Ballou <ianballou67@gmail.com>
+Imri Zvik <imrizvik@gmail.com>
+Ivan Nečas <inecas@redhat.com>
+Ivan Nečas <inecas@redhat.com> <necasik@gmail.com>
+Joseph Magen <jmagen@redhat.com>
+Joseph Magen <jmagen@redhat.com> <joseph@isratrade.co.il>
+Kamil Szubrycht <kamil.szubrycht@ironin.pl>
+Karolina Malyjurkova <kmalyjur@redhat.com> <78563507+kmalyjur@users.noreply.github.com>
+Leos Stejskal <lstejska@redhat.com> <github@stejskalleos.cz>
+Lukáš Zapletal <lzap@redhat.com>
+Lukáš Zapletal <lzap@redhat.com> <lukas@zapletalovi.com>
+Lukáš Zapletal <lzap@redhat.com> <lzap+git@redhat.com>
+Marcel Kühlhorn <marcelk@atix.de> <tux93@users.noreply.github.com>
+Marek Hulán <mhulan@redhat.com> <ares@igloonet.cz>
+Marek Hulán <mhulan@redhat.com> <ares@users.noreply.github.com>
+Marek Hulán <mhulan@redhat.com> <mhulan@redhat.com>
+Maria Agaphontzev <mariaaga@redhat.com>
+Maria Agaphontzev <mariaaga@redhat.com> <magaphon@localhost.localdomain>
+Maria Agaphontzev <mariaaga@redhat.com> <mariaagaphonchev@gmail.com>
+Maria Nita <maria.nita.dn@gmail.com>
+Martin Bačovský <mbacovsk@redhat.com> <martin.bacovsky@gmail.com>
+Martin Matuska <martin@matuska.org> <martin.matuska@axelspringer.de>
+Matan Werbner <mwerbner@redhat.com>
+Matan Werbner <mwerbner@redhat.com> <matan@dhcp-3-121.tlv.redhat.com>
+Matan Werbner <mwerbner@redhat.com> <matan@dhcp-3-123.tlv.redhat.com>
+Matan Werbner <mwerbner@redhat.com> <matanw@dhcp-2-138.tlv.redhat.com>
+Matan Werbner <mwerbner@redhat.com> <verbmat@gmail.com>
+Mirek Długosz <mzalewsk@redhat.com>
+Nadja Heitmann <nadjah@atix.de> <71487468+nadjaheitmann@users.noreply.github.com>
+Nofar Alfassi <nalfassi@redhat.com>
+Nofar Alfassi <nalfassi@redhat.com> <nofaralfasi@gmail.com>
+Ondřej Ezr <oezr@redhat.com>
+Ondřej Ezr <oezr@redhat.com> <ezrik12@gmail.com>
+Ondřej Pražák <oprazak@redhat.com>
+Ondřej Pražák <oprazak@redhat.com> <xprazak2@users.noreply.github.com>
+Ori Rabin <orabin@redhat.com>
+Ori Rabin <orabin@redhat.com> <orrabin@gmail.com>
+Peter Koprda <petokoprda@gmail.com> <47797196+pkoprda@users.noreply.github.com>
+Peter Koprda <petokoprda@gmail.com> <petokoprda@gmail.com>
+Sean O'Keeffe <seanokeeffe797@gmail.com>
+Shimon Shtein <sshtein@redhat.com> <sshtein@redhat.com>
+Till Adam <till.adam@dm.de>
+Yifat Makias <ymakias@redhat.com> <42476762+yifatmakias@users.noreply.github.com>
+Yifat Makias <ymakias@redhat.com> <ymakias@redhat.com>
+Štefan Németh <snemeth@dynamic-2a00-1028-83a6-3cba-0eb1-2bbc-4b42-8938.ipv6.o2.cz>


### PR DESCRIPTION
In the release notes we like to credit people based on the git log, but regularly people use multiple names. Git has a [mailmap feature](https://git-scm.com/docs/gitmailmap) which allows mapping it back to one single name.

Today we have a [script with an author map](https://github.com/theforeman/theforeman.org/blob/fa324567d2ccb032dbf8bfe9b289d0e2606d1dd0/scripts/committers.rb#L42-L133) but as we're moving to foreman-documentation it's nice to implement this in repositories themselves so no specific tooling is needed.

To test this out, use `git log --pretty="%aN" --abbrev-commit`.

@evgeni this currently doesn't work for Adam and Nofar, but I can't seem to find the right way to do this. Any idea?