### PR TITLE
Fixes #37002 - Add pagelet anchor for user and usergroup tabs

### DIFF
--- a/app/views/usergroups/_form.html.erb
+++ b/app/views/usergroups/_form.html.erb
@@ -6,6 +6,7 @@
     <% if AuthSource.non_internal.present? %>
       <li><a href="#external" data-toggle="tab"><%= _("External Groups") %></a></li>
     <% end %>
+    <%= render_tab_header_for(:main_tabs, :subject => @usergroup, :form => f) %>
   </ul>
   <div class="tab-content">
     <div class="tab-pane active" id="primary">
@@ -71,6 +72,7 @@
         </div>
       </div>
     <% end %>
+    <%= render_tab_content_for(:main_tabs, :subject => @usergroup, :form => f) %>
   </div>
   <%= submit_or_cancel f %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -18,6 +18,7 @@
     <% if @editing_self || (@user.persisted? && authorized_for(hash_for_api_user_personal_access_tokens_path(user_id: @user))) %>
       <li><a href='#personal_access_tokens' data-toggle='tab'><%= _('Personal Access Tokens') %></a></li>
     <% end %>
+    <%= render_tab_header_for(:main_tabs, :subject => @user, :form => f) %>
   </ul>
 
   <div class='tab-content'>
@@ -134,6 +135,7 @@
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @user,
                :html_options => user_taxonomies_html_options(@user)
     %>
+    <%= render_tab_content_for(:main_tabs, :subject => @user, :form => f) %>
   </div>
 
   <%= submit_or_cancel f %>


### PR DESCRIPTION
Allow plugins to add pagelets for the users/usergroups edit page.

I'm currently working on a plugin that is about to add an attribute to the users/usergroups model and such attribute shall be modifiable on the corresponding edit pages. Therefore, I would like to add such anchor for pagelet rendering.

Suggestions/feedback is welcome :)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
