### PR TITLE
Fixes #36177 - install additional-packages

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -140,6 +140,9 @@ description: |
 <% if puppet_enabled -%>
       <package>rubygem-puppet</package>
 <% end -%>
+<% if host_param('additional-packages').present? -%>
+      <%= host_param('additional-packages').split(" ").collect{|x| "<package>#{x}</package>" }.join("\n") %>
+<% end -%>
     </packages>
   </software>
   <users config:type="list">

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -170,6 +170,9 @@ description: |
 <% if spacewalk_enabled -%>
       <package>rhn-setup</package>
 <% end -%>
+<% if host_param('additional-packages').present? -%>
+      <%= host_param('additional-packages').split(" ").collect{|x| "<package>#{x}</package>" }.join("\n") %>
+<% end -%>
     </packages>
   </software>
   <users config:type="list">

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -45,6 +45,7 @@ description: |
   - encrypt_grub: boolean (default=false)
   - use_graphical_installer: boolean (default=false)
   - enable-remote-execution-pull: boolean (default=false)
+  - additional-packages: string (default=undef)
 
   Reference links:
   - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/installation_guide/s1-kickstart2-options
@@ -259,6 +260,9 @@ wget
 <% end -%>
 <% if host_param_true?('fips_enabled') -%>
 <%=   snippet 'fips_packages' %>
+<% end -%>
+<% if host_param('additional-packages').present? -%>
+<%= host_param('additional-packages').split(" ").join("\n") %>
 <% end -%>
 <%= section_end %>
 


### PR DESCRIPTION
The additional-packages parameter does already exist in pressed provisioning template and it would be good to have the same for kickstart and autoyast.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
