### PR TITLE
Fixes #37142 - Cloud-init breaks due to newline

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -59,11 +59,11 @@ EOF
 
 <% if ssh_user != 'root' && host_param('remote_execution_effective_user_method') == 'sudo' -%>
 <% if @host.operatingsystem.family == 'Redhat' || @host.operatingsystem.family == 'Debian' -%>
-echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL
-Defaults:<%= ssh_user %> !requiretty" > /etc/sudoers.d/<%= ssh_user %>
+echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL" > /etc/sudoers.d/<%= ssh_user %>
+echo "Defaults:<%= ssh_user %> !requiretty" >> /etc/sudoers.d/<%= ssh_user %>
 <% elsif @host.operatingsystem.family == 'Suse' -%>
-echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL
-Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers
+echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL" >> /etc/sudoers
+echo "Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers
 <% end -%>
 <% end -%>
 else


### PR DESCRIPTION
This fixes cloud-init based deployment on Proxmox for Debian and Ubuntu.