### PR TITLE
Fixes #36587 - rename Host - Applicable Errata report

### DIFF
--- a/app/views/unattended/report_templates/host_-_available_errata.erb
+++ b/app/views/unattended/report_templates/host_-_available_errata.erb
@@ -1,5 +1,5 @@
 <%#
-name: Host - Applicable Errata
+name: Host - Available Errata
 snippet: false
 template_inputs:
 - name: Hosts filter
@@ -27,7 +27,7 @@ template_inputs:
 model: ReportTemplate
 require:
 - plugin: katello
-￼ version: 4.9.0
+  version: 4.9.0
 -%>
 <%- report_headers 'Host', 'Operating System', 'Environment', 'Erratum', 'Type', 'Published', 'Available since', 'Severity', 'Packages', 'CVEs', 'Reboot suggested' -%>
 <%- errata_filter = input('Errata filter') %>

--- a/app/views/unattended/report_templates/host_-_registered_content_hosts.erb
+++ b/app/views/unattended/report_templates/host_-_registered_content_hosts.erb
@@ -21,7 +21,7 @@ template_inputs:
 model: ReportTemplate
 require:
 - plugin: katello
-￼ version: 4.9.0
+  version: 4.9.0
 -%>
 <%- if input('Installability') == 'applicable' -%>
     <%- report_headers 'Name', 'Ip', 'Operating System', 'Subscriptions', 'Applicable Errata', 'Owner', 'Kernel', 'Latest kernel available' -%>

--- a/db/migrate/20230803180552_rename_applicable_errata_report_template.rb
+++ b/db/migrate/20230803180552_rename_applicable_errata_report_template.rb
@@ -1,0 +1,20 @@
+class RenameApplicableErrataReportTemplate < ActiveRecord::Migration[6.1]
+  TEMPLATE_NAMES = {
+    "Host - Applicable Errata" => "Host - Available Errata",
+  }
+
+  def up
+    TEMPLATE_NAMES.each do |from, to|
+      token = SecureRandom.base64(5)
+      ReportTemplate.unscoped.find_by(name: to)&.update_columns(:name => "#{to} Backup #{token}")
+      ReportTemplate.unscoped.find_by(name: from)&.update_columns(:name => to)
+    end
+  end
+
+  def down
+    TEMPLATE_NAMES.each do |from, to|
+      ReportTemplate.unscoped.find_by(name: from)&.delete
+      ReportTemplate.unscoped.find_by(name: to)&.update_columns(:name => from)
+    end
+  end
+end


### PR DESCRIPTION
* ...and fix comment typos

Renames the applicable errata report since it no longer only reports on applicable errata.

Also, remove some odd characters that look like whitespace in GitHub but really aren't.  They were breaking syntax highlighting in Foreman.

To test:

1) Create a report template called "Host - Available Errata"
2) Apply this PR and run the migration
3) Ensure that the report template you created is backed up under a different name
4) Ensure that the "Host - Available Errata" report has what the "Host - Applicable Errata" report used to have
5) Ensure that the "Host - Applicable Errata" report is gone
6) Ensure that the syntax highlighting is not broken for "Host - Available Errata" or "Host - Registered Content Hosts"