### PR TITLE
Fixes #35816 - ISE when passing org_id as an array

### DIFF
--- a/app/controllers/concerns/application_shared.rb
+++ b/app/controllers/concerns/application_shared.rb
@@ -118,7 +118,7 @@ module ApplicationShared
     end
 
     # If the id is an integer or parameterized string, scope by it
-    return base_scope.where(id: resource_id.to_i) if resource_id.integer? || resource_id.start_with?(/\d+-/)
+    return base_scope.where(id: resource_id.to_i) if resource_id.integer? || (resource_id.respond_to?(:start_with?) && resource_id.start_with?(/\d+-/))
 
     # The parameter doesn't match any supported format, return empty scope
     base_scope.none


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Steps to reproduce:

curl -u admin:<password> -k -H "Content-Type:application/json" -H "Accept:application/json" -X POST https://$FQDN/katello/api/v2/content_views -d '{"name": "test1", "organization_id": [1], "api_version": "v2", "content_view": {"name": "test1", "organization_id": [1]}}'

Note the organization_id passed as an array. 
