### PR TITLE
Fixes #36860 - Remove workaround for fixing layout rendering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,8 +23,6 @@ $(document).on('click', 'a[disabled="disabled"]', function(event) {
 });
 
 function onContentLoad() {
-  tfm.store.observeStore('layout', tfm.nav.showContent);
-
   if ($('input[focus_on_load=true]').length > 0) {
     $('input[focus_on_load]')
       .first()

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -143,10 +143,6 @@ select {
   cursor: auto;
 }
 
-#main > #content {
-  display: none;
-}
-
 .used_by_hosts {
   color: #000 !important;
   cursor: auto;

--- a/webpack/assets/javascripts/foreman_navigation.js
+++ b/webpack/assets/javascripts/foreman_navigation.js
@@ -1,6 +1,3 @@
-/* eslint-disable jquery/no-show */
-
-import $ from 'jquery';
 import URI from 'urijs';
 import { push } from 'connected-react-router';
 import store from './react_app/redux';
@@ -36,14 +33,3 @@ export const hideLoading = () => {
 export const changeActive = () => {
   deprecate('changeActive', '', '3.8');
 };
-
-export function showContent(layout, unsubscribe) {
-  const content = () => {
-    $('#content').show();
-    unsubscribe();
-  };
-  // workaround for pages with no layout object
-  if (layout.items.length && !layout.isLoading) {
-    content();
-  } else if ($('#layout').length === 0) content();
-}


### PR DESCRIPTION
Navigation now loads before the content so the workaround is not needed.
The workaround causes issues in the Webpack 5 migration due to different loading order.
undoing most of: https://github.com/theforeman/foreman/pull/6502