### PR TITLE
Fixes #36571 - Remove dividers between navigation items

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -113,17 +113,14 @@ const Navigation = ({
               {groups.map((group, groupIndex) =>
                 groupIndex === 0 ? (
                   group.groupItems.map(
-                    (
-                      {
-                        id,
-                        title: subItemTitle,
-                        className: subItemClassName,
-                        href,
-                        onClick,
-                        isActive,
-                      },
-                      groupItemsIndex
-                    ) => (
+                    ({
+                      id,
+                      title: subItemTitle,
+                      className: subItemClassName,
+                      href,
+                      onClick,
+                      isActive,
+                    }) => (
                       <React.Fragment key={id}>
                         <NavItem
                           className={subItemClassName}
@@ -134,9 +131,6 @@ const Navigation = ({
                         >
                           {subItemTitle}
                         </NavItem>
-                        {groupItemsIndex !== group.groupItems.length - 1 && (
-                          <NavItemSeparator />
-                        )}
                       </React.Fragment>
                     )
                   )
@@ -150,17 +144,14 @@ const Navigation = ({
                       )}
                     >
                       {group.groupItems.map(
-                        (
-                          {
-                            id,
-                            title: subItemTitle,
-                            className: subItemClassName,
-                            href,
-                            onClick,
-                            isActive,
-                          },
-                          groupItemsIndex
-                        ) => (
+                        ({
+                          id,
+                          title: subItemTitle,
+                          className: subItemClassName,
+                          href,
+                          onClick,
+                          isActive,
+                        }) => (
                           <React.Fragment key={id}>
                             <NavItem
                               className={subItemClassName}
@@ -171,10 +162,6 @@ const Navigation = ({
                             >
                               {subItemTitle}
                             </NavItem>
-                            {groupItemsIndex !==
-                              group.groupItems.length - 1 && (
-                              <NavItemSeparator />
-                            )}
                           </React.Fragment>
                         )
                       )}


### PR DESCRIPTION
before:
 
![image](https://github.com/theforeman/foreman/assets/30431079/9fedcb9c-59b7-422e-9096-717439661488)
after:
 
![image](https://github.com/theforeman/foreman/assets/30431079/0881d11b-4a64-43cb-96e5-7f13f6feaf48)
