### PR TITLE
Fixes #35836 - Drop "BIOS" UUID field

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
@@ -18,7 +18,6 @@ import { STATUS } from '../../../../../../constants';
 const SystemPropertiesCard = ({ status, hostDetails }) => {
   const {
     name,
-    uuid,
     model_name: model,
     location_name: location,
     organization_name: organization,
@@ -60,21 +59,6 @@ const SystemPropertiesCard = ({ status, hostDetails }) => {
           multi
           hostDetails={hostDetails}
         />
-        <DescriptionListGroup>
-          <DescriptionListTerm>{__('BIOS UUID')}</DescriptionListTerm>
-          <DescriptionListDescription>
-            <SkeletonLoader
-              status={status}
-              emptyState={<DefaultLoaderEmptyState />}
-            >
-              {uuid && (
-                <ClipboardCopy isBlock variant="inline-compact">
-                  {uuid}
-                </ClipboardCopy>
-              )}
-            </SkeletonLoader>
-          </DescriptionListDescription>
-        </DescriptionListGroup>
       </DescriptionList>
       <Divider className="padded-divider" />
       <DescriptionList isCompact isHorizontal>
@@ -166,7 +150,6 @@ SystemPropertiesCard.propTypes = {
     owner_name: PropTypes.string,
     owner_type: PropTypes.string,
     name: PropTypes.string,
-    uuid: PropTypes.string,
     domain_name: PropTypes.string,
     created_at: PropTypes.string,
     updated_at: PropTypes.string,
@@ -183,7 +166,6 @@ SystemPropertiesCard.defaultProps = {
     hostgroup_name: undefined,
     owner_type: undefined,
     owner_name: undefined,
-    uuid: undefined,
     domain_name: undefined,
     created_at: undefined,
     updated_at: undefined,


### PR DESCRIPTION
The host.uuid property is actually the virtualization UUID (for managed hosts). This has nothing to do with the BIOS and is only confusing.

The UUID should also be considered an internal property and users shouldn't be bothered by this. Instead, they should see a card showing the virtual machine's details.

Fixes: 4e7ac8c11cb1f936fc6103bd837492e152ccfe65