### PR TITLE
Fixes #37575 - Foreman Table columns sort is inconsistent

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
@@ -32,6 +32,9 @@ export const getColumnHelpers = columns => {
   columnNamesKeys.sort((a, b) => {
     const columnBWeight = columns[b]?.weight;
     const columnAWeight = columns[a]?.weight;
+    if (columnAWeight === undefined && columnBWeight === undefined) {
+      return 0;
+    }
     if (columnBWeight === undefined) {
       return -1;
     }


### PR DESCRIPTION
To test you can open the models table in firefox and chrome and see that the order is different before the pr.
Firefox and Chrome implement the sort function differently