### PR TITLE
Fixes #35378 - Add systemd first boot service for host provisioning

### DIFF
--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -4,8 +4,9 @@ module HostStatus
     TOKEN_EXPIRED = 2
     BUILD_FAILED = 3
     BUILT = 0
+    RUNNING = 4
 
-    OK_STATUSES = [PENDING, BUILT]
+    OK_STATUSES = [PENDING, BUILT, RUNNING]
     WARN_STATUSES = []
     ERROR_STATUSES = [TOKEN_EXPIRED, BUILD_FAILED]
 
@@ -14,6 +15,7 @@ module HostStatus
       TOKEN_EXPIRED => N_("Token expired"),
       BUILD_FAILED => N_("Installation error"),
       BUILT => N_("Installed"),
+      RUNNING => N_("Host running"),
     }.freeze
 
     SEARCH = {
@@ -21,6 +23,7 @@ module HostStatus
       TOKEN_EXPIRED => 'build_status = token_expired',
       BUILD_FAILED => 'build_status = build_failed',
       BUILT => 'build_status = built',
+      RUNNING => 'build_status = running',
     }.freeze
 
     def self.status_name

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -361,6 +361,8 @@ sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/ker
 
 <%= snippet 'insights' if host_param_true?('host_registration_insights') && os_major < 9 -%>
 
+<%= snippet 'first_boot_setup' %>
+
 touch /tmp/foreman_built
 
 <% if host_param_true?('use_graphical_installer') -%>
@@ -388,12 +390,11 @@ The last post section halts Anaconda to prevent endless loop in case HTTP reques
 <%= snippet 'eject_cdrom' -%>
 
 if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
+echo "calling home: build is done!"
+<%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 else
-  echo "calling home: build failed!"
-  <%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
+echo "calling home: build failed!"
+<%= indent(2, skip1: true) { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 fi
-
 sync
 <%= section_end %>

--- a/app/views/unattended/provisioning_templates/snippet/first_boot_service.erb
+++ b/app/views/unattended/provisioning_templates/snippet/first_boot_service.erb
@@ -1,0 +1,20 @@
+<%#
+kind: snippet
+name: first_boot_service
+model: ProvisioningTemplate
+snippet: true
+description: |
+  Post replacement service
+-%>
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target

--- a/app/views/unattended/provisioning_templates/snippet/first_boot_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/first_boot_setup.erb
@@ -1,0 +1,29 @@
+<%#
+kind: snippet
+name: first_boot_setup
+model: ProvisioningTemplate
+snippet: true
+description: |
+  Post replacement for both systemd and non-systemd platforms
+-%>
+<%
+  os_major = @host.operatingsystem.major.to_i
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
+  has_systemd = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7) || (@host.operatingsystem.name == 'Ubuntu' && os_major >= 15) || (@host.operatingsystem.name == 'Debian' && os_major >= 8)
+-%>
+<% if has_systemd -%>
+  <%= save_to_file('/etc/systemd/system/first_boot_service.service', snippet('first_boot_service')) %>
+  <%= save_to_file('/root/first_boot_script.sh', snippet('running', :variables => { })) %>
+
+  systemctl enable first_boot_service
+<% else -%>
+  <%= save_to_file('/root/first_boot_script.sh', snippet('running', :variables => { }) +
+    "\nmv /root/first_boot_script.sh /root/first_boot_script.disabled") %>
+  <%= save_to_file('/etc/init.d/first_boot_setup', snippet('first_boot_initd')) %>
+
+  chmod +x /etc/init.d/first_boot_setup
+  chkconfig --add /etc/init.d/first_boot_setup
+  chkconfig --level 2345 first_boot_setup on
+<% end -%>
+
+chmod +x /root/first_boot_script.sh

--- a/app/views/unattended/provisioning_templates/snippet/fist_boot_initd.erb
+++ b/app/views/unattended/provisioning_templates/snippet/fist_boot_initd.erb
@@ -1,0 +1,34 @@
+<%#
+kind: snippet
+name: first_boot_initd
+model: ProvisioningTemplate
+snippet: true
+description: |
+  Post replacement initd script
+-%>
+#! /bin/bash
+
+### BEGIN INIT INFO
+# Provides:          RedHat
+# Required-Start:    $local_fs $network
+# Required-Stop:     $local_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Execute first boot script
+# Description:       Execute first boot script which executes after machine is successfully built for the first time.
+### END INIT INFO
+
+# Source function library
+. /etc/rc.d/init.d/functions
+
+##Service start/stop functions##
+start() {
+/tmp/first_boot_script
+chkconfig --del first_boot_setup
+}
+
+start
+
+exit 5
+esac
+exit $?

--- a/app/views/unattended/provisioning_templates/snippet/running.erb
+++ b/app/views/unattended/provisioning_templates/snippet/running.erb
@@ -1,0 +1,27 @@
+<%#
+kind: snippet
+name: running
+model: ProvisioningTemplate
+snippet: true
+description: |
+  Sends 'running' request to Foreman to indicate that the host is running.
+-%>
+<%
+  endpoint = @endpoint || 'change-status'
+  method = @method || 'GET'
+  base_url = foreman_url(endpoint)
+  url = base_url.split('?').first + '/' + @host.mac + '/' + 4.to_s
+  curl_opts = ["-H 'Content-Type: text/plain'"]
+  wget_opts = ["--header 'Content-Type: text/plain'"]
+  if url.start_with?('https')
+    curl_opts << "--insecure"
+    wget_opts << "--no-check-certificate"
+  end
+-%>
+if [ -x /usr/bin/curl ]; then
+/usr/bin/curl -o /dev/null --noproxy \* <%= curl_opts.join(' ') %> --silent '<%= url %>'
+elif [ -x /usr/bin/wget ]; then
+/usr/bin/wget -q -O /dev/null --no-proxy --method <%= method %> <%= wget_opts.join(' ') %> '<%= url %>'
+else
+wget -q -O /dev/null --header 'Content-Type: text/plain' '<%= url %>'
+fi

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,6 +472,7 @@ Foreman::Application.routes.draw do
   post 'unattended/failed/(:id(:format))', controller: 'unattended', action: 'failed', format: 'text'
   # get for all unattended scripts
   get 'unattended/(:kind/(:id(:format)))', controller: 'unattended', action: 'host_template', format: 'text'
+  get 'unattended/change-status/:mac/:status', controller: 'unattended', action: 'change_host_status', format: 'text'
 
   get 'userdata/(:mac)/user-data', controller: 'userdata', action: 'userdata', format: 'text'
   get 'userdata/(:mac)/meta-data', controller: 'userdata', action: 'metadata', format: 'text'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -164,6 +164,35 @@ systemctl enable ansible-callback
 
 
 
+  cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+  cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+EOF-76fe21d9
+
+  systemctl enable first_boot_service
+
+chmod +x /root/first_boot_script.sh
+
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -179,16 +208,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-else
+if ! test -f /tmp/foreman_built; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -164,6 +164,35 @@ systemctl enable ansible-callback
 
 
 
+  cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+  cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+EOF-76fe21d9
+
+  systemctl enable first_boot_service
+
+chmod +x /root/first_boot_script.sh
+
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -179,16 +208,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-else
+if ! test -f /tmp/foreman_built; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -164,6 +164,35 @@ systemctl enable ansible-callback
 
 
 
+  cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+  cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+EOF-76fe21d9
+
+  systemctl enable first_boot_service
+
+chmod +x /root/first_boot_script.sh
+
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -179,16 +208,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-else
+if ! test -f /tmp/foreman_built; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -164,6 +164,35 @@ systemctl enable ansible-callback
 
 
 
+  cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+  cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+EOF-76fe21d9
+
+  systemctl enable first_boot_service
+
+chmod +x /root/first_boot_script.sh
+
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -179,16 +208,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-else
+if ! test -f /tmp/foreman_built; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -164,6 +164,35 @@ systemctl enable ansible-callback
 
 
 
+  cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+  cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+EOF-76fe21d9
+
+  systemctl enable first_boot_service
+
+chmod +x /root/first_boot_script.sh
+
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -179,16 +208,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-else
+if ! test -f /tmp/foreman_built; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -157,6 +157,35 @@ systemctl enable ansible-callback
 
 
 
+  cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+  cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+EOF-76fe21d9
+
+  systemctl enable first_boot_service
+
+chmod +x /root/first_boot_script.sh
+
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -172,16 +201,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --no-proxy --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-else
+if ! test -f /tmp/foreman_built; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null --noproxy \* -H 'Content-Type: text/plain' --data @/root/install.post.log --silent 'http://foreman.example.com/unattended/failed'


### PR DESCRIPTION
This PR implements some improvements suggested in [RFC - Systemd first boot service for host provisioning](https://community.theforeman.org/t/rfc-systemd-first-boot-service-for-host-provisioning/29892).

The main one is reducing `%post` section and moving some of it to service which is going to run after the first reboot of the machine. 
This should also ensure that the callback to foreman indicating that the build is done is going to be made only from a machine that successfully rebooted and is ready to use.

This solution was successfully tested on Centos 7, Stream 8 and Stream 9 with libvirt.