### PR TITLE
Fixes #37035 - add unit starting limits in place

### DIFF
--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -6,7 +6,6 @@ Requires=foreman.socket
 StartLimitIntervalSec=120
 StartLimitBurst=5
 
-
 [Service]
 Type=notify
 User=foreman

--- a/extras/systemd/foreman.service
+++ b/extras/systemd/foreman.service
@@ -3,6 +3,9 @@ Description=Foreman
 Documentation=https://theforeman.org
 After=network.target remote-fs.target nss-lookup.target
 Requires=foreman.socket
+StartLimitIntervalSec=120
+StartLimitBurst=5
+
 
 [Service]
 Type=notify


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Systemd unit is configured in a way to start the application over and over again. In case the app fails e.g. on missing seeded data or some bug, it's always restarted. We should put the limit in place.

