### PR TITLE
Fixes #36999 - Drop libvirt CPU model option for VM creation

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -4,9 +4,6 @@ module Foreman::Model
 
     ALLOWED_DISPLAY_TYPES = %w(vnc spice)
 
-    # 'custom' is not implemented. This needs extra UI.
-    CPU_MODES = %w(default host-model host-passthrough)
-
     validates :url, :format => { :with => URI::DEFAULT_PARSER.make_regexp }, :presence => true
     validates :display_type, :inclusion => { :in => ALLOWED_DISPLAY_TYPES }
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -3,7 +3,6 @@
 <div id="cpus_input">
   <%= counter_f(f, :cpus, label: _('CPUs'), disabled: !new_vm, recommended_max_value: compute_resource.max_cpu_count) %>
 </div>
-<%= select_f f, :cpu_mode, Foreman::Model::Libvirt::CPU_MODES, :to_s, :to_s, { }, :label => _("CPU mode"), :label_size => "col-md-2" %>
 <%= byte_size_f(f, :memory, disabled: !new_vm, label: _('Memory'), recommended_max_value: compute_resource.max_memory.to_i) %>
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>

--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '>= 0.9.0'
+  gem 'fog-libvirt', '>= 0.12.0'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end

--- a/lib/fog_extensions/libvirt/server.rb
+++ b/lib/fog_extensions/libvirt/server.rb
@@ -11,14 +11,6 @@ module FogExtensions
         name
       end
 
-      def cpu_mode
-        attributes[:cpu][:mode]
-      end
-
-      def cpu_mode=(cpumode)
-        attributes[:cpu][:mode] = (cpumode == 'default') ? nil : cpumode
-      end
-
       def nics_attributes=(attrs)
       end
 


### PR DESCRIPTION
Since fog-libvirt 0.12.0 the default CPU model was some abstract type with a low compatibility level. Since 0.12.0 it defaults to CPU passthrough, as recommended by qemu if live migration is not required (https://www.qemu.org/docs/master/system/qemu-cpu-models.html). That's not something we support today, so it should be safe to drop the CPU model selection.

RFC open for this: https://community.theforeman.org/t/drop-cpu-type-option-from-libvirt-compute-resource-provisioning/36267