### PR TITLE
Refs #35796 - Reduce empty lines

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -54,24 +54,24 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 <%= snippet "blacklist_kernel_modules" %>
 
 <%= snippet_if_exists(template_name + " custom post") -%>
-
 <% unless host_param('kernel_parameters').nil? -%>
+
 # Allow overriding the default kernel parameters
   sed -i 's/GRUB_CMDLINE_LINUX_DEFAULT=".*"/GRUB_CMDLINE_LINUX_DEFAULT="<%= host_param('kernel_parameters') %>"/g' /etc/default/grub && update-grub
-
 <% end -%>
-<% if chef_enabled %>
+<% if chef_enabled -%>
+
 <%= snippet 'chef_client' %>
 <% end -%>
+<% if puppet_enabled -%>
 
-<% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= snippet 'puppetlabs_repo' %>
 <% end -%>
 <%= snippet 'puppet_setup' %>
 <% end -%>
+<% if salt_enabled -%>
 
-<% if salt_enabled %>
 <%= snippet 'saltstack_setup' %>
 <% end -%>
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -9,7 +9,6 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 
-
 apt-get update
 apt-get install -y puppet
 
@@ -42,7 +41,6 @@ export FACTER_is_installer=true
 echo "Performing initial puppet run for --tags no_such_tag"
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -9,7 +9,6 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 
-
 apt-get update
 apt-get install -y puppet
 
@@ -42,7 +41,6 @@ export FACTER_is_installer=true
 echo "Performing initial puppet run for --tags no_such_tag"
 /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
-
 
 
 


### PR DESCRIPTION
In 699b7a3b4e9069237031b2dfbee8dba2bbaadf8c an additional empty line was generated which broke the snapshots. This takes it a step further and also removes various other lines in the generated output.

Fixes: 699b7a3b4e9069237031b2dfbee8dba2bbaadf8c