### PR TITLE
Fixes #37016 - stop trying to report CV / LCE for hypervisors

### DIFF
--- a/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
+++ b/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
@@ -27,8 +27,8 @@ require:
 <%-       report_row(
             'Host Name': host.name,
             'Organization': host.organization,
-            'Lifecycle Environment': host.single_lifecycle_environment.name,
-            'Content View': host.single_content_view.name,
+            'Lifecycle Environment': host.single_lifecycle_environment&.name,
+            'Content View': host.single_content_view&.name,
             'Host Collections': host_collections_names(host),
             'Virtual': host.virtual,
             'Guest of Host': host.hypervisor_host,


### PR DESCRIPTION
Uses safe navigation to allow reporting on hosts without content views or lifecycle environments (virt-who hypervisors).

I haven't been able to test it with a virt-who host, so I'd recommend that the reviewer be familiar with virt-who.

Reproducer steps from the Redmine:

1. Disable SCA
2. Configure virt-who and run it so that virt-who* hypervisor hosts will be created
3. Attach VDC subscription to the virt-who* hypervisor hosts.
4. Generate the "Subscription - Entitlement Report".
