### PR TITLE
Fixes #35957 - Close template popovers on tab change

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -22,3 +22,4 @@
 //= link proxy_status.js
 //= link about.js
 //= link parameter_override.js
+//= link templates.js

--- a/app/assets/javascripts/templates.js
+++ b/app/assets/javascripts/templates.js
@@ -1,0 +1,5 @@
+$(document).on('ContentLoad', function() {
+  $('a[data-toggle=\"tab\"]').on('shown.bs.tab', function (e) {
+    $('a[rel="popover"]').popover("destroy");
+  });
+});

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -1,4 +1,5 @@
 <%= javascript_tag("$(document).on('ContentLoad', tfm.templateInputs.initTypeChanges)"); %>
+<%= javascript 'templates' %>
 
 <% url = if @template.persisted?
            public_send("#{@type_name_singular}_path", :id => @template)


### PR DESCRIPTION
Previously, popovers opened in template form stuck around even after changing to a different tab. With this changes, the popovers get closed when switching to a different tab.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
