### PR TITLE
Refs #37010 - Ensure correct yaml for netplan

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -34,8 +34,8 @@ oses:
                   :interface => bond,
                   :subnet => bond.subnet,
                   :subnet6 => bond.subnet6,
-                  :dhcp => bond.subnet&.dhcp_boot_mode?,
-                  :dhcp6 => bond.subnet&.dhcp_boot_mode? }) -%>
+                  :dhcp => bond.subnet.nil? ? false : bond.subnet.dhcp_boot_mode?,
+                  :dhcp6 => bond.subnet6.nil? ? false : bond.subnet6.dhcp_boot_mode? }) -%>
   <%= result -%>
         interfaces: <%= bond.attached_devices_identifiers %>
         parameters:
@@ -60,8 +60,8 @@ oses:
                   :interface => bridge,
                   :subnet => bridge.subnet,
                   :subnet6 => bridge.subnet6,
-                  :dhcp => bridge.subnet&.dhcp_boot_mode?,
-                  :dhcp6 => bridge.subnet6&.dhcp_boot_mode? }) -%>
+                  :dhcp => bridge.subnet.nil? ? false : bridge.subnet.dhcp_boot_mode?,
+                  :dhcp6 => bridge.subnet6.nil? ? false : bridge.subnet6.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>
 <%#
@@ -81,8 +81,8 @@ oses:
                   :interface => vlan,
                   :subnet => vlan.subnet,
                   :subnet6 => vlan.subnet6,
-                  :dhcp => vlan.subnet&.dhcp_boot_mode?,
-                  :dhcp6 => vlan.subnet6&.dhcp_boot_mode? }) -%>
+                  :dhcp => vlan.subnet.nil? ? false : vlan.subnet.dhcp_boot_mode?,
+                  :dhcp6 => vlan.subnet6.nil? ? false : vlan.subnet6.dhcp_boot_mode? }) -%>
   <%= result -%>
         id: <%= vlan.tag %>
         link: <%= vlan.attached_to %>
@@ -104,8 +104,8 @@ oses:
                   :interface => interface,
                   :subnet => interface.subnet,
                   :subnet6 => interface.subnet6,
-                  :dhcp => interface.subnet.dhcp_boot_mode?,
-                  :dhcp6 => interface.subnet6&.dhcp_boot_mode? }) -%>
+                  :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode?,
+                  :dhcp6 => interface.subnet6.nil? ? false : interface.subnet6.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
The changes in #9967 introduce the save navigation operator. Unfortunately, the corresponding [snippet](https://github.com/theforeman/foreman/blob/e87de8d1a30aeba3da6d0cb2518d94aa450db55e/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb#L18) relies on the passed arguments being `true`/`false` instead of `nil`.

@ekohl should we add a safety check to the `preseed_netplan_generic_interface` that turns `nil` into `false` or revert the save navigator change in this snippet?

Or am I overseeing something here?

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
