### PR TITLE
Fixes #35843 - add alias for configuration_status searching

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -15,7 +15,7 @@ module Hostext
       scoped_search :on => :last_report,   :complete_value => true, :only_explicit => true
       scoped_search :on => :created_at,    :complete_value => true, :only_explicit => true
       scoped_search :on => :comment,       :complete_value => true
-      scoped_search :on => :enabled,       :complete_value => {:true => true, :false => false}, :rename => :'status.enabled'
+      scoped_search :on => :enabled,       :complete_value => {:true => true, :false => false}, :rename => :'status.enabled', :aliases => [:'configuration_status.enabled']
       scoped_search :on => :managed,       :complete_value => {:true => true, :false => false}
       scoped_search :on => :owner_type,    :complete_value => true, :only_explicit => true
       scoped_search :on => :owner_id,      :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
@@ -23,13 +23,13 @@ module Hostext
 
       scoped_search :relation => :last_report_object, :on => :origin, :only_explicit => true
 
-      scoped_search :relation => :configuration_status_object, :on => :status, :offset => 0, :word_size => ConfigReport::BIT_NUM * 4, :rename => :'status.interesting', :complete_value => {:true => true, :false => false}, :only_explicit => true
-      scoped_search_status "applied",         :relation => :configuration_status_object, :on => :status, :rename => :'status.applied'
-      scoped_search_status "restarted",       :relation => :configuration_status_object, :on => :status, :rename => :'status.restarted'
-      scoped_search_status "failed",          :relation => :configuration_status_object, :on => :status, :rename => :'status.failed'
-      scoped_search_status "failed_restarts", :relation => :configuration_status_object, :on => :status, :rename => :'status.failed_restarts'
-      scoped_search_status "skipped",         :relation => :configuration_status_object, :on => :status, :rename => :'status.skipped'
-      scoped_search_status "pending",         :relation => :configuration_status_object, :on => :status, :rename => :'status.pending'
+      scoped_search :relation => :configuration_status_object, :on => :status, :offset => 0, :word_size => ConfigReport::BIT_NUM * 4, :rename => :'status.interesting', :complete_value => {:true => true, :false => false}, :only_explicit => true, :aliases => [:'configuration_status.interesting']
+      scoped_search_status "applied",         :relation => :configuration_status_object, :on => :status, :rename => :'status.applied', :aliases => ['configuration_status.applied']
+      scoped_search_status "restarted",       :relation => :configuration_status_object, :on => :status, :rename => :'status.restarted', :aliases => ['configuration_status.restarted']
+      scoped_search_status "failed",          :relation => :configuration_status_object, :on => :status, :rename => :'status.failed', :aliases => ['configuration_status.failed']
+      scoped_search_status "failed_restarts", :relation => :configuration_status_object, :on => :status, :rename => :'status.failed_restarts', :aliases => ['configuration_status.failed_restarts']
+      scoped_search_status "skipped",         :relation => :configuration_status_object, :on => :status, :rename => :'status.skipped', :aliases => ['configuration_status.skipped']
+      scoped_search_status "pending",         :relation => :configuration_status_object, :on => :status, :rename => :'status.pending', :aliases => ['configuration_status.pending']
 
       scoped_search :relation => :build_status_object, :on => :status, :rename => :build_status, :only_explicit => true, :operators => ['=', '!=', '<>'], :complete_value => {
         built: HostStatus::BuildStatus::BUILT,


### PR DESCRIPTION
Historically, the configuration status was the only status users can search hosts by. When sub-statuses were introduced we kept "status" as the search term representing the configuration status. However with many more sub statuses available, this is now inconsistent and hard to find.

This adds alias so that people are able to search by configuration_status, similary to e.g. build_status. Also it keeps the old status for bookmarks and scripts backwards compatibility.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
