### PR TITLE
Fixes #37184 - Report template generates incorrect kernel version

### DIFF
--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -28,7 +28,7 @@ module Host
     has_one :domain, :through => :primary_interface
     has_one :subnet, :through => :primary_interface
     has_one :subnet6, :through => :primary_interface
-    has_one :kernel_release, -> { joins(:fact_name).where({ 'fact_names.name' => KERNEL_RELEASE_FACTS }).order('fact_names.type') }, :class_name => '::FactValue', :foreign_key => 'host_id'
+    has_one :kernel_release, -> { joins(:fact_name).where({ 'fact_names.name' => KERNEL_RELEASE_FACTS }).order('fact_values.updated_at desc') }, :class_name => '::FactValue', :foreign_key => 'host_id'
     accepts_nested_attributes_for :interfaces, :allow_destroy => true
 
     belongs_to :location

--- a/test/unit/foreman/renderer/scope/macros/base_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/base_test.rb
@@ -149,7 +149,7 @@ class BaseMacrosTest < ActiveSupport::TestCase
       FactoryBot.create(:fact_value, fact_name: ansible_kernel_fact, host: host, value: '1.2.3')
       FactoryBot.create(:fact_value, fact_name: chef_kernel_fact, host: host, value: '2.2.2')
       FactoryBot.create(:fact_value, fact_name: unrelated_fact, host: host, value: 'Fedora 29')
-      assert_equal '1.2.3', @scope.host_kernel_release(host)
+      assert_equal '2.2.2', @scope.host_kernel_release(host)
       FactoryBot.create(:fact_value, fact_name: puppet_and_salt_fact, host: host, value: '4.5.6')
       assert_equal '4.5.6', @scope.host_kernel_release(host.reload)
       FactoryBot.create(:fact_value, fact_name: rhsm_fact, host: rhsm_host, value: '7.8.9')


### PR DESCRIPTION
Sort the kernel version facts of a host by updated date.