### PR TITLE
Fixes #37156 - Pin victory-core to 36.8.z

### DIFF
--- a/package-exclude.json
+++ b/package-exclude.json
@@ -28,7 +28,8 @@
         "surge",
         "webpack-bundle-analyzer",
         "tabbable",
-        "@adobe/css-tools"
+        "@adobe/css-tools",
+        "victory-core"
     ],
     "EXCLUDE_NPM_PREFIXES": [
         "@babel/eslint-",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "stylelint": "^9.3.0",
     "stylelint-config-standard": "^18.0.0",
     "tabbable": "~5.2.0",
+    "victory-core": "~36.8.6",
     "webpack": "^5.75.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^5.0.1",


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Pin victory-core to less than 36.9.0 which breaks react-charts. See https://github.com/patternfly/patternfly-react/issues/10064