### PR TITLE
Fixes #36350 - Add line breaks to long bookmarks

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarkItems.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/BookmarkItems.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import EllipisWithTooltip from 'react-ellipsis-with-tooltip';
 import { PlusIcon } from '@patternfly/react-icons';
 import {
   DropdownItem,
@@ -10,6 +9,7 @@ import {
 import { sprintf, translate as __ } from '../../../common/I18n';
 import { STATUS } from '../../../constants';
 import DocumentationUrl from '../DocumentationLink';
+import './bookmarks.scss';
 
 export const addBookmarkItem = ({ setModalOpen }) => (
   <DropdownGroup key="create-bookmark">
@@ -39,27 +39,40 @@ const pendingItem = (
   </DropdownItem>
 );
 
-const bookmarksList = ({ bookmarks, onBookmarkClick }) =>
-  (bookmarks.length > 0 &&
-    bookmarks.map(({ name, query }) => (
-      <DropdownItem
-        ouiaId={`${name}-dropdown-item`}
-        key={name}
-        onClick={() => onBookmarkClick(query)}
-      >
-        <EllipisWithTooltip>{name}</EllipisWithTooltip>
+const bookmarksList = ({ bookmarks, onBookmarkClick }) => {
+  const hasLongerName = bookmarks.some(bookmark => bookmark.name.length > 90);
+
+  return (
+    (bookmarks.length > 0 &&
+      bookmarks.map(({ name, query }) => (
+        <DropdownItem
+          ouiaId={`${name}-dropdown-item`}
+          className={`bookmarks-dropdown-item ${
+            hasLongerName ? 'adapt-long-bookmark' : ''
+          }`}
+          key={name}
+          onClick={() => onBookmarkClick(query)}
+        >
+          {name}
+        </DropdownItem>
+      ))) || (
+      <DropdownItem ouiaId="not-found-dropdown-item" key="not found" isDisabled>
+        {__('None found')}
       </DropdownItem>
-    ))) || (
-    <DropdownItem ouiaId="not-found-dropdown-item" key="not found" isDisabled>
-      {__('None found')}
-    </DropdownItem>
+    )
   );
+};
 
 const errorItem = errors => (
-  <DropdownItem ouiaId="error-dropdown-item" key="bookmarks-errors" isDisabled>
-    <EllipisWithTooltip>
-      {sprintf('Failed to load bookmarks: %s', errors)}
-    </EllipisWithTooltip>
+  <DropdownItem
+    ouiaId="error-dropdown-item"
+    className={`bookmarks-dropdown-item ${
+      errors.length > 90 ? 'adapt-long-bookmark' : ''
+    }`}
+    key="bookmarks-errors"
+    isDisabled
+  >
+    {sprintf('Failed to load bookmarks: %s', errors)}
   </DropdownItem>
 );
 

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/bookmarks.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/bookmarks.scss
@@ -1,0 +1,26 @@
+@import '~@theforeman/vendor/scss/variables';
+
+.bookmarks-dropdown-item {
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: nowrap;
+}
+
+.bookmarks-dropdown-item.adapt-long-bookmark {
+  width: 450px;
+  white-space: normal;
+}
+
+@media only screen and (min-width: $pf-global--breakpoint--xl) {
+  .bookmarks-dropdown-item.adapt-long-bookmark {
+    width: 600px;
+    white-space: normal;
+  }
+}
+
+@media only screen and (min-width: $pf-global--breakpoint--2xl) {
+  .bookmarks-dropdown-item.adapt-long-bookmark {
+    width: 700px;
+    white-space: normal;
+  }
+}


### PR DESCRIPTION
The dropdown was stretching with long names and it was overflowing the page too much:
![long-bookmark-name](https://github.com/theforeman/foreman/assets/78563507/fb77955e-ea2a-462f-988a-45ecf9123c99)

Now the dropdown shrinks and the words break if it is too long so that it is nicely visible:
![image](https://github.com/theforeman/foreman/assets/78563507/bd057639-97b2-435e-8a46-493893c9f8d3)

This is a quick resolution that could be redone in the future.