### PR TITLE
Fixes #36869 - Redirect /hosts to /new/hosts in index

### DIFF
--- a/app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman/controller/puppet/hosts_controller_extensions.rb
@@ -58,7 +58,7 @@ module Foreman::Controller::Puppet::HostsControllerExtensions
         "The %{proxy_type} puppet ca proxy could not be set for hosts: %{host_names}",
         failed_hosts.count) % {:proxy_type => proxy_type, :host_names => failed_hosts.map { |h, err| "#{h} (#{err})" }.to_sentence}
     end
-    redirect_back_or_to hosts_path
+    redirect_back_or_to helpers.current_hosts_path
   end
 
   def handle_proxy_messages(errors, proxy, proxy_type)

--- a/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
@@ -31,7 +31,7 @@ module Foreman::Controller::TaxonomyMultiple
     # simple validations
     if params[type].nil? || (id = params[type][:id]).blank?
       error "No #{type.to_s.classify} selected!"
-      redirect_to(hosts_path)
+      redirect_to(helpers.current_hosts_path)
       return
     end
 
@@ -46,11 +46,11 @@ module Foreman::Controller::TaxonomyMultiple
         @hosts.update_all("#{type}_id".to_sym => taxonomy.id)
       else
         error "Cannot update #{taxonomy.type} to #{taxonomy.name} because of mismatch in settings"
-        redirect_back_or_to hosts_path
+        redirect_back_or_to helpers.current_hosts_path
         return
       end
     end
     success "Updated hosts: Changed #{type.to_s.classify}"
-    redirect_back_or_to hosts_path
+    redirect_back_or_to helpers.current_hosts_path
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -44,7 +44,7 @@ class UsersController < ApplicationController
     if @user.update(user_params)
       update_sub_hostgroups_owners
 
-      process_success((editing_self? && !current_user.allowed_to?({:controller => 'users', :action => 'index'})) ? { :success_redirect => hosts_path } : { :success_redirect => users_path })
+      process_success((editing_self? && !current_user.allowed_to?({:controller => 'users', :action => 'index'})) ? { :success_redirect => helpers.current_hosts_path } : { :success_redirect => users_path })
     else
       process_error
     end
@@ -86,7 +86,7 @@ class UsersController < ApplicationController
       success _("You impersonated user %s, to cancel the session, click the impersonation icon in the top bar.") % user.name
       Audit.create :auditable_type => 'User', :auditable_id => user.id, :user_id => User.current.id, :action => 'impersonate', :audited_changes => {}
       logger.info "User #{User.current.name} impersonated #{user.name}"
-      redirect_to hosts_path
+      redirect_to helpers.current_hosts_path
     else
       info _("You are already impersonating, click the impersonation icon in the top bar before starting a new impersonation.")
       redirect_to users_path
@@ -217,7 +217,7 @@ class UsersController < ApplicationController
     store_default_taxonomy(user, 'location') unless session.has_key?(:location_id)
     TopbarSweeper.expire_cache
     telemetry_increment_counter(:successful_ui_logins)
-    redirect_to (uri || hosts_path)
+    redirect_to (uri || helpers.current_hosts_path)
   end
 
   def parameter_filter_context
@@ -230,9 +230,9 @@ class UsersController < ApplicationController
       # Prevent a redirect loop in case the previous page was login page -
       # e.g when csrf token expired but user already logged in from another tab
       if request.headers["Referer"] == login_users_url
-        redirect_to hosts_path and return
+        redirect_to helpers.current_hosts_path and return
       end
-      redirect_back_or_to hosts_path
+      redirect_back_or_to helpers.current_hosts_path
       nil
     end
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,6 +50,23 @@ module ApplicationHelper
     Time.zone&.tzinfo&.name || 'UTC'
   end
 
+  def current_hosts_path(*args)
+    ApplicationHelper.current_hosts_path(*args)
+  end
+
+  def self.current_hosts_path(*args)
+    @url_helpers ||= Rails.application.routes.url_helpers
+    if Setting[:new_hosts_page]
+      @url_helpers.new_hosts_index_page_path(*args)
+    else
+      @url_helpers.hosts_path(*args)
+    end
+  end
+
+  def current_host_details_path(host)
+    Setting['host_details_ui'] ? host_details_page_path(host) : host_path(host)
+  end
+
   protected
 
   def generate_date_id
@@ -417,17 +434,5 @@ module ApplicationHelper
       displayFqdnForHosts: Setting[:display_fqdn_for_hosts],
       displayNewHostsPage: Setting[:new_hosts_page],
     }
-  end
-
-  def current_host_details_path(host)
-    Setting['host_details_ui'] ? host_details_page_path(host) : host_path(host)
-  end
-
-  def hosts_path(*args)
-    if Setting[:new_hosts_page]
-      new_hosts_index_page_path(*args)
-    else
-      super
-    end
   end
 end

--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -199,7 +199,7 @@ module AuditsHelper
       items: [
         {
           caption: _("Hosts"),
-          url: (hosts_path if authorized_for(hash_for_hosts_path)),
+          url: (current_hosts_path if authorized_for(hash_for_hosts_path)),
         },
         {
           caption: @host.name,

--- a/app/helpers/dashboard_helper.rb
+++ b/app/helpers/dashboard_helper.rb
@@ -79,7 +79,7 @@ module DashboardHelper
 
     {
       data: state_labels.map { |key, label| [label, report[key], report_color[key]] },
-      searchUrl: hosts_path(search: '~VAL~'),
+      searchUrl: current_hosts_path(search: '~VAL~'),
       searchFilters: state_filters.each_with_object({}) do |(key, filter), filters|
         filters[state_labels[key]] = search_filter_with_origin(filter, options[:origin], within_interval.include?(key), ignore_interval.include?(key))
       end,
@@ -96,7 +96,7 @@ module DashboardHelper
     content_tag :li do
       content_tag(:span, raw('&nbsp;'), :class => 'label', :style => "background-color:" + report_color[counter]) +
       raw('&nbsp;') +
-      link_to(name, hosts_path(:search => search), :class => "dashboard-links") +
+      link_to(name, current_hosts_path(:search => search), :class => "dashboard-links") +
       content_tag(:h4, @data.report[counter])
     end
   end

--- a/app/helpers/host_description_helper.rb
+++ b/app/helpers/host_description_helper.rb
@@ -63,21 +63,21 @@ module HostDescriptionHelper
     fields << { :field => [_("Build duration"), build_duration(host)], :priority => 90 }
     fields << { :field => [_("Build errors"), link_to("Logs from OS installer", build_errors_host_path(:id => host.id))], :priority => 91 } if host.build_errors.present?
     fields << { :field => [_("Token"), host.token || _("N/A")], :priority => 92 } if User.current.admin
-    fields << { :field => [_("Domain"), link_to(host.domain, hosts_path(:search => "domain = #{host.domain}"))], :priority => 100 } if host.domain.present?
-    fields << { :field => [_("Realm"), link_to(host.realm, hosts_path(:search => "realm = #{host.realm}"))], :priority => 200 } if host.realm.present?
+    fields << { :field => [_("Domain"), link_to(host.domain, current_hosts_path(:search => "domain = #{host.domain}"))], :priority => 100 } if host.domain.present?
+    fields << { :field => [_("Realm"), link_to(host.realm, current_hosts_path(:search => "realm = #{host.realm}"))], :priority => 200 } if host.realm.present?
     fields << { :field => [_("IP Address"), host.ip], :priority => 300 } if host.ip.present?
     fields << { :field => [_("IPv6 Address"), host.ip6], :priority => 400 } if host.ip6.present?
     fields << { :field => [_("Comment"), host.comment], :priority => 500 } if host.comment.present?
     fields << { :field => [_("MAC Address"), host.mac], :priority => 600 } if host.mac.present?
-    fields << { :field => [_("Architecture"), link_to(host.arch, hosts_path(:search => "architecture = #{host.arch}"))], :priority => 700 } if host.arch.present?
-    fields << { :field => [_("Operating System"), link_to(host.operatingsystem.to_label, hosts_path(:search => %{os_title = "#{host.operatingsystem.title}"}))], :priority => 800 } if host.operatingsystem.present?
+    fields << { :field => [_("Architecture"), link_to(host.arch, current_hosts_path(:search => "architecture = #{host.arch}"))], :priority => 700 } if host.arch.present?
+    fields << { :field => [_("Operating System"), link_to(host.operatingsystem.to_label, current_hosts_path(:search => %{os_title = "#{host.operatingsystem.title}"}))], :priority => 800 } if host.operatingsystem.present?
     fields << { :field => [_("PXE Loader"), host.pxe_loader], :priority => 900 } if host.operatingsystem.present? && !host.image_build?
-    fields << { :field => [_("Host group"), link_to(host.hostgroup, hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))], :priority => 1000 } if host.hostgroup.present?
+    fields << { :field => [_("Host group"), link_to(host.hostgroup, current_hosts_path(:search => %{hostgroup_title = "#{host.hostgroup}"}))], :priority => 1000 } if host.hostgroup.present?
     fields << { :field => [_("Boot time"), (boot_time = host&.reported_data&.boot_time) ? date_time_relative(boot_time) : _('Not reported')], :priority => 1100 }
-    fields << { :field => [_("Location"), link_to(host.location.title, hosts_path(:search => "location = \"#{host.location}\""))], :priority => 1200 } if host.location.present?
-    fields << { :field => [_("Organization"), link_to(host.organization.title, hosts_path(:search => "organization = \"#{host.organization}\""))], :priority => 1300 } if host.organization.present?
+    fields << { :field => [_("Location"), link_to(host.location.title, current_hosts_path(:search => "location = \"#{host.location}\""))], :priority => 1200 } if host.location.present?
+    fields << { :field => [_("Organization"), link_to(host.organization.title, current_hosts_path(:search => "organization = \"#{host.organization}\""))], :priority => 1300 } if host.organization.present?
     if host.owner_type == "User"
-      fields << { :field => [_("Owner"), (link_to(host.owner, hosts_path(:search => %{user.login = "#{host.owner.login}"})) if host.owner)], :priority => 1400 }
+      fields << { :field => [_("Owner"), (link_to(host.owner, current_hosts_path(:search => %{user.login = "#{host.owner.login}"})) if host.owner)], :priority => 1400 }
     else
       fields << { :field => [_("Owner"), host.owner], :priority => 1400 }
     end

--- a/app/helpers/provisioning_templates_helper.rb
+++ b/app/helpers/provisioning_templates_helper.rb
@@ -55,7 +55,7 @@ module ProvisioningTemplatesHelper
 
   def building_hosts_path(template)
     oses = template.operatingsystem_ids.map { |id| "os_id = #{id}" }.join(" or ")
-    hosts_path(:search => "build = true and ( #{oses} )")
+    current_hosts_path(:search => "build = true and ( #{oses} )")
   end
 
   def how_templates_are_determined

--- a/app/presenters/host_status_presenter.rb
+++ b/app/presenters/host_status_presenter.rb
@@ -36,6 +36,10 @@ class HostStatusPresenter
     end
   end
 
+  def current_hosts_path(*args)
+    ApplicationHelper.current_hosts_path(*args)
+  end
+
   [:ok, :warn, :error].each do |status_name|
     define_method :"#{status_name}_total_query" do
       query = total_queries.select { |k, v| send("#{status_name}_statuses").include?(k) }.values.compact.join(' OR ')
@@ -55,14 +59,14 @@ class HostStatusPresenter
       query = send("#{status_name}_total_query")
       return if query.empty?
 
-      Rails.application.routes.url_helpers.hosts_path(search: query)
+      current_hosts_path(search: query)
     end
 
     define_method :"#{status_name}_owned_path" do
       query = send("#{status_name}_owned_query")
       return if query.empty?
 
-      Rails.application.routes.url_helpers.hosts_path(search: query)
+      current_hosts_path(search: query)
     end
   end
 
@@ -87,13 +91,13 @@ class HostStatusPresenter
 
   def total_paths
     total_queries.transform_values do |query|
-      Rails.application.routes.url_helpers.hosts_path(search: query)
+      current_hosts_path(search: query)
     end
   end
 
   def owned_paths
     owned_queries.transform_values do |query|
-      Rails.application.routes.url_helpers.hosts_path(search: query)
+      current_hosts_path(search: query)
     end
   end
 

--- a/app/views/architectures/index.html.erb
+++ b/app/views/architectures/index.html.erb
@@ -16,7 +16,7 @@
       <td class='ellipsis'><%= link_to_if_authorized(architecture.name,
                                                      hash_for_edit_architecture_path(:id => architecture).merge(:auth_object => architecture, :authorizer => authorizer)) %></td>
       <td class="ellipsis"><%= architecture.operatingsystems.map(&:to_label).to_sentence %></td>
-      <td><%= link_to hosts_count[architecture], hosts_path(:search => "architecture = #{architecture}") %>
+      <td><%= link_to hosts_count[architecture], current_hosts_path(:search => "architecture = #{architecture}") %>
       <td>
         <%= action_buttons(display_delete_if_authorized hash_for_architecture_path(:id => architecture).merge(:auth_object => architecture, :authorizer => authorizer),
           :data => { :confirm => _("Delete %s?") % architecture.name } ) %>

--- a/app/views/config_reports/index.html.erb
+++ b/app/views/config_reports/index.html.erb
@@ -2,7 +2,7 @@
     items: [
     {
       caption: _("Hosts"),
-      url: (hosts_path if authorized_for(hash_for_hosts_path))
+      url: (current_hosts_path if authorized_for(hash_for_hosts_path))
     },
     {
       caption: @host.name,

--- a/app/views/domains/index.html.erb
+++ b/app/views/domains/index.html.erb
@@ -14,7 +14,7 @@
     <% @domains.each do |domain| %>
     <tr>
       <td class="ellipsis"><%= link_to_if_authorized (domain.fullname.empty? ? domain.name : domain.fullname), hash_for_edit_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer) %></td>
-      <td><%= link_to hosts_count[domain], hosts_path(:search => "domain = #{domain}") %>
+      <td><%= link_to hosts_count[domain], current_hosts_path(:search => "domain = #{domain}") %>
       <td class="col-md-1"><%= action_buttons(display_delete_if_authorized hash_for_domain_path(:id => domain).merge(:auth_object => domain, :authorizer => authorizer), :data => { :confirm => _("Delete %s?") % domain.name }) %></td>
       </tr>
     <% end %>

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -18,10 +18,10 @@
         <%= label_with_link(hostgroup, 150, authorizer) %>
       </td>
       <td>
-        <%= link_to hosts_count[hostgroup], hosts_path(:search => %Q[hostgroup_fullname = "#{hostgroup.title}"]) %>
+        <%= link_to hosts_count[hostgroup], current_hosts_path(:search => %Q[hostgroup_fullname = "#{hostgroup.title}"]) %>
       </td>
       <td>
-        <%= link_to hostgroup.children_hosts_count, hosts_path(:search => %Q[parent_hostgroup = "#{hostgroup.title}"]) %>
+        <%= link_to hostgroup.children_hosts_count, current_hosts_path(:search => %Q[parent_hostgroup = "#{hostgroup.title}"]) %>
       </td>
       <td>
         <%= hostgroup_actions_dropdown(hostgroup) %>

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -139,6 +139,6 @@
 
     <%= hidden_field_tag 'bare_metal_capabilities', @host.bare_metal_capabilities, :disabled => true %>
     <%= f.hidden_field :overwrite? %>
-    <%= submit_or_cancel f, @host.overwrite?, :cancel_path => resource_prev_url_with_search_filters || (@host.new_record? ? hosts_path : current_host_details_path(@host)) %>
+    <%= submit_or_cancel f, @host.overwrite?, :cancel_path => resource_prev_url_with_search_filters || (@host.new_record? ? current_hosts_path : current_host_details_path(@host)) %>
   <% end %>
 <% end %>

--- a/app/views/hosts/multiple_disassociate.html.erb
+++ b/app/views/hosts/multiple_disassociate.html.erb
@@ -8,6 +8,6 @@
          'The list is excluding %{count} %{link_start}physical hosts%{link_end}.',
          physical_count).html_safe % {
            :count => physical_count,
-           :link_start => tag('a', {:href => hosts_path(:search => "name ^ (#{@physical_hosts.join(',')})")}, true),
+           :link_start => tag('a', {:href => current_hosts_path(:search => "name ^ (#{@physical_hosts.join(',')})")}, true),
            :link_end => '</a>'.html_safe} %>
 <% end %>

--- a/app/views/hosts/update_multiple_parameters.html.erb
+++ b/app/views/hosts/update_multiple_parameters.html.erb
@@ -15,4 +15,4 @@
     </li>
   <% end %>
 </ul>
-<%= link_to _("Back to host list"), hosts_path %>
+<%= link_to _("Back to host list"), current_hosts_path %>

--- a/app/views/operatingsystems/index.html.erb
+++ b/app/views/operatingsystems/index.html.erb
@@ -19,7 +19,7 @@
       %>
       <tr>
         <td class="ellipsis"><%= link_to_if_authorized(os_name(operatingsystem), hash_for_edit_operatingsystem_path(:id => operatingsystem).merge(:auth_object => operatingsystem, :authorizer => authorizer)) %></td>
-        <td><%= link_to hosts_count[operatingsystem], hosts_path(:search => "os_id = #{operatingsystem.id}") %></td>
+        <td><%= link_to hosts_count[operatingsystem], current_hosts_path(:search => "os_id = #{operatingsystem.id}") %></td>
         <td>
           <%= action_buttons(edit_btn, clone_btn, delete_btn) %>
         </td>

--- a/app/views/realms/index.html.erb
+++ b/app/views/realms/index.html.erb
@@ -14,7 +14,7 @@
     <% @realms.each do |realm| %>
     <tr>
       <td class="ellipsis"><%= link_to_if_authorized realm.name, hash_for_edit_realm_path(:id => realm)%></td>
-      <td><%= link_to hosts_count[realm], hosts_path(:search => "realm = #{realm}") %>
+      <td><%= link_to hosts_count[realm], current_hosts_path(:search => "realm = #{realm}") %>
       <td class="col-md-1"><%= action_buttons display_delete_if_authorized hash_for_realm_path(:id => realm), :data => { :confirm => _("Delete %s?") % realm.name } %></td>
     </tr>
     <% end %>

--- a/app/views/smart_proxies/plugins/_puppet_ca.html.erb
+++ b/app/views/smart_proxies/plugins/_puppet_ca.html.erb
@@ -15,7 +15,7 @@
         <div class="row">
           <div class="col-md-4"><strong><%= _('Hosts managed:') %></strong></div>
           <div class="col-md-8">
-            <%= link_to Host::Managed.where(:puppet_ca_proxy_id => @smart_proxy.id).count, hosts_path(:search => "puppet_ca = \"#{@smart_proxy.name}\"") %>
+            <%= link_to Host::Managed.where(:puppet_ca_proxy_id => @smart_proxy.id).count, current_hosts_path(:search => "puppet_ca = \"#{@smart_proxy.name}\"") %>
           </div>
         </div>
       </div>

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -77,7 +77,7 @@
             <strong><%= _('Hosts managed') %></strong>
           </div>
           <div class="col-md-8">
-            <%= link_to @smart_proxy.hosts_count, hosts_path(:search => "smart_proxy = \"#{@smart_proxy.name}\"") %>
+            <%= link_to @smart_proxy.hosts_count, current_hosts_path(:search => "smart_proxy = \"#{@smart_proxy.name}\"") %>
           </div>
         </div>
         <% if @smart_proxy.has_feature?('Logs') %>

--- a/app/views/taxonomies/index.html.erb
+++ b/app/views/taxonomies/index.html.erb
@@ -8,7 +8,7 @@
                       link_to(n_("%{count} host with no %{taxonomy_single} assigned",
                       "%{count} hosts with no %{taxonomy_single} assigned", @count_nil_hosts) %
                       {:count => @count_nil_hosts , :taxonomy_single => taxonomy_single },
-                      hosts_path(:search => "not has #{controller_name.singularize}"))).html_safe %>
+                      current_hosts_path(:search => "not has #{controller_name.singularize}"))).html_safe %>
 <% end %>
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>
@@ -22,7 +22,7 @@
     <% @taxonomies.each do |taxonomy| %>
       <tr class="<%= cycle("even", "odd") %>">
         <td><%= label_with_link(taxonomy, 150) %></td>
-        <td><%= link_to hosts_count[taxonomy], hosts_path(:search => "#{controller_name.singularize} = \"#{taxonomy}\"") %></td>
+        <td><%= link_to hosts_count[taxonomy], current_hosts_path(:search => "#{controller_name.singularize} = \"#{taxonomy}\"") %></td>
         <td>
           <%= action_buttons(
             display_link_if_authorized(_("Edit"), hash_for_edit_taxonomy_path(taxonomy).merge(:auth_object => taxonomy) ),

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -223,18 +223,18 @@ class HostsControllerTest < ActionController::TestCase
 
   test "when host is not saved after setBuild, the flash should inform it" do
     Host.any_instance.stubs(:setBuild).returns(false)
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
 
     put :setBuild, params: { :id => @host.name }, session: set_session_user
     assert_response :found
-    assert_redirected_to hosts_path
+    assert_redirected_to current_hosts_path
     assert_not_nil flash[:error]
     assert flash[:error] =~ /Failed to enable #{@host} for installation/
   end
 
   context "when host is saved after setBuild" do
     setup do
-      @request.env['HTTP_REFERER'] = hosts_path
+      @request.env['HTTP_REFERER'] = current_hosts_path
     end
 
     teardown do
@@ -246,7 +246,7 @@ class HostsControllerTest < ActionController::TestCase
       Host::Managed.any_instance.stubs(:setBuild).returns(true)
       put :setBuild, params: { :id => @host.name }, session: set_session_user
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not_nil flash[:success]
       assert flash[:success] == "Enabled #{@host} for rebuild on next boot"
     end
@@ -263,7 +263,7 @@ class HostsControllerTest < ActionController::TestCase
 
       put :setBuild, params: { :id => @host.name, :host => {:build => '1'} }, session: set_session_user
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not_nil flash[:success]
       assert_equal(flash[:success], "Enabled #{@host} for reboot and rebuild")
     end
@@ -280,7 +280,7 @@ class HostsControllerTest < ActionController::TestCase
       put :setBuild, params: { :id => @host.name, :host => {:build => '1'} }, session: set_session_user
       @host.power.reset
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not_nil flash[:success]
       assert_equal(flash[:success], "Enabled #{@host} for rebuild on next boot, but failed to power cycle the host")
     end
@@ -304,7 +304,7 @@ class HostsControllerTest < ActionController::TestCase
         @host.power.reset
       end
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not_nil flash[:success]
       assert_equal(flash[:success], "Enabled #{@host} for rebuild on next boot")
     end
@@ -445,7 +445,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test 'multiple hostgroup change by host ids' do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     # check that we have hosts and their hostgroup is empty
     hosts = FactoryBot.create_list(:host, 2)
     hosts.each { |host| assert_nil host.hostgroup }
@@ -461,7 +461,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test 'multiple hostgroup change by host names' do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     hosts = FactoryBot.create_list(:host, 2)
     host_names = hosts.map(&:name)
     # check that we have hosts and their hostgroup is empty
@@ -485,7 +485,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test "user with edit host rights with update owner should change owner" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     setup_user_and_host "edit"
     assert_equal users(:admin).id_and_type, @host1.is_owned_by
     assert_equal users(:admin).id_and_type, @host2.is_owned_by
@@ -506,7 +506,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test "should change the power of multiple hosts" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     setup_multiple_compute_resource
 
     params = { :host_ids => [@host1.id, @host2.id],
@@ -573,7 +573,7 @@ class HostsControllerTest < ActionController::TestCase
     end
 
     test "should change the puppet ca proxy" do
-      @request.env['HTTP_REFERER'] = hosts_path
+      @request.env['HTTP_REFERER'] = current_hosts_path
 
       proxy = as_admin { FactoryBot.create(:smart_proxy, :features => [FactoryBot.create(:feature, :puppetca)]) }
 
@@ -593,7 +593,7 @@ class HostsControllerTest < ActionController::TestCase
     end
 
     test "should clear the puppet ca proxy" do
-      @request.env['HTTP_REFERER'] = hosts_path
+      @request.env['HTTP_REFERER'] = current_hosts_path
 
       params = { :host_ids => @hosts.map(&:id),
                  :proxy => { :proxy_id => "" } }
@@ -779,7 +779,7 @@ class HostsControllerTest < ActionController::TestCase
     def multiple_hosts_submit_request(method, ids, success, params = {})
       post :"submit_multiple_#{method}", params: params.merge({:host_ids => ids}), session: set_session_user
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_equal success, flash[:success]
     end
   end
@@ -804,7 +804,7 @@ class HostsControllerTest < ActionController::TestCase
 
   # Pessimistic - Location
   test "update multiple location fails on pessimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     location = taxonomies(:location1)
     post :update_multiple_location, params: {
       :location => {:id => location.id, :optimistic_import => "no"},
@@ -814,7 +814,7 @@ class HostsControllerTest < ActionController::TestCase
     assert flash[:error] == "Cannot update Location to Location 1 because of mismatch in settings"
   end
   test "update multiple location does not update location of hosts if fails on pessimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     location = taxonomies(:location1)
     assert_difference "location.hosts.count", 0 do
       post :update_multiple_location, params: {
@@ -824,7 +824,7 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
   test "update multiple location does not import taxable_taxonomies rows if fails on pessimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     location = taxonomies(:location1)
     assert_difference "location.taxable_taxonomies.count", 0 do
       post :update_multiple_location, params: {
@@ -836,7 +836,7 @@ class HostsControllerTest < ActionController::TestCase
 
   # Optimistic - Location
   test "update multiple location updates location of hosts if succeeds on optimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     location = taxonomies(:location1)
     cnt_hosts_location = location.hosts.count
     assert_difference "location.hosts.count", (Host.unscoped.count - cnt_hosts_location) do
@@ -849,7 +849,7 @@ class HostsControllerTest < ActionController::TestCase
     assert_equal "Updated hosts: Changed Location", flash[:success]
   end
   test "update multiple location imports taxable_taxonomies rows if succeeds on optimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     location = taxonomies(:location1)
     domain = FactoryBot.create(:domain, :locations => [taxonomies(:location2)])
     hosts = FactoryBot.create_list(:host, 2, :domain => domain, :location => taxonomies(:location2))
@@ -863,7 +863,7 @@ class HostsControllerTest < ActionController::TestCase
 
   # Pessimistic - organization
   test "update multiple organization fails on pessimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization = taxonomies(:organization1)
     post :update_multiple_organization, params: {
       :organization => {:id => organization.id, :optimistic_import => "no"},
@@ -873,7 +873,7 @@ class HostsControllerTest < ActionController::TestCase
     assert_equal "Cannot update Organization to Organization 1 because of mismatch in settings", flash[:error]
   end
   test "update multiple organization does not update organization of hosts if fails on pessimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization = taxonomies(:organization1)
     assert_difference "organization.hosts.count", 0 do
       post :update_multiple_organization, params: {
@@ -883,7 +883,7 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
   test "update multiple organization does not import taxable_taxonomies rows if fails on pessimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization = taxonomies(:organization1)
     assert_difference "organization.taxable_taxonomies.count", 0 do
       post :update_multiple_organization, params: {
@@ -895,7 +895,7 @@ class HostsControllerTest < ActionController::TestCase
 
   # Optimistic - Organization
   test "update multiple organization succeeds on optimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization = taxonomies(:organization1)
     post :update_multiple_organization, params: {
       :organization => {:id => organization.id, :optimistic_import => "yes"},
@@ -905,7 +905,7 @@ class HostsControllerTest < ActionController::TestCase
     assert_equal "Updated hosts: Changed Organization", flash[:success]
   end
   test "update multiple organization succeeds with search" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization1 = taxonomies(:organization1)
     organization2 = taxonomies(:organization2)
     hosts = FactoryBot.create_list(:host, 2, :managed, organization: organization1)
@@ -921,7 +921,7 @@ class HostsControllerTest < ActionController::TestCase
     assert hosts.all? { |host| host.organization == organization2 }
   end
   test "update multiple organization updates organization of hosts if succeeds on optimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization = taxonomies(:organization1)
     cnt_hosts_organization = organization.hosts.count
     assert_difference "organization.hosts.count", (Host.unscoped.count - cnt_hosts_organization) do
@@ -932,7 +932,7 @@ class HostsControllerTest < ActionController::TestCase
     end
   end
   test "update multiple organization imports taxable_taxonomies rows if succeeds on optimistic import" do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     organization = taxonomies(:organization1)
     domain = FactoryBot.create(:domain, :organizations => [taxonomies(:organization2)])
     hosts = FactoryBot.create_list(:host, 2, :domain => domain, :organization => taxonomies(:organization2))
@@ -1033,13 +1033,13 @@ class HostsControllerTest < ActionController::TestCase
 
   test "select multiple action with empty host_ids should redirect to hosts page" do
     post :multiple_parameters, params: {:host_ids => []}, session: set_session_user, xhr: true
-    assert_response :redirect, hosts_path
+    assert_response :redirect, current_hosts_path
     assert_not_nil flash[:error]
   end
 
   test "select multiple action with not exists host_ids should redirect to hosts page" do
     post :multiple_parameters, params: {:host_ids => [-1, 2]}, session: set_session_user, xhr: true
-    assert_response :redirect, hosts_path
+    assert_response :redirect, current_hosts_path
     assert_not_nil flash[:error]
   end
 
@@ -1061,17 +1061,17 @@ class HostsControllerTest < ActionController::TestCase
 
   test "#disassociate shows error when used on non-CR host" do
     host = FactoryBot.create(:host)
-    @request.env["HTTP_REFERER"] = hosts_path
+    @request.env["HTTP_REFERER"] = current_hosts_path
     put :disassociate, params: { :id => host.to_param }, session: set_session_user
-    assert_response :redirect, hosts_path
+    assert_response :redirect, current_hosts_path
     assert_not_nil flash[:error]
   end
 
   test "#disassociate removes UUID and CR association from host" do
     host = FactoryBot.create(:host, :on_compute_resource)
-    @request.env["HTTP_REFERER"] = hosts_path
+    @request.env["HTTP_REFERER"] = current_hosts_path
     put :disassociate, params: { :id => host.to_param }, session: set_session_user
-    assert_response :redirect, hosts_path
+    assert_response :redirect, current_hosts_path
     host.reload
     refute host.uuid
     refute host.compute_resource_id
@@ -1097,7 +1097,7 @@ class HostsControllerTest < ActionController::TestCase
   test '#update_multiple_disassociate' do
     host = FactoryBot.create(:host, :on_compute_resource)
     post :update_multiple_disassociate, params: { :host_ids => [host.id], :host_names => [host.name] }, session: set_session_user
-    assert_response :redirect, hosts_path
+    assert_response :redirect, current_hosts_path
     assert_not_nil flash[:success]
     host.reload
     refute host.uuid
@@ -1177,26 +1177,26 @@ class HostsControllerTest < ActionController::TestCase
 
   context 'test submit multiple rebuild config' do
     def test_submit_multiple_rebuild_config_optimistic
-      @request.env['HTTP_REFERER'] = hosts_path
+      @request.env['HTTP_REFERER'] = current_hosts_path
       Host.any_instance.expects(:recreate_config).returns({"TFTP" => true, "DHCP" => true, "DNS" => true})
       h = as_admin { FactoryBot.create(:host) }
 
       post :submit_rebuild_config, params: { :host_ids => [h.id] }, session: set_session_user
 
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not_nil flash[:success]
     end
 
     def test_submit_multiple_rebuild_config_pessimistic
-      @request.env['HTTP_REFERER'] = hosts_path
+      @request.env['HTTP_REFERER'] = current_hosts_path
       Host.any_instance.expects(:recreate_config).returns({"TFTP" => false, "DHCP" => false, "DNS" => false})
       h = as_admin { FactoryBot.create(:host) }
 
       post :submit_rebuild_config, params: { :host_ids => [h.id] }, session: set_session_user
 
       assert_response :found
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not_nil flash[:error]
     end
   end
@@ -1369,7 +1369,7 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test 'failed cancelBuild shows errors' do
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = current_hosts_path
     HostsController.any_instance.stubs(:resource_finder).returns(@host)
     @host.errors.add(:test, 'my error')
     @host.interfaces = [] # force save failure
@@ -1510,7 +1510,7 @@ class HostsControllerTest < ActionController::TestCase
     end
 
     test "after deleting host search filter should remain as it is" do
-      hosts_search_path = hosts_path(search: "hostgroup_name = #{@hostgroup1.name}")
+      hosts_search_path = current_hosts_path(search: "hostgroup_name = #{@hostgroup1.name}")
       @request.session["redirect_to_url_hosts"] = hosts_search_path
 
       delete :destroy, params: { :id => @managed_host1.id }, session: set_session_user
@@ -1520,7 +1520,7 @@ class HostsControllerTest < ActionController::TestCase
 
     test "after deleting host, it should redirect to hosts page if no session" do
       delete :destroy, params: { :id => @managed_host1.id }, session: set_session_user
-      assert_redirected_to hosts_path
+      assert_redirected_to current_hosts_path
       assert_not Host.exists?(@managed_host1.id)
     end
   end
@@ -1541,6 +1541,10 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   private
+
+  def current_hosts_path(*args)
+    ApplicationHelper.current_hosts_path(*args)
+  end
 
   def initialize_host
     User.current = users(:admin)

--- a/test/controllers/puppetca_controller_test.rb
+++ b/test/controllers/puppetca_controller_test.rb
@@ -7,7 +7,7 @@ class PuppetcaControllerTest < ActionController::TestCase
 
   test 'problems when signing certificate redirect to certificates page' do
     # Try set any random path in the referer to ensure it doesn't redirect_to :back
-    @request.env['HTTP_REFERER'] = hosts_path
+    @request.env['HTTP_REFERER'] = ApplicationHelper.current_hosts_path
     ProxyStatus::PuppetCA.any_instance.expects(:find).raises("A problem")
     # This will try to find the certificate to no avail and will raise a ProxyException
     post :update, params: { :smart_proxy_id => @proxy.id, :id => 1 }, session: set_session_user

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -222,7 +222,7 @@ class UsersControllerTest < ActionController::TestCase
     time = Time.zone.now
     @request.env['HTTP_REMOTE_USER'] = users(:admin).login
     get :extlogin, session: {:user => users(:admin).id }
-    assert_redirected_to hosts_path
+    assert_redirected_to ApplicationHelper.current_hosts_path
     users(:admin).reload
     assert users(:admin).last_login_on.to_i >= time.to_i, 'User last login time was not updated'
   end
@@ -280,7 +280,7 @@ class UsersControllerTest < ActionController::TestCase
     SSO::FormIntercept.any_instance.stubs(:authenticated?).returns(true)
     SSO::FormIntercept.any_instance.stubs(:current_user).returns(users(:admin))
     post :login, params: { :login => {:login => 'ares', :password => 'password_that_does_not_match'} }
-    assert_redirected_to hosts_path
+    assert_redirected_to ApplicationHelper.current_hosts_path
   end
 
   test 'non admin user should edit itself' do
@@ -337,13 +337,13 @@ class UsersControllerTest < ActionController::TestCase
       session: set_session_user(user)
 
     assert_response :redirect
-    assert_redirected_to hosts_path
+    assert_redirected_to ApplicationHelper.current_hosts_path
   end
 
   test "#login sets the session user and bumps last log in time" do
     time = Time.zone.now
     post :login, params: { :login => {'login' => users(:admin).login, 'password' => 'secret'} }
-    assert_redirected_to hosts_path
+    assert_redirected_to ApplicationHelper.current_hosts_path
     assert_equal users(:admin).id, session[:user]
     users(:admin).reload
     assert users(:admin).last_login_on.to_i >= time.to_i, 'User last login on was not updated'
@@ -399,7 +399,7 @@ class UsersControllerTest < ActionController::TestCase
     AuthSourceLdap.any_instance.stubs(:organizations).returns([taxonomies(:organization1)])
     AuthSourceLdap.any_instance.stubs(:locations).returns([taxonomies(:location1)])
     post :login, params: { :login => {'login' => 'ldap-user', 'password' => 'password'} }
-    assert_redirected_to hosts_path
+    assert_redirected_to ApplicationHelper.current_hosts_path
     assert_match /mail.*invalid/i, flash[:warning]
 
     # Subsequent redirects to the user edit page should preserve the warning
@@ -454,11 +454,11 @@ class UsersControllerTest < ActionController::TestCase
       assert_redirected_to @previous_url
     end
 
-    test "#login if referer absent redirect to hosts_path" do
+    test "#login if referer absent redirect to ApplicationHelper.current_hosts_path" do
       request.env['HTTP_REFERER'] = nil
 
       get :login
-      assert_redirected_to hosts_path
+      assert_redirected_to ApplicationHelper.current_hosts_path
     end
   end
 
@@ -527,7 +527,7 @@ class UsersControllerTest < ActionController::TestCase
     session[:impersonated_by] = nil
     user = users(:one)
     get :impersonate, params: { :id => user.id }, session: set_session_user
-    assert_redirected_to hosts_path
+    assert_redirected_to ApplicationHelper.current_hosts_path
     assert flash.to_hash["success"]
   end
 

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -75,7 +75,7 @@ class HostJSTest < IntegrationTestWithJavascript
     end
 
     test "assert breadcrumbs" do
-      visit hosts_path
+      visit current_hosts_path
       click_link @host.fqdn
       find('.pf-c-breadcrumb__item', :text => @host.fqdn)
     end
@@ -89,7 +89,7 @@ class HostJSTest < IntegrationTestWithJavascript
     end
 
     test "new show page" do
-      visit hosts_path
+      visit current_hosts_path
       click_link @host.fqdn
       find('h5', :text => @host.fqdn)
     end
@@ -113,7 +113,7 @@ class HostJSTest < IntegrationTestWithJavascript
       find('#hostdetails-kebab').click
       click_button 'Delete'
       find('button.pf-c-button.pf-m-danger').click # the red delete button, not the menu item
-      assert_current_path hosts_path
+      assert_current_path current_hosts_path
       assert_raises(ActiveRecord::RecordNotFound) do
         Host.find(host.id)
       end
@@ -218,42 +218,42 @@ class HostJSTest < IntegrationTestWithJavascript
     end
 
     test "index page" do
-      assert_index_page(hosts_path, "Hosts", "Create Host")
+      assert_index_page(current_hosts_path, "Hosts", "Create Host")
     end
 
     test 'hosts counter should refer to per_page value first (max prespective)' do
       Setting[:entries_per_page] = 2
-      visit hosts_path(per_page: 3)
+      visit current_hosts_path(per_page: 3)
       check 'check_all'
       assert page.has_text?(:all, "All 3 hosts on this page are selected")
     end
 
     test 'hosts counter should refer to per_page value first (min prespective)' do
       Setting[:entries_per_page] = 3
-      visit hosts_path(per_page: 2)
+      visit current_hosts_path(per_page: 2)
       check 'check_all'
       assert page.has_text?(:all, "All 2 hosts on this page are selected")
     end
 
     test 'hosts counter should refer to setting- entries_per_page when there is no per_page value' do
       Setting[:entries_per_page] = 3
-      visit hosts_path()
+      visit current_hosts_path()
       check 'check_all'
       assert page.has_text?(:all, "All 3 hosts on this page are selected")
     end
 
     test 'cookie should exist after checking all, cookie should clear after search' do
       Setting[:entries_per_page] = 3
-      visit hosts_path()
+      visit current_hosts_path()
       check 'check_all'
       assert_not_nil get_me_the_cookie('_ForemanSelectedhosts')
-      visit hosts_path(search: "name = abc")
+      visit current_hosts_path(search: "name = abc")
       assert_nil get_me_the_cookie('_ForemanSelectedhosts')
     end
 
     test 'bulk select all hosts' do
       Setting[:entries_per_page] = 3
-      visit hosts_path(per_page: 2)
+      visit current_hosts_path(per_page: 2)
       check 'check_all'
       assert page.has_text?(:all, "Select all 3 hosts")
       find('#multiple-alert > .text > a').click
@@ -263,7 +263,7 @@ class HostJSTest < IntegrationTestWithJavascript
 
   describe "create new host page" do
     test "default primary interface is in the overview table" do
-      assert_new_button(hosts_path, "Create Host", new_host_path)
+      assert_new_button(current_hosts_path, "Create Host", new_host_path)
 
       # switch to interfaces tab
       page.find(:link, "Interfaces").click
@@ -458,7 +458,7 @@ class HostJSTest < IntegrationTestWithJavascript
 
   describe "hosts index multiple actions" do
     test 'show action buttons' do
-      visit hosts_path
+      visit current_hosts_path
       check 'check_all'
 
       # Ensure and wait for all hosts to be checked, and that no unchecked hosts remain
@@ -482,20 +482,20 @@ class HostJSTest < IntegrationTestWithJavascript
 
       # remove hosts cookie on submit
       index_modal.find('.btn-primary').click
-      assert_current_path hosts_path
+      assert_current_path current_hosts_path
       assert_empty(get_me_the_cookie('_ForemanSelectedhosts'))
     end
 
     test 'redirect js with parameter in URL' do
-      path1 = hosts_path(param1: 'val1')
-      path2 = hosts_path(param1: 'val1', param2: 'val2')
+      path1 = current_hosts_path(param1: 'val1')
+      path2 = current_hosts_path(param1: 'val1', param2: 'val2')
 
-      visit hosts_path
+      visit current_hosts_path
       check 'check_all'
       page.execute_script("tfm.hosts.table.buildRedirect('#{path1}')")
       assert(current_url.include?("#{path1}&host_ids"))
 
-      visit hosts_path
+      visit current_hosts_path
       check 'check_all'
       page.execute_script("tfm.hosts.table.buildRedirect('#{path2}')")
       assert(current_url.include?("#{path2}&host_ids"))

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -9,13 +9,13 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "index page with search" do
-    visit hosts_path(search: "name = #{@host.name}")
-    assert page.has_link?('Export', href: hosts_path(format: 'csv', search: "name = #{@host.name}"))
+    visit current_hosts_path(search: "name = #{@host.name}")
+    assert page.has_link?('Export', href: current_hosts_path(format: 'csv', search: "name = #{@host.name}"))
   end
 
   describe "create new host page" do
     test "tabs are present" do
-      assert_new_button(hosts_path, "Create Host", new_host_path)
+      assert_new_button(current_hosts_path, "Create Host", new_host_path)
       assert page.has_link?("Host", :href => "#primary")
       assert page.has_link?("Interfaces", :href => "#network")
       assert page.has_link?("Operating System", :href => "#os")

--- a/test/integration/shared/host_finders.rb
+++ b/test/integration/shared/host_finders.rb
@@ -12,7 +12,7 @@ module HostFinders
 
   def go_to_interfaces_tab
     # go to New Host page
-    assert_new_button(hosts_path, "Create Host", new_host_path)
+    assert_new_button(current_hosts_path, "Create Host", new_host_path)
     # switch to interfaces tab
     switch_form_tab_to_interfaces
   end
@@ -55,5 +55,9 @@ module HostFinders
 
   def click_on_inherit(attribute, prefix: 'host_')
     find("##{prefix}#{attribute}_id + .input-group-btn .btn").click
+  end
+
+  def current_hosts_path(*args)
+    ApplicationHelper.current_hosts_path(*args)
   end
 end


### PR DESCRIPTION
Also removed logic in the hosts controller and application helper to rewrite the URL. Decided to go with the redirect on index approach instead since we want this redirect to happen only on get requests.

Test this
- Go to Administer-> Settings -> New Hosts Page. Set that to Yes
- Go to `http://<satellite>/hosts` and notice that it should get redirected to `http://<satellite>/new/hosts`
- Make operations like create/update/delete hosts all work ok.
  

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
