### PR TITLE
Fixes #36791 - Fix typo in variable name

### DIFF
--- a/app/views/taxonomies/_form.html.erb
+++ b/app/views/taxonomies/_form.html.erb
@@ -22,7 +22,7 @@
       <% if User.current.allowed_to?(:view_provisioning_templates) %>
         <li><a href="#provisioning_templates" data-toggle="tab"><%= _("Provisioning Templates") %></a></li>
       <% end %>
-      <% if User.current.allowed_to?(:view_ptales) %>
+      <% if User.current.allowed_to?(:view_ptables) %>
         <li><a href="#ptables" data-toggle="tab"><%= _("Partition Tables") %></a></li>
       <% end %>
       <% if User.current.allowed_to?(:view_domains) %>


### PR DESCRIPTION


I found this while looking for another issue when creating an organization.