### PR TITLE
pressed netplan provisioning template should treat no subnet consistently with finished template

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -11,7 +11,6 @@ oses:
 - Ubuntu
 -%>
 <% os_major = @host.operatingsystem.major.to_i -%>
-<% os_minor = @host.operatingsystem.minor.to_i -%>
 <%- -%>
 <%# Begin Ubuntu 18.04 and newer uses netplan instead of /etc/network/interfaces -%>
 <%- if os_major >= 20 -%>
@@ -34,7 +33,7 @@ oses:
                   :interface => bond,
                   :subnet => bond.subnet,
                   :subnet6 => bond.subnet6,
-                  :dhcp => bond.subnet.nil? ? false : bond.subnet.dhcp_boot_mode?,
+                  :dhcp => bond.subnet.nil? ? true : bond.subnet.dhcp_boot_mode?,
                   :dhcp6 => bond.subnet6.nil? ? false : bond.subnet.dhcp_boot_mode? }) -%>
   <%= result -%>
         interfaces: <%= bond.attached_devices_identifiers %>
@@ -60,7 +59,7 @@ oses:
                   :interface => bridge,
                   :subnet => bridge.subnet,
                   :subnet6 => bridge.subnet6,
-                  :dhcp => bridge.subnet.nil? ? false : bridge.subnet.dhcp_boot_mode?,
+                  :dhcp => bridge.subnet.nil? ? true : bridge.subnet.dhcp_boot_mode?,
                   :dhcp6 => bridge.subnet6.nil? ? false : bridge.subnet.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>
@@ -81,7 +80,7 @@ oses:
                   :interface => vlan,
                   :subnet => vlan.subnet,
                   :subnet6 => vlan.subnet6,
-                  :dhcp => vlan.subnet.nil? ? false : vlan.subnet.dhcp_boot_mode?,
+                  :dhcp => vlan.subnet.nil? ? true : vlan.subnet.dhcp_boot_mode?,
                   :dhcp6 => vlan.subnet6.nil? ? false : vlan.subnet.dhcp_boot_mode? }) -%>
   <%= result -%>
         id: <%= vlan.tag %>
@@ -95,7 +94,6 @@ oses:
 <%- next if bonding_interfaces.include?(interface.identifier) -%>
 <%- next if bridged_interfaces.include?(interface.identifier) -%>
 <%- next if vlans_interfaces.include?(interface.identifier) -%>
-  <%- interface_subnet = interface.subnet -%>
   <%- if !found -%>
   <%- found = true -%>
     ethernets:
@@ -104,7 +102,7 @@ oses:
                   :interface => interface,
                   :subnet => interface.subnet,
                   :subnet6 => interface.subnet6,
-                  :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode?,
+                  :dhcp => interface.subnet.nil? ? true : interface.subnet.dhcp_boot_mode?,
                   :dhcp6 => interface.subnet6.nil? ? false : interface.subnet.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>


### PR DESCRIPTION
fixes #36181 - pressed netplan provisioning template should treat no subnet consistently with finished template

This changes the netplan setup to output `dhcp4: true` if there is no ipv4 subnet. This matches how the preseed finished template does it and is IMHO correct.

I have not changed how `:dhcp6` is calculated. If the same change was applied there then the netplan would for have `dhcp6: true` on networks that probably don't want to use ipv6. And anyway, I do not have an ipv6 network on which to test and therefore don't want to change how that works. 

NOTE: I suspect there is another bug in the `preseed_netplan_setup.erb` template in that all the checks for the `:dhcp6` parameter look like the following:
```
:dhcp6 => bond.subnet6.nil? ? false : bond.subnet.dhcp_boot_mode?
```

I think the second reference to `.subnet` should be `.subnet6` like the first.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
