### PR TITLE
Fixes #37444 - get rid of sidekiq deprecation warnings

### DIFF
--- a/extras/dynflow-sidekiq.rb
+++ b/extras/dynflow-sidekiq.rb
@@ -16,15 +16,15 @@ end
 rails_env_file = File.expand_path('./config/environment.rb', rails_root)
 require rails_env_file
 
-if Sidekiq.options[:queues].include?("dynflow_orchestrator")
-  Sidekiq.options[:dynflow_executor] = true
+if Sidekiq[:queues].include?("dynflow_orchestrator")
+  Sidekiq[:dynflow_executor] = true
   ::Rails.application.dynflow.executor!
-elsif (Sidekiq.options[:queues] - ['dynflow_orchestrator']).any?
+elsif (Sidekiq[:queues] - ['dynflow_orchestrator']).any?
   ::Rails.application.dynflow.config.remote = true
 end
 
 ::Rails.application.dynflow.config.on_init(false) do |world|
-  Sidekiq.options[:dynflow_world] = world
+  Sidekiq[:dynflow_world] = world
 end
 
 # To be able to ensure ordering, dynflow requires that there is only one
@@ -33,7 +33,7 @@ end
 # dynflow.initialize! block until the lock is acquired by the current process.
 # To play nice with sd_notify, we need to mark the process as ready before it
 # attempts to acquire the lock.
-if Sidekiq.options[:dynflow_executor]
+if Sidekiq[:dynflow_executor]
   msg = 'orchestrator in passive mode'
   Rails.logger.info(msg)
   Sidekiq::SdNotify.status(msg)


### PR DESCRIPTION
Get rid of messages like:

```
May 13 19:54:29 or dynflow-sidekiq@orchestrator[29190](https://projects.theforeman.org/issues/37444#fn29190): 2024-05-13T17:54:29.245Z pid=29190 tid=nfe WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/usr/share/foreman/extras/dynflow-sidekiq.rb:19:in `<top (required)>'", "/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:83:in `require'"]
May 13 19:54:29 or dynflow-sidekiq@orchestrator[29190](https://projects.theforeman.org/issues/37444#fn29190): 2024-05-13T17:54:29.245Z pid=29190 tid=nfe WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/usr/share/foreman/extras/dynflow-sidekiq.rb:20:in `<top (required)>'", "/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:83:in `require'"]
May 13 19:54:29 or dynflow-sidekiq@orchestrator[29190](https://projects.theforeman.org/issues/37444#fn29190): 2024-05-13T17:54:29.245Z pid=29190 tid=nfe WARN: `config.options[:key] = value` is deprecated, use `config[:key] = value`: ["/usr/share/foreman/extras/dynflow-sidekiq.rb:36:in `<top (required)>'", "/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:83:in `require'"]
```

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
