### PR TITLE
Fixes #35764 - Add last report to host details

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/RecentCommunicationCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/RecentCommunicationCard/index.js
@@ -1,20 +1,38 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useSelector } from 'react-redux';
-import { DescriptionList } from '@patternfly/react-core';
+import {
+  Button,
+  DescriptionList,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  DescriptionListDescription,
+} from '@patternfly/react-core';
 import { translate as __ } from '../../../common/I18n';
 import Slot from '../../common/Slot';
 import CardTemplate from '../Templates/CardItem/CardTemplate';
-import { selectFillsAmount } from '../../common/Slot/SlotSelectors';
+import RelativeDateTime from '../../common/dates/RelativeDateTime';
 
-const RecentCommunicationCard = ({ hostDetails }) => {
-  const itemCount = useSelector(state =>
-    selectFillsAmount(state, 'recent-communication-card-item')
-  );
-  if (!itemCount) return null;
+const RecentCommunicationCard = ({ hostName, hostDetails }) => {
+  const lastReport = hostDetails.last_report;
   return (
     <CardTemplate header={__('Recent communication')}>
       <DescriptionList isHorizontal>
+        <DescriptionListGroup>
+          <DescriptionListTerm>
+            {__('Last configuration report')}
+          </DescriptionListTerm>
+          <DescriptionListDescription>
+            <Button
+              variant="link"
+              component="a"
+              isInline
+              isDisabled={!lastReport?.length}
+              href={`/hosts/${hostName}/config_reports/last`}
+            >
+              <RelativeDateTime date={lastReport} defaultValue={__('Never')} />
+            </Button>
+          </DescriptionListDescription>
+        </DescriptionListGroup>
         <Slot
           hostDetails={hostDetails}
           id="recent-communication-card-item"
@@ -28,9 +46,11 @@ const RecentCommunicationCard = ({ hostDetails }) => {
 export default RecentCommunicationCard;
 
 RecentCommunicationCard.propTypes = {
-  hostDetails: PropTypes.shape({}),
+  hostName: PropTypes.string,
+  hostDetails: PropTypes.shape({ last_report: PropTypes.string }),
 };
 
 RecentCommunicationCard.defaultProps = {
+  hostName: '',
   hostDetails: {},
 };


### PR DESCRIPTION
With Katello (but without data)
![Screenshot from 2022-11-18 16-34-10](https://user-images.githubusercontent.com/30431079/202742106-65e9faae-088f-4f04-87e1-b7437105f4c9.png)

without Katello.
link leads to the same place that "Last Report" in hosts table leads to 
![Screenshot from 2022-11-18 16-33-40](https://user-images.githubusercontent.com/30431079/202742113-c2f2c7ea-fdaf-470d-81b4-c4cc0cbe1495.png)
