### PR TITLE
Fixes #36549 - params tab show buttons only with premissions

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/EditTableRow.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/EditTableRow.js
@@ -191,7 +191,11 @@ export const EditParametersTableRow = ({
           </>
         </Td>
       )}
-      <RowActions hostId={hostId} param={param} />
+      <RowActions
+        hostId={hostId}
+        param={param}
+        editHostsPermission={editHostsPermission}
+      />
     </Tr>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/ParametersTable.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/ParametersTable.js
@@ -89,12 +89,14 @@ export const ParametersTable = ({
             />
           </ToolbarItem>
           <ToolbarItem>
-            <Button
-              ouiaId="add-parameter-btn"
-              onClick={() => setShowNewRow(true)}
-            >
-              {__('Add parameter')}
-            </Button>
+            {editHostsPermission && (
+              <Button
+                ouiaId="add-parameter-btn"
+                onClick={() => setShowNewRow(true)}
+              >
+                {__('Add parameter')}
+              </Button>
+            )}
           </ToolbarItem>
           <ToolbarItem>
             {status === STATUS.PENDING && <Spinner loading size="sm" />}

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/RowActions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/RowActions.js
@@ -8,7 +8,7 @@ import { HOST_PARAM } from './ParametersConstants';
 import { openConfirmModal } from '../../../ConfirmModal';
 import { updateHost } from '../../ActionsBar/actions';
 
-export const RowActions = ({ hostId, param }) => {
+export const RowActions = ({ hostId, param, editHostsPermission }) => {
   const dispatch = useDispatch();
   const onDelete = () =>
     dispatch(
@@ -27,23 +27,24 @@ export const RowActions = ({ hostId, param }) => {
       })
     );
   const rowActions = [
-    param.associated_type === HOST_PARAM && {
-      title: __('Delete'),
-      onClick: () => {
-        dispatch(
-          openConfirmModal({
-            title: sprintf(__('Delete %s'), param.name),
-            message: __(
-              'This will change the delete the parameter, are you sure?'
-            ),
-            isWarning: true,
-            onConfirm: () => {
-              onDelete();
-            },
-          })
-        );
+    editHostsPermission &&
+      param.associated_type === HOST_PARAM && {
+        title: __('Delete'),
+        onClick: () => {
+          dispatch(
+            openConfirmModal({
+              title: sprintf(__('Delete %s'), param.name),
+              message: __(
+                'This will change the delete the parameter, are you sure?'
+              ),
+              isWarning: true,
+              onConfirm: () => {
+                onDelete();
+              },
+            })
+          );
+        },
       },
-    },
   ].filter(a => a);
   return (
     <Td isActionCell className="parameters-actions">
@@ -63,4 +64,5 @@ RowActions.propTypes = {
     associated_type: PropTypes.string,
   }).isRequired,
   hostId: PropTypes.number.isRequired,
+  editHostsPermission: PropTypes.bool.isRequired,
 };

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/ViewTableRow.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Tabs/Parameters/ViewTableRow.js
@@ -71,7 +71,11 @@ export const ViewParametersTableRow = ({
         </Tooltip>
       </Td>
     )}
-    <RowActions hostId={hostId} param={param} />
+    <RowActions
+      hostId={hostId}
+      param={param}
+      editHostsPermission={editHostsPermission}
+    />
   </Tr>
 );
 


### PR DESCRIPTION
In host details, parameters tab, delete and new buttons were shown and enabled for users with no premissions