### PR TITLE
Fixes #36759 - only call allowed transpilers

### DIFF
--- a/app/registries/foreman/settings/provisioning.rb
+++ b/app/registries/foreman/settings/provisioning.rb
@@ -2,6 +2,9 @@ require 'foreman/provision'
 
 Foreman::SettingManager.define(:foreman) do
   category(:provisioning, N_('Provisioning')) do
+    CT_LOCATIONS = %w(/usr/bin/ct /usr/local/bin/ct)
+    FCCT_LOCATIONS = %w(/usr/bin/fcct /usr/local/bin/fcct)
+
     owner_select = proc do
       [{:name => _("Users"), :class => 'user', :scope => 'visible', :value_method => 'id_and_type', :text_method => 'login'},
        {:name => _("Usergroups"), :class => 'usergroup', :scope => 'visible', :value_method => 'id_and_type', :text_method => 'name'}]
@@ -119,16 +122,28 @@ Foreman::SettingManager.define(:foreman) do
       description: N_("Default 'Host initial configuration' template, automatically assigned when a new operating system is created"),
       default: 'Linux host_init_config default',
       full_name: N_("Default 'Host initial configuration' template"))
-    setting('ct_command',
+    setting('ct_location',
+      type: :string,
+      description: N_("Full path to CoreOS transpiler (ct)"),
+      default: CT_LOCATIONS.first,
+      full_name: N_("CoreOS Transpiler Command"),
+      collection: proc { CT_LOCATIONS.zip(CT_LOCATIONS).to_h })
+    setting('ct_arguments',
       type: :array,
-      description: N_("Full path to CoreOS transpiler (ct) with arguments as an comma-separated array"),
-      default: [which('ct'), '--pretty', '--files-dir', Rails.root.join('config', 'ct').to_s],
-      full_name: N_("CoreOS Transpiler Command"))
-    setting('fcct_command',
+      description: N_("CoreOS transpiler (ct) arguments as an comma-separated array"),
+      default: ['--pretty', '--files-dir', Rails.root.join('config', 'ct').to_s],
+      full_name: N_("CoreOS Transpiler Command Arguments"))
+    setting('fcct_location',
+      type: :string,
+      description: N_("Full path to Fedora CoreOS transpiler (fcct)"),
+      default: FCCT_LOCATIONS.first,
+      full_name: N_("Fedora CoreOS Transpiler Command"),
+      collection: proc { FCCT_LOCATIONS.zip(FCCT_LOCATIONS).to_h })
+    setting('fcct_arguments',
       type: :array,
-      description: N_("Full path to Fedora CoreOS transpiler (fcct) with arguments as an comma-separated array"),
-      default: [which('fcct'), '--pretty', '--files-dir', Rails.root.join('config', 'ct').to_s],
-      full_name: N_("Fedora CoreOS Transpiler Command"))
+      description: N_("Fedora CoreOS transpiler (fcct) arguments as an comma-separated array"),
+      default: ['--pretty', '--files-dir', Rails.root.join('config', 'ct').to_s],
+      full_name: N_("Fedora CoreOS Transpiler Command Arguments"))
 
     # We have following loop twice to keep the historical order.
     # TODO: First resolve the correct order and then optimize this loop.

--- a/app/services/foreman/renderer/scope/macros/transpilers.rb
+++ b/app/services/foreman/renderer/scope/macros/transpilers.rb
@@ -15,7 +15,8 @@ module Foreman
           end
           def transpile_coreos_linux_config(input, validate_input = true, validate_output = false)
             YAML.safe_load(input) if validate_input
-            result = Foreman::CommandRunner.new(Setting[:ct_command], input).run!
+            ct_command = [Setting[:ct_location]] + Setting[:ct_arguments]
+            result = Foreman::CommandRunner.new(ct_command, input).run!
             JSON.parse(result) if validate_output
             result
           end
@@ -29,7 +30,8 @@ module Foreman
             example "transpile_coreos_linux_config(\"---\\nyaml: blah\") #=> JSON"
           end
           def transpile_fedora_coreos_config(input)
-            Foreman::CommandRunner.new(Setting[:fcct_command], input).run!
+            fcct_command = [Setting[:fcct_location]] + Setting[:fcct_arguments]
+            Foreman::CommandRunner.new(fcct_command, input).run!
           end
         end
       end

--- a/db/migrate/20230920093000_move_ct_command_into_own_setting.rb
+++ b/db/migrate/20230920093000_move_ct_command_into_own_setting.rb
@@ -1,0 +1,27 @@
+class MoveCtCommandIntoOwnSetting < ActiveRecord::Migration[6.1]
+  def up
+    ['ct', 'fcct'].each do |setting_prefix|
+      setting = Setting.find_by(name: "#{setting_prefix}_command")
+      if setting
+        new_setting = setting.dup
+        new_setting.value = setting.value.drop(1)
+        new_setting.name = "#{setting_prefix}_arguments"
+        new_setting.save
+        setting.delete
+      end
+    end
+  end
+
+  def down
+    ['ct', 'fcct'].each do |setting_prefix|
+      setting = Setting.find_by(name: "#{setting_prefix}_arguments")
+      if setting
+        new_setting = setting.dup
+        new_setting.value = ["/usr/bin/#{setting_prefix}"] + setting.value
+        new_setting.name = "#{setting_prefix}_command"
+        new_setting.save
+        setting.delete
+      end
+    end
+  end
+end

--- a/test/fixtures/settings.yml
+++ b/test/fixtures/settings.yml
@@ -3,8 +3,14 @@ attributes66:
   name: delivery_method
   value: :test
 attribute97:
-  name: ct_command
-  value: "['/usr/bin/cat']"
+  name: ct_location
+  value: "/usr/bin/cat"
 attribute98:
-  name: fcct_command
-  value: "['/usr/bin/cat']"
+  name: fcct_location
+  value: "/usr/bin/cat"
+attribute99:
+  name: ct_arguments
+  value: []
+attribute100:
+  name: fcct_arguments
+  value: []

--- a/test/unit/foreman/renderer/scope/macros/transpilers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/transpilers_test.rb
@@ -19,7 +19,7 @@ class TranspilersTest < ActiveSupport::TestCase
 
   describe '#transpile_coreos_linux_config' do
     test 'should call the transpiler' do
-      Foreman::CommandRunner.any_instance.expects(:capture3).with(Setting[:ct_command], "IGNORE")
+      Foreman::CommandRunner.any_instance.expects(:capture3).with([Setting[:ct_location]] + Setting[:ct_arguments], "IGNORE")
         .returns(["JSON", "", @success])
 
       assert_equal "JSON", @scope.transpile_coreos_linux_config("IGNORE")
@@ -28,7 +28,7 @@ class TranspilersTest < ActiveSupport::TestCase
 
   describe '#transpile_fedora_coreos_config' do
     test 'should call the transpiler' do
-      Foreman::CommandRunner.any_instance.expects(:capture3).with(Setting[:fcct_command], "IGNORE")
+      Foreman::CommandRunner.any_instance.expects(:capture3).with([Setting[:fcct_location]] + Setting[:fcct_arguments], "IGNORE")
         .returns(["JSON", "", @success])
 
       assert_equal "JSON", @scope.transpile_fedora_coreos_config("IGNORE")


### PR DESCRIPTION
CVE-2022-3874: OS command injection via ct_command and fcct_command

Instead of allowing to call *any* command by changing a setting, only allow specific paths to ct/fcct. If the user needs a different path, they can set it via settings.yaml.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
