### PR TITLE
Fixes #36936 - Switch to terser

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -4,7 +4,7 @@ group :assets do
   gem 'gettext_i18n_rails_js', '~> 1.4'
   gem 'po_to_json', '~> 1.1'
   gem 'execjs', '>= 1.4.0', '< 3.0'
-  gem 'uglifier', '>= 1.0.3'
+  gem 'terser', '~> 1.1'
   gem 'sass-rails', '~> 6.0'
   # this one is a dependecy for x-editable-rails
   gem 'coffee-rails', '~> 5.0.0'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Foreman::Application.configure do |app|
   config.public_file_server.enabled = ENV.fetch('RAILS_SERVE_STATIC_FILES', false) == 'true'
 
   # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.


### PR DESCRIPTION
This includes temporary updates to packit in order to test this update against terser. This points to the scratch repo generated by the packaging PR (https://github.com/theforeman/foreman-packaging/pull/9877) and also points to a branch on my foreman-packaging fork that updates the spec file dependency.