### PR TITLE
Fixes #29939 - drop category column from settings

### DIFF
--- a/app/presenters/setting_presenter.rb
+++ b/app/presenters/setting_presenter.rb
@@ -101,11 +101,11 @@ class SettingPresenter
   # ----- UI helpers ------
 
   def category_label
-    Foreman::SettingManager.categories[category] || category.safe_constantize&.humanized_category || category_name
+    Foreman::SettingManager.categories[category] || category_name
   end
 
   def category_name
-    category.delete_prefix('Setting::')
+    category
   end
 
   def select_values

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -132,18 +132,9 @@ class SettingRegistry
     end
   end
 
-  def known_categories
-    unless @known_descendants == Setting.descendants
-      @known_descendants = Setting.descendants
-      @known_categories = @known_descendants.map(&:name) << 'Setting'
-      @values_loaded_at = nil # force all values to be reloaded
-    end
-    @known_categories
-  end
-
   def load_values(ignore_cache: false)
     # we are loading only known STIs as we load settings fairly early the first time and plugin classes might not be loaded yet.
-    settings = Setting.unscoped.where(category: known_categories)
+    settings = Setting.unscoped
     settings = settings.where('updated_at >= ?', @values_loaded_at) unless ignore_cache || @values_loaded_at.nil?
     settings.each do |s|
       unless (definition = find(s.name))
@@ -179,8 +170,6 @@ class SettingRegistry
   end
 
   def _new_db_record(definition)
-    Setting.new(name: definition.name,
-                value: definition.value,
-                category: definition.category.safe_constantize&.name || 'Setting')
+    Setting.new(name: definition.name, value: definition.value)
   end
 end

--- a/db/migrate/20221126232030_remove_category_from_settings.rb
+++ b/db/migrate/20221126232030_remove_category_from_settings.rb
@@ -1,0 +1,6 @@
+class RemoveCategoryFromSettings < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :settings, :category
+    remove_column :settings, :category, :string
+  end
+end

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -17,11 +17,4 @@ class SettingsControllerTest < ActionController::TestCase
     get :index, session: set_session_user
     assert_match /id='valid'/, @response.body
   end
-
-  test "does not render an old sti type setting" do
-    assert setting = Setting.create(:name => "foo")
-    setting.send(:write_attribute, :category, "Setting::Invalid")
-    get :index, session: set_session_user
-    assert_no_match /id='Invalid'/, @response.body
-  end
 end

--- a/test/factories/settings.rb
+++ b/test/factories/settings.rb
@@ -1,6 +1,5 @@
 FactoryBot.define do
   factory :setting do
-    category               { 'Setting' }
-    sequence(:name)        { |n| "setting#{n}" }
+    sequence(:name) { |n| "setting#{n}" }
   end
 end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -1,13 +1,10 @@
 ---
 attributes66:
   name: delivery_method
-  category: Setting
   value: :test
 attribute97:
   name: ct_command
-  category: Setting
   value: "['/usr/bin/cat']"
 attribute98:
   name: fcct_command
-  category: Setting
   value: "['/usr/bin/cat']"

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -372,29 +372,11 @@ class SettingTest < ActiveSupport::TestCase
     assert !setting.save
   end
 
-  test 'orders settings alphabetically' do
-    a_name = 'a_foo'
-    b_name = 'b_foo'
-    c_name = 'c_foo'
-    FactoryBot.create(:setting, :name => b_name, :value => 'whatever')
-    FactoryBot.create(:setting, :name => a_name, :value => 'whatever')
-    FactoryBot.create(:setting, :name => c_name, :value => 'whatever')
-    settings = Setting.live_descendants.select(&:name)
-    a_foo = settings.index { |item| item.name == a_name }
-    b_foo = settings.index { |item| item.name == b_name }
-    c_foo = settings.index { |item| item.name == c_name }
-    assert a_foo
-    assert b_foo
-    assert c_foo
-    assert a_foo < b_foo
-    assert b_foo < c_foo
-  end
-
   test "should update login page footer text with multiple valid long values" do
     setting = Setting.create(name: 'login_text')
     RFauxFactory.gen_strings(1000).values.each do |value|
       setting.value = value
-      assert setting.valid?, "Can't update discovery_prefix setting with valid value #{value}"
+      assert setting.valid?, "Can't update login_text setting with valid value #{value}"
     end
   end
 end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -5,7 +5,7 @@ class SettingRegistryTest < ActiveSupport::TestCase
   let(:default) { 5 }
   let(:setting_value) { nil }
   let(:setting_memo) { {} }
-  let(:setting) { Setting.create(name: 'foo', category: 'Setting') }
+  let(:setting) { Setting.create(name: 'foo') }
 
   setup do
     registry._add('foo', type: :integer, category: 'Setting', default: default, full_name: 'test foo', description: 'test foo', context: :test)


### PR DESCRIPTION
Settings table was holding category column to support old style of  settings, but it is now ready to be decomissioned as plugins were given  enough time.

I'll try to take this PR to the merge, but if you have an idea, feel free to push to my branch! :)