### PR TITLE
Revert "Fixes #35890 - enable harmony mode with Uglifier to use ES6 syntax"

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,8 +12,8 @@ $(function() {
 
 // Prevents all links with the disabled attribute set to "disabled"
 // from being clicked.
-const handleDisabledClick = (event, element) => {
-  const disabled = element.disabled || $(element).attr('disabled') === 'disabled';
+var handleDisabledClick = function(event, element){
+  var disabled = element.disabled || $(element).attr('disabled') === 'disabled';
   if (disabled) event.preventDefault();
   return !disabled;
 }

--- a/app/assets/javascripts/hidden_values.js
+++ b/app/assets/javascripts/hidden_values.js
@@ -14,7 +14,8 @@ function hidden_value_control() {
   });
 }
 
-function replace_value_control(link, tag_type = a) {
+function replace_value_control(link, tag_type) {
+  var tag_type = tag_type || 'a'
   var link = $(link);
   link
     .find('.glyphicon')

--- a/app/assets/javascripts/hosts.js
+++ b/app/assets/javascripts/hosts.js
@@ -29,7 +29,7 @@ $(document).on('ContentLoad', function() {
     $('#build-review').click();
   });
 
-  const action_buttons = $('.btn-toolbar a')
+  var action_buttons = $('.btn-toolbar a')
     .not('.dropdown-toggle')
     .not('.dropdown-toggle > a');
   var wait_msg = $('#processing_message');
@@ -40,7 +40,9 @@ $(document).on('ContentLoad', function() {
     show: false,
   });
 
-  const is_in_array = (val, arr) => arr.indexOf(val) > -1;
+  var is_in_array = function(val, arr) {
+    return arr.indexOf(val) > -1;
+  };
 
   action_buttons.on('click', function() {
     if (this.id === 'delete-button' && !confirm($(this).attr('data-message')))

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Foreman::Application.configure do |app|
   config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', false) == 'true'
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = Uglifier.new(harmony: true)
+  config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
Reverts theforeman/foreman#9567

Failed in nightly https://community.theforeman.org/t/foreman-nightly-rpm-pipeline-1763-failed/31996

and as Evgeni stated there: "ES6 support in Uglifier is not [documented as production ready](https://github.com/lautis/uglifier/issues/142) (and not enabled by default), and it’s [recommended to use terser-ruby instead](https://github.com/lautis/uglifier/blob/master/README.md)?"

we can investigate about shifting to terser-ruby instead