### PR TITLE
#32795 - Update confirm modal in editor options

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorOptions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorOptions.js
@@ -1,14 +1,14 @@
 /* eslint-disable no-alert */
 import React from 'react';
 import PropTypes from 'prop-types';
-
 import { Button, Icon, FormControl } from 'patternfly-react';
-
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
+import store from '../../../../react_app/redux';
 import { translate as __ } from '../../../common/I18n';
 import { bindMethods } from '../../../common/helpers';
 import DiffToggle from '../../DiffView/DiffToggle';
 import EditorSettings from './EditorSettings';
+import { openConfirmModal } from '../../ConfirmModal';
 
 class EditorOptions extends React.Component {
   constructor(props) {
@@ -79,14 +79,19 @@ class EditorOptions extends React.Component {
               className="editor-button"
               id="undo-btn"
               onClick={() => {
-                if (
-                  window.confirm(
-                    'Are you sure you would like to revert all changes?'
-                  )
-                ) {
-                  revertChanges(template);
-                  if (selectedView !== 'input') changeTab('input');
-                }
+                store.dispatch(
+                  openConfirmModal({
+                    title: __('Revert Local Changes'),
+                    message: __(
+                      'Are you sure you would like to revert all changes?'
+                    ),
+                    isWarning: true,
+                    onConfirm: () => {
+                      revertChanges(template);
+                      if (selectedView !== 'input') changeTab('input');
+                    },
+                  })
+                );
               }}
               bsStyle="link"
             >

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/EditorOptions.test.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/EditorOptions.test.js
@@ -1,52 +1,58 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { mount } from '@theforeman/test';
-import { testComponentSnapshotsWithFixtures } from '../../../../common/testHelpers';
 
 import EditorOptions from '../EditorOptions';
 import { editorOptions, showBooleans } from '../../Editor.fixtures';
+import store from '../../../../redux';
+import ConfirmModal from '../../../ConfirmModal';
 
 const props = { ...editorOptions, ...showBooleans, isDiff: true };
 
-const fixtures = {
-  'renders EditorOptions': props,
-};
-
 describe('EditorOptions', () => {
-  describe('EditorOptions', () =>
-    testComponentSnapshotsWithFixtures(EditorOptions, fixtures));
-
-  describe('simulate onClick', () => {
+  it('simulate onClick', async () => {
     const toggleMaskValue = jest.fn();
     const changeTab = jest.fn();
     const revertChanges = jest.fn();
     jest.mock('../EditorOptions');
-    window.confirm = jest.fn(() => true);
 
     const diffWrapper = mount(
-      <EditorOptions
-        {...props}
-        changeTab={changeTab}
-        toggleMaskValue={toggleMaskValue}
-        revertChanges={revertChanges}
-        isDiff
-        selectedView="diff"
-      />
+      <Provider store={store}>
+        <EditorOptions
+          {...props}
+          changeTab={changeTab}
+          toggleMaskValue={toggleMaskValue}
+          revertChanges={revertChanges}
+          isDiff
+          selectedView="diff"
+        />
+        <ConfirmModal />
+      </Provider>
     );
 
     const inputWrapper = mount(
-      <EditorOptions
-        {...props}
-        changeTab={changeTab}
-        toggleMaskValue={toggleMaskValue}
-        revertChanges={revertChanges}
-        isDiff
-      />
+      <Provider store={store}>
+        <EditorOptions
+          {...props}
+          changeTab={changeTab}
+          toggleMaskValue={toggleMaskValue}
+          revertChanges={revertChanges}
+          isDiff
+        />
+      </Provider>
     );
 
     diffWrapper
       .find('#undo-btn')
       .at(0)
       .simulate('click');
+
+    expect(diffWrapper.text().includes('Revert Local Changes')).toBe(true);
+    diffWrapper
+      .find('button.pf-c-button.pf-m-danger')
+      .at(0)
+      .simulate('click');
+
     inputWrapper
       .find('#hide-btn')
       .at(0)
@@ -58,6 +64,6 @@ describe('EditorOptions', () => {
 
     expect(toggleMaskValue).toHaveBeenCalledTimes(1);
     expect(changeTab).toHaveBeenCalledTimes(1);
-    expect(window.confirm).toHaveBeenCalledTimes(1);
+    expect(revertChanges).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Update window.confirm dialog in editor options to PF4 confirmation modal.