### PR TITLE
Fixes #35463 - Allow newer rdoc on Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'apipie-rails', '>= 0.8.0', '< 2'
 gem 'apipie-dsl', '>= 2.6.2'
 # Pin rdoc to prevent updating bundled psych (https://github.com/ruby/rdoc/commit/ebe185c8775b2afe844eb3da6fa78adaa79e29a4)
 # Rails 6.0 is incompatible with Psych 4, Rails 6.1 should work
-gem 'rdoc', '< 6.4'
+gem 'rdoc', RUBY_VERSION < '3.1' ? '< 6.4' : nil
 gem 'rabl', '>= 0.15.0', '< 1'
 gem 'oauth', '~> 1.0'
 gem 'deep_cloneable', '>= 3', '< 4'


### PR DESCRIPTION
Ruby 3.1 ships rdoc 6.1 by default.