### PR TITLE
Fixes #35893 - Pin to audited 5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 6.1.6'
 gem 'rest-client', '>= 2.0.0', '< 3', :require => 'rest_client'
-gem 'audited', '~> 5.0.0'
+gem 'audited', '~> 5.0', '!= 5.1.0'
 gem 'will_paginate', '~> 3.3'
 gem 'ancestry', '~> 4.0'
 gem 'scoped_search', '>= 4.1.10', '< 5'


### PR DESCRIPTION
In eb15f5eab69325edbae1147a58c53e9ffe9e17d8 audited was pinned because of a regression in 5.1.0. Version 5.2.0 fixes the regression introduced in 5.1.0, so this should be safe again. It does mark it incompatible with 5.1.0 to be sure it's not pulled in accidentally.