### PR TITLE
Fixes #35853 - compute_resources_vms_controller_test

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -54,7 +54,7 @@ module Foreman::Model
 
     # we default to destroy the VM's storage as well.
     def destroy_vm(uuid, args = { })
-      find_vm_by_uuid(uuid).destroy({ :destroy_volumes => true }.merge(args))
+      find_vm_by_uuid(uuid).destroy({ destroy_volumes: true, flags: 0 }.merge(args))
     rescue ActiveRecord::RecordNotFound
       true
     end

--- a/app/views/compute_resources_vms/show/_libvirt.html.erb
+++ b/app/views/compute_resources_vms/show/_libvirt.html.erb
@@ -40,7 +40,7 @@
           <td><%= "#{nic.bridge} - #{nic.mac} (#{nic.model})" %></td>
         </tr>
       <% end %>
-      <% @vm.volumes.each do |vol| %>
+      <% @vm.volumes.compact.each do |vol| %>
         <tr>
           <td><%= _('Disk') %></td>
           <td><%= _("using %{allocation} GB out of %{capacity} GB, %{pool_name} storage pool") % { :allocation => vol.allocation, :capacity => vol.capacity, :pool_name => vol.pool_name } %></td>


### PR DESCRIPTION
**Issues:**
1) @vm.volumes with array of nils instead of volumes
```
ComputeResourcesVmsControllerTest#test_0001_should show vm:
ActionView::Template::Error: undefined method `allocation' for nil:NilClass
```
2) Missing flags => 0 in default options for destroy method, see fog-libvirt PR [0] 
```
ComputeResourcesVmsControllerTest#test_0001_should destroy vm:
NoMethodError: undefined method `zero?' for nil:NilClass
```

[0] https://github.com/fog/fog-libvirt/pull/102/files

**How to test:**
```
bundle exec rails test test/controllers/compute_resources_vms_controller_test.rb
```
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
