### PR TITLE
Fixes #37193 - trap ERR not supported on dash

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
+++ b/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
@@ -21,7 +21,7 @@ set -e
 
 echo "Getting configuration from subscription-manager..."
 KPPTEMPFILE=$(mktemp kpp_tempfile_XXXXXXXX)
-trap "rm -f $KPPTEMPFILE" ERR EXIT
+trap "rm -f $KPPTEMPFILE" EXIT
 subscription-manager config --list > $KPPTEMPFILE
 CONSUMER_CERT_DIR=$(grep 'consumercertdir' $KPPTEMPFILE | cut -d= -f2 | xargs | sed 's/[][]//g')
 CERT_FILE=$CONSUMER_CERT_DIR/cert.pem


### PR DESCRIPTION
`trap ERR` is not supported on dash (default debian/ubuntu shell)

We should get rid of this. 


Testscript:
```
#!/bin/sh

runme() {
  echo "Catched"
}

set -e
trap "runme" EXIT

if [ -z "$1" ]; then
  echo "I will crash"
  cd /doesnexist
fi
```

Test execution:

```
$ bash test.sh 
I will crash
test.sh: line 12: cd: /doesnexist: No such file or directory
Catched

$ dash test.sh 
I will crash
test.sh: 12: cd: can't cd to /doesnexist
Catched

$ bash test.sh continue
Catched

$ dash test.sh continue
Catched
```