### PR TITLE
Fixes #36084 - set config.action_mailer.raise_delivery_errors = true

### DIFF
--- a/app/jobs/template_render_job.rb
+++ b/app/jobs/template_render_job.rb
@@ -12,7 +12,7 @@ class TemplateRenderJob < ApplicationJob
       result = composer.render
       end_time = Time.now
       if composer.send_mail?
-        ReportMailer.report(composer_params, result, start: start_time, end: end_time).deliver_now
+        ReportMailer.report(composer_params, result, start: start_time, end: end_time).deliver_later
       else
         StoredValue.write(provider_job_id, result, expire_at: Time.now + 1.day)
         UINotifications::ReportFinished.new(composer, provider_job_id).deliver!

--- a/app/models/mail_notifications/mail_notification.rb
+++ b/app/models/mail_notifications/mail_notification.rb
@@ -47,10 +47,10 @@ class MailNotification < ApplicationRecord
     if args.last.is_a?(Hash) && args.last.has_key?(:users)
       options = args.pop
       options.delete(:users).each do |user|
-        mailer.constantize.send(method, *args, options.merge(:user => user)).deliver_now
+        mailer.constantize.send(method, *args, options.merge(:user => user)).deliver_later
       end
     else
-      mailer.constantize.send(method, *args).deliver_now
+      mailer.constantize.send(method, *args).deliver_later
     end
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,8 +13,7 @@ Foreman::Application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Foreman::Application.configure do |app|
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/initializers/mailer.rb
+++ b/config/initializers/mailer.rb
@@ -1,0 +1,3 @@
+ActionMailer::DeliveryJob.rescue_from(Net::SMTPSyntaxError) do |exception|
+  raise exception
+end

--- a/test/jobs/template_render_job_test.rb
+++ b/test/jobs/template_render_job_test.rb
@@ -20,7 +20,7 @@ class TemplateRenderJobTest < ActiveJob::TestCase
 
     it 'render report and delivers it to mail' do
       mailer = mock('mailer')
-      mailer.expects('deliver_now')
+      mailer.expects('deliver_later')
       composer_params = { 'foo' => 'bar', 'send_mail' => true, 'mail_to' => 'test@example.org', 'gzip' => true }
 
       ReportComposer.any_instance.expects('render').returns('result')

--- a/test/mailers/application_mailer_test.rb
+++ b/test/mailers/application_mailer_test.rb
@@ -28,7 +28,7 @@ class ApplicationMailerTest < ActiveSupport::TestCase
   end
 
   def mail(to = 'nobody@example.com', subject = 'Danger, Will Robinson!')
-    TestMailer.test(to, subject).deliver_now
+    TestMailer.test(to, subject).deliver_later
     ActionMailer::Base.deliveries.last
   end
 

--- a/test/mailers/audit_mailer_test.rb
+++ b/test/mailers/audit_mailer_test.rb
@@ -16,40 +16,40 @@ class AuditMailerTest < ActionMailer::TestCase
   end
 
   test 'Audit mail subject should be Audit summary' do
-    assert_not_nil(AuditMailer.summary(@options).deliver_now.subject)
-    assert_includes(AuditMailer.summary(@options).deliver_now.subject, _("Audit summary"))
+    assert_not_nil(AuditMailer.summary(@options).deliver_later.subject)
+    assert_includes(AuditMailer.summary(@options).deliver_later.subject, _("Audit summary"))
   end
 
   test 'Audit mail should support two mime-types' do
     # text is first, html second
-    assert_equal(AuditMailer.summary(@options).deliver_now.body.parts.length, 2)
-    assert_equal(AuditMailer.summary(@options).deliver_now.body.parts.first.content_type, "text/plain; charset=UTF-8")
-    assert_equal(AuditMailer.summary(@options).deliver_now.body.parts.last.content_type, "text/html; charset=UTF-8")
-    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, "<body")
+    assert_equal(AuditMailer.summary(@options).deliver_later.body.parts.length, 2)
+    assert_equal(AuditMailer.summary(@options).deliver_later.body.parts.first.content_type, "text/plain; charset=UTF-8")
+    assert_equal(AuditMailer.summary(@options).deliver_later.body.parts.last.content_type, "text/html; charset=UTF-8")
+    assert_includes(AuditMailer.summary(@options).deliver_later.body.parts.last.body, "<body")
   end
 
   test 'Audit mail should display query results' do
     @options[:query] = "action != #{@audit.action}"
-    refute_includes(AuditMailer.summary(@options).deliver_now.body.parts.first.body, "#{@audit.action}d")
+    refute_includes(AuditMailer.summary(@options).deliver_later.body.parts.first.body, "#{@audit.action}d")
   end
 
   test 'Audit mail should display total count of audits' do
     @options[:time] = '1973-01-13 00:12'
     count = Audit.all.count
     number_of = (Setting[:entries_per_page] > count) ? count : Setting[:entries_per_page]
-    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.first.body, "Displaying #{number_of} of #{count} audits")
+    assert_includes(AuditMailer.summary(@options).deliver_later.body.parts.first.body, "Displaying #{number_of} of #{count} audits")
   end
 
   test 'Audit html mail should include link to query' do
     @options[:time] = '1970-01-01'
     @options[:query] = 'action = create'
     query_should_be = CGI.escape(%(#{@options[:query]} and time >= "#{@options[:time]}"))
-    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, query_should_be)
+    assert_includes(AuditMailer.summary(@options).deliver_later.body.parts.last.body, query_should_be)
   end
 
   test 'Audit html mail should include correct id query' do
     @options[:query] = 'id = 21'
     query_should_be = CGI.escape(@options[:query])
-    assert_includes(AuditMailer.summary(@options).deliver_now.body.parts.last.body, query_should_be)
+    assert_includes(AuditMailer.summary(@options).deliver_later.body.parts.last.body, query_should_be)
   end
 end

--- a/test/mailers/host_mailer_test.rb
+++ b/test/mailers/host_mailer_test.rb
@@ -20,31 +20,31 @@ class HostMailerTest < ActionMailer::TestCase
   end
 
   test "mail should have the specified recipient" do
-    assert HostMailer.summary(@options).deliver_now.to.include?("admin@someware.com")
+    assert HostMailer.summary(@options).deliver_later.to.include?("admin@someware.com")
   end
 
   test "mail should have a subject" do
-    assert !HostMailer.summary(@options).deliver_now.subject.empty?
+    assert !HostMailer.summary(@options).deliver_later.subject.empty?
   end
 
   test "mail should have a body" do
-    assert !HostMailer.summary(@options).deliver_now.body.empty?
+    assert !HostMailer.summary(@options).deliver_later.body.empty?
   end
 
   test "mail should report at least one host" do
-    assert HostMailer.summary(@options).deliver_now.body.include?(@host.name)
+    assert HostMailer.summary(@options).deliver_later.body.include?(@host.name)
   end
 
   test "mail should report disabled hosts" do
     @host.enabled = false
     @host.save
-    assert HostMailer.summary(@options).deliver_now.body.include?(@host.name)
+    assert HostMailer.summary(@options).deliver_later.body.include?(@host.name)
   end
 
   test 'error_state sends mail with correct headers' do
     report = FactoryBot.create(:report)
     user = FactoryBot.create(:user, :with_mail)
-    mail = HostMailer.error_state(report, :user => user).deliver_now
+    mail = HostMailer.error_state(report, :user => user).deliver_later
     assert_includes mail.from, Setting["email_reply_address"]
     assert_includes mail.to, user.mail
     assert_includes mail.subject, report.host.name

--- a/test/models/mail_notification_test.rb
+++ b/test/models/mail_notification_test.rb
@@ -28,7 +28,7 @@ class MailNotificationTest < ActiveSupport::TestCase
     users = FactoryBot.create_pair(:user, :with_mail)
     mailer = FactoryBot.create(:mail_notification)
     mail = mock('mail')
-    mail.expects(:deliver_now).twice
+    mail.expects(:deliver_later).twice
     HostMailer.expects(:test_mail).with(:foo, :user => users[0]).returns(mail)
     HostMailer.expects(:test_mail).with(:foo, :user => users[1]).returns(mail)
     mailer.deliver(:foo, :users => users)


### PR DESCRIPTION
in case that delivery_method is "sendmail",
we should also check if the executable file exist. currently the mail can be seen as sent succesfully from the UI, although the executable to send it is missing


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
