### PR TITLE
Fixes #36930 - Make invalid YAML test compatible with libyaml 0.2.x

### DIFF
--- a/test/models/lookup_key_test.rb
+++ b/test/models/lookup_key_test.rb
@@ -220,7 +220,7 @@ class LookupKeyTest < ActiveSupport::TestCase
       },
       {
         :sc_type => 'yaml',
-        :value => '{a:test}',
+        :value => '@@',
       },
       {
         :sc_type => 'json',


### PR DESCRIPTION
The valid {a:test} is invalid with libyaml 0.1.x but is valid with 0.2.x. This changes the test to @@ which should still raise a Psych::SyntaxError.