### PR TITLE
Fixes #36309 - Increase LDAP auth source password length limit

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -32,7 +32,7 @@ class AuthSourceLdap < AuthSource
   validates :host, :presence => true, :length => {:maximum => 60}
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :presence => true, :if => proc { |auth| auth.onthefly_register? }
   validates :attr_login, :attr_firstname, :attr_lastname, :attr_mail, :length => {:maximum => 30}, :allow_nil => true
-  validates :account_password, :length => {:maximum => 60}, :allow_nil => true
+  validates :account_password, :length => {:maximum => 69}, :allow_nil => true
   validates :port, :presence => true, :numericality => {:only_integer => true}
   validates :server_type, :presence => true, :inclusion => { :in => SERVER_TYPES.keys.map(&:to_s) }
   validate :validate_ldap_filter, :unless => proc { |auth| auth.ldap_filter.blank? }

--- a/test/models/auth_sources/auth_source_ldap_test.rb
+++ b/test/models/auth_sources/auth_source_ldap_test.rb
@@ -19,7 +19,7 @@ class AuthSourceLdapTest < ActiveSupport::TestCase
   should allow_value("key=#{'a' * 256}").for(:ldap_filter)
   should validate_length_of(:name).is_at_most(60)
   should validate_length_of(:host).is_at_most(60)
-  should validate_length_of(:account_password).is_at_most(60)
+  should validate_length_of(:account_password).is_at_most(69)
   should validate_length_of(:account).is_at_most(255)
   should validate_length_of(:base_dn).is_at_most(255)
   should validate_length_of(:attr_login).is_at_most(30)


### PR DESCRIPTION
The database field is 255 characters long, but the encryption adds quite a lot of fluff. From my testing, 69 characters is the longest password than can fit in.

Both FreeIPA and openldap cli tools seem to support passwords of up to 1000 characters. However, bypassing the database and using passwords longer than 69 characters lead to failures. Increasing the limit further would most likely require additional patches to net-ldap.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
