### PR TITLE
Refs #37102 - Read real webpack manifest in test

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,9 +66,16 @@ def invalid_name_list
     "\t",
   ]
 end
+
 module ReactjsHelper
   def read_webpack_manifest
-    {"assetsByChunkName" => {"foreman-vendor" => ["foreman-vendor.js", "foreman-vendor.css"]}}
+    manifest = Rails.root.join('public/webpack/manifest.json')
+    if manifest.exist?
+      JSON.parse(manifest.read)
+    else
+      # Stubbed method to deal with a missing manifest for controller tests
+      {"assetsByChunkName" => {"foreman-vendor" => ["foreman-vendor.js", "foreman-vendor.css"]}}
+    end
   end
 end
 


### PR DESCRIPTION
The system tests rely on this actually working.

This is to investigate the failures seen in https://github.com/theforeman/foreman_ansible/pull/693 and https://github.com/theforeman/foreman_ansible/pull/693. They also happen with current Foreman develop.