### PR TITLE
Fixes #36617 - Pin minitest < 5.19 to resolve test failures

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,7 +1,7 @@
 group :test do
   gem 'mocha', '~> 1.11'
   gem 'single_test', '~> 0.6'
-  gem 'minitest', '~> 5.1'
+  gem 'minitest', '~> 5.1', '< 5.19'
   gem 'minitest-reporters', '~> 1.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 6.0'


### PR DESCRIPTION
(cherry picked from commit 1c3a4155f286352e0abbf0d0b298e47e81c2d6c5)