### PR TITLE
Fixes #36892 - Pass host results to REX slot and make permissions nodes extensible

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -47,7 +47,7 @@ module Api
       layout 'api/v2/layouts/index_layout', :only => :index
 
       helper_method :root_node_name, :metadata_total, :metadata_subtotal, :metadata_search,
-        :metadata_order, :metadata_by, :metadata_page, :metadata_per_page
+        :metadata_order, :metadata_by, :metadata_page, :metadata_per_page, :index_node_permissions_snippet
       def root_node_name
         @root_node_name ||= if Rabl.configuration.use_controller_name_as_json_root
                               controller_name.split('/').last
@@ -56,6 +56,21 @@ module Api
                             else
                               Rabl.configuration.json_root_default_name
                             end
+      end
+
+      # may be extended by plugins to add additional permissions
+      def index_node_permissions
+        {
+          :can_create => can_create?,
+          :can_edit => authorized_for(:controller => controller_name, :action => 'edit'),
+        }
+      end
+
+      def index_node_permissions_snippet
+        perms = index_node_permissions.map do |key, value|
+          "#{key.to_json}: #{value.to_json}"
+        end
+        perms.join(",")
       end
 
       def metadata_total

--- a/app/views/api/v2/layouts/index_layout.json.erb
+++ b/app/views/api/v2/layouts/index_layout.json.erb
@@ -5,8 +5,7 @@
   "per_page": <%= metadata_per_page.to_json %>,
   "search": <%= metadata_search.to_json.html_safe %>,
 <% if params.has_key?(:include_permissions) %>
-  "can_create": <%= can_create?.to_json %>,
-  "can_edit": <%= can_edit?.to_json %>,
+  <%= index_node_permissions_snippet.html_safe %>,
 <% end %>
   "sort": {
     "by": <%= metadata_by.to_json.html_safe %>,

--- a/test/controllers/api/v2/base_controller_subclass_test.rb
+++ b/test/controllers/api/v2/base_controller_subclass_test.rb
@@ -129,4 +129,16 @@ class Api::V2::TestableControllerTest < ActionController::TestCase
     msg << "There may be more information in the server's logs."
     assert_equal JSON.parse(response.body)['error']['message'], msg
   end
+
+  test "adds permissions to index node" do
+    @controller.stubs(:index_node_permissions).returns({:test_permission => true})
+    result = @controller.index_node_permissions_snippet
+    assert_equal result, "\"test_permission\": true"
+  end
+
+  test "correctly handles nested hashes in index_node_permissions" do
+    @controller.stubs(:index_node_permissions).returns({:test_permission => {:nested => true}})
+    result = @controller.index_node_permissions_snippet
+    assert_equal result, "\"test_permission\": {\"nested\":true}"
+  end
 end

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -213,7 +213,8 @@ const HostsIndex = () => {
           <SplitItem>
             <Slot
               id="_all-hosts-schedule-a-job"
-              hostSearch={selectedCount && fetchBulkParams()}
+              hostSearch={selectedCount ? fetchBulkParams() : null}
+              hostResponse={response}
               selectedCount={selectedCount}
             />
           </SplitItem>


### PR DESCRIPTION
foreman_remote_execution needs access to the host response on the new host overview page (without making another api request).

This also allows plugins to override an `index_node_permissions` method to add permissions of their own to the API response.

