### PR TITLE
Fixes #35701 - Export button should use selectable columns

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -912,7 +912,7 @@ class HostsController < ApplicationController
   end
 
   def csv_columns
-    [:name, :operatingsystem, :compute_resource_or_model, :hostgroup, :last_report]
+    User.current.table_preferences.find_by(name: controller_name)&.columns&.map { |col| col == 'os_title' ? 'operatingsystem' : col }
   end
 
   def origin_intervals_query(compare_with)

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -39,12 +39,13 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test "should get csv index with data" do
-    host = FactoryBot.create(:host, :with_hostgroup, :on_compute_resource, :with_reports)
+    User.current.table_preferences.create(name: 'hosts', columns: ['name', 'os_title', 'model', 'owner', 'hostgroup', 'last_report'])
+    host = FactoryBot.create(:host, :with_model, :with_hostgroup, :with_reports)
     get :index, params: { :format => 'csv', :search => "name = #{host.name}" }, session: set_session_user
     assert_response :success
     buf = response.stream.instance_variable_get(:@buf)
-    assert_equal "Name,Operatingsystem,Compute Resource Or Model,Hostgroup,Last Report\n", buf.next
-    assert_equal "#{host.name},#{host.operatingsystem},#{host.compute_resource.name},#{host.hostgroup},#{host.last_report}\n", buf.next
+    assert_equal "Name,Operatingsystem,Model,Owner,Hostgroup,Last Report\n", buf.next
+    assert_equal "#{host.name},#{host.operatingsystem},#{host.model},#{host.owner.name},#{host.hostgroup},#{host.last_report}\n", buf.next
     assert_raises StopIteration do
       buf.next
     end


### PR DESCRIPTION
Export button on the host index page should export columns selected by column selector.
