### PR TITLE
Fixes #36715 - Speed up host fact retrieval when you only need a subset of facts

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -119,6 +119,16 @@ class ActiveSupport::TestCase
     Foreman::Plugin.send(:clear, @plugins_backup, @registries_backup)
     @clear_plugins = nil
   end
+
+  def assert_sql_queries(num_of_queries, match = /SELECT/)
+    queries = []
+    ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _start, _finish, _id, payload|
+      queries << payload[:sql] if payload[:sql] =~ match
+    end
+    yield
+    ActiveSupport::Notifications.unsubscribe("sql.active_record")
+    assert_equal num_of_queries, queries.size, "Expected #{num_of_queries} queries, but got #{queries.size}"
+  end
 end
 
 class ActionView::TestCase


### PR DESCRIPTION
A user with about 3k hosts has a report that runs `host.facts` on each host multiple times. This was causing the report generation time to be over an hour, since `host.facts` runs a few `includes` which result in quite a few SQL queries:

```rb
fact_values.includes(:fact_name).collect do |fact|
        hash[fact.fact_name.name] = fact.value
      end
```

This PR adds a new argument to host.facts so you can pass specific fact names. It also changes `collect` to `each` in the above code because we don't use the resulting arrays, we just iterate and build the final hash.

The report template can look something like this:

```rb
<%- load_hosts(search: input('Hosts filter')).each_record do |host| -%>
<%- host_facts = host.facts(['net::interface::eth0::ipv4_address', 'network::hostname']) -%>
<%-   report_row(
        'Hostname': host_facts['network::hostname'],
        'IP': host_facts['net::interface::eth0::ipv4_address']
    ) -%>
<%- end -%>

<%= report_render -%>
```


