### PR TITLE
Fixes #36867 - Add host delete & create to new host overview

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -387,7 +387,7 @@ module Api
         'create'
       when 'edit', 'update'
         'edit'
-      when 'destroy'
+      when 'destroy', 'bulk_destroy'
         'destroy'
       when 'index', 'show', 'status'
         'view'

--- a/app/controllers/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/api/v2/hosts_bulk_actions_controller.rb
@@ -1,0 +1,35 @@
+module Api
+  module V2
+    class HostsBulkActionsController < V2::BaseController
+      include Api::Version2
+      include Api::V2::BulkHostsExtension
+
+      before_action :find_deletable_hosts, :only => [:bulk_destroy]
+
+      def_param_group :bulk_host_ids do
+        param :organization_id, :number, :required => true, :desc => N_("ID of the organization")
+        param :included, Hash, :desc => N_("Hosts to include in the action"), :required => true, :action_aware => true do
+          param :search, String, :required => false, :desc => N_("Search string describing which hosts to perform the action on")
+          param :ids, Array, :required => false, :desc => N_("List of host ids to perform the action on")
+        end
+        param :excluded, Hash, :desc => N_("Hosts to explicitly exclude in the action."\
+                                           " All other hosts will be included in the action,"\
+                                           " unless an included parameter is passed as well."), :required => true, :action_aware => true do
+          param :ids, Array, :required => false, :desc => N_("List of host ids to exclude and not perform the action on")
+        end
+      end
+
+      api :DELETE, "/hosts/bulk/", N_("Delete multiple hosts")
+      param_group :bulk_host_ids
+      def bulk_destroy
+        process_response @hosts.destroy_all
+      end
+
+      private
+
+      def find_deletable_hosts
+        find_bulk_hosts(:destroy_hosts, params)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -2,6 +2,7 @@ module Api
   module V2
     class HostsController < V2::BaseController
       include Api::Version2
+      include Api::V2::BulkHostsExtension
       include ScopesPerAction
       include Foreman::Controller::SmartProxyAuth
       include Foreman::Controller::Parameters::Host

--- a/app/controllers/concerns/api/v2/bulk_hosts_extension.rb
+++ b/app/controllers/concerns/api/v2/bulk_hosts_extension.rb
@@ -1,0 +1,45 @@
+module Api::V2::BulkHostsExtension
+  extend ActiveSupport::Concern
+
+  def bulk_hosts_relation(permission, org)
+    relation = ::Host::Managed.authorized(permission)
+    relation = relation.where(organization: org) if org
+    relation
+  end
+
+  def find_bulk_hosts(permission, bulk_params, restrict_to = nil)
+    # works on a structure of param_group bulk_params and transforms it into a list of systems
+    bulk_params[:included] ||= {}
+    bulk_params[:excluded] ||= {}
+    search_param = bulk_params[:included][:search] || bulk_params[:search]
+
+    if !params[:install_all] && bulk_params[:included][:ids].blank? && search_param.nil?
+      render_error :custom_error, :status => :bad_request, :locals => { :message => _('No hosts have been specified') }
+    end
+
+    find_organization
+    @hosts = bulk_hosts_relation(permission, @organization)
+
+    if bulk_params[:included][:ids].present?
+      @hosts = @hosts.where(id: bulk_params[:included][:ids])
+    end
+
+    if search_param.present?
+      @hosts = @hosts.search_for(search_param)
+    end
+
+    @hosts = restrict_to.call(@hosts) if restrict_to
+
+    if bulk_params[:excluded][:ids].present?
+      @hosts = @hosts.where.not(id: bulk_params[:excluded][:ids])
+    end
+    if @hosts.empty?
+      render_error :custom_error, :status => :forbidden, :locals => { :message => _('No hosts matched search, or action unauthorized for selected hosts.') }
+    end
+    @hosts
+  end
+
+  def find_organization
+    @organization ||= Organization.find_by_id(params[:organization_id])
+  end
+end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -275,6 +275,7 @@ Foreman::AccessControl.map do |permission_set|
                                   }
     map.permission :destroy_hosts, {:hosts => [:destroy, :multiple_actions, :reset_multiple, :multiple_destroy, :submit_multiple_destroy],
                                     :"api/v2/hosts" => [:destroy],
+                                    :"api/v2/hosts_bulk_actions" => [:bulk_destroy],
                                     :"api/v2/interfaces" => [:destroy],
                                   }
     map.permission :build_hosts,   {:hosts => [:setBuild, :cancelBuild, :multiple_build, :submit_multiple_build, :review_before_build,

--- a/config/routes/api/puppet/api/v2.rb
+++ b/config/routes/api/puppet/api/v2.rb
@@ -3,7 +3,7 @@ Foreman::Application.routes.draw do
     # new v2 routes that point to v2
     scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       constraints(:id => /[^\/]+/) do
-        resources :hosts, :except => [:new, :edit] do
+        resources :hosts, :only => [] do # only: [] to avoid adding other api/v2/hosts routes
           put :puppetrun, :on => :member, :to => 'puppet_hosts#puppetrun'
         end
       end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -3,6 +3,8 @@ Foreman::Application.routes.draw do
   namespace :api, :defaults => {:format => 'json'} do
     # new v2 routes that point to v2
     scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
+      match 'hosts/bulk', :to => 'hosts_bulk_actions#bulk_destroy', :via => [:delete]
+
       resources :architectures, :except => [:new, :edit] do
         constraints(:id => /[^\/]+/) do
           resources :hosts, :except => [:new, :edit]

--- a/test/controllers/concerns/bulk_hosts_extension_test.rb
+++ b/test/controllers/concerns/bulk_hosts_extension_test.rb
@@ -1,0 +1,168 @@
+require 'test_helper'
+
+class BulkHostsExtensionTestController < ::Api::BaseController
+  include Api::Version2
+  include ::Api::V2::BulkHostsExtension
+
+  def initialize(params = {})
+    @params = params
+  end
+
+  attr_reader :params
+end
+
+class BulkHostsExtensionTest < ActiveSupport::TestCase
+  def models
+    as_admin do
+      @organization = FactoryBot.create(:organization)
+      @host1 = FactoryBot.create(:host, :managed, :organization => @organization)
+      @host2 = FactoryBot.create(:host, :organization => @organization)
+      @host3 = FactoryBot.create(:host, :organization => @organization)
+      @host4 = FactoryBot.create(:host, :organization => @organization)
+      @host5 = FactoryBot.create(:host, :organization => @organization)
+      @host6 = FactoryBot.create(:host, :organization => @organization)
+      @host_ids = [@host1, @host2, @host3, @host4, @host5, @host6].map(&:id)
+    end
+  end
+
+  def permissions
+    @edit = :edit_hosts
+  end
+
+  def setup
+    # set_user
+    models
+    permissions
+    @controller = BulkHostsExtensionTestController.new(organization_id: @organization.id)
+  end
+
+  def test_search
+    bulk_params = {
+      :included => {
+        :search => "name = #{@host1.name}",
+      },
+    }
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    assert_equal result, [@host1]
+  end
+
+  def test_search_restrict
+    bulk_params = {
+      :included => {
+        :search => "name ~ host",
+      },
+    }
+    restrict = ->(hosts) { hosts.where("id != #{@host2.id}") }
+    result = @controller.find_bulk_hosts(@edit, bulk_params, restrict)
+
+    assert_includes result, @host1
+    refute_includes result, @host2
+    assert_includes result, @host3
+  end
+
+  def test_search_exclude
+    bulk_params = {
+      :included => {
+        :search => "name ~ host",
+      },
+    :excluded => {
+      :ids => [@host1.id],
+    },
+    }
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    refute_includes result, @host1
+    assert_includes result, @host2
+    assert_includes result, @host3
+  end
+
+  def test_no_hosts_specified
+    bulk_params = {
+      :included => {},
+    }
+    @controller.expects(:render_error).with(:custom_error, :status => :bad_request, :locals => { :message => _('No hosts have been specified') })
+    @controller.find_bulk_hosts(@edit, bulk_params)
+  end
+
+  def test_ids
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id, @host2.id],
+      },
+    }
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    assert_equal [@host1, @host2].sort, result.sort
+  end
+
+  def test_ids_excluded
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id, @host2.id],
+      },
+      :excluded => {
+        :ids => [@host2.id],
+      },
+    }
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    assert_equal result, [@host1]
+  end
+
+  def test_ids_restricted
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id, @host2.id],
+      },
+    }
+    restrict = ->(hosts) { hosts.where("id != #{@host2.id}") }
+    result = @controller.find_bulk_hosts(@edit, bulk_params, restrict)
+
+    assert_equal result, [@host1]
+  end
+
+  def test_included_ids_with_nil_scoped_search
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id, @host2.id],
+        :search => nil,
+      },
+    }
+
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    assert_equal [@host1, @host2].sort, result.sort
+  end
+
+  def test_ids_with_scoped_search
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id, @host2.id],
+        :search => "name != #{@host2.name}",
+      },
+    }
+
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    assert_equal result, [@host1]
+  end
+
+  def test_forbidden
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id],
+      },
+      :excluded => {
+        :ids => [@host1.id],
+      },
+    }
+    @controller.expects(:render_error).with(:custom_error, :status => :forbidden, :locals => { :message => _('No hosts matched search, or action unauthorized for selected hosts.') })
+    @controller.find_bulk_hosts(@edit, bulk_params)
+  end
+
+  def test_empty_params
+    @controller.expects(:render_error).with(:custom_error, :status => :bad_request, :locals => { :message => _('No hosts have been specified') })
+    @controller.find_bulk_hosts(@edit, {})
+  end
+end

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -112,7 +112,7 @@ class HostJSTest < IntegrationTestWithJavascript
       visit host_details_page_path(host)
       find('#hostdetails-kebab').click
       click_button 'Delete'
-      click_button 'Delete host'
+      find('button.pf-c-button.pf-m-danger').click # the red delete button, not the menu item
       assert_current_path hosts_path
       assert_raises(ActiveRecord::RecordNotFound) do
         Host.find(host.id)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -129,6 +129,10 @@ class ActiveSupport::TestCase
     ActiveSupport::Notifications.unsubscribe("sql.active_record")
     assert_equal num_of_queries, queries.size, "Expected #{num_of_queries} queries, but got #{queries.size}"
   end
+
+  def assert_equal_arrays(array1, array2)
+    assert_equal array1.sort, array2.sort
+  end
 end
 
 class ActionView::TestCase

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/index.js
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Modal, Button, ModalVariant } from '@patternfly/react-core';
+import { Modal, Button, ModalVariant, Checkbox } from '@patternfly/react-core';
 import { translate as __ } from '../../common/I18n';
 import { closeConfirmModal, selectConfirmModal } from './slice';
 
 const ConfirmModal = () => {
   const {
+    id,
     isOpen,
     title,
     message,
@@ -14,11 +15,16 @@ const ConfirmModal = () => {
     onCancel,
     modalProps,
     isWarning,
+    isDireWarning,
   } = useSelector(selectConfirmModal);
 
   const dispatch = useDispatch();
+  const [direWarningChecked, setDireWarningChecked] = useState(false);
 
-  const closeModal = () => dispatch(closeConfirmModal());
+  const closeModal = () => {
+    setDireWarningChecked(false);
+    return dispatch(closeConfirmModal());
+  };
 
   const handleCancel = () => {
     onCancel();
@@ -36,6 +42,7 @@ const ConfirmModal = () => {
       variant={isWarning ? 'danger' : 'primary'}
       onClick={handleConfirm}
       ouiaId="btn-modal-confirm"
+      isDisabled={isDireWarning && !direWarningChecked}
     >
       {confirmButtonText || __('Confirm')}
     </Button>,
@@ -49,12 +56,22 @@ const ConfirmModal = () => {
     </Button>,
   ];
 
+  const direWarningCheckbox = (
+    <Checkbox
+      id="dire-warning-checkbox"
+      ouiaId="dire-warning-checkbox"
+      label={__('I understand that this action cannot be undone.')}
+      isChecked={direWarningChecked}
+      onChange={val => setDireWarningChecked(val)}
+    />
+  );
+
   if (!isOpen) return null;
 
   return (
     <Modal
       ouiaId="app-confirm-modal"
-      id="app-confirm-modal"
+      id={id ?? 'app-confirm-modal'}
       aria-label="application confirm modal"
       variant={ModalVariant.small}
       title={title}
@@ -64,7 +81,10 @@ const ConfirmModal = () => {
       titleIconVariant={isWarning ? 'warning' : null}
       {...modalProps}
     >
-      {message}
+      <>
+        {message}
+        {isDireWarning && direWarningCheckbox}
+      </>
     </Modal>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
+++ b/webpack/assets/javascripts/react_app/components/ConfirmModal/slice.js
@@ -11,9 +11,11 @@ const confirmModalSlice = createSlice({
       const {
         title = '',
         message = '',
+        id = 'app-confirm-modal',
         onConfirm = noop,
         onCancel = noop,
         isWarning = false,
+        isDireWarning = false,
         confirmButtonText = null,
         modalProps = {},
       } = action.payload;
@@ -21,10 +23,12 @@ const confirmModalSlice = createSlice({
         isOpen: true,
         title,
         message,
+        id,
         onConfirm,
         onCancel,
         modalProps,
         isWarning,
+        isDireWarning,
         confirmButtonText,
       };
     },

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
@@ -14,8 +14,7 @@ export const deleteHost = (
   compute,
   destroyVmOnHostDelete
 ) => dispatch => {
-  const successToast = () =>
-    sprintf(__('Host %s has been removed successfully'), hostName);
+  const successToast = () => sprintf(__('Host %s deleted'), hostName);
   const errorToast = ({ message }) => message;
   const url = foremanUrl(`/api/hosts/${hostName}`);
 
@@ -37,7 +36,7 @@ export const deleteHost = (
     openConfirmModal({
       isWarning: true,
       title: __('Delete host?'),
-      confirmButtonText: __('Delete host'),
+      confirmButtonText: __('Delete'),
       onConfirm: () =>
         dispatch(
           APIActions.delete({

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDelete.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDelete.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { visit } from '../../../../foreman_navigation';
+import { foremanUrl } from '../../../common/helpers';
+import { sprintf, translate as __ } from '../../../common/I18n';
+import { openConfirmModal } from '../../ConfirmModal';
+import { APIActions } from '../../../redux/API';
+import './bulkDeleteModal.scss';
+
+export const bulkDeleteHosts = ({
+  bulkParams,
+  selectedCount,
+  destroyVmOnHostDelete,
+}) => dispatch => {
+  const successToast = () => sprintf(__('%s hosts deleted'), selectedCount);
+  const errorToast = ({ message }) => message;
+  const url = foremanUrl(`/api/v2/hosts/bulk?search=${bulkParams}`);
+
+  // TODO: Replace with a checkbox instead of a global setting for cascade host destroy
+  const cascadeMessage = () =>
+    destroyVmOnHostDelete
+      ? __(
+          'For hosts with compute resources, this will delete the VM and its disks.'
+        )
+      : __(
+          'For hosts with compute resources, VMs and their disks will not be deleted.'
+        );
+
+  dispatch(
+    openConfirmModal({
+      isWarning: true,
+      isDireWarning: true,
+      id: 'bulk-delete-hosts-modal',
+      title: (
+        <FormattedMessage
+          defaultMessage="Delete {count, plural, one {{singular}} other {{plural}}}?"
+          values={{
+            count: selectedCount,
+            singular: __('host'),
+            plural: __('hosts'),
+          }}
+          id="bulk-delete-host-count"
+        />
+      ),
+      confirmButtonText: __('Delete'),
+      onConfirm: () =>
+        dispatch(
+          APIActions.delete({
+            url,
+            key: `BULK-HOSTS-DELETE`,
+            successToast,
+            errorToast,
+            handleSuccess: () => visit(foremanUrl('/new/hosts')),
+          })
+        ),
+      message: (
+        <FormattedMessage
+          id="bulk-delete-hosts"
+          values={{
+            hostsCount: (
+              <strong>
+                <FormattedMessage
+                  defaultMessage="{count, plural, one {# {singular}} other {# {plural}}}"
+                  values={{
+                    count: selectedCount,
+                    singular: __('host'),
+                    plural: __('hosts'),
+                  }}
+                  id="bulk-delete-host-count"
+                />
+              </strong>
+            ),
+            cascade: cascadeMessage(),
+            settings: (
+              <a href={foremanUrl('/settings?search=destroy')}>
+                {__('Provisioning settings')}
+              </a>
+            ),
+            br: <br />,
+          }}
+          defaultMessage={__(
+            '{hostsCount} will be deleted. This action is irreversible. {br}{br} {cascade} {br}{br} This behavior can be changed via global setting "Destroy associated VM on host delete" in {settings}.{br}{br}'
+          )}
+        />
+      ),
+    })
+  );
+};

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDeleteModal.scss
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDeleteModal.scss
@@ -1,0 +1,8 @@
+#bulk-delete-hosts-modal {
+  min-height: 21rem;
+  .pf-c-check label {
+    font-size: 14px;
+    position: relative;
+    top: 2px;
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -1,8 +1,20 @@
 import React, { createContext } from 'react';
+import { useHistory, Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { useSelector, shallowEqual } from 'react-redux';
+import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Td } from '@patternfly/react-table';
-import { ToolbarItem } from '@patternfly/react-core';
+import {
+  ToolbarItem,
+  Dropdown,
+  DropdownItem,
+  KebabToggle,
+  Flex,
+  FlexItem,
+  Button,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
+import { UndoIcon } from '@patternfly/react-icons';
 import { translate as __ } from '../../common/I18n';
 import TableIndexPage from '../PF4/TableIndexPage/TableIndexPage';
 import { ActionKebab } from './ActionKebab';
@@ -12,6 +24,13 @@ import { useAPI } from '../../common/hooks/API/APIHooks';
 import { useBulkSelect } from '../PF4/TableIndexPage/Table/TableHooks';
 import SelectAllCheckbox from '../PF4/TableIndexPage/Table/SelectAllCheckbox';
 import { getPageStats } from '../PF4/TableIndexPage/Table/helpers';
+import { deleteHost } from '../HostDetails/ActionsBar/actions';
+import { useForemanSettings } from '../../Root/Context/ForemanContext';
+import { getURIsearch } from '../../common/urlHelpers';
+import { bulkDeleteHosts } from './BulkActions/bulkDelete';
+import { foremanUrl } from '../../common/helpers';
+import Slot from '../common/Slot';
+import './index.scss';
 
 export const ForemanHostsIndexActionsBarContext = createContext({});
 
@@ -19,11 +38,19 @@ const HostsIndex = () => {
   const columns = {
     name: {
       title: __('Name'),
-      wrapper: ({ id, name }) => <a href={`hosts/${id}`}>{name}</a>,
+      wrapper: ({ name }) => <Link to={`hosts/${name}`}>{name}</Link>,
       isSorted: true,
     },
   };
-  const defaultParams = { search: '' }; // search ||
+
+  const history = useHistory();
+  const { location: { search: historySearch } = {} } = history || {};
+  const urlParams = new URLSearchParams(historySearch);
+  const urlParamsSearch = urlParams.get('search') || '';
+  const searchFromUrl = urlParamsSearch || getURIsearch();
+  const initialSearchQuery = apiSearchQuery || searchFromUrl || '';
+
+  const defaultParams = { search: initialSearchQuery };
 
   const response = useAPI('get', `${HOSTS_API_PATH}?include_permissions=true`, {
     key: API_REQUEST_KEY,
@@ -34,6 +61,7 @@ const HostsIndex = () => {
     response: {
       search: apiSearchQuery,
       results,
+      subtotal,
       total,
       per_page: perPage,
       page,
@@ -42,10 +70,14 @@ const HostsIndex = () => {
 
   const { pageRowCount } = getPageStats({ total, page, perPage });
 
-  const { fetchBulkParams, ...selectAllOptions } = useBulkSelect({
+  const {
+    fetchBulkParams,
+    updateSearchQuery,
+    ...selectAllOptions
+  } = useBulkSelect({
     results,
-    metadata: { total, page },
-    initialSearchQuery: apiSearchQuery || '',
+    metadata: { total, page, selectable: subtotal },
+    initialSearchQuery,
   });
 
   const {
@@ -81,7 +113,7 @@ const HostsIndex = () => {
       select={{
         rowIndex: rowData.id,
         onSelect: (_event, isSelecting) => {
-          selectOne(isSelecting, rowData.id);
+          selectOne(isSelecting, rowData.id, rowData);
         },
         isSelected: isSelected(rowData.id),
         disable: false,
@@ -92,24 +124,133 @@ const HostsIndex = () => {
   RowSelectTd.propTypes = {
     rowData: PropTypes.object.isRequired,
   };
+  const dispatch = useDispatch();
+  const { destroyVmOnHostDelete } = useForemanSettings();
+  const deleteHostHandler = ({ hostName, computeId }) =>
+    dispatch(deleteHost(hostName, computeId, destroyVmOnHostDelete));
+  const handleBulkDelete = () => {
+    const bulkParams = fetchBulkParams();
+    dispatch(
+      bulkDeleteHosts({
+        bulkParams,
+        selectedCount,
+        destroyVmOnHostDelete,
+      })
+    );
+  };
 
-  const actionNode = [];
+  const dropdownItems = [
+    <DropdownItem
+      ouiaId="delete=hosts-dropdown-item"
+      key="delete=hosts-dropdown-item"
+      onClick={handleBulkDelete}
+      isDisabled={selectedCount === 0}
+    >
+      {__('Delete')}
+    </DropdownItem>,
+  ];
   const registeredItems = useSelector(selectKebabItems, shallowEqual);
   const customToolbarItems = (
     <ForemanHostsIndexActionsBarContext.Provider
       value={{ ...selectAllOptions, fetchBulkParams }}
     >
-      <ActionKebab items={actionNode.concat(registeredItems)} />
+      <ActionKebab items={dropdownItems.concat(registeredItems)} />
     </ForemanHostsIndexActionsBarContext.Provider>
+  );
+
+  const rowKebabItems = ({
+    id,
+    name: hostName,
+    compute_id: computeId,
+    canDelete,
+  }) => [
+    {
+      title: __('Delete'),
+      onClick: () => deleteHostHandler({ id, hostName, computeId }),
+      isDisabled: !canDelete,
+    },
+  ];
+
+  const [legacyUIKebabOpen, setLegacyUIKebabOpen] = React.useState(false);
+  const legacyUIKebab = (
+    <Dropdown
+      ouiaId="legacy-ui-kebab"
+      id="legacy-ui-kebab"
+      position="right"
+      toggle={
+        <KebabToggle
+          aria-label="legacy-ui-kebab-toggle"
+          id="legacy-ui-kebab-toggle"
+          onToggle={setLegacyUIKebabOpen}
+        />
+      }
+      isOpen={legacyUIKebabOpen}
+      isPlain
+      dropdownItems={[
+        <DropdownItem
+          component="a"
+          ouiaId="legacy-ui-link-dropdown-item"
+          key="legacy-ui-link-dropdown-item"
+          href="/hosts"
+          icon={<UndoIcon />}
+        >
+          {__('Legacy UI')}
+        </DropdownItem>,
+      ]}
+    />
+  );
+
+  const hostsIndexHeader = (
+    <Flex
+      alignItems={{ default: 'alignItemsCenter' }}
+      justifyContent={{ default: 'justifyContentSpaceBetween' }}
+    >
+      <FlexItem>
+        <h1>{__('Hosts')}</h1>
+      </FlexItem>
+      <FlexItem align={{ default: 'alignRight' }}>
+        <Split hasGutter>
+          <SplitItem>
+            <Slot
+              id="_all-hosts-schedule-a-job"
+              hostSearch={selectedCount && fetchBulkParams()}
+              selectedCount={selectedCount}
+            />
+          </SplitItem>
+          <SplitItem>
+            <Button
+              component="a"
+              ouiaId="register-host-button"
+              href={foremanUrl('/hosts/register')}
+              variant="secondary"
+              isDisabled={false}
+            >
+              {__('Register')}
+            </Button>
+          </SplitItem>
+          <SplitItem>
+            <Button
+              variant="primary"
+              component="a"
+              ouiaId="create-host-button"
+              href={foremanUrl('/hosts/new')}
+            >
+              {__('Create')}
+            </Button>
+          </SplitItem>
+          <SplitItem>{legacyUIKebab}</SplitItem>
+        </Split>
+      </FlexItem>
+    </Flex>
   );
 
   return (
     <TableIndexPage
       apiUrl={HOSTS_API_PATH}
       apiOptions={{ key: API_REQUEST_KEY }}
-      header={__('Hosts')}
+      headerText={__('Hosts')}
+      header={hostsIndexHeader}
       controller="hosts"
-      isDeleteable
       columns={columns}
       creatable={false}
       replacementResponse={response}
@@ -117,6 +258,8 @@ const HostsIndex = () => {
       selectionToolbar={selectionToolbar}
       showCheckboxes
       rowSelectTd={RowSelectTd}
+      rowKebabItems={rowKebabItems}
+      updateSearchQuery={updateSearchQuery}
     />
   );
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.scss
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.scss
@@ -1,0 +1,15 @@
+#legacy-ui-kebab ul.pf-c-dropdown__menu {
+  padding-left: 0;
+  li {
+    display: unset;
+    a {
+      font-size: 16px;
+      color: var(--pf-c-dropdown__menu-item--Color);
+      font-weight: 300;
+    }
+  }
+}
+
+#header-text .pf-l-flex {
+  align-items: center;
+}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -69,7 +69,7 @@ export const Table = ({
         onClick: () => onDeleteClick({ id, name }),
         isDisabled: !canDelete,
       },
-      getActions && getActions({ id, name, ...item }),
+      ...((getActions && getActions({ id, name, canDelete, ...item })) ?? []),
     ].filter(Boolean);
   const columnNamesKeys = Object.keys(columns);
   const RowSelectTd = rowSelectTd;
@@ -105,7 +105,7 @@ export const Table = ({
               <Td colSpan={100}>
                 <EmptyPage
                   message={{
-                    type: 'empty',
+                    type: 'loading',
                     text: __('Loading...'),
                   }}
                 />

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
@@ -205,7 +205,7 @@ describe('Table', () => {
       </Provider>
     );
     expect(screen.queryAllByText('items')).toHaveLength(0);
-    expect(screen.queryAllByText('No Results')).toHaveLength(1);
+    expect(screen.queryAllByText('No Results')).toHaveLength(0);
     expect(screen.queryAllByText('Loading...')).toHaveLength(1);
   });
 });

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/TableHooks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/TableHooks.js
@@ -227,7 +227,7 @@ export const useBulkSelect = ({
   const fetchBulkParams = ({
     idColumnName = idColumn,
     selectAllQuery = '',
-  }) => {
+  } = {}) => {
     const searchQueryWithExclusionSet = () => {
       const query = [
         searchQuery,

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -55,7 +55,8 @@ A page component that displays a table with data fetched from an API. It provide
 @param {Array<Object>} {customToolbarItems} - an array of custom toolbar items to be displayed
 @param {boolean} {exportable} - whether or not to show export button
 @param {boolean} {hasHelpPage} - whether or not to show documentation button
-@param {string}{header} - the header text for the page
+@param {string}{headerText} - the header text for the page
+@param {string}{header} - header node; default is <title>{headerText}</title>
 @param {boolean} {isDeleteable} - whether or not entries can be deleted
 @param {boolean} {searchable} - whether or not the table can be searched
 @param {React.ReactNode} {children} - optional children to be rendered inside the page instead of the table
@@ -77,6 +78,7 @@ const TableIndexPage = ({
   customToolbarItems,
   exportable,
   hasHelpPage,
+  headerText,
   header,
   isDeleteable,
   searchable,
@@ -85,6 +87,8 @@ const TableIndexPage = ({
   replacementResponse,
   showCheckboxes,
   rowSelectTd,
+  rowKebabItems,
+  updateSearchQuery,
 }) => {
   const history = useHistory();
   const { location: { search: historySearch } = {} } = history || {};
@@ -153,6 +157,7 @@ const TableIndexPage = ({
   const setSearch = newSearch => {
     const uri = new URI();
     uri.setSearch(newSearch);
+    updateSearchQuery(newSearch.search);
     history.push({ search: uri.search() });
     setParamsAndAPI({ ...params, ...newSearch });
   };
@@ -185,9 +190,7 @@ const TableIndexPage = ({
 
   return (
     <div id="foreman-page">
-      <Head>
-        <title>{header}</title>
-      </Head>
+      <Head>{headerText}</Head>
       {breadcrumbOptions && (
         <PageSection variant={PageSectionVariants.light} type="breadcrumb">
           <BreadcrumbBar {...breadcrumbOptions} />
@@ -199,7 +202,7 @@ const TableIndexPage = ({
       >
         <TextContent>
           <Text ouiaId="header-text" component="h1">
-            {header}
+            {header ?? <title>{headerText}</title>}
           </Text>
         </TextContent>
       </PageSection>
@@ -259,6 +262,7 @@ const TableIndexPage = ({
           <Table
             params={params}
             setParams={setParamsAndAPI}
+            getActions={rowKebabItems}
             itemCount={subtotal}
             results={results}
             url={apiUrl}
@@ -323,13 +327,16 @@ TableIndexPage.propTypes = {
   replacementResponse: PropTypes.object,
   exportable: PropTypes.bool,
   hasHelpPage: PropTypes.bool,
-  header: PropTypes.string,
+  headerText: PropTypes.string,
+  header: PropTypes.node,
   isDeleteable: PropTypes.bool,
   searchable: PropTypes.bool,
   children: PropTypes.node,
   selectionToolbar: PropTypes.node,
   rowSelectTd: PropTypes.func,
   showCheckboxes: PropTypes.bool,
+  rowKebabItems: PropTypes.func,
+  updateSearchQuery: PropTypes.func,
 };
 
 TableIndexPage.defaultProps = {
@@ -348,13 +355,16 @@ TableIndexPage.defaultProps = {
   customToolbarItems: null,
   exportable: false,
   hasHelpPage: false,
-  header: '',
+  headerText: '',
+  header: undefined,
   isDeleteable: false,
   searchable: true,
   selectionToolbar: null,
   rowSelectTd: noop,
   showCheckboxes: false,
   replacementResponse: null,
+  rowKebabItems: noop,
+  updateSearchQuery: noop,
 };
 
 export default TableIndexPage;

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
@@ -29,4 +29,14 @@
     padding-left: 0;
     padding-right: 0;
   }
+  .pf-c-toolbar__group {
+    flex-grow: 1;
+    &.pf-m-align-right{
+      justify-content: flex-end;
+    }
+    &:first-child {
+      margin-right: auto;
+      width: min-content;
+    }
+  }
 }

--- a/webpack/assets/javascripts/react_app/routes/common/EmptyPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/common/EmptyPage/index.js
@@ -4,17 +4,25 @@ import { translate as __ } from '../../../common/I18n';
 import DefaultEmptyState from '../../../components/common/EmptyState';
 import './emptypage.scss';
 
-const EmptyPage = ({ message: { type, text } }) => (
-  <DefaultEmptyState
-    icon={type === 'error' ? 'error-circle-o' : 'add-circle-o'}
-    header={type === 'error' ? __('Error') : __('No Results')}
-    description={text}
-  />
-);
+const EmptyPage = ({ message: { type, text } }) => {
+  const headerTextMap = {
+    empty: __('No Results'),
+    error: __('Error'),
+    loading: __('Loading'),
+  };
+  const headerText = headerTextMap[type];
+  return (
+    <DefaultEmptyState
+      icon={type === 'error' ? 'error-circle-o' : 'add-circle-o'}
+      header={headerText}
+      description={text}
+    />
+  );
+};
 
 EmptyPage.propTypes = {
   message: PropTypes.shape({
-    type: PropTypes.oneOf(['empty', 'error']),
+    type: PropTypes.oneOf(['empty', 'error', 'loading']),
     text: PropTypes.string,
   }),
 };


### PR DESCRIPTION
Adds the following features to the new All Hosts page:

* Bulk host delete added to main kebab, with modal as per mockup
* Link directly to the exact setting for VM host delete
* Host Create and Register buttons, which link to their respective pages
* Links to each host now use React (much faster)
* Links to each host now use the host name, not database ID. This means you'll see 'rhel8.example.com' as your tab title, instead of, for example, '7.'
* also fixed spacing of main kebab
* also fixed loading screen so it doesn't say 'No Results'

![image](https://github.com/theforeman/foreman/assets/22042343/4ce45c1d-10ae-4b4f-b5e8-3bd40d515a63)

![image](https://github.com/theforeman/foreman/assets/22042343/403afaa8-28c3-4691-868c-c31f4d2faa70)


If you're using Katello, requires https://github.com/Katello/katello/pull/10782
