### PR TITLE
Fixes #36646 - compare remote address against correct IP address family

### DIFF
--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -18,7 +18,7 @@ class UnattendedControllerTest < ActionController::TestCase
       media(:one).locations << @loc
       media(:ubuntu).organizations << @org
       media(:ubuntu).locations << @loc
-      @rh_host = FactoryBot.create(:host, :managed, :with_dhcp_orchestration, :build => true,
+      @rh_host = FactoryBot.create(:host, :managed, :with_dhcp_orchestration, :dualstack, :build => true,
                                     :operatingsystem => operatingsystems(:redhat),
                                     :ptable => ptable,
                                     :medium => media(:one),
@@ -60,6 +60,13 @@ class UnattendedControllerTest < ActionController::TestCase
 
     test "should get a kickstart when IPv6 mapped IPv4 address is used" do
       @request.env["HTTP_X_FORWARDED_FOR"] = "::ffff:" + @rh_host.ip
+      @request.env["REMOTE_ADDR"] = "127.0.0.1"
+      get :host_template, params: { :kind => 'provision' }
+      assert_response :success
+    end
+
+    test "should get a kickstart over IPv6" do
+      @request.env["HTTP_X_FORWARDED_FOR"] = @rh_host.ip6
       @request.env["REMOTE_ADDR"] = "127.0.0.1"
       get :host_template, params: { :kind => 'provision' }
       assert_response :success


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

So far, the  find_host_by_ip_or_mac function in the HostFinder class was unable to identify a host if the remote address (e.g. in a user-data query) was an IPv6 address because the address was not checked for whether it was an IPv6 address and always compared to the ip field of the NICs. 

This PR contains a minimal change that checks whether the remote address is an IPv6 address and in that case checks the ip6 field instead of the ip field. In all other cases, it defaults to the previous behaviour.

To test this, an IPv6-enabled Foreman installation or at least a capsule server is required. 

I tested the change against a dual-stacked capsule server which is connected to an IPv4-only Redhat Satellite server with properly configured trusted-proxies setting. Without the change, a request for endpoint /userdata/user-data via IPv6 to the capsule server would fail (but give the correct result via IPv4), after applying the change, the result was the same for IPv4 and IPv6.