### PR TITLE
Fixes #36826 - add new Host - Installed Products report for SCA hosts

### DIFF
--- a/app/views/unattended/report_templates/host_-_installed_products.erb
+++ b/app/views/unattended/report_templates/host_-_installed_products.erb
@@ -1,0 +1,41 @@
+<%#
+name: Host - Installed Products
+snippet: false
+model: ReportTemplate
+template_inputs:
+- name: Hosts filter
+  required: false
+  input_type: user
+  description: Limit the report only on hosts found by this search query. Keep empty
+    to report on all available hosts.
+  advanced: false
+  value_type: search
+  resource_type: Host
+require:
+- plugin: katello
+  version: 4.11.0
+-%>
+<%- report_headers 'Host Name', 'Organization', 'Lifecycle Environment', 'Content View', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 'Arch', 'Sockets', 'RAM (MB)', 'Cores', 'SLA', 'Role', 'Usage', 'Release Version', 'Products', 'Last Checkin' -%>
+<%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :architecture, :content_view_environments, :organization, :reported_data, :subscription_facet]).each_record do |host| -%>
+<%-   report_row(
+        'Host Name': host.name,
+        'Organization': host.organization,
+        'Lifecycle Environment': host.single_lifecycle_environment,
+        'Content View': host.single_content_view,
+        'Host Collections': host_collections_names(host),
+        'Virtual': host.virtual,
+        'Guest of Host': host.hypervisor_host,
+        'OS': host.operatingsystem,
+        'Arch': host.architecture,
+        'Sockets': host.sockets,
+        'RAM (MB)': host.ram,
+        'Cores': host.cores,
+        'SLA': host_sla(host),
+        'Role': host.purpose_role,
+        'Usage': host.purpose_usage,
+        'Release Version': host.release_version,
+        'Products': host_products_names_and_ids(host),
+        'Last Checkin': last_checkin(host).to_s,
+      ) -%>
+<%- end -%>
+<%= report_render -%>

--- a/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
+++ b/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
@@ -12,45 +12,52 @@ template_inputs:
   options: "no limit\r\n7\r\n30\r\n60\r\n90\r\n120\r\n180"
 require:
 - plugin: katello
-  version: 4.8.0
+  version: 4.11.0
 -%>
 <%- days_from_now = input('Days from Now') -%>
 <%- days_from_now = "" if days_from_now == 'no limit' -%>
 <%- should_filter = days_from_now.present? -%>
-<%- report_headers 'Host Name', 'Organization', 'Lifecycle Environment', 'Content View', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 'Arch', 'Sockets', 'RAM', 'Cores', 'SLA', 'Products', 'Last Checkin', 'Subscription Name', 'Subscription Type', 'Subscription Total Quantity', 'Subscription Total Consumed', 'Subscriptions Consumed by Host', 'Subscription SKU', 'Subscription Contract', 'Subscription Account', 'Subscription Start', 'Subscription End', 'Subscription Guest', 'Days Remaining' -%>
+<%- report_headers 'Host Name', 'Organization', 'Lifecycle Environment', 'Content View', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 'Arch', 'Sockets', 'RAM (MB)', 'Cores', 'SLA', 'Role', 'Usage', 'Release Version', 'Products', 'Last Checkin', 'Subscription Name', 'Subscription Type', 'Subscription Total Quantity', 'Subscription Total Consumed', 'Subscriptions Consumed by Host', 'Subscription SKU', 'Subscription Contract', 'Subscription Account', 'Subscription Start', 'Subscription End', 'Subscription Guest', 'Days Remaining' -%>
 <%- load_hosts(includes: [:operatingsystem, :architecture, :content_view_environments, :organization, :reported_data, :subscription_facet, :pools => [:subscription]], -%>
 <%-   search: should_filter && "pools_expiring_in_days = #{days_from_now}" -%>
 <%- ).each_record do |host| -%>
 <%-   host.pools.expiring_in_days(days_from_now).sort_by { |p| p.end_date }.each do |pool| -%>
-<%-     report_row(
-          'Host Name': host.name,
-          'Organization': host.organization,
-          'Lifecycle Environment': host.single_lifecycle_environment.name,
-          'Content View': host.single_content_view.name,
-          'Host Collections': host_collections_names(host),
-          'Virtual': host.virtual,
-          'Guest of Host': host.hypervisor_host,
-          'OS': host.operatingsystem,
-          'Arch': host.architecture,
-          'Sockets': host.sockets,
-          'RAM': host.ram,
-          'Cores': host.cores,
-          'SLA': host_sla(host),
-          'Products': host_products_names(host),
-          'Last Checkin': last_checkin(host).to_s,
-          'Subscription Name': sub_name(pool),
-          'Subscription Type': pool.type,
-          'Subscription Total Quantity': pool.quantity,
-          'Subscription Total Consumed': pool.consumed,
-          'Subscriptions Consumed by Host': host.filtered_entitlement_quantity_consumed(pool),
-          'Subscription SKU': sub_sku(pool),
-          'Subscription Contract': pool.contract_number,
-          'Subscription Account': pool.account_number,
-          'Subscription Start': pool.start_date,
-          'Subscription End': pool.end_date,
-          'Subscription Guest': registered_through(host),
-          'Days Remaining': pool.days_until_expiration
-          ) -%>
+<%-     unless host.organization.simple_content_access? -%>
+<%-       report_row(
+            'Host Name': host.name,
+            'Organization': host.organization,
+            'Lifecycle Environment': host.single_lifecycle_environment.name,
+            'Content View': host.single_content_view.name,
+            'Host Collections': host_collections_names(host),
+            'Virtual': host.virtual,
+            'Guest of Host': host.hypervisor_host,
+            'OS': host.operatingsystem,
+            'Arch': host.architecture,
+            'Sockets': host.sockets,
+            'RAM (MB)': host.ram,
+            'Cores': host.cores,
+            'SLA': host_sla(host),
+            'Role': host.purpose_role,
+            'Role Status': host.purpose_role_status_label,
+            'Usage': host.purpose_usage,
+            'Usage Status': host.purpose_usage_status_label,
+            'Release Version': host.release_version,
+            'Products': host_products_names(host),
+            'Last Checkin': last_checkin(host).to_s,
+            'Subscription Name': sub_name(pool),
+            'Subscription Type': pool.type,
+            'Subscription Total Quantity': pool.quantity,
+            'Subscription Total Consumed': pool.consumed,
+            'Subscriptions Consumed by Host': host.filtered_entitlement_quantity_consumed(pool),
+            'Subscription SKU': sub_sku(pool),
+            'Subscription Contract': pool.contract_number,
+            'Subscription Account': pool.account_number,
+            'Subscription Start': pool.start_date,
+            'Subscription End': pool.end_date,
+            'Subscription Guest': registered_through(host),
+            'Days Remaining': pool.days_until_expiration
+            ) -%>
+<%-     end -%>
 <%-   end -%>
 <%- end -%>
 <%= report_render -%>

--- a/db/migrate/20231016000000_introduce_host_products_report.rb
+++ b/db/migrate/20231016000000_introduce_host_products_report.rb
@@ -1,0 +1,10 @@
+class IntroduceHostProductsReport < ActiveRecord::Migration[6.1]
+  def up
+    token = SecureRandom.base64(5)
+    ReportTemplate.unscoped.find_by(name: "Host - Installed Products")&.update_columns(:name => "Host - Installed Products #{token}")
+  end
+
+  def down
+    ReportTemplate.unscoped.find_by(name: "Host - Installed Products")&.destroy
+  end
+end


### PR DESCRIPTION



Makes the old Subscriptions Entitlements Report work for SCA users. Only shows subscription information if there is any.  Also adds system purpose statuses to the host output.

To test:

0) Checkout the Katello PR: https://github.com/Katello/katello/pull/10769
1) Create a report template called 'Host - Products and Subscriptions'
2) Run the DB migration
3) Check that the old template was backed up
4) Register some hosts and generate the new report
5) Switch an org or two to non-sca mode and regenerate it
  -> There should now be subscription data for the hosts in the report
6) Ensure that the host filter input works

---

The above is out of date -- see my later comment for new information.