### PR TITLE
Fixes #36134 - kickstart in graphical mode runs chvt to the wrong terminal

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -362,7 +362,11 @@ sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/ker
 
 touch /tmp/foreman_built
 
+<% if host_param_true?('use_graphical_installer') -%>
+chvt 6
+<% else -%>
 chvt 1
+<% end -%>
 ) 2>&1 | tee /root/install.post.log
 <%= section_end %>
 


### PR DESCRIPTION
This should resolve the issue where anaconda detects an open VTTY and doesn't halt.

Ideally, there is a way to check what VTTY is in use before the first chvt.  But I do not know what that is.