### PR TITLE
Refs #35578: preseed_netplan_generic_interface with DHCP interface

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -34,19 +34,19 @@ static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?
 <%-   if static_v6 && @subnet6.gateway.present? -%>
         gateway6: <%= @subnet6.gateway %>
 <%-   end -%>
-<%- end -%>
-<%- if @interface.primary -%>
+<%-   if @interface.primary -%>
         nameservers:
           search: [ <%= @interface.domain %> ]
           addresses:
-<%- if static_v4 -%>
-<%-   @subnet.dns_servers.each do |dns_server| -%>
+<%-     if static_v4 -%>
+<%-       @subnet.dns_servers.each do |dns_server| -%>
             - <%= dns_server %>
-<%-   end -%>
-<%-   end -%>
-<%- if static_v6 -%>
-<%-   @subnet6.dns_servers.each do |dns6_server| -%>
+<%-       end -%>
+<%-     end -%>
+<%-     if static_v6 -%>
+<%-       @subnet6.dns_servers.each do |dns6_server| -%>
             - <%= dns6_server %>
+<%-       end -%>
+<%-     end -%>
 <%-   end -%>
-<%- end -%>
 <%- end -%>


### PR DESCRIPTION
Do not generate the 'nameservers:' line in netplan for hosts with DHCP primary interface. The content of this clause is only generated for statically-configured interfaces, causing it to fail on DHCP-only interfaces.