### PR TITLE
Fixes #35865 - Update future Debian release names and versions

### DIFF
--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -30,15 +30,18 @@ module ForemanAnsible
     end
 
     def debian_os_major_sid
-      case facts[:ansible_distribution_major_version]
-      when /wheezy/i
-        '7'
-      when /jessie/i
-        '8'
-      when /stretch/i
-        '9'
-      when /buster/i
-        '10'
+      release = if facts[:ansible_distribution_major_version] == 'n/a'
+                  facts[:ansible_distribution_release]
+                else
+                  facts[:ansible_distribution_major_version]
+                end
+      case release
+      when /bookworm/i
+        '12'
+      when /trixie/i
+        '13'
+      when /forky/i
+        '14'
       end
     end
 
@@ -49,7 +52,8 @@ module ForemanAnsible
 
     def os_major
       if os_name == 'Debian' &&
-          facts[:ansible_distribution_major_version][%r{\/sid}i]
+          (facts[:ansible_distribution_major_version][%r{\/sid}i] ||
+           facts[:ansible_distribution_major_version] == 'n/a')
         debian_os_major_sid
       else
         facts[:ansible_distribution_major_version] ||

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -248,11 +248,14 @@ class PuppetFactParser < FactParser
       # Archlinux is a rolling release, so it has no releases. 1.0 is always used
       '1.0'
     when /Debian/i
-      return "99" if distro_codename =~ /sid/
       release = os_release_full
       case release
-      when 'bullseye/sid' # Debian Bullseye testing will be 11
-        '11'
+      when 'bookworm/sid' # Debian Bookworm will be 12
+        '12'
+      when 'trixie/sid' # Debian Trixie will be 13
+        '13'
+      when 'forky/sid' # Debian Forky will be 14
+        '14'
       else
         release
       end


### PR DESCRIPTION
Debian dropped the VERSION_ID from /etc/os-release of unreleased releases (read: testing and unstable), which makes the common tools report it as 'n/a'. See https://bugs.debian.org/1021663 for details.

The Puppet parser already coped with that by *also* looking at major version which gets reported as `<codename>/sid` and now the Ansible parser gained similar logic (but looking at the codename) too.

The list of upcoming releases is based on
https://wiki.debian.org/DebianReleases


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
