### PR TITLE
Fixes #36775 - Allow creation of unlimited PATs again

### DIFF
--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokenModal.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokenModal.js
@@ -112,13 +112,20 @@ const PersonalAccessTokenModal = ({ controller, url }) => {
     return true;
   };
 
+  const formatExpiration = () => {
+    if (endsNever) {
+      return null;
+    }
+    return `${date} ${time}`;
+  };
+
   const handleSubmit = () => {
     if (isDateTimeInFuture() && isDateValid && isTimeValid) {
       dispatch(
         APIActions.post({
           key: PERSONAL_ACCESS_TOKEN_FORM_SUBMITTED,
           url,
-          params: { name, expires_at: `${date} ${time}`, controller },
+          params: { name, expires_at: formatExpiration(), controller },
           handleSuccess: ({ data }) => {
             closeModal();
             dispatch({


### PR DESCRIPTION
Before this patch, the expires_at field was set to a single space, which the backend considered invalid. With this patch, the value is null for unlimited PATs, which the backend accepts.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
