### PR TITLE
Refs #37016 - remove safe nav from subs entitlement report

### DIFF
--- a/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
+++ b/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
@@ -27,8 +27,8 @@ require:
 <%-       report_row(
             'Host Name': host.name,
             'Organization': host.organization,
-            'Lifecycle Environment': host.single_lifecycle_environment&.name,
-            'Content View': host.single_content_view&.name,
+            'Lifecycle Environment': host.single_lifecycle_environment ? host.single_lifecycle_environment.name : nil,
+            'Content View': host.single_content_view ? host.single_content_view.name : nil,
             'Host Collections': host_collections_names(host),
             'Virtual': host.virtual,
             'Guest of Host': host.hypervisor_host,


### PR DESCRIPTION
The safe navigation doesn't work with older safemode. Changing it upstream so backports make more sense.

To test, try this report with:
1) No subs
2) SCA mode and subs
3) non-SCA mode and subs on hosts