### PR TITLE
Fixes #36688 - Provide option to use wget for the new Register Host feature

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -184,6 +184,7 @@
           "vnc",
           "vnic",
           "webpack",
+          "wget",
           "wss",
           "x86_64",
           "xml",

--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -15,7 +15,7 @@ module Api
         param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems")
         param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
         param :jwt_expiration, :number, desc: N_("Expiration of the authorization token (in hours), 0 means 'unlimited'.")
-        param :insecure, :bool, desc: N_("Enable insecure argument for the initial curl")
+        param :insecure, :bool, desc: N_("Enable insecure argument for the initial curl/wget")
         param :packages, String, desc: N_("Packages to install on the host when registered. Can be set by `host_packages` parameter, example: `pkg1 pkg2`")
         param :update_packages, :bool, desc: N_("Update all packages on the host")
         param :repo, String, desc: N_("DEPRECATED, use the `repo_data` param instead."), deprecated: true
@@ -25,6 +25,7 @@ module Api
           param :repo, String, desc: N_("Repository URL / details, for example, for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat and SUSE OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
           param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
         end
+        param :download_utility, ["curl", "wget"], desc: N_("The download utility to use during host registration")
       end
       def create
         unless os_with_template?

--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -30,6 +30,7 @@ module Api
         param :repo, String, desc: N_("Repository URL / details, for example, for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
         param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
       end
+      param :download_utility, ["curl", "wget"], desc: N_("The download utility to use during host registration")
       def global
         find_global_registration
 

--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -41,6 +41,7 @@ module Foreman::Controller::Registration
       packages: params['packages'],
       update_packages: params['update_packages'],
       repo_data: repo_data,
+      download_utility: params['download_utility'],
     }
 
     params.permit(permitted)

--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -80,7 +80,8 @@ module Foreman
         :host_puppet_environment,
         :host_enc,
         :install_packages,
-        :update_packages
+        :update_packages,
+        :generate_web_request
       ]
 
       DEFAULT_ALLOWED_VARIABLES = [

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -14,7 +14,7 @@ description: |
 # Make sure, all command output can be parsed (e.g. from subscription-manager)
 export LC_ALL=C LANG=C
 <%
-    headers = ["-H 'Authorization: Bearer #{@auth_token}'"]
+    headers = ["--header 'Authorization: Bearer #{@auth_token}'"]
     activation_keys = [(@hostgroup.params['kt_activation_keys'] if @hostgroup), @activation_keys].compact.join(',')
 -%>
 
@@ -35,6 +35,7 @@ export LC_ALL=C LANG=C
 <%= "\n# Ignore subman errors: [#{@ignore_subman_errors}]" unless @ignore_subman_errors.nil? -%>
 <%= "\n# Lifecycle environment id: [#{@lifecycle_environment_id}]" if @lifecycle_environment_id.present? -%>
 <%= "\n# Activation keys: [#{activation_keys}]" if activation_keys.present? -%>
+<%= "\n# Download utility: [#{@download_utility}]" unless @download_utility.nil? -%>
 
 
 if ! [ $(id -u) = 0 ]; then
@@ -91,11 +92,11 @@ elif [ -f /etc/debian_version ]; then
 <% if repo_gpg_key_url.present? -%>
 <%# "apt 1.2.35" on Ubuntu 16.04 does not support storing GPG public keys in "/etc/apt/trusted.gpg.d/" in ASCII format -%>
   if [ "$(. /etc/os-release ; echo "$VERSION_ID")" = "16.04" ]; then
-    $PKG_MANAGER_INSTALL ca-certificates curl gnupg
-    curl --silent --show-error <%= shell_escape repo_gpg_key_url %> | gpg --dearmor > /etc/apt/trusted.gpg.d/client<%= index %>.gpg
+    $PKG_MANAGER_INSTALL ca-certificates gnupg
+    <%= indent(4, skip1: true) { generate_web_request(utility: @download_utility, url: shell_escape(repo_gpg_key_url)) } %> | gpg --dearmor > /etc/apt/trusted.gpg.d/client<%= index %>.gpg
   else
-    $PKG_MANAGER_INSTALL ca-certificates curl
-    curl --silent --show-error --output /etc/apt/trusted.gpg.d/client<%= index %>.asc <%= shell_escape repo_gpg_key_url %>
+    $PKG_MANAGER_INSTALL ca-certificates
+    <%= indent(4, skip1: true) { generate_web_request(utility: @download_utility, url: shell_escape(repo_gpg_key_url), output_file: "/etc/apt/trusted.gpg.d/client#{index}.asc") } %>
   fi
 <% end -%>
   apt-get update
@@ -108,22 +109,22 @@ fi
 <% end -%>
 
 register_host() {
-  curl --silent --show-error --cacert $SSL_CA_CERT --request POST <%= @registration_url %> \
-       <%= headers.join(' ') %> \
-       --data "host[name]=$(hostname --fqdn)" \
-       --data "host[build]=false" \
-       --data "host[managed]=false" \
-<%= "       --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
-<%= "       --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
-<%= "       --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
-<%= "       --data 'host[operatingsystem_id]=#{@operatingsystem.id}' \\\n" if @operatingsystem -%>
-<%= "       --data host[interfaces_attributes][0][identifier]=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
-<%= "       --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
-<%= "       --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
-<%= "       --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
-<%= "       --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
-<%= "       --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
-
+<%
+  params = ["host[name]=$(hostname --fqdn)"]
+  params << "host[build]=false"
+  params << "host[managed]=false"
+  params << "host[organization_id]=#{@organization.id}" if @organization
+  params << "host[location_id]=#{@location.id}" if @location
+  params << "host[hostgroup_id]=#{@hostgroup.id}" if @hostgroup
+  params << "host[operatingsystem_id]=#{@operatingsystem.id}" if @operatingsystem
+  params << "host[interfaces_attributes][0][identifier]=#{shell_escape(@remote_execution_interface)}" if @remote_execution_interface.present?
+  params << "setup_insights=#{@setup_insights}" unless @setup_insights.nil?
+  params << "setup_remote_execution=#{@setup_remote_execution}" unless @setup_remote_execution.nil?
+  params << "remote_execution_interface=#{shell_escape(@remote_execution_interface)}" if @remote_execution_interface.present?
+  params << "packages=#{shell_escape(@packages)}" if @packages.present?
+  params << "update_packages=#{@update_packages}" unless @update_packages.nil?
+-%>
+  <%= indent(2, skip1: true) { generate_web_request(utility: @download_utility, url: @registration_url, ssl_ca_cert: "$SSL_CA_CERT", headers: headers, params: params) } %>
 }
 
 echo "#"
@@ -132,22 +133,22 @@ echo "#"
 
 <% if plugin_present?('katello') && activation_keys.present? -%>
 register_katello_host(){
-    UUID=$(subscription-manager identity | grep --max-count 1 --only-matching '\([[:xdigit:]]\{8\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{12\}\)')
-    curl --silent --show-error --cacert $KATELLO_SERVER_CA_CERT --request POST "<%= @registration_url %>" \
-         <%= headers.join(' ') %> \
-         --data "uuid=$UUID" \
-         --data "host[build]=false" \
-<%= "      --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
-<%= "      --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
-<%= "      --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
-<%= "      --data 'host[lifecycle_environment_id]=#{@lifecycle_environment_id}' \\\n" if @lifecycle_environment_id.present? -%>
-<%= "      --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
-<%= "      --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
-<%= "      --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
-<%= "      --data 'setup_remote_execution_pull=#{@setup_remote_execution_pull}' \\\n" unless @setup_remote_execution_pull.nil? -%>
-<%= "      --data packages=#{shell_escape(@packages)} \\\n" if @packages.present? -%>
-<%= "      --data 'update_packages=#{@update_packages}' \\\n" unless @update_packages.nil? -%>
-
+<%
+  params = ["uuid=$UUID"]
+  params << "host[build]=false"
+  params << "host[organization_id]=#{@organization.id}" if @organization
+  params << "host[location_id]=#{@location.id}" if @location
+  params << "host[hostgroup_id]=#{@hostgroup.id}" if @hostgroup
+  params << "host[lifecycle_environment_id]=#{@lifecycle_environment_id}" if @lifecycle_environment_id.present?
+  params << "setup_insights=#{@setup_insights}" unless @setup_insights.nil?
+  params << "setup_remote_execution=#{@setup_remote_execution}" unless @setup_remote_execution.nil?
+  params << "remote_execution_interface=#{shell_escape(@remote_execution_interface)}" if @remote_execution_interface.present?
+  params << "setup_remote_execution_pull=#{@setup_remote_execution_pull}" unless @setup_remote_execution_pull.nil?
+  params << "packages=#{shell_escape(@packages)}" if @packages.present?
+  params << "update_packages=#{@update_packages}" unless @update_packages.nil?
+-%>
+  UUID=$(subscription-manager identity | grep --max-count 1 --only-matching '\([[:xdigit:]]\{8\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{12\}\)')
+  <%= indent(2, skip1: true) { generate_web_request(utility: @download_utility, url: @registration_url, ssl_ca_cert: "$KATELLO_SERVER_CA_CERT", headers: headers, params: params) } %>
 }
 
 # Set up subscription-manager

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -45,6 +45,27 @@ module Foreman
   def self.settings
     SettingRegistry.instance
   end
+
+  def self.download_utilities
+    {
+      'curl' => {
+        :ca_cert => '--cacert',
+        :download_command => 'curl --silent --show-error',
+        :insecure => '--insecure',
+        :output_file => '--output',
+        :request_type_post => '--request POST',
+        :format_params => proc { |params| params.map { |param| "--data #{param}" } },
+      },
+      'wget' => {
+        :ca_cert => '--ca-certificate',
+        :download_command => 'wget --no-verbose --no-hsts',
+        :insecure => '--no-check-certificate',
+        :output_file => '--output-document',
+        :output_pipe => '--output-document -',
+        :format_params => proc { |params| ["--post-data #{params.join('\&')}"] },
+      },
+    }.freeze
+  end
 end
 
 # Consider moving these to config.autoload_lib_once in Rails 7.1

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -26,6 +26,7 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
         location_id: taxonomies(:location1).id,
         hostgroup_id: hostgroups(:common).id,
         operatingsystem_id: operatingsystems(:centos5_3).id,
+        download_utility: 'wget',
       }
 
       get :global, params: params, session: set_session_user
@@ -38,6 +39,7 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
       assert_equal operatingsystems(:centos5_3), vars[:operatingsystem]
       assert_equal users(:admin), vars[:user]
       assert_equal register_url, vars[:registration_url].to_s
+      assert_equal 'wget', vars[:download_utility].to_s
     end
 
     test "should not pass unpermitted params to template" do

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -37,6 +37,7 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
         hostgroupId: hostgroups(:common).id,
         operatingsystemId: operatingsystems(:redhat).id,
         update_packages: true,
+        download_utility: 'wget',
       }
       post :create, params: params, session: set_session_user
       command = JSON.parse(@response.body)['command']
@@ -46,6 +47,7 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       assert_includes command, 'hostgroupId='
       assert_includes command, 'operatingsystemId='
       assert_includes command, 'update_packages=true'
+      assert_includes command, 'download_utility=wget'
     end
 
     test 'with params ignored in URL' do
@@ -61,7 +63,7 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       post :create, params: params, session: set_session_user
       command = JSON.parse(@response.body)['command']
 
-      assert_includes command, "curl -sS --insecure '#{proxy.url}/register"
+      assert_includes command, "curl --silent --show-error  --insecure '#{proxy.url}/register"
       refute command.include?('smart_proxy_id')
       refute command.include?('insecure=true')
       refute command.include?('jwt_expiration')

--- a/test/unit/foreman/renderer/scope/macros/helpers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/helpers_test.rb
@@ -109,4 +109,54 @@ class HelpersTest < ActiveSupport::TestCase
     it { assert scope.falsy?('false') }
     it { refute scope.falsy?('true') }
   end
+
+  describe '#generate_web_request' do
+    it "generate curl get request" do
+      utility = "curl"
+      url = "https://www.example.com/keys/client.asc"
+      output_file = "/etc/apt/trusted.gpg.d/client1.asc"
+      expected_request = "curl --silent --show-error https://www.example.com/keys/client.asc \\\n" \
+                         "  --output /etc/apt/trusted.gpg.d/client1.asc"
+      assert_equal expected_request, scope.generate_web_request(utility: utility, url: url, output_file: output_file)
+    end
+
+    it "generate curl post request" do
+      utility = "curl"
+      url = "https://www.example.com/register"
+      ssl_ca_cert = "/etc/ssl/custom_certs/ca_cert.crt"
+      headers = ["--header \'Authorization: Bearer my_token\'"]
+      params = ["host[build]=false", "host[organization_id]=1"]
+      expected_request = "curl --silent --show-error https://www.example.com/register \\\n" \
+                         "  --cacert /etc/ssl/custom_certs/ca_cert.crt \\\n" \
+                         "  --request POST \\\n" \
+                         "  --header 'Authorization: Bearer my_token' \\\n" \
+                         "  --data host[build]=false \\\n" \
+                         "  --data host[organization_id]=1"
+      assert_equal expected_request, scope.generate_web_request(utility: utility, url: url, ssl_ca_cert: ssl_ca_cert, headers: headers, params: params)
+    end
+
+    it "generate wget get request" do
+      utility = "wget"
+      url = "https://www.example.com/keys/client.asc"
+      output_file = "/etc/apt/trusted.gpg.d/client1.asc"
+      expected_request = "wget --no-verbose --no-hsts https://www.example.com/keys/client.asc \\\n" \
+                         "  --output-document /etc/apt/trusted.gpg.d/client1.asc"
+      assert_equal expected_request, scope.generate_web_request(utility: utility, url: url, output_file: output_file)
+    end
+
+    it "generate wget post request" do
+      utility = "wget"
+      url = "https://www.example.com/register"
+      ssl_ca_cert = "/etc/ssl/custom_certs/ca_cert.crt"
+      headers = ["--header \'Authorization: Bearer my_token\'"]
+      params = ["host[build]=false", "host[organization_id]=1"]
+      expected_request = "wget --no-verbose --no-hsts https://www.example.com/register \\\n" \
+                         "  --ca-certificate /etc/ssl/custom_certs/ca_cert.crt \\\n" \
+                         "  --output-document - \\\n" \
+                         "  --header 'Authorization: Bearer my_token' \\\n" \
+                         "  --post-data host[build]=false\\&host[organization_id]=1"
+
+      assert_equal expected_request, scope.generate_web_request(utility: utility, url: url, ssl_ca_cert: ssl_ca_cert, headers: headers, params: params)
+    end
+  end
 end

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
@@ -8,6 +8,7 @@ Object {
         "payload": Object {
           "key": "REGISTRATION_COMMANDS",
           "params": Object {
+            "downloadUtility": "curl",
             "hostgroupId": undefined,
             "insecure": false,
             "jwtExpiration": 4,

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/General.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/General.test.js.snap
@@ -33,6 +33,11 @@ exports[`RegistrationCommandsPage - General renders 1`] = `
     smartProxies={Array []}
     smartProxyId={0}
   />
+  <DownloadUtility
+    downloadUtility="curl"
+    handleDownloadUtility={[Function]}
+    isLoading={false}
+  />
   <Insecure
     handleInsecure={[Function]}
     insecure={false}

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
@@ -1,4 +1,5 @@
 import { STATUS } from '../../../../constants';
+import { DownloadUtilities } from '../components/fields/DownloadUtility'
 
 export const generalComponentProps = {
   organizationId: 0,
@@ -21,6 +22,8 @@ export const generalComponentProps = {
   handleInsecure: () => {},
   handleInvalidField: () => {},
   isLoading: false,
+  downloadUtility: DownloadUtilities.curl,
+  handleDownloadUtility: () => {},
 };
 export const advancedComponentProps = {
   configParams: {},
@@ -95,6 +98,12 @@ export const packagesProps = {
 export const updatePackagesProps = {
   updatePackages: false,
   handleUpdatePackages: () => {},
+  isLoading: false,
+};
+
+export const downloadUtilityProps = {
+  downloadUtility: DownloadUtilities.curl,
+  handleDownloadUtility: () => {},
   isLoading: false,
 };
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/General.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/General.js
@@ -6,6 +6,7 @@ import HostGroup from './fields/HostGroup';
 import OperatingSystem from './fields/OperatingSystem';
 import SmartProxy from './fields/SmartProxy';
 import Insecure from './fields/Insecure';
+import DownloadUtility, { DownloadUtilities } from './fields/DownloadUtility';
 
 const General = ({
   organizationId,
@@ -28,6 +29,8 @@ const General = ({
   handleInsecure,
   handleInvalidField,
   isLoading,
+  downloadUtility,
+  handleDownloadUtility,
 }) => (
   <>
     <Taxonomies
@@ -65,6 +68,12 @@ const General = ({
       isLoading={isLoading}
     />
 
+    <DownloadUtility
+      downloadUtility={downloadUtility}
+      handleDownloadUtility={handleDownloadUtility}
+      isLoading={isLoading}
+    />
+
     <Insecure
       insecure={insecure}
       handleInsecure={handleInsecure}
@@ -97,6 +106,8 @@ General.propTypes = {
   handleInsecure: PropTypes.func.isRequired,
   handleInvalidField: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
+  downloadUtility: PropTypes.oneOf(DownloadUtilities),
+  handleDownloadUtility: PropTypes.func.isRequired,
 };
 
 General.defaultProps = {
@@ -111,6 +122,7 @@ General.defaultProps = {
   operatingSystemId: undefined,
   operatingSystemTemplate: undefined,
   smartProxyId: undefined,
+  downloadUtility: DownloadUtilities[0],
 };
 
 export default General;

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/DownloadUtility.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/DownloadUtility.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+  FormGroup,
+  FormSelect,
+  FormSelectOption,
+} from '@patternfly/react-core';
+
+import { translate as __ } from '../../../../../common/I18n';
+
+export const DownloadUtilities = ['curl', 'wget'];
+const DownloadUtility = ({
+  downloadUtility,
+  handleDownloadUtility,
+  isLoading,
+}) => (
+  <FormGroup label={__('Download utility')} fieldId="reg_download_utility">
+    <FormSelect
+      ouiaId="reg_download_utility"
+      value={downloadUtility}
+      onChange={v => handleDownloadUtility(v)}
+      className="without_select2"
+      id="reg_download_utility"
+      isDisabled={isLoading}
+    >
+      {DownloadUtilities.map(item => (
+        <FormSelectOption key={item} value={item} label={item} />
+      ))}
+    </FormSelect>
+  </FormGroup>
+);
+
+DownloadUtility.propTypes = {
+  downloadUtility: PropTypes.oneOf(DownloadUtilities),
+  handleDownloadUtility: PropTypes.func.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+};
+
+DownloadUtility.defaultProps = {
+  downloadUtility: DownloadUtilities[0],
+};
+
+export default DownloadUtility;

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -44,6 +44,7 @@ import Advanced from './components/Advanced';
 import Actions from './components/Actions';
 import Command from './components/Command';
 import './RegistrationCommandsPage.scss';
+import { DownloadUtilities } from './components/fields/DownloadUtility';
 
 const RegistrationCommandsPage = () => {
   const dispatch = useDispatch();
@@ -94,6 +95,7 @@ const RegistrationCommandsPage = () => {
   const [repoData, setRepoData] = useState([]);
   const [repoDataInternal, setRepoDataInternal] = useState([]);
   const [invalidFields, setInvalidFields] = useState([]);
+  const [downloadUtility, setDownloadUtility] = useState(DownloadUtilities[0]);
 
   // Command
   const command = useSelector(selectCommand);
@@ -134,6 +136,7 @@ const RegistrationCommandsPage = () => {
       packages,
       repoData,
       updatePackages,
+      downloadUtility,
       ...pluginValues,
     };
 
@@ -280,6 +283,8 @@ const RegistrationCommandsPage = () => {
                   handleInvalidField={handleInvalidField}
                   invalidFields={invalidFields}
                   isLoading={isLoading}
+                  downloadUtility={downloadUtility}
+                  handleDownloadUtility={setDownloadUtility}
                 />
 
                 <Slot


### PR DESCRIPTION
The Register hosts page uses `curl` for registering hosts. This seems to be a good approach for EL based systems as most of these come with `curl` preinstalled. On Debian based systems this is not always the case (at least for recent versions of Debian and Ubuntu).

This feature request aims to provide an option to use `wget` for registering hosts as `wget` is as widely used as `curl`. By this system administrators that only have `wget` installed are not forced to also install curl anymore.