### PR TITLE
Templates & errors for taxonomies

### DIFF
--- a/app/models/provisioning_template.rb
+++ b/app/models/provisioning_template.rb
@@ -266,4 +266,10 @@ class ProvisioningTemplate < Template
   def reject_template_combination_attributes?(params)
     params[:hostgroup_id].blank?
   end
+
+  # Skip checking taxonomy for snippets
+  def ensure_taxonomies_not_escalated
+    return true if snippet?
+    super
+  end
 end

--- a/app/views/provisioning_templates/_alerts.html.erb
+++ b/app/views/provisioning_templates/_alerts.html.erb
@@ -1,3 +1,10 @@
 <% if @template.locked? -%>
   <%= locked_warning(::Template.find(params[:id])) %>
 <% end -%>
+
+<% if @template.errors.any? -%>
+<%= alert :header => _("Unable to save"),
+          :class  => 'alert-danger base in fade',
+          :text   => @template.errors.map { |e| ("<li>#{e.attribute}: #{e.message}</li>") }.join.html_safe
+-%>
+<% end -%>


### PR DESCRIPTION
Fix for two issues:
- Show errors in the UI for missing type and taxonomies
- Ignore taxonomies for snippets, unify it with behavior in UI

**TODO**
This must be done for report templates, job templates, etc. But first I'd like to get agreement on the approach before editing other areas and tests.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
