### PR TITLE
Fixes #36915 - Correct datetime input for report generation

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -92,6 +92,8 @@ class DateTimePicker extends React.Component {
           />
           <Popover
             position={placement}
+            className="container"
+            style={{ minWidth: '50em', width: '33%'}}
             bodyContent={popover}
             onShown={() => this.setState({ hiddenValue: false })}
           >


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Steps to reproduce:
1. Go to Monitor > Report Templates > Click on Generate against any template.
2. On the template generate form > Click the Generate at calendar icon to open input datetime calendar. The date/time overlap.
3. Patch with this PR.
4.  On the template generate form > Click the Generate at calendar icon to open input datetime calendar. The date/time should not overlap.
5. Upon entering some value in the field and generating report, make sure report generation task is scheduled for the selected time in foreman tasks.