### PR TITLE
Fixes #35701 - Export button should use selectable columns

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -273,16 +273,7 @@ module Api
       param :timeout, String, required: false, desc: N_("Timeout to retrieve the power status of the host in seconds. Default is 3 seconds.")
 
       def power_status
-        render json: PowerManager::PowerStatus.new(host: @host).power_state(params[:timeout])
-      rescue => e
-        Foreman::Logging.exception("Failed to fetch power status", e)
-
-        resp = {
-          id: @host.id,
-          statusText: _("Failed to fetch power status: %s") % e,
-        }
-
-        render json: resp.merge(PowerManager::PowerStatus::HOST_POWER[:na])
+        render json: PowerManager::PowerStatus.safe_power_state(@host, timeout: params[:timeout])
       end
 
       api :PUT, "/hosts/:id/boot", N_("Boot host from specified device")

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -912,7 +912,9 @@ class HostsController < ApplicationController
   end
 
   def csv_columns
-    [:name, :operatingsystem, :compute_resource_or_model, :hostgroup, :last_report]
+    Pagelets::Manager.pagelets_at("hosts/_list", 'hosts_table_column_header', filter: { selected: @selected_columns })
+      .map { |pagelet| pagelet.opts[:export_data] || pagelet.opts[:export_key] || pagelet.opts[:key] }
+      .flatten
   end
 
   def origin_intervals_query(compare_with)

--- a/app/services/csv_exporter.rb
+++ b/app/services/csv_exporter.rb
@@ -1,25 +1,59 @@
 require 'csv'
 
 module CsvExporter
-  def self.export(resources, columns, header = nil)
-    header ||= default_header(columns)
-    raise ArgumentError, "Columns and header row aren't the same length" unless columns.length == header.length
-    # need to save the current context as the enumerator is executed by a separate thread
-    context = Foreman::ThreadSession::Context.get
+  class ExportDefinition
+    attr_reader :label
 
-    Enumerator.new do |csv|
-      Foreman::ThreadSession::Context.set(**context)
-      csv << CSV.generate_line(header)
-      cols = columns.map { |c| c.to_s.split('.').map(&:to_sym) }
-      resources.uncached do
-        resources.reorder(nil).limit(nil).find_each do |obj|
-          csv << CSV.generate_line(cols.map { |c| c.inject(obj, :try) })
-        end
+    def initialize(key, label: nil, callback: nil)
+      @key = key.to_s.split('.').map(&:to_sym)
+      @label = label || derive_label(key)
+      @callback = callback
+    end
+
+    def derive_label(key)
+      key.to_s.titleize.gsub('.', ' - ')
+    end
+
+    def evaluate(object)
+      if @callback
+        @callback.call(object)
+      else
+        @key.inject(object, :try)
       end
     end
   end
 
-  def self.default_header(columns)
-    columns.map { |c| c.to_s.titleize }
+  class << self
+    def export(resources, columns, header = nil)
+      columns = preprocess_columns(columns)
+      header ||= default_header(columns)
+      raise ArgumentError, "Columns and header row aren't the same length" unless columns.length == header.length
+      # need to save the current context as the enumerator is executed by a separate thread
+      context = Foreman::ThreadSession::Context.get
+
+      Enumerator.new do |csv|
+        Foreman::ThreadSession::Context.set(**context)
+        csv << CSV.generate_line(header)
+        resources.uncached do
+          resources.reorder(nil).limit(nil).find_each do |obj|
+            csv << CSV.generate_line(columns.map { |c| c.evaluate(obj) }.flatten)
+          end
+        end
+      end
+    end
+
+    def preprocess_columns(columns)
+      columns.map do |column|
+        if column.is_a? ExportDefinition
+          column
+        else
+          ExportDefinition.new(column)
+        end
+      end
+    end
+
+    def default_header(columns)
+      columns.map(&:label)
+    end
   end
 end

--- a/app/services/power_manager/power_status.rb
+++ b/app/services/power_manager/power_status.rb
@@ -20,6 +20,19 @@ module PowerManager
       result
     end
 
+    def self.safe_power_state(host, timeout: DEFAULT_TIMEOUT)
+      new(host: host).power_state(timeout)
+    rescue => e
+      Foreman::Logging.exception("Failed to fetch power status", e)
+
+      resp = {
+        id: host.id,
+        statusText: _("Failed to fetch power status: %s") % e,
+      }
+
+      resp.merge(PowerManager::PowerStatus::HOST_POWER[:na])
+    end
+
     private
 
     def host_power_ping(result, timeout = DEFAULT_TIMEOUT)

--- a/config/initializers/foreman_register.rb
+++ b/config/initializers/foreman_register.rb
@@ -9,17 +9,18 @@ Pagelets::Manager.with_key 'hosts/_list' do |ctx|
   ctx.with_profile :general, _('General'), default: true do
     common_th_class = 'hidden-tablet hidden-xs'
     common_td_class = common_th_class + ' ellipsis'
-    add_pagelet :hosts_table_column_header, key: :power_status, label: _('Power'), sortable: false, width: '80px', class: 'ca'
+    add_pagelet :hosts_table_column_header, key: :power_status, label: _('Power'), sortable: false, width: '80px', class: 'ca',
+                export_data: CsvExporter::ExportDefinition.new(:power_status, callback: ->(host) { PowerManager::PowerStatus.safe_power_state(host)[:state] })
     add_pagelet :hosts_table_column_content, key: :power_status, class: 'ca', callback: ->(host) { react_component('PowerStatus', id: host.id, url: power_api_host_path(host)) }
-    add_pagelet :hosts_table_column_header, key: :name, label: _('Name'), sortable: true, width: '25%', locked: true
+    add_pagelet :hosts_table_column_header, key: :name, label: _('Name'), sortable: true, width: '24%', locked: true
     add_pagelet :hosts_table_column_content, key: :name, class: 'ellipsis', callback: ->(host) { name_column(host) }, locked: true
-    add_pagelet :hosts_table_column_header, key: :os_title, label: _('OS'), sortable: true, width: '17%', class: 'hidden-xs', attr_callbacks: { title: ->(host) { _('Operating system') } }
+    add_pagelet :hosts_table_column_header, key: :os_title, label: _('OS'), sortable: true, width: '17%', class: 'hidden-xs', attr_callbacks: { title: ->(host) { _('Operating system') } }, export_key: 'operatingsystem'
     add_pagelet :hosts_table_column_content, key: :os_title, class: 'hidden-xs ellipsis', callback: ->(host) { (icon(host.operatingsystem, size: "16x16") + " #{host.operatingsystem.to_label}").html_safe if host.operatingsystem }
     add_pagelet :hosts_table_column_header, key: :owner, label: _('Owner'), sortable: true, width: '8%', class: common_th_class
     add_pagelet :hosts_table_column_content, key: :owner, class: common_td_class, callback: ->(host) { host_owner_column(host) }
     add_pagelet :hosts_table_column_header, key: :hostgroup, label: _('Host group'), sortable: true, width: '15%', class: common_th_class
     add_pagelet :hosts_table_column_content, key: :hostgroup, class: common_th_class, callback: ->(host) { label_with_link host.hostgroup, 23, @hostgroup_authorizer }
-    add_pagelet :hosts_table_column_header, key: :boot_time, label: _('Boot time'), sortable: true, width: '10%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :boot_time, label: _('Boot time'), sortable: true, width: '10%', class: common_th_class, export_key: 'reported_data.boot_time'
     add_pagelet :hosts_table_column_content, key: :boot_time, callback: ->(host) { date_time_unless_empty(host.reported_data&.boot_time) }, class: common_td_class
     add_pagelet :hosts_table_column_header, key: :last_report, label: _('Last report'), sortable: true, default_sort: 'DESC', width: '10%', class: common_th_class
     add_pagelet :hosts_table_column_content, key: :last_report, class: common_td_class, callback: ->(host) { last_report_column(host) }
@@ -39,25 +40,25 @@ Pagelets::Manager.with_key 'hosts/_list' do |ctx|
   ctx.with_profile :reported_data, _('Reported data'), default: false do
     common_th_class = 'hidden-tablet hidden-xs'
     common_td_class = common_th_class + ' ellipsis'
-    add_pagelet :hosts_table_column_header, key: :model, label: _('Model'), sortable: true, width: '10%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :model, label: _('Model'), sortable: true, width: '10%', class: common_th_class, export_key: 'compute_resource_or_model'
     add_pagelet :hosts_table_column_content, key: :model, class: common_td_class, callback: ->(host) { host.compute_resource_or_model }
-    add_pagelet :hosts_table_column_header, key: :sockets, label: _('Sockets'), width: '5%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :sockets, label: _('Sockets'), width: '5%', class: common_th_class, export_key: 'reported_data.sockets'
     add_pagelet :hosts_table_column_content, key: :sockets, callback: ->(host) { host.reported_data&.sockets }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :cores, label: _('Cores'), width: '5%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :cores, label: _('Cores'), width: '5%', class: common_th_class, export_key: 'reported_data.cores'
     add_pagelet :hosts_table_column_content, key: :cores, callback: ->(host) { host.reported_data&.cores }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :ram, label: _('RAM'), width: '5%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :ram, label: _('RAM'), width: '5%', class: common_th_class, export_key: 'reported_data.ram'
     add_pagelet :hosts_table_column_content, key: :ram, callback: ->(host) { humanize_bytes(host.reported_data&.ram, from: :mega) }, class: common_td_class
     add_pagelet :hosts_table_column_header, key: :virtual, label: _('Virtual'), width: '5%', class: common_th_class
     add_pagelet :hosts_table_column_content, key: :virtual, callback: ->(host) { virtual?(host) }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :disks_total, label: _('Disks space'), width: '8%', class: common_th_class, attr_callbacks: { title: ->(host) { _('Disks total space') } }
+    add_pagelet :hosts_table_column_header, key: :disks_total, label: _('Disks space'), width: '8%', class: common_th_class, attr_callbacks: { title: ->(host) { _('Disks total space') } }, export_key: 'reported_data.disks_total'
     add_pagelet :hosts_table_column_content, key: :disks_total, callback: ->(host) { humanize_bytes(host.reported_data&.disks_total) }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :kernel_version, label: _('Kernel version'), width: '12%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :kernel_version, label: _('Kernel version'), width: '12%', class: common_th_class, export_key: 'reported_data.kernel_version'
     add_pagelet :hosts_table_column_content, key: :kernel_version, callback: ->(host) { host.reported_data&.kernel_version }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :bios_vendor, label: _('BIOS vendor'), width: '8%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :bios_vendor, label: _('BIOS vendor'), width: '8%', class: common_th_class, export_key: 'reported_data.bios_vendor'
     add_pagelet :hosts_table_column_content, key: :bios_vendor, callback: ->(host) { host.reported_data&.bios_vendor }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :bios_release_date, label: _('BIOS release date'), width: '10%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :bios_release_date, label: _('BIOS release date'), width: '10%', class: common_th_class, export_key: 'reported_data.bios_release_date'
     add_pagelet :hosts_table_column_content, key: :bios_release_date, callback: ->(host) { host.reported_data&.bios_release_date }, class: common_td_class
-    add_pagelet :hosts_table_column_header, key: :bios_version, label: _('BIOS version'), width: '12%', class: common_th_class
+    add_pagelet :hosts_table_column_header, key: :bios_version, label: _('BIOS version'), width: '12%', class: common_th_class, export_key: 'reported_data.bios_version'
     add_pagelet :hosts_table_column_content, key: :bios_version, callback: ->(host) { host.reported_data&.bios_version }, class: common_td_class
   end
 end

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -487,6 +487,8 @@ notice that `key` is mandatory, since we will present it to the user when select
 * `class` - additional html classes to put on the `<th>` element
 * `attr_callbacks` - a hash where the key is the name of html attribute, and the value is a function in the form `->(host) { attribute_value }`
 * `callback` - a function that receives the host model and returns html content for the `<th>` element: `->(host) { "<span>...</span>".html_safe }`
+* `export_key` - a string that is used to derive exported column's name and value from. Passing `reported_data.sockets` results into header called `Reported Data - Sockets` and value corresponding to the result of calling `host&.reported_data&.sockets`. Alternatively, for cases where WebUI columns aggregate multiple values, this can be an array of strings to split the values into their own columns in the export.
+* `export_data` - An instance (or an array of instances) of CsvExporter::ExportDefinition to be used when the data to be exported cannot be retrieved by a series of calls from the exported object. A lambda can be passed into it with the callback keyword argument. First positional argument is the key, a label can be derived from it unless provided explicitly with the label keyword argument.
 
 `hosts_table_column_content` supports the following attributes:
 

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -39,12 +39,13 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test "should get csv index with data" do
-    host = FactoryBot.create(:host, :with_hostgroup, :on_compute_resource, :with_reports)
+    User.current.table_preferences.create(name: 'hosts', columns: ['name', 'os_title', 'model', 'owner', 'hostgroup', 'last_report'])
+    host = FactoryBot.create(:host, :with_model, :with_hostgroup, :with_reports)
     get :index, params: { :format => 'csv', :search => "name = #{host.name}" }, session: set_session_user
     assert_response :success
     buf = response.stream.instance_variable_get(:@buf)
-    assert_equal "Name,Operatingsystem,Compute Resource Or Model,Hostgroup,Last Report\n", buf.next
-    assert_equal "#{host.name},#{host.operatingsystem},#{host.compute_resource.name},#{host.hostgroup},#{host.last_report}\n", buf.next
+    assert_equal "Name,Operatingsystem,Owner,Hostgroup,Last Report,Compute Resource Or Model\n", buf.next
+    assert_equal "#{host.name},#{host.operatingsystem},#{host.owner.name},#{host.hostgroup},#{host.last_report},#{host.compute_resource_or_model}\n", buf.next
     assert_raises StopIteration do
       buf.next
     end

--- a/test/unit/csv_exporter_test.rb
+++ b/test/unit/csv_exporter_test.rb
@@ -46,7 +46,7 @@ class CsvExporterTest < ActiveSupport::TestCase
   test 'calls nested methods on records' do
     host = FactoryBot.create(:host)
     result = CsvExporter.export(Host::Managed, [:name, 'location.name'])
-    assert_equal "Name,Location.Name\n", result.next
+    assert_equal "Name,Location - Name\n", result.next
     assert_equal "#{host.name},#{host.location.name}\n", result.next
     assert_raises StopIteration do
       result.next


### PR DESCRIPTION
Follows from where https://github.com/theforeman/foreman/pull/9529 left off.

As noted by @ofedoren, the original implementation didn't work for data obtained through associations of the main object. This should now be addressed.

However there is another issue, some selectable columns (such as errata counts in katello) stuff multiple values into a single column. I can imagine us either:
1) picking one of them in the export
2) somehow serializing all the values into the same column
3) expanding the single selected column into multiple columns in the export

Number 3 feels like the most correct one, but would also most likely need the biggest amount of changes. Opinions @ofedoren , @ShimShtein ?