### PR TITLE
Fixes #37273 - Use delegation syntax for resource_scope

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ inherit_gem:
 
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  TargetRubyVersion: 2.7
+
 Bundler/OrderedGems:
   Enabled: false
 

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -70,8 +70,8 @@ module Api
     end
 
     # overwrites resource_scope in FindCommon to consider nested objects
-    def resource_scope(options = {})
-      super(options).merge(parent_scope).readonly(false)
+    def resource_scope(...)
+      super(...).merge(parent_scope).readonly(false)
     end
 
     def parent_scope
@@ -110,8 +110,8 @@ module Api
       resource_class.joins(association.name).merge(scope)
     end
 
-    def resource_scope_for_index(options = {})
-      scope = resource_scope(options).search_for(*search_options)
+    def resource_scope_for_index(...)
+      scope = resource_scope(...).search_for(*search_options)
       return scope if paginate_options[:per_page] == 'all'
       scope.paginate(**paginate_options)
     end

--- a/app/controllers/api/v2/auth_sources_controller.rb
+++ b/app/controllers/api/v2/auth_sources_controller.rb
@@ -14,7 +14,7 @@ module Api
         @auth_sources = resource_scope_for_index.except_hidden
       end
 
-      def resource_scope(*args)
+      def resource_scope(...)
         super.except_hidden
       end
 

--- a/app/controllers/api/v2/common_parameters_controller.rb
+++ b/app/controllers/api/v2/common_parameters_controller.rb
@@ -59,7 +59,7 @@ module Api
         'params'
       end
 
-      def resource_scope(*args, &block)
+      def resource_scope(...)
         super.where(:type => 'CommonParameter')
       end
 

--- a/app/controllers/api/v2/config_reports_controller.rb
+++ b/app/controllers/api/v2/config_reports_controller.rb
@@ -72,9 +72,9 @@ module Api
         params[:search] += " host = " + params[:host_id] if params[:host_id]
       end
 
-      def resource_scope(options = {})
+      def resource_scope(*args, **options)
         options[:permission] = :view_config_reports
-        super(options).my_reports
+        super(*args, **options).my_reports
       end
 
       def action_permission

--- a/app/controllers/api/v2/filters_controller.rb
+++ b/app/controllers/api/v2/filters_controller.rb
@@ -55,7 +55,7 @@ module Api
         process_response @filter.destroy
       end
 
-      def resource_scope(*args)
+      def resource_scope(...)
         resource_class.unscoped
       end
 

--- a/app/controllers/api/v2/host_statuses_controller.rb
+++ b/app/controllers/api/v2/host_statuses_controller.rb
@@ -12,7 +12,7 @@ module Api
 
       private
 
-      def resource_scope(*args, &block)
+      def resource_scope(...)
         HostStatusPresenter.all
       end
 

--- a/app/controllers/api/v2/instance_hosts_controller.rb
+++ b/app/controllers/api/v2/instance_hosts_controller.rb
@@ -7,7 +7,7 @@ module Api
         @resource_class ||= Host::Managed
       end
 
-      def resource_scope(*args)
+      def resource_scope(...)
         super.authorized(:view_hosts).joins(:infrastructure_facet).merge(::HostFacets::InfrastructureFacet.where(foreman_instance: true))
       end
 

--- a/app/controllers/api/v2/personal_access_tokens_controller.rb
+++ b/app/controllers/api/v2/personal_access_tokens_controller.rb
@@ -67,7 +67,7 @@ module Api
         end
       end
 
-      def resource_scope(*args)
+      def resource_scope(...)
         if editing_self?
           resource_class.where(user: @user).readonly(false)
         else

--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -57,7 +57,7 @@ module Api
         render_error :custom_error, :locals => { :message => e.bare_message }, :status => :unprocessable_entity
       end
 
-      def resource_scope(_options = {})
+      def resource_scope(...)
         Foreman.settings
       end
     end

--- a/app/controllers/api/v2/smart_proxy_hosts_controller.rb
+++ b/app/controllers/api/v2/smart_proxy_hosts_controller.rb
@@ -8,7 +8,7 @@ module Api
         @resource_class ||= Host::Managed
       end
 
-      def resource_scope(*args)
+      def resource_scope(...)
         resource_class.authorized(:view_hosts).joins(:infrastructure_facet).merge(::HostFacets::InfrastructureFacet.where(smart_proxy_id: @proxy.id))
       end
 

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -93,8 +93,8 @@ module Api::V2::TaxonomiesController
   end
 
   # overriding public FindCommon#resource_scope to scope only to user's taxonomies
-  def resource_scope(*args)
-    @resource_scope ||= scope_for(resource_class, args).send("my_#{taxonomies_plural}")
+  def resource_scope(*args, **kwargs)
+    @resource_scope ||= scope_for(resource_class, *args, **kwargs).send("my_#{taxonomies_plural}")
   end
 
   private

--- a/app/controllers/concerns/foreman/controller/bookmark_common.rb
+++ b/app/controllers/concerns/foreman/controller/bookmark_common.rb
@@ -3,7 +3,7 @@ module Foreman::Controller::BookmarkCommon
     Bookmark.my_bookmarks
   end
 
-  def resource_scope(*args)
+  def resource_scope(...)
     Bookmark.my_bookmarks
   end
 end

--- a/app/controllers/concerns/foreman/controller/taxonomies_controller.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomies_controller.rb
@@ -194,7 +194,7 @@ module Foreman::Controller::TaxonomiesController
     end
   end
 
-  def resource_scope
+  def resource_scope(...)
     taxonomy_class.send("my_#{taxonomies_plural}")
   end
 

--- a/app/controllers/concerns/foreman/controller/user_aware.rb
+++ b/app/controllers/concerns/foreman/controller/user_aware.rb
@@ -8,7 +8,7 @@ module Foreman::Controller::UserAware
 
   private
 
-  def resource_scope(*args, &block)
+  def resource_scope(...)
     super.where(:user => @user)
   end
 

--- a/app/controllers/concerns/foreman/controller/users_mixin.rb
+++ b/app/controllers/concerns/foreman/controller/users_mixin.rb
@@ -6,8 +6,8 @@ module Foreman::Controller::UsersMixin
     before_action :clear_session_locale_on_update, :only => :update
   end
 
-  def resource_scope(options = {})
-    super(options).except_hidden
+  def resource_scope(...)
+    super.except_hidden
   end
 
   protected

--- a/test/controllers/application_controller_subclass_test.rb
+++ b/test/controllers/application_controller_subclass_test.rb
@@ -212,7 +212,7 @@ class TestableResourcesControllerTest < ActionController::TestCase
       mock_scope = mock('mock_scope')
 
       auth_scope = mock('auth_scope')
-      auth_scope.stubs(:where).returns(mock_scope)
+      auth_scope.stubs(:all).returns(mock_scope)
 
       resource_class = mock('authorized_resource')
       resource_class.stubs(:authorized).returns(auth_scope)


### PR DESCRIPTION
In Ruby 3 you need to explicitly delegate keyword arguments, or if you don't care about Ruby 2.6 or prior then you can use the new delegation syntax (see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

It deals with the difference in calling where. When calling `.where([])` it returns an array while `.where(*[])` returns an instance of `WhereChain` which consumers of the method can't deal with. Because of that it calls `.all`.