### PR TITLE
Fixes #37067 - closing parent nav should close child nav

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -82,11 +82,25 @@ const Navigation = ({
     [items.length, currentPath]
   );
 
+  const [currentExpandedSecondary, setCurrentExpandedSecondary] = useState(
+    null
+  );
   const [currentExpanded, setCurrentExpanded] = useState(
     subItemToItemMap[pathFragment(getCurrentPath())]
   );
   useEffect(() => {
     setCurrentExpanded(subItemToItemMap[pathFragment(getCurrentPath())]);
+    groupedItems.some(({ groups }) =>
+      groups.some(({ groupItems, title }) =>
+        groupItems.some(({ href }) => {
+          if (href === pathFragment(getCurrentPath())) {
+            setCurrentExpandedSecondary(title);
+            return true;
+          }
+          return false;
+        })
+      )
+    );
     // we only want to run this when we get new items from the API to set the default expanded item, which is the current location
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items.length]);
@@ -125,6 +139,8 @@ const Navigation = ({
               onExpand={() => {
                 // if the current expanded item is the same as the clicked item, collapse it
                 const isExpanded = currentExpanded === title;
+                // close the Secondary nav if it's open
+                if (isExpanded) setCurrentExpandedSecondary(null);
                 // only have 1 item expanded at a time
                 setCurrentExpanded(isExpanded ? null : title);
               }}
@@ -162,9 +178,14 @@ const Navigation = ({
                     <NavExpandable
                       ouiaId={`nav-expandable-${index}-${groupIndex}`}
                       title={group.title}
-                      isExpanded={group.groupItems.some(
-                        ({ isActive }) => isActive
-                      )}
+                      isExpanded={currentExpandedSecondary === group.title}
+                      onExpand={() => {
+                        setCurrentExpandedSecondary(
+                          currentExpandedSecondary === group.title
+                            ? null
+                            : group.title
+                        );
+                      }}
                     >
                       {group.groupItems.map(
                         ({


### PR DESCRIPTION
Only one secondary nav can be open
If a user collapses one main nav, next time they expend it again all secondary navs will be closes.
