### PR TITLE
Fixes #35591 - Fix error missing attribute: fact_name_id when querying facts

### DIFF
--- a/app/controllers/api/v2/fact_values_controller.rb
+++ b/app/controllers/api/v2/fact_values_controller.rb
@@ -15,7 +15,7 @@ module Api
           no_timestamp_facts.
           search_for(*search_options).paginate(paginate_options).
           joins(:fact_name, :host).
-          select(:value, 'fact_names.name as factname', 'hosts.name as hostname')
+          select(:value, :fact_name_id, 'fact_names.name as factname', 'hosts.name as hostname')
 
         @fact_values = build_facts_hash(values)
       end


### PR DESCRIPTION
The `/api/fact_values` and `/api/host/<id>/facts` API are broken when using `?search=...` at the moment since 21fefa341f59fb2af63494aab5133e99d6a7e98b was introduced. 