### PR TITLE
Fixes #37059 - Templates - cloned_from reference

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -110,7 +110,9 @@ module Api
       param_group :provisioning_template_clone, :as => :create
 
       def clone
+        original = @provisioning_template
         @provisioning_template = @provisioning_template.clone
+        @provisioning_template.cloned_from = original
         load_vars_from_template
         @provisioning_template.name = params[:provisioning_template][:name]
         process_response @provisioning_template.save

--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -95,8 +95,12 @@ module Api
       param_group :report_template_clone, :as => :create
 
       def clone
-        @report_template = @report_template.dup
+        original = @report_template
+
+        @report_template = original.dup
         @report_template.name = params[:report_template][:name]
+        @report_template.cloned_from = original
+
         process_response @report_template.save
       end
 

--- a/app/controllers/concerns/foreman/controller/parameters/template.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/template.rb
@@ -13,6 +13,7 @@ module Foreman::Controller::Parameters::Template
         :template,
         :template_kind, :template_kind_id, :template_kind_name,
         :vendor,
+        :cloned_from_id,
         :template_inputs_attributes => [template_input_params_filter]
     end
   end

--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -24,7 +24,9 @@ class TemplatesController < ApplicationController
   # parent classes (so all controllers don't have actions like id, clone, dup, ...), unfortunatelly they don't
   # detect method definitions in controller ancestors, only methods defined directly in child controller
   def clone_template
+    original = @template
     @template = @template.dup
+    @template.cloned_from = original
     @template.name += ' clone'
     @template.locked = false
     load_vars_from_template

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -3,6 +3,7 @@ class Template < ApplicationRecord
   attr_accessor :modify_locked, :modify_default
 
   has_many :template_inputs, :dependent => :destroy, :foreign_key => 'template_id', :autosave => true
+  belongs_to :cloned_from, class_name: 'Template'
 
   accepts_nested_attributes_for :template_inputs, :allow_destroy => true
 

--- a/app/views/api/v2/provisioning_templates/show.json.rabl
+++ b/app/views/api/v2/provisioning_templates/show.json.rabl
@@ -2,7 +2,7 @@ object @provisioning_template
 
 extends "api/v2/provisioning_templates/main"
 
-attributes :template, :locked
+attributes :template, :locked, :cloned_from_id
 
 child :template_combinations do
   extends "api/v2/template_combinations/base"

--- a/app/views/api/v2/report_templates/show.json.rabl
+++ b/app/views/api/v2/report_templates/show.json.rabl
@@ -2,7 +2,7 @@ object @report_template
 
 extends "api/v2/report_templates/main"
 
-attributes :template, :default, :snippet, :locked
+attributes :template, :default, :snippet, :locked, :cloned_from_id
 
 node do |report_template|
   partial("api/v2/taxonomies/children_nodes", :object => report_template)

--- a/app/views/templates/_form.html.erb
+++ b/app/views/templates/_form.html.erb
@@ -67,6 +67,17 @@
         </div>
       </div>
 
+      <% if @template.cloned_from %>
+      <div class="clearfix">
+        <div class="form-group ">
+          <%= label_tag :cloned_from, _('Cloned from'), class: 'col-md-2 control-label' %>
+          <div class="col-md-10">
+            <%= link_to @template.cloned_from.name, url_for(template_hash_for_member(@template.cloned_from, 'edit')), target: '_blank' %>
+          </div>
+        </div>
+      </div>
+      <% end %>
+
       <%= textarea_f f, :description, :size => 'col-md-10', :rows => 3, :label => _('Description'), :disabled => @template.locked? %>
 
       <%= textarea_f f, :audit_comment, :size => "col-md-10", :rows => 3, :label => _("Audit Comment"),
@@ -199,4 +210,5 @@
 
     <%= submit_or_cancel f, false, :cancel_path => template_path_for(@template.class) %>
   </div>
+  <%= f.hidden_field :cloned_from_id %>
 <% end %>

--- a/db/migrate/20231115151349_add_cloned_from_to_templates.rb
+++ b/db/migrate/20231115151349_add_cloned_from_to_templates.rb
@@ -1,0 +1,5 @@
+class AddClonedFromToTemplates < ActiveRecord::Migration[6.1]
+  def change
+    add_reference(:templates, :cloned_from, foreign_key: { to_table: :templates, on_delete: :nullify })
+  end
+end

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -125,6 +125,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
     template = ActiveSupport::JSON.decode(@response.body)
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_provisioning_template.template)
+    assert_equal(template['cloned_from_id'], original_provisioning_template.id)
   end
 
   test 'clone name should not be blank' do

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -172,6 +172,7 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
     template = ActiveSupport::JSON.decode(@response.body)
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_report_template.template)
+    assert_equal(template['cloned_from_id'], original_report_template.id)
     refute_equal(template['id'], original_report_template.id)
   end
 


### PR DESCRIPTION
Keep reference to the original template in cloned templates.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
