### PR TITLE
Fixes #37093 - Drop single_test gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,4 @@ require 'rake'
 require 'rake/testtask'
 include Rake::DSL
 
-require 'single_test/tasks' if defined? SingleTest
-
 Foreman::Application.load_tasks

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,6 +1,5 @@
 group :test do
   gem 'mocha', '~> 2.1'
-  gem 'single_test', '~> 0.6'
   gem 'minitest', '~> 5.1'
   gem 'minitest-reporters', '~> 1.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false


### PR DESCRIPTION
The rails command (bin/rails test) provides mechanisms to run individual tests while the last commit to single_test was 7 years ago.