### PR TITLE
Fixes #37224 - Force Hosts to have a comment

### DIFF
--- a/db/migrate/20240305131306_enforce_not_null_host_comment.rb
+++ b/db/migrate/20240305131306_enforce_not_null_host_comment.rb
@@ -1,0 +1,8 @@
+class EnforceNotNullHostComment < ActiveRecord::Migration[6.1]
+  def up
+    ::Host.where(comment: nil).update(comment: '')
+
+    change_column_default :hosts, :comment, ''
+    change_column_null :hosts, :comment, false
+  end
+end


### PR DESCRIPTION
To prevent the nil -> empty string transition we would either have to:
- check the incoming changes and discard the unwanted ones
- ignore these transitions when creating audits
- just force hosts to always have a comment

The last option felt like the least wrong one. This has an added benefit that searching for hosts without comment becomes somewhat easier.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
