### PR TITLE
Fixes #36199 - LoadingPage PF4 refactor

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/LoadingPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/common/LoadingPage/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Spinner } from 'patternfly-react';
+import { Spinner } from '@patternfly/react-core';
 import './loadingpage.scss';
 
 const LoadingPage = () => (
   <div id="loading-page">
-    <Spinner loading size="lg" />
+    <Spinner isSVG size="xl" aria-label="Loading Page" />
   </div>
 );
 


### PR DESCRIPTION
Switching the PF3 Spinner with a PF4 one

Screen recording showing the actual loading page preview
[screen-capture.webm](https://user-images.githubusercontent.com/93318917/235364593-e384767a-141a-4617-bef0-f71653900fb8.webm)
