### PR TITLE
Fixes #37439 - API 'build_pxe_default' with taxonomies

### DIFF
--- a/app/controllers/api/v2/provisioning_templates_controller.rb
+++ b/app/controllers/api/v2/provisioning_templates_controller.rb
@@ -6,7 +6,7 @@ module Api
       include Foreman::Controller::Parameters::ProvisioningTemplate
       include Foreman::Controller::TemplateImport
 
-      before_action :find_optional_nested_object
+      before_action :find_optional_nested_object, except: [:build_pxe_default]
       before_action :find_resource, :only => %w{show update destroy clone export}
 
       before_action :handle_template_upload, :only => [:create, :update]

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -92,7 +92,19 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
   test "should build pxe menu" do
     ProxyAPI::TFTP.any_instance.stubs(:create_default).returns(true)
     ProxyAPI::TFTP.any_instance.stubs(:fetch_boot_file).returns(true)
+
     post :build_pxe_default
+    assert_response 200
+  end
+
+  test "should build pxe menu with taxonomies" do
+    organization = taxonomies(:organization1)
+    location = taxonomies(:location1)
+
+    ProxyAPI::TFTP.any_instance.stubs(:create_default).returns(true)
+    ProxyAPI::TFTP.any_instance.stubs(:fetch_boot_file).returns(true)
+
+    post :build_pxe_default, params: { :organization_id => organization.id, :location_id => location.id }
     assert_response 200
   end
 


### PR DESCRIPTION
The `hammer template build-pxe-default` command works only when no organization or location is passed.

The fix is to skip `:find_optional_nested_object` for the `build_pxe_default` action, as it does not make sense here.

**How to test**
* Proxy 1 in Default Organization & Default location
* Proxy 2 in Second Organization & Second location
* Run
```
hammer template build-pxe-default
hammer template build-pxe-default --organization-title "Default Organization" --location-title "Default Location"
hammer template build-pxe-default --organization-title "Second Organization" --location-title "Second Location"
```
Check that it works fine

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
