### PR TITLE
Fixes #37168 - fix potential for duplicate html-id

### DIFF
--- a/app/views/settings/index.html.erb
+++ b/app/views/settings/index.html.erb
@@ -15,7 +15,7 @@
   <ul class="nav nav-tabs" data-tabs="tabs">
     <% @settings.categories.each do |category, label| %>
       <li class="<%= 'active' if category == @settings.categories.keys.first %>">
-        <a href="#<%= category %>" data-toggle="tab"><%= _(label) %></a>
+        <a href="#<%= category %>_settings_tab" data-toggle="tab"><%= _(label) %></a>
       </li>
     <% end %>
   </ul>
@@ -23,7 +23,7 @@
 
 <div class="tab-content">
   <% @settings.categories.each do |category, _label| %>
-    <div class="tab-pane<%= ' active' if category == @settings.categories.keys.first %>" id='<%= category %>' >
+    <div class="tab-pane<%= ' active' if category == @settings.categories.keys.first %>" id='<%= category %>_settings_tab' >
       <%= render_if_partial_exists "settings/category/#{category.downcase}", category %>
 
       <%= react_component('SettingsTable', { category: category }) %>

--- a/test/controllers/settings_controller_test.rb
+++ b/test/controllers/settings_controller_test.rb
@@ -15,6 +15,6 @@ class SettingsControllerTest < ActionController::TestCase
     end
     Foreman.settings.load
     get :index, session: set_session_user
-    assert_match /id='valid'/, @response.body
+    assert_match /id='valid_settings_tab'/, @response.body
   end
 end

--- a/test/integration/setting_js_test.rb
+++ b/test/integration/setting_js_test.rb
@@ -3,11 +3,11 @@ require 'integration_test_helper'
 class SettingJSTest < IntegrationTestWithJavascript
   test "index page" do
     assert_index_page(settings_path, "Settings", false, true, false)
-    assert page.has_link?("General", :href => "#general")
-    assert page.has_link?("Provisioning", :href => "#provisioning")
-    assert page.has_link?("Facts", :href => "#facts")
-    assert page.has_link?("Config Management", :href => "#cfgmgmt")
-    assert page.has_link?("Authentication", :href => "#auth")
+    assert page.has_link?("General", :href => "#general_settings_tab")
+    assert page.has_link?("Provisioning", :href => "#provisioning_settings_tab")
+    assert page.has_link?("Facts", :href => "#facts_settings_tab")
+    assert page.has_link?("Config Management", :href => "#cfgmgmt_settings_tab")
+    assert page.has_link?("Authentication", :href => "#auth_settings_tab")
   end
 
   test "humanized tab label for setting category" do
@@ -27,6 +27,6 @@ class SettingJSTest < IntegrationTestWithJavascript
     Foreman.settings.load
 
     assert_index_page(settings_path, "Settings", false, true, false)
-    assert page.has_link?("My Pretty Setting Label", :href => "#category_label_test")
+    assert page.has_link?("My Pretty Setting Label", :href => "#category_label_test_settings_tab")
   end
 end


### PR DESCRIPTION
This issue is visible, if Katello is installed
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
