### PR TITLE
cloud-init user data: replace deprecated `lock-passwd` with `lock_passwd`

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -47,7 +47,7 @@ autoinstall:
     users:
     - name: <%= username_to_create %>
       gecos: <%= realname_to_create %>
-      lock-passwd: false
+      lock_passwd: false
       hashed_passwd: <%= password_to_create %>
 <% if !host_param('remote_execution_ssh_keys').blank? -%>
 <%   if host_param('remote_execution_ssh_keys').is_a?(String) -%>

--- a/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
+++ b/app/views/unattended/provisioning_templates/user_data/userdata_default.erb
@@ -47,7 +47,7 @@ users:
   groups: users
   shell: /bin/bash
   sudo: ['ALL=(ALL) ALL']
-  lock-passwd: false
+  lock_passwd: false
   passwd: <%= @host.root_pass %>
 <% end -%>
 <% if host_param('ssh_authorized_keys') -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -15,7 +15,7 @@ autoinstall:
     users:
     - name: root
       gecos: root
-      lock-passwd: false
+      lock_passwd: false
       hashed_passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
       ssh_authorized_keys: []
   keyboard:

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -12,7 +12,7 @@ users:
   groups: users
   shell: /bin/bash
   sudo: ['ALL=(ALL) ALL']
-  lock-passwd: false
+  lock_passwd: false
   passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 
 package_upgrade: true


### PR DESCRIPTION
https://cloudinit.readthedocs.io/en/latest/reference/modules.html#users-and-groups says that `lock-passwd` was deprecated in cloud-init version 22.3, use `lock_passwd` instead.