### PR TITLE
Refs #37010 - Ensure dhcp4 and dhcp6 are booleans

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -14,8 +14,8 @@ oses:
 <%- else -%>
     <%= @interface.identifier %>:
 <%- end -%>
-        dhcp4: <%= @dhcp %>
-        dhcp6: <%= @dhcp6 %>
+        dhcp4: <%= @dhcp || false %>
+        dhcp6: <%= @dhcp6 || false %>
 <%-
 static_v4 = !@dhcp && !@subnet.nil? && !@interface.ip.nil?
 static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?

--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -35,7 +35,7 @@ oses:
                   :subnet => bond.subnet,
                   :subnet6 => bond.subnet6,
                   :dhcp => bond.subnet&.dhcp_boot_mode?,
-                  :dhcp6 => bond.subnet&.dhcp_boot_mode? }) -%>
+                  :dhcp6 => bond.subnet6&.dhcp_boot_mode? }) -%>
   <%= result -%>
         interfaces: <%= bond.attached_devices_identifiers %>
         parameters:
@@ -104,7 +104,7 @@ oses:
                   :interface => interface,
                   :subnet => interface.subnet,
                   :subnet6 => interface.subnet6,
-                  :dhcp => interface.subnet.dhcp_boot_mode?,
+                  :dhcp => interface.subnet&.dhcp_boot_mode?,
                   :dhcp6 => interface.subnet6&.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>

--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -34,8 +34,8 @@ oses:
                   :interface => bond,
                   :subnet => bond.subnet,
                   :subnet6 => bond.subnet6,
-                  :dhcp => bond.subnet.nil? ? false : bond.subnet.dhcp_boot_mode?,
-                  :dhcp6 => bond.subnet6.nil? ? false : bond.subnet6.dhcp_boot_mode? }) -%>
+                  :dhcp => bond.subnet&.dhcp_boot_mode?,
+                  :dhcp6 => bond.subnet&.dhcp_boot_mode? }) -%>
   <%= result -%>
         interfaces: <%= bond.attached_devices_identifiers %>
         parameters:
@@ -60,8 +60,8 @@ oses:
                   :interface => bridge,
                   :subnet => bridge.subnet,
                   :subnet6 => bridge.subnet6,
-                  :dhcp => bridge.subnet.nil? ? false : bridge.subnet.dhcp_boot_mode?,
-                  :dhcp6 => bridge.subnet6.nil? ? false : bridge.subnet6.dhcp_boot_mode? }) -%>
+                  :dhcp => bridge.subnet&.dhcp_boot_mode?,
+                  :dhcp6 => bridge.subnet6&.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>
 <%#
@@ -81,8 +81,8 @@ oses:
                   :interface => vlan,
                   :subnet => vlan.subnet,
                   :subnet6 => vlan.subnet6,
-                  :dhcp => vlan.subnet.nil? ? false : vlan.subnet.dhcp_boot_mode?,
-                  :dhcp6 => vlan.subnet6.nil? ? false : vlan.subnet6.dhcp_boot_mode? }) -%>
+                  :dhcp => vlan.subnet&.dhcp_boot_mode?,
+                  :dhcp6 => vlan.subnet6&.dhcp_boot_mode? }) -%>
   <%= result -%>
         id: <%= vlan.tag %>
         link: <%= vlan.attached_to %>
@@ -104,8 +104,8 @@ oses:
                   :interface => interface,
                   :subnet => interface.subnet,
                   :subnet6 => interface.subnet6,
-                  :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode?,
-                  :dhcp6 => interface.subnet6.nil? ? false : interface.subnet6.dhcp_boot_mode? }) -%>
+                  :dhcp => interface.subnet.dhcp_boot_mode?,
+                  :dhcp6 => interface.subnet6&.dhcp_boot_mode? }) -%>
   <%= result -%>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
This reverts 8c140b0a8326ea1ab9e0dedee288c77fa8140919 and applies an easier
fix. Due to the safemode operator the value may be nil. This ensures a boolean
value is present.