### PR TITLE
Fixes #37189 - Registration before & after snippets

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -56,6 +56,8 @@ cleanup_and_exit() {
   exit $1
 }
 
+<%= snippet_if_exists('before_registration') -%>
+
 <% unless @repo.blank? -%>
 echo '#'
 echo '# Adding repository'
@@ -151,5 +153,7 @@ register_katello_host | bash
 <% else -%>
 register_host | bash
 <% end -%>
+
+<%= snippet_if_exists('after_registration') -%>
 
 cleanup_and_exit


### PR DESCRIPTION
`before_registration` & `after_registration` snippets allow users to add their code to the template without directly editing it.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
