### PR TITLE
Ignore theforeman-eslint-plugin-rules in packaging

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -3,6 +3,7 @@
         "@sheerun/mutationobserver-shim",
         "@theforeman/env",
         "@theforeman/eslint-plugin-foreman",
+        "@theforeman/eslint-plugin-rules",
         "@theforeman/stories",
         "@theforeman/test",
         "@theforeman/vendor-dev",


### PR DESCRIPTION
This is a development only package and shouldn't end up in real production environments. Not even in their build process.