### PR TITLE
Foreman 3.9.0-rc2 picks

### DIFF
--- a/app/helpers/puppet_related_helper.rb
+++ b/app/helpers/puppet_related_helper.rb
@@ -1,0 +1,13 @@
+module PuppetRelatedHelper
+  UI.register_host_description do
+    multiple_actions_provider :puppet_actions
+  end
+
+  def puppet_actions
+    return [] unless Foreman::Plugin.installed?('foreman_puppet')
+    return [] unless authorized_for(:controller => :hosts, :action => :edit)
+    return [] unless SmartProxy.unscoped.authorized.with_features("Puppet CA").exists?
+
+    [{ :action => [_('Change Puppet CA'), select_multiple_puppet_ca_proxy_hosts_path], :priority => 1051 }]
+  end
+end

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -72,13 +72,15 @@ class LinksControllerTest < ActionController::TestCase
     end
 
     test 'new docs on nightly' do
-      get :show, params: {
-        type: 'docs',
-        section: 'TestSection',
-        chapter: 'TestChapter',
-      }
+      with_temporary_settings(version: Foreman::Version.new('3.10-develop')) do
+        get :show, params: {
+          type: 'docs',
+          section: 'TestSection',
+          chapter: 'TestChapter',
+        }
 
-      assert_redirected_to %r{https://docs\.theforeman\.org/nightly/TestSection/index-(foreman-(deb|el)|katello)\.html#TestChapter}
+        assert_redirected_to %r{https://docs\.theforeman\.org/nightly/TestSection/index-(foreman-(deb|el)|katello)\.html#TestChapter}
+      end
     end
 
     test 'new docs on a stable release' do


### PR DESCRIPTION
One prevents 3.9-stable from being green (which only showed up after branching) and the other is a bugfix I just merged and applies to 3.9 too.