### PR TITLE
Fixes #36088 - translate the description values on the settings page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableSchema.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTableSchema.js
@@ -1,8 +1,8 @@
 import {
   column,
   headerFormatterWithProps,
-  cellFormatter,
   cellFormatterWithProps,
+  translatedCellFormatter,
 } from '../common/table';
 import { translate as __ } from '../../common/I18n';
 
@@ -30,7 +30,7 @@ const createSettingsTableSchema = [
     'description',
     __('Description'),
     [headerFormatterWithProps],
-    [cellFormatter]
+    [translatedCellFormatter]
   ),
 ];
 

--- a/webpack/assets/javascripts/react_app/components/common/table/formatters/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/formatters/index.js
@@ -2,6 +2,7 @@ export {
   headerFormatterWithProps,
   cellFormatterWithProps,
 } from './formatterWithProps';
+export { default as translatedCellFormatter } from './translatedCellFormatter';
 export { default as cellFormatter } from './cellFormatter';
 export { default as ellipsisCellFormatter } from './ellipsisCellFormatter';
 export { default as nameCellFormatter } from './nameCellFormatter';

--- a/webpack/assets/javascripts/react_app/components/common/table/formatters/translatedCellFormatter.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/formatters/translatedCellFormatter.js
@@ -1,0 +1,5 @@
+import { translate as __ } from '../../../../../react_app/common/I18n';
+import cellFormatter from './cellFormatter';
+
+/* Note: the caller must ensure that the value is extracted for translation */
+export default value => cellFormatter(__(value));


### PR DESCRIPTION
Add the translatedCellFormatter.js file, which
enables the translation of settings descriptions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
