### PR TITLE
Expired build token should return 401 instead of 412

### DIFF
--- a/app/services/foreman/unattended_installation/host_verifier.rb
+++ b/app/services/foreman/unattended_installation/host_verifier.rb
@@ -30,7 +30,7 @@ module Foreman
 
         errors << {
           message: N_('%{controller}: provisioning token for host %{host} expired'),
-          type: :precondition_failed,
+          type: :unauthorized,
           params: { host: @host.name, controller: controller_name },
         }
 

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -377,7 +377,7 @@ class UnattendedControllerTest < ActionController::TestCase
       @request.env["REMOTE_ADDR"] = @ub_host.ip
       @ub_host.create_token(:value => "expired_token", :expires => Time.now.utc - 1.minute)
       get :host_template, params: { :kind => 'provision'}
-      assert_response :precondition_failed
+      assert_response :unauthorized
     end
 
     test "should not find host by ip if token is present" do


### PR DESCRIPTION
Smart Proxy: https://github.com/theforeman/smart-proxy/pull/864
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
