### PR TITLE
Fixes #36502 - iPXE Discovery Only Works On net0

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/ipxe_global_default.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/ipxe_global_default.erb
@@ -51,7 +51,7 @@ exit 1
 
 :discovery
 dhcp
-kernel http://${next-server}:8000/httpboot/boot/fdi-image/vmlinuz0 initrd=initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset nokaslr proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-${net0/mac}
+kernel http://${next-server}:8000/httpboot/boot/fdi-image/vmlinuz0 initrd=initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset nokaslr proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-${mac} fdi.initnet=bootif
 initrd http://${next-server}:8000/httpboot/boot/fdi-image/initrd0.img
 imgstat
 sleep 2
@@ -60,7 +60,7 @@ goto start
 
 :discovery_custom
 dhcp
-kernel http://${next-server}:${port}/httpboot/boot/fdi-image/vmlinuz0 initrd=initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset nokaslr proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-${net0/mac}
+kernel http://${next-server}:${port}/httpboot/boot/fdi-image/vmlinuz0 initrd=initrd0.img rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nomodeset nokaslr proxy.url=<%= foreman_server_url %> proxy.type=foreman BOOTIF=01-${mac} fdi.initnet=bootif
 initrd http://${next-server}:${port}/httpboot/boot/fdi-image/initrd0.img
 imgstat
 sleep 2


### PR DESCRIPTION
Adjusted BOOTIF=01-${mac} and added fdi.initnet=all which allows any network port to work with discovery.

To recreate: Boot a machine to fdi discovery image from iPXE using a network port that does not identify as net0.

Expected outcome: Discovery image updates Foreman server with machine information using the mac address of the port that established the connection.

Actual outcome: Discovery image fails while attempting to update Foreman server using the mac address of net0.