### PR TITLE
Fixes #36153 - host_puppet_environment ignores host param

### DIFF
--- a/app/services/foreman/renderer/scope/macros/host_template.rb
+++ b/app/services/foreman/renderer/scope/macros/host_template.rb
@@ -73,7 +73,7 @@ module Foreman
           end
           def host_puppet_environment
             check_host
-            host.respond_to?(:environment) ? host.environment : host_param('puppet_environment')
+            host.try(:environment).presence || host_param('puppet_environment')
           end
 
           apipie :method, 'Checks whether a parameter value is truthly or not' do


### PR DESCRIPTION
If host responds to :environment, it always returns value of the :environment, ignoring the :puppet_environment host parameter.

Correct behavior is to check if :environment is set, and if not, then return the value of host parameter.

Fixes: 6414052b615fa57d3768ce3ea229cd9c31bb2dcf
(cherry picked from commit c7778b161cc4a380d60f30952a9a25f100af322e)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
