### PR TITLE
Fixes #36966 - broken link in Register Host documentation

### DIFF
--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -171,7 +171,7 @@ export const getWikiURL = section => foremanUrl(`/links/wiki/${section}`);
  */
 export const getDocsURL = (guide, chapter = null) => {
   const url = foremanUrl(`/links/docs/${guide}`);
-  return chapter ? `{url}?chapter={encodeURIComponent(chapter)}` : url;
+  return chapter ? `${url}?chapter=${encodeURIComponent(chapter)}` : url;
 };
 
 /**

--- a/webpack/assets/javascripts/react_app/common/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.test.js
@@ -10,6 +10,7 @@ import {
   stringIsPositiveNumber,
   formatDate,
   formatDateTime,
+  getDocsURL,
 } from './helpers';
 
 describe('isoCompatibleDate', () => {
@@ -128,5 +129,22 @@ describe('formatDateTime', () => {
   it('should return datetime string', () => {
     const date = new Date('2020-03-06 14:00');
     expect(formatDateTime(date)).toEqual('2020-03-06 14:00:00');
+  });
+});
+
+describe('getDocsURL', () => {
+  it('should return URL with guide and chapter', () => {
+    const guide = 'Managing_Hosts';
+    const chapter = 'registering-a-host_managing-hosts';
+    const expectedUrl = '/links/docs/Managing_Hosts?chapter=registering-a-host_managing-hosts';
+
+    expect(getDocsURL(guide, chapter)).toEqual(expectedUrl);
+  });
+
+  it('should return URL with guide only when chapter is not provided', () => {
+    const guide = 'Managing_Hosts';
+    const expectedUrl = '/links/docs/Managing_Hosts';
+
+    expect(getDocsURL(guide)).toEqual(expectedUrl);
   });
 });


### PR DESCRIPTION
in Register Host page, the documentation button is using `getDocsURL`.
