### PR TITLE
Fixes #37428 - Fix Style/ExplicitBlockArgument cop

### DIFF
--- a/app/helpers/compute_resources_vms_helper.rb
+++ b/app/helpers/compute_resources_vms_helper.rb
@@ -169,16 +169,14 @@ module ComputeResourcesVmsHelper
     selectable_f form, :resource_pool, resource_pools, options, :class => "col-md-2", :label => _('Resource pool'), :disabled => disabled
   end
 
-  def vms_table
+  def vms_table(&block)
     data = if @compute_resource.supports_vms_pagination?
              { :table => 'server', :source => compute_resource_vms_path }
            else
              { :table => 'inline' }
            end
 
-    content_tag :table, :class => table_css_classes, :width => '100%', :data => data do
-      yield
-    end
+    content_tag :table, :class => table_css_classes, :width => '100%', :data => data, &block
   end
 
   # Really counting vms is as expansive as loading them all, especially when

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -262,11 +262,9 @@ module FormHelper
     options
   end
 
-  def add_help_to_label(size_class, label, help_inline)
+  def add_help_to_label(size_class, label, help_inline, &block)
     label.html_safe +
-        content_tag(:div, :class => size_class) do
-          yield
-        end.html_safe + help_inline.html_safe
+        content_tag(:div, :class => size_class, &block).html_safe + help_inline.html_safe
   end
 
   def is_required?(f, attr)
@@ -356,7 +354,7 @@ module FormHelper
     link_to_function(name, "add_fields('#{options[:target]}', '#{association}', '#{escape_javascript(fields)}', '#{options[:direction] || 'append'}')".html_safe, options)
   end
 
-  def field(f, attr, options = {})
+  def field(f, attr, options = {}, &block)
     table_field = options.delete(:table_field)
     error       = options.delete(:error) || get_attr_error(f, attr)
     help_inline = help_inline(options.delete(:help_inline), error)
@@ -367,9 +365,7 @@ module FormHelper
     label = options[:no_label] ? "" : add_label(options, f, attr)
 
     if table_field
-      add_help_to_label(size_class, label, help_inline) do
-        yield
-      end.html_safe
+      add_help_to_label(size_class, label, help_inline, &block).html_safe
     else
       help_block = content_tag(:span, options.delete(:help_block), :class => "help-block")
 

--- a/app/models/concerns/orchestration/tftp.rb
+++ b/app/models/concerns/orchestration/tftp.rb
@@ -191,10 +191,8 @@ module Orchestration::TFTP
     proxies.uniq { |p| p.url }
   end
 
-  def each_unique_feasible_tftp_proxy
-    results = unique_feasible_tftp_proxies.map do |proxy|
-      yield(proxy)
-    end
+  def each_unique_feasible_tftp_proxy(&block)
+    results = unique_feasible_tftp_proxies.map(&block)
     results.all?
   end
 end

--- a/app/registries/menu/node.rb
+++ b/app/registries/menu/node.rb
@@ -27,9 +27,9 @@ module Menu
       children.select(&:authorized?)
     end
 
-    def children
+    def children(&block)
       if block_given?
-        @children.each { |child| yield child }
+        @children.each(&block)
       else
         @children
       end

--- a/app/services/host_counter.rb
+++ b/app/services/host_counter.rb
@@ -19,11 +19,9 @@ class HostCounter
 
   private
 
-  def cache
+  def cache(&block)
     delay = Rails.env.test? ? 0 : 2.minutes
-    Rails.cache.fetch("hosts_count/#{@association}/#{User.current.id}", expires_in: delay) do
-      yield
-    end
+    Rails.cache.fetch("hosts_count/#{@association}/#{User.current.id}", expires_in: delay, &block)
   end
 
   def counted_hosts

--- a/app/services/host_fact_importer.rb
+++ b/app/services/host_fact_importer.rb
@@ -90,11 +90,9 @@ class HostFactImporter
     end
   end
 
-  def skipping_orchestration
+  def skipping_orchestration(&block)
     if host.is_a?(Host::Managed)
-      host.without_orchestration do
-        yield
-      end
+      host.without_orchestration(&block)
     else
       yield
     end

--- a/app/services/proxy_status/base.rb
+++ b/app/services/proxy_status/base.rb
@@ -43,11 +43,9 @@ module ProxyStatus
       raise Foreman::WrappedException.new(e, N_('Unable to initialize ProxyAPI class %s'), "ProxyAPI::#{self.class.humanized_name}")
     end
 
-    def fetch_proxy_data(subkey = '')
+    def fetch_proxy_data(subkey = '', &block)
       if cache
-        Rails.cache.fetch(cache_key + subkey, :expires_in => cache_duration) do
-          yield
-        end
+        Rails.cache.fetch(cache_key + subkey, :expires_in => cache_duration, &block)
       else
         yield
       end

--- a/lib/foreman/logging.rb
+++ b/lib/foreman/logging.rb
@@ -72,10 +72,8 @@ module Foreman
 
     # Structured fields to log in addition to log messages. Every log line created within given block is enriched with these fields.
     # Fields appear in joruand and/or JSON output (hash named 'ndc').
-    def with_fields(fields = {})
-      ::Logging.ndc.push(fields) do
-        yield
-      end
+    def with_fields(fields = {}, &block)
+      ::Logging.ndc.push(fields, &block)
     end
 
     # Standard way for logging exceptions to get the most data in the log.

--- a/test/benchmark/memory/memory_benchmark_helper.rb
+++ b/test/benchmark/memory/memory_benchmark_helper.rb
@@ -2,17 +2,13 @@ require "benchmark/benchmark_helper"
 require 'memory_profiler'
 require "stackprof"
 
-def with_memory_profiler
-  report = MemoryProfiler.report do
-    yield
-  end
+def with_memory_profiler(&block)
+  report = MemoryProfiler.report(&block)
   report.pretty_print
 end
 
-def with_stackprof
-  StackProf.run(mode: :object, raw: true, out: '/tmp/stackprof_objects.dump', interval: 1) do
-    yield
-  end
+def with_stackprof(&block)
+  StackProf.run(mode: :object, raw: true, out: '/tmp/stackprof_objects.dump', interval: 1, &block)
   puts '/tmp/stackprof_objects.dump dump created, please use "stackprof --text /tmp/stackprof_objects.dump" to investigate'
 end
 


### PR DESCRIPTION
Reviewed and updated block literals flagged by the `Style/ExplicitBlockArgument` cop to use explicit block arguments instead of passing arguments to another block directly.