### PR TITLE
Refs #35530 - Dont use shellescape on the filename

### DIFF
--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -105,15 +105,18 @@ module Foreman
             desc "This is useful if some multiline string needs to be saved somewhere on the hard disk. This
               is typically used in provisioning or job templates, e.g. when puppet configuration file is
               generated based on host configuration and stored for puppet agent. The content must end with
-              a line end, if not an extra trailing line end is appended automatically."
+              a line end, if not an extra trailing line end is appended automatically.
+              Note that, the file name or path is printed as it is without any escaping
+              even if it contains any whitespace or special charecters. In order to escape the special
+              charecters, process the file name using the shell_escape function."
             required :filename, String, desc: 'the file path to store the content to'
             required :content, String, desc: 'content to be stored'
             keyword :verbatim, [true, false], desc: 'Controls whether the file should be put on disk as-is or if variables should be replaced by shell before the file is written out', default: false
             returns String, desc: 'String representing the shell command'
             example "save_to_file('/etc/motd', \"hello\\nworld\\n\") # => 'cat << EOF-0e4f089a > /etc/motd\\nhello\\nworld\\nEOF-0e4f089a'"
+            example "save_to_file(shell_escape('/tmp/a file with spaces'), nil) # => 'cp /dev/null /tmp/a\ file\ with\ spaces'"
           end
           def save_to_file(filename, content, verbatim: false)
-            filename = filename.shellescape
             delimiter = 'EOF-' + Digest::SHA512.hexdigest(filename)[0..7]
             if content.empty?
               "cp /dev/null #{filename}"

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -217,9 +217,9 @@ class BaseMacrosTest < ActiveSupport::TestCase
       assert_equal command, "cat << #{delimiter} | base64 -d > /tmp/test\n#{base64}#{delimiter}"
     end
 
-    test "should properly escape filename" do
-      command = @scope.save_to_file('/tmp/a file with spaces', nil)
-      assert_equal command, 'cp /dev/null /tmp/a\ file\ with\ spaces'
+    test "should ignore escaping of filename by default" do
+      command = @scope.save_to_file('/tmp/ifcfg-$sanitized_real', nil)
+      assert_equal command, 'cp /dev/null /tmp/ifcfg-$sanitized_real'
     end
   end
 end


### PR DESCRIPTION
Don't use shellescape on the filename for the save_to_file macro, when the filename contains a dollar (`$`) , Otherwise, It breaks the functionality of kickstart_networking_setup snippet.

Please refer to the issue https://projects.theforeman.org/issues/35792 for the detailed explanation

**UPDATE:**

Based on the detailed discussion later with the reviewers, The following has been finalized:

* By default, The filename will not be escaped ( even if it has any whitespace or special characters ) when `save_to_file` macro is used.
* End-users will need to process such filenames via `shell_escape` if any special characters need to be escaped. 
* The same updates along with an example should be updated in the macro description as well. 
* The test cases need to be updated to validate the first point.