### PR TITLE
Fixes #35837 - Allow non admin users update table preferences

### DIFF
--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -8,7 +8,7 @@ Foreman::AccessControl.map do |permission_set|
     map.permission :my_account, {
       :users => [:edit],
       :notification_recipients => [:index, :update, :destroy, :update_group_as_read, :destroy_group],
-      :"api/v2/table_preferences" => [:show, :create, :edit, :delete, :index],
+      :"api/v2/table_preferences" => [:show, :create, :update, :destroy, :index],
     }, :public => true
     map.permission :api_status, { :"api/v2/home" => [:status]}, :public => true
     map.permission :about_index, { :about => [:index] }, :public => true


### PR DESCRIPTION
Non admin user could not update existing table preferences (getting 403).