### PR TITLE
Fixes #36280 - Persist attributes on os_select

### DIFF
--- a/webpack/assets/javascripts/foreman_hosts.js
+++ b/webpack/assets/javascripts/foreman_hosts.js
@@ -29,7 +29,13 @@ export function registerPluginAttributes(componentType, attributes) {
 export function getAttributesToPost(componentType) {
   const defaultAttributes = {
     architecture: ['architecture_id', 'organization_id', 'location_id'],
-    os: ['operatingsystem_id', 'organization_id', 'location_id'],
+    os: [
+      'operatingsystem_id',
+      'organization_id',
+      'location_id',
+      'ptable_id',
+      'medium_id',
+    ],
     medium: ['medium_id', 'operatingsystem_id', 'architecture_id'],
     image: ['medium_id', 'operatingsystem_id', 'architecture_id', 'model_id'],
   };

--- a/webpack/assets/javascripts/foreman_hosts.test.js
+++ b/webpack/assets/javascripts/foreman_hosts.test.js
@@ -19,6 +19,8 @@ describe('getAttributesToPost', () => {
       'operatingsystem_id',
       'organization_id',
       'location_id',
+      'ptable_id',
+      'medium_id',
     ]);
   });
 
@@ -28,6 +30,8 @@ describe('getAttributesToPost', () => {
       'operatingsystem_id',
       'organization_id',
       'location_id',
+      'ptable_id',
+      'medium_id',
       'foo',
     ]);
   });


### PR DESCRIPTION
Changing os in hostgroup edit form triggers an ajax call to /hostgroups/os_selected and the response is used as a new set of fields to be displayed in the form. However, some values from the form were not passed to the backend as part of this request so certain values, namely partition table and selected media, could get lost.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
