### PR TITLE
Fixes #35326 - Rename hostname/fqdn ENC vars to avoid conflicts

### DIFF
--- a/app/models/host_info_providers/static_info.rb
+++ b/app/models/host_info_providers/static_info.rb
@@ -4,8 +4,8 @@ module HostInfoProviders
       # Static parameters
       param = {}
 
-      param["hostname"] = host.shortname unless host.shortname.nil?
-      param["fqdn"] = host.fqdn unless host.fqdn.nil?
+      param["foreman_hostname"] = host.shortname unless host.shortname.nil?
+      param["foreman_fqdn"] = host.fqdn unless host.fqdn.nil?
       param["hostgroup"] = host.hostgroup.to_label unless host.hostgroup.nil?
       param["comment"] = host.comment if host.comment.present?
       param["root_pw"] = host.root_pass unless (!host.operatingsystem.nil? && host.operatingsystem.password_hash == 'Base64')


### PR DESCRIPTION
(cherry picked from commit dd9f24f47de2c7c173a8c0f77c313df5856827cb)