### PR TITLE
Template for Ubuntu autoinstall through iPXE

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
@@ -20,20 +20,13 @@ test_on:
 #
 <%
   efi_suffix = 'efi'
-  image_path = @preseed_path.sub(/\/?$/, '.iso')
-  options = []
-  options << 'ramdisk_size=1500000'
-  options << 'root=/dev/rd/0 rw auto'
-  options << "url=http://#{@preseed_server}#{image_path}"
-  options << 'cloud-config-url=/dev/null'
-  options << 'autoinstall'
 -%>
 
 set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %> <%= @kernel %> <%= options.compact.join(' ') %> "ds=nocloud-net;s=http://<%= foreman_request_addr %>/userdata/" <%= snippet('preseed_kernel_options_autoinstall').strip %>
+  linux<%= efi_suffix %> <%= @kernel %> root=/dev/rd/0 rw auto <%= snippet('preseed_kernel_options_autoinstall', variables: {add_userdata_quotes: true}).strip %>
   initrd<%= efi_suffix %> <%= @initrd %>
 }
 

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe_autoinstall.erb
@@ -1,6 +1,7 @@
+#!gpxe
 <%#
-kind: PXELinux
-name: Preseed default PXELinux Autoinstall
+kind: iPXE
+name: Preseed default iPXE Autoinstall
 model: ProvisioningTemplate
 oses:
 - ubuntu
@@ -24,10 +25,15 @@ test_on:
 # the official Ubuntu documentation and extract the files from the LiveCD (DVD) manually
 # and optionally update the KERNEL and INITRD lines in this template.
 #
-DEFAULT linux cloud-init autoinstall
-LABEL linux cloud-init autoinstall
-    KERNEL <%= @kernel %>
-    INITRD <%= @initrd %>
-    APPEND root=/dev/ram0 <%= snippet('preseed_kernel_options_autoinstall').strip %>
 
-<%= snippet_if_exists(template_name + " custom menu") %>
+<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
+<% kernel = boot_files_uris[0] -%>
+<% initrd = boot_files_uris[1] -%>
+
+kernel <%= kernel %> initrd=initrd root=/dev/rd/0 rw auto <%= snippet('preseed_kernel_options_autoinstall').strip %>
+
+initrd <%= initrd %>
+
+imgstat
+sleep 2
+boot

--- a/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options_autoinstall.erb
@@ -3,7 +3,11 @@ kind: snippet
 name: preseed_kernel_options_autoinstall
 model: ProvisioningTemplate
 snippet: true
-description: options for the kernel / preseed startup initialization 
+description: options for the kernel / preseed startup initialization
+oses:
+- ubuntu
+test_on:
+- ubuntu_autoinst4dhcp
 -%>
 <%
   hostname = @host.name
@@ -12,6 +16,8 @@ description: options for the kernel / preseed startup initialization
   mac = @host.provision_interface.mac
   subnet4 = iface.subnet
   subnet6 = iface.subnet6
+  image_path = @preseed_path.sub(/\/?$/, '.iso')
+  userdata_option = "ds=nocloud-net;s=http://#{foreman_request_addr}/userdata/#{mac ? mac + '/' : ''}"
   options = []
 
   if host_param('blacklist')
@@ -30,7 +36,18 @@ description: options for the kernel / preseed startup initialization
     options << "ip=[#{iface.ip6}]::[#{subnet6.gateway}]:[#{subnet6.mask}]:#{hostname}:#{iface.identifier}:none:[#{subnet6.dns_servers.join(']:[')}]"
   end
 
+  options << 'ramdisk_size=1500000'
+  options << 'fsck.mode=skip'
+  options << 'autoinstall'
+  options << "url=http://#{@preseed_server}#{image_path}"
+  options << 'cloud-config-url=/dev/null'
+  if @add_userdata_quotes
+    options << "\"#{userdata_option}\""
+  else
+    options << userdata_option
+  end
   options << 'console-setup/ask_detect=false'
+  options << "locale=#{host_param('lang') || 'en_US'}"
   options << 'localechooser/translation/warn-light=true'
   options << 'localechooser/translation/warn-severe=true'
   options << "hostname=#{hostname}"

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -79,3 +79,4 @@ files:
   - iPXE/ipxe_intermediate_script.erb
   - iPXE/kickstart_default_ipxe.erb
   - iPXE/preseed_default_ipxe.erb
+  - iPXE/preseed_default_ipxe_autoinstall.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -15,7 +15,7 @@ set default=0
 set timeout=10
 
 menuentry 'Preseed default PXEGrub2 Autoinstall' {
-  linuxefi boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz ramdisk_size=1500000 root=/dev/rd/0 rw auto url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null autoinstall "ds=nocloud-net;s=http://foreman.example.com/userdata/" ip=dhcp console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
+  linuxefi boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz root=/dev/rd/0 rw auto ip=dhcp ramdisk_size=1500000 fsck.mode=skip autoinstall url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null "ds=nocloud-net;s=http://foreman.example.com/userdata/00-f0-54-1a-7e-e0/" console-setup/ask_detect=false locale=en_US localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
   initrdefi boot/ubuntu-mirror-rf32u3HGTMZf-initrd
 }
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXELinux/Preseed_default_PXELinux_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -9,7 +9,6 @@
 # lang = en_US
 #   System locale
 #
-#
 # WARNING
 #
 # Foreman will not download the kernel/initramdisk to PXE automatically. Please follow
@@ -20,6 +19,6 @@ DEFAULT linux cloud-init autoinstall
 LABEL linux cloud-init autoinstall
     KERNEL boot/ubuntu-mirror-rf32u3HGTMZf-vmlinuz
     INITRD boot/ubuntu-mirror-rf32u3HGTMZf-initrd
-    APPEND root=/dev/ram0 ramdisk_size=1500000 fsck.mode=skip url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null ds=nocloud-net;s=http://foreman.example.com/userdata/ autoinstall ip=dhcp console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
+    APPEND root=/dev/ram0 ip=dhcp ramdisk_size=1500000 fsck.mode=skip autoinstall url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null ds=nocloud-net;s=http://foreman.example.com/userdata/00-f0-54-1a-7e-e0/ console-setup/ask_detect=false locale=en_US localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -1,0 +1,27 @@
+#!gpxe
+#
+# This file was deployed via 'Preseed default iPXE Autoinstall' template
+#
+# Supported host/hostgroup parameters:
+#
+# blacklist = module1, module2
+#   Blacklisted kernel modules
+#
+# lang = en_US
+#   System locale
+#
+# WARNING
+#
+# Foreman will not download the kernel/initramdisk to PXE automatically. Please follow
+# the official Ubuntu documentation and extract the files from the LiveCD (DVD) manually
+# and optionally update the KERNEL and INITRD lines in this template.
+#
+
+
+kernel http://archive.ubuntu.com/ubuntu/casper/vmlinuz initrd=initrd root=/dev/rd/0 rw auto ip=dhcp ramdisk_size=1500000 fsck.mode=skip autoinstall url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null ds=nocloud-net;s=http://foreman.example.com/userdata/00-f0-54-1a-7e-e0/ console-setup/ask_detect=false locale=en_US localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
+
+initrd http://archive.ubuntu.com/ubuntu/casper/initrd
+
+imgstat
+sleep 2
+boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options_autoinstall.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options_autoinstall.host4dhcp.snap.txt
@@ -1,3 +1,0 @@
-
-
-ip=dhcp console-setup/ask_detect=false localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-el7 domain=snap.example.com

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options_autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/preseed_kernel_options_autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -1,0 +1,3 @@
+
+
+ip=dhcp ramdisk_size=1500000 fsck.mode=skip autoinstall url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null ds=nocloud-net;s=http://foreman.example.com/userdata/00-f0-54-1a-7e-e0/ console-setup/ask_detect=false locale=en_US localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
fixes #36180 - iPXE provisioning template for Ubuntu autoinstall

Related discussion: https://community.theforeman.org/t/foreman-3-4-change-for-subiquity-breaks-generic-bootdisk-preseed-ipxe-install-of-ubuntu-20-04-and-above/32310

This template works with the new Ubuntu autoinstall mechanism but for iPXE, similarly to other autoinstall provisioning templates.

I have tested it with the bootdisk plugin using DHCP. I have not tested it through iPXE network boot or with static addresses but the static address code was taken from a working example in the above community discussion. 