### PR TITLE
Fixes #37065 - report_row now explicitly accepts args and kwargs

### DIFF
--- a/test/unit/foreman/renderer/scope/report_test.rb
+++ b/test/unit/foreman/renderer/scope/report_test.rb
@@ -58,6 +58,29 @@ class ReportScopeTest < ActiveSupport::TestCase
       assert_equal expected_yaml, @scope.report_render(format: :yaml)
     end
 
+    test 'report_row handles symbol keys with safemode merge' do
+      renderer = Foreman::Renderer::SafeModeRenderer
+      base_opts = { 'Fruit1' => 'Apple', 'Fruit2' => 'Banana' }
+
+      content = "<%= report_row({
+        :Name => 'Orange',
+        :Global => 'Pomegranate'
+      }.merge(@base_opts)) %>"
+      source = OpenStruct.new(
+        name: 'Test',
+        content: content
+      )
+      @scope = Foreman::Renderer::Scope::Report.new(
+        source: source,
+        variables: { base_opts: base_opts }
+      )
+      result = ""
+      assert_nothing_raised do
+        result = renderer.render(source, @scope)
+      end
+      assert_equal result, "[[\"Orange\", \"Pomegranate\", \"Apple\", \"Banana\"]]"
+    end
+
     test 'render types' do
       @scope.report_row(
         'List': ['Val1', 1, true],


### PR DESCRIPTION
With Ruby 3-related changes in `safemode` 1.4 (maybe?), the `Host - Statuses` report breaks with

```
ArgumentError

unknown keywords: :Name, :Global
```

The issue does not occur when using safemode 1.3.8.

In my testing, to trigger this requires both of the following conditions:

1. `report_row` is called with the result of `Hash#merge`
2. The merged hash contains at least one key that is a Symbol.

To work around this, we can either (a) make sure none of our Hash keys are symbols; or (b) call `report_row` with kwargs rather than positional arguments, by adding `**` to the call.

With this change, we make `report_row` explicitly accept both args and kwargs. This makes it so you don't have to do either of these workarounds.

Update: Added a test that fails without the `report_row` change.
