### PR TITLE
Fixes #37079 - Show current user in nav menu when screen too small

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -41,7 +41,7 @@ export const combineMenuItems = (data, displayNewHostsPage) => {
 
     const translatedItem = {
       ...item,
-      name: __(item.name),
+      name: item.name === 'User' ? data.user.current_user.name : __(item.name),
       children: translatedChildren,
       // Hiding user if not on Mobile view
       className: item.name === 'User' ? 'hidden-nav-lg' : '',

--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -16,8 +16,8 @@ import {
 } from '../../Root/Context/ForemanContext';
 
 const titleWithIcon = (title, iconClass) => (
-  <div>
-    <span className={classNames(iconClass, 'nav-title-icon')} />
+  <div className="nav-title-icon">
+    <span className={classNames(iconClass, 'nav-icon')} />
     <span className="nav-title">{title}</span>
   </div>
 );

--- a/webpack/assets/javascripts/react_app/components/Layout/layout.scss
+++ b/webpack/assets/javascripts/react_app/components/Layout/layout.scss
@@ -33,6 +33,11 @@
 
 .pf-c-nav {
   .nav-title-icon {
+    word-break: break-word;
+    overflow-wrap: break-word;
+    white-space: normal;
+  }
+  .nav-icon {
     pointer-events: none;
     padding-right: 10px;
   }


### PR DESCRIPTION
Show the current user name in the left navigation menu (when the screen is too small to have the user dropdown on top).

This is how it's dealing with long names. I'll take any other suggestions.
![image](https://github.com/theforeman/foreman/assets/78563507/6da1e85d-3b9b-4cf6-84ce-aeb46c1d0504)
_EDIT: see in the comments_

If you're curious, this is how long names in Organization and Location look like:
![image](https://github.com/theforeman/foreman/assets/78563507/72c2d8c9-53f1-4b15-9c2c-c4a7430ba711)
