### PR TITLE
Fixes #36535 - pin fog-vsphere to 3.6.0

### DIFF
--- a/bundler.d/vmware.rb
+++ b/bundler.d/vmware.rb
@@ -1,3 +1,4 @@
 group :vmware do
-  gem 'fog-vsphere', '>= 3.6.0', '< 4.0'
+  # With 3.6.1 test/controllers/api/v2/hosts_controller_test is failing
+  gem 'fog-vsphere', '~> 3.6', '!= 3.6.1'
 end


### PR DESCRIPTION
fog-vsphere 3.6.1 [0] is causing failures in the
`test/controllers/api/v2/hosts_controller_test`.

The temporary fix is to pin the version to `3.6.0`.

[0] https://github.com/fog/fog-vsphere/pull/285


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
