### PR TITLE
do not explicitly enable the ruby module in packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -29,7 +29,7 @@ jobs:
     trigger: pull_request
     targets:
       centos-stream-8:
-        additional_modules: "foreman:el8,ruby:2.7,nodejs:12"
+        additional_modules: "foreman:el8,nodejs:12"
         additional_repos:
           - http://koji.katello.org/releases/yum/foreman-nightly/el8/x86_64/
     module_hotfixes: true


### PR DESCRIPTION
we should get that via the foreman module


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
