### PR TITLE
Fixes #37287 - Iterate on hashes when both key and value are used

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -302,10 +302,10 @@ module Api
     # e.g. /hosts/fqdn/reports # would add host = fqdn to the search bar
     def setup_search_options
       params[:search] ||= ""
-      params.keys.each do |param|
+      params.each do |param, value|
         if param =~ /(\w+)_id$/
-          if params[param].present?
-            query = " #{Regexp.last_match(1)} = #{params[param]}"
+          if value.present?
+            query = " #{Regexp.last_match(1)} = #{value}"
             params[:search] += query unless params[:search].include? query
           end
         end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -194,10 +194,10 @@ class ApplicationController < ActionController::Base
   def setup_search_options
     @original_search_parameter = params[:search]
     params[:search] ||= ""
-    params.keys.each do |param|
+    params.each do |param, value|
       if param =~ /(\w+)_id$/
-        if params[param].present?
-          query = "#{Regexp.last_match(1)} = #{params[param]}"
+        if value.present?
+          query = "#{Regexp.last_match(1)} = #{value}"
           unless params[:search].include? query
             params[:search] += ' and ' if params[:search].present?
             params[:search] += query

--- a/app/controllers/filters_controller.rb
+++ b/app/controllers/filters_controller.rb
@@ -66,15 +66,15 @@ class FiltersController < ApplicationController
   def setup_search_options
     @original_search_parameter = params[:search]
     params[:search] ||= ""
-    params.keys.each do |param|
+    params.each do |param, value|
       if param =~ /role_id$/
-        if (role = Role.find_by_id(params[param])).present?
+        if (role = Role.find_by_id(value)).present?
           query = "role_id = #{role.id}"
           params[:search] += query unless params[:search].include? query
         end
       elsif param =~ /(\w+)_id$/
-        if params[param].present?
-          query = "#{Regexp.last_match(1)} = #{params[param]}"
+        if value.present?
+          query = "#{Regexp.last_match(1)} = #{value}"
           params[:search] += query unless params[:search].include? query
         end
       end

--- a/app/views/common_parameters/_inherited_parameters.html.erb
+++ b/app/views/common_parameters/_inherited_parameters.html.erb
@@ -9,11 +9,8 @@
   </thead>
   <% if inherited_parameters.present? %>
     <tbody>
-      <% keys = inherited_parameters.keys.sort %>
-      <% keys.each do |name| %>
-        <% overriden = parameters.detect{|param| param.name == name}.present?
-           param_obj = inherited_parameters[name]
-        %>
+      <% inherited_parameters.sort.each do |name, param_obj| -%>
+        <% overriden = parameters.detect{|param| param.name == name}.present? -%>
         <tr class="<%="override-param" if overriden %>">
           <td class="ellipsis"><%= content_tag :span, name, :id => "name_#{name}"%>
           </td>

--- a/lib/tasks/exception.rake
+++ b/lib/tasks/exception.rake
@@ -18,8 +18,7 @@ namespace :exception do
       end
     end
 
-    result.keys.sort.each do |k|
-      v = result[k]
+    result.sort.each do |k, v|
       puts " * [[#{k}]] - #{v}"
     end
   end

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -379,7 +379,7 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
     end
 
     def stub_plan(opts = {})
-      opts.keys.each { |k| plan.send("#{k}=", opts[k]) }
+      opts.each { |k, v| plan.send("#{k}=", v) }
       @controller.expects(:load_dynflow_plan).with('JOBID').returns(plan)
     end
 

--- a/test/models/template_kind_test.rb
+++ b/test/models/template_kind_test.rb
@@ -20,8 +20,8 @@ class TemplateKindTest < ActiveSupport::TestCase
 
   test '#default_template_descriptions returns description of every template kind' do
     tmpl = TemplateKind.default_template_descriptions
-    tmpl.keys.each do |type|
-      assert_not_empty tmpl[type]
+    tmpl.each_value do |value|
+      assert_not_empty value
     end
   end
 end


### PR DESCRIPTION
This replaces the `hash.keys.each { |k| hash[k] }` and `hash.keys.sort` patterns with `hash.each { |k, v| }` where it makes sense. This avoids doing hash lookups when you already know the value anyway.