### PR TITLE
Normalize all plugin assets on underscores

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -55,7 +55,7 @@ module ReactjsHelper
 
   def js_tags_for(requested_plugins)
     requested_plugins.map do |plugin|
-      name = plugin.to_s.tr('-', '_')
+      name = plugin.normalized_id
       javascript_tag("window.tfm.tools.loadPluginModule('/webpack/#{name}','#{name}','./index');".html_safe)
     end
   end
@@ -69,7 +69,7 @@ module ReactjsHelper
       end
 
       plugin.global_js_files.map do |file|
-        name = plugin.id.to_s.tr('-', '_')
+        name = plugin.normalized_id
         javascript_tag("window.tfm.tools.loadPluginModule('/webpack/#{name}','#{name}','./#{file}_index');".html_safe)
       end
     end

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -222,6 +222,11 @@ module Foreman #:nodoc:
       "Foreman plugin: #{id}, #{version}, #{author}, #{description}"
     end
 
+    # @return [String] The ID with underscores
+    def normalized_id
+      id.to_s.tr('-', '_')
+    end
+
     # Sets a requirement on Foreman version
     # Raises a PluginRequirementError exception if the requirement is not met
     # matcher format is gem dependency format

--- a/app/registries/foreman/plugin/assets.rb
+++ b/app/registries/foreman/plugin/assets.rb
@@ -48,7 +48,7 @@ module Foreman
         # automatically detect and include them. Requires manual configuration
         # to use this unsupported layout.
         new_assets, outside_prefix = new_assets.partition do |p|
-          p.start_with?("#{id}/") || p.start_with?("#{id.to_s.tr('-', '_')}/")
+          p.start_with?("#{id}/")
         end
 
         if outside_prefix.present?

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -69,7 +69,7 @@ Foreman::Application.configure do
   config.after_initialize do
     Foreman::Plugin.all.each do |plugin|
       unless File.exist?(File.join(plugin.path, 'config', 'as_deprecation_whitelist.yaml'))
-        ASDeprecationTracker.whitelist.add(engine: plugin.id.to_s.tr('-', '_'))
+        ASDeprecationTracker.whitelist.add(engine: plugin.normalized_id)
       end
     end
     ASDeprecationTracker.resume!

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -18,14 +18,8 @@ Foreman::Application.configure do |app|
       foreman_manifest = JSON.parse(File.read(manifest_file))
 
       Foreman::Plugin.all.each do |plugin|
-        # Manifests may be stored under the engine installation or under the Foreman app root, then
-        # either with just the plugin name or with hyphens replaced with underscores.
-        possible_manifests = [plugin.path, app.root].map do |root_dir|
-          [File.join(root_dir, "public/assets/#{plugin.id}/#{plugin.id}.json"),
-           File.join(root_dir, "public/assets/#{plugin.id.to_s.tr('-', '_')}/#{plugin.id.to_s.tr('-', '_')}.json")]
-        end.flatten
-
-        if (manifest_path = possible_manifests.detect { |path| File.file?(path) })
+        path = File.join(root_dir, 'public', 'assets', plugin.normalized_id, "#{plugin.normalized_id}.json")
+        if File.file?(path)
           Rails.logger.debug { "Loading #{plugin.id} precompiled asset manifest from #{manifest_path}" }
           assets = JSON.parse(File.read(manifest_path))
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -29,8 +29,8 @@ Foreman::Application.configure do |app|
           Rails.logger.debug { "Loading #{plugin.id} precompiled asset manifest from #{manifest_path}" }
           assets = JSON.parse(File.read(manifest_path))
 
-          foreman_manifest['files']  = foreman_manifest['files'].merge(assets.fetch('files', {}))
-          foreman_manifest['assets'] = foreman_manifest['assets'].merge(assets.fetch('assets', {}))
+          foreman_manifest['files'].merge!(assets.fetch('files', {}))
+          foreman_manifest['assets'].merge!(assets.fetch('assets', {}))
         end
       end
 

--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -8,8 +8,8 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
     class PluginAssetsTask < Sprockets::Rails::Task
       attr_accessor :plugin
 
-      def initialize(plugin_id)
-        @plugin = Foreman::Plugin.find(plugin_id) or raise("Unable to find registered plugin #{plugin_id}")
+      def initialize(plugin)
+        @plugin = plugin
 
         Rails.env = 'production'
         app = Rails.application
@@ -43,8 +43,8 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
     class PluginWebpackTask
       attr_accessor :plugin
 
-      def initialize(plugin_id)
-        @plugin = Foreman::Plugin.find(plugin_id) or raise("Unable to find registered plugin #{plugin_id}")
+      def initialize(plugin)
+        @plugin = plugin
       end
 
       def compile
@@ -58,10 +58,12 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
   end
 
   if args[:plugin]
-    task = Foreman::PluginAssetsTask.new(args[:plugin])
+    plugin = Foreman::Plugin.find(args[:plugin]) or raise("Unable to find registered plugin #{args[:plugin]}")
+
+    task = Foreman::PluginAssetsTask.new(plugin)
     task.compile
 
-    task = Foreman::PluginWebpackTask.new(args[:plugin])
+    task = Foreman::PluginWebpackTask.new(plugin)
     task.compile
   else
     puts "You must specify the name of the plugin (e.g. rake plugin:assets:precompile['my_plugin'])"

--- a/lib/tasks/plugin_assets.rake
+++ b/lib/tasks/plugin_assets.rake
@@ -30,7 +30,7 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
       end
 
       def manifest_path
-        File.join(output, plugin.id.to_s, "#{plugin.id}.json")
+        File.join(output, plugin.normalized_id, "#{plugin.normalized_id}.json")
       end
 
       def manifest
@@ -52,7 +52,7 @@ task 'plugin:assets:precompile', [:plugin] => [:environment] do |t, args|
         return unless File.exist?("#{@plugin.path}/package.json")
         ENV["NODE_ENV"] ||= 'production'
         config_file = Rails.root.join('config', 'webpack.config.js')
-        sh "npx --max_old_space_size=2048 webpack --config #{config_file} --bail --env pluginName=#{@plugin.id}"
+        sh "npx --max_old_space_size=2048 webpack --config #{config_file} --bail --env pluginName=#{@plugin.normalized_id}"
       end
     end
   end


### PR DESCRIPTION
This introduces the helper `normalized_id` on a plugin and then consistently uses it everywhere. While in most cases it already is using underscores, this helps to deal with foreman-tasks.