### PR TITLE
Fixes #36312 - Remove toast alert for register host validation

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Actions.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Actions.js
@@ -2,28 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
-import { Alert, ActionGroup, Button, FormGroup } from '@patternfly/react-core';
+import { ActionGroup, Button } from '@patternfly/react-core';
 
-import { sprintf, translate as __ } from '../../../../common/I18n';
+import { translate as __ } from '../../../../common/I18n';
 import { foremanUrl } from '../../../../../foreman_tools';
 
 const Actions = ({ isLoading, isGenerating, handleSubmit, invalidFields }) => (
   <>
-    <FormGroup fieldId="actions_help" className="pf-u-pt-xl">
-      {invalidFields.length === 1 && (
-        <Alert
-          variant="warning"
-          title={sprintf('Invalid field: %s', invalidFields[0])}
-        />
-      )}
-      {invalidFields.length > 1 && (
-        <Alert
-          variant="warning"
-          title={sprintf('Invalid fields: %s', invalidFields.join(', '))}
-        />
-      )}
-    </FormGroup>
-    <ActionGroup>
+    <ActionGroup style={{ marginTop: '50px' }}>
       <Button
         variant="primary"
         id="generate_btn"


### PR DESCRIPTION
This PR is in reference to Katello PR: 
https://github.com/Katello/katello/pull/10518

This is to remove the alert toast on register host page 