### PR TITLE
Fixes #36225 - fix Host Details path in config report

### DIFF
--- a/app/views/config_reports/show.html.erb
+++ b/app/views/config_reports/show.html.erb
@@ -16,7 +16,7 @@
 <%= render 'metrics', :status => @config_report.status, :metrics => @config_report.metrics["time"] if @config_report.metrics["time"] %>
 
 <%= title_actions display_delete_if_authorized(hash_for_config_report_path(:id => @config_report), :class=> "btn btn-danger"),
-  link_to(_("Host details"), @config_report.host, :class => 'btn btn-default'),
+  link_to(_("Host details"), current_host_details_path(@config_report.host), :class => 'btn btn-default'),
   link_to(_("Other reports for this host"), host_config_reports_path(@config_report.host), :class => 'btn btn-default')
 %>
 


### PR DESCRIPTION
- Host Details button of config report points to older host ui page as per [upstream issue #36225](https://projects.theforeman.org/issues/36225)
- So with this changes new host ui page will be rendered