### PR TITLE
Fixes #37390 - drop jquery-ui

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,3 @@
-@import 'jquery-ui/theme';
-@import 'jquery-ui/core';
-@import 'jquery-ui/menu';
-//we need to import all the above because we are using jquery-ui-rails and it uses sprockets require instaed of sass import.
 @import 'patternfly-sprockets';
 @import 'colors';
 @import 'patternfly';

--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -1,5 +1,4 @@
 group :assets do
-  gem 'jquery-ui-rails', '~> 6.0'
   gem 'patternfly-sass', '~> 3.59.4'
   gem 'gettext_i18n_rails_js', '~> 1.4'
   gem 'po_to_json', '~> 1.1'


### PR DESCRIPTION
Last use was in https://github.com/theforeman/foreman/commit/b55d3ed74669e8b0e6f5027df98da38f10cf0ed2
didnt find any other use for the jquery-ui js or css