### PR TITLE
Fixes #36519 - Fix python-version on debian12

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/preseed_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/preseed_default.erb
@@ -18,7 +18,11 @@ description: |
   salt_enabled = host_param('salt_master') ? true : false
   os_major = @host.operatingsystem.major.to_i
   squeeze_or_older = (@host.operatingsystem.name == 'Debian' && os_major <= 6)
-  python_package = (@host.operatingsystem.name == 'Ubuntu' && os_major >= 20) ? 'python3' : 'python'
+  python_package = case
+                   when (@host.operatingsystem.name == 'Ubuntu' && os_major < 20) then 'python'
+                   when (@host.operatingsystem.name == 'Debian' && os_major < 11) then 'python'
+                   else 'python3'
+                   end
 
   additional_packages = ['lsb-release', 'wget']
   additional_packages << host_param('additional-packages')


### PR DESCRIPTION
I kinda inverted the default to `python3` maybe more `python(2)`-using distributions need to mentioned, but one could argue that Python2 has been deprecated long enough now :stuck_out_tongue_winking_eye: 
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
