### PR TITLE
Fixes #37092 - Use minitest_reporters_github in GHA

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -5,6 +5,7 @@ group :test do
   gem 'minitest-reporters', '~> 1.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false
   gem 'minitest-spec-rails', '~> 7.1'
+  gem 'minitest_reporters_github', '~> 1.0', :require => false
   gem 'capybara', '~> 3.33', :require => false
   gem 'show_me_the_cookies', '~> 6.0', :require => false
   gem 'database_cleaner', '~> 1.3', :require => false

--- a/test/test_report_helper.rb
+++ b/test/test_report_helper.rb
@@ -1,7 +1,16 @@
 require 'minitest/reporters'
 
-junit_reporter = Minitest::Reporters::JUnitReporter.new('jenkins/reports/unit/')
-meantime_reporter = Minitest::Reporters::MeanTimeReporter.new(previous_runs_filename: Rails.root.join('tmp', 'foreman_minitest_reporters_previous_run'),
-                                                              report_filename: Rails.root.join('tmp', 'foreman_minitest_reporters_report'))
+if ENV['GITHUB_ACTIONS'] == 'true'
+  require 'minitest_reporters_github'
+  reporters = [MinitestReportersGithub.new]
+else
+  reporters = [
+    Minitest::Reporters::JUnitReporter.new('jenkins/reports/unit/'),
+    Minitest::Reporters::MeanTimeReporter.new(
+      previous_runs_filename: Rails.root.join('tmp', 'foreman_minitest_reporters_previous_run'),
+      report_filename: Rails.root.join('tmp', 'foreman_minitest_reporters_report')
+    ),
+  ]
+end
 
-Minitest::Reporters.use! [junit_reporter, meantime_reporter]
+Minitest::Reporters.use! reporters


### PR DESCRIPTION
This is a specialized reporter to provide GitHub annotations on failure.