### PR TITLE
Fixes #36185 - Allow for Sequel::SQL::Blop data type

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -184,6 +184,7 @@ module Foreman
       ActiveSupport::HashWithIndifferentAccess,
       ActiveSupport::TimeZone,
       ActiveSupport::TimeWithZone,
+      Sequel::SQL::Blob,
     ]
 
     # enables JSONP support in the Rack middleware


### PR DESCRIPTION
GPG keys are exported as Sequel::SQL::Blop data type that needs to be explicitly allowed to be used by Psych since Rails 6.1.6.1  

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
