### PR TITLE
Fixes #35908 - Remove hidden boundaries for power column

### DIFF
--- a/app/views/hosts/_list.html.erb
+++ b/app/views/hosts/_list.html.erb
@@ -4,7 +4,6 @@
   <thead>
     <tr>
       <th class="ca" width="40px"><%= check_box_tag "check_all", "", false, { :onchange => "tfm.hosts.table.toggleCheck()", :'check-title' => _("Select all items on this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
-      <th hidden="true" class="ca" width="80px"><%= _('Power') %></th>
       <%= render_pagelets_for(:hosts_table_column_header) %>
       <th hidden="true" width="25%"><%= sort :name, :as => _('Name') %></th>
       <th hidden="true" class="hidden-xs" width="17%"><%= sort :os_title, :as => _("Operating system") %></th>
@@ -21,9 +20,6 @@
       <tr>
         <td class="ca">
           <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{host.id}", :class => 'host_select_boxes', :onclick => 'tfm.hosts.table.hostChecked(this)' %>
-        </td>
-        <td hidden="true" class="ca">
-          <%= react_component('PowerStatus', id: host.id, url: power_api_host_path(host)) %>
         </td>
         <%= render_pagelets_for(:hosts_table_column_content, :subject => host) %>
         <td hidden="true" class="ellipsis"><%= name_column(host) %></td>


### PR DESCRIPTION
As @ekohl noticed in https://github.com/theforeman/foreman/pull/9462#issuecomment-1341637075 we do some unnecessary API calls for power column even if the column is hidden per user preferences. As @ShimShtein noticed this is due to overlook in ensuring compatibility. We agreed that since this particular compatibility is not necessary, we can simply remove it.