### PR TITLE
Fixes #36768: Prevent redirection to other hosts via HTTP referer header

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -336,7 +336,7 @@ class ApplicationController < ActionController::Base
   end
 
   def redirect_back_or_to(url)
-    redirect_back(fallback_location: url)
+    redirect_back(fallback_location: url, allow_other_host: false)
   end
 
   def saved_redirect_url_or(default)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -446,7 +446,7 @@ class UsersControllerTest < ActionController::TestCase
 
   context "when user is logged in" do
     test "#login redirects to previous url" do
-      @previous_url = "/bookmarks"
+      @previous_url = "http://test.host/bookmarks"
       get :login, session: set_session_user
       request.env['HTTP_REFERER'] = @previous_url
 


### PR DESCRIPTION
CVE-2022-4130: Blind SSRF via Referer header

For routes that use `redirect_back_or_to` the HTTP referer header can be set and cause a redirection to a different URL on a different machine. The presence of this option forces the fallback URL to be used.

https://api.rubyonrails.org/classes/ActionController/Redirecting.html#method-i-redirect_back_or_to