### PR TITLE
Fixes #36265 - Make redirect when editing host tad more reliable

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -176,10 +176,10 @@ function submit_with_all_params() {
     type: 'POST',
     url: $('form').attr('action'),
     data: serializeForm(),
-    success: function(response, _responseStatus, _jqXHR) {
+    success: function(response, _responseStatus, jqXHR) {
       // workaround for redirecting to the new host details page
       if (!response.includes('id="main"')) {
-        return tfm.nav.pushUrl(tfm.tools.foremanUrl('/new/hosts/' + construct_host_name()));
+        return tfm.nav.pushUrl(tfm.tools.foremanUrl(jqXHR.getResponseHeader('X-Request-Path')));
       }
 
       $('#host-progress').hide();

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -64,6 +64,7 @@ class HostsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
+        response.headers['X-Request-Path'] = request.path
         # filter graph time range
         @range = (params["range"].empty? ? 7 : params["range"].to_i)
 

--- a/app/controllers/react_controller.rb
+++ b/app/controllers/react_controller.rb
@@ -3,6 +3,7 @@ class ReactController < ApplicationController
   skip_before_action :authorize, :only => :index
 
   def index
+    response.headers['X-Request-Path'] = request.path
     render 'react/index'
   end
 end


### PR DESCRIPTION
When the form is submitted, we do a POST via ajax. The post the redirects to host details, JS follows the redirect and the success callback is executed only after the redirect is followed. ~~Here we assume we are redirected back to the edit page after the changes have been processed, meaning we can take the new hostname from the url.~~

Edit: That would be nice, but it is just wishful thinking. 

I was hoping we could access the Location header from the redirect, but as we get control after the redirect is followed, this doesn't seem to be possible.

What we however can do, is make the backend return back the path as a custom header. I cannot say I'm happy about it, but it is probably the most reliable option we have right now and it works for both the new and old host details page.

Follows changes introduced in f13142e9e

CC @ekohl You originally proposed the location header approach. Is there something I'm missing?

Alternatively, to absolutely reliable solution would be to just use IDs which don't change with edits instead of friendly ids