### PR TITLE
Fixes #36917 - Create current user permissions API

### DIFF
--- a/app/controllers/api/v2/permissions_controller.rb
+++ b/app/controllers/api/v2/permissions_controller.rb
@@ -25,6 +25,14 @@ module Api
         @total = @resource_types.size
         render :resource_types, :layout => 'api/v2/layouts/index_layout'
       end
+
+      api :GET, "/permissions/current_permissions", N_("List all permissions for current user")
+      def current_permissions
+        @user = User.current
+        @current_permissions = @user.admin? ? Permission.all : @user.permissions
+        @total = @current_permissions.size
+        render :current_permissions, :layout => 'api/v2/layouts/index_layout'
+      end
     end
   end
 end

--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -18,6 +18,7 @@ Foreman::AccessControl.map do |permission_set|
       :bookmarks => [:index, :show, :auto_complete_search, :welcome],
       :"api/v2/bookmarks" => [:index, :show],
     }, :public => true
+    map.permission :current_permissions, { :"api/v2/permissions" => [:current_permissions] }, :public => true
   end
 
   permission_set.security_block :architectures do |map|

--- a/app/views/api/v2/permissions/current_permissions.json.rabl
+++ b/app/views/api/v2/permissions/current_permissions.json.rabl
@@ -1,0 +1,3 @@
+collection @current_permissions
+
+extends 'api/v2/permissions/main'

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -158,6 +158,7 @@ Foreman::Application.routes.draw do
       resources :permissions, :only => [:index, :show] do
         collection do
           get :resource_types
+          get :current_permissions
         end
       end
 

--- a/test/controllers/api/v2/permissions_controller_test.rb
+++ b/test/controllers/api/v2/permissions_controller_test.rb
@@ -22,4 +22,10 @@ class Api::V2::PermissionsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:resource_types)
     assert_response_not_empty
   end
+
+  test "should list current user permissions" do
+    get :current_permissions
+    assert_not_nil assigns(:current_permissions)
+    assert_response_not_empty
+  end
 end


### PR DESCRIPTION
Creates API for getting current user permissions
Needed for https://github.com/theforeman/foreman_remote_execution/pull/842
