### PR TITLE
Only use {linux,initrd}efi commands for x86/64 KS PXEGrub2 EL7

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -24,13 +24,28 @@ test_on:
   rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
   os_major = @host.operatingsystem.major.to_i
 
-  if (rhel_compatible && os_major < 7) || !@host.pxe_loader_efi?
-    # Grub EFI commands are RHEL7+ only (prevents "Kernel is too old") or for non-EFI arch
-    linuxcmd = "linux"
-    initrdcmd = "initrd"
-  else
+  if rhel_compatible && os_major == 7 && ['i386','x86_64'].include?(@host.architecture.to_s) && @host.pxe_loader_efi?
+    #
+    # The linuxefi and initrdefi commands, despite their names, are specific to
+    # x86 and its "EFI Handover Protocol." They do not exist in upstream Grub
+    # and have been added to Fedora's since Fedora 17.
+    #
+    # https://docs.kernel.org/arch/x86/boot.html#efi-handover-protocol-deprecated
+    # https://src.fedoraproject.org/rpms/grub2/blob/f39/f/0004-Add-support-for-Linux-EFI-stub-loading.patch
+    #
+    # EL6's kernel did not support EFI Handover ("kernel too old"). EL7's does,
+    # and its Grubby generates {linux,initrd}efi commands (excluding aarch64),
+    # but that ends in EL8's BLS support.
+    #
+    # https://projects.theforeman.org/issues/24026
+    # https://git.centos.org/rpms/grubby/blob/c7/f/SOURCES/0008-Use-the-correct-load-commands-for-aarch64-efi.patch
+    # https://git.centos.org/rpms/grub2/blob/c8s/f/SOURCES/0207-blscfg-Get-rid-of-the-linuxefi-linux16-linux-distinc.patch
+    #
     linuxcmd = "linuxefi"
     initrdcmd = "initrdefi"
+  else
+    linuxcmd = "linux"
+    initrdcmd = "initrd"
   end
 -%>
 


### PR DESCRIPTION
Fixes #36658.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
