### PR TITLE
Start Katello event daemon in Puma after a worker boots

### DIFF
--- a/bundler.d/service.rb
+++ b/bundler.d/service.rb
@@ -1,4 +1,4 @@
-gem 'puma', '>= 5.1', '< 7', groups: [:test, :service], require: false
+gem 'puma', '>= 6', '< 7', groups: [:test, :service], require: false
 group :service do
   # Puma has a soft dependency on this
   gem 'sd_notify', '~> 0.1.0'

--- a/config/puma/production.rb
+++ b/config/puma/production.rb
@@ -67,3 +67,17 @@ activate_control_app "unix://#{run_dir}/sockets/pumactl.sock"
 before_fork do
   Foreman::Gettext::Support.human_available_locales
 end
+
+on_worker_boot do
+  begin
+    require 'katello/middleware/event_daemon'
+  rescue LoadError
+    # No Katello
+  else
+    Katello::EventDaemon::Runner.start
+  end
+end
+
+on_worker_shutdown do
+  Katello::EventDaemon::Runner.stop if defined?(Katello::EventDaemon::Runner)
+end


### PR DESCRIPTION
Katello has an event daemon that listens to Candlepin events. Currently it abuses middleware to start a deamon thread, but that way the additional database connections end up consuming the connection thread pool intended for worker threads.

This aims to replace the abuse of middleware. It starts the worker in a Puma hook. This way it should use threads from the puma main thread instead of worker threads.

Currently this is an untested theory and this PR is used in a discussion.

There are some things to consider here.

First of all, the middleware is still in place. However, that checks if there's already an event daemon listening. If it would crash, the middleware will start in the classical way and cause the same problems. Implementing some sort of watchdog in Puma and removing the middleware is probably the best way forward.

Second, the current config is only for production but a proper patch will also deal with development.

Third, the hook only works for Puma clustered mode. In practice I don't know how many people set the number of workers to 0 but this approach makes it unsupported for Katello.

Lastly, it's not pretty to have Katello code in Foreman, but I don't see a cleaner way. It's so early in the boot process that we don't know about plugins yet.