### PR TITLE
Fixes #37312 - Pin @redhat-cloud-services/frontend-components-utilities <= 4.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "prettier": "^1.19.1",
     "pretty-format": "26.6.2",
     "react-dnd-test-backend": "^9.4.0",
+    "@redhat-cloud-services/frontend-components-utilities": "<=4.0.7",
     "redux-mock-store": "^1.2.2",
     "sass": "~1.60.0",
     "sass-loader": "^13.3.2",


### PR DESCRIPTION
Pin @redhat-cloud-services/frontend-components-utilities@4.0.7

4.0.8 includes p-all (https://www.npmjs.com/package/@redhat-cloud-services/frontend-components-utilities?activeTab=dependencies) which require node16 which our projects are not using.

foreman-js pulls in the package as a dependency of @redhat-cloud-services/frontend-components which is pinned at 3.8.12 https://github.com/theforeman/foreman-js/blob/3c22a72326bd176f518e1297bdebc216b06545aa/packages/vendor-core/package.json#L34

However, @redhat-cloud-services/frontend-components uses @redhat-cloud-services/frontend-components-ulitilities >=3.0.0 which pulls in 4.0.8 breaking CI.
