### PR TITLE
Fixes #36963 - Table index new button far in large screens

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -231,7 +231,10 @@ const TableIndexPage = ({
               </ToolbarGroup>
             )}
             {actionButtons.length > 0 && (
-              <ToolbarGroup alignment={{ default: 'alignLeft' }}>
+              <ToolbarGroup
+                alignment={{ default: 'alignLeft' }}
+                className="table-toolbar-actions"
+              >
                 <ToolbarItem>
                   <ActionButtons buttons={actionButtons} />
                 </ToolbarItem>

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
@@ -13,8 +13,8 @@
       .toolbar-search {
         flex-grow: 1;
       }
-      .autocomplete-search {
-        max-width: 600px;
+      .table-toolbar-actions {
+        padding-left: 16px;
       }
     }
     .pf-c-toolbar__group {

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.scss
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchBar.scss
@@ -15,4 +15,7 @@
   .pf-c-dropdown.pf-m-align-right {
     width: unset;
   }
+  .pf-c-dropdown { 
+    width: unset; // just in case Katello overrides it
+  }
 }


### PR DESCRIPTION
Before
![Screenshot from 2023-12-05 10-53-09](https://github.com/theforeman/foreman/assets/30431079/bb7b6da2-e01d-407a-956a-01d90a982784)
After
![Screenshot from 2023-12-05 10-51-45](https://github.com/theforeman/foreman/assets/30431079/7ce634af-af3f-48bf-a179-4366c35e2965)
