### PR TITLE
Fixes #36228 - add installable option to errata reports

### DIFF
--- a/app/views/unattended/report_templates/host_-_applicable_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applicable_errata.erb
@@ -16,15 +16,23 @@ template_inputs:
   description: Limit the report only on errata found by this search query. Keep empty
     for report on all available errata.
   advanced: false
+- name: Installability
+  required: true
+  input_type: user
+  description: Select Applicable to show all applicable errata. Select Installable to show errata that are in the host's content view environment(s) and can thus be installed.
+  advanced: false
+  value_type: plain
+  options: "applicable\r\ninstallable"
+  default: "applicable"
 model: ReportTemplate
 require:
 - plugin: katello
-￼ version: 4.8.0
+￼ version: 4.9.0
 -%>
-<%- report_headers 'Host', 'Operating System', 'Environment', 'Erratum', 'Type', 'Published', 'Applicable since', 'Severity', 'Packages', 'CVEs', 'Reboot suggested' -%>
+<%- report_headers 'Host', 'Operating System', 'Environment', 'Erratum', 'Type', 'Published', 'Available since', 'Severity', 'Packages', 'CVEs', 'Reboot suggested' -%>
 <%- errata_filter = input('Errata filter') %>
 <%- load_hosts(search: input('Hosts filter'), preload: [:operatingsystem]).each_record do |host| -%>
-<%-   host_applicable_errata_filtered(host, errata_filter).each do |erratum| -%>
+<%-   (input('Installability') == 'applicable' ? host_applicable_errata_filtered(host, errata_filter) : host_installable_errata_filtered(host, errata_filter)).each do |erratum| -%>
 <%-     report_row(
           'Host': host.name,
           'Operating System': host.operatingsystem,
@@ -32,7 +40,7 @@ require:
           'Erratum': erratum.errata_id,
           'Type': erratum.errata_type,
           'Published': erratum.issued,
-          'Applicable since': erratum.created_at,
+          'Available since': erratum.created_at,
           'Severity': erratum.severity,
           'Packages': erratum.package_names,
           'CVEs': erratum.cves.map { |c| c.cve_id },

--- a/app/views/unattended/report_templates/host_-_registered_content_hosts.erb
+++ b/app/views/unattended/report_templates/host_-_registered_content_hosts.erb
@@ -10,22 +10,34 @@ template_inputs:
   advanced: false
   value_type: search
   resource_type: Host
+- name: Installability
+  required: true
+  input_type: user
+  description: Select Applicable to show all applicable errata. Select Installable to show errata that are in the host's content view environment(s) and can thus be installed.
+  advanced: false
+  value_type: plain
+  options: "applicable\r\ninstallable"
+  default: "applicable"
 model: ReportTemplate
 require:
 - plugin: katello
-￼ version: 3.9.0
+￼ version: 4.9.0
 -%>
-<%- report_headers 'Name', 'Ip', 'Operating System', 'Subscriptions', 'Applicable Errata', 'Owner', 'Kernel', 'Latest kernel available' -%>
+<%- if input('Installability') == 'applicable' -%>
+    <%- report_headers 'Name', 'Ip', 'Operating System', 'Subscriptions', 'Applicable Errata', 'Owner', 'Kernel', 'Latest kernel available' -%>
+<%- else -%>
+    <%- report_headers 'Name', 'Ip', 'Operating System', 'Subscriptions', 'Installable Errata', 'Owner', 'Kernel', 'Latest kernel available' -%>
+<%- end -%>
 <%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :subscriptions, :interfaces, :applicable_errata], preload: [:kernel_release, :owner]).each_record do |host| -%>
 <%-   report_row(
         'Name': host.name,
         'Ip': host.ip,
         'Operating System': host.operatingsystem,
         'Subscriptions': host_subscriptions_names(host),
-        'Applicable Errata': host_applicable_errata_ids(host),
+        'Errata': (input('Installability') == 'applicable' ? host_applicable_errata_ids(host) : host_installable_errata_ids(host)),
         'Owner': host.owner,
         'Kernel': host_kernel_release(host),
-        'Latest kernel available': host_latest_applicable_rpm_version(host, 'kernel')
+        'Latest kernel available': (input('Installability') == 'applicable' ? host_latest_applicable_rpm_version(host, 'kernel') : host_latest_installable_rpm_version(host, 'kernel'))
       ) -%>
 <%- end -%>
 <%= report_render -%>


### PR DESCRIPTION
Adds the ability to select if errata should be applicable or installable in two reports.

Test with a host that has both applicable and installable rpms.

Requires https://github.com/Katello/katello/pull/10497