### PR TITLE
Fixes #36441 - quote ipv6 addresses

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -26,13 +26,13 @@ static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?
           - <%= @interface.ip %>/<%= @subnet.cidr %>
 <%-   end -%>
 <%-   if static_v6 -%>
-          - <%= @interface.ip6 %>/<%= @subnet6.cidr %>
+          - "<%= @interface.ip6 %>/<%= @subnet6.cidr %>"
 <%-   end -%>
 <%-   if static_v4 && @subnet.gateway.present? -%>
         gateway4: <%= @subnet.gateway %>
 <%-   end -%>
 <%-   if static_v6 && @subnet6.gateway.present? -%>
-        gateway6: <%= @subnet6.gateway %>
+        gateway6: "<%= @subnet6.gateway %>"
 <%-   end -%>
 <%-   if @interface.primary -%>
         nameservers:
@@ -45,7 +45,7 @@ static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?
 <%-     end -%>
 <%-     if static_v6 -%>
 <%-       @subnet6.dns_servers.each do |dns6_server| -%>
-            - <%= dns6_server %>
+            - "<%= dns6_server %>"
 <%-       end -%>
 <%-     end -%>
 <%-   end -%>


### PR DESCRIPTION
Hello. I encountered a bug when foreman shortens an IPv6 address form the end leading to the invalid yaml netpan config. The simple solution is to quote gateway6 and dns6 values.