### PR TITLE
Fixes #36135 - Correct host links in dashboard

### DIFF
--- a/app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb
+++ b/app/views/dashboard/_hosts_in_build_mode_widget_host_list.html.erb
@@ -8,7 +8,7 @@
   <tbody>
     <% hosts.each do |host| %>
       <tr>
-        <td class="ellipsis"><%= host_build_status_icon(host) %> <%= link_to host.name, host_path(host) %></td>
+        <td class="ellipsis"><%= host_build_status_icon(host) %> <%= link_to host.name, current_host_details_path(host) %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= host.owner %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= build_duration(host) %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= date_time_relative(host.token&.expires)%></td>

--- a/app/views/dashboard/_new_hosts_widget_host_list.html.erb
+++ b/app/views/dashboard/_new_hosts_widget_host_list.html.erb
@@ -9,7 +9,7 @@
   <tbody>
     <% hosts.each do |host| %>
       <tr>
-        <td class="ellipsis"><%= link_to host.name, host_path(host) %></td>
+        <td class="ellipsis"><%= link_to host.name, current_host_details_path(host) %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= safe_join([icon(host.operatingsystem, :size => '16x16'), host.operatingsystem.to_label]) if host.operatingsystem.present? %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= host.owner %></td>
         <td class="hidden-tablet hidden-xs ellipsis"><%= date_time_relative(host.created_at) %></td>


### PR DESCRIPTION
The links always pointed at the old host details page, ignoring the setting controlling whether new or old host details should be the default.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
