### PR TITLE
Fixes #37014 - set correct Host owner during registration

### DIFF
--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -21,6 +21,7 @@ module Api
         param :update_packages, :bool, desc: N_("Update all packages on the host")
         param :repo, String, desc: N_("Repository URL / details, for example for Debian OS family: 'deb http://deb.example.com/ buster 1.0', for Red Hat and SUSE OS family: 'http://yum.theforeman.org/client/latest/el8/x86_64/'")
         param :repo_gpg_key_url, String, desc: N_("URL of the GPG key for the repository")
+        param :owner_id, :number, desc: N_("ID of the user who generated the registration command")
       end
       def create
         unless os_with_template?

--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -19,6 +19,7 @@ module Api
       param :location_id, :number, desc: N_("ID of the Location to register the host in")
       param :hostgroup_id, :number, desc: N_("ID of the Host group to register the host in")
       param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in")
+      param :owner_id, :number, desc: N_("ID of the user who generated the registration command")
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
       param :packages, String, desc: N_("Packages to install on the host when registered. Can be set by `host_packages` parameter, example: `pkg1 pkg2`")
@@ -41,6 +42,7 @@ module Api
         param :name, String, required: true
         param :location_id, :number, required: true
         param :organization_id, :number, required: true
+        param :owner_id, :number, desc: N_("ID of the user who generated the registration command")
         param :ip, String, desc: N_("IPv4 address, not required if using a subnet with DHCP proxy")
         param :ip6, String, desc: N_("IPv6 address, not required if using a subnet with DHCP proxy")
         param :mac, String, desc: N_("required for managed host that is bare metal, not required if it's a virtual machine")
@@ -117,7 +119,6 @@ module Api
         host_attributes = @host.apply_inherited_attributes(host_params('host'))
 
         @host.assign_attributes(host_attributes)
-        @host.owner = User.current
         @host.save!
       end
 

--- a/app/controllers/concerns/foreman/controller/parameters/registration.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/registration.rb
@@ -22,6 +22,7 @@ module Foreman::Controller::Parameters::Registration
           :managed,
           :comment,
           :uuid,
+          :owner_id,
           interfaces: [nic_interface_params_filter],
           interfaces_attributes: [nic_interface_params_filter],
           host_parameters_attributes: [parameter_params_filter(HostParameter)]

--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -18,9 +18,10 @@ module Foreman::Controller::Registration
     location = Location.authorized(:view_locations).find(params['location_id']) if params['location_id'].present?
     host_group = Hostgroup.authorized(:view_hostgroups).find(params['hostgroup_id']) if params["hostgroup_id"].present?
     operatingsystem = Operatingsystem.authorized(:view_operatingsystems).find(params['operatingsystem_id']) if params["operatingsystem_id"].present?
+    user = User.authorized(:view_users).find(params['owner_id']) if params['owner_id'].present?
 
     context = {
-      user: User.current,
+      user: (user || User.current),
       auth_token: api_authorization_token,
       organization: (organization || User.current.default_organization || User.current.my_organizations.first),
       location: (location || User.current.default_location || User.current.my_locations.first),

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -106,6 +106,7 @@ register_host() {
 <%= "       --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
 <%= "       --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
 <%= "       --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
+<%= "       --data 'host[owner_id]=#{@user.id}' \\\n" if @user -%>
 <%= "       --data 'host[operatingsystem_id]=#{@operatingsystem.id}' \\\n" if @operatingsystem -%>
 <%= "       --data host[interfaces_attributes][0][identifier]=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
 <%= "       --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
@@ -130,6 +131,7 @@ register_katello_host(){
 <%= "      --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
 <%= "      --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
 <%= "      --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
+<%= "      --data 'host[owner_id]=#{@user.id}' \\\n" if @user -%>
 <%= "      --data 'host[lifecycle_environment_id]=#{@lifecycle_environment_id}' \\\n" if @lifecycle_environment_id.present? -%>
 <%= "      --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
 <%= "      --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>


### PR DESCRIPTION
Add the `owner_id` parameter to the Host registration command.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
