### PR TITLE
Refs #37034 - Fix ERB syntax for comments

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -88,7 +88,7 @@ EOF
 elif [ -f /etc/debian_version ]; then
   <%= save_to_file('/etc/apt/sources.list.d/foreman_registration.list', @repo) %>
 <% if @repo_gpg_key_url.present? -%>
-<# "apt 1.2.35" on Ubuntu 16.04 does not support storing GPG public keys in "/etc/apt/trusted.gpg.d/" in ASCII format #>
+<%# "apt 1.2.35" on Ubuntu 16.04 does not support storing GPG public keys in "/etc/apt/trusted.gpg.d/" in ASCII format -%>
   if [ "$(. /etc/os-release ; echo "$VERSION_ID")" = "16.04" ]; then
     $PKG_MANAGER_INSTALL ca-certificates curl gnupg
     curl --silent --show-error <%= shell_escape @repo_gpg_key_url %> | gpg --dearmor > /etc/apt/trusted.gpg.d/client.gpg


### PR DESCRIPTION
:upside_down_face: 

The original idea was to only have the commend in ERB but hide it in the bash script because it's not really necessary for users. This fails when executed on Debian 12:

````
# on Debian 12
$ curl ... > register me
$ bash -x register_me

register_me: line 167: syntax error near unexpected token `newline'
register_me: line 167: `<# "apt 1.2.35" on Ubuntu 16.04 does not support storing GPG public keys in "/etc/apt/trusted.gpg.d/" in ASCII format #>'
````

Reproducer: Run "Register Host" for Debian 12 with a custom DEB repo and custom GPG key. Tested on Foreman 3.9.