### PR TITLE
Fixes #36509 - Fix totalCount handling for GraphQL queries with first parameter

### DIFF
--- a/app/graphql/connections/base_connection.rb
+++ b/app/graphql/connections/base_connection.rb
@@ -3,7 +3,7 @@ module Connections
     field :total_count, Integer, null: false
 
     def total_count
-      object.nodes.size
+      object.items&.size || 0
     end
   end
 end

--- a/test/graphql/queries/models_query_test.rb
+++ b/test/graphql/queries/models_query_test.rb
@@ -2,10 +2,12 @@ require 'test_helper'
 
 module Queries
   class ModelsQueryTest < GraphQLQueryTestCase
+    let(:page_size) { 10 }
+
     let(:query) do
       <<-GRAPHQL
       query {
-        models {
+        models(first: #{page_size}) {
           totalCount
           pageInfo {
             startCursor
@@ -27,17 +29,16 @@ module Queries
     let(:data) { result['data']['models'] }
 
     setup do
-      FactoryBot.create_list(:model, 2)
+      FactoryBot.create_list(:model, 20)
     end
 
     test 'fetching models attributes' do
       assert_empty result['errors']
 
-      expected_count = Model.count
+      expected_total_count = Model.count
 
-      assert_not_equal 0, expected_count
-      assert_equal expected_count, data['totalCount']
-      assert_equal expected_count, data['edges'].count
+      assert_equal expected_total_count, data['totalCount']
+      assert_equal page_size, data['edges'].count
     end
   end
 end


### PR DESCRIPTION


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
