### PR TITLE
Fixes #37558 - Properly clean up temporary settings in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -198,13 +198,13 @@ class ActionController::TestCase
   end
 
   def with_temporary_settings(**kwargs)
-    old_settings = SETTINGS.slice(*kwargs.keys)
+    old_settings = SETTINGS.dup
     begin
       SETTINGS.update(kwargs)
 
       yield
     ensure
-      SETTINGS.update(old_settings)
+      SETTINGS.replace(old_settings)
     end
   end
 end


### PR DESCRIPTION
Previously, if a setting wasn't present in SETTINGS then it wasn't removed. It could only revert previous values. Now it should properly clean up by duplicating the old settings and replacing it after the tests.