### PR TITLE
Fixes #36019 - Pass URL params to foreman_url as hash

### DIFF
--- a/app/views/unattended/provisioning_templates/discovery/debian_kexec.erb
+++ b/app/views/unattended/provisioning_templates/discovery/debian_kexec.erb
@@ -40,6 +40,6 @@ require:
 {
 "kernel": "<%= @kernel_uri %>",
 "initram": "<%= @initrd_uri %>",
-"append": "url=<%= foreman_url('provision') + "&static=yes" %> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.compact.join(' ') %>",
+"append": "url=<%= foreman_url('provision', { static: 'yes' })%> interface=<%= mac %> netcfg/get_ipaddress=<%= ip %> netcfg/get_netmask=<%= mask %> netcfg/get_gateway=<%= gw %> netcfg/get_nameservers=<%= dns %> netcfg/disable_dhcp=true netcfg/get_hostname=<%= @host.name %> BOOTIF=<%= bootif %> <%= options.compact.join(' ') %>",
 "extra": <%= extra %>
 }

--- a/app/views/unattended/provisioning_templates/discovery/redhat_kexec.erb
+++ b/app/views/unattended/provisioning_templates/discovery/redhat_kexec.erb
@@ -52,9 +52,9 @@ require:
 "initram": "<%= @initrd_uri %>",
 <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or
   (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
-  "append": "inst.ks=<%= foreman_url('provision') + "&static=yes" %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
+  "append": "inst.ks=<%= foreman_url('provision', { static: 'yes' }) %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
 <% else -%>
-  "append": "inst.ks=<%= foreman_url('provision') + "&static=yes" %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
+  "append": "inst.ks=<%= foreman_url('provision', { static: 'yes' }) %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
 <% end -%>
 "extra": <%= extra %>
 }


### PR DESCRIPTION
Some templates add URL params to the foreman_url like this:
`<%= foreman_url('provision') + "&static=yes" %>`

That cause issues when `token_duration` setting is set to `0`, 
generating URL `'.../unattended/provision&static=yes'`
instead of  `'.../unattended/provision?static=yes'`

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
