### PR TITLE
Fixes #35912 - template autocomplete has incorrect props

### DIFF
--- a/app/helpers/templates_helper.rb
+++ b/app/helpers/templates_helper.rb
@@ -81,7 +81,15 @@ module TemplatesHelper
       elsif input_type == 'search'
         input_type = 'autocomplete'
         resource_type = input.resource_type&.tableize
-        options.merge!(resource_type: resource_type, use_key_shortcuts: false, url: search_path(resource_type))
+        options[:data] = {
+          autocomplete: {
+            searchQuery: options[:search_query] || f.object&.value || '',
+            controller: options[:path] || auto_complete_controller_name,
+            disabled: options[:disabled] || false,
+            url: search_path(resource_type),
+          },
+        }
+        options[:onSearch] = nil
       end
       react_form_input(input_type, f, :value, options)
     end

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchAutocomplete.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchAutocomplete.js
@@ -21,7 +21,7 @@ export const SearchAutocomplete = ({
 
   const _onSearch = searchValue => {
     setIsAutocompleteOpen(false);
-    onSearch(searchValue);
+    onSearch && onSearch(searchValue);
   };
   const onClear = () => {
     onSearchChange('');


### PR DESCRIPTION
similar to the change that was done in the autocomplete refactor pr: https://github.com/theforeman/foreman/pull/9277/files#diff-da41d2b9457536824c4449989bf5af074c265e061e3db6b9a20ad2f4560aec40L222
when using
```
 <%= render :partial => 'template_inputs/invocation_form'...
```
for autocomplete input, the autocomplete is missing props