### PR TITLE
Fixes #37009 - Implement EFI for libvirt

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -146,7 +146,7 @@ module Foreman::Model
         opts[collection] = nested_attributes_for(collection, nested_attrs) if nested_attrs
       end
 
-      opts.reject! { |k, v| v.nil? }
+      opts.compact!
 
       opts[:boot_order] = %w[hd]
       opts[:boot_order].unshift 'network' unless attr[:image_id]

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -14,6 +14,14 @@ module Foreman::Model
       Fog::Compute.providers.include?(:libvirt)
     end
 
+    def firmware_types
+      {
+        "automatic" => N_("Automatic"),
+        "bios" => N_("BIOS"),
+        "efi" => N_("EFI"),
+      }
+    end
+
     # Some getters/setters for the attrs Hash
     def display_type
       attrs[:display].presence || 'vnc'
@@ -151,6 +159,23 @@ module Foreman::Model
       opts[:boot_order] = %w[hd]
       opts[:boot_order].unshift 'network' unless attr[:image_id]
 
+      # Named firmware for consistency with VMware
+      opts[:os_firmware] = opts.delete(:firmware)
+
+      firmware_type = opts.delete(:firmware_type)
+      if opts[:os_firmware] == 'automatic'
+        # See PxeLoaderSupport.firmware_type for possible values
+        case firmware_type
+        when :uefi
+          # TODO opts[:os_loader] = 'secure' for secure boot
+          opts[:os_firmware] = 'efi'
+        when :bios
+          opts[:os_firmware] = 'bios'
+        else
+          opts.delete(:os_firmware)
+        end
+      end
+
       vm = client.servers.new opts
       vm.memory = opts[:memory] if opts[:memory]
       vm
@@ -285,6 +310,7 @@ module Foreman::Model
 
     def vm_instance_defaults
       super.merge(
+        :firmware   => 'automatic',
         :memory     => 2048.megabytes,
         :nics       => [new_nic],
         :volumes    => [new_volume].compact,

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -460,7 +460,7 @@ module Foreman::Model
       firmware_type = args.delete(:firmware_type)
       args[:firmware] = firmware_mapping(firmware_type) if args[:firmware] == 'automatic'
 
-      args.reject! { |k, v| v.nil? }
+      args.compact!
       args
     end
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -5,6 +5,11 @@
 </div>
 <%= select_f f, :cpu_mode, Foreman::Model::Libvirt::CPU_MODES, :to_s, :to_s, { }, :label => _("CPU mode"), :label_size => "col-md-2" %>
 <%= byte_size_f(f, :memory, disabled: !new_vm, label: _('Memory'), recommended_max_value: compute_resource.max_memory.to_i) %>
+<%= field(f, :firmware, :disabled => !new_vm, :label => _('Firmware'), :label_size => "col-md-2") do
+  compute_resource.firmware_types.collect do |type, name|
+    radio_button_f f, :firmware, {:disabled => !new_vm, :value => type, :text => _(name)}
+  end.join(' ').html_safe
+end %>
 <!--TODO # Move to a helper-->
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2"} if new_vm && controller_name != "compute_attributes" %>

--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '>= 0.9.0'
+  gem 'fog-libvirt', github: 'ekohl/fog-libvirt', branch: 'implement-efi'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end


### PR DESCRIPTION
By default this derives the firmware type from the PXE loader, just like VMware does.

It does not yet implement secure boot.

Depends on https://github.com/fog/fog-libvirt/pull/134 to be released.

Currently only tested via the API, not the UI.