### PR TITLE
Fixes #35839 - Move Details tab out of experimental labs

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/index.js
@@ -7,7 +7,7 @@ import DetailTab from './Details';
 import ReportsTab from './ReportsTab';
 import ParametersTab from './Parameters';
 
-export const registerCoreTabs = ({ except = [] }) => {
+export const registerCoreTabs = () => {
   addGlobalFill(
     TABS_SLOT_ID,
     DEFAULT_TAB,
@@ -20,10 +20,7 @@ export const registerCoreTabs = ({ except = [] }) => {
     'Details',
     <DetailTab key="host-details-detail-tab" />,
     4000,
-    {
-      title: __('Details'),
-      hideTab: () => except.includes('host-details-detail-tab'),
-    }
+    { title: __('Details') }
   );
   addGlobalFill(
     TABS_SLOT_ID,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -40,7 +40,6 @@ import TabRouter from './Tabs/TabRouter';
 import RedirectToEmptyHostPage from './EmptyState';
 import BreadcrumbBar from '../BreadcrumbBar';
 import { foremanUrl } from '../../common/helpers';
-import { useForemanSettings } from '../../Root/Context/ForemanContext';
 import { CardExpansionContextWrapper } from './CardExpansionContext';
 import Head from '../Head';
 
@@ -70,13 +69,9 @@ const HostDetails = ({
   useEffect(() => {
     if (tabs?.length) dispatchEvent(new Event('resize'));
   }, [tabs]);
-  const hideDetailsTab = useForemanSettings()?.labFeatures === false;
-
   useEffect(() => {
-    registerCoreTabs({
-      except: hideDetailsTab ? ['host-details-detail-tab'] : [],
-    });
-  }, [hideDetailsTab]);
+    registerCoreTabs();
+  }, []);
 
   const activeTab = decodeURI(
     hash


### PR DESCRIPTION
The Details tab of the new host details UI is no longer an experimental feature. It should no longer be behind the 'Show experimental labs' setting.
