### PR TITLE
Refs #37179 - explicitly include SelectiveClone in facets 

### DIFF
--- a/app/models/concerns/facets/hostgroup_extensions.rb
+++ b/app/models/concerns/facets/hostgroup_extensions.rb
@@ -4,6 +4,7 @@ module Facets
   module HostgroupExtensions
     extend ActiveSupport::Concern
     include Facets::ModelExtensionsBase
+    include SelectiveClone
 
     included do
       configure_facet(:hostgroup, :hostgroup, :hostgroup_id) do |facet_config|

--- a/app/models/concerns/facets/managed_host_extensions.rb
+++ b/app/models/concerns/facets/managed_host_extensions.rb
@@ -4,6 +4,7 @@ module Facets
   module ManagedHostExtensions
     extend ActiveSupport::Concern
     include Facets::BaseHostExtensions
+    include SelectiveClone
 
     included do
       configure_facet(:host, :host, :host_id) do |facet_config|


### PR DESCRIPTION
That way plugins that try to use Hostgroup.include don't fail with

    undefined method `include_in_clone' for Hostgroup


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
