### PR TITLE
Fixes #36651 - Support Minitest 5.19+

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,10 +1,10 @@
 group :test do
-  gem 'mocha', '~> 1.11'
+  gem 'mocha', '~> 2.1'
   gem 'single_test', '~> 0.6'
-  gem 'minitest', '~> 5.1', '< 5.19'
+  gem 'minitest', '~> 5.1'
   gem 'minitest-reporters', '~> 1.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false
-  gem 'minitest-spec-rails', '~> 6.0'
+  gem 'minitest-spec-rails', '~> 7.1'
   gem 'capybara', '~> 3.33', :require => false
   gem 'show_me_the_cookies', '~> 6.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false

--- a/test/jobs/stored_values_cleanup_job_test.rb
+++ b/test/jobs/stored_values_cleanup_job_test.rb
@@ -6,7 +6,7 @@ class StoredValuesCleanupJobTest < ActiveJob::TestCase
   end
 
   it 'removes expired stored values and enqueue itself' do
-    scope = MiniTest::Mock.new
+    scope = Minitest::Mock.new
     scope.expect('destroy_all', nil)
     StoredValue.expects(:expired).with(0).returns(scope)
     @job.perform_now

--- a/test/jobs/template_render_job_test.rb
+++ b/test/jobs/template_render_job_test.rb
@@ -9,7 +9,7 @@ class TemplateRenderJobTest < ActiveJob::TestCase
     end
 
     it 'render report and stores it' do
-      composer = MiniTest::Mock.new
+      composer = Minitest::Mock.new
       composer.expect('render', 'result')
       composer.expect('send_mail?', false)
       ReportComposer.expects('new').with('foo' => 'bar', 'gzip' => false).returns(composer)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ WebMock.disable_net_connect!(allow_localhost: true)
 # Configure shoulda
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
-    with.test_framework :minitest_4
+    with.test_framework :minitest
     with.library :rails
   end
 end

--- a/test/unit/seed_helper_test.rb
+++ b/test/unit/seed_helper_test.rb
@@ -137,7 +137,7 @@ class SeedHelperTest < ActiveSupport::TestCase
       type.stubs(:unscoped).returns(unscoped_mock)
     end
 
-    let(:metadata) do
+    let(:template_metadata) do
       {
         'name' => 'Test template',
         'model' => 'ProvisioningTemplate',
@@ -147,25 +147,25 @@ class SeedHelperTest < ActiveSupport::TestCase
 
     it 'requires name in metadata' do
       ex = assert_raises RuntimeError do
-        SeedHelper.import_raw_template(get_template(metadata.except('name')))
+        SeedHelper.import_raw_template(get_template(template_metadata.except('name')))
       end
       assert_match("Attribute 'name' is required", ex.message)
     end
 
     it 'requires template model in metadata' do
       ex = assert_raises RuntimeError do
-        SeedHelper.import_raw_template(get_template(metadata.except('model')))
+        SeedHelper.import_raw_template(get_template(template_metadata.except('model')))
       end
       assert_match("Attribute 'model' is required", ex.message)
     end
 
     it 'skips templates that have been changed' do
       SeedHelper.expects(:audit_modified?).with(ProvisioningTemplate, 'Test template').returns(true)
-      assert_nil SeedHelper.import_raw_template(get_template(metadata))
+      assert_nil SeedHelper.import_raw_template(get_template(template_metadata))
     end
 
     it 'skips template that have unknown model' do
-      assert_nil SeedHelper.import_raw_template(get_template(metadata.merge({'model' => 'unknown'})))
+      assert_nil SeedHelper.import_raw_template(get_template(template_metadata.merge({'model' => 'unknown'})))
     end
 
     it 'skips templates that require a missing plugin' do
@@ -174,7 +174,7 @@ class SeedHelperTest < ActiveSupport::TestCase
           'plugin' => 'unknown_plugin',
         }],
       }
-      assert_nil SeedHelper.import_raw_template(get_template(metadata.merge(requirements)))
+      assert_nil SeedHelper.import_raw_template(get_template(template_metadata.merge(requirements)))
     end
 
     it 'skips templates that require a plugin in higher version' do
@@ -185,7 +185,7 @@ class SeedHelperTest < ActiveSupport::TestCase
         }],
       }
       Foreman::Plugin.expects(:find).with('some_plugin').returns(mock(:version => '1.9'))
-      assert_nil SeedHelper.import_raw_template(get_template(metadata.merge(requirements)))
+      assert_nil SeedHelper.import_raw_template(get_template(template_metadata.merge(requirements)))
     end
 
     it 'accepts prereleases to satisty version condition ' do
@@ -196,7 +196,7 @@ class SeedHelperTest < ActiveSupport::TestCase
         }],
       }
       Foreman::Plugin.expects(:find).with('some_plugin').returns(mock(:version => '2.0.1.rc2'))
-      refute_nil SeedHelper.import_raw_template(get_template(metadata.merge(requirements)))
+      refute_nil SeedHelper.import_raw_template(get_template(template_metadata.merge(requirements)))
     end
 
     it 'imports the template and sets taxonomies' do
@@ -206,7 +206,7 @@ class SeedHelperTest < ActiveSupport::TestCase
       mock_taxonomies(Organization, orgs)
       mock_taxonomies(Location, locs)
 
-      tpl = SeedHelper.import_raw_template(get_template(metadata))
+      tpl = SeedHelper.import_raw_template(get_template(template_metadata))
       assert(tpl.valid?)
       assert(tpl.persisted?)
       assert_equal(orgs, tpl.organizations)
@@ -214,7 +214,7 @@ class SeedHelperTest < ActiveSupport::TestCase
     end
 
     it 'sets correct vendor' do
-      tpl = SeedHelper.import_raw_template(get_template(metadata), 'SomePlugin')
+      tpl = SeedHelper.import_raw_template(get_template(template_metadata), 'SomePlugin')
       assert_equal('SomePlugin', tpl.vendor)
     end
 
@@ -225,7 +225,7 @@ class SeedHelperTest < ActiveSupport::TestCase
       mock_taxonomies(Organization, orgs)
       mock_taxonomies(Location, locs)
 
-      tpl = SeedHelper.import_raw_template(get_template(metadata.merge({'name' => 'MyScript'})))
+      tpl = SeedHelper.import_raw_template(get_template(template_metadata.merge({'name' => 'MyScript'})))
       assert_equal([], tpl.organizations)
       assert_equal([], tpl.locations)
     end
@@ -237,7 +237,7 @@ class SeedHelperTest < ActiveSupport::TestCase
       mock_taxonomies(Organization, orgs)
       mock_taxonomies(Location, locs)
 
-      template_body = get_template(metadata.merge({'name' => 'MyScript'}))
+      template_body = get_template(template_metadata.merge({'name' => 'MyScript'}))
 
       tpl = SeedHelper.import_raw_template(template_body)
       assert(tpl.valid?)


### PR DESCRIPTION
* This reverts commit 1c3a4155f286352e0abbf0d0b298e47e81c2d6c5.
  Thus un-pinning minitest again
* update minitest-spec-rails to 7.1+
  This contains a fix required for minitest 5.19+
* Update mocha to 2.1+ for minitest 5.19+ compat
* Use minitest (5) support in shoulda-matchers
  We've not been using Minitest 4 for a while now
* Use Minitest namespace, not MiniTest
* Don't override metadata, minitest doesn't like that



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
