### PR TITLE
Fixes #36896 - override plugin toolbar css

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/components/Toolbar/HeaderToolbar.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/Toolbar/HeaderToolbar.scss
@@ -11,6 +11,12 @@
   }
 }
 
+.pf-c-toolbar#data-toolbar {
+  // Override for unupdated plugins that use unupdated foreman CSS
+  display: grid;
+  justify-content: normal;
+}
+
 .pf-c-masthead__brand {
   padding-right: 15px;
 


### PR DESCRIPTION
Instead of users updating/releasing old plugins that were built with previous version of this css, Foreman will just override it.
Ideally I also want to cp it to 3.8.
https://community.theforeman.org/t/user-dropdown-shifted-to-the-left-after-upgrade-to-3-8/35400
I tested it by adding the previous css to the file and seeing that the user dropdown is on the right
``` css
#data-toolbar {
  grid-column: 2 / 3;
  margin-left: 0;
  display: flex;
  justify-content: space-between;
  flex-wrap: wrap;

  .pf-c-page__header-tools-item {
    margin-left: 10px;
  }

  .pf-c-spinner {
    margin-left: 10px;
  }
  background-color: unset;
  @media (max-width: $header-max-width) {
    justify-content: flex-end;

    .header-tool-item-hidden-lg {
      display: none;
    }
  }
}
```