### PR TITLE
use runuser instead of su to run rake as the foreman user

### DIFF
--- a/script/foreman-rake
+++ b/script/foreman-rake
@@ -15,5 +15,5 @@ if [ $# -eq 0 ]; then
 elif [ "$USERNAME" = foreman ]; then
   RUBYOPT=-W0 RAILS_ENV=production $CMD "$@"
 else
-  su foreman -s /bin/bash -c 'RUBYOPT=-W0 RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
+  runuser - foreman -s /bin/bash -c 'RUBYOPT=-W0 RAILS_ENV=production "$0" "$@"' -- $CMD "$@"
 fi


### PR DESCRIPTION
foreman-rake is designed to be run as root (and switch to foreman) or by foreman directly. any other user can't use it as it is installed in sbin and the foreman user has no password set, making switching users as non root impossible, but su will still try it:

    [nobody@foreman /]$ su foreman -s /bin/bash -c id
    Password:
    [nobody@foreman /]$ foreman-rake console
    Password:

runuser is designed to be used in scripts and refuses to work as non root:

    [nobody@foreman /]$ runuser foreman -s /bin/bash -c id
    runuser: may not be used by non-root users
    [nobody@foreman /]$ foreman-rake console
    runuser: may not be used by non-root users


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
