### PR TITLE
Fixes #35923 - Switchable power on host index page

### DIFF
--- a/config/initializers/foreman_register.rb
+++ b/config/initializers/foreman_register.rb
@@ -9,8 +9,8 @@ Pagelets::Manager.with_key 'hosts/_list' do |ctx|
   ctx.with_profile :general, _('General'), default: true do
     common_th_class = 'hidden-tablet hidden-xs'
     common_td_class = common_th_class + ' ellipsis'
-    add_pagelet :hosts_table_column_header, key: :power_status, label: _('Power'), sortable: false, width: '80px', class: 'ca'
-    add_pagelet :hosts_table_column_content, key: :power_status, class: 'ca', callback: ->(host) { react_component('PowerStatus', id: host.id, url: power_api_host_path(host)) }
+    add_pagelet :hosts_table_column_header, key: :power_status, label: _('Power'), sortable: false, width: '100px', class: 'ca'
+    add_pagelet :hosts_table_column_content, key: :power_status, callback: ->(host) { react_component('PowerStatusDropDown', hostID: host.id, hasPowerPermission: Authorizer.new(User.current).can?('power_hosts', host, false), iconSize: 'sm') }
     add_pagelet :hosts_table_column_header, key: :name, label: _('Name'), sortable: true, width: '25%', locked: true
     add_pagelet :hosts_table_column_content, key: :name, class: 'ellipsis', callback: ->(host) { name_column(host) }, locked: true
     add_pagelet :hosts_table_column_header, key: :os_title, label: _('OS'), sortable: true, width: '17%', class: 'hidden-xs', attr_callbacks: { title: ->(host) { _('Operating system') } }

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
@@ -106,7 +106,7 @@ export const cancelBuild = hostId => dispatch => {
   );
 };
 
-export const isHostTurnOn = store => {
-  const { state } = selectAPIResponse(store, POWER_REQURST_KEY);
+export const isHostTurnOn = hostId => store => {
+  const { state } = selectAPIResponse(store, `${POWER_REQURST_KEY}_${hostId}`);
   return state === 'on';
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -47,7 +47,7 @@ const ActionsBar = ({
   const onKebabToggle = isOpen => setKebab(isOpen);
   const { destroyVmOnHostDelete } = useForemanSettings();
   const registeredItems = useSelector(selectKebabItems, shallowEqual);
-  const isHostActive = useSelector(isHostTurnOn);
+  const isHostActive = useSelector(isHostTurnOn(hostId));
 
   const dispatch = useDispatch();
   const deleteHostHandler = () =>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/PowerStatusIcon.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/PowerStatusIcon.js
@@ -4,8 +4,8 @@ import { PowerOffIcon } from '@patternfly/react-icons';
 import { Spinner } from '@patternfly/react-core';
 import { STATUS } from '../../../../constants';
 
-const PowerStatusIcon = ({ state, responseStatus }) => {
-  if (responseStatus === STATUS.PENDING) return <Spinner size="md" />;
+const PowerStatusIcon = ({ state, responseStatus, size }) => {
+  if (responseStatus === STATUS.PENDING) return <Spinner size={size} />;
   return (
     <span className={`power-${state}`}>
       <PowerOffIcon id="power-status-icon" className={`power-${state}`} />
@@ -16,11 +16,13 @@ const PowerStatusIcon = ({ state, responseStatus }) => {
 PowerStatusIcon.propTypes = {
   responseStatus: PropTypes.string,
   state: PropTypes.string,
+  size: PropTypes.string,
 };
 
 PowerStatusIcon.defaultProps = {
   state: 'na',
   responseStatus: STATUS.PENDING,
+  size: 'md',
 };
 
 export default PowerStatusIcon;

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/PowerStatusSelectors.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/PowerStatusSelectors.js
@@ -1,0 +1,39 @@
+import { createSelector } from 'reselect';
+import {
+  selectAPIErrorMessage,
+  selectAPIResponse,
+  selectAPIStatus,
+} from '../../../../redux/API/APISelectors';
+
+const selectErrorMessage = (state, key) => selectAPIErrorMessage(state, key);
+
+const selectStateFromAPI = (state, key) => selectAPIResponse(state, key).state;
+
+const selectTitleFromAPI = (state, key) => selectAPIResponse(state, key).title;
+
+const selectStatusText = (state, key) =>
+  selectAPIResponse(state, key).statusText;
+
+export const selectState = createSelector(
+  selectStateFromAPI,
+  selectErrorMessage,
+  (state, error) => (error ? 'na' : state)
+);
+
+export const selectTitle = createSelector(
+  selectTitleFromAPI,
+  selectErrorMessage,
+  selectStatusText,
+  (title, error, statusText) => {
+    if (error) {
+      let errorTitle = error;
+      if (title || statusText) {
+        errorTitle = `${title} ${statusText}`.trim();
+      }
+      return errorTitle;
+    }
+    return statusText || title;
+  }
+);
+
+export const selectResponseStatus = (state, key) => selectAPIStatus(state, key);

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/actions.js
@@ -4,7 +4,7 @@ import { POWER_REQURST_KEY, SUPPORTED_POWER_STATES } from './constants';
 
 export const changeHostPower = (state, hostID) =>
   put({
-    key: POWER_REQURST_KEY,
+    key: `${POWER_REQURST_KEY}_${hostID}`,
     params: { power_action: state },
     url: `/api/hosts/${hostID}/power`,
     errorToast: err => sprintf(__('an error occurred: %s'), err),

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/constants.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/PowerStatus/constants.js
@@ -1,7 +1,7 @@
 import { translate as __ } from '../../../../common/I18n';
 
 export const POWER_REQURST_KEY = 'HOST_TOGGLE_POWER';
-export const POWER_REQUEST_OPTIONS = { key: POWER_REQURST_KEY, params: { timeout: 30 } };
+export const POWER_REQUEST_OPTIONS = { params: { timeout: 30 } };
 export const BASE_POWER_STATES = { off: __('Off'), on: __('On') };
 export const BMC_POWER_STATES = { soft: __('Reboot'), cycle: __('Reset') };
 export const SUPPORTED_POWER_STATES = {

--- a/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/DetailsCard/index.js
@@ -31,6 +31,7 @@ const DetailsCard = ({
   status,
   hostName,
   hostDetails: {
+    id: hostID,
     ip,
     ip6,
     mac,
@@ -48,7 +49,7 @@ const DetailsCard = ({
         <CardTitle>{__('Details')}</CardTitle>
         <CardActions>
           <PowerStatusDropDown
-            hostID={hostName}
+            hostID={hostID || hostName}
             hasPowerPermission={hasPowerPermission}
           />
         </CardActions>
@@ -184,6 +185,7 @@ DetailsCard.propTypes = {
   hostName: PropTypes.string,
   status: PropTypes.string,
   hostDetails: PropTypes.shape({
+    id: PropTypes.number,
     comment: PropTypes.string,
     hostgroup_name: PropTypes.string,
     hostgroup_id: PropTypes.number,
@@ -200,6 +202,7 @@ DetailsCard.defaultProps = {
   hostName: undefined,
   status: STATUS.PENDING,
   hostDetails: {
+    id: undefined,
     comment: undefined,
     hostgroup_name: undefined,
     hostgroup_id: undefined,

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -7,6 +7,7 @@ import BarChart from './common/charts/BarChart';
 import DonutChart from './common/charts/DonutChart';
 import LineChart from './common/charts/LineChart';
 import PowerStatus from './hosts/powerStatus/';
+import PowerStatusDropDown from './HostDetails/DetailsCard/PowerStatus/PowerStatusDropDown';
 import NotificationContainer from './notifications/';
 import ToastsList from './ToastsList/';
 import RelativeDateTime from './common/dates/RelativeDateTime';
@@ -124,6 +125,7 @@ const coreComponets = [
   { name: 'DonutChart', type: DonutChart },
   { name: 'LineChart', type: LineChart },
   { name: 'PowerStatus', type: PowerStatus },
+  { name: 'PowerStatusDropDown', type: PowerStatusDropDown },
   { name: 'NotificationContainer', type: NotificationContainer },
   { name: 'ToastNotifications', type: ToastsList },
   { name: 'StorageContainer', type: StorageContainer },


### PR DESCRIPTION
This patch eventually adjusts `PowerStatusDropDown` component to be re-used on hosts index page as power status column data.

After some manual testing I've noticed that it's pretty annoying to go to host's details page just to power on/off a host. Especially if I want to change the state for multiple hosts (a bulk action for that is also a good idea, but that I'd leave for a different PR)

This how it looks:

![power](https://user-images.githubusercontent.com/32508194/211825850-2f0ae584-6132-4f5f-811e-e581a6364e83.gif)

P.S. I think if we merge this, `PowerStatus` component currently used on hosts index page can be deleted.