### PR TITLE
Fixes #37553 - Wait for all plugin JS to load before rendering ColumnSelector

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
@@ -152,7 +152,7 @@ const ColumnSelector = props => {
           icon={<ColumnsIcon />}
           iconPosition="left"
           className="columns-selector"
-          onClick={() => toggleModal()}
+          onClick={toggleModal}
           title={__('Manage columns')}
         >
           <span className="columns-selector-text">{__('Manage columns')}</span>

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -58,6 +58,10 @@ export const ForemanHostsIndexActionsBarContext = forceSingleton(
 );
 
 const HostsIndex = () => {
+  const [allColumns, setAllColumns] = useState(
+    getColumnData({ tableName: 'hosts' })
+  );
+  const [allJsLoaded, setAllJsLoaded] = useState(false);
   const {
     searchParam: urlSearchQuery = '',
     page: urlPage,
@@ -92,7 +96,16 @@ const HostsIndex = () => {
     setAPIOptions: response.setAPIOptions,
   });
 
-  const allColumns = getColumnData({ tableName: 'hosts' });
+  useEffect(() => {
+    const handleLoadJS = () => {
+      setAllColumns(getColumnData({ tableName: 'hosts' }));
+      setAllJsLoaded(true);
+    };
+    document.addEventListener('loadJS', handleLoadJS);
+    return () => {
+      document.removeEventListener('loadJS', handleLoadJS);
+    };
+  }, [setAllColumns]);
   const {
     hasPreference,
     columns: userColumns,
@@ -200,12 +213,12 @@ const HostsIndex = () => {
   ];
 
   const registeredItems = useSelector(selectKebabItems, shallowEqual);
-  const pluginToolbarItems = (
+  const pluginToolbarItems = jsReady => (
     <ForemanHostsIndexActionsBarContext.Provider
       value={{ ...selectAllOptions, fetchBulkParams }}
     >
       <ActionKebab items={dropdownItems.concat(registeredItems)} />
-      <ColumnSelector data={columnSelectData} />
+      {jsReady && <ColumnSelector data={columnSelectData} />}
     </ForemanHostsIndexActionsBarContext.Provider>
   );
 
@@ -305,7 +318,7 @@ const HostsIndex = () => {
       controller="hosts"
       creatable={false}
       replacementResponse={response}
-      customToolbarItems={pluginToolbarItems}
+      customToolbarItems={pluginToolbarItems(allJsLoaded)}
       selectionToolbar={selectionToolbar}
       updateSearchQuery={updateSearchQuery}
     >


### PR DESCRIPTION
In the case of slow network connections, Katello (and other plugins') JS would load very late, after the rendering of `HostsIndexPage`. This caused the `ColumnSelector` not to have all the columns from plugins.

I added console.logs in a second commit for ease of testing. I will remove the commit before merging.

To reproduce the issue on develop, you can turn on network throttling and throttle to 3mbps.

To test:

Load the HostsIndex page with the JS console open

Observe the log from `core.js` when new columns are registered
Observe the log from `helpers.js` with the list of registered columns

The ColumnSelector should not render before you see the third log:

Observe the log from `AwaitedMount.js` when all JS has been loaded

At this point you should see no further columns registered, and no further logs from `core.js`.
The registered columns list should now have all columns (~26 depending on your plugins).

You should be able to see the Content section (and all other sections) in the ColumnSelector.
