### PR TITLE
Fixes #36190 - add issued date to applied report template

### DIFF
--- a/app/views/unattended/report_templates/host_-_applied_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applied_errata.erb
@@ -53,7 +53,7 @@ require:
 - plugin: katello
   version: 3.12.0
 -%>
-<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'status' -%>
+<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'issued', 'status' -%>
 <%- load_errata_applications(filter_errata_type: input('Filter Errata Type'),
                              include_last_reboot: input('Include Last Reboot'),
                              since: input('Since'),


### PR DESCRIPTION
This PR is dependent on https://github.com/Katello/katello/pull/10441

when Applied errata report template is generated, it would look as below

~~~
date,hostname,erratum_id,erratum_type,issued,status
2023-02-01 13:40:12 +0530,client.example.com,RHSA-2022:8900,security,2022-12-08,success
2023-02-01 13:40:19 +0530,client.example.com,RHSA-2022:4803,security,2022-05-30,success
2023-02-01 13:49:20 +0530,client.example.com,RHBA-2021:4789,bugfix,2021-11-23,success
~~~
