### PR TITLE
Fixes #37353 - always read cached webpack manifest

### DIFF
--- a/app/helpers/reactjs_helper.rb
+++ b/app/helpers/reactjs_helper.rb
@@ -26,20 +26,23 @@ module ReactjsHelper
   end
 
   def read_webpack_manifest
-    JSON.parse(Rails.root.join('public/webpack/manifest.json').read)
-  end
-
-  def get_webpack_foreman_vendor_js
-    Rails.cache.fetch('webpack_foreman_vendor_js', expires_in: 1.minute) do
-      data = read_webpack_manifest
-      foreman_vendor_js = data['assetsByChunkName']['foreman-vendor'].find { |value| value.end_with?('.js') }
-      javascript_include_tag("/webpack/#{foreman_vendor_js}")
+    Rails.cache.fetch('webpack_foreman_manifest', expires_in: 1.minute) do
+      JSON.parse(Rails.root.join('public/webpack/manifest.json').read)
     end
   end
 
-  def get_webpack_foreman_vendor_css
+  def get_webpack_chunk(name, extension)
     data = read_webpack_manifest
-    foreman_vendor_css = data['assetsByChunkName']['foreman-vendor'].find { |value| value.end_with?('.css') }
+    data['assetsByChunkName'][name].find { |value| value.end_with?(".#{extension}") }
+  end
+
+  def get_webpack_foreman_vendor_js
+    foreman_vendor_js = get_webpack_chunk('foreman-vendor', 'js')
+    javascript_include_tag("/webpack/#{foreman_vendor_js}")
+  end
+
+  def get_webpack_foreman_vendor_css
+    foreman_vendor_css = get_webpack_chunk('foreman-vendor', 'css')
     stylesheet_link_tag("/webpack/#{foreman_vendor_css}")
   end
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
