### PR TITLE
Fixes #36617 - Pin minitest < 5.19 to resolve test failures

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,7 +1,7 @@
 group :test do
   gem 'mocha', '~> 1.11'
   gem 'single_test', '~> 0.6'
-  gem 'minitest', '~> 5.1'
+  gem 'minitest', '~> 5.1', '< 5.19'
   gem 'minitest-reporters', '~> 1.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 6.0'


### PR DESCRIPTION
5.19.0 release of minitest causes errors with several of test gems we use.
I was able to see issues with minitest-spec-rails-6.2.0, mocha(Their latest release fixes this), shoulda-matchers-4.3.0.. I didn't go further.. We should pin minitest to 5.18.1 for now to unblock our tests.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
