### PR TITLE
Refs #36815 - explicitly require redis

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -303,6 +303,8 @@ module Foreman
     # config.cache_store = TimedCachedStore.new
     rails_cache_settings = SETTINGS[:rails_cache_store]
     if (rails_cache_settings && rails_cache_settings[:type] == 'redis')
+      require 'redis'
+
       options = [:redis_cache_store]
       redis_urls = Array.wrap(rails_cache_settings[:urls])
 


### PR DESCRIPTION
ActiveSupport only loads the Redis gem when one enables RedisCacheStore, but we need to obtain the default values before that.

For some reason this did not break on EL, but only on Debian. Maybe because we use plain gems on the one vs bundler on the other.

Error:

    rake aborted!
    NameError: uninitialized constant Redis
    /usr/share/foreman/config/application.rb:312:in `<class:Application>'
    /usr/share/foreman/config/application.rb:102:in `<module:Foreman>'
    /usr/share/foreman/config/application.rb:101:in `<top (required)>'
    /usr/share/foreman/Rakefile:1:in `require'
    /usr/share/foreman/Rakefile:1:in `<top (required)>'
    /usr/share/foreman/vendor/ruby/2.7.0/gems/rake-13.1.0/exe/rake:27:in `<top (required)>'
    (See full trace by running task with --trace)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
