### PR TITLE
Fixes #36466 - Allow gathering information on deleted records

### DIFF
--- a/app/models/concerns/foreman/observable_model.rb
+++ b/app/models/concerns/foreman/observable_model.rb
@@ -4,6 +4,7 @@ module Foreman
     include Foreman::Observable
 
     included do
+      attr_reader :preloaded_object
       class_attribute :event_subscription_hooks
       self.event_subscription_hooks ||= []
     end
@@ -12,6 +13,8 @@ module Foreman
       def set_hook(hook_name, namespace: Foreman::Observable::DEFAULT_NAMESPACE, payload: nil, **options, &blk)
         event_name = Foreman::Observable.event_name_for(hook_name, namespace: namespace)
         self.event_subscription_hooks |= [event_name]
+
+        before_destroy :preload_object, prepend: true
 
         after_commit(**options) do
           trigger_hook hook_name, namespace: namespace, payload: payload, &blk
@@ -29,10 +32,22 @@ module Foreman
           set_hook hook_name, namespace: namespace, on: k, payload: payload, &blk
         end
       end
+
+      def preload_scopes_builder
+        @preload_scopes_builder ||= Foreman::PreloadScopesBuilder.new(self)
+      end
     end
 
     def event_payload_for(payload, block_argument, blk)
-      super || { object: self }
+      super || { object: preloaded_object || self }
+    end
+
+    def preload_object
+      @preloaded_object = self.class.includes(self.class.preload_scopes_builder.scopes).find(id)
+    rescue => e
+      Rails.logger.error("Could not find a #{self.class} with id #{id}")
+      Rails.logger.error(e.full_message)
+      nil
     end
   end
 end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -159,7 +159,7 @@ module Foreman #:nodoc:
     attr_reader :id, :logging, :provision_methods, :compute_resources, :to_prepare_callbacks,
       :facets, :rbac_registry, :dashboard_widgets, :info_providers, :smart_proxy_references,
       :renderer_variable_loaders, :host_ui_description, :hostgroup_ui_description, :ping_extension, :status_extension,
-      :allowed_registration_vars, :observable_events, :gettext_domain, :locale_path
+      :allowed_registration_vars, :observable_events, :gettext_domain, :locale_path, :preload_scopes
 
     delegate :fact_importer_registry, :fact_parser_registry, :graphql_types_registry, :medium_providers_registry, :report_scanner_registry, :report_origin_registry, to: :class
 
@@ -190,6 +190,7 @@ module Foreman #:nodoc:
       @observable_events = []
       @gettext_domain = nil
       @locale_path = nil
+      @preload_scopes = {}
     end
 
     def engine
@@ -600,6 +601,11 @@ module Foreman #:nodoc:
 
     def extend_observable_events(events)
       (@observable_events << events).flatten!.uniq!
+    end
+
+    def extend_preload_scopes(model, scopes)
+      @preload_scopes[model.to_s] ||= []
+      (@preload_scopes[model.to_s] << scopes).flatten!.uniq!
     end
 
     delegate :subscribe, to: ActiveSupport::Notifications

--- a/app/services/foreman/preload_scopes_builder.rb
+++ b/app/services/foreman/preload_scopes_builder.rb
@@ -1,0 +1,55 @@
+module Foreman
+  class PreloadScopesBuilder
+    attr_reader :original_model
+
+    def initialize(original_model)
+      @original_model = original_model
+    end
+
+    def scopes
+      @scopes ||= begin
+        (preload_scopes + Foreman::Plugin.all.map { |plugin| plugin.preload_scopes[original_model.to_s] }).flatten.compact.uniq
+      end
+    end
+
+    private
+
+    # Must return an Array
+    # Can be defined on an ActiveRecord model's class to add custom scopes which can't be created automatically
+    def preload_scopes
+      original_model_scopes = original_model.try(:preload_scopes) || []
+      (build_scopes(original_model)&.values || []) + original_model_scopes
+    rescue => e
+      Rails.logger.error('Could not automatically build scopes for preload:')
+      Rails.logger.error(e.full_message)
+      original_model_scopes
+    end
+
+    def build_scopes(model, ignore: [], assoc_name: nil)
+      scopes = dependent_associations(model).map do |assoc|
+        next if ignore.include?(assoc.name)
+
+        dep_associations = dependent_associations(assoc.klass)
+        if dep_associations.any?
+          ignore += dep_associations.select { |to_ignore| to_ignore.options.key?(:through) }.map(&:name)
+          ignore << assoc.name
+          dep_scopes = build_scopes(assoc.klass, ignore: ignore, assoc_name: assoc.name)
+          if assoc.options.key?(:through) && dep_scopes.is_a?(Hash)
+            next { assoc.options[:through] => assoc.source_reflection_name }.merge(dep_scopes)
+          end
+          next dep_scopes
+        end
+
+        assoc.name
+      end.compact
+
+      scopes.empty? ? assoc_name : { assoc_name => scopes }
+    end
+
+    def dependent_associations(model)
+      model.reflect_on_all_associations.select do |assoc|
+        (assoc.options.values & [:destroy, :delete_all, :destroy_async]).any?
+      end
+    end
+  end
+end

--- a/test/models/hosts/managed_test.rb
+++ b/test/models/hosts/managed_test.rb
@@ -184,6 +184,21 @@ module Host
           end
         end
       end
+
+      describe 'host_destroyed hook' do
+        test 'can reference dependent object' do
+          host = FactoryBot.build(:host, :managed)
+          host.interfaces.build(mac: '66:55:44:33:22:11', identifier: 'eth0')
+          host.save!
+          ActiveSupport::Notifications.subscribed(callback, 'host_destroyed.event.foreman') do
+            callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+              payload[:object].interfaces.first.mac == '66:55:44:33:22:11'
+            end
+
+            host.destroy!
+          end
+        end
+      end
     end
 
     describe 'AR hooks' do

--- a/test/unit/ensure_not_used_by_test.rb
+++ b/test/unit/ensure_not_used_by_test.rb
@@ -48,7 +48,7 @@ class EnsureNotUsedByTest < ActiveSupport::TestCase
   end
 
   test "hostgroup should be deleted if not used by host" do
-    hostgroup = FactoryBot.build(:hostgroup, :organizations => [@org1, @org2])
+    hostgroup = FactoryBot.create(:hostgroup, :organizations => [@org1, @org2])
     FactoryBot.build(:host, :organization => @org2)
 
     as_user @user do


### PR DESCRIPTION
Foreman allows subscriptions to the events that occur on ActiveRecord objects (such as an object being created). The problem is that when an object is destroyed, the dependent bonds are being destroyed also with relational links, and can't be referenced afterwards.

Mostly this change can be tested either via foreman_webhooks plugin, or in Rails console :/

The fix is simple: try to load the ActiveModel object with references to dependent objects before the actual deletion. For example, host's interface gets deleted before the host and apparently with the references, so `host.interfaces` on a deleted host will always return an empty array.

I've tried to do preloading automatical, so devs don't need to specify what needs to be in `Model.includes`, but just in case I've made this to be hybrid: most of the scopes for preloading are being created automatically, but there is possibility to override or add explicitly scopes in the model itself via `self.preload_scopes; super + [:scope]; end`. And since some dependent models can be created by plugins, there is a plugin DSL entry to add scopes from plugins as well (usage is: `extend_preload_scopes(Model, [:scope])`). Automatical scope builder takes in consideration plugins as well.

@adamruzicka, could you take a look at this as well?