### PR TITLE
Fixes #37341 - catch exception if host parameter can not be rendered

### DIFF
--- a/app/models/host_status/configuration_status.rb
+++ b/app/models/host_status/configuration_status.rb
@@ -27,12 +27,15 @@ module HostStatus
 
     def reported_origin_interval
       if last_report.origin
-        if host.params.has_key? "#{last_report.origin.downcase}_interval"
-          interval = host.params["#{last_report.origin.downcase}_interval"]
-        else
-          interval = Setting[:"#{last_report.origin.downcase}_interval"]
+        interval = nil
+        begin
+          if host.params.has_key? "#{last_report.origin.downcase}_interval"
+            interval = host.params["#{last_report.origin.downcase}_interval"]
+          end
+        rescue NameError, Safemode::SecurityError, Safemode::NoMethodError => exception
+          Foreman::Logging.logger('app').error("A parameter (Global, Org, OS, Host...) for the host #{host} is used which can not be rendered: #{exception}.")
         end
-        interval
+        interval || Setting[:"#{last_report.origin.downcase}_interval"]
       end
     end
 


### PR DESCRIPTION
See https://projects.theforeman.org/issues/37341#note-1 for the reproducer
rescue blocks catches exception if safemode is 'on' and if 'off'

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
