### PR TITLE
Fixes #36864 - Show entire opened bookmarks properly

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/layout.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/layout.scss
@@ -2,6 +2,8 @@
 @import '../../common/variables.scss';
 
 .react-page #foreman-main-container {
+  overflow-x: auto;
+  white-space: normal;
   height: 100%;
 }
 #foreman-main-container {

--- a/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/Bookmarks/Bookmarks.js
@@ -72,7 +72,6 @@ const Bookmarks = ({
         searchQuery={searchQuery}
       />
       <Dropdown
-        position="right"
         ouiaId="bookmarks-dropdown"
         isOpen={isDropdownOpen}
         onSelect={() => setIsDropdownOpen(false)}


### PR DESCRIPTION
Bookmarks were opened to the left side before, which caused problems with long names:
![278306773-65403126-770c-4bd3-8317-027978cd899d](https://github.com/theforeman/foreman/assets/78563507/a14f6a2a-9053-4fe6-ab24-d8aeeeecb5d1)

The bookmarks are now opened to the right side, and a horizontal scrollbar is added if it exceeds the page:
![image](https://github.com/theforeman/foreman/assets/78563507/e5a87367-0deb-4222-9b06-ca07efec1215)
