### PR TITLE
Fixes #35819 - Details tab cards have horizontal scroll

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/DetailsCard.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/DetailsCard.scss
@@ -1,0 +1,9 @@
+.masonry-root {
+  columns: 24rem;
+  column-gap: 1rem;
+  .masonry-item {
+    margin-bottom: 2rem;
+    display: inline-block;
+    width: 100%;
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/index.js
@@ -5,7 +5,7 @@ import { registerCoreCards } from './CardRegistry';
 import Slot from '../../../common/Slot';
 import { STATUS } from '../../../../constants';
 import '../Overview/styles.css';
-import './styles.css';
+import './DetailsCard.scss';
 import { translate as __ } from '../../../../common/I18n';
 import { CardExpansionContext } from '../../CardExpansionContext';
 
@@ -33,7 +33,7 @@ const DetailsTab = ({ response, status, hostName }) => {
   return (
     <div className="host-details-tab-item details-tab">
       <Flex style={{ marginBottom: '1rem' }}>
-        <FlexItem align={{ default: 'alignRight' }}>
+        <FlexItem align={{ default: 'alignLeft' }}>
           <Button
             ouiaId="expand-button"
             onClick={areAllCardsExpanded ? collapseAllCards : expandAllCards}
@@ -43,11 +43,7 @@ const DetailsTab = ({ response, status, hostName }) => {
           </Button>
         </FlexItem>
       </Flex>
-      <Flex
-        direction={{ default: 'column' }}
-        flexWrap={{ default: 'wrap' }}
-        className="details-tab-flex-container"
-      >
+      <div className="masonry-root">
         <Slot
           hostDetails={response}
           status={status}
@@ -55,7 +51,7 @@ const DetailsTab = ({ response, status, hostName }) => {
           id="host-tab-details-cards"
           multi
         />
-      </Flex>
+      </div>
     </div>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/styles.css
@@ -1,5 +1,0 @@
-.details-tab-flex-container {
-  max-height: min(1000px, calc(100vh - 225px));
-  width: 24rem;
-  gap: 1.2rem;
-}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -10,7 +10,6 @@ import {
   CardTitle,
   CardBody,
   GridItem,
-  FlexItem,
 } from '@patternfly/react-core';
 
 import { CardExpansionContext } from '../../../CardExpansionContext';
@@ -45,7 +44,7 @@ const CardTemplate = ({
     // eslint-disable-next-line no-unused-expressions
     overrideDropdownProps?.onSelect?.(event);
   };
-  const CardContainer = masonryLayout ? FlexItem : GridItem;
+  const CardContainer = masonryLayout ? 'div' : GridItem;
   const gridWidthProps = masonryLayout
     ? {}
     : {
@@ -54,13 +53,14 @@ const CardTemplate = ({
         md: 6,
         lg: 4,
       };
-  const cardProps = masonryLayout
-    ? { style: { width: '24rem', marginTop: '-0.8rem' } }
-    : {};
 
   return (
-    <CardContainer {...gridWidthProps} {...overrideGridProps}>
-      <Card isExpanded={isExpanded} ouiaId="card-template" {...cardProps}>
+    <CardContainer
+      {...gridWidthProps}
+      {...overrideGridProps}
+      className="masonry-item"
+    >
+      <Card isExpanded={isExpanded} ouiaId="card-template">
         <CardHeader
           onExpand={expandable && onExpandCallback}
           isToggleRightAligned


### PR DESCRIPTION
small screen:
![Screenshot from 2022-12-02 18-32-31](https://user-images.githubusercontent.com/30431079/205648445-7d38e77f-7a09-429d-a911-8e024e6bc5ab.png)
"large" (zoomed out) screen with different amount of (some fake) cards
![Screenshot from 2022-12-02 17-11-51](https://user-images.githubusercontent.com/30431079/205648466-9ad1142d-e219-4b96-a003-3630f9da746f.png)
![Screenshot from 2022-12-02 17-11-42](https://user-images.githubusercontent.com/30431079/205648468-77157727-b34c-4770-beb1-26bfe84270b1.png)
![Screenshot from 2022-12-02 17-11-29](https://user-images.githubusercontent.com/30431079/205648469-09284a7f-acfc-4c0b-8c44-08e9e9f88707.png)
