### PR TITLE
Fixes #36548 - Avoid parsing interfaces with shared MACs

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -206,8 +206,12 @@ class FactParser
   end
 
   # meant to be implemented in inheriting classes
-  # should return array of interfaces names, e.g.
-  #   ['eth0', 'eth0.0', 'eth1']
+  #
+  # @return Array[String]
+  #   A list of interface names
+  #
+  # @example
+  #   get_interfaces # => ['eth0', 'eth0.0', 'eth1']
   def get_interfaces
     raise NotImplementedError, "parsing interfaces is not supported in #{self.class}"
   end
@@ -217,6 +221,15 @@ class FactParser
     @ignored_interfaces ||= Setting.convert_array_to_regexp(Setting[:ignored_interface_identifiers])
   end
 
+  # @param interfaces Array[String]
+  # @result Array[String]
+  #   A filtered list of interfaces
+  #
+  # @example Ignoring bridges
+  #   ignored_interfaces #=> /^br/
+  #   remove_ignored(['eth0', 'eth1', 'br0']) #=> ['eth0', 'eth1']
+  #
+  # @see #ignored_interfaces
   def remove_ignored(interfaces)
     interfaces.clone.delete_if do |identifier|
       if (remove = identifier.match(ignored_interfaces))

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -92,7 +92,7 @@ class FactParser
   end
 
   def parse_interfaces?
-    support_interfaces_parsing? && !Setting['ignore_puppet_facts_for_provisioning']
+    support_interfaces_parsing? && !Setting['ignore_puppet_facts_for_provisioning'] && !has_duplicate_mac?
   end
 
   def class_name_humanized
@@ -135,6 +135,14 @@ class FactParser
   end
 
   private
+
+  # Return if multiple interfaces have the same MAC address
+  # This can happen on Azure and Foreman can't parse that since a MAC is
+  # supposed to uniquely identify an interface in Foreman
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2088782
+  def has_duplicate_mac?
+    interfaces.group_by { |_interface, facts| facts['macaddress'] }.any? { |_mac, interfaces| interfaces.length > 1 }
+  end
 
   def find_interface_by_name(host_name)
     resolver = Resolv::DNS.new

--- a/app/services/foreman_chef/fact_parser.rb
+++ b/app/services/foreman_chef/fact_parser.rb
@@ -93,10 +93,6 @@ module ForemanChef
       true
     end
 
-    def parse_interfaces?
-      support_interfaces_parsing? && !Setting['ignore_puppet_facts_for_provisioning']
-    end
-
     def boot_timestamp
       Time.zone.now.to_i - facts['system_uptime::seconds'].to_i
     end

--- a/test/unit/puppet_fact_parser_test.rb
+++ b/test/unit/puppet_fact_parser_test.rb
@@ -458,6 +458,43 @@ class PuppetFactsParserTest < ActiveSupport::TestCase
     assert_nil parser.interfaces['eth1_1']
   end
 
+  describe "#parse_interfaces?" do
+    describe "with structured facts" do
+      test "with normal data" do
+        facts = {
+          "facterversion" => "4.0.0",
+          "networking" => {
+            "interfaces" => {
+              "em1": {
+                "mac": "00:00:00:00:ab:11",
+              },
+            },
+          },
+        }
+
+        assert get_parser(facts).parse_interfaces?
+      end
+
+      test "with duplicate mac addresses" do
+        facts = {
+          "facterversion" => "4.0.0",
+          "networking" => {
+            "interfaces" => {
+              "em1": {
+                "mac": "00:00:00:00:ab:11",
+              },
+              "em2": {
+                "mac": "00:00:00:00:ab:11",
+              },
+            },
+          },
+        }
+
+        refute get_parser(facts).parse_interfaces?
+      end
+    end
+  end
+
   test "#test boot time based on uptime" do
     host = FactoryBot.build(:host, :hostgroup => FactoryBot.build(:hostgroup))
     freeze_time do


### PR DESCRIPTION
In Azure it is possible to see the same interface share the same MAC address. Foreman wants to identify an interface by its MAC address, and doesn't handle it.

This patch makes `parse_interfaces?` take duplicate MAC addresses into account and ignores them. While it's not pretty, it at least allows other facts to be imported.

At the moment it's completely untested, but allows me to share the concept easier then describing it.