### PR TITLE
Fixes #37503 - Delay plugin finalization until seeds are seeded

### DIFF
--- a/config/initializers/foreman.rb
+++ b/config/initializers/foreman.rb
@@ -23,10 +23,6 @@ Foreman::Plugin.medium_providers_registry.register MediumProviders::Default
 
 Rails.application.config.after_initialize do
   Foreman.settings.load_values unless Foreman.in_setup_db_rake? || !(Setting.table_exists? rescue false)
-
-  Foreman::Plugin.registered_plugins.each do |_name, plugin|
-    plugin.finalize_setup!
-  end
 end
 
 Rails.application.config.to_prepare do

--- a/config/initializers/y_finalize_plugins.rb
+++ b/config/initializers/y_finalize_plugins.rb
@@ -1,0 +1,3 @@
+Rails.application.config.after_initialize do
+  Foreman::Plugin.registered_plugins.each_value(&:finalize_setup!)
+end


### PR DESCRIPTION
Moving it to a different file alphabetically after seeds.rb makes the callback finalizing plugin end up being put after the callback that does the seeding.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
