### PR TITLE
Refs #34975 - fix kickstart_kernel_options.erb escaping

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -36,19 +36,19 @@ description: |
   # both current and legacy syntax provided
   if (is_fedora && os_major >= 33) || (rhel_compatible && os_major >= 9)
     if subnet4 && !subnet4.dhcp_boot_mode?
-      options.push("inst.ks=#{foreman_url('provision', static: '1')}")
+      options.push("inst.ks=#{foreman_url('provision', static: '1').gsub("&", "\\\\&")}")
     elsif subnet6 && !subnet6.dhcp_boot_mode?
-      options.push("inst.ks=#{foreman_url('provision', static6: '1')}")
+      options.push("inst.ks=#{foreman_url('provision', static6: '1').gsub("&", "\\\\&")}")
     else
-      options.push("inst.ks=#{foreman_url('provision')}", "inst.ks.sendmac")
+      options.push("inst.ks=#{foreman_url('provision').gsub("&", "\\\\&")}", "inst.ks.sendmac")
     end
   else
     if subnet4 && !subnet4.dhcp_boot_mode?
-      options.push("ks=#{foreman_url('provision', static: '1')}")
+      options.push("ks=#{foreman_url('provision', static: '1').gsub("&", "\\\\&")}")
     elsif subnet6 && !subnet6.dhcp_boot_mode?
-      options.push("ks=#{foreman_url('provision', static6: '1')}")
+      options.push("ks=#{foreman_url('provision', static6: '1').gsub("&", "\\\\&")}")
     else
-      options.push("ks=#{foreman_url('provision')}", "kssendmac", "ks.sendmac")
+      options.push("ks=#{foreman_url('provision').gsub("&", "\\\\&")}", "kssendmac", "ks.sendmac")
     end  
   end
 


### PR DESCRIPTION
fix for PR #9308 - for explanation see https://community.theforeman.org/t/foreman-uefi-provisioning-grub-failure/30577/5

(cherry picked from commit 42fd5e07a84ea7cd7524cefaf5489ca1f66c9094, https://github.com/theforeman/foreman/pull/9477)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
