### PR TITLE
Fixes #36575 - Use apipie-dsl default model descriptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'ancestry', '~> 4.0'
 gem 'scoped_search', '>= 4.1.10', '< 5'
 gem 'ldap_fluff', '>= 0.5.0', '< 1.0'
 gem 'apipie-rails', '>= 0.8.0', '< 2'
-gem 'apipie-dsl', '>= 2.2.6'
+gem 'apipie-dsl', '>= 2.6.1'
 # Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
 # Rails 6.0 is incompatible with Psych 4, Rails 6.1 should work
 gem 'rdoc', '< 6.4'

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -51,7 +51,7 @@ class Domain < ApplicationRecord
 
   set_crud_hooks :domain
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord, meta: { example: 'example.com' }
     property :fullname, String, desc: 'User name for this domain, e.g. "Primary domain for our company"'

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -83,7 +83,7 @@ class Hostgroup < ApplicationRecord
     where(conditions)
   }
 
-  apipie :class, "A class representing #{model_name.human} object" do
+  apipie :class do
     prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'host group' }
     property :architecture, 'Architecture', desc: 'Returns architecture to be used on hosts within this host group'
     property :arch, 'Architecture', desc: 'Returns architecture to be used on hosts within this host group'

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -79,7 +79,7 @@ class Operatingsystem < ApplicationRecord
 
   graphql_type '::Types::Operatingsystem'
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'operating system consisting', example: 'RedHat, Fedora, Debian' }
     property :major, String, desc: 'Major version of the operating system'

--- a/app/models/realm.rb
+++ b/app/models/realm.rb
@@ -35,7 +35,7 @@ class Realm < ApplicationRecord
     end
   }
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord, meta: { example: 'EXAMPLE.COM' }
     property :realm_type, String, desc: 'Realm type, e.g. FreeIPA or Active Directory'

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -196,7 +196,7 @@ class SmartProxy < ApplicationRecord
     end
   end
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     name 'Smart Proxy'
     refs 'SmartProxy'
     sections only: %w[all additional]

--- a/app/models/ssh_key.rb
+++ b/app/models/ssh_key.rb
@@ -35,7 +35,7 @@ class SshKey < ApplicationRecord
 
   delegate :login, to: :user, prefix: true
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord, meta: { friendly_name: 'SSH key' }
     property :user, 'User', desc: 'Returns the user object which is linked to the SSH key'

--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -124,7 +124,7 @@ class Subnet < ApplicationRecord
 
   set_crud_hooks :subnet
 
-  apipie :class, "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     refs 'Subnet::Ipv4', 'Subnet::Ipv6'
     prop_group :basic_model_props, ApplicationRecord

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -37,7 +37,7 @@ class Taxonomy < ApplicationRecord
       scoped_search :on => :description, :complete_enabled => :false, :only_explicit => true
       scoped_search :on => :id, :validator => ScopedSearch::Validators::INTEGER
 
-      apipie :class, desc: "A class representing #{model_name.human} object" do
+      apipie :class do
         sections only: %w[all additional]
         name_exl, title_exl = class_scope.model_name.human == 'Location' ? ['Europe', 'Europe/Prague'] : ['Red Hat', 'Red Hat/Engineering']
         prop_group :basic_model_props, ApplicationRecord, meta: { example: name_exl }

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -25,7 +25,7 @@ class Template < ApplicationRecord
 
   attr_exportable :name, :description, :snippet, :template_inputs, :model => ->(template) { template.class.to_s }
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     prop_group :basic_model_props, ApplicationRecord
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -149,7 +149,7 @@ class User < ApplicationRecord
 
   set_crud_hooks :user
 
-  apipie :class, desc: "A class representing #{model_name.human} object" do
+  apipie :class do
     sections only: %w[all additional]
     property :id, Integer, desc: 'Numerical ID of the User'
     property :firstname, String, desc: 'Returns the user first name'

--- a/config/initializers/apipie.rb
+++ b/config/initializers/apipie.rb
@@ -27,6 +27,11 @@ ApipieDSL.configure do |config|
     trans
   end
   config.help_layout = 'apipie_dsl/apipie_dsls/help.html.erb'
+  config.default_class_description = lambda do |model|
+    return nil unless model.respond_to?(:model_name)
+    _("A class representing %s object") % model.model_name.human
+  end
+  config.reload_dsl = false
 end
 
 Apipie.configure do |config|


### PR DESCRIPTION
This pull request updates the `apipie-dsl` gem to version `2.6.1` and makes configuration changes to enhance our API documentation.