### PR TITLE
Fixes #36361 - Change vlan interface notation

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -126,7 +126,7 @@ description: |
     if (is_fedora && os_major < 17) || (rhel_compatible && os_major < 7)
       options.push("vlanid=#{iface.tag}")
     else
-      options.push("vlan=vlan#{iface.tag}:#{iface.attached_to}")
+      options.push("vlan=#{iface.attached_to}.#{iface.tag}:#{iface.attached_to}")
     end
   end
 


### PR DESCRIPTION
The current snippet renders vlan interfaces as "vlan=vlanXXX:ensY" which is against acceptable options. It should be "vlan=ensY.XXX:ensY". The host ends up with vlanXXX interfaces with no IPs and no links. 

I believe the snippet should be changed as follows:

from
options.push("vlan=vlan#{iface.tag}:#{iface.attached_to}")

to
options.push("vlan=#{iface.attached_to}.#{iface.tag}:#{iface.attached_to}")

It should give us the correct "vlan=ens6.123:ens6" notation