### PR TITLE
Fixes #37532 - display_fqdn_for_hosts on Facts page

### DIFF
--- a/app/helpers/fact_values_helper.rb
+++ b/app/helpers/fact_values_helper.rb
@@ -60,7 +60,7 @@ module FactValuesHelper
           url: (fact_values_path if authorized_for(hash_for_fact_values_path)),
         },
         {
-          caption: Setting[:display_fqdn_for_hosts] ? params[:host_id].split('.')[0] : params[:host_id],
+          caption: HostPresenter.display_name(params[:host_id]),
         },
       ],
       resource_url: api_hosts_path(thin: true),

--- a/app/models/host/base.rb
+++ b/app/models/host/base.rb
@@ -370,8 +370,7 @@ module Host
     end
 
     def to_label
-      return name if Setting[:display_fqdn_for_hosts]
-      name.split('.')[0]
+      HostPresenter.display_name(name)
     end
 
     private

--- a/app/presenters/host_presenter.rb
+++ b/app/presenters/host_presenter.rb
@@ -1,0 +1,6 @@
+class HostPresenter
+  def self.display_name(name)
+    return name if Setting[:display_fqdn_for_hosts]
+    (name || '').split('.')[0]
+  end
+end

--- a/test/presenters/host_presenter_test.rb
+++ b/test/presenters/host_presenter_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class HostPresenterTest < ActiveSupport::TestCase
+  let(:host) { Host.new(:name => "test.example.com") }
+
+  test "display_name when :display_fqdn_for_hosts is true" do
+    Setting[:display_fqdn_for_hosts] = true
+    assert_equal "test.example.com", HostPresenter.display_name("test.example.com")
+  end
+
+  test "display_name when :display_fqdn_for_hosts is false" do
+    Setting[:display_fqdn_for_hosts] = false
+    assert_equal "test", HostPresenter.display_name("test.example.com")
+  end
+
+  test "host.to_label when :display_fqdn_for_hosts is true" do
+    Setting[:display_fqdn_for_hosts] = true
+    assert_equal "test.example.com", host.to_label
+  end
+
+  test "host.to_label when :display_fqdn_for_hosts is false" do
+    Setting[:display_fqdn_for_hosts] = false
+    assert_equal "test", host.to_label
+  end
+end


### PR DESCRIPTION
Keeping as draft as there might be other places to fix.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
