### PR TITLE
Fixes #36799 - Add Salt image path to ConfigReportsController

### DIFF
--- a/app/controllers/config_reports_controller.rb
+++ b/app/controllers/config_reports_controller.rb
@@ -81,6 +81,7 @@ class ConfigReportsController < ApplicationController
     @origin_image_paths ||= {
       Ansible: helpers.image_path('Ansible.png'),
       Puppet: helpers.image_path('Puppet.png'),
+      Salt: helpers.image_path('Salt.png'),
     }
     { src: @origin_image_paths[:"#{report.origin}"], label: report.origin }
   end

--- a/test/controllers/config_reports_controller_test.rb
+++ b/test/controllers/config_reports_controller_test.rb
@@ -44,6 +44,33 @@ class ConfigReportsControllerTest < ActionController::TestCase
     assert_equal 1, response.body.lines.size
   end
 
+  test 'Ansible origin and icon are identified' do
+    FactoryBot.create(:config_report, origin: 'Ansible')
+    get :index, params: {format: :json}, session: set_session_user
+    parsed = YAML.safe_load(response.body)
+    assert_response :success
+    assert_equal 'Ansible', parsed['reports'][0]['origin']['label']
+    assert_match %r{/assets/Ansible-[0-9a-f]+.png}, parsed['reports'][0]['origin']['src']
+  end
+
+  test 'Puppet origin and icon are identified' do
+    FactoryBot.create(:config_report, origin: 'Puppet')
+    get :index, params: {format: :json}, session: set_session_user
+    parsed = YAML.safe_load(response.body)
+    assert_response :success
+    assert_equal 'Puppet', parsed['reports'][0]['origin']['label']
+    assert_match %r{/assets/Puppet-[0-9a-f]+.png}, parsed['reports'][0]['origin']['src']
+  end
+
+  test 'Salt origin and icon are identified' do
+    FactoryBot.create(:config_report, origin: 'Salt')
+    get :index, params: {format: :json}, session: set_session_user
+    parsed = YAML.safe_load(response.body)
+    assert_response :success
+    assert_equal 'Salt', parsed['reports'][0]['origin']['label']
+    assert_match %r{/assets/Salt-[0-9a-f]+.png}, parsed['reports'][0]['origin']['src']
+  end
+
   def test_show
     get :show, params: { :id => report.id }, session: set_session_user
     assert_template 'show'


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

For Salt reports, no icon is printed in the "origins" column.

This PR adds the Salt image path to the `ConfigReportsController`. The image is already part of Foreman core.
(It has probably been forgotten when adding the Reports tab to the new host details page here: https://github.com/theforeman/foreman/commit/616c0d3b8638613124a51671ba807f0f8930d743)