### PR TITLE
Fixes #36292 - show placeholder in host details card values

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Details/Cards/SystemProperties/index.js
@@ -118,17 +118,36 @@ const SystemPropertiesCard = ({ status, hostDetails }) => {
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>{__('Owner type')}</DescriptionListTerm>
-          <DescriptionListDescription>{ownerType}</DescriptionListDescription>
+          <DescriptionListDescription>
+            <SkeletonLoader
+              status={status}
+              emptyState={<DefaultLoaderEmptyState />}
+            >
+              {ownerType}
+            </SkeletonLoader>
+          </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>{__('Organization')}</DescriptionListTerm>
           <DescriptionListDescription>
-            {organization}
+            <SkeletonLoader
+              status={status}
+              emptyState={<DefaultLoaderEmptyState />}
+            >
+              {organization}
+            </SkeletonLoader>
           </DescriptionListDescription>
         </DescriptionListGroup>
         <DescriptionListGroup>
           <DescriptionListTerm>{__('Location')}</DescriptionListTerm>
-          <DescriptionListDescription>{location}</DescriptionListDescription>
+          <DescriptionListDescription>
+            <SkeletonLoader
+              status={status}
+              emptyState={<DefaultLoaderEmptyState />}
+            >
+              {location}
+            </SkeletonLoader>
+          </DescriptionListDescription>
         </DescriptionListGroup>
         <Slot
           id="host-details-tab-properties-3"


### PR DESCRIPTION
Show `Not available` if the owner type, location, or organization value is missing.
Adding this for consistency.
example:
![image](https://user-images.githubusercontent.com/30431079/231424730-d1a6d195-966f-4d1b-b4ce-a081b71ef36b.png)
