### PR TITLE
Fixes #37478 - Add host power status column to new All Hosts page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/components/HostPowerStatus.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/components/HostPowerStatus.js
@@ -1,0 +1,67 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import {
+  PowerOffIcon as PowerOnIcon,
+  OffIcon as PowerOffIcon,
+  UnknownIcon,
+} from '@patternfly/react-icons';
+import { useAPI } from '../../../../common/hooks/API/APIHooks';
+import SkeletonLoader from '../../../common/SkeletonLoader';
+import { selectAPIResponse } from '../../../../redux/API/APISelectors';
+import { STATUS } from '../../../../constants';
+
+const HostPowerStatus = ({ hostName }) => {
+  const key = `HOST_POWER_STATUS_${hostName}`;
+  const existingResponse = useSelector(state => selectAPIResponse(state, key));
+  const useExistingResponse = !!existingResponse.state;
+  const response = useAPI(
+    useExistingResponse ? null : 'get',
+    `/api/v2/hosts/${hostName}/power`,
+    {
+      key,
+    }
+  );
+  if (useExistingResponse) {
+    response.response = existingResponse;
+  }
+  const { state, statusText, title } = response.response || {};
+  const tooltipText = state === 'na' ? `${title} - ${statusText}` : title;
+  let powerIcon = <UnknownIcon />;
+  const moveItALittleUp = { position: 'relative', top: '-0.1em' };
+  const green = 'var(--pf-global--palette--green-300)';
+  const disabledGray = 'var(--pf-global--disabled-color--200)';
+  switch (state) {
+    case 'on':
+      powerIcon = (
+        <span style={{ ...moveItALittleUp, color: green }}>
+          <PowerOnIcon title={tooltipText} />
+        </span>
+      );
+      break;
+    case 'off':
+      powerIcon = (
+        <span style={{ ...moveItALittleUp }}>
+          <PowerOffIcon title={tooltipText} />
+        </span>
+      );
+      break;
+    default:
+      powerIcon = (
+        <span style={{ ...moveItALittleUp, color: disabledGray }}>
+          <UnknownIcon title={tooltipText} />
+        </span>
+      );
+  }
+  return (
+    <SkeletonLoader status={response.status ?? STATUS.PENDING}>
+      {powerIcon}
+    </SkeletonLoader>
+  );
+};
+
+HostPowerStatus.propTypes = {
+  hostName: PropTypes.string.isRequired,
+};
+
+export default HostPowerStatus;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.js
@@ -6,15 +6,16 @@ import { UserIcon, UsersIcon } from '@patternfly/react-icons';
 import { translate as __ } from '../../../common/I18n';
 import forceSingleton from '../../../common/forceSingleton';
 import RelativeDateTime from '../../common/dates/RelativeDateTime';
+import HostPowerStatus from './components/HostPowerStatus';
 
 const coreHostsIndexColumns = [
-  // { // TODO: make power status work
-  //   columnName: 'power_status',
-  //   title: __('Power'),
-  //   wrapper: ({ power_status: powerStatus }) => powerStatus ?? __('Unknown'),
-  //   isSorted: false,
-  //   weight: 0,
-  // },
+  {
+    columnName: 'power_status',
+    title: __('Power'),
+    wrapper: ({ name }) => <HostPowerStatus hostName={name} />,
+    isSorted: false,
+    weight: 0,
+  },
   {
     columnName: 'name',
     title: __('Name'),


### PR DESCRIPTION
![image](https://github.com/theforeman/foreman/assets/22042343/404ea4a9-653f-4259-972d-9b7bfa14ba52)

This adds a Power Status column to the new All Hosts page.

Since there is no bulk endpoint for power status, I decided to use the existing API endpoint `/hosts/power`.

- Displays a skeleton while loading
- If we've already received and stored a host's power status, don't request it again (unless you refresh your browser page).
- Because of the above, we should avoid anything more than `per_page` API requests at a time. This seems reasonable to me.

I added a fake delay and random power status for ease of testing. This will wait 1-4 seconds and give you a random power status back. This way you can see what it looks like when requests come in at different times.

The old page had red for powered off, but I decided to go with black here; it seems a bit less harsh.

I used the PF4-recommended icons for denoting "powered on," "powered off," and "unknown state."