### PR TITLE
Fixes #36947 - Broken openSUSE Leap 15 provisioning

### DIFF
--- a/app/views/unattended/partition_tables_templates/autoyast_entire_scsi_disk.erb
+++ b/app/views/unattended/partition_tables_templates/autoyast_entire_scsi_disk.erb
@@ -4,7 +4,7 @@ name: AutoYaST entire SCSI disk
 model: Ptable
 oses:
 - SLES
-- OpenSUSE
+- openSUSE
 %>
   <partitioning  config:type="list">
     <drive>

--- a/app/views/unattended/partition_tables_templates/autoyast_entire_virtual_disk.erb
+++ b/app/views/unattended/partition_tables_templates/autoyast_entire_virtual_disk.erb
@@ -4,7 +4,7 @@ name: AutoYaST entire virtual disk
 model: Ptable
 oses:
 - SLES
-- OpenSUSE
+- openSUSE
 %>
   <partitioning  config:type="list">
     <drive>

--- a/app/views/unattended/partition_tables_templates/autoyast_lvm.erb
+++ b/app/views/unattended/partition_tables_templates/autoyast_lvm.erb
@@ -4,7 +4,7 @@ name: AutoYaST LVM
 model: Ptable
 oses:
 - SLES
-- OpenSUSE
+- openSUSE
 %>
   <partitioning config:type="list">
     <drive>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
@@ -4,7 +4,7 @@ name: AutoYaST default PXEGrub2
 model: ProvisioningTemplate
 oses:
 - SLES
-- OpenSUSE
+- openSUSE
 description: |
   The template to render PXEGrub2 bootloader configuration for AutoYaST based distributions.
   The output is deployed on the host's subnet TFTP proxy.

--- a/app/views/unattended/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
+++ b/app/views/unattended/provisioning_templates/PXELinux/autoyast_default_pxelinux.erb
@@ -4,7 +4,7 @@ name: AutoYaST default PXELinux
 model: ProvisioningTemplate
 oses:
 - SLES
-- OpenSUSE
+- openSUSE
 description: |
   The template to render PXELinux bootloader configuration for SLES and OpenSUSE distributions.
   The output is deployed on the host's subnet TFTP proxy.

--- a/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -5,7 +5,7 @@ name: AutoYaST default iPXE
 model: ProvisioningTemplate
 oses:
 - SLES
-- OpenSUSE
+- openSUSE
 description: |
   The template to render iPXE installation script for SLES and OpenSUSE
   The output is deployed on the host's subnet TFTP proxy.
@@ -18,6 +18,15 @@ if host_param('http-proxy') && host_param('http-proxy-port')
 elsif host_param('http-proxy')
   extra_args << "proxy=http://" + host_param('http-proxy')
 end
+
+subnet = @host.subnet
+if subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode?
+  extra_args << "useDHCP=1"
+else
+  extra_args << "netsetup=-dhcp"
+  extra_args << "ifcfg=*=\"${netX/ip}/#{@host.primary_interface.subnet.cidr},${netX/gateway},${dns},#{@host.domain}\""
+end
+extra_args << "BOOTIF=01-${netX/mac:hexhyp}"
 -%>
 echo Trying to ping Gateway: ${netX/gateway}
 ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command not available.
@@ -28,11 +37,6 @@ ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not availa
 <% kernel = boot_files_uris[0] -%>
 <% initrd = boot_files_uris[1] -%>
 
-<% subnet = @host.subnet -%>
-<% if subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode? -%>
-kernel <%= kernel %> initrd=initrd.img splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1 <%= extra_args.join(' ')%>
-<% else -%>
-kernel <%= kernel %> initrd=initrd.img splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=0 netsetup=-dhcp ifcfg=*="${netX/ip}/<%= @host.primary_interface.subnet.cidr -%>,${netX/gateway},${dns},<%= @host.domain %>" <%= extra_args.join(' ')%>
-<% end -%>
-initrd <%= initrd %>
+kernel <%= kernel %> initrd=initrd.img splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 <%= extra_args.join(' ')%>
+initrd --name initrd.img <%= initrd %>
 boot

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -3,15 +3,17 @@ kind: provision
 name: AutoYaST default
 model: ProvisioningTemplate
 oses:
-- OpenSUSE
+- openSUSE
 description: |
   Provisioning template for the OpenSUSE AutoYaST installer.
 -%>
 <%
   # safemode renderer does not support unary negation
+  aio_enabled = host_param_true?('enable-puppetlabs-repo') || %w[official-puppet8 official-puppet7].any? { |repo| host_param_true?("enable-#{repo}-repo") }
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
   salt_enabled = host_param('salt_master') ? true : false
   os_major = @host.operatingsystem.major.to_i
+  os_minor = @host.operatingsystem.minor.to_i
   primary_interface_identifier = @host.primary_interface.identifier.blank? ? 'eth0' : @host.primary_interface.identifier
   primary_interface_subnet = @host.primary_interface.subnet
 -%>
@@ -29,7 +31,9 @@ description: |
       <hostname><%= @host.name %></hostname>
 <% unless primary_interface_subnet.dhcp_boot_mode? -%>
       <dhcp_hostname config:type="boolean">false</dhcp_hostname>
+<% if os_major <= 12 -%>
       <dhcp_resolv config:type="boolean">false</dhcp_resolv>
+<% end -%>
 <% if @host.domain -%>
       <domain><%= @host.domain -%></domain>
 <% end -%>
@@ -96,9 +100,28 @@ description: |
     </routing>
 <% end -%>
   </networking>
-  <%# NTP client configuration has incompatible changes in Leap 15 -%>
-  <% if os_major <= 12 || os_major == 42 -%>
   <ntp-client>
+<% if os_major >= 15 -%>
+    <ntp_policy>auto</ntp_policy>
+    <ntp_servers config:type="list">
+     <%- if host_param('ntp-server').respond_to?(:join) -%>
+     <%- host_param('ntp-server').each do |ntp| -%>
+     <ntp_server>
+      <iburst config:type="boolean">true</iburst>
+      <address><%= ntp %></address>
+      <offline config:type="boolean">false</offline>
+     </ntp_server>
+     <%- end -%>
+     <%- else -%>
+     <ntp_server>
+      <iburst config:type="boolean">true</iburst>
+      <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
+      <offline config:type="boolean">false</offline>
+     </ntp_server>
+     <%- end -%>
+    </ntp_servers>
+    <ntp_sync>systemd</ntp_sync>
+<% else -%>
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
       <peer>
@@ -114,33 +137,21 @@ description: |
     </peers>
     <start_at_boot config:type="boolean">true</start_at_boot>
     <start_in_chroot config:type="boolean">true</start_in_chroot>
+<% end -%>
   </ntp-client>
-<% else -%>
-  <ntp-client>
-   <ntp_policy>auto</ntp_policy>
-   <ntp_servers config:type="list">
-    <%- if host_param('ntp-server').respond_to?(:join) -%>
-    <%- host_param('ntp-server').each do |ntp| -%>
-    <ntp_server>
-     <iburst config:type="boolean">true</iburst>
-     <address><%= ntp %></address>
-     <offline config:type="boolean">false</offline>
-    </ntp_server>
-    <%- end -%>
-    <%- else -%>
-    <ntp_server>
-     <iburst config:type="boolean">true</iburst>
-     <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
-     <offline config:type="boolean">false</offline>
-    </ntp_server>
-    <%- end -%>
-   </ntp_servers>
-   <ntp_sync>systemd</ntp_sync>
-   </ntp-client>
-<% end -%>
 <% if ! @dynamic -%>
-  <%= @host.diskLayout %>
+<%= @host.diskLayout %>
 <% end -%>
+<% if os_major >= 15 -%>
+  <services-manager>
+    <default_target>multi-user</default_target>
+    <services>
+      <enable config:type="list">
+        <service>sshd</service>
+      </enable>
+    </services>
+  </services-manager>
+<% else -%>
   <runlevel>
     <default>3</default>
     <services config:type="list">
@@ -150,8 +161,11 @@ description: |
       </service>
     </services>
   </runlevel>
+<% end -%>
   <software>
+<% if os_major < 15 -%>
     <base>default</base>
+<% end -%>
     <patterns config:type="list">
       <pattern>base</pattern>
       <pattern>enhanced_base</pattern>
@@ -160,7 +174,11 @@ description: |
     </patterns>
     <packages config:type="list">
 <% if puppet_enabled -%>
+<% if aio_enabled -%>
+      <package>puppet-agent</package>
+<% else -%>
       <package>rubygem-puppet</package>
+<% end -%>
 <% end -%>
 <% if host_param('additional-packages').present? -%>
       <%= host_param('additional-packages').split(" ").collect{|x| "<package>#{x}</package>" }.join("\n") %>
@@ -194,6 +212,7 @@ description: |
     </pre-scripts>
 <% end -%>
     <chroot-scripts config:type="list">
+<% if os_major < 15 -%>
       <script>
         <filename>cp-resolv.sh</filename>
         <chrooted config:type="boolean">false</chrooted>
@@ -204,6 +223,7 @@ cp /etc/resolv.conf /mnt/etc
 ]]>
         </source>
       </script>
+<% end -%>
       <script>
         <filename>foreman.sh</filename>
         <chrooted config:type="boolean">true</chrooted>
@@ -237,6 +257,22 @@ rm /etc/resolv.conf
       </script>
     </chroot-scripts>
   </scripts>
+<% if os_major >= 15 -%>
+  <firewall>
+    <enable_firewall config:type="boolean">true</enable_firewall>
+    <log_denied_packets>off</log_denied_packets>
+    <default_zone>public</default_zone>
+    <zones config:type="list">
+      <zone>
+        <name>public</name>
+        <services config:type="list">
+          <service>ssh</service>
+          <service>dhcpv6-client</service>
+        </services>
+      </zone>
+    </zones>
+  </firewall>
+<% end -%>
   <keyboard>
     <keymap>english-us</keymap>
   </keyboard>
@@ -244,4 +280,33 @@ rm /etc/resolv.conf
     <hwclock>UTC</hwclock>
     <timezone><%= host_param('time-zone') || 'Etc/UTC' %></timezone>
   </timezone>
+  <add-on>
+    <add_on_others config:type="list">
+<% if puppet_enabled && aio_enabled -%>
+<%
+  puppet_repo_url_base = 'https://yum.puppet.com'
+  if host_param_true?('enable-official-puppet8-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet8/sles/#{os_major}/#{@host.architecture}/"
+    puppet_repo_alias = 'puppet8-release'
+  elsif host_param_true?('enable-official-puppet7-repo')
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet7/sles/#{os_major}/#{@host.architecture}/"
+    puppet_repo_alias = 'puppet7-release'
+  else
+    puppet_repo_url = "#{puppet_repo_url_base}/puppet/sles/#{os_major}/#{@host.architecture}/"
+    puppet_repo_alias = 'puppet-release'
+  end
+-%>
+      <listentry>
+        <media_url><![CDATA[<%= puppet_repo_url %>]]></media_url>
+        <alias><%= puppet_repo_alias %></alias>
+        <name>Puppet AutoYaST repository</name>
+        <signature-handling>
+          <import_gpg_key>
+            <all config:type="boolean">true</all>
+          </import_gpg_key>
+        </signature-handling>
+      </listentry>
+<% end -%>
+    </add_on_others>
+  </add-on>
 </profile>

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -13,7 +13,7 @@ description: |
   os_name   = @host.operatingsystem.name
 
   aio_enabled = host_param_true?('enable-puppetlabs-repo') ||  host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
-  aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
+  aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_family == 'Suse'
 
   if os_family == 'Windows'
     var_dir = 'C:\ProgramData\PuppetLabs\puppet\cache'

--- a/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/autoyast_default_user_data.erb
@@ -3,7 +3,7 @@ kind: user_data
 name: AutoYaST default user data
 model: ProvisioningTemplate
 oses:
-- OpenSUSE
+- openSUSE
 - SLES
 description: |
   This template is used during image based provisioning, when the image is configured to use user-data.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/AutoYaST_default_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/AutoYaST_default_iPXE.host4dhcp.snap.txt
@@ -5,6 +5,6 @@ echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
 
-kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img splash=silent install=http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.example.com/unattended/provision text-mode=1 useDHCP=1 
-initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
+kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img splash=silent install=http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.example.com/unattended/provision text-mode=1 useDHCP=1 BOOTIF=01-${netX/mac:hexhyp}
+initrd --name initrd.img http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -24,7 +24,7 @@
       </interface>
     </interfaces>
   </networking>
-      <ntp-client>
+  <ntp-client>
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
       <peer>
@@ -37,7 +37,7 @@
     <start_at_boot config:type="boolean">true</start_at_boot>
     <start_in_chroot config:type="boolean">true</start_in_chroot>
   </ntp-client>
-  zerombr
+zerombr
 clearpart --all    --initlabel
 part /boot --fstype ext3 --size=100 --asprimary
 part /     --fstype ext3 --size=1024 --grow
@@ -210,4 +210,8 @@ rm /etc/resolv.conf
     <hwclock>UTC</hwclock>
     <timezone>Etc/UTC</timezone>
   </timezone>
+  <add-on>
+    <add_on_others config:type="list">
+    </add_on_others>
+  </add-on>
 </profile>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Currently Puppet uses a mix of keys which are not all retrievable properly using the regular AutoYaST template, so this will directly import them from the RPM repo instead.  
Puppet AIO packages also work on openSUSE, so this removes the limitation on SLES to allow proper Puppet installs to work.  
Also cleans up the iPXE template and ensures BOOTIF is provided, so that boot works properly on multi-NIC devices.