### PR TITLE
Fixes #37085 - Add netiq as an authentication source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'audited', '~> 5.0', '!= 5.1.0'
 gem 'will_paginate', '~> 3.3'
 gem 'ancestry', '~> 4.0'
 gem 'scoped_search', '>= 4.1.10', '< 5'
-gem 'ldap_fluff', '>= 0.5.0', '< 1.0'
+gem 'ldap_fluff', '>= 0.7.0', '< 1.0'
 gem 'apipie-rails', '>= 0.8.0', '< 2'
 gem 'apipie-dsl', '>= 2.6.2'
 # Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)

--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -20,7 +20,7 @@ require 'timeout'
 
 class AuthSourceLdap < AuthSource
   SERVER_TYPES = { :free_ipa => 'FreeIPA', :active_directory => 'Active Directory',
-                   :posix    => 'POSIX'}
+                   :posix    => 'POSIX', :netiq => "NetIQ"}
 
   extend FriendlyId
   friendly_id :name


### PR DESCRIPTION
- Bump version of ldap_fluff to the next version
- Add netiq to LDAP auth-sources 

This PR is a consequence of [Bump version to 0.7.0 #80](https://github.com/theforeman/ldap_fluff/pull/80) and [Add NetIQ ldap-flavour #71](https://github.com/theforeman/ldap_fluff/pull/71)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
