### PR TITLE
Fixes #35876 - Add tag_type parameter to replace_value_control

### DIFF
--- a/app/assets/javascripts/hidden_values.js
+++ b/app/assets/javascripts/hidden_values.js
@@ -14,7 +14,8 @@ function hidden_value_control() {
   });
 }
 
-function replace_value_control(link) {
+function replace_value_control(link, tag_type) {
+  var tag_type = tag_type || 'a'
   var link = $(link);
   link
     .find('.glyphicon')
@@ -27,7 +28,7 @@ function replace_value_control(link) {
   link
     .parent()
     .parent()
-    .find('a.pull-left')
+    .find(tag_type + '.pull-left')
     .toggleClass('hide');
 }
 


### PR DESCRIPTION
Currently, the `replace_value_control` [function](https://github.com/theforeman/foreman/blob/a2c20eab3c78b7bfb78157477d7f667f0a7448f2/app/assets/javascripts/hidden_values.js#L17) works only for `a` tag elements. 
I want to be able to use this function for `div` tag elements as well.

Required for: 
- theforeman/foreman_ansible/pull/577 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
