### PR TITLE
Fixes #35938 - quote ks url when & present

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -36,17 +36,17 @@ description: |
   # both current and legacy syntax provided
   if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
     if subnet4 && !subnet4.dhcp_boot_mode?
-      options.push("inst.ks=#{foreman_url('provision', static: '1')}")
+      options.push("inst.ks='#{foreman_url('provision', static: '1')}'")
     elsif subnet6 && !subnet6.dhcp_boot_mode?
-      options.push("inst.ks=#{foreman_url('provision', static6: '1')}")
+      options.push("inst.ks='#{foreman_url('provision', static6: '1')}'")
     else
       options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
     end
   else
     if subnet4 && !subnet4.dhcp_boot_mode?
-      options.push("ks=#{foreman_url('provision', static: '1')}")
+      options.push("ks='#{foreman_url('provision', static: '1')}'")
     elsif subnet6 && !subnet6.dhcp_boot_mode?
-      options.push("ks=#{foreman_url('provision', static6: '1')}")
+      options.push("ks='#{foreman_url('provision', static6: '1')}'")
     else
       options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
     end  


### PR DESCRIPTION
Add some quotes to the foreman_url when there are extra options like static=1 present.

Should fix kickstarting a rhel 7 server. With the old template it boots to grub> prompt with no error present. 
