### PR TITLE
Fixes #36104 - Distinguish host events

### DIFF
--- a/app/models/concerns/foreman/observable_model.rb
+++ b/app/models/concerns/foreman/observable_model.rb
@@ -26,13 +26,19 @@ module Foreman
           destroy: :destroyed,
         }.each do |k, v|
           hook_name = "#{model_name}_#{v}".to_sym
-          set_hook hook_name, namespace: namespace, on: k, payload: payload, &blk
+          set_hook hook_name, namespace: namespace, on: k, payload: payload, **options, &blk
         end
       end
     end
 
     def event_payload_for(payload, block_argument, blk)
       super || { object: self }
+    end
+
+    def anonymous_admin_context?
+      [
+        ::User::ANONYMOUS_ADMIN, ::User::ANONYMOUS_API_ADMIN, ::User::ANONYMOUS_CONSOLE_ADMIN
+      ].include?(::Logging.mdc.context['user_login'])
     end
   end
 end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -45,7 +45,9 @@ class Host::Managed < Host::Base
     output
   end
 
-  set_crud_hooks :host
+  set_hook :host_created, on: :create
+  set_hook :host_destroyed, on: :destroy
+  set_hook :host_updated, on: :update, unless: -> { anonymous_admin_context? }
 
   set_hook :build_entered, if: -> { saved_change_to_build? && build? } do |h|
     { id: h.id, hostname: h.hostname }

--- a/app/services/host_fact_importer.rb
+++ b/app/services/host_fact_importer.rb
@@ -31,7 +31,13 @@ class HostFactImporter
       host.save(:validate => false)
     end
 
-    parse_facts(facts, type, source_proxy)
+    state = parse_facts(facts, type, source_proxy)
+    begin
+      host.trigger_hook(:host_facts_updated)
+    rescue => e
+      Foreman::Logging.exception("Cannot trigger hook :host_facts_updated on #{host.class} with #{host.id} ID, ignoring", e)
+    end
+    state
   end
 
   def parse_facts(facts, type, source_proxy)


### PR DESCRIPTION
Testable with `foreman_webhooks`. Adds new events to better distinguish between host events, whether it was triggered by user or via some automation.

@adamruzicka, what do you think? This is the simplest solution I could find and it seems to solve the issue...