### PR TITLE
Fixes #35744 - Date components are not translated

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -14,11 +14,10 @@ class IntlLoader {
 
   async init() {
     await this.fetchIntl();
-    addLocaleData(
-      await import(
-        /* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${this.locale}`
-      )
+    const localeData = await import(
+      /* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${this.locale}`
     );
+    addLocaleData(localeData.default);
     return true;
   }
 


### PR DESCRIPTION
Every component that uses react-intl (mostly dates and relative times) doesnt get translated, for example: Last login time data in users table, boot time in host details, details, Operating system card.
Error:
```
[React Intl] Missing locale data for locale: "ru". Using default locale: "en" as fallback.
```

Tested this fix with both react-intl 2.8 and 2.9