### PR TITLE
Fixes #36219 - use YAML.safe_load instead of YAML.load

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -804,7 +804,7 @@ module Foreman::Model
     end
 
     def valid_cloudinit_for_customspec?(cloudinit)
-      parsed = YAML.load(cloudinit)
+      parsed = YAML.safe_load(cloudinit)
       return false if parsed.nil?
       return true if parsed.is_a?(Hash)
       raise Foreman::Exception.new('The user-data template must be a hash in YAML format for VM customization to work.')

--- a/app/models/lookup_keys/lookup_key.rb
+++ b/app/models/lookup_keys/lookup_key.rb
@@ -177,7 +177,7 @@ class LookupKey < ApplicationRecord
     begin
       JSON.load value
     rescue
-      YAML.load value
+      YAML.safe_load(value, permitted_classes: [Symbol])
     end
   end
 

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,7 +62,7 @@ class Report < ApplicationRecord
   # extracts serialized metrics and keep them as a hash_with_indifferent_access
   def metrics
     return {} if self[:metrics].nil?
-    YAML.load(read_metrics).with_indifferent_access
+    YAML.safe_load(read_metrics).with_indifferent_access
   end
 
   # serialize metrics as YAML

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -105,7 +105,7 @@ class Setting < ApplicationRecord
   def value
     v = self[:value]
     v = decrypt_field(v)
-    v.nil? ? default : YAML.load(v)
+    v.nil? ? default : YAML.safe_load(v, permitted_classes: [Symbol, Pathname])
   end
   alias_method :value_before_type_cast, :value
 
@@ -130,7 +130,7 @@ class Setting < ApplicationRecord
     when "array"
       if val =~ /\A\[.*\]\Z/
         begin
-          self.value = YAML.load(val.gsub(/(\,)(\S)/, "\\1 \\2"))
+          self.value = YAML.safe_load(val.gsub(/(\,)(\S)/, "\\1 \\2"))
         rescue => e
           invalid_value_error e.to_s
         end

--- a/app/services/foreman/importer_puppetclass.rb
+++ b/app/services/foreman/importer_puppetclass.rb
@@ -29,7 +29,7 @@ class Foreman::ImporterPuppetclass
         begin
           return "json" if JSON.load value
         rescue
-          return "yaml" if YAML.load value
+          return "yaml" if YAML.safe_load value
         end
       end
       "string"

--- a/app/services/foreman/parameters/caster.rb
+++ b/app/services/foreman/parameters/caster.rb
@@ -107,13 +107,13 @@ module Foreman
       end
 
       def cast_yaml
-        YAML.load value
+        YAML.safe_load(value, permitted_classes: [Symbol])
       end
 
       def load_yaml_or_json
         return value unless value.is_a? String
         begin
-          YAML.load value
+          YAML.safe_load(value, permitted_classes: [Symbol])
         rescue Psych::SyntaxError
           JSON.load value
         end

--- a/lib/tasks/parameters.rake
+++ b/lib/tasks/parameters.rake
@@ -23,7 +23,6 @@ namespace :parameters do
   END_DESC
   task :cast_key_types_and_values => :environment do
     def override_key_type_and_value(param)
-      key_type_name = 'string'
       value = YAML.safe_load param.value
       key_type_name = value.is_a?(Hash) ? 'yaml' : find_key_type(value)
 

--- a/lib/tasks/parameters.rake
+++ b/lib/tasks/parameters.rake
@@ -24,7 +24,7 @@ namespace :parameters do
   task :cast_key_types_and_values => :environment do
     def override_key_type_and_value(param)
       key_type_name = 'string'
-      value = YAML.load param.value
+      value = YAML.safe_load param.value
       key_type_name = value.is_a?(Hash) ? 'yaml' : find_key_type(value)
 
       # Avoid updating parameter with true/false when param.value

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -24,40 +24,6 @@ namespace :puppet do
     end
   end
 
-  namespace :import do
-    desc "
-    Import your hosts classes and parameters classifications from another external node source.
-    define script=/dir/node as the script which provides the external nodes information.
-    This will only scan for hosts that already exists in our database, if you want to
-    import hosts, use one of the other importers.
-    YOU Must import your classes first!"
-
-    task :external_nodes => :environment do
-      User.as_anonymous_admin do
-        if Puppetclass.count == 0
-          $stdout.puts "You dont have any classes defined.. aborting!"
-          exit(1)
-        end
-
-        if (script = ENV['script']).nil?
-          $stdout.puts "You must define the old external nodes script to use. script=/path/node"
-          exit(1)
-        end
-
-        Host.find_each do |host|
-          $stdout.print "processing #{host.name} "
-          nodeinfo = YAML.safe_load `#{script} #{host.name}`
-          if nodeinfo.is_a?(Hash)
-            $stdout.puts "DONE" if host.importNode nodeinfo
-          else
-            $stdout.puts "ERROR: invalid output from external nodes"
-          end
-          $stdout.flush
-        end
-      end
-    end
-  end
-
   namespace :migrate do
     desc "
     Migrate Puppet configuration from Host and Hostgroup attributes to parameters.

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -15,7 +15,7 @@ namespace :puppet do
         name = yaml.match(/.*\/(.*).yaml/)[1]
         puts "Importing #{name}"
         puppet_facts = File.read(yaml)
-        facts_stripped_of_class_names = YAML.load(puppet_facts.gsub(/\!ruby\/object.*$/, ''))
+        facts_stripped_of_class_names = YAML.safe_load(puppet_facts.gsub(/\!ruby\/object.*$/, ''))
         User.as_anonymous_admin do
           host = Host::Managed.import_host(facts_stripped_of_class_names['name'], 'puppet')
           HostFactImporter.new(host).import_facts(facts_stripped_of_class_names['values'])
@@ -46,7 +46,7 @@ namespace :puppet do
 
         Host.find_each do |host|
           $stdout.print "processing #{host.name} "
-          nodeinfo = YAML.load `#{script} #{host.name}`
+          nodeinfo = YAML.safe_load `#{script} #{host.name}`
           if nodeinfo.is_a?(Hash)
             $stdout.puts "DONE" if host.importNode nodeinfo
           else

--- a/test/factories/reports_related.rb
+++ b/test/factories/reports_related.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     host
     reported_at { Time.now.utc }
     status { 0 }
-    metrics { YAML.load("--- \n  time: \n    schedule: 0.00083\n    service: 0.149739\n    mailalias: 0.000283\n    cron: 0.000419\n    config_retrieval: 16.3637869358063\n    package: 0.003989\n    filebucket: 0.000171\n    file: 0.007025\n    exec: 0.000299\n  resources: \n    total: 33\n  changes: {}\n  events: \n    total: 0") }
+    metrics { YAML.safe_load("--- \n  time: \n    schedule: 0.00083\n    service: 0.149739\n    mailalias: 0.000283\n    cron: 0.000419\n    config_retrieval: 16.3637869358063\n    package: 0.003989\n    filebucket: 0.000171\n    file: 0.007025\n    exec: 0.000299\n  resources: \n    total: 33\n  changes: {}\n  events: \n    total: 0") }
     type { 'ConfigReport' }
   end
 


### PR DESCRIPTION
as explained in this rubocop rule https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Security/YAMLLoad


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
