### PR TITLE
Refs #36815 - Require redis group if it is present

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ else
       end
     end
     Bundler.require(*Rails.groups)
-    optional_bundler_groups = %w[assets ec2 fog libvirt openstack ovirt vmware]
+    optional_bundler_groups = %w[assets ec2 fog libvirt openstack ovirt vmware redis]
     optional_bundler_groups.each do |group|
       Bundler.require(group)
     rescue LoadError
@@ -303,8 +303,6 @@ module Foreman
     # config.cache_store = TimedCachedStore.new
     rails_cache_settings = SETTINGS[:rails_cache_store]
     if (rails_cache_settings && rails_cache_settings[:type] == 'redis')
-      require 'redis'
-
       options = [:redis_cache_store]
       redis_urls = Array.wrap(rails_cache_settings[:urls])
 


### PR DESCRIPTION
This is an alternative approach to https://github.com/theforeman/foreman/pull/9886 which aims to use the existing optional loading methodology rather than a direct requires.

In an RPM environment, we use BundlerExt which has an explicit require for all gems/groups that are found -- https://github.com/theforeman/foreman/blob/develop/config/application.rb#L36

For standard (Debian, devel) bundler based environment, the groups are selectively loaded based on what is available -- https://github.com/theforeman/foreman/blob/develop/config/application.rb#L59-L63
