### PR TITLE
Fixes #36229 - Fix template documentation

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -13,7 +13,7 @@ description: |
   This template accepts the following parameters:
   - lang: string (default="en_US.UTF-8")
   - keyboard: string (default="us")
-  - package_upgrade: boolean (default=true)
+  - package_upgrade: boolean (default=false)
   - remote_execution_ssh_keys: string (default="")
   - username_to_create: string (default="root")
   - realname_to_create: string (default=username_to_create)


### PR DESCRIPTION
The template description states the default for `package_upgrade` would be `true`. 
But, it is actually `false` e.g. the host parameter is not defined by default (which I assume is the same as being `false` by default).

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
