### PR TITLE
Fixes #36796 - Make host_facts_updated event visible

### DIFF
--- a/app/models/concerns/foreman/observable_model.rb
+++ b/app/models/concerns/foreman/observable_model.rb
@@ -33,6 +33,11 @@ module Foreman
         end
       end
 
+      def register_custom_hook(hook_name, namespace: Foreman::Observable::DEFAULT_NAMESPACE)
+        event_name = Foreman::Observable.event_name_for(hook_name, namespace: namespace)
+        self.event_subscription_hooks |= [event_name]
+      end
+
       def preload_scopes_builder
         @preload_scopes_builder ||= Foreman::PreloadScopesBuilder.new(self)
       end

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -10,6 +10,7 @@ module Host
     include Hostext::Ownership
     include Foreman::TelemetryHelper
     include Facets::BaseHostExtensions
+    include Foreman::ObservableModel
 
     self.table_name = :hosts
     extend FriendlyId
@@ -46,6 +47,8 @@ module Host
     before_create :set_creator_id
 
     default_scope -> { where(taxonomy_conditions) }
+
+    register_custom_hook :host_facts_updated
 
     def self.taxonomy_conditions
       conditions = {}

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -21,7 +21,6 @@ class Host::Managed < Host::Base
   include HostInfoExtensions
   include HostParams
   include Facets::ManagedHostExtensions
-  include Foreman::ObservableModel
   include ::ForemanRegister::HostExtensions
 
   has_many :reports, :foreign_key => :host_id, :class_name => 'ConfigReport'

--- a/test/models/hosts/managed_test.rb
+++ b/test/models/hosts/managed_test.rb
@@ -136,6 +136,7 @@ module Host
           'build_entered.event.foreman',
           'build_exited.event.foreman',
           'status_changed.event.foreman',
+          'host_facts_updated.event.foreman',
         ]
 
         assert_same_elements expected, Host::Managed.event_subscription_hooks

--- a/test/unit/host_fact_importer_test.rb
+++ b/test/unit/host_fact_importer_test.rb
@@ -349,4 +349,19 @@ class HostFactImporterTest < ActiveSupport::TestCase
       assert_equal 'br_customer', host.primary_interface.identifier
     end
   end
+
+  describe 'events' do
+    let(:callback) { -> {} }
+
+    it 'fires a host_facts_updated event on success import' do
+      host = FactoryBot.create(:host, :managed)
+      ActiveSupport::Notifications.subscribed(callback, 'host_facts_updated.event.foreman') do
+        callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+          payload[:object].operatingsystem.name == 'CentOS'
+        end
+
+        HostFactImporter.new(host).import_facts(operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
+      end
+    end
+  end
 end


### PR DESCRIPTION
During https://github.com/theforeman/foreman/pull/9780, a new event `host_facts_updated` was added. We do fire it on facts upload, but we don't show it to the users to be able to subscribe to it. This PR fixes that.

Needs foreman_webhooks to test this out.

@adamruzicka, could you please take a look?