### PR TITLE
Fixes #37424 - Fix Style/RedundantRegexpEscape cop

### DIFF
--- a/app/models/architecture.rb
+++ b/app/models/architecture.rb
@@ -26,7 +26,7 @@ class Architecture < ApplicationRecord
     when /aarch64|aa64/
       'aa64'
     else # ppc64, ppc64le and others
-      name.parameterize.gsub(/[^\w\.-]/, '_')
+      name.parameterize.gsub(/[^\w.-]/, '_')
     end
   end
 end

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -262,7 +262,7 @@ module Foreman::Model
 
     def url_for_fog
       u = URI.parse(url)
-      match_data = u.path.match(%r{(.*)\/v\d+.*})
+      match_data = u.path.match(%r{(.*)/v\d+.*})
       path = match_data && (match_data[1] || '')
       "#{u.scheme}://#{u.host}:#{u.port}#{path}"
     end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -16,7 +16,7 @@ class Medium < ApplicationRecord
   has_many :hostgroups, :dependent => :nullify
 
   # We need to include $ in this as $arch, $release, can be in this string
-  VALID_NFS_PATH = /\A([-\w\d\.]+):(\/[\w\d\/\$\.]+)\Z/
+  VALID_NFS_PATH = /\A([-\w\d.]+):(\/[\w\d\/$.]+)\Z/
   validates :name, :uniqueness => true, :presence => true
   validates :path, :uniqueness => true, :presence => true,
     :url_schema => ['http', 'https', 'ftp', 'nfs']

--- a/app/models/operatingsystems/solaris.rb
+++ b/app/models/operatingsystems/solaris.rb
@@ -2,7 +2,7 @@ class Solaris < Operatingsystem
   PXEFILES = {:initrd => "x86.miniroot", :kernel => "multiboot"}
 
   def file_prefix
-    to_s.gsub(/[\s\(\)]/, "-").gsub("--", "-").gsub(/-\Z/, "")
+    to_s.gsub(/[\s()]/, "-").gsub("--", "-").gsub(/-\Z/, "")
   end
 
   # sets the prefix for the tftp files based on the OS

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -134,7 +134,7 @@ class Setting < ApplicationRecord
     when "array"
       if val =~ /\A\[.*\]\Z/
         begin
-          self.value = YAML.safe_load(val.gsub(/(\,)(\S)/, "\\1 \\2"))
+          self.value = YAML.safe_load(val.gsub(/(,)(\S)/, "\\1 \\2"))
         rescue => e
           invalid_value_error e.to_s
         end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,11 +93,11 @@ class User < ApplicationRecord
   end
 
   def self.name_format
-    /\A[[:alnum:]\s'_\-\.()<>;=,]*\z/
+    /\A[[:alnum:]\s'_\-.()<>;=,]*\z/
   end
 
   validates :login, :presence => true, :uniqueness => {:case_sensitive => false, :message => N_("already exists")},
-                    :format => {:with => /\A[[:alnum:]_\-@\.\\$#+]*\Z/}, :length => {:maximum => 100},
+                    :format => {:with => /\A[[:alnum:]_\-@.\\$#+]*\Z/}, :length => {:maximum => 100},
                     :exclusion => { in: %w(current_user) }
   validates :auth_source_id, :presence => true
   validates :password_hash, :presence => true, :if => proc { |user| user.manage_password? }

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -1,9 +1,9 @@
 class FactParser
   delegate :logger, :to => :Rails
-  VIRTUAL = /\A([a-z0-9]+)[_|\.|:]([a-z0-9]+)\Z/
+  VIRTUAL = /\A([a-z0-9]+)[_|.|:]([a-z0-9]+)\Z/
   BRIDGES = /\A(vir|lxc)?br(\d+|-[a-z0-9]+)(_nic)?\Z/
   BONDS = /\A(bond\d+)\Z|\A(lagg\d+)\Z/
-  ALIASES = /(\A[a-z0-9\.]+):([a-z0-9]+)\Z/
+  ALIASES = /(\A[a-z0-9.]+):([a-z0-9]+)\Z/
   VLANS = /\A([a-zA-Z0-9]+)\.([0-9]+)\Z/
   VIRTUAL_NAMES = /#{ALIASES}|#{VLANS}|#{VIRTUAL}|#{BRIDGES}|#{BONDS}/
   # spend 500ms per IP on primary interface lookup

--- a/app/services/foreman_ansible/operating_system_parser.rb
+++ b/app/services/foreman_ansible/operating_system_parser.rb
@@ -52,7 +52,7 @@ module ForemanAnsible
 
     def os_major
       if os_name == 'Debian' &&
-          (facts[:ansible_distribution_major_version][%r{\/sid}i] ||
+          (facts[:ansible_distribution_major_version][%r{/sid}i] ||
            facts[:ansible_distribution_major_version] == 'n/a')
         debian_os_major_sid
       else

--- a/app/services/ipam/eui64.rb
+++ b/app/services/ipam/eui64.rb
@@ -24,7 +24,7 @@ module IPAM
 
     def mac_to_ip(mac)
       # cleanup MAC address
-      mac.gsub!(/[\.\:\-]/, '')
+      mac.gsub!(/[.:\-]/, '')
 
       # separate the 48-bit MAC address into two 24-bits
       oui = mac.slice(0..5)

--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -251,7 +251,7 @@ class PuppetFactParser < FactParser
       majorjunos, minorjunos = os_release_full.split("R")
       majorjunos + "." + minorjunos
     when /FreeBSD/i
-      os_release_full.gsub(/\-RELEASE\-p[0-9]+/, '')
+      os_release_full.gsub(/-RELEASE-p[0-9]+/, '')
     when /Solaris/i
       os_release_full.gsub(/_u/, '.')
     when /PSBM/i

--- a/lib/tasks/puppet.rake
+++ b/lib/tasks/puppet.rake
@@ -15,7 +15,7 @@ namespace :puppet do
         name = yaml.match(/.*\/(.*).yaml/)[1]
         puts "Importing #{name}"
         puppet_facts = File.read(yaml)
-        facts_stripped_of_class_names = YAML.safe_load(puppet_facts.gsub(/\!ruby\/object.*$/, ''))
+        facts_stripped_of_class_names = YAML.safe_load(puppet_facts.gsub(/!ruby\/object.*$/, ''))
         User.as_anonymous_admin do
           host = Host::Managed.import_host(facts_stripped_of_class_names['name'], 'puppet')
           HostFactImporter.new(host).import_facts(facts_stripped_of_class_names['values'])

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -101,21 +101,21 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       test 'with default expiration' do
         post :create, session: set_session_user
         command = JSON.parse(@response.body)['command']
-        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=\')/).flatten[0]
+        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=')/).flatten[0]
         assert JwtToken.new(parsed_token).decode['exp']
       end
 
       test 'with expiration' do
         post :create, params: { jwt_expiration: 23 }, session: set_session_user
         command = JSON.parse(@response.body)['command']
-        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=\')/).flatten[0]
+        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=')/).flatten[0]
         assert JwtToken.new(parsed_token).decode['exp']
       end
 
       test 'unlimited' do
         post :create, params: { jwt_expiration: 'unlimited' }, session: set_session_user
         command = JSON.parse(@response.body)['command']
-        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=\')/).flatten[0]
+        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=')/).flatten[0]
 
         refute JwtToken.new(parsed_token).decode['exp']
       end
@@ -123,7 +123,7 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
       test '0' do
         post :create, params: { jwt_expiration: 0 }, session: set_session_user
         command = JSON.parse(@response.body)['command']
-        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=\')/).flatten[0]
+        parsed_token = command.scan(/(?<=Bearer )(.*)(?=.*)(?=')/).flatten[0]
         refute JwtToken.new(parsed_token).decode['exp']
       end
 

--- a/test/helpers/form_helper_test.rb
+++ b/test/helpers/form_helper_test.rb
@@ -102,7 +102,7 @@ class FormHelperTest < ActionView::TestCase
     user = FactoryBot.build_stubbed(:user,
       :organizations => [taxonomies(:organization1)])
     form_for Filter.new do |f|
-      assert_match(/input name=\"filter\[organization_ids\]\[\].*/,
+      assert_match(/input name="filter\[organization_ids\]\[\].*/,
         multiple_checkboxes(f, :organizations, f.object, user.organizations))
     end
   end

--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -111,8 +111,8 @@ module Hostext
         end
 
         test "invalid fact property should properly format" do
-          assert_match /\'goofy.bad\'/, Host.search_for("facts.goofy.bad=value").to_sql
-          assert_match /\'goofy\'/, Host.search_for("facts.goofy=value").to_sql
+          assert_match /'goofy.bad'/, Host.search_for("facts.goofy.bad=value").to_sql
+          assert_match /'goofy'/, Host.search_for("facts.goofy=value").to_sql
         end
 
         test "searching fact on complex search returns correct host" do


### PR DESCRIPTION
Addressed flagged instances of redundant escape sequences within Regexp literals. 

For reference: https://docs.rubocop.org/rubocop/cops_style.html#styleredundantregexpescape

This was generated with `rubocop --auto-correct-all --only Style/RedundantRegexpEscape`