### PR TITLE
Remove unused cssnano and css-minimizer-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "buffer": "^5.7.1",
     "cross-env": "^5.2.0",
     "css-loader": "^6.8.1",
-    "css-minimizer-webpack-plugin": "^4.2.2",
-    "cssnano": "^5.0.1",
     "dotenv": "^5.0.0",
     "eslint": "^6.7.2",
     "eslint-plugin-spellcheck": "0.0.17",


### PR DESCRIPTION
This appears to be unreferenced and thus unused after webpack 5 merge.