### PR TITLE
Fixes #36575 - Avoid translating labels during startup

### DIFF
--- a/app/services/input_type/base.rb
+++ b/app/services/input_type/base.rb
@@ -52,8 +52,11 @@ module InputType
 
     def self.api_params_for_input_group(context)
       attributes.each do |attr|
+        # TODO: humanized_name is translated, but that can't work
         context.param attr, String, required: false,
-                                    desc: format(N_('%{input_type_attr_name}, used when input type is %{input_type}'), input_type_attr_name: attr.to_s.humanize, input_type: humanized_name)
+                                    desc: format(N_('%{input_type_attr_name}, used when input type is %{input_type}'),
+                                                 input_type_attr_name: ->() { attr.to_s.humanize },
+                                                 input_type: ->() { humanized_name })
       end
     end
 


### PR DESCRIPTION
It's invalid to do translations during startup, such as in models or in controllers. You should always use `N_()` (see https://projects.theforeman.org/projects/foreman/wiki/Translating#Extracting-strings). This is because when it's running you actually don't have translations at all, so it's effectively a noop anyway.

When updating fast_gettext to 2.1+ (https://github.com/theforeman/foreman/pull/9770) it turns into infinite recursion so it must be addressed if we want to move forward.