### PR TITLE
Fixes #36077 - Let link from Content Hosts navigate to Host's Content tab

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -552,6 +552,9 @@ Foreman::Application.routes.draw do
 
   match 'host_statuses' => 'react#index', :via => :get
   constraints(id: /[^\/]+/) do
+    get 'new/hosts/:id/content', to: redirect('new/hosts/%{id}#/Content')
+  end
+  constraints(id: /[^\/]+/) do
     match 'new/hosts/:id' => 'react#index', :via => :get, :as => :host_details_page
   end
   get 'page-not-found' => 'react#index'


### PR DESCRIPTION
Links from Content Hosts should navigate to Host's Content tab.
Blocks https://github.com/Katello/katello/pull/10445.

Angular could not handle a link like: /new/hosts/:id#/Content