### PR TITLE
Fixes #36189 - Add AlmaLinux UEFI provisioning support

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_default_local_boot.erb
@@ -12,7 +12,7 @@ description: |
 <%
   # Grub1 only supports numeric default statement, this allows conversion to number. First define
   # array of directories we will search for EFI booloaders:
-  paths = ["fedora", "redhat", "centos", "rocky", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  paths = ["fedora", "redhat", "centos", "rocky", "almalinux", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
   # Add remaining entries to it and use this to convert to number:
   items = paths.push("local_chain_hd0")
   # Read default setting but since "local" is missing, use the first path available.

--- a/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub/pxegrub_global_default.erb
@@ -11,7 +11,7 @@ description: |
 <%
   # Grub1 only supports numeric default statement, this allows conversion to number. First define
   # array of directories we will search for EFI booloaders:
-  paths = ["fedora", "redhat", "centos", "rocky", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
+  paths = ["fedora", "redhat", "centos", "rocky", "almalinux", "debian", "ubuntu", "sles", "opensuse", "Microsoft", "EFI"]
   # Add remaining entries to it and use this to convert to number:
   items = paths.push("local_chain_hd0", "discovery")
   # Read default setting but since "local" is missing, use the first path available.

--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -18,6 +18,8 @@ description: |
     '/EFI/centos/grubx64.efi',
     '/EFI/rocky/shim.efi',
     '/EFI/rocky/grubx64.efi',
+    '/EFI/almalinux/shim.efi',
+    '/EFI/almalinux/grubx64.efi',
     '/EFI/debian/grubx64.efi',
     '/EFI/ubuntu/grubx64.efi',
     '/EFI/sles/grubx64.efi',

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -66,6 +66,11 @@ Medium.without_auditing do
       :path => "https://download.rockylinux.org/pub/rocky/$version/BaseOS/$arch/os",
     },
     {
+      :name => "AlmaLinux",
+      :os_family => "Redhat",
+      :path => "https://repo.almalinux.org/almalinux/$version/BaseOS/$arch/os/",
+    },
+    {
       :name => "CoreOS mirror",
       :os_family => "Coreos",
       :path => "http://$release-temporary-archive.release.core-os.net",

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_default_local_boot.host4dhcp.snap.txt
@@ -2,7 +2,7 @@
 default=0
 timeout=20
 
-fallback=1 2 3 4 5 6 7 8 9 10 11
+fallback=1 2 3 4 5 6 7 8 9 10 11 12
   
 title Chainload Grub from /EFI/fedora or try next
   rootnoverify (hd0,0)
@@ -19,6 +19,10 @@ title Chainload Grub from /EFI/centos or try next
 title Chainload Grub from /EFI/rocky or try next
   rootnoverify (hd0,0)
   chainloader /EFI/rocky/grubx64.efi
+  
+title Chainload Grub from /EFI/almalinux or try next
+  rootnoverify (hd0,0)
+  chainloader /EFI/almalinux/grubx64.efi
   
 title Chainload Grub from /EFI/debian or try next
   rootnoverify (hd0,0)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub/PXEGrub_global_default.host4dhcp.snap.txt
@@ -2,7 +2,7 @@
 default=0
 timeout=20
 
-fallback=1 2 3 4 5 6 7 8 9 10 11 12
+fallback=1 2 3 4 5 6 7 8 9 10 11 12 13
   
 title Chainload Grub from /EFI/fedora or try next
   rootnoverify (hd0,0)
@@ -19,6 +19,10 @@ title Chainload Grub from /EFI/centos or try next
 title Chainload Grub from /EFI/rocky or try next
   rootnoverify (hd0,0)
   chainloader /EFI/rocky/grubx64.efi
+  
+title Chainload Grub from /EFI/almalinux or try next
+  rootnoverify (hd0,0)
+  chainloader /EFI/almalinux/grubx64.efi
   
 title Chainload Grub from /EFI/debian or try next
   rootnoverify (hd0,0)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -103,6 +103,26 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
+  echo "Trying /EFI/almalinux/shim.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/almalinux/shim.efi
+  if [ -f ($chroot)/EFI/almalinux/shim.efi ]; then
+    chainloader ($chroot)/EFI/almalinux/shim.efi
+    echo "Found /EFI/almalinux/shim.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
+  echo "Trying /EFI/almalinux/grubx64.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/almalinux/grubx64.efi
+  if [ -f ($chroot)/EFI/almalinux/grubx64.efi ]; then
+    chainloader ($chroot)/EFI/almalinux/grubx64.efi
+    echo "Found /EFI/almalinux/grubx64.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
   # add --efidisk-only when using Software RAID

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -119,6 +119,26 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
+  echo "Trying /EFI/almalinux/shim.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/almalinux/shim.efi
+  if [ -f ($chroot)/EFI/almalinux/shim.efi ]; then
+    chainloader ($chroot)/EFI/almalinux/shim.efi
+    echo "Found /EFI/almalinux/shim.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
+  echo "Trying /EFI/almalinux/grubx64.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/almalinux/grubx64.efi
+  if [ -f ($chroot)/EFI/almalinux/grubx64.efi ]; then
+    chainloader ($chroot)/EFI/almalinux/grubx64.efi
+    echo "Found /EFI/almalinux/grubx64.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
   # add --efidisk-only when using Software RAID

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -99,6 +99,26 @@ menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
     sleep 2
     boot
   fi
+  echo "Trying /EFI/almalinux/shim.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/almalinux/shim.efi
+  if [ -f ($chroot)/EFI/almalinux/shim.efi ]; then
+    chainloader ($chroot)/EFI/almalinux/shim.efi
+    echo "Found /EFI/almalinux/shim.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
+  echo "Trying /EFI/almalinux/grubx64.efi "
+  unset chroot
+  # add --efidisk-only when using Software RAID
+  search --file --no-floppy --set=chroot /EFI/almalinux/grubx64.efi
+  if [ -f ($chroot)/EFI/almalinux/grubx64.efi ]; then
+    chainloader ($chroot)/EFI/almalinux/grubx64.efi
+    echo "Found /EFI/almalinux/grubx64.efi at $chroot, attempting to chainboot it..."
+    sleep 2
+    boot
+  fi
   echo "Trying /EFI/debian/grubx64.efi "
   unset chroot
   # add --efidisk-only when using Software RAID


### PR DESCRIPTION
This is a bit-for-bit copy of #9295, modified for AlmaLinux.

In pxegrub2_chainload.erb various paths are tried, but the /EFI/almalinux/grubx64.efi path is missing. This causes the server to refuse to boot.

To make it easier to use the AlmaLinux installation medium is added.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
