### PR TITLE
Fixes #37179 - Clone hostgroup facets when cloning hostgroup

### DIFF
--- a/app/models/concerns/facets/hostgroup_extensions.rb
+++ b/app/models/concerns/facets/hostgroup_extensions.rb
@@ -6,7 +6,9 @@ module Facets
     include Facets::ModelExtensionsBase
 
     included do
-      configure_facet(:hostgroup, :hostgroup, :hostgroup_id)
+      configure_facet(:hostgroup, :hostgroup, :hostgroup_id) do |facet_config|
+        include_in_clone facet_config.name
+      end
     end
 
     def hostgroup_ancestry_cache

--- a/test/unit/facet_test.rb
+++ b/test/unit/facet_test.rb
@@ -278,6 +278,16 @@ class FacetTest < ActiveSupport::TestCase
     test 'hostgroup and facet are connected two-way' do
       assert_equal @hostgroup, @facet.hostgroup
     end
+
+    test 'a cloned hostgroup also clones facets' do
+      @hostgroup.name = "test"
+      @hostgroup.hostgroup_facet.id = 42
+      cloned_hg = @hostgroup.clone
+      cloned_facet = cloned_hg.hostgroup_facet
+      assert_nil cloned_facet.id
+      refute_equal cloned_facet.id, @hostgroup.hostgroup_facet.id
+      assert_equal cloned_facet.attributes.except("id"), @facet.attributes.except("id")
+    end
   end
 
   context 'host and hostgroup relationship' do


### PR DESCRIPTION
When cloning a hostgroup, its facets were not being cloned. Because of this, the hostgroup form would be pre-filled with some attributes, but not all.

This change clones all registered facets when cloning a hostgroup, enabling improvements in plugins such as https://github.com/Katello/katello/pull/10894.