### PR TITLE
Fixes #37395 - New Hosts page perform build actions

### DIFF
--- a/app/registries/foreman/access_permissions.rb
+++ b/app/registries/foreman/access_permissions.rb
@@ -273,6 +273,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :"api/v2/hosts" => [:update, :disassociate, :forget_status],
                                     :"api/v2/interfaces" => [:create, :update, :destroy],
                                     :"api/v2/compute_resources" => [:associate],
+                                    :"api/v2/hosts_bulk_actions" => [:build],
                                   }
     map.permission :destroy_hosts, {:hosts => [:destroy, :multiple_actions, :reset_multiple, :multiple_destroy, :submit_multiple_destroy],
                                     :"api/v2/hosts" => [:destroy],

--- a/app/services/bulk_hosts_manager.rb
+++ b/app/services/bulk_hosts_manager.rb
@@ -1,0 +1,34 @@
+class BulkHostsManager
+  def initialize(hosts:)
+    @hosts = hosts
+  end
+
+  def build(reboot: false)
+    # returns missed hosts
+    @hosts.select do |host|
+      success = true
+      begin
+        host.built(false) if host.build? && host.token_expired?
+        host.setBuild
+        host.power.reset if reboot && host.supports_power_and_running?
+      rescue => error
+        Foreman::Logging.exception("Failed to redeploy #{host}.", error)
+        success = false
+      end
+      !success
+    end
+  end
+
+  def rebuild_configuration
+    # returns a hash with a key/value configuration
+    all_fails = {}
+    @hosts.each do |host|
+      result = host.recreate_config
+      result.each_pair do |k, v|
+        all_fails[k] ||= []
+        all_fails[k] << host unless v
+      end
+    end
+    all_fails
+  end
+end

--- a/app/views/api/v2/errors/bulk_hosts_error.json.rabl
+++ b/app/views/api/v2/errors/bulk_hosts_error.json.rabl
@@ -1,0 +1,7 @@
+node :message do
+  locals[:message]
+end
+
+node :failed_host_ids do
+  locals[:failed_host_ids]
+end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -4,6 +4,7 @@ Foreman::Application.routes.draw do
     # new v2 routes that point to v2
     scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       match 'hosts/bulk', :to => 'hosts_bulk_actions#bulk_destroy', :via => [:delete]
+      match 'hosts/bulk/build', :to => 'hosts_bulk_actions#build', :via => [:put]
 
       resources :architectures, :except => [:new, :edit] do
         constraints(:id => /[^\/]+/) do

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/BulkBuildHostModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/BulkBuildHostModal.js
@@ -1,0 +1,168 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+import {
+  Modal,
+  Button,
+  TextContent,
+  Text,
+  Checkbox,
+  Radio,
+} from '@patternfly/react-core';
+import { addToast } from '../../../ToastsList/slice';
+import { translate as __ } from '../../../../common/I18n';
+import { failedHostsToastParams } from '../helpers';
+import { STATUS } from '../../../../constants';
+import { selectAPIStatus } from '../../../../redux/API/APISelectors';
+import { bulkBuildHosts, HOST_BUILD_KEY } from './actions';
+
+const BulkBuildHostModal = ({
+  isOpen,
+  closeModal,
+  selectedCount,
+  orgId,
+  fetchBulkParams,
+}) => {
+  const dispatch = useDispatch();
+  const [buildRadioChecked, setBuildRadioChecked] = useState(true);
+  const [rebootChecked, setRebootChecked] = useState(false);
+  const hostUpdateStatus = useSelector(state =>
+    selectAPIStatus(state, HOST_BUILD_KEY)
+  );
+  const handleModalClose = () => {
+    setRebootChecked(false);
+    setBuildRadioChecked(true);
+    closeModal();
+  };
+
+  const handleError = ({ response }) => {
+    handleModalClose();
+    dispatch(
+      addToast(
+        failedHostsToastParams({ ...response.data.error, key: HOST_BUILD_KEY })
+      )
+    );
+  };
+  const handleSave = () => {
+    const requestBody = {
+      included: {
+        search: fetchBulkParams(),
+      },
+      reboot: rebootChecked,
+      rebuild_configuration: !buildRadioChecked,
+    };
+
+    dispatch(bulkBuildHosts(requestBody, handleModalClose, handleError));
+  };
+
+  const handleBuildRadioSelected = selected => {
+    setBuildRadioChecked(selected);
+    if (!selected) {
+      setRebootChecked(false);
+    }
+  };
+  const modalActions = [
+    <Button
+      key="add"
+      ouiaId="bulk-build-hosts-modal-add-button"
+      variant="primary"
+      onClick={handleSave}
+      isDisabled={hostUpdateStatus === STATUS.PENDING}
+      isLoading={hostUpdateStatus === STATUS.PENDING}
+    >
+      {__('Confirm')}
+    </Button>,
+    <Button
+      key="cancel"
+      ouiaId="bulk-build-hosts-modal-cancel-button"
+      variant="link"
+      onClick={handleModalClose}
+    >
+      Cancel
+    </Button>,
+  ];
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleModalClose}
+      onEscapePress={handleModalClose}
+      title={__('Build management')}
+      width="50%"
+      position="top"
+      actions={modalActions}
+      id="bulk-build-hosts-modal"
+      key="bulk-build-hosts-modal"
+      ouiaId="bulk-build-hosts-modal"
+    >
+      <TextContent>
+        <Text ouiaId="bulk-set-build-options">
+          <FormattedMessage
+            defaultMessage={__(
+              'Choose an action that will be performed on {hosts}.'
+            )}
+            values={{
+              hosts: (
+                <strong>
+                  <FormattedMessage
+                    defaultMessage="{count, plural, one {# {singular}} other {# {plural}}}"
+                    values={{
+                      count: selectedCount,
+                      singular: __('selected host'),
+                      plural: __('selected hosts'),
+                    }}
+                    id="ccs-options-i18n"
+                  />
+                </strong>
+              ),
+            }}
+            id="bulk-build-host-description"
+          />
+        </Text>
+      </TextContent>
+      <hr />
+      <Radio
+        isChecked={buildRadioChecked}
+        name="buildHostRadioGroup"
+        onChange={checked => handleBuildRadioSelected(checked)}
+        label={__('Build')}
+        id="build-host-radio"
+        ouiaId="build-host-radio"
+        body={
+          <Checkbox
+            label={__('Reboot now')}
+            id="reboot-now-checkbox-id"
+            name="reboot-now"
+            isChecked={rebootChecked}
+            isDisabled={!buildRadioChecked}
+            onChange={setRebootChecked}
+            ouiaId="build-reboot-checkbox"
+          />
+        }
+      />
+      <hr />
+      <Radio
+        name="buildHostRadioGroup"
+        onChange={checked => handleBuildRadioSelected(!checked)}
+        label={__('Rebuild provisioning configuration only')}
+        id="rebuild-host-radio"
+        ouiaId="rebuild-host-radio"
+      />
+    </Modal>
+  );
+};
+
+BulkBuildHostModal.propTypes = {
+  isOpen: PropTypes.bool,
+  closeModal: PropTypes.func,
+  selectedCount: PropTypes.number.isRequired,
+  fetchBulkParams: PropTypes.func.isRequired,
+  orgId: PropTypes.number.isRequired,
+};
+
+BulkBuildHostModal.defaultProps = {
+  isOpen: false,
+  closeModal: () => {},
+};
+
+export default BulkBuildHostModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/actions.js
@@ -1,0 +1,17 @@
+import { APIActions } from '../../../../redux/API';
+import { foremanUrl } from '../../../../common/helpers';
+
+export const HOST_BUILD_KEY = 'HOST_BUILD_KEY';
+export const bulkBuildHosts = (params, handleSuccess, handleError) => {
+  const url = foremanUrl(`/api/v2/hosts/bulk/build`);
+  return APIActions.put({
+    key: HOST_BUILD_KEY,
+    url,
+    successToast: response => response.data.message,
+    handleSuccess,
+    handleError,
+    params,
+  });
+};
+
+export default bulkBuildHosts;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/index.js
@@ -1,0 +1,27 @@
+import React, { useContext } from 'react';
+import { ForemanActionsBarContext } from '../../../../components/HostDetails/ActionsBar';
+import { useForemanModal } from '../../../../components/ForemanModal/ForemanModalHooks';
+import { useForemanOrganization } from '../../../../Root/Context/ForemanContext';
+import BulkBuildHostModal from './BulkBuildHostModal';
+
+const BulkBuildHostModalScene = () => {
+  const { selectedCount, fetchBulkParams } = useContext(
+    ForemanActionsBarContext
+  );
+  const { modalOpen, setModalClosed } = useForemanModal({
+    id: 'bulk-build-hosts-modal',
+  });
+  const org = useForemanOrganization();
+  return (
+    <BulkBuildHostModal
+      key="bulk-build-hosts-modal"
+      selectedCount={selectedCount}
+      fetchBulkParams={fetchBulkParams}
+      isOpen={modalOpen}
+      closeModal={setModalClosed}
+      orgId={org?.id}
+    />
+  );
+};
+
+export default BulkBuildHostModalScene;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/helpers.js
@@ -1,0 +1,32 @@
+import { actionTypeGenerator } from '../../../redux/API/APIActionTypeGenerator';
+import { translate as __ } from '../../../common/I18n';
+import { urlWithSearch } from '../../../common/urlHelpers';
+import { foremanUrl } from '../../../common/helpers';
+
+export const searchLink = ({ query, message, baseUrl }) => ({
+  children: message,
+  href: urlWithSearch(baseUrl, query),
+});
+
+export const failedHostsToastParams = ({
+  message,
+  failed_host_ids: failedHostIds,
+  key,
+}) => {
+  const { FAILURE } = actionTypeGenerator(key);
+  const toastParams = {
+    type: 'danger',
+    message,
+    key: FAILURE,
+  };
+  if (failedHostIds) {
+    const query = `id ^ (${failedHostIds.join(',')})`;
+    toastParams.link = searchLink({
+      query,
+      message: __('Failed hosts'),
+      baseUrl: foremanUrl('new/hosts'),
+    });
+  }
+
+  return toastParams;
+};

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-import React, { createContext, useState } from 'react';
+import React, { createContext, useState, useEffect } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { Tr, Td, ActionsColumn } from '@patternfly/react-table';
 import {
@@ -14,6 +14,8 @@ import {
   SplitItem,
 } from '@patternfly/react-core';
 import { UndoIcon } from '@patternfly/react-icons';
+import { useForemanModal } from '../ForemanModal/ForemanModalHooks';
+import { addModal } from '../ForemanModal/ForemanModalActions';
 import { Table } from '../PF4/TableIndexPage/Table/Table';
 import { translate as __ } from '../../common/I18n';
 import TableIndexPage from '../PF4/TableIndexPage/TableIndexPage';
@@ -33,6 +35,7 @@ import {
 import { deleteHost } from '../HostDetails/ActionsBar/actions';
 import { useForemanSettings } from '../../Root/Context/ForemanContext';
 import { bulkDeleteHosts } from './BulkActions/bulkDelete';
+import BulkBuildHostModal from './BulkActions/buildHosts';
 import { foremanUrl } from '../../common/helpers';
 import Slot from '../common/Slot';
 import forceSingleton from '../../common/forceSingleton';
@@ -167,6 +170,16 @@ const HostsIndex = () => {
     );
   };
 
+  useEffect(() => {
+    dispatch(
+      addModal({
+        id: 'bulk-build-hosts-modal',
+      })
+    );
+  }, [dispatch]);
+
+  const { setModalOpen } = useForemanModal({ id: 'bulk-build-hosts-modal' });
+
   const dropdownItems = [
     <DropdownItem
       ouiaId="delete=hosts-dropdown-item"
@@ -175,6 +188,14 @@ const HostsIndex = () => {
       isDisabled={selectedCount === 0}
     >
       {__('Delete')}
+    </DropdownItem>,
+    <DropdownItem
+      ouiaId="build-hosts-dropdown-item"
+      key="build-hosts-dropdown-item"
+      onClick={setModalOpen}
+      isDisabled={selectedCount === 0}
+    >
+      {__('Build management')}
     </DropdownItem>,
   ];
 
@@ -332,6 +353,7 @@ const HostsIndex = () => {
       <ForemanActionsBarContext.Provider
         value={{ selectedCount, fetchBulkParams }}
       >
+        <BulkBuildHostModal key="bulk-build-hosts-modal" />
         <Slot id="_all-hosts-modals" multi />
       </ForemanActionsBarContext.Provider>
     </TableIndexPage>


### PR DESCRIPTION
Added build actions to work with the new hosts page.

![image](https://github.com/theforeman/foreman/assets/1069779/5aa0cf2a-9456-4515-9692-f0a690ad6d8c)


Steps to verify
1. Have a foreman with multiple hosts
2. Check out this PR
3. go to http://<url>/new/hosts
4. Select 1 host and choose `Build Hosts` from the kebab 
5. Play with different options

