### PR TITLE
Fixes #36699 - Reject invalid expiration dates for PATs

### DIFF
--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1176,7 +1176,12 @@ class UserTest < ActiveSupport::TestCase
       token.save
       token_value
     end
-    let(:expired_token) { FactoryBot.create(:personal_access_token, :user => user, :expires_at => 4.weeks.ago) }
+    let(:expired_token) do
+      token = FactoryBot.create(:personal_access_token, :user => user)
+      token.expires_at = 4.weeks.ago
+      token.save(validate: false)
+      token
+    end
     let(:expired_token_value) do
       token_value = expired_token.generate_token
       expired_token.save


### PR DESCRIPTION
Previously invalid dates were silently discarded, resulting into PATs being created without expiration dates.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
