### PR TITLE
Fixes #36366 - Monospace font for variables and facts

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -274,6 +274,11 @@ table {
 .fact-col {
   max-width: 500px;
   white-space: normal;
+  font-family: monospace;
+}
+
+.parameter-value {
+  font-family: monospace;
 }
 
 .fact-origin {

--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -17,7 +17,7 @@
     <% for common_parameter in @common_parameters %>
       <tr id="<%= dom_id(common_parameter) %>_row">
         <td class="ellipsis"><%= link_to_if_authorized common_parameter, hash_for_edit_common_parameter_path(:id => common_parameter).merge(:auth_object => common_parameter, :authorizer => authorizer, :permission => 'edit_params') %></td>
-        <td class='ellipsis'>
+        <td class='ellipsis parameter-value' >
           <%= common_parameter.hidden_value? ? common_parameter.hidden_value : common_parameter.value %>
         </td>
         <td class='ellipsis'><%= common_parameter.parameter_type %></td>


### PR DESCRIPTION
Added monospace fonts for variables, parameters and facts
![Screenshot from 2023-05-16 16-46-34](https://github.com/theforeman/foreman/assets/115526987/6540b4e6-4e27-4661-8343-43fce9c028ed)
![Screenshot from 2023-05-16 16-45-37](https://github.com/theforeman/foreman/assets/115526987/9a6e3dc4-9e83-46ca-806d-099d3bac29b3)
