### PR TITLE
Fixes #35802 - Use per_page=all in the UI

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostStatuses/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostStatuses/index.js
@@ -15,7 +15,7 @@ import Head from '../Head/index';
 import './HostStatuses.scss';
 
 const HostStatuses = () => {
-  const url = foremanUrl('/api/v2/host_statuses?per_page=99');
+  const url = foremanUrl('/api/v2/host_statuses?per_page=all');
   const { status = STATUS.PENDING } = useAPI('get', url, API_OPTIONS);
 
   const Skeleton = () => (

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokensActions.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokensActions.js
@@ -13,7 +13,7 @@ import {
 export const getPersonalAccessTokens = ({ url }) => dispatch => {
   const uri = new URI(url);
   // eslint-disable-next-line camelcase
-  uri.setSearch({ per_page: 9999 });
+  uri.setSearch({ per_page: 'all' });
 
   ajaxRequestAction({
     dispatch,


### PR DESCRIPTION
The client code doesn't implement pagination so you actually want to retrieve everything, rather than some magic high number.

Introduced in ec35c4d82e493574da0b55e0d52dd24dbc6b638f and 1c02010e9d334c7449ada31c2292e2348a686777.

I haven't tested this myself so consider it a detailed bug report with potential fix.