### PR TITLE
Fixes #37011 - Apply latest Ubuntu Autoinstall userdata changes

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -39,6 +39,7 @@ autoinstall:
 <% unless enable_auto_update -%>
     disable_components: [multiverse]
     disable_suites: [backports,security,updates] 
+    fallback: offline-install
 <% end -%>
 <%= indent(4) { snippet_if_exists(template_name + " custom apt") } -%>
   user-data:
@@ -47,7 +48,7 @@ autoinstall:
     users:
     - name: <%= username_to_create %>
       gecos: <%= realname_to_create %>
-      lock-passwd: false
+      lock_passwd: false
       hashed_passwd: <%= password_to_create %>
 <% if !host_param('remote_execution_ssh_keys').blank? -%>
 <%   if host_param('remote_execution_ssh_keys').is_a?(String) -%>
@@ -55,8 +56,6 @@ autoinstall:
 <%   else -%>
       ssh_authorized_keys: <%= host_param('remote_execution_ssh_keys') %>
 <%   end -%>
-<% else -%>
-      ssh_authorized_keys: []
 <% end -%>
   keyboard:
     layout: <%= host_param('keyboard', 'us') %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -15,9 +15,8 @@ autoinstall:
     users:
     - name: root
       gecos: root
-      lock-passwd: false
+      lock_passwd: false
       hashed_passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
-      ssh_authorized_keys: []
   keyboard:
     layout: us
     toggle: null


### PR DESCRIPTION
As mentioned in the ticket, the latest version of Ubuntu Autoinstall introduces some changes.
Therefore, the following adaptions are made:

* Add explicit fallback for offline installation
* Replace deprecated lock-passwd with lock_passwd
* Remove empty ssh keys array if none provided

Still, Autoinstall deployment will fail at the moment, due to #10036

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
