### PR TITLE
Fixes #36741 - Check Ubuntu version more explicitly

### DIFF
--- a/app/models/operatingsystems/debian.rb
+++ b/app/models/operatingsystems/debian.rb
@@ -81,7 +81,7 @@ class Debian < Operatingsystem
   def is_subiquity?
     return false if guess_os != "ubuntu"
     return false if major.to_i < 20
-    return false if major.to_i == 20 && minor.to_i <= 2
+    return false if major.to_i == 20 && minor.present? && minor.to_i <= 2
     true # Ubuntu release 20.04.3 or newer
   end
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

If no minor version is defined, the function `minor.to_i` makes it a "0". Accordingly, Ubuntu 20.04 is interpreted as "no subiquity/Autoinstall" - but, it should not assume a specific version here. 

Therefore, `is_subiquity` should return ´true` in this case (especially, since all 20.04.x versions support subiquity/Autoinstall provisioning, but only specific ones allow Preseed/debian-installer still).