### PR TITLE
Fixes #35757 - Same columns should have the same status

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
@@ -80,6 +80,20 @@ const ColumnSelector = props => {
         }
       });
     }
+    selectedColumns.forEach(category => {
+      category.children.forEach(column => {
+        if (treeViewItem.key === column.key && !column.checkProps.disabled) {
+          column.checkProps.checked = checked;
+        }
+        if (treeViewItem.children) {
+          treeViewItem.children.forEach(item => {
+            if (item.key === column.key && !column.checkProps.disabled) {
+              column.checkProps.checked = checked;
+            }
+          });
+        }
+      });
+    });
   };
 
   const onCheck = (evt, treeViewItem) => {


### PR DESCRIPTION
Same columns in different categories should have the same status of checkbox in modal window on host index page and should affect each other (in attachment `Operating system` column in the `General` category does not have the same status of checkbox as the same column in the  `Content` category).

![selectable-columns-os-title](https://user-images.githubusercontent.com/47797196/203732055-524ff9eb-e485-405e-831a-490f5d942b63.png)
