### PR TITLE
sort taxable_ids before comparing them

### DIFF
--- a/test/models/concerns/taxonomix_test.rb
+++ b/test/models/concerns/taxonomix_test.rb
@@ -218,8 +218,8 @@ class TaxonomixTest < ActiveSupport::TestCase
         # table of the caller.
         # Since TaxonomixDummy is defined in terms of the Domain table,
         # the table will have Domain, not TaxonomixDummy as taxable_type
-        assert_equal visible_dummies, Domain.taxable_ids(nil, nil)
-        assert_equal visible_dummies, Domain.taxable_ids([], [])
+        assert_equal_arrays visible_dummies, Domain.taxable_ids(nil, nil)
+        assert_equal_arrays visible_dummies, Domain.taxable_ids([], [])
       end
     end
 


### PR DESCRIPTION
For some reason, taxable_ids and visible_dummies are sometimes sorted differently, resulting in failed tests even tho the right taxonomies are found, just in the wrong order.

Use assert_equal_arrays that sorts the arrays before comparing them.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
