### PR TITLE
add back stories to exclude list for now

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -3,6 +3,7 @@
         "@sheerun/mutationobserver-shim",
         "@theforeman/env",
         "@theforeman/eslint-plugin-foreman",
+        "@theforeman/stories",
         "@theforeman/test",
         "@theforeman/vendor-dev",
         "@theforeman/find-foreman",
@@ -35,6 +36,7 @@
     ],
     "EXCLUDE_NPM_PREFIXES": [
         "@babel/eslint-",
+        "@storybook/",
         "@testing-library/",
         "enzyme",
         "eslint",


### PR DESCRIPTION
while this has been dropped from core, many plugins still refer to `@theforeman/stories` and thus generate wrong dependencies after 5e7343ecdad7632a94efa26fcba84889e66b06b4


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
