### PR TITLE
Fixes #35648 - Fixes API documentation typo

### DIFF
--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -52,7 +52,7 @@ module Api
         process_response @ptable.save
       end
 
-      api :POST, "/ptables/import", N_("Import a provisioning template")
+      api :POST, "/ptables/import", N_("Import a partition table")
       param :ptable, Hash, :required => true, :action_aware => true do
         param :name, String, :required => true, :desc => N_("template name")
         param :template, String, :required => true, :desc => N_("template contents including metadata")


### PR DESCRIPTION
This does introduce a new string to a stable branch, but generally speaking API documentation isn't that important to translate. In this case I think it's better to have an untranslated but correct header than an incorrect but translated header.

(cherry picked from commit b06f500d51f6655f0fe1fe6e6ac24a2d5e81b694)