### PR TITLE
Fixes #36747 - create new snippet for subscription-manager setup

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -43,6 +43,7 @@ if ! [ $(id -u) = 0 ]; then
   exit 1
 fi
 
+# Select package manager for the OS (sets the $PKG_MANAGER* variables)
 <%= snippet 'pkg_manager' %>
 
 SSL_CA_CERT=$(mktemp)
@@ -139,73 +140,8 @@ register_katello_host(){
 
 }
 
-KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
-RHSM_CFG=/etc/rhsm/rhsm.conf
-
-# Backup rhsm.conf
-if [ -f $RHSM_CFG ] ; then
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-fi
-
-# rhn-client-tools conflicts with subscription-manager package
-# since rhn tools replaces subscription-manager, we need to explicitly
-# install subscription-manager after the rhn tools cleanup
-if [ x$ID = xol ]; then
-  $PKG_MANAGER_REMOVE rhn-client-tools
-  $PKG_MANAGER_INSTALL --setopt=obsoletes=0 subscription-manager
-fi
-
-<% if truthy?(@force) -%>
-# Unregister host and remove all local system and subscription data
-
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager unregister || true
-  subscription-manager clean
-fi
-
-$PKG_MANAGER_REMOVE katello-ca-consumer\* > /dev/null 2>&1
-<% end -%>
-
-# Prepare SSL certificate
-mkdir -p /etc/rhsm/ca
-cp -f $SSL_CA_CERT $KATELLO_SERVER_CA_CERT
-chmod 644 $KATELLO_SERVER_CA_CERT
-
-# Prepare subscription-manager
-if ! [ -x "$(command -v subscription-manager)" ] ; then
-  $PKG_MANAGER_INSTALL subscription-manager
-else
-  $PKG_MANAGER_UPGRADE subscription-manager > /dev/null 2>&1
-fi
-
-if ! [ -f $RHSM_CFG ] ; then
-  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-  cleanup_and_exit 1
-fi
-
-# Configure subscription-manager
-test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-subscription-manager config \
-  --server.hostname="<%= @rhsm_url.host if @rhsm_url %>" \
-  --server.port="<%= @rhsm_url.port if @rhsm_url %>" \
-  --server.prefix="<%= @rhsm_url.path if @rhsm_url %>" \
-  --rhsm.repo_ca_cert="$KATELLO_SERVER_CA_CERT" \
-  --rhsm.baseurl="<%= @pulp_content_url %>"
-
-# Older versions of subscription manager may not recognize
-# report_package_profile and package_profile_on_trans options.
-# So set them separately and redirect out & error to /dev/null
-# to fail silently.
-subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-
-# Configuration for EL6
-if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-else
-  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-fi
+# Set up subscription-manager
+<%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'registration' }).strip -%>
 
 subscription-manager register <%= '--force' if truthy?(@force) %> \
   --org='<%= @organization.label if @organization %>' \

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -94,25 +94,14 @@ description: |
   echo
   echo "Starting the subscription-manager registration process"
 
-  # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-  #  assuming subscription-manager is installed in custom packages section.
-  if ! rpm --query --quiet subscription-manager ; then
-    if [ -f /usr/bin/dnf ]; then
-      dnf -y install subscription-manager
-    else
-      yum -t -y install subscription-manager
-    fi
-  fi
+  # Set up subscription-manager
+  <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'provisioning' }).strip -%>
 
   <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla') || host_param('syspurpose_addons')) %>
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      if [ -f /usr/bin/dnf ]; then
-        dnf -y install subscription-manager-syspurpose
-      else
-        yum -t -y install subscription-manager-syspurpose
-      fi
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
     fi
 
     if [ -f /usr/sbin/syspurpose ]; then
@@ -147,11 +136,7 @@ description: |
       subscription-manager config --server.proxy_port='<%= host_param("http-proxy-port") %>'
     <% end %>
   <% end %>
-
-  <% if subscription_manager_certpkg_url %>
-    rpm -Uvh <%= subscription_manager_certpkg_url %>
-  <% end %>
-
+  
   <% if host_param('subscription_manager_username') && host_param('subscription_manager_password') %>
     <% if host_param('subscription_manager_pool') %>
       subscription-manager register --name="<%= @host.name %>" --username='<%= host_param("subscription_manager_username") %>' --password='<%= host_param("subscription_manager_password") %>'
@@ -196,20 +181,12 @@ description: |
     done
   <% end %>
 
-  <% if redhat_install_host_tools || redhat_install_host_tracer_tools %>
-     if [ -f /usr/bin/dnf ]; then
-       PACKAGE_MAN="dnf -y"
-     else
-       PACKAGE_MAN="yum -t -y"
-     fi
-  <% end %>
-
   <% if redhat_install_host_tools %>
-    $PACKAGE_MAN install katello-host-tools
+    $PKG_MANAGER_INSTALL katello-host-tools
   <% end %>
 
   <% if redhat_install_host_tracer_tools %>
-    $PACKAGE_MAN install katello-host-tools-tracer
+    $PKG_MANAGER_INSTALL katello-host-tools-tracer
   <% end %>
 <% end %>
 

--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -1,0 +1,145 @@
+<%#
+kind: snippet
+name: subscription_manager_setup
+model: ProvisioningTemplate
+snippet: true
+description: |
+  This snippet installs and configures subscription-manager that is required for host registration.
+  The snippet is included in the "global_registration" template and in the "redhat_register" snippet.
+  The latter ensures host registration during the provisioning process.
+-%>
+
+# Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ <%= snippet 'pkg_manager' -%>
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+<% if @subman_setup_scenario == 'registration' -%>
+  # Backup the original rhsm.conf file
+  if [ -f $RHSM_CFG ] ; then
+    test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+  fi
+<% end -%>
+
+<% if plugin_present?('katello') -%>
+  # Define the path to the Katello server CA certificate
+  KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
+
+  # If SSL_CA_CERT is not set, create a temporary file for it
+  if [ -z "$SSL_CA_CERT" ]; then
+    SSL_CA_CERT=$(mktemp)
+    cat << EOF > "$SSL_CA_CERT"
+<%= foreman_server_ca_cert %>
+EOF
+  fi
+
+  <% if @subman_setup_scenario == 'registration' -%>
+    # rhn-client-tools conflicts with subscription-manager package
+    # since rhn tools replaces subscription-manager, we need to explicitly
+    # install subscription-manager after the rhn tools cleanup
+    if [ x$ID = xol ]; then
+      $PKG_MANAGER_REMOVE rhn-client-tools
+      $PKG_MANAGER_INSTALL --setopt=obsoletes=0 subscription-manager
+    fi
+
+    <% if truthy?(@force) -%>
+      # Unregister host and remove all local system and subscription data
+      if [ -x "$(command -v subscription-manager)" ] ; then
+        subscription-manager unregister || true
+        subscription-manager clean
+      fi
+
+      $PKG_MANAGER_REMOVE katello-ca-consumer\* > /dev/null 2>&1
+    <% end -%>
+  <% end -%>
+
+  # Prepare the SSL certificate
+  mkdir -p /etc/rhsm/ca
+  cp -f $SSL_CA_CERT $KATELLO_SERVER_CA_CERT
+  chmod 644 $KATELLO_SERVER_CA_CERT
+<% end -%>
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  <% if @subman_setup_scenario == 'registration' -%>
+    $PKG_MANAGER_UPGRADE subscription-manager > /dev/null 2>&1
+  <% end %>
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+  <% if plugin_present?('katello') -%>
+    rm -f $SSL_CA_CERT
+  <% end -%>
+  exit 1
+fi
+
+<% if @subman_setup_scenario == 'registration'
+     if plugin_present?('katello')
+       server_hostname = @rhsm_url.host if @rhsm_url
+       server_port = @rhsm_url.port if @rhsm_url
+       server_prefix = @rhsm_url.path if @rhsm_url
+       repo_ca_cert = "$KATELLO_SERVER_CA_CERT"
+       rhsm_baseurl = @pulp_content_url
+     end
+   elsif @subman_setup_scenario == 'provisioning'
+     if plugin_present?('katello')
+       server_hostname = @host.content_source
+       server_port = @host.content_source.rhsm_url.port
+       server_prefix = @host.content_source.rhsm_url.path
+       repo_ca_cert = "$KATELLO_SERVER_CA_CERT"
+       rhsm_baseurl = @host.content_source.pulp_content_url
+     else
+       server_hostname = "subscription.rhsm.redhat.com"
+       server_port = "443"
+       server_prefix = "/subscription"
+       repo_ca_cert = "/etc/rhsm/ca/redhat-uep.pem"
+       rhsm_baseurl = "https://cdn.redhat.com"
+     end
+   end
+%>
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="<%= server_hostname %>" \
+  --server.port="<%= server_port %>" \
+  --server.prefix="<%= server_prefix %>" \
+  --rhsm.repo_ca_cert="<%= repo_ca_cert %>" \
+  --rhsm.baseurl="<%= rhsm_baseurl %>"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+<% if @subman_setup_scenario == 'provisioning' && plugin_present?('katello') -%>
+  CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors
+
+  # Add the Katello CA certificate to the system-wide CA certificate store
+  if [ -d $CA_TRUST_ANCHORS ]; then
+    update-ca-trust enable
+    cp $KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
+    update-ca-trust
+  fi
+<% end -%>
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true


### PR DESCRIPTION
This snippet replaces the use of the katello-ca-consumer RPM for host registration. It incorporates the necessary code from the Global Registration template to streamline subscription-manager configuration during provisioning.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
