### PR TITLE
Fixes #36262 - allow newer prometheus-client gem

### DIFF
--- a/bundler.d/telemetry.rb
+++ b/bundler.d/telemetry.rb
@@ -1,4 +1,4 @@
 group :telemetry do
-  gem 'prometheus-client', '~> 1.0'
+  gem 'prometheus-client', '>= 1.0', '< 5'
   gem 'statsd-instrument', '< 3'
 end


### PR DESCRIPTION
While there were breaking changes, none of them affect us, so let's just allow the new versions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
