### PR TITLE
Fixes #36159 - Duplicate hosts report template

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -124,19 +124,23 @@ module Foreman
 
       DEFAULT_ALLOWED_LOADERS = Foreman::Renderer::Scope::Macros::Loaders::LOADERS.map(&:first)
 
+      DEFAULT_DUPLICATE_FINDERS = [:duplicate_hosts]
+
       def initialize
         @allowed_variables = DEFAULT_ALLOWED_VARIABLES
         @allowed_global_settings = DEFAULT_ALLOWED_GLOBAL_SETTINGS
         @allowed_generic_helpers = DEFAULT_ALLOWED_GENERIC_HELPERS
         @allowed_host_helpers = DEFAULT_ALLOWED_HOST_HELPERS
         @allowed_loaders = DEFAULT_ALLOWED_LOADERS
+        @allowed_duplicate_finders = DEFAULT_DUPLICATE_FINDERS
       end
 
       attr_accessor :allowed_variables, :allowed_global_settings,
-        :allowed_generic_helpers, :allowed_host_helpers, :allowed_loaders
+        :allowed_generic_helpers, :allowed_host_helpers, :allowed_loaders,
+        :allowed_duplicate_finders
 
       def allowed_helpers
-        allowed_generic_helpers + allowed_host_helpers + allowed_loaders
+        allowed_generic_helpers + allowed_host_helpers + allowed_loaders + allowed_duplicate_finders
       end
     end
   end

--- a/app/services/foreman/renderer/scope/base.rb
+++ b/app/services/foreman/renderer/scope/base.rb
@@ -4,6 +4,7 @@ module Foreman
       class Base
         include Foreman::Renderer::Scope::Variables
         include Foreman::Renderer::Scope::Macros::Base
+        include Foreman::Renderer::Scope::Macros::Duplicates
         include Foreman::Renderer::Scope::Macros::Helpers
         include Foreman::Renderer::Scope::Macros::Loaders
         include Foreman::Renderer::Scope::Macros::TemplateLogging

--- a/app/services/foreman/renderer/scope/macros/duplicates.rb
+++ b/app/services/foreman/renderer/scope/macros/duplicates.rb
@@ -1,0 +1,32 @@
+module Foreman
+  module Renderer
+    module Scope
+      module Macros
+        module Duplicates
+          include Foreman::Renderer::Errors
+          extend ApipieDSL::Class
+
+          apipie :class, desc: 'Loader macros to find duplicate records' do
+            name 'Duplicate records'
+            sections only: %w[reports]
+          end
+
+          apipie :method, "Return count of duplicate hosts" do
+            required :attribute, String, desc: 'Attribute to group by.'
+            returns Hash
+            example 'duplicate_hosts("name") #=> { "hostname.example.com" => "23"}'
+          end
+          def duplicate_hosts(attribute)
+            sanitized = ActiveRecord::Base.sanitize_sql(attribute)
+
+            Host.authorized(:view_hosts)
+                .joins(:interfaces)
+                .group(sanitized)
+                .having("count(*) > 1")
+                .count
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/views/unattended/report_templates/hosts_duplicate.erb
+++ b/app/views/unattended/report_templates/hosts_duplicate.erb
@@ -1,0 +1,35 @@
+<%#
+name: Hosts - Duplicate
+snippet: false
+template_inputs:
+- name: attribute
+  required: true
+  input_type: user
+  description: Host attribute to group by
+  options: "Name\r\nFQDN\r\nIP\r\nIPv6\r\nMAC\r\nUUID"
+  advanced: false
+  value_type: plain
+  hidden_value: false
+model: ReportTemplate
+-%>
+<% attribute = case input('attribute')
+     when "IP"
+      'nics.ip'
+     when "IPv6"
+      'nics.ip6'
+     when "MAC"
+      'nics.mac'
+     when "UUID"
+      'uuid'
+     else
+      'name'
+  end
+-%>
+<%- report_headers 'Attribute', 'Count' -%>
+<%- duplicate_hosts(attribute).each do |value, count| -%>
+<%- report_row({
+      input('attribute') => value,
+      'Count': count
+    }) -%>
+<%- end -%>
+<%= report_render -%>


### PR DESCRIPTION
New report template for searching duplicate hosts
by host attribute, like :name, :ip or :mac.

Loader methods now accept sql sanitized group_by parameter.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
