### PR TITLE
Fixes #35797 - libvirt nil network comparison

### DIFF
--- a/lib/fog_extensions/libvirt/server.rb
+++ b/lib/fog_extensions/libvirt/server.rb
@@ -50,8 +50,13 @@ module FogExtensions
 
       def select_nic(fog_nics, nic)
         nic_attrs = nic.compute_attributes
-        match =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
-        match ||= fog_nics.detect { |fn| fn.bridge  == nic_attrs['bridge']  } # no network? try a bridge...
+        match = nil
+        unless nic_attrs['network'].nil?
+          match =   fog_nics.detect { |fn| fn.network == nic_attrs['network'] } # grab any nic on the same network
+        end
+        unless nic_attrs['bridge'].nil?
+          match ||= fog_nics.detect { |fn| fn.bridge  == nic_attrs['bridge'] } # no network? try a bridge...
+        end
         match
       end
     end


### PR DESCRIPTION
When libvirt compares networks, it is possible that `network` will be `nil` resulting in a match instead of continuing on to the bridge comparison.

Signed-off-by: Ben Magistro <koncept1@gmail.com>

----

Issue and patch developed by @stefan-baranoff 
