### PR TITLE
Fixes #35835 - Hide provisioning cards for unmanaged hosts

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/Provisioning/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/Provisioning/index.js
@@ -17,11 +17,16 @@ import { STATUS } from '../../../../../../constants';
 
 const ProvisioningCard = ({ status, hostDetails }) => {
   const {
+    managed,
     initiated_at: initiatedAt,
     installed_at: installedAt,
     token,
     pxe_loader: PXELoader,
   } = hostDetails;
+
+  if (!managed) {
+    return null;
+  }
 
   const dateOptions = {
     largest: 1,
@@ -96,6 +101,7 @@ const ProvisioningCard = ({ status, hostDetails }) => {
 ProvisioningCard.propTypes = {
   status: PropTypes.string,
   hostDetails: PropTypes.shape({
+    managed: PropTypes.bool,
     initiated_at: PropTypes.string,
     installed_at: PropTypes.string,
     token: PropTypes.string,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/TemplatesCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/TemplatesCard/index.js
@@ -12,8 +12,14 @@ import CardTemplate from '../../../../Templates/CardItem/CardTemplate';
 import { STATUS } from '../../../../../../constants';
 import { ReviewModal } from './ReviewModal';
 
-const TemplatesCard = ({ hostName }) => {
-  const templatesUrl = foremanUrl(`/api/hosts/${hostName}/templates`);
+const TemplatesCard = ({ hostDetails }) => {
+  const { id, managed, name } = hostDetails;
+
+  if (!managed) {
+    return null;
+  }
+
+  const templatesUrl = foremanUrl(`/api/hosts/${id}/templates`);
   const TemplateTypeTitle = __('Template type');
   const {
     response: {
@@ -23,7 +29,7 @@ const TemplatesCard = ({ hostName }) => {
     },
     status,
   } = useAPI('get', templatesUrl);
-  const editTemplateUrl = id => `/templates/provisioning_templates/${id}/edit`;
+  const editTemplateUrl = tplId => `/templates/provisioning_templates/${tplId}/edit`;
   const [currentTemplate, setCurrentTemplate] = useState(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const onReviewClick = template => {
@@ -45,7 +51,7 @@ const TemplatesCard = ({ hostName }) => {
           <ReviewModal
             isModalOpen={isModalOpen}
             setIsModalOpen={setIsModalOpen}
-            hostName={hostName}
+            hostName={name}
             template={currentTemplate}
           />
         )}
@@ -97,9 +103,13 @@ const TemplatesCard = ({ hostName }) => {
 export default TemplatesCard;
 
 TemplatesCard.propTypes = {
-  hostName: PropTypes.string,
+  hostDetails: PropTypes.shape({
+    id: PropTypes.number,
+    managed: PropTypes.bool,
+    name: PropTypes.string,
+  }),
 };
 
 TemplatesCard.defaultProps = {
-  hostName: undefined,
+  hostDetails: {},
 };


### PR DESCRIPTION
Unmanaged hosts do not have provisioning so the cards shouldn't be shown.

In addition to this it also moves away from using the hostname in the API URL and instead uses the host ID. Host IDs are stable while a host can be renamed. Application code should never use the names in URLs.

I should mention I wasn't able to test this out yet (don't have a development environment with a compatible nodejs version).