### PR TITLE
Fixes #36067 - Dropping Reports Link From the Kebab Menu in New Host Details Page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -15,7 +15,6 @@ import {
   TrashIcon,
   CloneIcon,
   UndoIcon,
-  FileInvoiceIcon,
   BuildIcon,
   TerminalIcon,
 } from '@patternfly/react-icons';
@@ -34,7 +33,6 @@ const ActionsBar = ({
   hostName,
   computeId,
   isBuild,
-  hasReports,
   permissions: {
     destroy_hosts: canDestroy,
     create_hosts: canCreate,
@@ -123,18 +121,6 @@ const ActionsBar = ({
     >
       {__('Facts')}
     </DropdownItem>,
-    <DropdownItem
-      ouiaId="report-dropdown-item"
-      isDisabled={!hasReports}
-      onClick={() =>
-        visit(foremanUrl(`/hosts/${hostFriendlyId}/config_reports`))
-      }
-      key="report"
-      component="button"
-      icon={<FileInvoiceIcon />}
-    >
-      {__('Reports')}
-    </DropdownItem>,
     <DropdownSeparator key="sp-2" ouiaId="dropdown-separator-2" />,
     <DropdownItem
       ouiaId="pre-version-dropdown-item"
@@ -191,7 +177,6 @@ ActionsBar.propTypes = {
   hostName: PropTypes.string,
   computeId: PropTypes.number,
   permissions: PropTypes.object,
-  hasReports: PropTypes.bool,
   isBuild: PropTypes.bool,
 };
 ActionsBar.defaultProps = {
@@ -205,7 +190,6 @@ ActionsBar.defaultProps = {
     edit_hosts: false,
     build_hosts: false,
   },
-  hasReports: false,
   isBuild: false,
 };
 

--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -201,7 +201,6 @@ const HostDetails = ({
                     hostId={response.id}
                     hostName={response.name}
                     permissions={response.permissions}
-                    hasReports={!!response.last_report}
                     isBuild={response.build}
                   />
                 </FlexItem>


### PR DESCRIPTION
This information can be accessed from the Reports tab on the same page

Screenshot of the dropped link:

Before removing the reports link:
![Before removing the reports link](https://github.com/theforeman/foreman/assets/93318917/1e188fd9-2c39-4885-ab68-6247d99509b9)

After removing the reports link:
![After removing the reports link](https://github.com/theforeman/foreman/assets/93318917/c6d5471a-9812-48a1-b3b6-898476362e07)
