### PR TITLE
Fixes #37548 - Fix BulkBuildHostModal and add alert

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/BulkBuildHostModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/BulkBuildHostModal.js
@@ -21,7 +21,6 @@ const BulkBuildHostModal = ({
   isOpen,
   closeModal,
   selectedCount,
-  orgId,
   fetchBulkParams,
 }) => {
   const dispatch = useDispatch();
@@ -157,7 +156,6 @@ BulkBuildHostModal.propTypes = {
   closeModal: PropTypes.func,
   selectedCount: PropTypes.number.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
-  orgId: PropTypes.number.isRequired,
 };
 
 BulkBuildHostModal.defaultProps = {

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/index.js
@@ -1,7 +1,6 @@
 import React, { useContext } from 'react';
 import { ForemanActionsBarContext } from '../../../../components/HostDetails/ActionsBar';
 import { useForemanModal } from '../../../../components/ForemanModal/ForemanModalHooks';
-import { useForemanOrganization } from '../../../../Root/Context/ForemanContext';
 import BulkBuildHostModal from './BulkBuildHostModal';
 
 const BulkBuildHostModalScene = () => {
@@ -11,7 +10,6 @@ const BulkBuildHostModalScene = () => {
   const { modalOpen, setModalClosed } = useForemanModal({
     id: 'bulk-build-hosts-modal',
   });
-  const org = useForemanOrganization();
   return (
     <BulkBuildHostModal
       key="bulk-build-hosts-modal"
@@ -19,7 +17,6 @@ const BulkBuildHostModalScene = () => {
       fetchBulkParams={fetchBulkParams}
       isOpen={modalOpen}
       closeModal={setModalClosed}
-      orgId={org?.id}
     />
   );
 };


### PR DESCRIPTION
The Bulk Build Hosts modal was throwing a console error on the HostsIndex page when 'Any organization' was selected as the organization context.

We need to make sure the HostsIndex page handles 'Any organization' correctly.

- Turns out the orgId wasn't required for BulkBuildHostsModal, so I removed it.
- ~~Added an alert to remind users when 'Any organization' is selected~~

Some actions will need to be disabled unless you select an org: See [the Katello PR](https://github.com/Katello/katello/pull/11023).
