### PR TITLE
Fixes #36330 - Make translated strings from plugins available in the browser and modern frontend code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,8 @@
           "debian",
           "decrement", // should be removed once https://github.com/aotaduy/eslint-plugin-spellcheck/issues/67 is resolved.
           "devs",
+          "dgettext",
+          "dngettext",
           "donut",
           "dow",
           "dropdown",
@@ -93,6 +95,7 @@
           "navitem",
           "netgroups",
           "networksurl",
+          "ngettext",
           "nic",
           "nfs",
           "nonpersistent",

--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -65,6 +65,16 @@ module ReactjsHelper
     end
   end
 
+  def locale_js_tags
+    locale = FastGettext.locale
+    ::Foreman::Plugin.all.filter_map do |plugin|
+      domain = plugin.gettext_domain
+      if domain && (FastGettext.translation_repositories[domain]&.available_locales || []).include?(locale)
+        javascript_include_tag("locale/#{locale}/#{domain}")
+      end
+    end.join.html_safe
+  end
+
   private
 
   def global_plugins_list

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -32,6 +32,7 @@
       <% end %>
     </script>
     <%= javascript_include_tag "locale/#{FastGettext.locale}/app" %>
+    <%= locale_js_tags %>
     <%= javascript_include_tag *webpack_asset_paths('foreman-vendor', :extension => 'js') %>
     <%= javascript_include_tag *webpack_asset_paths('vendor', :extension => 'js') %>
     <%= javascript_include_tag *webpack_asset_paths('bundle', :extension => 'js') %>

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,7 +1,8 @@
 group :assets do
   gem 'jquery-ui-rails', '~> 6.0'
   gem 'patternfly-sass', '~> 3.59.4'
-  gem 'gettext_i18n_rails_js', '~> 1.3.1'
+  gem 'gettext_i18n_rails_js', '~> 1.4'
+  gem 'po_to_json', '~> 1.1'
   gem 'execjs', '>= 1.4.0', '< 3.0'
   gem 'uglifier', '>= 1.0.3'
   gem 'sass-rails', '~> 6.0'

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -2387,6 +2387,7 @@ folder):
 $ mkdir ../foreman_plugin/locale
 $ mkdir ../foreman_plugin/locale/en
 $ rake plugin:gettext[foreman_plugin]
+$ rake plugin:po_to_json[foreman_plugin]
 ----
 
 This should create locale/foreman_plugin.pot file. Edit the header
@@ -2455,7 +2456,9 @@ the latest updates:
 `make -C locale tx-update`
 2.  In the Foreman dir, merge the updates into the PO files:
 `rake plugin:gettext[foreman_plugin]`
-3.  In the plugin dir, rebuild the MO files: `make -C locale mo-files`
+3.  In the Foreman dir, generate files with translations for use in frontend:
+`rake plugin:po_to_json[foreman_plugin]`
+4.  In the plugin dir, rebuild the MO files: `make -C locale mo-files`
 
 These files should be .gitignored:
 
@@ -2467,6 +2470,7 @@ locale/*/*.po.time_stamp
 These files must be committed to git:
 
 ....
+app/assets/javascripts/locale/**/*.js
 locale/foreman_plugin.pot +
 locale/*/foreman_plugin.po +
 locale/*/LC_MESSAGES/foreman_plugin.mo


### PR DESCRIPTION
For context about the problem see https://gist.github.com/adamruzicka/f578c2e519f51230d475fd72848629d1

## Concerns

~~[webhippie/po_to_json](https://github.com/webhippie/po_to_json) had last change in June 2018, this change is still unreleased. Sadly, the changes proposed here rely on that unreleased change. Unless https://github.com/webhippie/po_to_json/issues/8 is resolved soon-ish, we may need to either depend (and maybe package?) latest master or carry the project ourselves.~~ Version 1.1.0 is out.

[webhippie/gettext_i18n_rails_js](https://github.com/webhippie/gettext_i18n_rails_js) doesn't really support doing the conversion for other rails engines (and domains) than just ::Rails. The changes proposed here work around that in a rather hacky fashion. If https://github.com/webhippie/gettext_i18n_rails_js/pull/57 is accepted and released soon, we could have a more sensible way of doing that, along the lines of https://github.com/theforeman/foreman/compare/develop...adamruzicka:foreman:potojson-next?expand=1

After this change is merged, *all plugins* will need to run the new rake task to make translations pop up.

## Followup changes
- [ ] refresh translations in all plugins
- [ ] update plugin template