### PR TITLE
Fixes #37496 - RHEL registration template prioritizes paramaters

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_rhsm.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_rhsm.erb
@@ -10,7 +10,7 @@ test_on:
 -%>
 <%
   subman_keys = host_param('kt_activation_keys') || host_param('activation_key')
-  subman_org = (plugin_present?('katello') && @host.rhsm_organization_label) || host_param('subscription_manager_org')
+  subman_org = host_param('subscription_manager_org') || (plugin_present?('katello') && @host.rhsm_organization_label)
   subman_registration = host_param_true?('subscription_manager') || subman_keys.present?
   subman_hostname = " --server-hostname #{@host.content_source.rhsm_url.host}" if (plugin_present?('katello') && @host.content_source)
   subman_rhsm_baseurl = " --rhsm-baseurl #{@host.content_source.pulp_content_url}" if (plugin_present?('katello') && @host.content_source)


### PR DESCRIPTION
Fixes #37496

This changes the priority on subman_org to use host_parm if present, then use katello generated org.  This will allow users to override the katello generated org through a host_parm, and if not present continue to work as today with the katello generated org.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
