### PR TITLE
Fixes #36978 - Add possibility to use remote webdriver

### DIFF
--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -51,6 +51,7 @@ class ComputeProfileJSTest < IntegrationTestWithJavascript
   test "create compute profile" do
     visit compute_profiles_path()
     click_on("Create Compute Profile")
+    work_around_selenium_file_detector_bug
     fill_in('compute_profile_name', :with => 'test')
     click_on("Submit")
     assert click_link(compute_resources(:ovirt).to_s)

--- a/test/integration/search_bar_js_test.rb
+++ b/test/integration/search_bar_js_test.rb
@@ -3,6 +3,7 @@ require 'integration_test_helper'
 class SearchBarTest < IntegrationTestWithJavascript
   test "backslash key clicked should opens the search" do
     visit bookmarks_path
+    work_around_selenium_file_detector_bug
     # needs to be interactive element
     find('table thead').find('a', text: 'Name').send_keys("/")
     assert_includes(page.evaluate_script("document.activeElement.classList"), "pf-c-text-input-group__text-input")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,11 @@ require 'test_report_helper'
 FactoryBot.use_parent_strategy = false
 
 # Do not allow network connections and external processes
-WebMock.disable_net_connect!(allow_localhost: true)
+if ENV.fetch('SELENIUM_REMOTE_HOST', nil)
+  WebMock.disable_net_connect!(allow_localhost: true, allow: ENV['SELENIUM_REMOTE_HOST'])
+else
+  WebMock.disable_net_connect!(allow_localhost: true)
+end
 
 # Configure shoulda
 Shoulda::Matchers.configure do |config|


### PR DESCRIPTION
In order to easily execute the selenium tests it would be good to have the possibility to use selenium remote webdriver images

```
docker run -d -p 4444:4444 --shm-size="2g" selenium/standalone-chrome:119.0
```

To access the driver via vagrant or a CI docker image the IP address needs to be set using an evironment variable:
```
SELENIUM_REMOTE_HOST=<ip_of_docker_host>
JS_TEST_DRIVER=selenium_chrome_remote
```

There are certain environments that require different chrome options to work so it is possible to add them via semicolon separated string as environment variable:
```
ADDITIONAL_CHROME_OPTIONS="--disable-dev-shm-usage"
```