### PR TITLE
Fixes #36821 - Fix table pagination to be used separately

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -27,6 +27,7 @@ export const Table = ({
   setParams,
   url,
   isPending,
+  isEmbedded,
 }) => {
   const columnsToSortParams = {};
   Object.keys(columns).forEach(key => {
@@ -140,6 +141,7 @@ export const Table = ({
           perPage={params.perPage}
           itemCount={itemCount}
           onChange={onPagination}
+          updateParamsByUrl={!isEmbedded}
         />
       )}
     </>
@@ -162,6 +164,7 @@ Table.propTypes = {
   setParams: PropTypes.func.isRequired,
   url: PropTypes.string.isRequired,
   isPending: PropTypes.bool.isRequired,
+  isEmbedded: PropTypes.bool,
 };
 
 Table.defaultProps = {
@@ -170,4 +173,5 @@ Table.defaultProps = {
   itemCount: 0,
   getActions: null,
   results: [],
+  isEmbedded: false,
 };


### PR DESCRIPTION
New `Table` component is meant to be used within `TableIndexPage` template, but the table itself could be re-used separately from that template.

Pagination of that component expects parameters to be taken from URL, but in case the table is embedded in e.g. modal, the URL is not available as such. This patch makes `Table` component to be able to ignore URL dependency.

This mostly needed (and tested) for https://github.com/theforeman/foreman_openscap/pull/546.