### PR TITLE
Fixes #35779 - Correct generated provision snapshots

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -19,6 +19,7 @@ module Foreman
 
     def define_host_params(host)
       host_params = {
+        "dual_stack_provision_fallback" => "IPv6",
         "enable-epel" => "true",
         "kdump-options" => "--disable",
         "package_upgrade" => "true",
@@ -58,160 +59,113 @@ module Foreman
       host
     end
 
-    def ipv4_interface
-      FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '192.168.42.42')
-    end
-
-    def ipv6_interface
-      FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '2001:db8:42::42')
-    end
-
-    def ipv46_interface
-      FactoryBot.build(:nic_primary_and_provision, identifier: 'eth0',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '192.168.42.42',
-        ip6: '2001:db8:42::42')
-    end
-
     def host4dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_c7, :with_realm_freeipa,
         name: 'snapshot-ipv4-dhcp-el7',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def host4static
       host = FactoryBot.build(:host_for_snapshots, :with_c7,
         name: 'snapshot-ipv4-static-el7',
-        subnet: FactoryBot.build(:subnet_ipv4_static_for_snapshots),
-        interfaces: [ipv4_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_static)])
       define_host_params(host)
     end
 
     def host6dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_c7,
         name: 'snapshot-ipv6-dhcp-el7',
-        subnet: FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots),
-        interfaces: [ipv6_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v6_dhcp)])
       define_host_params(host)
     end
 
     def host6static
       host = FactoryBot.build(:host_for_snapshots, :with_c7,
         name: 'snapshot-ipv6-static-el7',
-        subnet: FactoryBot.build(:subnet_ipv6_static_for_snapshots),
-        interfaces: [ipv6_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v6_static)])
       define_host_params(host)
     end
 
     def host4and6dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_c7,
         name: 'snapshot-ipv4-6-dhcp-el7',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        subnet6: FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots),
-        interfaces: [ipv46_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp, :with_v6_dhcp)])
       define_host_params(host)
     end
 
     def debian4dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_deb10,
         name: 'snapshot-ipv4-dhcp-deb10',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def ubuntu4dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_ubuntu18,
         name: 'snapshot-ipv4-dhcp-ubuntu18',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def ubuntu_autoinst4dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_ubuntu20,
         name: 'snapshot-ipv4-dhcp-ubuntu20',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def ubuntu_autoinstmulti4dhcp
-      nic_a = FactoryBot.build(:nic_primary_and_provision, identifier: '',
-        mac: '00-f0-54-1a-7e-e0',
-        ip: '192.168.42.42')
+      nic_a = FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp, identifier: '')
       nic_b = FactoryBot.build(:nic_managed, identifier: '',
         mac: '00-f0-54-1a-7e-e1',
         ip: '192.168.42.43')
 
       host = FactoryBot.build(:host_for_snapshots, :with_ubuntu20,
         name: 'snapshot-ipv4-dhcp-ubuntu20',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         interfaces: [nic_a, nic_b])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
     def rhel9_dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_rhel9,
         name: 'snapshot-ipv4-dhcp-rhel9',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def rhel10_dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_rhel10,
         name: 'snapshot-ipv4-dhcp-rhel10',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
-      host.define_singleton_method(:managed_interfaces) { interfaces }
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def rocky8_dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_rocky8,
         name: 'snapshot-ipv4-dhcp-rocky8',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def rocky9_dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_rocky9,
         name: 'snapshot-ipv4-dhcp-rocky9',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def rocky10_dhcp
       host = FactoryBot.build(:host_for_snapshots, :with_rocky10,
         name: 'snapshot-ipv4-dhcp-rocky10',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 
     def windows10_dhcp
       host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_windows10,
         name: 'snapshot-ipv4-dhcp-windows10',
-        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
-        interfaces: [ipv4_interface])
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
       define_host_params(host)
     end
 

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -144,6 +144,33 @@ FactoryBot.define do
     sequence(:ip) { |n| ip_from_subnet(subnet, n) }
   end
 
+  trait :with_v4_dhcp do
+    ip { '192.168.42.42' }
+    subnet { FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots) }
+  end
+
+  trait :with_v4_static do
+    ip { '192.168.42.42' }
+    subnet { FactoryBot.build(:subnet_ipv4_static_for_snapshots) }
+  end
+
+  trait :with_v6_dhcp do
+    ip6 { '2001:db8:42::42' }
+    subnet6 { FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots) }
+  end
+
+  trait :with_v6_static do
+    ip6 { '2001:db8:42::42' }
+    subnet6 { FactoryBot.build(:subnet_ipv6_static_for_snapshots) }
+  end
+
+  factory :nic_for_snapshots, parent: :nic_managed, class: Nic::Managed do
+    primary { true }
+    provision { true }
+    identifier { 'eth0' }
+    mac { '00-f0-54-1a-7e-e0' }
+  end
+
   factory :model do
     sequence(:name) { |n| "hal900#{n}" }
   end
@@ -167,6 +194,9 @@ FactoryBot.define do
       end
 
       set_nic_attributes(host, deferred_nic_attrs, evaluator)
+      # these are hacks as otherwise those attributes return nil
+      host.define_singleton_method(:managed_interfaces) { interfaces }
+      host.define_singleton_method(:shortname) { name.split('.').first }
     end
 
     trait :with_build do
@@ -333,7 +363,6 @@ FactoryBot.define do
       hostname { name }
       managed { true }
       domain { FactoryBot.build(:domain_for_snapshots) }
-      subnet { FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots) }
       pxe_loader { "PXELinux BIOS" }
       architecture { operatingsystem.try(:architectures).try(:first) }
       medium { operatingsystem.try(:media).try(:first) }

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -92,56 +92,53 @@ FactoryBot.define do
       association :bmc, :ignore_validations, :factory => :bmc_smart_proxy, :name => "snapshot-proxy-bmc", :url => "http://localhost:8005"
     end
 
-    factory :subnet_ipv4_dhcp_for_snapshots, :class => Subnet::Ipv4 do
+    trait :snapshot do
+      domains { [FactoryBot.build(:domain_for_snapshots)] }
+      proxies_for_snapshots
+    end
+
+    trait :ipv4 do
       network { '192.168.42.0' }
       mask { '255.255.255.0' }
+      gateway { '192.168.42.1' }
+      dns_primary { '192.168.42.2' }
+      dns_secondary { '192.168.42.3' }
+    end
+
+    trait :ipv6 do
+      network { '2001:db8:42::' }
+      mask { 'ffff:ffff:ffff::' }
+      gateway { '2001:db8:42::1' }
+      dns_primary { '2001:db8:42::8' }
+      dns_secondary { '2001:db8:42::4' }
+    end
+
+    trait :dhcp do
+      boot_mode { :DHCP }
+    end
+
+    trait :static do
+      boot_mode { :Static }
+    end
+
+    factory :subnet_ipv4_dhcp_for_snapshots, class: Subnet::Ipv4, traits: [:snapshot, :ipv4, :dhcp] do
       name { 'snapshot-ipv4-dhcp' }
-      gateway { '192.168.42.1' }
-      dns_primary { '192.168.42.2' }
-      dns_secondary { '192.168.42.3' }
-      mtu { '1142' }
-      boot_mode { :DHCP }
-      domains { [FactoryBot.build(:domain_for_snapshots)] }
-      proxies_for_snapshots
-    end
-
-    factory :subnet_ipv4_static_for_snapshots, :class => Subnet::Ipv4 do
-      network { '192.168.42.0' }
-      mask { '255.255.255.0' }
-      name { 'snapshot-ipv4-static' }
-      gateway { '192.168.42.1' }
-      dns_primary { '192.168.42.2' }
-      dns_secondary { '192.168.42.3' }
-      mtu { '1242' }
-      boot_mode { :Static }
-      domains { [FactoryBot.build(:domain_for_snapshots)] }
-      proxies_for_snapshots
-    end
-
-    factory :subnet_ipv6_dhcp_for_snapshots, :class => Subnet::Ipv6 do
-      network { '2001:db8:42::' }
-      mask { 'ffff:ffff:ffff::' }
-      name { 'snapshot-ipv6-dhcp' }
-      gateway { '2001:db8:42::1' }
-      dns_primary { '2001:db8:42::8' }
-      dns_secondary { '2001:db8:42::4' }
       mtu { '1342' }
-      boot_mode { :DHCP }
-      domains { [FactoryBot.build(:domain_for_snapshots)] }
-      proxies_for_snapshots
     end
 
-    factory :subnet_ipv6_static_for_snapshots, :class => Subnet::Ipv6 do
-      network { '2001:db8:42::' }
-      mask { 'ffff:ffff:ffff::' }
-      name { 'snapshot-ipv6-static' }
-      gateway { '2001:db8:42::1' }
-      dns_primary { '2001:db8:42::8' }
-      dns_secondary { '2001:db8:42::4' }
+    factory :subnet_ipv4_static_for_snapshots, class: Subnet::Ipv4, traits: [:snapshot, :ipv4, :static] do
+      name { 'snapshot-ipv4-static' }
       mtu { '1442' }
-      boot_mode { :Static }
-      domains { [FactoryBot.build(:domain_for_snapshots)] }
-      proxies_for_snapshots
+    end
+
+    factory :subnet_ipv6_dhcp_for_snapshots, class: Subnet::Ipv6, traits: [:snapshot, :ipv6, :dhcp] do
+      name { 'snapshot-ipv6-dhcp' }
+      mtu { '1342' }
+    end
+
+    factory :subnet_ipv6_static_for_snapshots, class: Subnet::Ipv6, traits: [:snapshot, :ipv6, :static] do
+      name { 'snapshot-ipv6-static' }
+      mtu { '1442' }
     end
   end
 end

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv4-6-dhcp-el7::dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv4-6-dhcp-el7::auto6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv6-dhcp-el7::dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv6-dhcp-el7::auto6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -4,7 +4,7 @@ set default=0
 set timeout=10
 
 menuentry 'Kickstart default PXEGrub2' {
-  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+  linux boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static6=1 ip=[2001:db8:42::42]::[2001:db8:42::1]:48:snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
   initrd boot/centos-mirror-nrm0GtSX1ZC5-initrd.img
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host4and6dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv4-6-dhcp-el7::dhcp nameserver=192.168.42.2 nameserver=192.168.42.3 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv4-6-dhcp-el7::auto6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6dhcp.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv6-dhcp-el7::dhcp nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv6-dhcp-el7::auto6 nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Kickstart_default_PXELinux.host6static.snap.txt
@@ -7,7 +7,7 @@ ONTIMEOUT installer
 LABEL installer
 MENU LABEL Kickstart default PXELinux
 KERNEL boot/centos-mirror-nrm0GtSX1ZC5-vmlinuz
-APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=2001:db8:42::42::2001:db8:42::1:ffff:ffff:ffff:::snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
+APPEND initrd=boot/centos-mirror-nrm0GtSX1ZC5-initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static6=1 ip=[2001:db8:42::42]::[2001:db8:42::1]:48:snapshot-ipv6-static-el7:eth0:none nameserver=2001:db8:42::8 nameserver=2001:db8:42::4 fips=1
 
 IPAPPEND 2
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/ZTP/Junos_default_ZTP_config.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/ZTP/Junos_default_ZTP_config.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 system {
-    host-name ;
+    host-name snapshot-ipv4-dhcp-el7;
     root-authentication {
       encrypted-password "$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0"; ## SECRET-DATA
     }

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -10,12 +10,12 @@ chpasswd:
   - {name: root, password: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0}
 runcmd:
 - |
-  echo "" > /etc/hostname
+  echo "snapshot-ipv4-dhcp-deb10" > /etc/hostname
   
-  hostname 
+  hostname snapshot-ipv4-dhcp-deb10
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-deb10  localhost localhost.localdomain
+  127.0.0.1   snapshot-ipv4-dhcp-deb10 snapshot-ipv4-dhcp-deb10 localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -10,12 +10,12 @@ chpasswd:
   - {name: root, password: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0}
 runcmd:
 - |
-  echo "" > /etc/hostname
+  echo "snapshot-ipv4-dhcp-el7" > /etc/hostname
   
-  hostname 
+  hostname snapshot-ipv4-dhcp-el7
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+  127.0.0.1   snapshot-ipv4-dhcp-el7 snapshot-ipv4-dhcp-el7 localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -10,12 +10,12 @@ chpasswd:
   - {name: root, password: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0}
 runcmd:
 - |
-  echo "" > /etc/hostname
+  echo "snapshot-ipv4-dhcp-ubuntu18" > /etc/hostname
   
-  hostname 
+  hostname snapshot-ipv4-dhcp-ubuntu18
   
   cat > /etc/hosts << EOF
-  127.0.0.1   snapshot-ipv4-dhcp-ubuntu18  localhost localhost.localdomain
+  127.0.0.1   snapshot-ipv4-dhcp-ubuntu18 snapshot-ipv4-dhcp-ubuntu18 localhost localhost.localdomain
   ::1     ip6-localhost ip6-loopback
   fe00::0 ip6-localnet
   ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-echo "" > /etc/hostname
+echo "snapshot-ipv4-dhcp-el7" > /etc/hostname
 
-hostname 
+hostname snapshot-ipv4-dhcp-el7
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-el7 snapshot-ipv4-dhcp-el7 localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Windows_default_finish.windows10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Windows_default_finish.windows10_dhcp.snap.txt
@@ -24,6 +24,10 @@ for /f "delims=" %%a in ('ipconfig /all') do (
             set mac=!mac:-=:!
             call :tolower mac
 
+            if "00-f0-54-1a-7e-e0"=="!mac!" (
+                                    echo DHCP is active
+                                                    netsh interface set interface name="!name!" newname="eth0"
+                                                                    )
         )
     )
 )

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host4and6dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv4-6-dhcp-el7::dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv4-6-dhcp-el7::auto6 fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6dhcp.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv6-dhcp-el7::dhcp fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision kssendmac ks.sendmac ip=::::snapshot-ipv6-dhcp-el7::auto6 fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Kickstart_default_iPXE.host6static.snap.txt
@@ -5,7 +5,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static=1 ip=${netX/ip}::${netX/gateway}:${netX/netmask}:snapshot-ipv6-static-el7:eth0:none nameserver=${dns} fips=1
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img  network ksdevice=bootif ks.device=bootif BOOTIF=01-00-f0-54-1a-7e-e0 ks=http://foreman.example.com/unattended/provision?static6=1 ip=[2001:db8:42::42]::[2001:db8:42::1]:48:snapshot-ipv6-static-el7:eth0:none fips=1
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -12,7 +12,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-6-dhcp-el7 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-6-dhcp-el7 --mtu=1342 --bootproto dhcp --ipv6 auto --nameserver=192.168.42.2,192.168.42.3,2001:db8:42::8,2001:db8:42::4
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -12,7 +12,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-el7 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-el7 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -12,7 +12,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-static-el7 --noipv6 --mtu=1242 --bootproto static --ip=192.168.42.42 --netmask=255.255.255.0 --gateway=192.168.42.1 --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-static-el7 --noipv6 --mtu=1442 --bootproto static --ip=192.168.42.42 --netmask=255.255.255.0 --gateway=192.168.42.1 --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -12,7 +12,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-dhcp-el7 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=2001:db8:42::8,2001:db8:42::4
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-dhcp-el7 --noipv4 --mtu=1342 --ipv6 auto --nameserver=2001:db8:42::8,2001:db8:42::4
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -12,7 +12,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-static-el7 --noipv6 --mtu=1442 --bootproto static --ip=2001:db8:42::42 --netmask=ffff:ffff:ffff:: --gateway=2001:db8:42::1 --nameserver=2001:db8:42::8,2001:db8:42::4
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-static-el7 --noipv4 --mtu=1442 --ipv6=2001:db8:42::42/48 --ipv6gateway=2001:db8:42::1 --nameserver=2001:db8:42::8,2001:db8:42::4
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
@@ -11,7 +11,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rhel10 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3 --ipv4-dns-search=snap.example.com
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rhel10 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3 --ipv4-dns-search=snap.example.com
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -11,7 +11,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rhel9 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rhel9 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
@@ -11,7 +11,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky10 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3 --ipv4-dns-search=snap.example.com
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky10 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3 --ipv4-dns-search=snap.example.com
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -11,7 +11,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky8 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky8 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -11,7 +11,7 @@ lang en_US.UTF-8
 selinux --enforcing
 keyboard us
 
-network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky9 --noipv6 --mtu=1142 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
+network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky9 --noipv6 --mtu=1342 --bootproto dhcp --nameserver=192.168.42.2,192.168.42.3
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/RancherOS_provision.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/RancherOS_provision.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: 
+hostname: snapshot-ipv4-dhcp-el7
 rancher:
   network:
     dns:

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Windows_default_provision.windows10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Windows_default_provision.windows10_dhcp.snap.txt
@@ -91,7 +91,7 @@
             <IEHardenAdmin>false</IEHardenAdmin>
         </component>
         <component name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-            <ComputerName></ComputerName>
+            <ComputerName>snapshot-ipv4-dhcp-windows10</ComputerName>
                         <TimeZone>GMT Standard Time</TimeZone>
         </component>
         <component name="Networking-MPSSVC-Svc" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer_default_answerfile.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/XenServer_default_answerfile.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ clearpart --all    --initlabel
 part /boot --fstype ext3 --size=100 --asprimary
 part /     --fstype ext3 --size=1024 --grow
 part swap  --recommended  <keymap>us</keymap>
-  <hostname></hostname>
+  <hostname>snapshot-ipv4-dhcp-el7</hostname>
   <root-password type="hash">$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0</root-password>
   <source type="url">url --url http://mirror.centos.org/centos/7/os/x86_64</source>
   <admin-interface name="eth0" proto="dhcp">

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/fix_hosts.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/fix_hosts.host4dhcp.snap.txt
@@ -1,9 +1,9 @@
-echo "" > /etc/hostname
+echo "snapshot-ipv4-dhcp-el7" > /etc/hostname
 
-hostname 
+hostname snapshot-ipv4-dhcp-el7
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-el7 snapshot-ipv4-dhcp-el7 localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/rancheros_cloudconfig.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/rancheros_cloudconfig.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: 
+hostname: snapshot-ipv4-dhcp-el7
 rancher:
   network:
     dns:

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/windows_network.windows10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/windows_network.windows10_dhcp.snap.txt
@@ -15,6 +15,10 @@ for /f "delims=" %%a in ('ipconfig /all') do (
             set mac=!mac:-=:!
             call :tolower mac
 
+            if "00-f0-54-1a-7e-e0"=="!mac!" (
+                                    echo DHCP is active
+                                                    netsh interface set interface name="!name!" newname="eth0"
+                                                                    )
         )
     )
 )

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-echo "" > /etc/hostname
+echo "snapshot-ipv4-dhcp-el7" > /etc/hostname
 
-hostname 
+hostname snapshot-ipv4-dhcp-el7
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-el7 snapshot-ipv4-dhcp-el7 localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-echo "" > /etc/hostname
+echo "snapshot-ipv4-dhcp-el7" > /etc/hostname
 
-hostname 
+hostname snapshot-ipv4-dhcp-el7
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-el7  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-el7 snapshot-ipv4-dhcp-el7 localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-echo "" > /etc/hostname
+echo "snapshot-ipv4-dhcp-deb10" > /etc/hostname
 
-hostname 
+hostname snapshot-ipv4-dhcp-deb10
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-deb10  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-deb10 snapshot-ipv4-dhcp-deb10 localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 
-echo "" > /etc/hostname
+echo "snapshot-ipv4-dhcp-ubuntu18" > /etc/hostname
 
-hostname 
+hostname snapshot-ipv4-dhcp-ubuntu18
 
 cat > /etc/hosts << EOF
-127.0.0.1   snapshot-ipv4-dhcp-ubuntu18  localhost localhost.localdomain
+127.0.0.1   snapshot-ipv4-dhcp-ubuntu18 snapshot-ipv4-dhcp-ubuntu18 localhost localhost.localdomain
 ::1     ip6-localhost ip6-loopback
 fe00::0 ip6-localnet
 ff00::0 ip6-mcastprefix

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 #cloud-config
-hostname: 
+hostname: snapshot-ipv4-dhcp-el7
 fqdn: snapshot-ipv4-dhcp-el7
 manage_etc_hosts: true
 ssh_pwauth: true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_open-vm-tools.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_open-vm-tools.host4dhcp.snap.txt
@@ -2,7 +2,7 @@
 identity:
   LinuxPrep:
     domain: snap.example.com
-    hostName: 
+    hostName: snapshot-ipv4-dhcp-el7
     hwClockUTC: true
     timeZone: UTC
 


### PR DESCRIPTION
Previously it had incorrect data where IPv6 addresses were set in IPv4 subnets. This generated incorrect snapshots.

It uses traits to reduce duplication.

Fixes: 641c3f4a9bb5401a8ac06e70b925918125193957