### PR TITLE
Refactor smart_proxy factories and tests

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -25,8 +25,12 @@ class SmartProxy < ApplicationRecord
   has_many :infrastructure_host_facets, :class_name => '::HostFacets::InfrastructureFacet', :dependent => :nullify
   has_many :smart_proxy_hosts, :through => :infrastructure_host_facets, :source => :host
 
+  before_save :sanitize_url
+
   # There should be no problem with associating features before the proxy is saved as the whole operation is in a transaction
-  before_save :sanitize_url, :associate_features
+  # But it can be useful to skip in tests
+  attr_accessor :skip_associate_features
+  before_save :associate_features, unless: :skip_associate_features
 
   scoped_search :on => :id, :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
   scoped_search :on => :name, :complete_value => :true

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -1278,7 +1278,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
   end
 
   test "should update with puppet ca proxy" do
-    puppet_ca_proxy = FactoryBot.create(:puppet_ca_smart_proxy)
+    puppet_ca_proxy = FactoryBot.create(:smart_proxy, :puppetca)
     put :update, params: { :id => @host.id, :host => valid_attrs.merge(:puppet_ca_proxy_id => puppet_ca_proxy.id) }
     assert_response :success
     assert_equal puppet_ca_proxy['name'], JSON.parse(@response.body)['puppet_ca_proxy']['name'], "Can't update host with puppet ca proxy #{puppet_ca_proxy}"

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -2,16 +2,8 @@ FactoryBot.define do
   factory :feature do
     initialize_with { Feature.find_or_create_by(name: name) }
 
-    factory :templates do
-      name { 'Templates' }
-    end
-
-    factory :tftp_feature do
-      name { 'TFTP' }
-    end
-
     trait :tftp do
-      name { 'tftp' }
+      name { 'TFTP' }
     end
 
     trait :templates do

--- a/test/factories/host_related.rb
+++ b/test/factories/host_related.rb
@@ -258,7 +258,7 @@ FactoryBot.define do
 
     trait :with_ipv6 do
       subnet6 do
-        overrides = {:dns => FactoryBot.create(:dns_smart_proxy)}
+        overrides = {}
         # add taxonomy overrides in case it's set in the host object
         overrides[:locations] = [location] unless location.nil?
         overrides[:organizations] = [organization] unless organization.nil?
@@ -277,12 +277,12 @@ FactoryBot.define do
     trait :dualstack do
       with_ipv6
       subnet do
-        overrides = {:dns => FactoryBot.create(:dns_smart_proxy)}
+        overrides = {}
         # add taxonomy overrides in case it's set in the host object
         overrides[:locations] = [location] unless location.nil?
         overrides[:organizations] = [organization] unless organization.nil?
 
-        FactoryBot.create(:subnet_ipv4, overrides)
+        FactoryBot.create(:subnet_ipv4, :dns, overrides)
       end
       interfaces do
         [FactoryBot.build(:nic_managed,
@@ -348,16 +348,11 @@ FactoryBot.define do
       end
       domain
       subnet do
-        overrides = {
-          :dhcp => FactoryBot.create(:dhcp_smart_proxy),
-        }
+        overrides = {}
         # add taxonomy overrides in case it's set in the host object
         overrides[:locations] = [location] unless location.nil?
         overrides[:organizations] = [organization] unless organization.nil?
-        FactoryBot.create(
-          :subnet_ipv4_with_bmc,
-          overrides
-        )
+        association(:subnet_ipv4_with_bmc, :dhcp, **overrides)
       end
       interfaces do
         [FactoryBot.build(:nic_primary_and_provision, :ip => subnet.network.sub(/0\Z/, '1'))]
@@ -374,12 +369,12 @@ FactoryBot.define do
         FactoryBot.create(:libvirt_cr, taxonomies)
       end
       subnet do
-        overrides = {:dns => FactoryBot.create(:dns_smart_proxy)}
+        overrides = {}
         # add taxonomy overrides in case it's set in the host object
         overrides[:locations] = [location] unless location.nil?
         overrides[:organizations] = [organization] unless organization.nil?
 
-        FactoryBot.create(:subnet_ipv4, overrides)
+        FactoryBot.create(:subnet_ipv4, :dns, overrides)
       end
       domain do
         FactoryBot.create(:domain,
@@ -405,7 +400,7 @@ FactoryBot.define do
         FactoryBot.create(:libvirt_cr, taxonomies)
       end
       subnet6 do
-        overrides = {:dns => FactoryBot.create(:dns_smart_proxy)}
+        overrides = {}
         # add taxonomy overrides in case it's set in the host object
         overrides[:locations] = [location] unless location.nil?
         overrides[:organizations] = [organization] unless organization.nil?
@@ -453,7 +448,7 @@ FactoryBot.define do
     end
 
     trait :with_templates_subnet do
-      subnet { FactoryBot.build(:subnet_ipv4, :template, locations: [location], organizations: [organization]) }
+      subnet { FactoryBot.build(:subnet_ipv4, :templates, locations: [location], organizations: [organization]) }
     end
 
     trait :with_separate_provision_interface do

--- a/test/factories/realm.rb
+++ b/test/factories/realm.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :realm do
     sequence(:name) { |n| "EXAMPLE#{n}.COM" }
     realm_type { Realm::TYPES.first }
-    association :realm_proxy, :factory => :realm_smart_proxy
+    association :realm_proxy, :factory => [:smart_proxy, :realm]
   end
 end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -1,22 +1,30 @@
 FactoryBot.define do
+  proxy_features = [
+    :bmc,
+    :dhcp,
+    :dns,
+    :external_ipam,
+    :httpboot,
+    :puppetca,
+    :realm,
+    :templates,
+    :tftp,
+  ]
+
   factory :smart_proxy do
     sequence(:name) { |n| "proxy#{n}" }
     sequence(:url) { |n| "https://somewhere#{n}.net:8443" }
     organizations { [Organization.find_by_name('Organization 1')] }
     locations { [Location.find_by_name('Location 1')] }
 
-    before(:create, :build, :build_stubbed) do
-      default_features = {
-        "dhcp" => {
-          "capabilities" => ["dhcp_filename_hostname", "dhcp_filename_ipv4"],
-        },
-      }
-      result = Hash[Feature.name_map.keys.collect { |f| [f, {'state' => 'running'}.merge(default_features[f] || {})] }]
-      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(result)
+    transient do
+      skip_associate_features { true }
     end
 
-    after(:create) do |proxy|
-      proxy.reload unless proxy.new_record?
+    initialize_with do
+      obj = new
+      obj.skip_associate_features = skip_associate_features
+      obj
     end
 
     trait :ignore_validations do
@@ -25,93 +33,20 @@ FactoryBot.define do
       end
     end
 
-    factory :template_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :templates, :smart_proxy => smart_proxy)
-      end
-    end
-
-    factory :bmc_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :bmc, :smart_proxy => smart_proxy)
-      end
-    end
-
-    factory :dhcp_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :dhcp, :smart_proxy => smart_proxy, :capabilities => ["dhcp_filename_ipv4"])
-      end
-    end
-
-    factory :dns_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :dns, :smart_proxy => smart_proxy)
-      end
-    end
-
-    factory :ipam_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :external_ipam, :smart_proxy => smart_proxy)
-      end
-    end
-
-    factory :httpboot_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :httpboot, :smart_proxy => smart_proxy)
-      end
-    end
-
-    factory :puppet_ca_smart_proxy do
-      before(:create, :build, :build_stubbed) do
-        ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:puppetca => {'state' => 'running'})
-      end
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppetca, :smart_proxy => smart_proxy)
-      end
-    end
-
-    factory :realm_smart_proxy do
-      after(:build) do |smart_proxy, _evaluator|
-        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :realm, :smart_proxy => smart_proxy)
+    proxy_features.each do |feature|
+      trait feature do
+        smart_proxy_features do
+          [association(:smart_proxy_feature, feature, :smart_proxy => @instance)]
+        end
       end
     end
   end
 
   factory :smart_proxy_feature do
-    trait :templates do
-      association :feature, :templates
-    end
-
-    trait :tftp do
-      association :feature, :tftp
-    end
-
-    trait :dhcp do
-      association :feature, :dhcp
-    end
-
-    trait :dns do
-      association :feature, :dns
-    end
-
-    trait :realm do
-      association :feature, :realm
-    end
-
-    trait :puppetca do
-      association :feature, :puppetca
-    end
-
-    trait :bmc do
-      association :feature, :bmc
-    end
-
-    trait :external_ipam do
-      association :feature, :external_ipam
-    end
-
-    trait :httpboot do
-      association :feature, :httpboot
+    proxy_features.each do |feature|
+      trait feature do
+        association :feature, feature
+      end
     end
   end
 end

--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -15,28 +15,10 @@ FactoryBot.define do
       subnet.class.skip_callback(:validation, :after, :validate_against_external_ipam, raise: false)
     end
 
-    trait :tftp do
-      association :tftp, :factory => :template_smart_proxy
-    end
-
-    trait :httpboot do
-      association :httpboot, :factory => :template_smart_proxy
-    end
-
-    trait :dhcp do
-      association :dhcp, :factory => :dhcp_smart_proxy
-    end
-
-    trait :dns do
-      association :dns, :factory => :dns_smart_proxy
-    end
-
-    trait :bmc do
-      association :bmc, :factory => :bmc_smart_proxy
-    end
-
-    trait :template do
-      association :template, :factory => :template_smart_proxy
+    [:bmc, :dhcp, :dns, :httpboot, :templates, :tftp].each do |feature|
+      trait feature do
+        association feature, :factory => [:smart_proxy, feature]
+      end
     end
 
     trait :with_domains do
@@ -85,11 +67,11 @@ FactoryBot.define do
 
     trait :proxies_for_snapshots do
       # ability to build more than one smart proxies with the same url or name for snapshot testing
-      association :tftp, :ignore_validations, :factory => :template_smart_proxy, :name => "snapshot-proxy-tftp", :url => "http://localhost:8001"
-      association :httpboot, :ignore_validations, :factory => :template_smart_proxy, :name => "snapshot-proxy-httpboot", :url => "http://localhost:8002"
-      association :dhcp, :ignore_validations, :factory => :dhcp_smart_proxy, :name => "snapshot-proxy-dhcp", :url => "http://localhost:8003"
-      association :dns, :ignore_validations, :factory => :dns_smart_proxy, :name => "snapshot-proxy-dns", :url => "http://localhost:8004"
-      association :bmc, :ignore_validations, :factory => :bmc_smart_proxy, :name => "snapshot-proxy-bmc", :url => "http://localhost:8005"
+      association :tftp, :ignore_validations, :factory => [:smart_proxy, :tftp], :name => "snapshot-proxy-tftp", :url => "http://localhost:8001"
+      association :httpboot, :ignore_validations, :factory => [:smart_proxy, :httpboot], :name => "snapshot-proxy-httpboot", :url => "http://localhost:8002"
+      association :dhcp, :ignore_validations, :factory => [:smart_proxy, :dhcp], :name => "snapshot-proxy-dhcp", :url => "http://localhost:8003"
+      association :dns, :ignore_validations, :factory => [:smart_proxy, :dns], :name => "snapshot-proxy-dns", :url => "http://localhost:8004"
+      association :bmc, :ignore_validations, :factory => [:smart_proxy, :bmc], :name => "snapshot-proxy-bmc", :url => "http://localhost:8005"
     end
 
     factory :subnet_ipv4_dhcp_for_snapshots, :class => Subnet::Ipv4 do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -4,9 +4,8 @@ class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
 
   def test_generate_link_for
-    proxy = FactoryBot.create(:dhcp_smart_proxy)
-    subnet = FactoryBot.create(:subnet_ipv4, :name => 'My subnet')
-    proxy.subnets = [subnet]
+    subnet = FactoryBot.build_stubbed(:subnet_ipv4, :name => 'My subnet')
+    proxy = FactoryBot.build_stubbed(:smart_proxy, :dhcp, subnets: [subnet])
     links = generate_links_for(proxy.subnets)
     assert_equal(link_to(subnet.to_label, subnets_path(:search => "name = \"#{subnet.name}\"")), links)
   end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -337,7 +337,7 @@ class HostTest < ActiveSupport::TestCase
     assert_nil host.puppet_ca_server_uri
     assert_empty host.puppet_ca_server
 
-    proxy = FactoryBot.create(:puppet_ca_smart_proxy, url: 'https://smartproxy.example.com:8443')
+    proxy = FactoryBot.create(:smart_proxy, :puppetca, url: 'https://smartproxy.example.com:8443')
     host.puppet_ca_proxy = proxy
     assert_equal 'https://smartproxy.example.com:8140', host.puppet_ca_server_uri.to_s
     assert_equal 'smartproxy.example.com', host.puppet_ca_server

--- a/test/models/nics/bmc_test.rb
+++ b/test/models/nics/bmc_test.rb
@@ -76,7 +76,7 @@ class BMCTest < ActiveSupport::TestCase
     end
 
     test '#proxy instantiates ProxyAPI with password' do
-      @bmc_nic.expects(:bmc_proxy).returns(FactoryBot.create(:bmc_smart_proxy))
+      @bmc_nic.expects(:bmc_proxy).returns(FactoryBot.create(:smart_proxy, :bmc))
       ProxyAPI::BMC.expects(:new).with(has_entry(:password => 'secret'))
       @bmc_nic.proxy
     end

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -253,10 +253,9 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
     let(:tax_organization) { FactoryBot.create(:organization) }
     let(:tax_location) { FactoryBot.create(:location) }
     let(:subnet6) do
-      FactoryBot.build(:subnet_ipv6,
+      FactoryBot.build(:subnet_ipv6, :dns,
         :network => '2001:db8::',
         :mask => 'ffff:ffff:ffff:ffff::',
-        :dns => FactoryBot.create(:dns_smart_proxy),
         :organizations => [tax_organization],
         :locations => [tax_location],
         :ipam => IPAM::MODES[:eui64])

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -13,22 +13,19 @@ class SmartProxyTest < ActiveSupport::TestCase
   end
 
   context 'url validations' do
-    setup do
-      @proxy = FactoryBot.
-        build_stubbed(:smart_proxy, :url => 'https://secure.proxy:4568')
-    end
+    let(:proxy) { FactoryBot.build_stubbed(:smart_proxy, :url => 'https://secure.proxy:4568') }
 
     test "should be valid" do
-      assert_valid @proxy
+      assert_valid proxy
     end
 
     test "should not be modified if has no leading slashes" do
-      assert_equal @proxy.url, "https://secure.proxy:4568"
+      assert_equal proxy.url, "https://secure.proxy:4568"
     end
   end
 
   test "proxy should respond correctly to has_feature? method" do
-    proxy = FactoryBot.build(:template_smart_proxy)
+    proxy = FactoryBot.build(:smart_proxy, :templates)
     assert proxy.has_feature?('Templates')
     refute proxy.has_feature?('Puppet CA')
   end
@@ -43,26 +40,26 @@ class SmartProxyTest < ActiveSupport::TestCase
       ProxyAPI::V2::Features.any_instance.stubs(:features).raises(NotImplementedError.new('not supported'))
     end
 
+    let(:proxy) { FactoryBot.build(:smart_proxy, :skip_associate_features => false) }
+
     test "should not include trailing slash" do
       ProxyAPI::Features.any_instance.stubs(:features => Feature.name_map.keys)
-      @proxy = FactoryBot.build(:smart_proxy)
-      @proxy.url = 'http://some.proxy:4568/'
+      proxy = FactoryBot.build(:smart_proxy, :url => 'http://some.proxy:4568/')
 
       as_admin do
-        assert @proxy.save
+        assert proxy.save
       end
-      assert_equal @proxy.url, "http://some.proxy:4568"
+      assert_equal proxy.url, "http://some.proxy:4568"
     end
 
     test "should be saved if features exist" do
-      proxy = FactoryBot.build(:smart_proxy)
+      FactoryBot.create(:feature, :tftp)
       ProxyAPI::Features.any_instance.stubs(:features => ["tftp"])
       assert proxy.save
-      assert_include(proxy.reload.features, features(:tftp))
+      assert_include(proxy.features, features(:tftp))
     end
 
     test "should not be saved if features do not exist" do
-      proxy = SmartProxy.new(:name => 'Proxy', :url => 'https://some.where.net:8443')
       error_message = 'Features "feature" in this proxy are not recognized by Foreman. '\
       'If these features come from a Smart Proxy plugin, make sure Foreman has the plugin installed too.'
 
@@ -96,17 +93,19 @@ class SmartProxyTest < ActiveSupport::TestCase
   end
 
   describe "with v2 api" do
-    test "should be saved if features exist" do
-      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:tftp => {:settings => {}, :capabilities => [], :state => 'running'}, :puppet => {:state => 'not_running'})
-      proxy = FactoryBot.build(:smart_proxy)
+    let(:proxy) { FactoryBot.build(:smart_proxy, :skip_associate_features => false) }
 
+    test "should be saved if features exist" do
+      FactoryBot.create(:feature, :tftp)
+      FactoryBot.create(:feature, :puppetca)
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:tftp => {:settings => {}, :capabilities => [], :state => 'running'}, :puppet => {:state => 'not_running'})
       assert proxy.save
-      assert_include(proxy.reload.features, features(:tftp))
-      refute_includes(proxy.reload.features, features(:puppet))
+
+      assert_include(proxy.features, features(:tftp))
+      refute_includes(proxy.features, features(:puppetca))
     end
 
     test "should not be saved if features do not exist" do
-      proxy = SmartProxy.new(:name => 'Proxy', :url => 'https://some.where.net:8443')
       error_message = 'Features "feature" in this proxy are not recognized by Foreman. '\
       'If these features come from a Smart Proxy plugin, make sure Foreman has the plugin installed too.'
 
@@ -116,35 +115,30 @@ class SmartProxyTest < ActiveSupport::TestCase
     end
 
     test "can import and access capabilities and settings" do
+      FactoryBot.create(:feature, :tftp)
       ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:tftp => {:settings => {:foo => :bar}, :capabilities => ['FOO'], :state => 'running'})
-      proxy = FactoryBot.build(:smart_proxy)
-      proxy.save!
-      proxy.reload
+      assert proxy.save
 
       assert_include proxy.capabilities('TFTP'), 'FOO'
       assert_equal 'bar', proxy.setting('TFTP', 'foo')
     end
 
     test "can access httpboot_http_port exposed setting" do
+      FactoryBot.create(:feature, :httpboot)
       ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:httpboot => {:settings => {:http_port => 1234}, :state => 'running'})
-      proxy = FactoryBot.build(:httpboot_smart_proxy)
-      proxy.save!
-      proxy.reload
-
+      assert proxy.save
       assert_equal 1234, proxy.httpboot_http_port
     end
 
     test "can access httpboot_https_port exposed setting" do
+      FactoryBot.create(:feature, :httpboot)
       ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:httpboot => {:settings => {:https_port => 1234}, :state => 'running'})
-      proxy = FactoryBot.build(:httpboot_smart_proxy)
-      proxy.save!
-      proxy.reload
-
+      assert proxy.save
       assert_equal 1234, proxy.httpboot_https_port
     end
 
     describe '#ping' do
-      let(:proxy) { SmartProxy.new(name: 'Proxy', url: 'https://some.where.net:8443') }
+      let(:proxy) { FactoryBot.build(:smart_proxy) }
 
       test 'pings the smart proxy' do
         ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:tftp => {:settings => {}, :capabilities => []})

--- a/test/unit/foreman_url_renderer_test.rb
+++ b/test/unit/foreman_url_renderer_test.rb
@@ -64,7 +64,7 @@ class ForemanUrlRendererTest < ActiveSupport::TestCase
 
     test "should render template_url with templates proxy" do
       template_server_from_proxy = 'https://someproxy:8443'
-      proxy = FactoryBot.build_stubbed(:template_smart_proxy, :url => 'https://template.proxy:8443')
+      proxy = FactoryBot.build_stubbed(:smart_proxy, :templates, :url => 'https://template.proxy:8443')
 
       stub_request(:get, "https://template.proxy:8443/unattended/templateServer").
          to_return(status: 200, body: "{\"templateServer\":\"#{template_server_from_proxy}\"}")

--- a/test/unit/proxy_statuses/proxy_status_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ProxyStatusTest < ActiveSupport::TestCase
   setup do
     @proxy = FactoryBot.
-      build_stubbed(:template_smart_proxy, :url => 'https://secure.proxy:4568')
+      build_stubbed(:smart_proxy, :url => 'https://secure.proxy:4568')
   end
 
   test '#api returns new ProxyAPI object' do

--- a/test/unit/proxy_statuses/proxy_status_tftp_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_tftp_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ProxyStatusTftpTest < ActiveSupport::TestCase
   setup do
     @proxy = FactoryBot.
-      build_stubbed(:template_smart_proxy, :url => 'https://secure.proxy:4568')
+      build_stubbed(:smart_proxy, :tftp, :url => 'https://secure.proxy:4568')
   end
 
   test 'it returns tftp server ip' do

--- a/test/unit/proxy_statuses/proxy_status_versions_test.rb
+++ b/test/unit/proxy_statuses/proxy_status_versions_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ProxyStatusVersionsTest < ActiveSupport::TestCase
   setup do
     @proxy = FactoryBot.
-      build_stubbed(:template_smart_proxy, :url => 'https://secure.proxy:4568')
+      build_stubbed(:smart_proxy, :dns, :url => 'https://secure.proxy:4568')
     @expected_versions = {'version' => '1.11', 'modules' => {'dns' => '1.11'}}
     ProxyAPI::Version.any_instance.stubs(:proxy_versions).returns(@expected_versions)
   end

--- a/test/unit/validators/proxy_features_validator_test.rb
+++ b/test/unit/validators/proxy_features_validator_test.rb
@@ -12,12 +12,12 @@ class ProxyFeaturesValidatorTest < ActiveSupport::TestCase
   end
 
   test 'should pass when proxy feature is present' do
-    @validatable.proxy = FactoryBot.build(:dns_smart_proxy)
+    @validatable.proxy = FactoryBot.build(:smart_proxy, :dns)
     assert_valid @validatable
   end
 
   test 'should fail when proxy feature is not present' do
-    @validatable.proxy = FactoryBot.build(:dhcp_smart_proxy)
+    @validatable.proxy = FactoryBot.build(:smart_proxy, :dhcp)
     refute_valid @validatable
     assert_equal ['does not have the DNS feature'], @validatable.errors[:proxy_id]
   end


### PR DESCRIPTION
This makes the factories consistently use association, which works properly with build and create strategies. They're implemented as traits so can be mixed.

Because they're now consistent, it can use loops to define all features.

Currently a draft because I only did limited testing. If this works well, other factories should be cleaned up in a similar way. They can be made a lot shorter and more powerful. With association you can also use build_stubbed in more places, so eventually we can speed up more tests to avoid database interactions.