### PR TITLE
Fixes #37434 - Use nightly for develop manual links

### DIFF
--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -53,17 +53,20 @@ class LinksController < ApplicationController
     "https://theforeman.org/#{sub_path}"
   end
 
+  def documentation_version
+    SETTINGS[:version].tag == 'develop' ? 'nightly' : SETTINGS[:version].short
+  end
+
   def documentation_url(section = "", options = {})
-    root_url = options[:root_url] || foreman_org_path("manuals/#{SETTINGS[:version].short}/index.html#")
+    root_url = options[:root_url] || foreman_org_path("manuals/#{documentation_version}/index.html#")
     root_url + (section || '')
   end
 
   # For new documentation at docs.theforeman.org
   def docs_url(guide:, flavor:, chapter: nil)
-    version = SETTINGS[:version].tag == 'develop' ? 'nightly' : SETTINGS[:version].short
     chapter_hash = "##{chapter}" if chapter
 
-    "https://docs.theforeman.org/#{version}/#{guide}/index-#{flavor}.html#{chapter_hash}"
+    "https://docs.theforeman.org/#{documentation_version}/#{guide}/index-#{flavor}.html#{chapter_hash}"
   end
 
   def plugin_documentation_url

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -2,17 +2,28 @@ require 'test_helper'
 
 class LinksControllerTest < ActionController::TestCase
   describe 'documentation' do
-    test '#documentation_url returns global url if no section specified' do
-      get :show, params: { type: 'manual' }
+    test '#documentation_url returns global url if no section specified on develop' do
+      with_temporary_settings(version: Foreman::Version.new('3.10-develop')) do
+        get :show, params: { type: 'manual' }
 
-      assert_redirected_to /index.html/
+        assert_redirected_to 'https://theforeman.org/manuals/nightly/index.html#'
+      end
+    end
+
+    test '#documentation_url returns global url if no section specified on stable' do
+      with_temporary_settings(version: Foreman::Version.new('3.9.1')) do
+        get :show, params: { type: 'manual' }
+
+        assert_redirected_to 'https://theforeman.org/manuals/3.9/index.html#'
+      end
     end
 
     test '#documentation_url returns foreman docs url with a given section' do
-      get :show, params: { type: 'manual', section: '1.1TestSection' }
+      with_temporary_settings(version: Foreman::Version.new('3.10-develop')) do
+        get :show, params: { type: 'manual', section: '1.1TestSection' }
 
-      assert_redirected_to /TestSection/
-      assert_redirected_to /manuals/
+        assert_redirected_to 'https://theforeman.org/manuals/nightly/index.html#1.1TestSection'
+      end
     end
 
     test '#documentation_url receives a root_url option' do


### PR DESCRIPTION
Foreman has for the longest time had `https://theforeman.org/manuals/$next` redirect to `https://theforeman.org/manuals/nightly` in our Apache configuration. This means that on every branching we need to modify this. It also doesn't play well with caching and using pure static webservers.

If Foreman uses nightly as the version, this whole redirect is no longer needed.