### PR TITLE
Fixes #36639 - Use Templates feature on IPv6

### DIFF
--- a/app/services/foreman/foreman_url_renderer.rb
+++ b/app/services/foreman/foreman_url_renderer.rb
@@ -63,7 +63,8 @@ module Foreman
 
       host = @host
       host = self if @host.nil? && self.class < Host::Base
-      template_proxy = host.try(:provision_interface).try(:subnet).try(:template_proxy)
+      template_proxy = host.try(:provision_interface).try(:subnet6).try(:template_proxy)
+      template_proxy ||= host.try(:provision_interface).try(:subnet).try(:template_proxy)
 
       # Use template_url from the request if set, but otherwise look for a Template
       # feature proxy, as PXE templates are written without an incoming request.

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -462,6 +462,27 @@ FactoryBot.define do
       end
     end
 
+    trait :with_separate_provision_interface_dualstack do
+      interfaces do
+        [
+          FactoryBot.build(
+            :nic_managed,
+            :primary => true,
+            :provision => false,
+            :domain => FactoryBot.build(:domain)
+          ),
+          FactoryBot.build(
+            :nic_managed,
+            :primary => false,
+            :provision => true,
+            :domain => FactoryBot.build(:domain),
+            :subnet => FactoryBot.build(:subnet_ipv4, :tftp, locations: [location], organizations: [organization]),
+            :subnet6 => FactoryBot.build(:subnet_ipv6, :tftp, locations: [location], organizations: [organization])
+          ),
+        ]
+      end
+    end
+
     trait :with_tftp_v6_subnet do
       subnet6 { FactoryBot.build(:subnet_ipv6, :tftp, locations: [location], organizations: [organization]) }
     end


### PR DESCRIPTION
This now looks at, and prefers, the IPv6 subnet on the provision_interface to determine the template proxy. This allows using the Templates feature in pure IPv6 provisioning setups.