### PR TITLE
Refs #35893 - Pin to audited 5.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 6.1.6'
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '~> 5.0'
+gem 'audited', '~> 5.0.0'
 gem 'will_paginate', '~> 3.3'
 gem 'ancestry', '~> 4.0'
 gem 'scoped_search', '>= 4.1.10', '< 5'


### PR DESCRIPTION
Audited 5.1.0 released with [a breaking change where audited_class changed from a Class to a String](https://github.com/collectiveidea/audited/pull/609). This pins to a compatible version until Foreman is fixed or audited reverts the change.