### PR TITLE
Fixes #37247 - Refactor HostsIndex to map results directly

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/RowSelectTd.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/RowSelectTd.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Td } from '@patternfly/react-table';
+
+export const RowSelectTd = ({ rowData, selectOne, isSelected }) => (
+  <Td
+    select={{
+      rowIndex: rowData.id,
+      onSelect: (_event, isSelecting) => {
+        selectOne(isSelecting, rowData.id, rowData);
+      },
+      isSelected: isSelected(rowData.id),
+      disable: false,
+    }}
+  />
+);
+
+RowSelectTd.propTypes = {
+  rowData: PropTypes.object.isRequired,
+  selectOne: PropTypes.func.isRequired,
+  isSelected: PropTypes.func.isRequired,
+};

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
@@ -17,3 +17,17 @@ export const getPageStats = ({ total, page, perPage }) => {
     lastPage,
   };
 };
+
+/**
+ * Assembles column data into various forms needed
+ * @param {Object} columns - Object with column sort params as keys and column objects as values. Column objects must have a title key
+ * @returns {Array} - an array of column sort params and a map of keys to column names
+ */
+export const getColumnHelpers = columns => {
+  const columnNamesKeys = Object.keys(columns);
+  const keysToColumnNames = {};
+  columnNamesKeys.forEach(key => {
+    keysToColumnNames[key] = columns[key].title;
+  });
+  return [columnNamesKeys, keysToColumnNames];
+};


### PR DESCRIPTION
- In `HostsIndex/index.js`, previously we rendered a `<TableIndexPage />` with no children. Now, we render a `<TableIndexPage>` with an explicit `<Table>` child, which itself has children, and a `results?.map((result, rowIndex) => {`. This way you can see what is being rendered in the table in this single file, rather than having to look through 4 files.
- Add `children || ` to `<Table>` to enable the above. This should also allow you to use it "the old way" too, so HW models page, etc. won't break.
- Refactor `<HostsIndexPage>` and `<TableIndexPage>` to use the new hooks and helpers
- Extract `<RowSelectTd>` into its own file
- In `<HostsIndexPage>`, stop passing props down to `<TableIndexPage>` that are no longer used

Helpers added:
- `getColumnHelpers` - assembles column data into various forms needed

Hooks added (enables reuse of React state logic in multiple components):
- `useTableIndexAPIResponse` - encapsulates the `useAPI` logic 
- `useSetParamsAndApiAndSearch` - `setParamsAndApi` and `setSearch`

Documentation added and updated for various methods and components.