### PR TITLE
Refs #36537 - Drop description from setting search

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -55,7 +55,6 @@ class Setting < ApplicationRecord
 
   scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search on: :name, complete_value: :true, operators: ['=', '~']
-  scoped_search on: :description, complete_value: :true, operators: ['~']
 
   delegate :settings_type, :encrypted, :encrypted?, :default, to: :setting_definition, allow_nil: true
 


### PR DESCRIPTION
The description is no longer a field so it can't be searched anymore. This is
not a real fix, but prevents internal server errors on the settings search.

Fixes: de56ffb28064
(cherry picked from commit 620a6a51dffd876b4c28d5c8734bda264834c9a6)