### PR TITLE
Revert "Fixes #37501 - Clean up custom repositories from host registration"

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -153,17 +153,6 @@ register_katello_host(){
 # Set up subscription-manager
 <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'registration' }).strip -%>
 
-<% unless @repo_data.blank? -%>
-# clean repositories which were added for registration purposes (Katello context only)
-if [ x$PKG_MANAGER = xdnf -o x$PKG_MANAGER = xyum ]; then
-  rm -f /etc/yum.repos.d/foreman_registration*.repo
-elif [ x$PKG_MANAGER = xzypper ]; then
-  rm -f /etc/zypp/repos.d/foreman_register*.repo
-elif [ -f /etc/debian_version ]; then
-  rm -f /etc/apt/sources.list.d/foreman_registration*.list
-fi
-<% end %>
-
 subscription-manager register <%= '--force' if truthy?(@force) %> \
   --org='<%= @organization.label if @organization %>' \
   --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>


### PR DESCRIPTION
This reverts commit f884babadf8c78495442a54028333aefec123be1.

This is breaking workflow for users who expect to have these repositories available even after the registration.

It also breaks workflow with custom packages that might be consumed from the repositories.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
