### PR TITLE
Fixes #36559 - Provide a systemd sysusers.d file

### DIFF
--- a/extras/systemd/foreman.sysusers
+++ b/extras/systemd/foreman.sysusers
@@ -1,0 +1,2 @@
+u	foreman	-	"Foreman"	/usr/share/foreman	/usr/sbin/nologin
+g	foreman	-


### PR DESCRIPTION
The [sysusers.d format](https://www.freedesktop.org/software/systemd/man/sysusers.d.html) describes the user and group which should exist. This allows admins to introspect which users should exist. In the future it can also make packaging easier because both RPM and Debian packaging can (on sufficiently recent versions) utilize this.

This uses `/usr/sbin/nologin` which today we already use on Debian. For RPMs we use `/sbin/nologin` but on EL8 `realpath /sbin/nologin` returns `/usr/sbin/nologin` so by using this we avoid resolving a symlink.

Currently a draft since I still need to do the packaging side of it.