### PR TITLE
Fixes #35949 - fix "change Puppet Master" path

### DIFF
--- a/app/views/hosts/select_multiple_puppet_proxy.html.erb
+++ b/app/views/hosts/select_multiple_puppet_proxy.html.erb
@@ -1,5 +1,5 @@
 <%= render 'selected_hosts', :hosts => @hosts %>
 
-<%= form_for :proxy, :url => update_multiple_puppet_proxy_hosts_path(:host_ids => params[:host_ids]) do |f| %>
+<%= form_for :proxy, :url => foreman_puppet.update_multiple_puppet_proxy_hosts_path(:host_ids => params[:host_ids]) do |f| %>
   <%= multiple_proxy_select(f, 'Puppet') %>
 <% end %>


### PR DESCRIPTION
After pressing the "change Puppet Master",
it will prompt a dialog and spin forever because of the missing path error.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
