### PR TITLE
Fixes #36660 - drop value from settings dsl

### DIFF
--- a/app/registries/foreman/setting_manager.rb
+++ b/app/registries/foreman/setting_manager.rb
@@ -120,7 +120,7 @@ module Foreman
       #     end
       #   end
       #
-      def setting(name, default:, description:, type:, full_name: nil, value: nil, collection: nil, encrypted: false, validate: nil, **options)
+      def setting(name, default:, description:, type:, full_name: nil, collection: nil, encrypted: false, validate: nil, **options)
         raise ::Foreman::Exception.new(N_("Setting '%s' is already defined, please avoid collisions"), name) if storage.key?(name.to_s)
         raise ::Foreman::Exception.new(N_("Setting '%s' has an invalid type definition. Please use a valid type."), name) unless available_types.include?(type)
         storage[name.to_s] = {
@@ -130,7 +130,6 @@ module Foreman
           default: default,
           description: description,
           full_name: full_name,
-          value: value,
           collection: collection,
           encrypted: encrypted,
           options: options,

--- a/app/services/setting_registry.rb
+++ b/app/services/setting_registry.rb
@@ -148,9 +148,8 @@ class SettingRegistry
     @values_loaded_at = Time.zone.now if settings.any?
   end
 
-  def _add(name, category:, type:, default:, description:, full_name:, context:, value: nil, encrypted: false, collection: nil, options: {})
+  def _add(name, category:, type:, default:, description:, full_name:, context:, encrypted: false, collection: nil, options: {})
     select_collection_registry.add(name, collection: collection, **options) if collection
-    Foreman::Deprecation.deprecation_warning('3.3', "initial value of setting '#{name}' should be created in a migration") if value
 
     @settings[name.to_s] = SettingPresenter.new({ name: name,
                                                   context: context,
@@ -158,7 +157,6 @@ class SettingRegistry
                                                   settings_type: type.to_s,
                                                   description: description,
                                                   default: default,
-                                                  value: value,
                                                   full_name: full_name,
                                                   collection: collection,
                                                   encrypted: encrypted })

--- a/config/as_deprecation_whitelist.yaml
+++ b/config/as_deprecation_whitelist.yaml
@@ -1,4 +1,3 @@
 ---
 - message: Initialization autoloaded the constants
-- message: You are using a deprecated behavior, it will be removed in version 3.3, initial value of setting 'instance_id' should be created in a migration
 - message: DatabaseConfig#config will be removed in 6.2.0 in favor of DatabaseConfigurations#configuration_hash which returns a hash with symbol keys

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1810,15 +1810,12 @@ The `:text` type supports markdown and usage of such setting should expect markd
 
 ==== Initial setting value
 
-If you want the setting to have initial value please use migration to seed it.
+In most cases, a setting should only have a default defined via the DSL, not an initial value.
+If you really need the setting to have an initial value, please use a seed to set it.
 
 [source, ruby]
 ```
-class SeedInitialFooSettingValue < ActiveRecord::Migration[6.0]
-  def up
-    Setting.find_or_create(name: 'foo').update(value: Foreman.uuid)
-  end
-end
+Setting[:instance_id] = Foreman.uuid unless Setting.where(name: 'instance_id').exists?
 ```
 
 ==== Validate setting values

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -13,17 +13,6 @@ class SettingRegistryTest < ActiveSupport::TestCase
     registry.load_values
   end
 
-  describe '#load' do
-    it 'loads initial value from the inventory, tho deprecates it' do
-      uuid = Foreman.uuid
-      registry.stubs(:load_definitions)
-      Foreman::Deprecation.expects(:deprecation_warning)
-      registry._add('test_uuid', type: :string, category: 'general', default: 'uuid', value: uuid, full_name: 'test uuid', description: 'test uuid', context: :test)
-      registry.load
-      assert_equal uuid, Setting['test_uuid'], 'The initial value was not set'
-    end
-  end
-
   describe '#load_values' do
     it "doesn't update definitions for unchanged settings" do
       registry.expects(:find).never


### PR DESCRIPTION
also update plugin docs to use a seed instead of a migration if they need a value


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
