### PR TITLE
Fixes #37601 - Add Foreman CA refresh template

### DIFF
--- a/app/models/host_info_providers/static_info.rb
+++ b/app/models/host_info_providers/static_info.rb
@@ -14,6 +14,7 @@ module HostInfoProviders
       add_taxonomy_params param
       add_domain_params param
       add_login_params param
+      add_certificate_params param
 
       # Parse ERB values contained in the parameters
       param = ParameterSafeRender.new(self).render(param)
@@ -54,6 +55,21 @@ module HostInfoProviders
       param["realm"] = realm.name unless realm.nil?
       param['foreman_subnets'] = all_subnets.map(&:to_export).uniq
       param['foreman_interfaces'] = host.interfaces.map(&:to_export)
+    end
+
+    def add_certificate_params(param)
+      param['server_ca'] = read_cert(Setting[:server_ca_file])
+      param['ssl_ca'] = read_cert(Setting[:ssl_ca_file])
+    end
+
+    def read_cert(path)
+      return nil unless path
+
+      File.read(path)
+    rescue StandardError => e
+      Foreman::Logging.logger('app').warn("Failed to read CA file: #{e}")
+
+      nil
     end
 
     def all_subnets

--- a/app/models/template_kind.rb
+++ b/app/models/template_kind.rb
@@ -27,6 +27,7 @@ class TemplateKind < ApplicationRecord
       "registration" => N_("Registration template"),
       "kexec" => N_("Discovery Kexec"),
       "Bootdisk" => N_("Boot disk"),
+      "public" => N_("Templates accessible publicly"),
     }
   end
 
@@ -44,6 +45,7 @@ class TemplateKind < ApplicationRecord
       "POAP" => N_("Provisioning for switches running NX-OS."),
       "cloud-init" => N_("Template for cloud-init unattended endpoint."),
       "host_init_config" => N_("Contains the instructions in form of a bash script for the initial host configuration, after the host is registered in Foreman"),
+      "public" => N_("Templates from this category can be accessed publicly using the /unattended endpoint."),
     }
   end
 

--- a/app/services/foreman/unattended_installation/host_verifier.rb
+++ b/app/services/foreman/unattended_installation/host_verifier.rb
@@ -3,12 +3,13 @@ module Foreman
     class HostVerifier
       attr_reader :errors, :host, :request_ip, :for_host_template, :controller_name
 
-      def initialize(host, request_ip:, for_host_template:)
+      def initialize(host, request_ip:, for_host_template:, needs_token: true)
         @host = host
         @errors = []
         @for_host_template = for_host_template
         @request_ip = request_ip
         @controller_name = 'unattended'
+        @needs_token = needs_token
       end
 
       def valid?
@@ -25,6 +26,7 @@ module Foreman
       # In case the token expires during installation
       # Only relevant when the verifier is being used with `for_host_template`
       def valid_host_token?
+        return true unless @needs_token
         return true unless for_host_template
         return true unless @host&.token_expired?
 

--- a/app/views/unattended/provisioning_templates/registration/foreman_ca_refresh.erb
+++ b/app/views/unattended/provisioning_templates/registration/foreman_ca_refresh.erb
@@ -1,0 +1,17 @@
+<%#
+kind: public
+name: foreman_ca_refresh
+model: ProvisioningTemplate
+oses:
+- AlmaLinux
+- CentOS
+- CentOS_Stream
+- Fedora
+- RedHat
+- Rocky
+description: |
+  This template is used to refresh foreman CA certificates on Katello-registered hosts
+-%>
+#!/bin/sh
+
+<%= snippet('ca_registration') -%>

--- a/app/views/unattended/provisioning_templates/registration/foreman_raw_ca.erb
+++ b/app/views/unattended/provisioning_templates/registration/foreman_raw_ca.erb
@@ -1,0 +1,15 @@
+<%#
+kind: public
+name: foreman_raw_ca
+model: ProvisioningTemplate
+oses:
+- AlmaLinux
+- CentOS
+- CentOS_Stream
+- Fedora
+- RedHat
+- Rocky
+description: |
+  This template exposes the CA certificate to be consumed directly from a URL.
+-%>
+<%= foreman_server_ca_cert -%>

--- a/app/views/unattended/provisioning_templates/snippet/ca_registration.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ca_registration.erb
@@ -1,0 +1,34 @@
+<%#
+kind: snippet
+name: ca_registration
+model: ProvisioningTemplate
+snippet: true
+description: |
+  This template is used for updating Foreman's CA on hosts that are registered by Katello.
+  It replaces the CA used by subscription-manager and adds the CA to trusted anchors.
+-%>
+
+<% if plugin_present?('katello') -%>
+  # Define the path to the Katello server CA certificate
+  KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
+
+  # If katello ca cert file exists on host, update it and make sure it's in trust anchors
+  if [ -f "$KATELLO_SERVER_CA_CERT" ]; then
+    <%= save_to_file('"$KATELLO_SERVER_CA_CERT"', foreman_server_ca_cert) -%>
+
+    if [ -f /etc/debian_version ]; then
+      CA_TRUST_ANCHORS=/usr/local/share/ca-certificates/
+    else
+      CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors
+    fi
+
+    # Add the Katello CA certificate to the system-wide CA certificate store
+    cp $KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
+
+    if [ -f /etc/debian_version ]; then
+      update-ca-certificates
+    else
+      update-ca-trust
+    fi
+  fi
+<% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -24,17 +24,6 @@ RHSM_CFG=/etc/rhsm/rhsm.conf
 <% end -%>
 
 <% if plugin_present?('katello') -%>
-  # Define the path to the Katello server CA certificate
-  KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
-
-  # If SSL_CA_CERT is not set, create a temporary file for it
-  if [ -z "$SSL_CA_CERT" ]; then
-    SSL_CA_CERT=$(mktemp)
-    cat << EOF > "$SSL_CA_CERT"
-<%= foreman_server_ca_cert %>
-EOF
-  fi
-
   <% if @subman_setup_scenario == 'registration' -%>
     # rhn-client-tools conflicts with subscription-manager package
     # since rhn tools replaces subscription-manager, we need to explicitly
@@ -59,10 +48,15 @@ EOF
     <% end -%>
   <% end -%>
 
+  # Define the path to the Katello server CA certificate
+  KATELLO_SERVER_CA_CERT=/etc/rhsm/ca/katello-server-ca.pem
+
   # Prepare the SSL certificate
   mkdir -p /etc/rhsm/ca
-  cp -f $SSL_CA_CERT $KATELLO_SERVER_CA_CERT
+  touch $KATELLO_SERVER_CA_CERT
   chmod 644 $KATELLO_SERVER_CA_CERT
+
+  <%= snippet('ca_registration') -%>
 <% end -%>
 
 # Prepare subscription-manager
@@ -132,26 +126,6 @@ else
   full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
   sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
 fi
-
-<% if @subman_setup_scenario == 'provisioning' && plugin_present?('katello') -%>
-  if [ -f /etc/debian_version ]; then
-    CA_TRUST_ANCHORS=/usr/local/share/ca-certificates/
-  else
-    CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors
-  fi
-
-  # Add the Katello CA certificate to the system-wide CA certificate store
-  if [ -d $CA_TRUST_ANCHORS ]; then
-    if [ -f /etc/debian_version ]; then
-      cp $KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
-      update-ca-certificates
-    else
-      update-ca-trust enable
-      cp $KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
-      update-ca-trust
-    fi
-  fi
-<% end -%>
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -58,6 +58,16 @@ class UnattendedControllerTest < ActionController::TestCase
       assert_response :success
     end
 
+    test "should get a foreman CA refresh for a host" do
+      get :host_template, params: { kind: 'public', id: 'foreman_ca_refresh' }
+      assert_response :success
+    end
+
+    test "should get raw foreman CA certificate" do
+      get :host_template, params: { kind: 'public', id: 'foreman_raw_ca' }
+      assert_response :success
+    end
+
     test "should get a kickstart when IPv6 mapped IPv4 address is used" do
       @request.env["HTTP_X_FORWARDED_FOR"] = "::ffff:" + @rh_host.ip
       @request.env["REMOTE_ADDR"] = "127.0.0.1"

--- a/test/fixtures/template_kinds.yml
+++ b/test/fixtures/template_kinds.yml
@@ -34,3 +34,7 @@ host_init_config:
 registration:
   name: registration
   description: description for registration template
+
+public:
+  name: public
+  description: description for public template

--- a/test/fixtures/templates.yml
+++ b/test/fixtures/templates.yml
@@ -187,3 +187,19 @@ host_init_config:
   operatingsystems: centos5_3, redhat
   locked: true
   type: ProvisioningTemplate
+
+foreman_ca_refresh:
+  name: foreman_ca_refresh
+  template: 'echo "Refreshing certificates"'
+  template_kind: public
+  operatingsystems: centos5_3, redhat
+  locked: true
+  type: ProvisioningTemplate
+
+foreman_raw_ca:
+  name: foreman_raw_ca
+  template: 'echo "Raw CA certificate"'
+  template_kind: public
+  operatingsystems: centos5_3, redhat
+  locked: true
+  type: ProvisioningTemplate

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -121,7 +121,6 @@ runcmd:
       sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
     fi
     
-    
     # Restart yggdrasild if installed and running
     systemctl try-restart yggdrasil >/dev/null 2>&1 || true
       # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -106,7 +106,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -169,7 +169,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -169,7 +169,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -169,7 +169,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -169,7 +169,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -169,7 +169,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -167,7 +167,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -166,7 +166,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -120,7 +120,6 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
   fi
   
-  
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,


### PR DESCRIPTION
In this PR I am introducing a way to refresh CA certificate for Foreman
server. It will have the following parts:

- [X] Downloadable template to run directly on a server
- [x] REX script template to be used with SSH REX provider
- [x] REX Ansible template to be used with Ansible REX provider

All the ways would refresh `katello-server-ca.pem` file and refresh
CA root store accordingly.