### PR TITLE
Fix labeler configuration for v5

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,20 @@
 ---
 Docs:
-  - developer_docs/**
+  - changed-files:
+    - any-glob-to-any-file: developer_docs/**
 
 GraphQL:
-  - app/graphql/**
+  - changed-files:
+    - any-glob-to-any-file: app/graphql/**
 
 Legacy JS:
-  - app/assets/javascripts/**
+  - changed-files:
+    - any-glob-to-any-file: app/assets/javascripts/**
 
 Templates:
-  - app/views/unattended/**
+  - changed-files:
+    - any-glob-to-any-file: app/views/unattended/**
 
 UI:
-  - webpack/**
+  - changed-files:
+    - any-glob-to-any-file: webpack/**


### PR DESCRIPTION
This was merged accidentally because it was green, though it was incompatible. Version 5 restructured the whole configuration file and can now label based on head or base branch names, even though we currently don't use this.

Contains a temporary commit to test out the config correctly.

Fixes: 70b2144263dc ("Bump actions/labeler from 4 to 5")