### PR TITLE
update shoulda-matchers to 5.x

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -12,7 +12,7 @@ group :test do
   gem 'facterdb', '~> 1.7'
   gem 'factory_bot_rails', '~> 5.0', :require => false
   gem 'selenium-webdriver', :require => false
-  gem 'shoulda-matchers', '>= 4.0', '< 4.4'
+  gem 'shoulda-matchers', '~> 5.0'
   gem 'shoulda-context', '~> 1.2'
   gem 'as_deprecation_tracker', '~> 1.6'
   gem 'rails-controller-testing', '~> 1.0'


### PR DESCRIPTION
we had it pinned to <4.4 as 4.4 had a bug, but that is fixed since 4.4.1 and we really should update to the next major version


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
