### PR TITLE
Fixes #37409 - invalid netplan config in preseed Autoinstall

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -14,8 +14,8 @@ oses:
 <%- else -%>
     <%= @interface.identifier %>:
 <%- end -%>
-        dhcp4: <%= @dhcp %>
-        dhcp6: <%= @dhcp6 %>
+        dhcp4: <%= @dhcp.present? %>
+        dhcp6: <%= @dhcp6.present? %>
 <%-
 static_v4 = !@dhcp && !@subnet.nil? && !@interface.ip.nil?
 static_v6 = !@dhcp6 && !@subnet6.nil? && !@interface.ip6.nil?


### PR DESCRIPTION
preseed_netplan_generic_interface currently generates 'dhcp6: '
instead of 'dhcp6: false' when @dhcp6 is nil