### PR TITLE
Fixes #36131 - Remove puppet params for non-integrated

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -47,14 +47,10 @@ pluginsync      = true
 report          = true
 <%- if host_puppet_ca_server.present? -%>
 ca_server       = <%= host_puppet_ca_server %>
-<%- elsif host_param('puppet_ca_server').present? -%>
-ca_server       = <%= host_param('puppet_ca_server') %>
 <%- end -%>
 certname        = <%= @host.certname %>
 <%- if host_puppet_server.present? -%>
 server          = <%= host_puppet_server %>
-<%- elsif host_param('puppet_server').present? -%>
-server       = <%= host_param('puppet_server') %>
 <%- end -%>
 <%- if host_puppet_environment.present? -%>
 environment     = <%= host_puppet_environment %>


### PR DESCRIPTION
This reverts commit 04a93af8dacb7cc0611d6e1489d0ce88cd3b6090 because eebd309f89c71567c2b7e6d4e4fc8f4b00d0edc6 fixed it properly.