### PR TITLE
Fixes #36796 - Make host_facts_updated event visible

### DIFF
--- a/app/models/concerns/foreman/observable_model.rb
+++ b/app/models/concerns/foreman/observable_model.rb
@@ -29,6 +29,11 @@ module Foreman
           set_hook hook_name, namespace: namespace, on: k, payload: payload, **options, &blk
         end
       end
+
+      def register_custom_hook(hook_name, namespace: Foreman::Observable::DEFAULT_NAMESPACE)
+        event_name = Foreman::Observable.event_name_for(hook_name, namespace: namespace)
+        self.event_subscription_hooks |= [event_name]
+      end
     end
 
     def event_payload_for(payload, block_argument, blk)

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -10,6 +10,7 @@ module Host
     include Hostext::Ownership
     include Foreman::TelemetryHelper
     include Facets::BaseHostExtensions
+    include Foreman::ObservableModel
 
     self.table_name = :hosts
     extend FriendlyId
@@ -46,6 +47,8 @@ module Host
     before_create :set_creator_id
 
     default_scope -> { where(taxonomy_conditions) }
+
+    register_custom_hook :host_facts_updated
 
     def self.taxonomy_conditions
       conditions = {}

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -21,7 +21,6 @@ class Host::Managed < Host::Base
   include HostInfoExtensions
   include HostParams
   include Facets::ManagedHostExtensions
-  include Foreman::ObservableModel
   include ::ForemanRegister::HostExtensions
 
   has_many :reports, :foreign_key => :host_id, :class_name => 'ConfigReport'

--- a/test/models/hosts/managed_test.rb
+++ b/test/models/hosts/managed_test.rb
@@ -136,6 +136,7 @@ module Host
           'build_entered.event.foreman',
           'build_exited.event.foreman',
           'status_changed.event.foreman',
+          'host_facts_updated.event.foreman',
         ]
 
         assert_same_elements expected, Host::Managed.event_subscription_hooks

--- a/test/unit/host_fact_importer_test.rb
+++ b/test/unit/host_fact_importer_test.rb
@@ -349,4 +349,19 @@ class HostFactImporterTest < ActiveSupport::TestCase
       assert_equal 'br_customer', host.primary_interface.identifier
     end
   end
+
+  describe 'events' do
+    let(:callback) { -> {} }
+
+    it 'fires a host_facts_updated event on success import' do
+      host = FactoryBot.create(:host, :managed)
+      ActiveSupport::Notifications.subscribed(callback, 'host_facts_updated.event.foreman') do
+        callback.expects(:call).with do |_name, _started, _finished, _unique_id, payload|
+          payload[:object].operatingsystem.name == 'CentOS'
+        end
+
+        HostFactImporter.new(host).import_facts(operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
+      end
+    end
+  end
 end


### PR DESCRIPTION
(cherry picked from commit 001a7ffc6db9d6d3af197d1416df6b3cf262501f)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
