### PR TITLE
Fixes #35956 - Close popovers on tab change

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -530,6 +530,9 @@ function onHostEditLoad() {
   $('#params-tab').on('shown', function() {
     mark_params_override();
   });
+  $('a[data-toggle="tab"]').on('shown.bs.tab', function (e) {
+    $('a[rel="popover"]').popover("destroy");
+  });
   if ($('#supports_update') && !$('#supports_update').data('supports-update'))
     disable_vm_form_fields();
   pxeLoaderCompatibilityCheck();


### PR DESCRIPTION
Previously, popovers opened in host form stuck around even after changing to a different tab. With this changes, the popovers get closed when switching to a different tab.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
