### PR TITLE
[CP 3.9] Fixes #37025 - Navigation should only have 1 item expended

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorView.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorView.test.js.snap
@@ -52,7 +52,7 @@ exports[`EditorView EditorView renders EditorView 1`] = `
 
 exports[`EditorView EditorView renders EditorView w/vim&mask 1`] = `
 <ReactAce
-  className=" mask-editor"
+  className="mask-editor"
   cursorStart={1}
   debounceChangePeriod={250}
   editorProps={

--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -82,6 +82,14 @@ const Navigation = ({
     [items.length, currentPath]
   );
 
+  const [currentExpanded, setCurrentExpanded] = useState(
+    subItemToItemMap[pathFragment(getCurrentPath())]
+  );
+  useEffect(() => {
+    setCurrentExpanded(subItemToItemMap[pathFragment(getCurrentPath())]);
+    // we only want to run this when we get new items from the API to set the default expanded item, which is the current location
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [items.length]);
   if (!items.length) return null;
 
   const clickAndNavigate = (_onClick, href, event) => {
@@ -104,17 +112,21 @@ const Navigation = ({
             <NavExpandable
               ouiaId={`nav-expandable-${index}`}
               title={titleWithIcon(title, iconClass)}
-              groupId="nav-expandable-group-1"
+              groupId={`nav-expandable-group-${title}`}
               isActive={
                 subItemToItemMap[pathFragment(getCurrentPath())] === title
               }
-              isExpanded={
-                subItemToItemMap[pathFragment(getCurrentPath())] === title
-              }
+              isExpanded={currentExpanded === title}
               className={className}
               onClick={() => onMouseOver(index)}
               onFocus={() => {
                 onMouseOver(index);
+              }}
+              onExpand={() => {
+                // if the current expanded item is the same as the clicked item, collapse it
+                const isExpanded = currentExpanded === title;
+                // only have 1 item expanded at a time
+                setCurrentExpanded(isExpanded ? null : title);
               }}
             >
               {groups.map((group, groupIndex) =>

--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -143,6 +143,7 @@ const Navigation = ({
                 if (isExpanded) setCurrentExpandedSecondary(null);
                 // only have 1 item expanded at a time
                 setCurrentExpanded(isExpanded ? null : title);
+                setCurrentExpandedSecondary(null);
               }}
             >
               {groups.map((group, groupIndex) =>

--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -82,11 +82,25 @@ const Navigation = ({
     [items.length, currentPath]
   );
 
+  const [currentExpandedSecondary, setCurrentExpandedSecondary] = useState(
+    null
+  );
   const [currentExpanded, setCurrentExpanded] = useState(
     subItemToItemMap[pathFragment(getCurrentPath())]
   );
   useEffect(() => {
     setCurrentExpanded(subItemToItemMap[pathFragment(getCurrentPath())]);
+    groupedItems.some(({ groups }) =>
+      groups.some(({ groupItems, title }) =>
+        groupItems.some(({ href }) => {
+          if (href === pathFragment(getCurrentPath())) {
+            setCurrentExpandedSecondary(title);
+            return true;
+          }
+          return false;
+        })
+      )
+    );
     // we only want to run this when we get new items from the API to set the default expanded item, which is the current location
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items.length]);
@@ -125,6 +139,8 @@ const Navigation = ({
               onExpand={() => {
                 // if the current expanded item is the same as the clicked item, collapse it
                 const isExpanded = currentExpanded === title;
+                // close the Secondary nav if it's open
+                if (isExpanded) setCurrentExpandedSecondary(null);
                 // only have 1 item expanded at a time
                 setCurrentExpanded(isExpanded ? null : title);
               }}
@@ -162,9 +178,14 @@ const Navigation = ({
                     <NavExpandable
                       ouiaId={`nav-expandable-${index}-${groupIndex}`}
                       title={group.title}
-                      isExpanded={group.groupItems.some(
-                        ({ isActive }) => isActive
-                      )}
+                      isExpanded={currentExpandedSecondary === group.title}
+                      onExpand={() => {
+                        setCurrentExpandedSecondary(
+                          currentExpandedSecondary === group.title
+                            ? null
+                            : group.title
+                        );
+                      }}
                     >
                       {group.groupItems.map(
                         ({

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/Layout.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/Layout.test.js
@@ -28,7 +28,8 @@ describe('Layout', () => {
     await act(async () => {
       await fireEvent.click(screen.getByText('Hosts'));
     });
+    expect(screen.getByText('Monitor')).toBeVisible();
+    expect(screen.getByText('Dashboard')).not.toBeVisible();
     expect(screen.getByText('All Hosts')).toBeVisible();
-    expect(screen.getByText('Dashboard')).toBeVisible();
   });
 });


### PR DESCRIPTION
(cherry picked from commit bf39cd0471e4e9bc1653d152ba25accc85140366)
