### PR TITLE
Fixes #36371 - make provider_friendly_name a String

### DIFF
--- a/app/graphql/types/compute_resource.rb
+++ b/app/graphql/types/compute_resource.rb
@@ -8,7 +8,7 @@ module Types
     field :description, String
     field :url, String
     field :provider, Types::ProviderEnum
-    field :provider_friendly_name, Types::ProviderFriendlyNameEnum
+    field :provider_friendly_name, String
 
     has_many :compute_attributes, Types::ComputeAttribute
     has_many :hosts, Types::Host

--- a/app/graphql/types/provider_friendly_name_enum.rb
+++ b/app/graphql/types/provider_friendly_name_enum.rb
@@ -1,7 +1,0 @@
-module Types
-  class ProviderFriendlyNameEnum < Types::BaseEnum
-    ::ComputeResource.supported_providers.values.each do |class_name|
-      value class_name.constantize.provider_friendly_name
-    end
-  end
-end


### PR DESCRIPTION
an Enum imposes too many restrictions and doesn't bring any benefit on a read-only field


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
