### PR TITLE
Fixes #36583 - Remove power_manager from autoload_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -134,7 +134,6 @@ module Foreman
     # -- all .rb files in that directory are automatically loaded.
 
     # Autoloading
-    config.autoload_paths += %W(#{config.root}/app/models/power_manager)
     config.autoload_paths += %W(#{config.root}/app/models/auth_sources)
     config.autoload_paths += %W(#{config.root}/app/models/compute_resources)
     config.autoload_paths += %W(#{config.root}/app/models/fact_names)


### PR DESCRIPTION
This directory no longer exists.

Fixes: 3484613f7fb7 ("fixes #2411 - move files in /models to /concerns, /services, /mailers, /observers")