### PR TITLE
Refs #36822 - Removes an accidentally commented line in TableHooks

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/TableHooks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/TableHooks.js
@@ -281,6 +281,9 @@ export const useBulkSelect = ({
   };
 };
 
+export const friendlySearchParam = searchParam =>
+  decodeURIComponent(searchParam.replace(/\+/g, ' '));
+
 // takes a url query like ?type=security&search=name+~+foo
 // and returns an object
 // {
@@ -292,8 +295,7 @@ export const useUrlParams = () => {
   const { search: urlSearchParam, ...urlParams } = Object.fromEntries(
     new URLSearchParams(location.search).entries()
   );
-  //  const searchParam = urlSearchParam ? friendlySearchParam(urlSearchParam) : '';
-  const searchParam = '';
+  const searchParam = urlSearchParam ? friendlySearchParam(urlSearchParam) : '';
 
   return {
     searchParam,


### PR DESCRIPTION
The `useUrlParams` method  table hooks had a line incorrectly commented. This cause ChangeContentSource page to not work because the search parameter in the URL was getting ignored. This commit fixes that by uncommenting and adding the friendlySearchParam method.
