### PR TITLE
Fixes #37282 - Add the current_time macro

### DIFF
--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -59,6 +59,7 @@ module Foreman
         :shell_escape,
         :join_with_line_break,
         :current_date,
+        :current_time,
         :truthy?,
         :falsy?,
         :previous_revision,

--- a/app/services/foreman/renderer/scope/macros/helpers.rb
+++ b/app/services/foreman/renderer/scope/macros/helpers.rb
@@ -109,6 +109,15 @@ module Foreman
             Time.zone.today.strftime(format)
           end
 
+          apipie :method, 'Returns current time' do
+            keyword :format, String, desc: 'Format string to format time according to the directives in this string', default: '%T %z'
+            returns String
+            example '<%= current_time %> #=> "21:05:09 +0530"'
+          end
+          def current_time(format: '%T %z')
+            Time.zone.now.strftime(format)
+          end
+
           apipie :method, 'Checks whether a value is truthy or not' do
             optional :value, Object, desc: 'Value to check'
             returns one_of: [true, false], desc: 'Returns true if the value can be considered as truthy, false otherwise'


### PR DESCRIPTION
The [redmine 33907](https://projects.theforeman.org/issues/33907) introduced the current_date macro but end-users also need to print the time along with it for reporting purposes.

There should also be a current_time macro, which is this PR's end goal.

With that implementation now, in the report template, I can do this i.e. 

```
<%= current_date + ' ' + current_time + "\n" -%>
```

which will print something like this

```
2024-03-20 21:20:56 +0530
```