### PR TITLE
Refs #37034 - Use apt-key add on Ubuntu 16.04

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -86,8 +86,14 @@ EOF
 elif [ -f /etc/debian_version ]; then
   <%= save_to_file('/etc/apt/sources.list.d/foreman_registration.list', @repo) %>
 <% if @repo_gpg_key_url.present? -%>
-  apt-get -y install ca-certificates gpg
-  curl --silent --show-error --output /etc/apt/trusted.gpg.d/client.asc <%= shell_escape @repo_gpg_key_url %>
+<# "apt 1.2.35" on Ubuntu 16.04 does not support storing GPG public keys in "/etc/apt/trusted.gpg.d/" in ASCII format #>
+  if [ "$(. /etc/os-release ; echo "$VERSION_ID")" = "16.04" ]; then
+    $PKG_MANAGER_INSTALL ca-certificates curl gnupg
+    curl --silent --show-error <%= shell_escape @repo_gpg_key_url %> | gpg --dearmor > /etc/apt/trusted.gpg.d/client.gpg
+  else
+    $PKG_MANAGER_INSTALL ca-certificates curl
+    curl --silent --show-error --output /etc/apt/trusted.gpg.d/client.asc <%= shell_escape @repo_gpg_key_url %>
+  fi
 <% end -%>
   apt-get update
 


### PR DESCRIPTION
On Ubuntu 16.04, which is supported by Canonical until 2026, you cannot place a GPG public key in "/etc/apt/trusted.gpg.d/" and use it to verify the signature of "Release" files.

EoL see https://ubuntu.com/16-04

Ubuntu 14.04 is no longer supported by Canonical; Ubuntu 18.04 and all supported Debian version can handle GPG public keys in "/etc/apt/trusted.gpg.d/".

Test on Ubuntu 16.04 in Container (ignore the repository and package; this is just to ensure that the package installation works):

````
FROM ubuntu:xenial

RUN apt-get update && \
    apt-get install -y curl ca-certificates pgpgpg && \
    curl --silent --show-error https://oss.atix.de/atix_gpg.pub | apt-key add - && \
    mkdir -p /etc/apt/sources.list.d/ && \
    echo "deb http://oss.atix.de/Ubuntu20LTS/ stable main" > /etc/apt/sources.list.d/client.list && \
    apt-get update && \
    apt-get install -y apt-transport-katello
````