### PR TITLE
Fixes #37422 - Switch to method definition in template generators

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -114,7 +114,7 @@ module Foreman
         name: 'snapshot-ipv4-dhcp-el7',
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         interfaces: [ipv4_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
@@ -123,7 +123,7 @@ module Foreman
         name: 'snapshot-ipv4-static-el7',
         subnet: FactoryBot.build(:subnet_ipv4_static_for_snapshots),
         interfaces: [ipv4_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
@@ -132,7 +132,7 @@ module Foreman
         name: 'snapshot-ipv6-dhcp-el7',
         subnet: FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots),
         interfaces: [ipv6_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
@@ -141,7 +141,7 @@ module Foreman
         name: 'snapshot-ipv6-static-el7',
         subnet: FactoryBot.build(:subnet_ipv6_static_for_snapshots),
         interfaces: [ipv6_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
@@ -151,7 +151,7 @@ module Foreman
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         subnet6: FactoryBot.build(:subnet_ipv6_dhcp_for_snapshots),
         interfaces: [ipv46_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
@@ -160,7 +160,7 @@ module Foreman
         name: 'snapshot-ipv4-dhcp-deb10',
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         interfaces: [ipv4_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 
@@ -185,7 +185,7 @@ module Foreman
         name: 'snapshot-ipv4-dhcp-rhel9',
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         interfaces: [ipv4_interface])
-      host.stubs(:managed_interfaces).returns(host.interfaces)
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 


### PR DESCRIPTION
Mocha cannot be used in rake tasks like `rake snapshots:generate`


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
