### PR TITLE
Fixes #35871 - purge trends only when statistics not installed

### DIFF
--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -13,11 +13,13 @@ namespace :purge do
 
   desc 'Clean up all Trends data'
   task trends: :environment do
-    ::CleanupHelper.clean_trends
+    success = ::CleanupHelper.clean_trends
+    raise("Trends data could not be purged") unless success
   end
 
   task puppet: :environment do
-    ::CleanupHelper.clean_puppet
+    success = ::CleanupHelper.clean_puppet
+    raise("Puppet data could not be purged") unless success
   end
 
   task all: ['purge:foreman_docker', 'purge:trends', 'purge:puppet']


### PR DESCRIPTION
We instroduced migration to purge trends data in 34709a3781355b63e7afe2864e03c5f663479602.  It forgot to add condition to check if the statistics plugin is not installed.

I then forgot to pick this in https://github.com/theforeman/foreman/pull/9562 but yay for the TODO view which properly showed me that I forgot.

(cherry picked from commit 34728aee6b213c68e56df7bb5e3b86ab194b2a33)