### PR TITLE
 Fixes #35762 - No host error after editing host's interfaces

### DIFF
--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -391,9 +391,7 @@ $(document).on('change', '.virtual', function() {
 function construct_host_name() {
   var host_name_el = $('#host_name')
   var host_name = host_name_el.val();
-  if (host_name_el.data('appendDomainNameForHosts') === false ||
-      host_name_el.data('managed') === false
-  ) {
+  if (host_name_el.data('appendDomainNameForHosts') === false) {
     return host_name;
   }
   var domain_name = primary_nic_form()

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -32,9 +32,7 @@
         <%= text_f f, :name, :size => "col-md-4", :value => name_field(@host),
             :input_group_btn => randomize_mac_link,
             :help_inline => _("This value is used also as the host's primary interface name."),
-            :data => { 'append_domain_name_for_hosts' => Setting[:append_domain_name_for_hosts],
-              'managed' => @host.managed?
-            }
+            :data => { 'append_domain_name_for_hosts' => Setting[:append_domain_name_for_hosts] }
         %>
 
         <% if show_organization_tab?  %>


### PR DESCRIPTION
**When editing the interfaces of an unmanaged host**, this error occurred:
![Screenshot from 2022-12-19 11-36-46](https://user-images.githubusercontent.com/78563507/208406942-d39e3ecc-5d17-4cc1-8947-6045bbca31f0.png)

The issue was caused by the **_unmanaged_** host's primary interface name being shortname+domain; meanwhile, the same name of a **_managed_** host is just shortname.
![Screenshot from 2022-12-19 12-16-24](https://user-images.githubusercontent.com/78563507/208414141-58445601-da33-4107-8b2f-47dbb789a232.png)


This fix follows up the https://github.com/theforeman/foreman/commit/3bc478f4bea16ab557a41ea0fa72500045583d3d.
