### PR TITLE
Fixes #37531 - Autocomplete feature for search shows content from forbidden organization for user

### DIFF
--- a/app/controllers/concerns/foreman/controller/auto_complete_search.rb
+++ b/app/controllers/concerns/foreman/controller/auto_complete_search.rb
@@ -9,7 +9,7 @@ module Foreman::Controller::AutoCompleteSearch
   def auto_complete_search
     begin
       model = (controller_name == "hosts") ? Host::Managed : model_of_controller
-      @items = model.complete_for(params[:search], {:controller => controller_name})
+      @items = model.complete_for(params[:search], {:controller => controller_name, :enhanced_filter => {:has_column => "organization_id", :filter => {:organization_id => Organization.current.id}}})
       @items = @items.map do |item|
         category = ['and', 'or', 'not', 'has'].include?(item.to_s.sub(/^.*\s+/, '')) ? _('Operators') : ''
         part = item.to_s.sub(/^.*\b(and|or)\b/i) { |match| match.sub(/^.*\s+/, '') }


### PR DESCRIPTION
Currently, the suggestions provided by the auto-complete feature of the search-bars include content from different organizations. This PR fixes this by using the (yet to be merged) `enhanced_filter` function of scoped_search.


**Detailed problem description**:

The auto-complete functionality is handled by the action `auto_complete_search` of `AutoCompleteSearch.`
The action works by first inferring the Model (DB-Table) from the name of the controller it has been called from and then forming valid SQL queries, which are shown in its own query-language.
Since permissions are handled on a per-action basis, if a role permits a user to call `auto_complete_search` from a controller X, he is given de-facto read access to the whole DB-Table X.
It has not been tested, whether the scope may be expanded past X by injecting joins, etc..

**Changes**:
This PR filters the auto-complete suggestions by organization and only displays suggestions with content belonging to the user's current organization.
This does **NOT** fix the root issue, which is _scoped_search_ not properly leveraging the Foreman permission system, but provides an interim solution until an implementation is found that respects the Foreman permission model.


**Relations**:

- [BUG #37531](https://projects.theforeman.org/issues/37531) - This issue
- [BUG #32599](https://projects.theforeman.org/issues/32599) - The same root cause, not addressed here
- wvanbergen/scoped_search#221 - PR to add `enhanced_filter` to **scoped_search**