### PR TITLE
Fixes #35942 - pass from settings not encrypted

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -609,8 +609,12 @@ module Host
     end
 
     def password_base64_encrypted?
-      if root_pass_changed?
-        root_pass == hostgroup.try(:read_attribute, :root_pass)
+      hostgroup_root_pass = hostgroup.try(:read_attribute, :root_pass)
+
+      if self[:root_pass].blank? && hostgroup_root_pass.blank?
+        false
+      elsif root_pass_changed?
+        root_pass == hostgroup_root_pass
       else
         true
       end

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -273,7 +273,7 @@ class Hostgroup < ApplicationRecord
   end
 
   def password_base64_encrypted?
-    !root_pass_changed?
+    !(self[:root_pass].blank? && nested_root_pw.blank?) && !root_pass_changed?
   end
 
   def validate_subnet_types


### PR DESCRIPTION
Refs: #8878, #8887, #9038

In contrast to host and hostgroup `root_pass`, `Setting[:root_pass]` is not encrypted.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
