### PR TITLE
Fixes #35751 - Hide Manage columns text in small screens

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
@@ -134,8 +134,9 @@ const ColumnSelector = props => {
           iconPosition="left"
           className="columns-selector"
           onClick={() => toggleModal()}
+          title={__('Manage columns')}
         >
-          {__('Manage columns')}
+          <span className="columns-selector-text">{__('Manage columns')}</span>
         </Button>
         <Modal
           variant={ModalVariant.small}

--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/column-selector.scss
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/column-selector.scss
@@ -11,3 +11,11 @@
 .pf-c-tree-view {
   padding-top: 0px
 }
+
+#btn-select-columns{
+  @media (max-width: 1530px) {
+    .columns-selector-text {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
Temporary fix as we probably will change the buttons in the hosts page completely 
Before:
![Screenshot from 2022-11-14 13-37-41](https://user-images.githubusercontent.com/30431079/201727437-8031b3ba-c7bd-4181-92ef-77b90f7443ba.png)

After:
![image (4)](https://user-images.githubusercontent.com/30431079/201727362-a3544f03-6842-407b-aaf1-11364d19116f.png)
