### PR TITLE
Fixes #35840 - Install chrony on RHEL 7

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -64,7 +64,7 @@ description: |
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
   section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
-  use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7))
+  use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 6))
   iface = @host.provision_interface
   appstream_present = false
 -%>

--- a/app/views/unattended/provisioning_templates/snippet/ntp.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ntp.erb
@@ -13,7 +13,7 @@ description: |
 rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
 is_fedora = @host.operatingsystem.name == 'Fedora'
 os_major = @host.operatingsystem.major.to_i
-use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 7))
+use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 6))
 -%>
 
 echo "Updating system time"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -23,8 +23,8 @@ runcmd:
 - |
   
   echo "Updating system time"
-  yum -y install ntpdate
-    systemctl enable --now ntpd
+  systemctl enable --now chronyd
+  /usr/bin/chronyc -a makestep
   /usr/sbin/hwclock --systohc
 - |
   rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -11,8 +11,8 @@ service network restart
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -39,8 +39,8 @@ reboot
 
 yum
 dhclient
-ntp
--chrony
+chrony
+-ntp
 wget
 @Core
 dracut-fips
@@ -72,8 +72,8 @@ logger "Starting anaconda snapshot-ipv4-6-dhcp-el7 postinstall"
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -39,8 +39,8 @@ reboot
 
 yum
 dhclient
-ntp
--chrony
+chrony
+-ntp
 wget
 @Core
 dracut-fips
@@ -72,8 +72,8 @@ logger "Starting anaconda snapshot-ipv4-dhcp-el7 postinstall"
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -39,8 +39,8 @@ reboot
 
 yum
 dhclient
-ntp
--chrony
+chrony
+-ntp
 wget
 @Core
 dracut-fips
@@ -72,8 +72,8 @@ logger "Starting anaconda snapshot-ipv4-static-el7 postinstall"
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -39,8 +39,8 @@ reboot
 
 yum
 dhclient
-ntp
--chrony
+chrony
+-ntp
 wget
 @Core
 dracut-fips
@@ -72,8 +72,8 @@ logger "Starting anaconda snapshot-ipv6-dhcp-el7 postinstall"
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -39,8 +39,8 @@ reboot
 
 yum
 dhclient
-ntp
--chrony
+chrony
+-ntp
 wget
 @Core
 dracut-fips
@@ -72,8 +72,8 @@ logger "Starting anaconda snapshot-ipv6-static-el7 postinstall"
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -21,8 +21,8 @@ EOF
 
 
 echo "Updating system time"
-yum -y install ntpdate
-  systemctl enable --now ntpd
+systemctl enable --now chronyd
+/usr/bin/chronyc -a makestep
 /usr/sbin/hwclock --systohc
 
 


### PR DESCRIPTION
According to [1], Chrony should be preferred for all systems except for the systems that are managed or monitored by tools that do not support chrony, or the systems that have a hardware reference clock which cannot be used with chrony.

[1] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite#sect-Choosing_between_NTP_daemon

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
