### PR TITLE
Clean up the Puppet unattended templates

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -108,20 +108,11 @@ EOF
 <% end -%>
 <% if os_family == 'Freebsd' -%>
 echo 'puppet_enable="YES"' >>/etc/rc.conf
-<% end -%>
-<% unless aio_enabled -%>
-<% if os_family == 'Debian' -%>
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-<%= bin_path %>/puppet agent --enable
-<% elsif os_family == 'Suse' -%>
+<% elsif os_family == 'Suse' && !aio_enabled -%>
 if [ -f "/etc/sysconfig/puppet" ]
 then
 /usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= host_puppet_server %>/ /etc/sysconfig/puppet
 fi
-<% end -%>
 <% end -%>
 <%#
 IMPORTANT NOTE: Setting "run-puppet-in-installer" is UNSUPPORTED!

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -137,7 +137,6 @@ $puppet_agent_args = @(
   "--config", "<%= etc_path %>\puppet.conf",
   "--onetime",
   <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : "\"--tags #{puppet_tags}\"," %>
-  <%= host_puppet_server.blank? ? '' : "\"--server #{host_puppet_server}\"," %>
   "--no-daemonize"
 )
 Start-Process '<%= bin_path %>\puppet' -ArgumentList $puppet_agent_args -Wait -NoNewWindow
@@ -151,7 +150,7 @@ echo "Performing initial full puppet run"
 <% else -%>
 echo "Performing initial puppet run for --tags <%= puppet_tags %>"
 <% end -%>
-<%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : "--tags #{puppet_tags}" %> <%= host_puppet_server.blank? ? '' : "--server #{host_puppet_server}" %> --no-daemonize
+<%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : "--tags #{puppet_tags}" %> --no-daemonize
 <%= bin_path %>/puppet resource service puppet enable=true
 <% if @host.provision_method == 'image' -%>
 <%= bin_path %>/puppet resource service puppet ensure=running

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -101,9 +101,7 @@ EOF
 
 <% if os_family == 'Redhat' -%>
 <% if os_major > 6 -%>
-puppet_unit=puppet
-/usr/bin/systemctl list-unit-files | grep -q puppetagent && puppet_unit=puppetagent
-/usr/bin/systemctl enable ${puppet_unit}
+/usr/bin/systemctl enable puppet
 <% else -%>
 /sbin/chkconfig --level 345 puppet on
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -99,13 +99,6 @@ EOF
 <% end -%>
 <% end -%>
 
-<% if os_family == 'Redhat' -%>
-<% if os_major > 6 -%>
-/usr/bin/systemctl enable puppet
-<% else -%>
-/sbin/chkconfig --level 345 puppet on
-<% end -%>
-<% end -%>
 <% if os_family == 'Freebsd' -%>
 echo 'puppet_enable="YES"' >>/etc/rc.conf
 <% elsif os_family == 'Suse' && !aio_enabled -%>
@@ -126,14 +119,11 @@ run-puppet-in-installer to true.
 
 Note, that this is an *unsupported mode of operation* and not supported by Foreman at all. You have been warned!
 %>
-<% if host_param_true?('run-puppet-in-installer') -%>
 <% if (os_name == 'Ubuntu' && os_major >= 15) || (os_name == 'Debian' && os_major >= 8) -%>
 # Puppet tries to detect the init system by checking the presence of the directory /run/systemd/system. That detection
-# fails in a chroot environment like the one the installer provides. See Puppet tickets PA-136 and PUP-5577
-#
-# We work around that here until it gets fixed in Puppet (probably never for Puppet 3.x)
+# fails in a chroot environment like the one the installer provides. See Puppet tickets PA-136, PUP-10963 and PUP-5577
+# We work around that here until it gets fixed in Puppet
 mkdir -p /run/systemd/system
-<% end -%>
 <% end -%>
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 <% if os_family == 'Windows' -%>
@@ -162,13 +152,7 @@ echo "Performing initial full puppet run"
 echo "Performing initial puppet run for --tags <%= puppet_tags %>"
 <% end -%>
 <%= bin_path %>/puppet agent --config <%= etc_path %>/puppet.conf --onetime <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : "--tags #{puppet_tags}" %> <%= host_puppet_server.blank? ? '' : "--server #{host_puppet_server}" %> --no-daemonize
-<% if os_family == 'Suse' || (os_name == 'Debian' && os_major > 8) || (os_name == 'Ubuntu' && os_major >= 15) -%>
-<% if os_family == 'Suse' -%>
 <%= bin_path %>/puppet resource service puppet enable=true
-<% else -%>
-systemctl enable puppet
-<% end -%>
-<% end -%>
 <% if @host.provision_method == 'image' -%>
 <%= bin_path %>/puppet resource service puppet ensure=running
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -56,7 +56,7 @@ else
 fi
 <% elsif os_family == 'Suse' -%>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
+rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppet-20250406
 rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppet
 <% end -%>
 <% if @host.provision_method == 'image' -%>


### PR DESCRIPTION
I'm pushing some work I did to clean up the Puppet set up in unattended installations. It's still incomplete, but it's better to push it than to let it rot on my local hard drive. Now I can at least refer others to it.

The original intention for this PR was to start assuming Puppet 6+ and default to AIO packaging, or even automatically detect the style by using `puppet config set`, rather than hardcoding paths. That also means to utilize `puppet ssl bootstrap` than to run an install in noop mode with non-existing tags.