### PR TITLE
Fixes #36793 - Allow plugins to close ActionsBar kebab via React context

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, createContext } from 'react';
 import { useSelector, shallowEqual, useDispatch } from 'react-redux';
 import {
   Button,
@@ -26,6 +26,8 @@ import { cancelBuild, deleteHost, isHostTurnOn } from './actions';
 import { useForemanSettings } from '../../../Root/Context/ForemanContext';
 import BuildModal from './BuildModal';
 import Slot from '../../common/Slot';
+
+export const ForemanActionsBarContext = createContext();
 
 const ActionsBar = ({
   hostId,
@@ -147,16 +149,18 @@ const ActionsBar = ({
           >
             {__('Edit')}
           </Button>
-          <Dropdown
-            ouiaId="kebab-dropdown"
-            alignments={{ default: 'right' }}
-            toggle={
-              <KebabToggle id="hostdetails-kebab" onToggle={onKebabToggle} />
-            }
-            isOpen={kebabIsOpen}
-            isPlain
-            dropdownItems={dropdownItems.concat(registeredItems)}
-          />
+          <ForemanActionsBarContext.Provider value={{ onKebabToggle }}>
+            <Dropdown
+              ouiaId="kebab-dropdown"
+              alignments={{ default: 'right' }}
+              toggle={
+                <KebabToggle id="hostdetails-kebab" onToggle={onKebabToggle} />
+              }
+              isOpen={kebabIsOpen}
+              isPlain
+              dropdownItems={dropdownItems.concat(registeredItems)}
+            />
+          </ForemanActionsBarContext.Provider>
         </SplitItem>
       </Split>
       {isBuildModalOpen && (


### PR DESCRIPTION
The Foreman host details ActionsBar allows plugins to extend it and add items, but it doesn't expose a function that would allow a plugin to close the menu when you click on an item.

This PR fixes the issue by exposing the function via a React context, which can then be consumed from plugins via `useContext`.

Corresponding Katello PR: https://github.com/Katello/katello/pull/10757

Related React documentation: https://react.dev/reference/react/useContext
