### PR TITLE
Fixes #37345 - Improve "EFI local chainloading" on SecureBoot enabled hosts

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pxegrub2_chainload.erb
@@ -56,6 +56,18 @@ echo
   "connectefi #{connectefi_option}" if connectefi_option
 %>
 
+if [ "${lockdown}" == "y" ]; then
+  if [ "${default}" == "local" ]; then
+    set default="next_bootdevice"
+  fi
+
+  menuentry 'Booting from next boot device' --id next_bootdevice {
+    echo "SecureBoot is enabled, attempting next boot device..."
+    sleep 2
+    exit 1
+  }
+fi
+
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_default_local_boot.host4dhcp.snap.txt
@@ -26,6 +26,18 @@ echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
 connectefi scsi
 
+if [ "${lockdown}" == "y" ]; then
+  if [ "${default}" == "local" ]; then
+    set default="next_bootdevice"
+  fi
+
+  menuentry 'Booting from next boot device' --id next_bootdevice {
+    echo "SecureBoot is enabled, attempting next boot device..."
+    sleep 2
+    exit 1
+  }
+fi
+
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -42,6 +42,18 @@ echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
 connectefi scsi
 
+if [ "${lockdown}" == "y" ]; then
+  if [ "${default}" == "local" ]; then
+    set default="next_bootdevice"
+  fi
+
+  menuentry 'Booting from next boot device' --id next_bootdevice {
+    echo "SecureBoot is enabled, attempting next boot device..."
+    sleep 2
+    exit 1
+  }
+fi
+
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub2_chainload.host4dhcp.snap.txt
@@ -22,6 +22,18 @@ echo "(*) grub2-efi-x64-2.02-122.el8 (upstream doesn't have the patches yet)"
 echo
 connectefi scsi
 
+if [ "${lockdown}" == "y" ]; then
+  if [ "${default}" == "local" ]; then
+    set default="next_bootdevice"
+  fi
+
+  menuentry 'Booting from next boot device' --id next_bootdevice {
+    echo "SecureBoot is enabled, attempting next boot device..."
+    sleep 2
+    exit 1
+  }
+fi
+
 menuentry 'Chainload Grub2 EFI from ESP' --id local_chain_hd0 {
   echo "Chainloading Grub2 EFI from ESP, enabled devices for booting:"
   ls


### PR DESCRIPTION
Chainloading is not supported when SecureBoot is enabled [1].

Currently, this issue is tried to be tackled by changing the boot order during installation to boot from disk by default. But this disturbs the "always boot from network" workflow which might result in broken attempts for the user to re-provision a host (see
https://github.com/theforeman/foreman/pull/9123).

What we can do is to exit network booted GRUB2 with `exit 1` resulting in the boot of the next boot device, which is probably the boot file from disk.

The use of efibootmgr_netboot is still possible (if desired).  The proposed solution would also work when SecureBoot is disabled, however to avoid side effects I propose to only boot next device if SecureBoot is enabled (GRUB2 variable `lockdown=y` [2]).

[1]: https://www.gnu.org/software/grub/manual/grub/grub.html#UEFI-secure-boot-and-shim
[2]: https://www.gnu.org/software/grub/manual/grub/grub.html#Lockdown


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
