### PR TITLE
Fixes #36786 - Permit Symbol for YAML.safe_load report parser

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -62,7 +62,7 @@ class Report < ApplicationRecord
   # extracts serialized metrics and keep them as a hash_with_indifferent_access
   def metrics
     return {} if self[:metrics].nil?
-    YAML.safe_load(read_metrics, permitted_classes: [ActiveSupport::HashWithIndifferentAccess]).with_indifferent_access
+    YAML.safe_load(read_metrics, permitted_classes: [ActiveSupport::HashWithIndifferentAccess, Symbol]).with_indifferent_access
   end
 
   # serialize metrics as YAML


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

_Take a look at the Foreman ticket for the issue explanation._

I assumed the issue shouldn't appear due to this config:

https://github.com/theforeman/foreman/blob/2517ba4e36f07551a93519c062b057d73f621a32/config/application.rb#L201-L210

But, it seems like the exception for `HashWithIndifferentAccess` has been added to the `YAML.safe_load` call already (which is extended with this PR) - just the one for `Symbol` is missing which leads to the issue described in the Foreman ticket.

I might've gotten something wrong here tho :crossed_fingers: 
