### PR TITLE
Fixes #36834 - Add SecureBoot support for arbitrary operating systems to "Grub2 UEFI" PXE loaders

### DIFF
--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -87,7 +87,13 @@ module Orchestration::TFTP
       logger.info "Deploying TFTP #{kind} configuration for #{host.name}"
       each_unique_feasible_tftp_proxy do |proxy|
         mac_addresses_for_provisioning.each do |mac_addr|
-          proxy.set(kind, mac_addr, :pxeconfig => content)
+          proxy.set(kind, mac_addr, {
+                      :pxeconfig => content,
+                      :targetos => host.operatingsystem.name.downcase,
+                      :release => host.operatingsystem.release,
+                      :arch => host.arch.name,
+                      :bootfile_suffix => host.arch.bootfilename_efi,
+                    })
         end
       end
     else

--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -5,7 +5,7 @@ module PxeLoaderSupport
   PXE_KINDS = {
     :PXELinux => /^(pxelinux.*|PXELinux (BIOS|UEFI))$/,
     :PXEGrub => /^(grub\/|Grub UEFI).*/,
-    :PXEGrub2 => /^(grub2\/|Grub2 (BIOS|UEFI|ELF)|http.*grub2\/).*/,
+    :PXEGrub2 => /(^Grub2 (BIOS|UEFI|ELF).*|\/?grub2\/)/,
     :iPXE => /^((iPXE|http.*\/ipxe-).*|ipxe\.efi|undionly\.kpxe)$/,
   }.with_indifferent_access.freeze
 
@@ -26,11 +26,11 @@ module PxeLoaderSupport
         "Grub UEFI" => "grub/grub#{precision}.efi",
         "Grub2 BIOS" => "grub2/grub#{precision}.0",
         "Grub2 ELF" => "grub2/grub#{precision}.elf",
-        "Grub2 UEFI" => "grub2/grub#{precision}.efi",
-        "Grub2 UEFI SecureBoot" => "grub2/shim#{precision}.efi",
-        "Grub2 UEFI HTTP" => "http://#{httpboot_host}/httpboot/grub2/grub#{precision}.efi",
-        "Grub2 UEFI HTTPS" => "https://#{httpboot_host}/httpboot/grub2/grub#{precision}.efi",
-        "Grub2 UEFI HTTPS SecureBoot" => "https://#{httpboot_host}/httpboot/grub2/shim#{precision}.efi",
+        "Grub2 UEFI" => "@@subdir@@/grub2/grub#{precision}.efi",
+        "Grub2 UEFI SecureBoot" => "@@subdir@@/grub2/shim#{precision}.efi",
+        "Grub2 UEFI HTTP" => "http://#{httpboot_host}/httpboot/@@subdir@@/grub2/grub#{precision}.efi",
+        "Grub2 UEFI HTTPS" => "https://#{httpboot_host}/httpboot/@@subdir@@/grub2/grub#{precision}.efi",
+        "Grub2 UEFI HTTPS SecureBoot" => "https://#{httpboot_host}/httpboot/@@subdir@@/grub2/shim#{precision}.efi",
         "iPXE Embedded" => nil, # renders directly as foreman_url('iPXE')
         "iPXE UEFI HTTP" => "http://#{httpboot_host}/httpboot/ipxe-#{precision}.efi",
         "iPXE Chain BIOS" => "undionly-ipxe.0",

--- a/app/services/proxy_api/tftp.rb
+++ b/app/services/proxy_api/tftp.rb
@@ -10,6 +10,10 @@ module ProxyAPI
     # [+mac+]  : MAC address
     # [+args+] : Hash containing
     #    :pxeconfig => String containing the configuration
+    #    :targetos  => String containing the lowercase operating system name
+    #    :release  => String containing the operating system major and minor version
+    #    :arch  => String containing the operating system architecture
+    #    :bootfile_suffix => String containing the architecture specific boot filename suffix
     # Returns  : Boolean status
     def set(kind, mac, args)
       parse(post(args, "#{kind}/#{mac}"))

--- a/test/factories/architecture.rb
+++ b/test/factories/architecture.rb
@@ -5,5 +5,9 @@ FactoryBot.define do
     trait :for_snapshots_x86_64 do
       name { 'x86_64' }
     end
+
+    trait :x64 do
+      name { 'x64' }
+    end
   end
 end

--- a/test/factories/operatingsystem.rb
+++ b/test/factories/operatingsystem.rb
@@ -160,6 +160,17 @@ FactoryBot.define do
       title { 'Red Hat Enterprise Linux 7.5' }
     end
 
+    factory :rhel9, class: Redhat do
+      name { 'RHEL' }
+      major { '9' }
+      minor { '0' }
+      type { 'Redhat' }
+      title { 'Red Hat Enterprise Linux 9.0' }
+      architectures { [FactoryBot.build(:architecture, :x64)] }
+      media { [FactoryBot.build(:rhel_for_snapshots)] }
+      ptables { [FactoryBot.build(:ptable, name: 'ptable')] }
+    end
+
     factory :for_snapshots_centos_7_0, class: Redhat do
       name { 'CentOS' }
       major { '7' }

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -32,18 +32,28 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
       assert_equal :PXEGrub, @subject.pxe_loader_kind(@host)
     end
 
-    test "PXEGrub2 is found for given filename" do
-      @host.pxe_loader = "grub2/grubx64.efi"
+    test "PXEGrub2 is found for grubx64.elf filename" do
+      @host.pxe_loader = "grub2/grubx64.elf"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for grubx64.0 filename" do
+      @host.pxe_loader = "grub2/grubx64.0"
+      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
+    end
+
+    test "PXEGrub2 is found for grubx64.efi filename" do
+      @host.pxe_loader = "host-config/#{@host.mac.tr(':', '-')}/grub2/grubx64.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 
     test "PXEGrub2 is found for shimx64.efi filename" do
-      @host.pxe_loader = "grub2/shimx64.efi"
+      @host.pxe_loader = "host-config/#{@host.mac.tr(':', '-')}/grub2/shimx64.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 
     test "PXEGrub2 is found for shimia32.efi filename" do
-      @host.pxe_loader = "grub2/shimia32.efi"
+      @host.pxe_loader = "host-config/#{@host.mac.tr(':', '-')}/grub2/shimia32.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 
@@ -88,22 +98,17 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
     end
 
     test "PXEGrub2 is found for http://smart_proxy/tftp/grub2/grubx64.efi filename" do
-      @host.pxe_loader = "http://smart_proxy/tftp/grub2/grubx64.efi"
+      @host.pxe_loader = "http://smart_proxy/tftp/host-config/#{@host.mac.tr(':', '-')}/grub2/grubx64.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 
     test "PXEGrub2 is found for https://smart_proxy/tftp/grub2/grubx64.efi filename" do
-      @host.pxe_loader = "https://smart_proxy/tftp/grub2/grubx64.efi"
+      @host.pxe_loader = "https://smart_proxy/tftp/host-config/#{@host.mac.tr(':', '-')}/grub2/grubx64.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 
     test "PXEGrub2 is found for https://smart_proxy/tftp/grub2/shimx64.efi filename" do
-      @host.pxe_loader = "https://smart_proxy/tftp/grub2/shimx64.efi"
-      assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
-    end
-
-    test "PXEGrub2 is found for https://smart_proxy/tftp/grub2/shimx64.efi filename" do
-      @host.pxe_loader = "https://smart_proxy/tftp/grub2/shimx64.efi"
+      @host.pxe_loader = "https://smart_proxy/tftp/host-config/#{@host.mac.tr(':', '-')}/grub2/shimx64.efi"
       assert_equal :PXEGrub2, @subject.pxe_loader_kind(@host)
     end
 

--- a/test/models/operatingsystem_test.rb
+++ b/test/models/operatingsystem_test.rb
@@ -379,13 +379,13 @@ class OperatingsystemTest < ActiveSupport::TestCase
     test 'should be the smart proxy and httpboot port for UEFI HTTP' do
       SmartProxy.any_instance.expects(:setting).with(:HTTPBoot, 'http_port').returns(1234)
       host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'Grub2 UEFI HTTP')
-      assert_match(%r{http://somewhere.*net:1234/httpboot/grub2/grubx64.efi}, host.operatingsystem.boot_filename(host))
+      assert_match(%r{http://somewhere.*net:1234/httpboot/@@subdir@@/grub2/grubx64.efi}, host.operatingsystem.boot_filename(host))
     end
 
     test 'should be the smart proxy and httpboot port for UEFI HTTPS' do
       SmartProxy.any_instance.expects(:setting).with(:HTTPBoot, 'https_port').returns(1235)
       host = FactoryBot.build(:host, :managed, :with_tftp_and_httpboot_subnet, pxe_loader: 'Grub2 UEFI HTTPS')
-      assert_match(%r{https://somewhere.*net:1235/httpboot/grub2/grubx64.efi}, host.operatingsystem.boot_filename(host))
+      assert_match(%r{https://somewhere.*net:1235/httpboot/@@subdir@@/grub2/grubx64.efi}, host.operatingsystem.boot_filename(host))
     end
 
     test 'should not raise an error without httpboot feature for PXE' do

--- a/test/models/orchestration/dhcp_test.rb
+++ b/test/models/orchestration/dhcp_test.rb
@@ -371,7 +371,8 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
 
     h.build = true
     assert h.valid?, h.errors.messages.to_s
-    assert_equal ["dhcp_remove_aa:bb:cc:dd:ee:f1", "dhcp_create_aa:bb:cc:dd:ee:f1"], h.queue.task_ids
+    assert_includes h.queue.task_ids, "dhcp_remove_aa:bb:cc:dd:ee:f1"
+    assert_includes h.queue.task_ids, "dhcp_create_aa:bb:cc:dd:ee:f1"
   end
 
   test "when an existing host trigger a 'rebuild', its dhcp records should not be updated if valid dhcp records are found" do
@@ -383,7 +384,8 @@ class DhcpOrchestrationTest < ActiveSupport::TestCase
     h.build = true
     assert h.valid?
     assert_empty h.errors
-    assert_equal ["dhcp_create_aa:bb:cc:dd:ee:f1"], h.queue.task_ids
+    assert_includes h.queue.task_ids, "dhcp_create_aa:bb:cc:dd:ee:f1"
+    assert_not_includes h.queue.task_ids, "dhcp_remove_aa:bb:cc:dd:ee:f1"
   end
 
   test "when an existing host change its bmc mac address, its dhcp record should be updated" do


### PR DESCRIPTION
This feature consists of two patches, one for foreman and one for smart-proxy.

This patch introduces a new loader of kind `:PXEGrub2TargetOS` which allows to provide host-specific Network Bootstrap Programs (NPB) in order to enable network based installations for SecureBoot-enabled hosts.

SecureBoot expects to follow a chain of trust from the start of the host to the loading of Linux kernel modules. The very first shim that is loaded basically determines which distribution is allowed to be booted or kexec'ed until next reboot.

The existing "Grub2 UEFI SecureBoot" is not sufficient as it limits the possible installations to the vendor of the Foreman (Smart Proxy) host system.

Providing shim and GRUB2 by the vendor of the to-be-installed operating system allows Foreman to install any operating system on SecureBoot-enabled hosts over network.

To achieve this, the host's DHCP filename option is set to a shim path in a directory that is host-specific (contains MAC address). Corresponding shim and GRUB2 binaries are copied into that directory along with the generated GRUB2 configuration files as we know from "Grub2 UEFI".

The required binaries must be provided once in the so called "bootloader universe". This directory can be configured via the settings file `/etc/foreman-proxy/settings.d/tftp.yml` and defaults to `/usr/local/share/bootloader-universe/<os>/`. These binaries can be manually retrieved from the installation media and is not part of this patch set.

Full example:
-------------

[root@vm ~]# hammer host info --id 241 | grep -E "(MAC address|Operating System)"
    MAC address:  00:50:56:b4:75:5e
    Operating System:       Ubuntu 22.04 LTS

[root@vm ~]# tree /usr/local/share/bootloader-universe/ /usr/local/share/bootloader-universe/
|-- centos
|   |-- grubx64.efi
|   `-- shimx64.efi
`-- ubuntu
    |-- grubx64.efi
    `-- shimx64.efi

[root@vm ~]# hammer host update --id 241 --build true

[root@vm ~]# tree /var/lib/tftpboot/grub2/00-50-56-b4-75-5e/ /var/lib/tftpboot/grub2/00-50-56-b4-75-5e/
|-- grub.cfg
|-- grub.cfg-00:50:56:b4:75:5e
|-- grub.cfg-01-00-50-56-b4-75-5e
|-- grubx64.efi
|-- shimx64.efi
`-- targetos

[root@vm ~]# grep -B2 00-50-56-b4-75-5e /var/lib/dhcpd/dhcpd.leases
  hardware ethernet 00:50:56:b4:75:5e;
  fixed-address 192.168.145.84;
        supersede server.filename = "grub2/00-50-56-b4-75-5e/shimx64.efi";

[root@vm ~]# pesign -S -i /var/lib/tftpboot/grub2/00-50-56-b4-75-5e/grubx64.efi | grep Canonical The signer's common name is Canonical Ltd. Secure Boot Signing (2021 v1)