### PR TITLE
Fixes #37550 - per_page=all should return all parameters

### DIFF
--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -34,7 +34,8 @@ module Api
 
       def index
         base = nested_obj.send(parameters_method).authorized(current_permission)
-        @parameters = base.search_for(*search_options).paginate(paginate_options)
+        @parameters = base.search_for(*search_options)
+        @parameters = @parameters.paginate(paginate_options) unless paginate_options[:per_page] == 'all'
         @total = base.count
       end
 

--- a/test/controllers/api/v2/parameters_controller_test.rb
+++ b/test/controllers/api/v2/parameters_controller_test.rb
@@ -21,6 +21,34 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
     assert_not_nil assigns(:parameters)
     parameters = ActiveSupport::JSON.decode(@response.body)
     assert_not_empty parameters
+    assert_equal parameters['total'], 1
+  end
+
+  test "should paginate parameters of a specific domain" do
+    domain = FactoryBot.create(:domain)
+    FactoryBot.create_list(:domain_parameter, 2, :domain => domain)
+    with_temporary_settings(entries_per_page: 1) do
+      get :index, params: { :domain_id => domain.to_param }
+      assert_response :success
+      assert_not_nil assigns(:parameters)
+      parameters = ActiveSupport::JSON.decode(@response.body)
+      assert_equal parameters['total'], 2
+      assert_equal parameters['results'].size, 1
+    end
+  end
+
+  test "should get all parameters of a specific domain" do
+    domain = FactoryBot.create(:domain)
+    domain_parameters = FactoryBot.create_list(:domain_parameter, 2, :domain => domain)
+    with_temporary_settings(entries_per_page: 1) do
+      get :index, params: { :domain_id => domain.to_param, :per_page => 'all' }
+      assert_response :success
+      assert_not_nil assigns(:parameters)
+      parameters = ActiveSupport::JSON.decode(@response.body)
+      assert_equal parameters['total'], 2
+      assert_equal parameters['results'].size, parameters['total']
+      assert_equal parameters['results'].map { |p| p['name'] }.sort, domain_parameters.map(&:name).sort
+    end
   end
 
   test "should get index for specific hostgroup" do

--- a/test/factories/domain.rb
+++ b/test/factories/domain.rb
@@ -1,6 +1,9 @@
 FactoryBot.define do
   factory :domain_parameter, :parent => :parameter, :class => DomainParameter do
     type { 'DomainParameter' }
+
+    sequence(:name) { |n| "domain_parameter_#{n}" }
+    sequence(:value) { |n| "value_#{n}" }
   end
 
   factory :domain do


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
