### PR TITLE
Fixes #37089 - host details sub tabs are hidden

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/HostDetails.scss
@@ -49,3 +49,7 @@
     }
   }
 }
+
+.host-details-tabs-section + .pf-c-tabs {
+   overflow: visible;
+}


### PR DESCRIPTION
On small screens, can be seen in the puppet/ansible plugin tabs.
The secondary tabs are not under any host css classnames so I used "find the first element after .host-details-tabs-section to find the sub tabs" instead of wrapping the sub tabs in a div/changing the css in each plugin/changing the css for all foreman pages.