### PR TITLE
Fixes #37385 - Drop (un)check_all_roles event handlers

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -328,21 +328,6 @@ function spinner_placeholder(text) {
   );
 }
 
-function typeToIcon(type) {
-  switch (type) {
-    case 'success':
-      return tfm.tools.iconText('ok', __('Success') + ': ', 'pficon');
-    case 'warning':
-      return tfm.tools.iconText(
-        'warning-triangle-o',
-        __('Warning') + ': ',
-        'pficon'
-      );
-    case 'danger':
-      return tfm.tools.iconText('error-circle-o', __('Error') + ': ', 'pficon');
-  }
-}
-
 function setPowerState(item, status) {
   var power_actions = $('#power_actions'),
     loading_power_state = $('#loading_power_state');

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -168,18 +168,6 @@ function add_fields(target, association, content, direction) {
   }
 }
 
-$(document).ready(function() {
-  $('#check_all_roles').click(function(e) {
-    e.preventDefault();
-    $('.role_checkbox').prop('checked', true);
-  });
-
-  $('#uncheck_all_roles').click(function(e) {
-    e.preventDefault();
-    $('.role_checkbox').prop('checked', false);
-  });
-});
-
 function toggleCheckboxesBySelector(selector) {
   boxes = $(selector);
   var all_checked = true;

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -181,16 +181,6 @@ function toggleCheckboxesBySelector(selector) {
   }
 }
 
-function toggleRowGroup(el) {
-  var tr = $(el).closest('tr');
-  var n = tr.next();
-  tr.toggleClass('open');
-  while (n.length > 0 && !n.hasClass('group')) {
-    n.toggle();
-    n = n.next();
-  }
-}
-
 function template_info(div, url) {
   // Ignore method as PUT redirects to host page if used on update
   form = $("form :input[name!='_method']").serialize();
@@ -350,24 +340,6 @@ function typeToIcon(type) {
       );
     case 'danger':
       return tfm.tools.iconText('error-circle-o', __('Error') + ': ', 'pficon');
-  }
-}
-
-function filter_permissions(item) {
-  var term = $(item)
-    .val()
-    .trim();
-  if (term.length > 0) {
-    $('.form-group .collapse')
-      .parents('.form-group')
-      .hide();
-    $(".form-group .control-label:icontains('" + term + "')")
-      .parents('.form-group')
-      .show();
-  } else {
-    $('.form-group .collapse')
-      .parents('.form-group')
-      .show();
   }
 }
 


### PR DESCRIPTION
In acfbc45886c4d81a2a3ca5af433a6124a0a7191a the links with these IDs were removed, but the JavaScript handler remained. I can't find other traces of its usage. Originally added in feacea35f07f362d9e2c694a83516bbc902321a0.

Fixes: acfbc45886c4 ("fixes #812 - new permissions model, user group role and nest support, role filters for better granularity")