### PR TITLE
Fixes #29450 - Use sp-references in used taxonomy lookup

### DIFF
--- a/app/models/concerns/smart_proxy_host_extensions.rb
+++ b/app/models/concerns/smart_proxy_host_extensions.rb
@@ -1,6 +1,10 @@
 module SmartProxyHostExtensions
   extend ActiveSupport::Concern
 
+  included do
+    scope :with_smart_proxies, -> { eager_load(ProxyReferenceRegistry.smart_proxy_references.select(&:join?).map(&:join_relation)) }
+  end
+
   module ClassMethods
     # registers a reference to a proxy
     def smart_proxy_reference(hash)
@@ -8,7 +12,7 @@ module SmartProxyHostExtensions
     end
 
     def smart_proxy_ids(hosts_scope = Host::Managed.all)
-      hosts_scope.eager_load(proxy_join_tables).pluck(proxy_column_list).flatten.uniq.compact
+      hosts_scope.with_smart_proxies.pluck(proxy_column_list).flatten.uniq.compact
     end
 
     # table names containing reference to a proxy

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -99,6 +99,7 @@ class Host::Managed < Host::Base
   smart_proxy_reference :domain => [:dns_id]
   smart_proxy_reference :realm => [:realm_proxy_id]
   smart_proxy_reference :self => [:puppet_proxy_id, :puppet_ca_proxy_id]
+  smart_proxy_reference :infrastructure_facet => [:smart_proxy_id]
 
   graphql_type '::Types::Host'
 

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -74,6 +74,13 @@ class SmartProxy < ApplicationRecord
     !errors.any?
   end
 
+  def used_taxonomy_ids(type)
+    return [] if new_record? || !respond_to?(:hosts)
+
+    conditions = "#{id} IN (#{Host::Managed.proxy_column_list})"
+    ::Host::Managed.with_smart_proxies.where(conditions).distinct.pluck(type).compact
+  end
+
   def taxonomy_foreign_conditions
     conditions = {}
     if has_feature?('Puppet') && has_feature?('Puppet CA')

--- a/test/unit/concerns/smart_proxy_host_extensions_test.rb
+++ b/test/unit/concerns/smart_proxy_host_extensions_test.rb
@@ -6,6 +6,10 @@ class SmartProxyHostExtensionsTest < ActiveSupport::TestCase
     ProxyReferenceRegistry.references = nil
 
     class ProxyReferrer
+      # SmartProxyHostExtensions is expected to be included into a ActiveRecord model
+      def self.scope(...)
+      end
+
       include SmartProxyHostExtensions
       smart_proxy_reference :test_reference => [:test]
       smart_proxy_reference :test_reference => [:another_test]


### PR DESCRIPTION
TODOs:
- [ ] ? drop `SmartProxy#taxonomy_foreign_conditions` which is wrong anyway?
- [x] Set up smart proxy references in katello
https://github.com/Katello/katello/pull/10833
- [x] Set up smart proxy references in openscap
https://github.com/theforeman/foreman_openscap/pull/555