### PR TITLE
Refs #36658 - restrict linuxefi to x86/64 for PXEGrub2 (Ubuntu) Autoinstall

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
@@ -19,7 +19,11 @@ test_on:
 #   System locale
 #
 <%
-  efi_suffix = 'efi'
+  if ['i386','x86_64'].include?(@host.architecture.to_s) && @host.pxe_loader_efi?
+    efi_suffix = 'efi'
+  else
+    efi_suffix = ''
+  end
 -%>
 
 set default=0


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
