### PR TITLE
Fixes #36691 - use 'connectefi scsi' by default

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -32,9 +32,15 @@ insmod fat
 insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
-echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "partition due to not initializing all the EFI devices. To address this,"
+echo "use an up-to-date grub2 (*) version and include the "connectefi scsi" statement"
+echo "as provided below. If you're using an older grub2 version or"
+echo "the "connectefi" option isn't recognized by your grub2, grub2 will print a error"
+echo "like 'can't find command connectefi' but the boot process will continue."
+echo "For hosts, you can omit this by adding a (global) parameter to 'grub2-connectefi=false'."
+echo "For the default GRUB2 script, you can omit this by setting the"
+echo "default_connectefi_option below to 'false'."
+echo "Valid values of 'grub2-connectefi' parameter: false, scsi, pciroot"
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -43,7 +49,12 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
+<%=
+  default_connectefi_option = 'scsi'
+  connectefi_option = @host ? host_param('grub2-connectefi', default_connectefi_option) : default_connectefi_option
+  connectefi_option = nil if connectefi_option == 'false'
+  "connectefi #{connectefi_option}" if connectefi_option
+%>
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -7,9 +7,15 @@ insmod fat
 insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
-echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "partition due to not initializing all the EFI devices. To address this,"
+echo "use an up-to-date grub2 (*) version and include the "connectefi scsi" statement"
+echo "as provided below. If you're using an older grub2 version or"
+echo "the "connectefi" option isn't recognized by your grub2, grub2 will print a error"
+echo "like 'can't find command connectefi' but the boot process will continue."
+echo "For hosts, you can omit this by adding a (global) parameter to 'grub2-connectefi=false'."
+echo "For the default GRUB2 script, you can omit this by setting the"
+echo "default_connectefi_option below to 'false'."
+echo "Valid values of 'grub2-connectefi' parameter: false, scsi, pciroot"
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -18,7 +24,7 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
+connectefi scsi
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -23,9 +23,15 @@ insmod fat
 insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
-echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "partition due to not initializing all the EFI devices. To address this,"
+echo "use an up-to-date grub2 (*) version and include the "connectefi scsi" statement"
+echo "as provided below. If you're using an older grub2 version or"
+echo "the "connectefi" option isn't recognized by your grub2, grub2 will print a error"
+echo "like 'can't find command connectefi' but the boot process will continue."
+echo "For hosts, you can omit this by adding a (global) parameter to 'grub2-connectefi=false'."
+echo "For the default GRUB2 script, you can omit this by setting the"
+echo "default_connectefi_option below to 'false'."
+echo "Valid values of 'grub2-connectefi' parameter: false, scsi, pciroot"
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -34,7 +40,7 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
+connectefi scsi
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -3,9 +3,15 @@ insmod fat
 insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
-echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "partition due to not initializing all the EFI devices. To address this,"
+echo "use an up-to-date grub2 (*) version and include the "connectefi scsi" statement"
+echo "as provided below. If you're using an older grub2 version or"
+echo "the "connectefi" option isn't recognized by your grub2, grub2 will print a error"
+echo "like 'can't find command connectefi' but the boot process will continue."
+echo "For hosts, you can omit this by adding a (global) parameter to 'grub2-connectefi=false'."
+echo "For the default GRUB2 script, you can omit this by setting the"
+echo "default_connectefi_option below to 'false'."
+echo "Valid values of 'grub2-connectefi' parameter: false, scsi, pciroot"
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -14,7 +20,7 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
+connectefi scsi
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/templates/snippets/pxegrub2_chainload_test.rb
+++ b/test/unit/foreman/templates/snippets/pxegrub2_chainload_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class PxeGrub2ChainloadTest < ActiveSupport::TestCase
+  def renderer
+    @renderer ||= Foreman::Renderer::SafeModeRenderer
+  end
+
+  def render_template(host)
+    @snippet ||= File.read(Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'pxegrub2_chainload.erb'))
+
+    source = OpenStruct.new(
+      name: 'Test',
+      content: @snippet
+    )
+
+    scope = Class.new(Foreman::Renderer::Scope::Provisioning).send(
+      :new,
+      host: host,
+      source: source,
+      variables: {
+        host: host,
+      })
+
+    renderer.render(source, scope)
+  end
+
+  setup do
+    @host = FactoryBot.create(:host, :managed, :build => true)
+  end
+
+  test 'should render connectefi scsi option by default' do
+    actual = render_template(@host)
+
+    assert_match(/^ *connectefi scsi/, actual)
+  end
+
+  test 'should not render connectefi option if parameter false' do
+    FactoryBot.create(:host_parameter, host: @host, name: 'grub2-connectefi', value: 'false')
+
+    actual = render_template(@host)
+
+    assert_no_match(/^ *connectefi/, actual)
+  end
+
+  test 'should render connectefi option if parameter present' do
+    FactoryBot.create(:host_parameter, host: @host, name: 'grub2-connectefi', value: 'TESTOPT')
+
+    actual = render_template(@host)
+
+    assert_match(/^ *connectefi TESTOPT/, actual)
+  end
+
+  test 'should render connectefi option for default template' do
+    actual = render_template(nil)
+
+    assert_match(/^ *connectefi scsi/, actual)
+  end
+end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
