### PR TITLE
Fixes #35780 - Automatically deploy storybook

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,48 @@
+name: Deploy storybook to Pages
+
+on:
+  push:
+    branches: ['develop']
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14
+      - name: Generate npm dependencies package-lock
+        run: npm install --package-lock-only --no-audit
+      - name: Install npm dependencies
+        run: npm ci --no-audit
+
+      - name: Build storybook
+        run: npm run build-storybook
+      - name: Set up Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: .storybook-dist
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "publish-coverage": "tfm-publish-coverage",
     "stories": "./script/npm-fix-foreman-stories.sh && tfm-stories",
     "build-storybook": "./script/npm-fix-foreman-stories.sh && tfm-build-stories",
-    "deploy-storybook": "cross-env NODE_ENV=storybook NODE_OPTIONS=--max_old_space_size=8192 storybook-to-ghpages",
     "postinstall": "./script/npm_install_plugins.js",
     "analyze": "./script/webpack-analyze",
     "create-react-component": "yo react-domain"


### PR DESCRIPTION
Rather than building it in the gh-pages branch you can now upload pages directly. This action makes sure the storybook is up to date and we can delete the gh-pages branch.

I just ran this on my own fork and it looks like it can't even build: https://github.com/ekohl/foreman/actions/runs/3531042266/jobs/5923747028.

Today we had the discussion about https://theforeman.github.io/foreman/ which is very old. Looking at this we either need to make it work again or delete the old content.