### PR TITLE
Fixes #37161 - load public/webpack when available

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -321,7 +321,7 @@ module Foreman
 
     if config.public_file_server.enabled
       ::Rails::Engine.subclasses.map(&:instance).each do |engine|
-        if File.exist?("#{engine.root}/public/assets")
+        if File.exist?("#{engine.root}/public/assets") || File.exist?("#{engine.root}/public/webpack")
           config.middleware.use ::ActionDispatch::Static, "#{engine.root}/public"
         end
       end


### PR DESCRIPTION
when there is no public/assets folder, but there is still a public/webpack folder, the public folder should still be served.
Was specifically an issue with the theme plugin