### PR TITLE
Fixes #36426 - Introduce human-readable host statuses

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -169,7 +169,7 @@ class Host::Managed < Host::Base
       :provision_interface, :interfaces, :bond_interfaces, :bridge_interfaces, :interfaces_with_identifier,
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
-      :ssh_authorized_keys, :pxe_loader, :global_status, :get_status, :puppetca_token, :last_report, :build?, :smart_proxies, :host_param,
+      :ssh_authorized_keys, :pxe_loader, :global_status, :global_status_label, :get_status, :puppetca_token, :last_report, :build?, :smart_proxies, :host_param,
       :virtual, :ram, :sockets, :cores, :params, :pxe_loader_efi?, :comment
   end
 

--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -24,6 +24,7 @@ module Foreman
         :user_auth_source_name,
         :all_host_statuses,
         :all_host_statuses_hash,
+        :all_host_statuses_labels_hash,
         :host_status,
         :preview?,
         :raise,

--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -214,6 +214,16 @@ module Foreman
             all_host_statuses.map { |status| [status.status_name, host_status(host, status.status_name).status] }.to_h
           end
 
+          apipie :method, 'Returns hash representing all statuses for a given host in human-readable format' do
+            required :host, 'Host::Managed', desc: 'a host object to get the statuses for'
+            returns object_of: Hash, desc: 'Hash representing all statuses for a given host in human-readable format'
+            example 'all_host_statuses_labels(@host) # => {"Addons"=>"Unknown", "Build"=>"Installed", "Compliance"=>"Not applicable", "Configuration"=>"No reports", "Errata"=>"Security errata applicable", "Execution"=>"Last execution succeeded", "Role"=>"Unknown", "Service Level"=>"Unknown", "Subscription"=>"Simple Content Access", "System Purpose"=>"Unknown", "Traces"=>"No processes require restarting", "Usage"=>"Unknown"}'
+            example "<%- load_hosts.each_record do |host| -%>\n<%= host.name -%>, <%=   all_host_statuses_labels(host)['Subscription'] %>\n<%- end -%>"
+          end
+          def all_host_statuses_labels_hash(host)
+            all_host_statuses.map { |status| [status.status_name, host_status(host, status.status_name).to_label] }.to_h
+          end
+
           apipie :method, 'Returns a specific status for a given host' do
             desc "The return value is a human readable representation of the status.
               For details about the number meaning, see documentation for every status class."

--- a/app/views/unattended/report_templates/host_-_statuses.erb
+++ b/app/views/unattended/report_templates/host_-_statuses.erb
@@ -10,13 +10,21 @@ template_inputs:
   advanced: false
   value_type: search
   resource_type: Host
+- name: Output style
+  required: false
+  input_type: user
+  description: Select 'Human-readable' to show statuses as they would appear in the web UI, or 'Machine-readable' to show numeric statuses.
+  options: "Human-readable\r\nMachine-readable"
+  advanced: false
+  default: Human-readable
 model: ReportTemplate
 -%>
 <%- report_headers 'Name', 'Global' -%>
+<%- machine_readable = input('Output style') == 'Machine-readable' -%>
 <%- load_hosts(search: input('hosts'), includes: :host_statuses).each_record do |host| -%>
 <%-   report_row({
         'Name': host.name,
-        'Global': host.global_status
-      }.merge(all_host_statuses_hash(host))) -%>
+        'Global': machine_readable ? host.global_status : host.global_status_label
+      }.merge(machine_readable ? all_host_statuses_hash(host) : all_host_statuses_labels_hash(host))) -%>
 <%- end -%>
 <%= report_render -%>


### PR DESCRIPTION
This change introduces a new "Output style" input to the "Host - Statuses" report template. The options are Human-readable (default), and Machine-readable.

Example of Human-readable report
![image](https://github.com/theforeman/foreman/assets/22042343/a3d76220-e0de-4379-9f5b-d3b4eeaaef41)

Example of Machine-readable report
![image](https://github.com/theforeman/foreman/assets/22042343/11238744-6e51-4d4e-9109-f2a0b77324f8)


### Testing

Check out the branch and re-seed the new report:

```rb
# bundle exec rails console
=> ForemanInternal.all.first.destroy
```

Then, in Monitor > Report templates, generate the "Host - Statuses" report with the new options.

