### PR TITLE
Fixes #36201 - Remove window.update_interface_table from vmware.js

### DIFF
--- a/webpack/assets/javascripts/compute_resource/vmware.js
+++ b/webpack/assets/javascripts/compute_resource/vmware.js
@@ -75,8 +75,6 @@ function fetchNetworks(url, clusterId) {
       $.each(response.results, (idx, value) => {
         $networkOptions.append(new Option(value.name, value.id, false, false));
       });
-
-      window.update_interface_table();
     },
     complete() {
       hideSpinner();


### PR DESCRIPTION
The error it triggers is: Uncaught TypeError: window.update_interface_table is not a function

I don't think this ever worked, and everything still seem to work in vmware. it probably wanted to update the interfaces section on the vmware page when changing clusters, but the code for that update_interface_table function exists in host_edit_interface.js which is not in the webpack directory which means we would need to export it from there and move those methods into webpack and assign them under the window.tfm object.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
