### PR TITLE
Fixes #37421 - foreman_bootdisk templates not seeded

### DIFF
--- a/app/views/unattended/provisioning_templates/bootdisk/generic_efi_host.erb
+++ b/app/views/unattended/provisioning_templates/bootdisk/generic_efi_host.erb
@@ -7,7 +7,7 @@ description: |
   Boot disk Grub2 EFI - generic host
 require:
 - plugin: foreman_bootdisk
-￼ version: 20.0.0
+  version: 20.0.0
 -%>
 #
 # Boot disk Grub2 EFI - generic host

--- a/app/views/unattended/provisioning_templates/bootdisk/generic_host.erb
+++ b/app/views/unattended/provisioning_templates/bootdisk/generic_host.erb
@@ -5,15 +5,13 @@ model: ProvisioningTemplate
 kind: Bootdisk
 description: |
   Example foreman_bootdisk generic host template
- 
   This template is generic, but it will chainload to Foreman so expects the
   host to be registered already.
- 
   It loops through all interfaces using DHCP, requesting a template from
   Foreman in the hope that one of the MACs or IPs matches.
 require:
 - plugin: foreman_bootdisk
-￼ version: 20.0.0
+  version: 20.0.0
 -%>
 #!ipxe
 

--- a/app/views/unattended/provisioning_templates/bootdisk/generic_static_host.erb
+++ b/app/views/unattended/provisioning_templates/bootdisk/generic_static_host.erb
@@ -8,7 +8,7 @@ description: |
   must be disabled in order to access templates via MAC addresses.
 require:
 - plugin: foreman_bootdisk
-￼ version: 20.0.0
+  version: 20.0.0
 -%>
 #!ipxe
 

--- a/app/views/unattended/provisioning_templates/bootdisk/host.erb
+++ b/app/views/unattended/provisioning_templates/bootdisk/host.erb
@@ -8,7 +8,7 @@ description: |
   This template is rendered for use inside a host-specific boot disk.
 require:
 - plugin: foreman_bootdisk
-￼ version: 20.0.0
+  version: 20.0.0
 -%>
 #!ipxe
 


### PR DESCRIPTION
Remove some strange characters at the beginning of the version line, which were blocking the seed of the templates.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
