### PR TITLE
remove warning that prometheus does not support multithreading

### DIFF
--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -112,7 +112,6 @@
   # prefix for all metrics
   :prefix: 'fm_rails'
   # prometheus endpoint is at /metrics
-  # warning: ruby client library currently does not supprt multi-process web servers
   :prometheus:
     :enabled: false
   # works with statsd_exporter too, use the rake task to generate config


### PR DESCRIPTION
prometheus-client supports multithreaded servers since 1.0 when configured with a DirectFileStore, which we do

Fixes: b50324b4e899d1aa201496568757a4c905826aad


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
