### PR TITLE
Fixes #36744 - VM tab (legacy UI) shows error in case host is not associated to VM

### DIFF
--- a/app/views/hosts/show.html.erb
+++ b/app/views/hosts/show.html.erb
@@ -34,7 +34,7 @@
       <% if @host.managed? %>
         <li><a href="#template" data-toggle="tab"><%= _('Templates') %></a></li>
       <% end %>
-      <%  if @host.compute_resource_id %>
+      <%  if @host.compute_resource_id && @host.uuid %>
         <li><a href="#vm" data-toggle="tab"><%= _('VM') %></a></li>
       <% end %>
       <% if @host.bmc_available? %>


### PR DESCRIPTION
**Steps to reproduce:**

1. Register a host
2. Go to hosts > My_Registered_Host > Dot menu > Legacy UI > VM tab

**Actual Result:**
An error is shown

**Expected result:**
Upon registration, the host is not associated to a VM. In case the host is not associated to a VM, the VM tab should not be visible at all.
