### PR TITLE
Fixes #36730 - Implement pruning of old TFTP files

### DIFF
--- a/app/services/proxy_api/tftp.rb
+++ b/app/services/proxy_api/tftp.rb
@@ -59,5 +59,21 @@ module ProxyAPI
     rescue => e
       raise ProxyException.new(url, e, N_("Unable to create default TFTP boot menu"))
     end
+
+    # Prune old TFTP entries
+    # [+age+] : The age of a file in seconds
+    # Returns : Integer the number of files pruned or nil if it's not
+    # implemented
+    def prune(age)
+      args = {
+        age: age,
+      }
+      parse(post(args, "prune"))
+    rescue RestClient::ResourceNotFound
+      # Not implemented
+      nil
+    rescue => e
+      raise ProxyException.new(url, e, N_("Unable to prune old TFTP files"))
+    end
   end
 end

--- a/lib/tasks/orchestration.rake
+++ b/lib/tasks/orchestration.rake
@@ -73,4 +73,28 @@ namespace :orchestration do
       end
     end
   end
+
+  namespace :tftp do
+    task :prune => :environment do
+      duration = Setting['token_duration']
+      return if duration == 0
+
+      age = duration * 60
+
+      SmartProxy.unscoped.with_features('TFTP').sum do |smart_proxy|
+        tftp = ProxyAPI::TFTP.new(url: smart_proxy.url)
+        pruned = tftp.prune(age)
+
+        if pruned.nil?
+          puts "Smart Proxy #{smart_proxy} does not implement pruning"
+          0
+        else
+          puts "Smart Proxy #{smart_proxy} pruned #{pruned} files"
+          pruned
+        end
+      end
+
+      puts "Pruned #{pruned} files in total"
+    end
+  end
 end


### PR DESCRIPTION
This implements a rake task orchestration:tftp:prune to prune old files.  The actual pruning logic is implemented on the Smart Proxy where Foreman only specified the age (token_duration * 60).

I considered making this a foreman-task, but we can't rely on that so it's a rake task.