### PR TITLE
Fixes #36525 - kickstart's RHSM line only works on RHEL hosts

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -71,6 +71,7 @@ module Foreman
         "force-puppet" => "true",
         "remote_execution_create_user" => "true",
         "blacklist_kernel_modules" => "amodule",
+        "subscription_manager" => "true",
         "subscription_manager_org" => "Org",
         "activation_key" => "key",
         "host_registration_insights" => "true",

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -46,26 +46,28 @@ runcmd:
 <%= indent(2) { snippet 'yum_proxy' } -%>
 - |
 <%= indent(2) { snippet 'ntp' } -%>
+<% if rhel_compatible -%>
+<% if host_param_true?('enable-epel') -%>
 - |
-<% if rhel_compatible && host_param_true?('enable-epel') -%>
 <%= indent(2) { snippet 'epel' } -%>
 <% end -%>
 - |
 <%= indent(2) { snippet 'redhat_register' } -%>
-- |
+<% end -%>
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+- |
 <%= indent(2) { snippet 'freeipa_register' } %>
 <% end -%>
 - |
 <%= indent(2) { snippet 'remote_execution_ssh_keys' } %>
 - |
 <%= indent(2) { snippet 'blacklist_kernel_modules' } %>
+<% if chef_enabled -%>
 - |
-<% if chef_enabled %>
 <%= indent(2) { snippet 'chef_client' } %>
 <% end -%>
+<% if puppet_enabled -%>
 - |
-<% if puppet_enabled %>
 <% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
 <%= indent(2) { snippet 'puppetlabs_repo' } %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -71,6 +71,7 @@ description: |
   use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 6))
   iface = @host.provision_interface
   appstream_present = false
+  use_rhsm = (@host.operatingsystem.name == 'RedHat' || @host.operatingsystem.name == 'RHEL') && os_major >= 8
 -%>
 # This kickstart file was rendered from the Foreman provisioning template "<%= @template_name %>".
 # for <%= @host %> running <%= @host.operatingsystem.name %> <%= os_major %> <%= @arch %>
@@ -235,7 +236,7 @@ key --skip
 <% else -%>
 <%= @host.diskLayout %>
 <% end -%>
-<%= snippet('kickstart_rhsm') if rhel_compatible && os_major >= 9 -%>
+<%= snippet('kickstart_rhsm') if use_rhsm -%>
 
 <% if host_param_true?('use_graphical_installer') -%>
 graphical
@@ -309,7 +310,7 @@ logger "Starting anaconda <%= @host %> postinstall"
 <%= snippet 'epel' -%>
 <% end -%>
 
-<%= snippet 'redhat_register' if rhel_compatible && os_major < 9 -%>
+<%= snippet 'redhat_register' if rhel_compatible && !use_rhsm -%>
 
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>

--- a/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
@@ -8,7 +8,6 @@ description: |
   in the PKG_MANAGER env variable so it can be used in templates like this:
   $PKG_MANAGER install -y pkg1 pkg2
 -%>
-
 if [ -f /etc/os-release ] ; then
   . /etc/os-release
 fi

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -60,7 +60,6 @@ description: |
 
     spacewalk_host = <hostname>                 Hostname of Spacewalk server
 -%>
-
 <%
   # Katello or subscription-manager:
   if host_param_true?('subscription_manager') || host_param('kt_activation_keys')
@@ -68,10 +67,12 @@ description: |
   # Spacewalk:
   elsif host_param('spacewalk_host')
     registration_type = 'spacewalk'
-  end if
-%>
-
-<% if registration_type == 'subscription_manager' %>
+  else
+    registration_type = nil
+  end
+-%>
+# registration_type = '<%= registration_type %>'
+<% if registration_type == 'subscription_manager' -%>
   <%
     if host_param('kt_activation_keys')
       subscription_manager_certpkg_url = subscription_manager_configuration_url(@host)
@@ -86,7 +87,7 @@ description: |
       redhat_install_host_tools = host_param_true?('redhat_install_host_tools')
       redhat_install_host_tracer_tools = host_param_true?('redhat_install_host_tracer_tools')
     end
-  %>
+  -%>
 
   echo "##############################################################"
   echo "################# SUBSCRIPTION MANAGER #######################"
@@ -97,7 +98,7 @@ description: |
   # Set up subscription-manager
   <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'provisioning' }).strip -%>
 
-  <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla') || host_param('syspurpose_addons')) %>
+  <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla') || host_param('syspurpose_addons')) -%>
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then
@@ -105,53 +106,53 @@ description: |
     fi
 
     if [ -f /usr/sbin/syspurpose ]; then
-      <%- if host_param('syspurpose_role') %>
+      <%- if host_param('syspurpose_role') -%>
         syspurpose set-role "<%= host_param('syspurpose_role') %>"
-      <%- end %>
-      <%- if host_param('syspurpose_usage') %>
+      <%- end -%>
+      <%- if host_param('syspurpose_usage') -%>
         syspurpose set-usage "<%= host_param('syspurpose_usage') %>"
-      <%- end %>
-      <%- if host_param('syspurpose_sla') %>
+      <%- end -%>
+      <%- if host_param('syspurpose_sla') -%>
         syspurpose set-sla "<%= host_param('syspurpose_sla') %>"
-      <%- end %>
-      <%- if host_param('syspurpose_addons') %>
+      <%- end -%>
+      <%- if host_param('syspurpose_addons') -%>
         <%- addons = host_param('syspurpose_addons').split(',')
               .map { |add_on| "'#{add_on.strip}'" }.join(" ") %>
         syspurpose add-addons <%= addons %>
-      <%- end %>
+      <%- end -%>
     else
       echo "Syspurpose CLI not found."
     fi
-  <% end %>
+  <% end -%>
 
-  <% if host_param('http-proxy') %>
+  <% if host_param('http-proxy') -%>
     subscription-manager config --server.proxy_hostname='<%= host_param("http-proxy") %>'
-    <% if host_param('http-proxy-user') %>
+    <% if host_param('http-proxy-user') -%>
       subscription-manager config --server.proxy_user='<%= host_param("http-proxy-user") %>'
-    <% end %>
-    <% if host_param('http-proxy-password') %>
+    <% end -%>
+    <% if host_param('http-proxy-password') -%>
       subscription-manager config --server.proxy_password='<%= host_param("http-proxy-password") %>'
-    <% end %>
-    <% if host_param('http-proxy-port') %>
+    <% end -%>
+    <% if host_param('http-proxy-port') -%>
       subscription-manager config --server.proxy_port='<%= host_param("http-proxy-port") %>'
-    <% end %>
-  <% end %>
+    <% end -%>
+  <% end -%>
   
-  <% if host_param('subscription_manager_username') && host_param('subscription_manager_password') %>
-    <% if host_param('subscription_manager_pool') %>
+  <% if host_param('subscription_manager_username') && host_param('subscription_manager_password') -%>
+    <% if host_param('subscription_manager_pool') -%>
       subscription-manager register --name="<%= @host.name %>" --username='<%= host_param("subscription_manager_username") %>' --password='<%= host_param("subscription_manager_password") %>'
       subscription-manager attach --pool='<%= host_param('subscription_manager_pool') %>'
-    <% else %>
+    <% else -%>
       subscription-manager register --name="<%= @host.name %>" --username='<%= host_param("subscription_manager_username") %>' --password='<%= host_param("subscription_manager_password") %>' --auto-attach
-    <% end %>
+    <% end -%>
 
-  <% elsif activation_key %>
+  <% elsif activation_key -%>
     subscription-manager register --name="<%= @host.name %>" --org='<%= subscription_manager_org %>' --activationkey='<%= activation_key %>'
-  <% else %>
+  <% else -%>
     echo "No activation key found: Not registering to subscription manager"
-  <% end %>
+  <% end -%>
 
-  <% if host_param_true?('only_subscription_manager_repos') %>
+  <% if host_param_true?('only_subscription_manager_repos') -%>
     for subman_config_file in /etc/yum/pluginconf.d/subscription-manager.conf /etc/dnf/plugins/subscription-manager.conf; do
       if [ -f $subman_config_file ]; then
         egrep -q "^disable_system_repos=" $subman_config_file
@@ -163,39 +164,39 @@ description: |
         fi
       fi
     done
-  <% end %>
+  <% end -%>
 
   <% if host_param_true?('subscription_manager_auto_attach', false) -%>
     subscription-manager attach --auto
 
   <% end -%>
-  <% if host_param('subscription_manager_repos') %>
+  <% if host_param('subscription_manager_repos') -%>
     # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
     <%= "subscription-manager repos --enable #{host_param('subscription_manager_repos').gsub(/,\s*/, ' --enable ')}" %>
-  <% end %>
+  <% end -%>
 
-  <% if host_param('subscription_manager_override_repos_cost') %>
+  <% if host_param('subscription_manager_override_repos_cost') -%>
     for repo in $(subscription-manager repos --list-enabled | grep "Repo ID:" | awk -F' ' '{ print $3 }'); do
       <%= "subscription-manager repo-override --list --repo $repo | grep 'cost:' &>/dev/null || subscription-manager repo-override --repo $repo --add=cost:#{host_param('subscription_manager_override_repos_cost')}" %>
     done
-  <% end %>
+  <% end -%>
 
-  <% if redhat_install_host_tools %>
+  <% if redhat_install_host_tools -%>
     $PKG_MANAGER_INSTALL katello-host-tools
-  <% end %>
+  <% end -%>
 
-  <% if redhat_install_host_tracer_tools %>
+  <% if redhat_install_host_tracer_tools -%>
     $PKG_MANAGER_INSTALL katello-host-tools-tracer
-  <% end %>
-<% end %>
+  <% end -%>
+<% end -%>
 
-<% if registration_type == 'spacewalk' %>
+<% if registration_type == 'spacewalk' -%>
   echo "##############################################################"
   echo "################ SPACEWALK REGISTRATION ######################"
   echo "##############################################################"
 
-  <% if host_param('activation_key') %>
+  <% if host_param('activation_key') -%>
     rhn_activation_key="<%= host_param('activation_key') -%>"
     satellite_hostname="<%= host_param('spacewalk_host') -%>"
     rhn_cert_file="RHN-ORG-TRUSTED-SSL-CERT"
@@ -246,7 +247,7 @@ description: |
         echo "registration successful."
     fi
 
-  <% else %>
+  <% else -%>
     echo "No activation key found: Not registering"
-  <% end %>
-<% end %>
+  <% end -%>
+<% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -8,10 +8,9 @@ description: |
   The snippet is included in the "global_registration" template and in the "redhat_register" snippet.
   The latter ensures host registration during the provisioning process.
 -%>
-
 # Select package manager for the OS (sets the $PKG_MANAGER* variables)
 if [ -z "$PKG_MANAGER" ]; then
- <%= snippet 'pkg_manager' -%>
+<%= indent(2) { snippet 'pkg_manager' } -%>
 fi
 
 # Define the path to rhsm.conf
@@ -108,7 +107,7 @@ fi
        rhsm_baseurl = "https://cdn.redhat.com"
      end
    end
-%>
+-%>
 
 # Configure subscription-manager
 test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -27,23 +27,12 @@ runcmd:
   /usr/bin/chronyc -a makestep
   /usr/sbin/hwclock --systohc
 - |
-- |
-  
-  
-  
-  
-  
-  
-- |
-- |
   
 
 - |
   echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 - |
-- |
-
   apt-get update
   apt-get install -y puppet
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -29,13 +29,125 @@ runcmd:
 - |
   rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 - |
+  # registration_type = 'subscription_manager'
+    
+    echo "##############################################################"
+    echo "################# SUBSCRIPTION MANAGER #######################"
+    echo "##############################################################"
+    echo
+    echo "Starting the subscription-manager registration process"
+  
+    # Set up subscription-manager
+    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+  if [ -z "$PKG_MANAGER" ]; then
+    if [ -f /etc/os-release ] ; then
+      . /etc/os-release
+    fi
+    
+    if [ "${NAME%.*}" = 'FreeBSD' ]; then
+      PKG_MANAGER='pkg'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+      PKG_MANAGER='dnf'
+      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+        PKG_MANAGER='yum'
+      elif [ -f /etc/system-release ]; then
+        PKG_MANAGER='yum'
+      fi
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    elif [ -f /etc/debian_version ]; then
+      PKG_MANAGER='apt-get'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    elif [ -f /etc/arch-release ]; then
+      PKG_MANAGER='pacman'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+      PKG_MANAGER='zypper'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    fi
+  fi
+  
+  # Define the path to rhsm.conf
+  RHSM_CFG=/etc/rhsm/rhsm.conf
   
   
   
+  # Prepare subscription-manager
+  if ! [ -x "$(command -v subscription-manager)" ] ; then
+    $PKG_MANAGER_INSTALL subscription-manager
+  else
+    echo "subscription-manager is already installed!"
+    
+  fi
+  
+  # Check if rhsm.conf exists
+  if ! [ -f $RHSM_CFG ] ; then
+    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+      exit 1
+  fi
   
   
+  # Configure subscription-manager
+  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+  subscription-manager config \
+    --server.hostname="subscription.rhsm.redhat.com" \
+    --server.port="443" \
+    --server.prefix="/subscription" \
+    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+    --rhsm.baseurl="https://cdn.redhat.com"
   
-- |
+  # Older versions of subscription manager may not recognize
+  # report_package_profile and package_profile_on_trans options.
+  # So set them separately and redirect out & error to /dev/null
+  # to fail silently.
+  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+  
+  # Configuration for EL6
+  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+  else
+    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+  fi
+  
+  
+  # Restart yggdrasild if installed and running
+  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+      # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+      #  assuming subscription-manager-syspurpose is installed in custom packages section.
+      if ! rpm --query --quiet subscription-manager-syspurpose ; then
+        $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+      fi
+  
+      if [ -f /usr/sbin/syspurpose ]; then
+          syspurpose set-role "Red Hat Enterprise Linux Server"
+          syspurpose set-usage "Development/Test"
+          syspurpose set-sla "Self-Support"
+  
+          syspurpose add-addons 'first addon' 'second addon' 'third addon'
+      else
+        echo "Syspurpose CLI not found."
+      fi
+    
+      
+        subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+    
+    
+      
+    
+    
+    
 - |
   
 
@@ -43,8 +155,6 @@ runcmd:
   echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 - |
-- |
-
   if [ -f /usr/bin/dnf ]; then
     dnf -y install puppet
   else

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -27,23 +27,12 @@ runcmd:
   /usr/bin/chronyc -a makestep
   /usr/sbin/hwclock --systohc
 - |
-- |
-  
-  
-  
-  
-  
-  
-- |
-- |
   
 
 - |
   echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 - |
-- |
-
   apt-get update
   apt-get install -y puppet
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -18,12 +18,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -81,12 +81,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-6-dhcp-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -81,12 +81,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -81,12 +81,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-static-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -81,12 +81,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv6-dhcp-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -81,12 +81,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv6-static-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -79,12 +79,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-rocky8" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -29,8 +29,6 @@ clearpart --all    --initlabel
 part /boot --fstype ext3 --size=100 --asprimary
 part /     --fstype ext3 --size=1024 --grow
 part swap  --recommended
-rhsm --organization="Org" --activation-key="key" --connect-to-insights
-syspurpose --role 'Red Hat Enterprise Linux Server' --usage 'Development/Test' --sla 'Self-Support' --addon 'first addon' --addon 'second addon' --addon 'third addon'
 
 skipx
 text
@@ -80,6 +78,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-rocky9" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 # update all the base packages from the updates repository

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -28,12 +28,125 @@ systemctl enable --now chronyd
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
+# registration_type = 'subscription_manager'
+  
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
 
 
 
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
 
 
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
 
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+        syspurpose set-usage "Development/Test"
+        syspurpose set-sla "Self-Support"
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+  
+  
+    
+  
+  
+  
 
 
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

This patch gets my self managed katello working again with foreman kickstarts.