### PR TITLE
Fixes #37116 - Enable bullet in the test environment

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -18,7 +18,6 @@ group :development do
 
   gem 'rainbow', '>= 2.2.1'
 
-  gem 'bullet', '>= 6.1.0'
   gem "parallel_tests"
   gem 'spring', '>= 1.0', '< 3'
   gem 'benchmark-ips', '>= 2.8.2'

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,4 +1,5 @@
 group :test do
+  gem 'bullet', '>= 6.1.0'
   gem 'mocha', '~> 2.1'
   gem 'minitest', '~> 5.1'
   gem 'minitest-reporters', '~> 1.4', :require => false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -74,4 +74,10 @@ Foreman::Application.configure do
     end
     ASDeprecationTracker.resume!
   end
+
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.bullet_logger = true
+    Bullet.raise = true # raise an error if n+1 query occurs
+  end
 end


### PR DESCRIPTION
bullet is a tool to find n+1 query patterns. We already have it enabled in development, but not in testing. If we configure it to raise exceptions, we should have better guards against inefficient patterns.