### PR TITLE
Fixes #35946 - windows pass-crypt modifies input

### DIFF
--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -19,7 +19,7 @@ class PasswordCrypt
     when 'Base64'
       result = Base64.strict_encode64(passwd)
     when 'Base64-Windows'
-      result = Base64.strict_encode64(passwd.concat("AdministratorPassword").encode('utf-16le'))
+      result = Base64.strict_encode64("#{passwd}AdministratorPassword".encode('utf-16le'))
     else
       result = passwd.crypt("#{ALGORITHMS[hash_alg]}#{generate_linux_salt}")
     end


### PR DESCRIPTION
Bug introduced in #7131
Relates to #9583

`concat()` also modifies the string it is called on. This will be `Setting[:root_pass]` if neither Host nor Hostgroup defines a value for `root_pass`.
Thus appending `AdministratorPassword` to the Setting everytime the `passw_crypt`-method is called.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
