### PR TITLE
Fixes #37222 - Show error message if host fails to save

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -102,6 +102,10 @@ class HostsController < ApplicationController
     else
       load_vars_for_ajax
       offer_to_overwrite_conflicts
+      # add errors from other sources (e.g. Katello) to base errors
+      errors = @host.errors.full_messages | @host.errors[:base]
+      @host.errors.delete(:base)
+      @host.errors.add(:base, errors.join(', '))
       process_error
     end
   end


### PR DESCRIPTION
At present, Error is shown only if host fails to save due to errors caught in foreman or it shows inline errors. But there are cases where host fails to save due to wrong selection of Lifecycle environment or content view where it silently fails to save the host and only show error in production log. 

For example, if you specify the wrong lifecycle environment and deploy via foreman_proxy "Content view environment content facets is invalid" appears in production.log but nothing is displayed in GUI and it simply didn't save the host. These error come from different plugins (e.g., here error was from Katello ) and are not stored in `base errors` therefore, are not displayed.

![Screenshot from 2024-03-13 12-51-47](https://github.com/theforeman/foreman/assets/16632696/d258e24b-b860-493e-9288-25a7993db2ca)
