### PR TITLE
Fixes #35833 - Expose the origin of a config report

### DIFF
--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -33,6 +33,7 @@ module Api
           param :status, Hash, :required => true, :desc => N_("Hash of status type totals")
           param :metrics, Hash, :required => true, :desc => N_("Hash of report metrics, can be just {}")
           param :logs, Array, :desc => N_("Optional array of log hashes")
+          param :origin, Foreman::Plugin::ReportScannerRegistry.origins, :required => false, :desc => N_('Origin of the report')
         end
       end
 

--- a/app/registries/foreman/plugin/report_scanner_registry.rb
+++ b/app/registries/foreman/plugin/report_scanner_registry.rb
@@ -7,26 +7,40 @@ module Foreman
         ::Foreman::PuppetReportScanner,
       ].freeze
 
-      attr_accessor :report_scanners
-
       def initialize
-        @report_scanners = []
+        @report_scanners = {}
         register_default_scanner
       end
 
       def report_scanners
-        @report_scanners ||= []
+        @report_scanners.values
+      end
+
+      def origins
+        @report_scanners.keys
+      end
+
+      def [](name)
+        @report_scanners[name]
       end
 
       def register_report_scanner(scanner)
-        @report_scanners = (report_scanners << scanner).uniq
+        @report_scanners[origin(scanner)] = scanner
       end
 
       def unregister_report_scanner(scanner)
-        @report_scanners -= [scanner]
+        @report_scanners.delete(scanner)
       end
 
       private
+
+      def origin(scanner)
+        if scanner.respond_to?(:origin)
+          scanner.origin
+        else
+          Foreman::Deprecation.deprecation_warning('3.7', "Report scanner '#{scanner}' must declare an origin")
+          scanner.class_name.delete_suffix('ReportScanner')
+        end
 
       def register_default_scanner
         DEFAULT_REPORT_SCANNERS.each do |default_scanner|

--- a/app/services/report_scanner/puppet_report_scanner.rb
+++ b/app/services/report_scanner/puppet_report_scanner.rb
@@ -1,17 +1,20 @@
 module Foreman
   class PuppetReportScanner
     class << self
+      def origin
+        'Puppet'
+      end
+
       def identify_origin(report_data)
-        'Puppet' if puppet_report?(report_data['logs'] || [])
+        self.origin if puppet_report?(report_data)
       end
 
       def add_reporter_data(report, report_data)
         # no additional data apart of origin
       end
 
-      def puppet_report?(logs)
-        log = logs.last
-        log && log['log'].fetch('sources', {}).fetch('source', '') =~ /Puppet/
+      def puppet_report?(report)
+        report['logs']&.last&.dig('log', 'sources', 'source')&.match?(/Puppet/)
       end
     end
   end


### PR DESCRIPTION
Prior to this change there was no way to explicitly indicate the origin of a report and it used scanners to determine the origin. This is expensive because it relies on inspecting the data multiple times. On the other side it's pretty cheap to set the origin.

It is currently implemented as optional, falling back to the current behavior.

It also relies on the scanners to expose an origin. For compatibility it's guessed based on the class name. For example, AnsibleReportScanner is identified as Ansible. A deprecation warning for this is emitted.

Currently this is a draft to discuss the overall design. I'm sure I missed some details and it needs tests.