### PR TITLE
Fixes #37463 - Fix permission handling for table prefs

### DIFF
--- a/app/controllers/api/v2/table_preferences_controller.rb
+++ b/app/controllers/api/v2/table_preferences_controller.rb
@@ -54,8 +54,8 @@ module Api
         deny_access N_("You are trying access the preferences of a different user") if @user != User.current
       end
 
-      def resource_class
-        TablePreference
+      def resource_scope(...)
+        TablePreference.where(user: @user)
       end
     end
   end

--- a/test/controllers/api/v2/table_preferences_controller_test.rb
+++ b/test/controllers/api/v2/table_preferences_controller_test.rb
@@ -47,10 +47,11 @@ class Api::V2::TablePreferencesControllerTest < ActionController::TestCase
 
   def test_should_update_correctly
     resource = resources.first
+    setup_user 'view', resource
     current_user = User.current
-    TablePreference.create!(user: User.current,
-                       name: resource, columns: expected_columns)
 
+    TablePreference.create!(user: User.current,
+                            name: resource, columns: expected_columns)
     put :update, params: {user_id: User.current.id, id: resource, columns: expected_columns}
     assert_response :success
     columns = current_user.reload.table_preferences.first
@@ -60,7 +61,11 @@ class Api::V2::TablePreferencesControllerTest < ActionController::TestCase
   def test_should_destroy_correctly
     resource1 = resources[0]
     resource2 = resources[1]
+
+    setup_user 'view', resource1
+    setup_user 'view', resource2
     current_user = User.current
+
     TablePreference.create!(user: User.current,
                        name: resource1, columns: expected_columns)
     TablePreference.create!(user: User.current,


### PR DESCRIPTION
Before this change non-admin users could create, but not update their own table preferences as the default scope tried to check various *_table_preferences permissions which don't exist at all. Alternatively, we could introduce these permissions and grant the default role a permission to freely manage table preferences belonging to the current user, but that feels a bit overcomplicated.
