### PR TITLE
Fixes #37126 - Replace node-sass with sass

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -31,8 +31,7 @@
         "surge",
         "webpack-bundle-analyzer",
         "tabbable",
-        "@adobe/css-tools",
-	"sass"
+        "@adobe/css-tools"
     ],
     "EXCLUDE_NPM_PREFIXES": [
         "@babel/eslint-",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint-plugin-spellcheck": "0.0.17",
     "graphql": "^15.5.0",
     "highlight.js": "~9.14.0",
-    "node-sass": "^8.0.0",
     "path-browserify": "^1.0.1",
     "prettier": "^1.19.1",
     "pretty-format": "26.6.2",


### PR DESCRIPTION
sass was already added to package.json for Webpack 5, this just makes it used across the board and drops node-sass


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
