### PR TITLE
Fixes #35890 - enable harmony mode with Uglifier to use ES6 syntax

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,8 @@ $(function() {
 
 // Prevents all links with the disabled attribute set to "disabled"
 // from being clicked.
-var handleDisabledClick = function(event, element){
-  var disabled = element.disabled || $(element).attr('disabled') === 'disabled';
+const handleDisabledClick = (event, element) => {
+  const disabled = element.disabled || $(element).attr('disabled') === 'disabled';
   if (disabled) event.preventDefault();
   return !disabled;
 }

--- a/app/assets/javascripts/hidden_values.js
+++ b/app/assets/javascripts/hidden_values.js
@@ -14,8 +14,7 @@ function hidden_value_control() {
   });
 }
 
-function replace_value_control(link, tag_type) {
-  var tag_type = tag_type || 'a'
+function replace_value_control(link, tag_type = a) {
   var link = $(link);
   link
     .find('.glyphicon')

--- a/app/assets/javascripts/hosts.js
+++ b/app/assets/javascripts/hosts.js
@@ -29,7 +29,7 @@ $(document).on('ContentLoad', function() {
     $('#build-review').click();
   });
 
-  var action_buttons = $('.btn-toolbar a')
+  const action_buttons = $('.btn-toolbar a')
     .not('.dropdown-toggle')
     .not('.dropdown-toggle > a');
   var wait_msg = $('#processing_message');
@@ -40,9 +40,7 @@ $(document).on('ContentLoad', function() {
     show: false,
   });
 
-  var is_in_array = function(val, arr) {
-    return arr.indexOf(val) > -1;
-  };
+  const is_in_array = (val, arr) => arr.indexOf(val) > -1;
 
   action_buttons.on('click', function() {
     if (this.id === 'delete-button' && !confirm($(this).attr('data-message')))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Foreman::Application.configure do |app|
   config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', false) == 'true'
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = Uglifier.new(harmony: true)
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Using ES6 syntax requires enabling harmony mode with Uglifier.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
