### PR TITLE
Use actions/labeler to apply directory labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,15 @@
+---
+Docs:
+  - developer_docs/**
+
+GraphQL:
+  - app/graphql/**
+
+Legacy JS:
+  - app/assets/javascripts/**
+
+Templates:
+  - app/views/unattended/**
+
+UI:
+  - webpack/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+---
+name: "Pull Request Labeler"
+
+on:
+  - pull_request_target
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4


### PR DESCRIPTION
Today the legacy PR processor is used to apply directory labels, but it is the only repository to do so. This uses a common GitHub Action to do the same thing. Another benefit is that the configuration now lives close to the code.

A possible downside is that if there are changes, it needs to be cherry picked. That's unlikely, given how little these change. It may even be a benefit when files move around. It gives the possibility to use different labels in different branches.