### PR TITLE
Fixes #36018 - Added ellipsis for URL overflow in HTTP Proxy

### DIFF
--- a/app/views/http_proxies/index.html.erb
+++ b/app/views/http_proxies/index.html.erb
@@ -5,9 +5,9 @@
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
     <tr>
-      <th class="col-md-8"><%= sort :name, :as => s_('Name') %></th>
-      <th><%= _('URL') %></th>
-      <th><%= _('Actions') %></th>
+      <th class="col-md-4"><%= sort :name, :as => s_('Name') %></th>
+      <th class="col-md-6"><%= _('URL') %></th>
+      <th class="col-md-2"><%= _('Actions') %></th>
     </tr>
   </thead>
   <tbody>
@@ -16,8 +16,8 @@
         <td class="ellipsis">
           <%= link_to_if_authorized (http_proxy.name), hash_for_edit_http_proxy_path(:id => http_proxy).merge(:auth_object => http_proxy, :authorizer => authorizer) %>
         </td>
-        <td><%= http_proxy.url %></td>
-        <td class="col-md-1">
+        <td class="ellipsis"><%= http_proxy.url %></td>
+        <td>
           <%= action_buttons(display_delete_if_authorized hash_for_http_proxy_path(:id => http_proxy).merge(:auth_object => http_proxy, :authorizer => authorizer), :data => { :confirm => _("Delete %s?") % http_proxy.name }) %>
         </td>
       </tr>


### PR DESCRIPTION
Column sizes for each field previously was as shown in the screenshot below:-

![Screenshot from 2023-02-13 06-16-02](https://user-images.githubusercontent.com/115526987/218706820-35054a94-b570-4ec0-a4c0-bc7d13e939fe.png)

Changed the column width for the URL section and reduced it for the name section as name is comparatively smaller than the URL and also added the ellipsis for the overflow issue!


![Screenshot from 2023-02-14 05-23-38](https://user-images.githubusercontent.com/115526987/218708043-77866a88-2d4d-4f10-9bde-3a9f824cd6fa.png)



