### PR TITLE
Fixes #36923 - Navigation search menu should be less wide

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/layout.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/layout.scss
@@ -61,6 +61,8 @@
         word-break: break-word;
       }
     }
+    min-width: 0;
+    margin: 0;
     --pf-c-menu__list-item--hover--BackgroundColor: var(
       --pf-global--BackgroundColor--200
     );


### PR DESCRIPTION
Making it so it has some space on the right side of the menu
Before /after:
![Screenshot from 2023-11-16 12-59-50](https://github.com/theforeman/foreman/assets/30431079/7881ad9a-624d-4aef-8de5-ddcfea6f44f2) ![Screenshot from 2023-11-16 12-54-07](https://github.com/theforeman/foreman/assets/30431079/d0a0b04b-896a-4ba0-b492-596c8fb7ad64)
