### PR TITLE
Fixes #37034 - Replace apt-key on Debian/Ubuntu

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -87,7 +87,7 @@ elif [ -f /etc/debian_version ]; then
   <%= save_to_file('/etc/apt/sources.list.d/foreman_registration.list', @repo) %>
 <% if @repo_gpg_key_url.present? -%>
   apt-get -y install ca-certificates gpg
-  curl --silent --show-error <%= shell_escape @repo_gpg_key_url %> | apt-key add -
+  curl --silent --show-error --output /etc/apt/trusted.gpg.d/client.asc <%= shell_escape @repo_gpg_key_url %>
 <% end -%>
   apt-get update
 


### PR DESCRIPTION
My PR replaces `apt-key` which has been deprecated on Debian and Ubuntu. See https://salsa.debian.org/apt-team/apt/-/commit/9ef79abd2f7942c4c5d789fd29b83f493626e440

# local tests

````
$ cat apt_key.Containerfile
FROM debian:12

RUN apt-get update && \
    apt-get install -y curl ca-certificates gpg

RUN curl --silent --show-error https://oss.atix.de/atix_gpg.pub | apt-key add - && \
    mkdir -p /etc/apt/sources.list.d/ && \
    echo "deb https://oss.atix.de/Debian12/ stable main" > /etc/apt/sources.list.d/client.list && \
    apt-get update && \
    apt-get install -y subscription-manager

$ cat trusted.Containerfile
FROM debian:12

RUN apt-get update && \
    apt-get install -y curl ca-certificates gpg

RUN curl --silent --show-error https://oss.atix.de/atix_gpg.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/client.gpg && \
    mkdir -p /etc/apt/sources.list.d/ && \
    echo "deb https://oss.atix.de/Debian12/ stable main" > /etc/apt/sources.list.d/client.list && \
    apt-get update && \
    apt-get install -y subscription-manager

$ cat upstream.Containerfile
FROM debian:12

RUN apt-get update && \
    apt-get install -y curl ca-certificates gpg

RUN curl --silent --show-error https://oss.atix.de/atix_gpg.pub | gpg --no-default-keyring --keyring gnupg-ring:/etc/apt/trusted.gpg.d/client.gpg --import && \
    chmod 644 /etc/apt/trusted.gpg.d/client.gpg && \
    mkdir -p /etc/apt/sources.list.d/ && \
    echo "deb https://oss.atix.de/Debian12/ stable main" > /etc/apt/sources.list.d/client.list && \
    apt-get update && \
    apt-get install -y subscription-manager

# build container images locally to see stdout from apt/curl/gpg
$ podman build --tag apt_key_debian_12 --file apt_key.Containerfile .
$ podman build --tag trusted_debian_12 --file trusted.Containerfile .
$ podman build --tag upstream_debian_12 --file upstream.Containerfile .
````

Draft PR until I have tested my changes locally in forklift.