### PR TITLE
Fixes #37505 - Fix condition

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/disk_enc_clevis_tang.erb
+++ b/app/views/unattended/provisioning_templates/snippet/disk_enc_clevis_tang.erb
@@ -24,7 +24,7 @@ description: |
   end
 -%>
 
-<% if (@host.operatingsystem.family == 'Redhat' || @host.operatingsystem.name == 'Ubuntu') && unless tang_server_list.blank? -%>
+<% if (@host.operatingsystem.family == 'Redhat' || @host.operatingsystem.name == 'Ubuntu') && !tang_server_list.blank? -%>
 
 cat > /tmp/rootdir-luks-device.sh << "EOF"
 #!/bin/sh


### PR DESCRIPTION
`unless` doesn't work here, using `!` (not) instead. True if either Redhat or Ubuntu operating system family and list of tang servers is not blank.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
