### PR TITLE
Fixes #36082 - Ensure character & is escaped on ks URL

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -39,19 +39,19 @@ description: |
   # both current and legacy syntax provided
   if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
     if subnet4 && !subnet4.dhcp_boot_mode?
-      options.push("inst.ks=#{foreman_url('provision', static: '1')}")
+      options.push("inst.ks=#{foreman_url('provision', static: '1').gsub('&','\\\\&')}")
     elsif subnet6 && !subnet6.dhcp_boot_mode?
-      options.push("inst.ks=#{foreman_url('provision', static6: '1')}")
+      options.push("inst.ks=#{foreman_url('provision', static6: '1').gsub('&','\\\\&')}")
     else
-      options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+      options.push("inst.ks=#{foreman_url('provision').gsub('&','\\\\&')}", "inst.ks.sendmac")
     end
   else
     if subnet4 && !subnet4.dhcp_boot_mode?
-      options.push("ks=#{foreman_url('provision', static: '1')}")
+      options.push("ks=#{foreman_url('provision', static: '1').gsub('&','\\\\&')}")
     elsif subnet6 && !subnet6.dhcp_boot_mode?
-      options.push("ks=#{foreman_url('provision', static6: '1')}")
+      options.push("ks=#{foreman_url('provision', static6: '1').gsub('&','\\\\&')}")
     else
-      options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
+      options.push("ks=#{foreman_url('provision').gsub('&','\\\\&')}", "kssendmac", "ks.sendmac")
     end  
   end
 


### PR DESCRIPTION
This changes will ensure that character & is properly escaped on any ks URL used for provisioning. 