### PR TITLE
Fixes #35896 - Improvement to getControllerSearchProps

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.fixtures.js
@@ -1,6 +1,7 @@
 export const SearchBarProps = {
   data: {
     autocomplete: {
+      apiParams: {},
       searchQuery: null,
       url: 'model/auto_complete_search',
       id: 'searchBar',

--- a/webpack/assets/javascripts/react_app/components/SearchBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/index.js
@@ -10,7 +10,7 @@ import { noop } from '../../common/helpers';
 
 const SearchBar = ({
   data: {
-    autocomplete: { url, searchQuery } = { url: '' },
+    autocomplete: { url, searchQuery, apiParams } = { url: '' },
     controller,
     bookmarks,
     disabled,
@@ -21,20 +21,20 @@ const SearchBar = ({
 }) => {
   const [search, setSearch] = useState(initialQuery || searchQuery || '');
   const { response, status, setAPIOptions } = useAPI('get', url, {
-    params: { search },
+    params: { ...apiParams, search },
   });
   const [prevSearch, setPrevSearch] = useState(searchQuery);
   if (searchQuery !== prevSearch) {
     setPrevSearch(searchQuery);
     if (searchQuery !== search) {
       setSearch(searchQuery || '');
-      setAPIOptions({ params: { search: searchQuery || '' } });
+      setAPIOptions({ params: { ...apiParams, search: searchQuery || '' } });
     }
   }
   const _onSearchChange = newValue => {
     onSearchChange(newValue);
     setSearch(newValue);
-    setAPIOptions({ params: { search: newValue } });
+    setAPIOptions({ params: { ...apiParams, search: newValue } });
   };
   const error =
     status === STATUS.ERROR || response?.[0]?.error

--- a/webpack/assets/javascripts/react_app/constants.js
+++ b/webpack/assets/javascripts/react_app/constants.js
@@ -9,13 +9,15 @@ export const STATUS = {
 export const getControllerSearchProps = (
   controller,
   id = `searchBar-${controller}`,
-  canCreate = true
+  canCreate = true,
+  apiParams = {}
 ) => ({
   controller,
   autocomplete: {
     id,
     searchQuery: '',
     url: `${controller}/auto_complete_search`,
+    apiParams: apiParams,
     useKeyShortcuts: true,
   },
   bookmarks: {

--- a/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/Audits/AuditsPage/__tests__/__snapshots__/AuditsPage.test.js.snap
@@ -11,6 +11,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
+        "apiParams": Object {},
         "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
@@ -50,6 +51,7 @@ exports[`AuditsPage rendering render audits page 1`] = `
       Object {
         "data": Object {
           "autocomplete": Object {
+            "apiParams": Object {},
             "id": "searchBar",
             "searchQuery": null,
             "url": "model/auto_complete_search",
@@ -81,6 +83,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
+        "apiParams": Object {},
         "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
@@ -122,6 +125,7 @@ exports[`AuditsPage rendering render audits page w/empty audits 1`] = `
       Object {
         "data": Object {
           "autocomplete": Object {
+            "apiParams": Object {},
             "id": "searchBar",
             "searchQuery": null,
             "url": "model/auto_complete_search",
@@ -153,6 +157,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
+        "apiParams": Object {},
         "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
@@ -194,6 +199,7 @@ exports[`AuditsPage rendering render audits page w/error 1`] = `
       Object {
         "data": Object {
           "autocomplete": Object {
+            "apiParams": Object {},
             "id": "searchBar",
             "searchQuery": null,
             "url": "model/auto_complete_search",
@@ -225,6 +231,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
   searchProps={
     Object {
       "autocomplete": Object {
+        "apiParams": Object {},
         "id": "searchBar-audits",
         "searchQuery": "",
         "url": "audits/auto_complete_search",
@@ -266,6 +273,7 @@ exports[`AuditsPage rendering render loading audits page 1`] = `
       Object {
         "data": Object {
           "autocomplete": Object {
+            "apiParams": Object {},
             "id": "searchBar",
             "searchQuery": null,
             "url": "model/auto_complete_search",

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/__snapshots__/PageLayout.test.js.snap
@@ -56,6 +56,7 @@ exports[`render pageLayout w/beforeToolbarComponent 1`] = `
           data={
             Object {
               "autocomplete": Object {
+                "apiParams": Object {},
                 "id": "searchBar",
                 "searchQuery": "",
                 "url": "model/auto_complete_search",
@@ -145,6 +146,7 @@ exports[`render pageLayout w/search 1`] = `
           data={
             Object {
               "autocomplete": Object {
+                "apiParams": Object {},
                 "id": "searchBar",
                 "searchQuery": "",
                 "url": "model/auto_complete_search",
@@ -234,6 +236,7 @@ exports[`render pageLayout w/toolBar 1`] = `
           data={
             Object {
               "autocomplete": Object {
+                "apiParams": Object {},
                 "id": "searchBar",
                 "searchQuery": "",
                 "url": "model/auto_complete_search",
@@ -305,6 +308,7 @@ exports[`render pageLayout with custom breadcrumbs 1`] = `
           data={
             Object {
               "autocomplete": Object {
+                "apiParams": Object {},
                 "id": "searchBar",
                 "searchQuery": "",
                 "url": "model/auto_complete_search",
@@ -376,6 +380,7 @@ exports[`render pageLayout without breadcrumbs 1`] = `
           data={
             Object {
               "autocomplete": Object {
+                "apiParams": Object {},
                 "id": "searchBar",
                 "searchQuery": "",
                 "url": "model/auto_complete_search",


### PR DESCRIPTION
Katello is switching to Foreman's standard PF4 search input.

Katello may use an endpoint like this:
```autocompleteEndpoint={`/content_view_versions/auto_complete_search?content_view_id=${cvId}`}```

Improvement to getControllerSearchProps to accept search URL as it is.