### PR TITLE
Fixes #36533 - Hosts actions - Show error in modal

### DIFF
--- a/app/views/common/403.html.erb
+++ b/app/views/common/403.html.erb
@@ -11,5 +11,7 @@
     <%= _("Please request one of the required permissions listed below from a Foreman administrator:") %></br>
     <%= content_tag(:ul, permissions.join.html_safe, class: 'list-unstyled') %>
   </p>
+  <% unless request.xhr? %>
   <p><%= link_to(_('Back'), main_app.root_path, :class => 'btn btn-default') %></p>
+  <% end %>
 </div>

--- a/webpack/assets/javascripts/hosts/tableCheckboxes.js
+++ b/webpack/assets/javascripts/hosts/tableCheckboxes.js
@@ -231,6 +231,7 @@ function getBulkParam() {
 export function buildModal(element, url) {
   const data = getBulkParam();
   const title = $(element).attr('data-dialog-title');
+
   $('#confirmation-modal .modal-header h4').text(title);
   $('#confirmation-modal .modal-body')
     .empty()
@@ -242,11 +243,16 @@ export function buildModal(element, url) {
     (response, status, xhr) => {
       $('#loading').hide();
       $('#submit_multiple').val('');
-      if (isMultple()) $('#multiple-modal-alert').show();
-      const b = $('#confirmation-modal .btn-primary');
-      if ($(response).find('#content form select').length > 0)
-        b.addClass('disabled').attr('disabled', true);
-      else b.removeClass('disabled').attr('disabled', false);
+
+      if (status !== 'error') {
+        if (isMultple()) $('#multiple-modal-alert').show();
+        const b = $('#confirmation-modal .btn-primary');
+        if ($(response).find('#content form select').length > 0)
+          b.addClass('disabled').attr('disabled', true);
+        else b.removeClass('disabled').attr('disabled', false);
+      } else {
+        $('.modal-body').html(xhr.responseText);
+      }
     }
   );
   return false;


### PR DESCRIPTION
Show response in the modal when the API status is an error.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
