### PR TITLE
Fixes #33749 - Add connectefi host parameter

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -33,8 +33,7 @@ insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
 echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "to the latest grub2 (*) and set pxegrub_connectefi_option host parameter to \"scsi\" "
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -43,7 +42,10 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
+<%=
+connectefi_option = @host && host_param('pxegrub_connectefi_option')
+"connectefi #{connectefi_option}" if connectefi_option
+-%>
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -8,8 +8,7 @@ insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
 echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "to the latest grub2 (*) and set pxegrub_connectefi_option host parameter to \"scsi\" "
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -18,7 +17,6 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -24,8 +24,7 @@ insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
 echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "to the latest grub2 (*) and set pxegrub_connectefi_option host parameter to \"scsi\" "
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -34,7 +33,6 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -4,8 +4,7 @@ insmod chain
 
 echo "VMWare hosts with QuickBoot feature enabled may not find the local ESP"
 echo "partition due to not initializing all the EFI devices. To workaround, upgrade"
-echo "to the latest grub2 (*) and uncomment "connectefi scsi" statement in the"
-echo "grub2_chainload template."
+echo "to the latest grub2 (*) and set pxegrub_connectefi_option host parameter to \"scsi\" "
 echo
 echo "Virtual or physical hosts using Software RAID for the ESP partition may try"
 echo "booting on the Software RAID, which will fail. To workaround, upgrade to the"
@@ -14,7 +13,6 @@ echo "the grub2_chainload template."
 echo
 echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
-#connectefi scsi
 
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"

--- a/test/unit/foreman/templates/snippets/pxegrub2_chainload_test.rb
+++ b/test/unit/foreman/templates/snippets/pxegrub2_chainload_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class PxeGrub2ChainloadTest < ActiveSupport::TestCase
+  def renderer
+    @renderer ||= Foreman::Renderer::SafeModeRenderer
+  end
+
+  def render_template(host)
+    @snippet ||= File.read(Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'pxegrub2_chainload.erb'))
+
+    source = OpenStruct.new(
+      name: 'Test',
+      content: @snippet
+    )
+
+    scope = Class.new(Foreman::Renderer::Scope::Provisioning).send(
+      :new,
+      host: host,
+      source: source,
+      variables: {
+        host: host,
+      })
+
+    renderer.render(source, scope)
+  end
+
+  setup do
+    @host = FactoryBot.create(:host, :managed, :build => true)
+  end
+
+  test 'should not render connectefi option by default' do
+    actual = render_template(@host)
+
+    assert_no_match(/^ *connectefi/, actual)
+  end
+
+  test 'should render connectefi option if parameter present' do
+    FactoryBot.create(:host_parameter, host: @host, name: 'pxegrub_connectefi_option', value: 'TESTOPT')
+
+    actual = render_template(@host)
+
+    assert_match(/^ *connectefi TESTOPT/, actual)
+  end
+end


### PR DESCRIPTION
Now you won't have to mess around with the template directly. You can set `pxegrub_connectefi_option` parameter to `scsi` to make sure SCSI controllers are used to search for chainloading.


