### PR TITLE
Fixes #36677 - Added BOOTIF-parameter to autoinstall kernel_options

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_kernel_options_autoinstall.erb
@@ -36,6 +36,7 @@ test_on:
     options << "ip=[#{iface.ip6}]::[#{subnet6.gateway}]:[#{subnet6.mask}]:#{hostname}:#{iface.identifier}:none:[#{subnet6.dns_servers.join(']:[')}]"
   end
 
+  options << "BOOTIF=#{mac}" if mac
   options << 'ramdisk_size=1500000'
   options << 'fsck.mode=skip'
   options << 'autoinstall'


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/36677

Other that for kickstart the mac has to be separated with : instead of -

That change only makes a difference, if you try to provision hosts with more than one network interface.
