### PR TITLE
Refs #37102 - detect plugins webpack by looking for remoteEntry.js

### DIFF
--- a/app/registries/foreman/plugin/assets.rb
+++ b/app/registries/foreman/plugin/assets.rb
@@ -30,8 +30,14 @@ module Foreman
         File.file?(manifest_path) ? manifest_path : nil
       end
 
+      def webpack_remote_entry
+        webpack_id = id.to_s.tr('-', '_')
+        remote_entry_path = File.join(path, 'public', 'webpack', webpack_id, "#{webpack_id}_remoteEntry.js")
+        File.file?(remote_entry_path) ? remote_entry_path : nil
+      end
+
       def uses_webpack?
-        path && (File.file?(File.join(path, 'webpack', 'index.js')) || webpack_manifest_path.present?)
+        path && (File.file?(File.join(path, 'webpack', 'index.js')) || webpack_manifest_path.present? || webpack_remote_entry.present?)
       end
 
       private


### PR DESCRIPTION
Since we switched to Webpack 5, there are no more manifest.json in the plugins webpack folder, but we need some token to detect that we gotta load webpack stuff.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
