### PR TITLE
Fixes #36847 - Use initrd variable for Debian ipxe

### DIFF
--- a/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/autoyast_default_ipxe.erb
@@ -24,15 +24,11 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
-<% kernel = boot_files_uris[0] -%>
-<% initrd = boot_files_uris[1] -%>
-
 <% subnet = @host.subnet -%>
 <% if subnet.respond_to?(:dhcp_boot_mode?) && subnet.dhcp_boot_mode? -%>
-kernel <%= kernel %> initrd=initrd.img splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1 <%= extra_args.join(' ')%>
+kernel <%= @kernel_uri %> initrd=<%= @initrd_uri.split('/').last %> splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=1 <%= extra_args.join(' ')%>
 <% else -%>
-kernel <%= kernel %> initrd=initrd.img splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=0 netsetup=-dhcp ifcfg=*="${netX/ip}/<%= @host.primary_interface.subnet.cidr -%>,${netX/gateway},${dns},<%= @host.domain %>" <%= extra_args.join(' ')%>
+kernel <%= @kernel_uri %> initrd=<%= @initrd_uri.split('/').last %> splash=silent install=<%= medium_uri %> autoyast=<%= foreman_url('provision') %> text-mode=1 useDHCP=0 netsetup=-dhcp ifcfg=*="${netX/ip}/<%= @host.primary_interface.subnet.cidr -%>,${netX/gateway},${dns},<%= @host.domain %>" <%= extra_args.join(' ')%>
 <% end -%>
-initrd <%= initrd %>
+initrd <%= @initrd_uri %>
 boot

--- a/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/kickstart_default_ipxe.erb
@@ -27,8 +27,8 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-kernel <%= "#{@host.url_for_boot(:kernel)}" %> initrd=initrd.img <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
-initrd <%= "#{@host.url_for_boot(:initrd)}" %>
+kernel <%= @kernel_uri %> initrd=<%= @initrd_uri.split('/').last %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options", variables: {ipxe_net: true}).strip %>
+initrd <%= @initrd_uri %>
 imgstat
 sleep 2
 boot

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe.erb
@@ -32,13 +32,9 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
-<% kernel = boot_files_uris[0] -%>
-<% initrd = boot_files_uris[1] -%>
+kernel <%= @kernel_uri %> initrd=<%= @initrd_uri.split('/').last %> interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options", variables: {ipxe_net: true}).strip %>
 
-kernel <%= kernel %> initrd=initrd.img interface=auto url=<%= url %> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options", variables: {ipxe_net: true}).strip %>
-
-initrd <%= initrd %>
+initrd <%= @initrd_uri %>
 
 imgstat
 sleep 2

--- a/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/iPXE/preseed_default_ipxe_autoinstall.erb
@@ -26,13 +26,9 @@ test_on:
 # and optionally update the KERNEL and INITRD lines in this template.
 #
 
-<% boot_files_uris = @host.operatingsystem.boot_files_uri(medium_provider) -%>
-<% kernel = boot_files_uris[0] -%>
-<% initrd = boot_files_uris[1] -%>
+kernel <%= @kernel_uri %> initrd=<%= @initrd_uri.split('/').last %> root=/dev/rd/0 rw auto <%= snippet('preseed_kernel_options_autoinstall').strip %>
 
-kernel <%= kernel %> initrd=initrd root=/dev/rd/0 rw auto <%= snippet('preseed_kernel_options_autoinstall').strip %>
-
-initrd <%= initrd %>
+initrd <%= @initrd_uri %>
 
 imgstat
 sleep 2

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/AutoYaST_default_iPXE.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/AutoYaST_default_iPXE.host4dhcp.snap.txt
@@ -4,7 +4,6 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-
 kernel http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/vmlinuz initrd=initrd.img splash=silent install=http://mirror.centos.org/centos/7/os/x86_64 autoyast=http://foreman.example.com/unattended/provision text-mode=1 useDHCP=1 
 initrd http://mirror.centos.org/centos/7/os/x86_64/images/pxeboot/initrd.img
 boot

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.debian4dhcp.snap.txt
@@ -4,8 +4,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-
-kernel http://ftp.debian.org/debian/dists/buster/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} auto=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
+kernel http://ftp.debian.org/debian/dists/buster/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux initrd=initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} auto=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-deb10 domain=snap.example.com
 
 initrd http://ftp.debian.org/debian/dists/buster/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE.ubuntu4dhcp.snap.txt
@@ -4,8 +4,7 @@ ping --count 1 ${netX/gateway} || echo Ping to Gateway failed or ping command no
 echo Trying to ping DNS: ${netX/dns}
 ping --count 1 ${netX/dns} || echo Ping to DNS failed or ping command not available.
 
-
-kernel http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux initrd=initrd.img interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
+kernel http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/linux initrd=initrd.gz interface=auto url=http://foreman.example.com/unattended/provision ramdisk_size=10800 root=/dev/rd/0 rw auto BOOTIF=01-${netX/mac:hexhyp} console-setup/ask_detect=false console-setup/layout=USA console-setup/variant=USA keyboard-configuration/layoutcode=us localechooser/translation/warn-light=true localechooser/translation/warn-severe=true netcfg/disable_dhcp=false locale=en_US hostname=snapshot-ipv4-dhcp-ubuntu18 domain=snap.example.com
 
 initrd http://archive.ubuntu.com/ubuntu/dists/bionic/main/installer-amd64/current/images/netboot/ubuntu-installer/amd64/initrd.gz
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/iPXE/Preseed_default_iPXE_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -17,7 +17,6 @@
 # and optionally update the KERNEL and INITRD lines in this template.
 #
 
-
 kernel http://archive.ubuntu.com/ubuntu/casper/vmlinuz initrd=initrd root=/dev/rd/0 rw auto ip=dhcp BOOTIF=00-f0-54-1a-7e-e0 ramdisk_size=1500000 fsck.mode=skip autoinstall url=http://archive.ubuntu.com:80/ubuntu.iso cloud-config-url=/dev/null ds=nocloud-net;s=http://foreman.example.com/userdata/00-f0-54-1a-7e-e0/ console-setup/ask_detect=false locale=en_US localechooser/translation/warn-light=true localechooser/translation/warn-severe=true hostname=snapshot-ipv4-dhcp-ubuntu20 domain=snap.example.com
 
 initrd http://archive.ubuntu.com/ubuntu/casper/initrd


### PR DESCRIPTION
Previously the filename was hardcoded, but the OS layer actually provides this filename as a variable. This should match the actual filename on mirrors.