### PR TITLE
count db:abort_if_pending_migrations as a setup rake task

### DIFF
--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -23,7 +23,7 @@ module Foreman
   end
 
   def self.in_setup_db_rake?
-    in_rake?('db:create', 'db:migrate', 'db:drop')
+    in_rake?('db:create', 'db:migrate', 'db:drop', 'db:abort_if_pending_migrations')
   end
 
   def self.pending_migrations?


### PR DESCRIPTION
this avoids loading settings and friends just to check if a migration is required


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
