### PR TITLE
Fixes #35917 - PXEGrub2 broken, linuxefi and initrdefi grub2 commands deprecated in RHEL8

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
@@ -11,14 +11,6 @@ description: |
 -%>
 # This file was deployed via '<%= template_name %>' template
 <%
-  if !@host.pxe_loader_efi?
-    linuxcmd = "linux"
-    initrdcmd = "initrd"
-  else
-    linuxcmd = "linuxefi"
-    initrdcmd = "initrdefi"
-  end
-
   if host_param('http-proxy')
     if host_param('http-proxy-port')
       http_proxy_string = "proxy=http://" + host_param('http-proxy') + ":" + host_param('http-proxy-port')
@@ -36,8 +28,8 @@ set default=<%= host_param('default_grub_install_entry') || 0 %>
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> <%= kernel_options %>
-  <%= initrdcmd %> <%= @initrd %>
+  linux <%= @kernel %> <%= kernel_options %>
+  initrd <%= @initrd %>
 }
 
 <%
@@ -51,8 +43,8 @@ if subnet && subnet.httpboot
 -%>
 <% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
-  <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= kernel_options %>
-  <%= initrdcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
+  linux (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= kernel_options %>
+  initrd> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
@@ -60,8 +52,8 @@ menuentry '<%= template_name %> EFI HTTP' --id efi_http {
 
 <% if proxy_https_port -%>
 menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
-  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= kernel_options %>
-  <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
+  linux (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= kernel_options %>
+  initrd (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -20,26 +20,13 @@ test_on:
 - host6static
 -%>
 # This file was deployed via '<%= template_name %>' template
-<%
-  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
-  os_major = @host.operatingsystem.major.to_i
-
-  if (rhel_compatible && os_major < 7) || !@host.pxe_loader_efi?
-    # Grub EFI commands are RHEL7+ only (prevents "Kernel is too old") or for non-EFI arch
-    linuxcmd = "linux"
-    initrdcmd = "initrd"
-  else
-    linuxcmd = "linuxefi"
-    initrdcmd = "initrdefi"
-  end
--%>
 
 set default=<%= host_param('default_grub_install_entry') || 0 %>
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-  <%= initrdcmd %> <%= @initrd %>
+  linux <%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  initrd <%= @initrd %>
 }
 
 <%
@@ -53,8 +40,8 @@ if subnet && subnet.httpboot
 -%>
 <% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
-  <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-  <%= initrdcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
+  linux (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  initrd (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
@@ -62,8 +49,8 @@ menuentry '<%= template_name %> EFI HTTP' --id efi_http {
 
 <% if proxy_https_port -%>
 menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
-  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-  <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
+  linux (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  initrd (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
 }
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -15,22 +15,12 @@ description: |
 #
 # This file was deployed via '<%= template_name %>' template
 
-<%
-  os_major = @host.operatingsystem.major.to_i
-  os_name  = @host.operatingsystem.name
-
-  if (os_name == 'Ubuntu' && os_major > 12) || (os_name == 'Debian' && os_major > 8)
-    efi_suffix = 'efi'
-  else
-    efi_suffix = ''
-  end
--%>
 set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac <%= snippet("preseed_kernel_options").strip %>
-  initrd<%= efi_suffix %> <%= @initrd %>
+  linux <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-$net_default_mac <%= snippet("preseed_kernel_options").strip %>
+  initrd <%= @initrd %>
 }
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
@@ -19,7 +19,6 @@ test_on:
 #   System locale
 #
 <%
-  efi_suffix = 'efi'
   image_path = @preseed_path.sub(/\/?$/, '.iso')
   options = []
   options << 'ramdisk_size=1500000'
@@ -33,8 +32,8 @@ set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %> <%= @kernel %> <%= options.compact.join(' ') %> "ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/" <%= snippet('preseed_kernel_options_autoinstall').strip %>
-  initrd<%= efi_suffix %> <%= @initrd %>
+  linux <%= @kernel %> <%= options.compact.join(' ') %> "ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/" <%= snippet('preseed_kernel_options_autoinstall').strip %>
+  initrd <%= @initrd %>
 }
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
@@ -28,8 +28,8 @@ echo Default PXE global template entry is set to '<%= global_setting("default_px
     raise("PXE type #{profile[:pxe_type]} not supported by template #{template_name}")
   end %>
 menuentry '<%= "#{profile[:hostgroup]} - #{profile[:template]}" %>' {
-  linuxefi <%= profile[:kernel] %> <%= append %>
-  initrdefi <%= profile[:initrd] %>
+  linux <%= profile[:kernel] %> <%= append %>
+  initrd <%= profile[:initrd] %>
 }
 <% end %>
 <% end -%>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
