### PR TITLE
Fixes #37016 - don't reference CV / LCE name if nil

### DIFF
--- a/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
+++ b/app/views/unattended/report_templates/subscription_-_entitlement_report.erb
@@ -26,8 +26,8 @@ require:
 <%-       report_row(
             'Host Name': host.name,
             'Organization': host.organization,
-            'Lifecycle Environment': host.single_lifecycle_environment.name,
-            'Content View': host.single_content_view.name,
+            'Lifecycle Environment': host.single_lifecycle_environment ? host.single_lifecycle_environment.name : nil,
+            'Content View': host.single_content_view ? host.single_content_view.name : nil,
             'Host Collections': host_collections_names(host),
             'Virtual': host.virtual,
             'Guest of Host': host.hypervisor_host,


### PR DESCRIPTION
The safe navigation doesn't work with older safemode.

To test, try this report with:

    No subs
    SCA mode and subs
    non-SCA mode and subs on hosts

Make sure to test on Foreman 3.9.