### PR TITLE
Fixes #32359 - Entitlement report generation now shows all entitlements by default.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ npm-debug.log
 .solargraph.yml
 .nvmrc
 mkmf.log
+.yardoc/

--- a/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
+++ b/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
@@ -10,6 +10,7 @@ template_inputs:
   advanced: false
   value_type: plain
   options: "no limit\r\n7\r\n30\r\n60\r\n90\r\n120\r\n180"
+  default: "no limit"
 require:
 - plugin: katello
   version: 4.11.0


### PR DESCRIPTION
Modified gitignore to exclude .yardoc directory.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
This PR changes entitlement report generation via API to by default select 'no limit' in the 'Days from Now' field. This streamlines report generation in hammer, as requiring the 'Days from Now' field previously felt unnecessarily verbose. This PR also adds .yardoc/ to the gitignore; a few Phoenix members were encountering this directory and it seemed easy to just add this here.

Testing steps:

1.  Using hammer, run `hammer report-template list` to get the ids for your Foreman instance's report templates. Note the id of `Subscription - Entitlement Report` and insert where needed in the following steps.
2. Run `hammer report-template generate --id <id> --report-format yaml`. There should be no errors.
3. Run 'hammer report-template generate --id <id> --report-format yaml --inputs "Days from Now"="120"` to ensure the existing inputs for this report template still function.