### PR TITLE
Fixes #37300 - Change I18n loading from import to require

### DIFF
--- a/webpack/assets/javascripts/react_app/common/I18n.js
+++ b/webpack/assets/javascripts/react_app/common/I18n.js
@@ -1,3 +1,5 @@
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
 import Jed from 'jed';
 import { addLocaleData } from 'react-intl';
 import forceSingleton from './forceSingleton';
@@ -14,19 +16,15 @@ class IntlLoader {
 
   async init() {
     await this.fetchIntl();
-    const localeData = await import(
-      /* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${this.locale}`
-    );
-    addLocaleData(localeData.default);
+    const localeData = require(/* webpackChunkName: 'react-intl/locale/[request]' */ `react-intl/locale-data/${this.locale}`);
+    addLocaleData(localeData);
     return true;
   }
 
-  async fetchIntl() {
+  fetchIntl() {
     if (this.fallbackIntl) {
-      global.Intl = await import(/* webpackChunkName: "intl" */ 'intl');
-      await import(
-        /* webpackChunkName: 'intl/locale/[request]' */ `intl/locale-data/jsonp/${this.locale}`
-      );
+      global.Intl = require(/* webpackChunkName: "intl" */ 'intl');
+      require(/* webpackChunkName: 'intl/locale/[request]' */ `intl/locale-data/jsonp/${this.locale}`);
     }
   }
 }
@@ -61,7 +59,7 @@ const mergeLocaleData = locale => {
     Object.entries(translations).forEach(([source, translated]) => {
       if (
         result[source] === undefined ||
-        (result[source] === [''] && translated !== [''])
+        (result[source]?.[0]?.length === 0 && !translated[0]?.length === 0)
       ) {
         result[source] = translated;
       }


### PR DESCRIPTION
To avoid this error when updating babel-presets in foreman-js
```
Uncaught (in promise) ChunkLoadError: Loading chunk react-intl/locale/en failed.
(error: http://localhost:3808/webpack/react-intl/locale/en.js)
    at __webpack_require__.f.j (jsonp chunk loading:27:1)
    at ensure chunk:6:1
    at Array.reduce (<anonymous>)
    at __webpack_require__.e (ensure chunk:5:1)
    at webpackAsyncContext ([request] namespace object:69:1)
    at IntlLoader._callee$ (I18n.js:17:30)
    at tryCatch (I18n.js:2:1)
    at Generator.<anonymous> (I18n.js:2:1)
    at Generator.next (I18n.js:2:1)
    at asyncGeneratorStep (I18n.js:2:1)
```

Trying to update babel presets again. 
Tested with theforeman 12.2.2 as that one has the updates that we had to revert.
Updating babel/presets caused dynamic imports to be in their own chunk, which caused them to not be loaded, using dynamic require does not create the access chunks.  