### PR TITLE
Fixes #36815: Set Redis reconnect_attempts to default

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -305,7 +305,13 @@ module Foreman
     if (rails_cache_settings && rails_cache_settings[:type] == 'redis')
       options = [:redis_cache_store]
       redis_urls = Array.wrap(rails_cache_settings[:urls])
-      options << { namespace: 'foreman', url: redis_urls }.merge(rails_cache_settings[:options] || {})
+
+      options << {
+        namespace: 'foreman',
+        url: redis_urls,
+        reconnect_attempts: ::Redis::Client::DEFAULTS[:reconnect_attempts],
+      }.merge(rails_cache_settings[:options] || {})
+
       config.cache_store = options
       Foreman::Logging.logger('app').info "Rails cache backend: Redis"
     else


### PR DESCRIPTION
From [1] Rails sets this value to 0 rather than relying on the Redis default which results in errors. As [1] indicates:

> we need this to be 1 because
Redis connections need to reconnect after a fork so that forked
processes don't use the same socket


[1] https://gitlab.com/gitlab-org/gitlab/-/merge_requests/22704
