### PR TITLE
Fixes #36842 - Reduce impact of Rails' file-based cache bug

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -315,7 +315,7 @@ module Foreman
       config.cache_store = options
       Foreman::Logging.logger('app').info "Rails cache backend: Redis"
     else
-      config.cache_store = :file_store, Rails.root.join('tmp', 'cache')
+      config.cache_store = :file_store, Rails.root.join('tmp', 'cache/')
       Foreman::Logging.logger('app').info "Rails cache backend: File"
     end
 


### PR DESCRIPTION
Original rails-issue: https://github.com/rails/rails/issues/49690

According to the rails-documentation, the default-value also uses a trailing slash: https://guides.rubyonrails.org/caching_with_rails.html#activesupport-cache-filestore