### PR TITLE
Fixes #36107 - Suppress warnings from accessing undefined settings

### DIFF
--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -204,6 +204,6 @@ module DashboardHelper
 
   def origin_setting(origin, name)
     return nil unless origin
-    Setting[:"#{origin.downcase}_#{name}"]
+    SettingRegistry.instance.find(:"#{origin.downcase}_#{name}")&.value
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -182,7 +182,7 @@ class Host::Managed < Host::Base
   }
 
   scope :out_of_sync_for, lambda { |report_origin|
-    interval = Setting[:"#{report_origin.downcase}_interval"] || Setting[:outofsync_interval]
+    interval = SettingRegistry.instance.find(:"#{report_origin.downcase}_interval")&.value || Setting[:outofsync_interval]
     with_last_report_exceeded(interval.to_i.minutes)
       .not_disabled
       .with_last_report_origin(report_origin)
@@ -440,7 +440,7 @@ autopart"', desc: 'to render the content of host partition table'
   end
 
   def origin_interval
-    Setting[:"#{last_report.origin.downcase}_interval"] || 0
+    SettingRegistry.instance.find(:"#{last_report.origin.downcase}_interval")&.value || 0
   end
 
   def disabled?

--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -143,7 +143,7 @@ module HostStatus
 
     def out_of_sync_disabled?
       if last_report.origin
-        Setting[:"#{last_report.origin.downcase}_out_of_sync_disabled"]
+        SettingRegistry.instance.find(:"#{last_report.origin.downcase}_out_of_sync_disabled")&.value
       else
         false
       end

--- a/app/services/dashboard/data.rb
+++ b/app/services/dashboard/data.rb
@@ -81,7 +81,9 @@ module Dashboard
 
     def recent_hosts
       if settings[:origin] && settings[:origin] != 'All'
-        hosts.recent(Setting[:"#{settings[:origin].downcase}_interval"])
+        setting = :"#{settings[:origin].downcase}_interval"
+        interval = SettingRegistry.instance.find(setting)&.value
+        hosts.recent(interval)
       else
         hosts.recent
       end
@@ -98,7 +100,7 @@ module Dashboard
 
     def out_of_sync_enabled?
       return true if !settings[:origin] || settings[:origin] == 'All'
-      setting = Setting[:"#{settings[:origin].downcase}_out_of_sync_disabled"]
+      setting = SettingRegistry.instance.find(:"#{settings[:origin].downcase}_out_of_sync_disabled")&.value
       setting.nil? ? true : !setting
     end
   end


### PR DESCRIPTION
When Foreman is installed without puppet plugin, it still receives puppet report from installer run. Visiting dashboard then emits a lot of warning into logs as Foreman tries to access various puppet_* settings.

Alternatives:
- check if expected settings for a given origin exist and either use them or fall back to the global ones
- introduce a method behaving as `[]` without the warning and use that
- never emit the warning
