### PR TITLE
Refs #37067 - closing parent nav should close child nav

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -164,6 +164,7 @@ const Navigation = ({
                 if (isExpanded) setCurrentExpandedSecondary(null);
                 // only have 1 item expanded at a time
                 setCurrentExpanded(isExpanded ? null : title);
+                setCurrentExpandedSecondary(null);
               }}
             >
               {groups.map((group, groupIndex) =>


### PR DESCRIPTION
Also close secondaries when the parent gets closed because a different parent got expanded