### PR TITLE
Fixes #36919 - Add URL validation to HTTP Proxy URL field.

### DIFF
--- a/app/controllers/http_proxies_controller.rb
+++ b/app/controllers/http_proxies_controller.rb
@@ -24,7 +24,11 @@ class HttpProxiesController < ApplicationController
   end
 
   def test_connection
-    http_proxy = HttpProxy.new(http_proxy_params)
+    http_proxy = HttpProxy.new({name: 'dummy'}.update(http_proxy_params))
+    unless http_proxy.valid?
+      raise Foreman::Exception, http_proxy.errors.full_messages.join(', ')
+    end
+
     http_proxy.test_connection(params[:test_url])
 
     render :json => {:status => 'success', :message => _("HTTP Proxy connection successful.")}, :status => :ok

--- a/test/controllers/http_proxies_controller_test.rb
+++ b/test/controllers/http_proxies_controller_test.rb
@@ -54,4 +54,22 @@ class HttpProxiesControllerTest < ActionController::TestCase
     assert_includes @model.reload.locations.pluck(:id), location_id
     assert_includes @model.reload.organizations.pluck(:id), organization_id
   end
+
+  def test_test_connection_success
+    controller = HttpProxiesController.new
+    controller.stubs(:http_proxy_params).returns({ url: 'https://some_url'})
+    controller.stubs(:params).returns({test_url: "https://some.where.com"})
+    RestClient::Request.stubs(:execute).returns(['example', 1])
+    controller.expects(:render).with(:json => {:status => "success", :message => "HTTP Proxy connection successful."}, :status => :ok)
+    controller.test_connection
+  end
+
+  def test_test_connection_failure
+    controller = HttpProxiesController.new
+    controller.stubs(:http_proxy_params).returns({ url: 'https://some_url'})
+    controller.stubs(:params).returns({test_url: "https://some.where.com"})
+    RestClient::Request.stubs(:execute).raises(StandardError.new('some error'))
+    controller.expects(:render).with(:json => {:status => 'failure', :message => "some error"}, :status => :unprocessable_entity)
+    controller.test_connection
+  end
 end


### PR DESCRIPTION
Before PR:
![prproxybefore](https://github.com/theforeman/foreman/assets/1518655/8e5cb432-7ce2-4935-a8da-ebfdb040497d)

After PR:
![prproxy](https://github.com/theforeman/foreman/assets/1518655/7fc1a645-d9b7-4221-acfd-3e12c56bc895)

To Test:
* Apply PR
* Create an HTTP Proxy with a nonfqdn value
* Hit Test Connection