### PR TITLE
Fixes #36244 - Notify user if he is trying to compare the same host

### DIFF
--- a/app/views/unattended/report_templates/host_-_compare_content_hosts_packages.erb
+++ b/app/views/unattended/report_templates/host_-_compare_content_hosts_packages.erb
@@ -21,7 +21,9 @@ require:
 -%>
 <%- packages = [] -%>
 <%- hosts = load_hosts(search: "name ^ (#{input('Host 1')}, #{input('Host 2')})").to_a.flatten -%>
-<%- if hosts.length != 2 -%>
+<%- if (input('Host 1') == input('Host 2')) -%>
+<%-   raise _("You are trying to compare the same host.") -%>
+<%- elsif hosts.length != 2 -%>
 <%-   raise _("At least one of the hosts couldn't be found") -%>
 <%- else -%>
 <%-   host1 = hosts.first -%>


### PR DESCRIPTION
"Host - compare content hosts packages" report template should restrict or notify if Host 1* and Host 2* name are the same


Fix for https://projects.theforeman.org/issues/36244 
<!---


Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
