### PR TITLE
Fixes #35253 - Make boolean type parameters searchable

### DIFF
--- a/app/models/parameter.rb
+++ b/app/models/parameter.rb
@@ -83,7 +83,7 @@ class Parameter < ApplicationRecord
   end
 
   def set_searchable_value
-    self.searchable_value = Parameter.format_value_before_type_cast(value, key_type)
+    self.searchable_value = key_type == 'boolean' ? value.to_s : Parameter.format_value_before_type_cast(value, key_type)
   end
 
   def set_priority


### PR DESCRIPTION
Searchable value when value is a boolean is being set to "t" or "f" because the searchable_value field is "text" type in the database so when we set a boolean value to a string field in the application (Ruby on Rails), it will be converted to "t" or "f. In this fix, we are formatting the boolean type searchable values to the string before it happens automatically. A few points:

- This fix works for updated or new parameters as the existing ones already have their values saved as "t" or "f"
- If we create a boolean param with name boolparam and value true, we can search with `params.boolparam = true` or `params.boolparam != false` . 
- `params.boolparam = t` will not work. 