### PR TITLE
Refs #35578 - Fix netplan interface template logic

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -34,19 +34,19 @@ static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?
 <%-   if static_v6 && @subnet6.gateway.present? -%>
         gateway6: <%= @subnet6.gateway %>
 <%-   end -%>
-<%- end -%>
-<%- if @interface.primary -%>
+<%-   if @interface.primary -%>
         nameservers:
           search: [ <%= @interface.domain %> ]
           addresses:
-<%- if static_v4 -%>
-<%-   @subnet.dns_servers.each do |dns_server| -%>
+<%-     if static_v4 -%>
+<%-       @subnet.dns_servers.each do |dns_server| -%>
             - <%= dns_server %>
-<%-   end -%>
-<%-   end -%>
-<%- if static_v6 -%>
-<%-   @subnet6.dns_servers.each do |dns6_server| -%>
+<%-       end -%>
+<%-     end -%>
+<%-     if static_v6 -%>
+<%-       @subnet6.dns_servers.each do |dns6_server| -%>
             - <%= dns6_server %>
+<%-       end -%>
+<%-     end -%>
 <%-   end -%>
-<%- end -%>
 <%- end -%>


### PR DESCRIPTION
The previous fix introduced an `end` at the wrong place which results in bad configuration for systems with dhcp enabled. 

In the current version, the `nameserver` field is printed independent of a static or dhcp environment. AFAIK and in the prior behavior of this snippet, it should only be added in a static setup.

Current version:
```
 network:
    version: 2
    ethernets:
      <myidentifier>:
        dhcp4: true
        dhcp6: false
        nameservers:
          search: [ <someaddress> ]
          addresses:
```

New version:
```
  network:
    version: 2
    ethernets:
      <myidentifier>:
        dhcp4: true
        dhcp6: false
```

This PR adds indentation to the erb clauses which might explain the cause of this issue in the first place.

Fixes: e74661ef9b4e6f720480e47aabfd8ea4883e74d6

@anthonysomerset and @ekohl maybe you can verify this patch since the issue was introduced in #9515. 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
