### PR TITLE
Fixes #35593 - Use CentOS 8 Stream for container

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Foreman::Application.configure do |app|
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', false) == 'true'
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
       - POSTGRES_DATABASE=foreman
       - PGDATA=/var/lib/postgresql/data/pgdata
     hostname: db.example.com
-    image: postgres:10
+    image: postgres:12
     ports:
-      - 5432
+      - '5432'
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "nc -z 127.0.0.1 5432 || exit 1"]


### PR DESCRIPTION
Currently the container image is based on Fedora 33, but that's long EOL. Current Fedora versions have Ruby 3.1, but we're unable to use that. Changing it to CentOS 8 Stream is the closest match and also close to what we run in production.

It also updates to PostgreSQL 12 which we use in production.

To make docker-compose.yml compatible with podman-compose the port is changed to a string.

It should be noted that since 36be84a1cfae3c207f05975ba4cac8f448495a6f no assets are served anymore so effectively the UI can no longer be used. It now uses the RAILS_SERVE_STATIC_FILES env var that the container already set.

(cherry picked from commit 060eb9b37c6d59f0a5b41a32bd7f3d2bd7a632b9)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
