### PR TITLE
Fixes #37344 - enable compression for webpack assets

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,6 +13,7 @@ var fs = require('fs');
 const { ModuleFederationPlugin } = require('webpack').container;
 var pluginUtils = require('../script/plugin_webpack_directories');
 var { generateExportsFile }= require('../webpack/assets/javascripts/exportAll');
+var CompressionPlugin = require('compression-webpack-plugin');
 
 class AddRuntimeRequirement {
   // to avoid "webpackRequire.l is not a function" error
@@ -137,6 +138,7 @@ const commonConfig = function() {
         supportedLanguagesRE
       ),
       new AddRuntimeRequirement(),
+      new CompressionPlugin(),
     ],
     stats: process.env.WEBPACK_STATS || 'normal',
   };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-eslint": "^10.0.0",
     "babel-loader": "^8.0.0",
     "buffer": "^5.7.1",
+    "compression-webpack-plugin": "^10.0.0",
     "cross-env": "^5.2.0",
     "css-loader": "^6.8.1",
     "dotenv": "^5.0.0",


### PR DESCRIPTION
Before:
```
Assets: 
  bundle.js (3.26 MiB)
```

After:
```
Assets: 
  bundle.js (3.26 MiB)
  bundle.js.gz (513 KiB)
```

→ the user now only has to download 1/6 of the data :)