### PR TITLE
Align strings in registration API docs

### DIFF
--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -19,7 +19,7 @@ module Api
         param :insecure, :bool, desc: N_("Enable insecure argument for the initial curl")
         param :packages, String, desc: N_("Packages to install on the host when registered. Can be set by `host_packages` parameter, example: `pkg1 pkg2`")
         param :update_packages, :bool, desc: N_("Update all packages on the host")
-        param :repo, String, desc: N_("Repository URL / details, for example for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat and SUSE OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
+        param :repo, String, desc: N_("Repository URL / details, for example for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
         param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
       end
       def create


### PR DESCRIPTION
This matches app/controllers/api/v2/registration_controller.rb and app/controllers/api/v2/registration_commands_controller.rb and reduces one string to translate.

I've wondered if we should use string interpolation for the exact URLs but I'm not sure if that actually works.

@stejskalleos please consider this a bug report to address.