### PR TITLE
Fixes #36659 - Drop CentOS 8 mirror

### DIFF
--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -11,11 +11,6 @@ Medium.without_auditing do
       :path => "http://mirror.centos.org/centos/$major/os/$arch",
     },
     {
-      :name => "CentOS 8 mirror",
-      :os_family => "Redhat",
-      :path => "http://mirror.centos.org/centos/$major/BaseOS/$arch/kickstart",
-    },
-    {
       :name => "CentOS Stream",
       :os_family => "Redhat",
       :path => "http://mirror.centos.org/centos/$major-stream/BaseOS/$arch/os",


### PR DESCRIPTION
The CentOS 8 mirror is for CentOS Linux 8, but that's EOL and removed from the mirrors.