### PR TITLE
Refs #37224 - Force *all* Hosts to have a comment

### DIFF
--- a/db/migrate/20240305131306_enforce_not_null_host_comment.rb
+++ b/db/migrate/20240305131306_enforce_not_null_host_comment.rb
@@ -1,6 +1,6 @@
 class EnforceNotNullHostComment < ActiveRecord::Migration[6.1]
   def up
-    ::Host.where(comment: nil).update(comment: '')
+    ::Host::Base.where(comment: nil).update_all(comment: '')
 
     change_column_default :hosts, :comment, ''
     change_column_null :hosts, :comment, false


### PR DESCRIPTION
The previous implementation of the update had two issues:
1) It only operated on ::Host::Managed
2) It silently failed if the host was invalid for any other reason

Fixes 4c7f36edf2c6b78f4510108c9182d381817811ba

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
