### PR TITLE
Fixes #36980 - Update the Lifecycle environment and content view for the host with new hostgroup

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -434,11 +434,10 @@ class HostsController < ApplicationController
       redirect_to(select_multiple_hostgroup_hosts_path)
       return
     end
-    hg = Hostgroup.find_by_id(id)
     # update the hosts
     @hosts.each do |host|
-      host.hostgroup = hg
-      host.save(:validate => false)
+      attributes = host.apply_inherited_attributes("hostgroup_id" => id)
+      host.update(attributes)
     end
 
     success _('Updated hosts: changed host group')

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -462,7 +462,7 @@ class HostsControllerTest < ActionController::TestCase
 
   test 'multiple hostgroup change by host names' do
     @request.env['HTTP_REFERER'] = current_hosts_path
-    hosts = FactoryBot.create_list(:host, 2)
+    hosts = FactoryBot.create_list(:host, 2, :domain => domains(:mydomain))
     host_names = hosts.map(&:name)
     # check that we have hosts and their hostgroup is empty
     host_names.each do |name|


### PR DESCRIPTION
Hosts > All Hosts > select the Host > Select action > Change Group > Assign a HostGroup > Submit

Host should be updated with the Lifecycle environment and content view that are associated with the new hostgroup.
