### PR TITLE
Fixes #36370 - allow all providers in the graphql enum

### DIFF
--- a/app/graphql/types/provider_enum.rb
+++ b/app/graphql/types/provider_enum.rb
@@ -1,7 +1,9 @@
 module Types
   class ProviderEnum < Types::BaseEnum
-    ::ComputeResource.supported_providers.keys.each do |provider|
-      value provider
+    def self.enum_values(context = {})
+      ::ComputeResource.all_providers.keys.map do |provider|
+        GraphQL::Schema::EnumValue.new(provider, owner: self)
+      end
     end
   end
 end

--- a/test/graphql/types/provider_enum_test.rb
+++ b/test/graphql/types/provider_enum_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+module Types
+  class ProviderEnumTest < ActiveSupport::TestCase
+    let(:enum) { Types::ProviderEnum }
+
+    test 'contains all supported providers' do
+      assert_includes enum.values.keys, 'Libvirt'
+      assert_includes enum.values.keys, 'Ovirt'
+      assert_includes enum.values.keys, 'EC2'
+      assert_includes enum.values.keys, 'Vmware'
+      assert_includes enum.values.keys, 'Openstack'
+    end
+
+    test 'contains registered providers from plugins' do
+      plugin1 = stub('plugin1', :compute_resources => ['Best::Provider::MyBest'])
+      Foreman::Plugin.stubs(:all).returns([plugin1])
+
+      assert_includes enum.values.keys, 'MyBest'
+    end
+  end
+end


### PR DESCRIPTION
Otherwise plugin-based providers are not allowed


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
