### PR TITLE
Fixes #36305 - Pin sass version to 1.60.z to avoid node 14 dependency

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -31,7 +31,8 @@
         "webpack-bundle-analyzer",
         "webpack-dev-server",
         "webpack-dev-server-without-h2",
-        "tabbable"
+        "tabbable",
+	"sass"
     ],
     "EXCLUDE_NPM_PREFIXES": [
         "@babel/eslint-",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "webpack-bundle-analyzer": ">=3.3.2",
     "webpack-dev-server-without-h2": "^2.11.8",
     "webpack-stats-plugin": "^0.1.5",
-    "tabbable": "~5.2.0"
+    "tabbable": "~5.2.0",
+    "sass": "~1.60.0"
   }
 }


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Opening this to pin sass in foreman instead of foreman-js: https://github.com/theforeman/foreman-js/pull/464