### PR TITLE
Fixes #36650 - change the OS default hash function

### DIFF
--- a/app/services/password_crypt.rb
+++ b/app/services/password_crypt.rb
@@ -1,7 +1,7 @@
 require 'base64'
 
 class PasswordCrypt
-  ALGORITHMS = {'SHA256' => '$5$', 'SHA512' => '$6$', 'Base64' => '', 'Base64-Windows' => ''}
+  ALGORITHMS = {'SHA512' => '$6$', 'SHA256' => '$5$', 'Base64' => '', 'Base64-Windows' => ''}
 
   if Foreman::Fips.md5_available?
     ALGORITHMS['MD5'] = '$1$'

--- a/db/migrate/20240613133735_change_os_default_password_hash_to_sha512.rb
+++ b/db/migrate/20240613133735_change_os_default_password_hash_to_sha512.rb
@@ -1,0 +1,9 @@
+class ChangeOsDefaultPasswordHashToSha512 < ActiveRecord::Migration[4.2]
+  def up
+    change_column_default :operatingsystems, :password_hash, 'SHA512'
+  end
+
+  def down
+    change_column_default :operatingsystems, :password_hash, 'SHA256'
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -281,7 +281,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     post :create, params: { :host => valid_attrs }
     host = Host.find(JSON.parse(@response.body)['id'])
     assert_not_equal host.root_pass, 'password'
-    assert host.root_pass.starts_with?('$5$')
+    assert host.root_pass.starts_with?('$6$')
   end
 
   test "should create host with host_parameters_attributes" do

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -16,7 +16,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-6-dhcp-el7 --noipv6 
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -16,7 +16,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-el7 --noipv6 --
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -16,7 +16,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-static-el7 --noipv6 
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -16,7 +16,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-dhcp-el7 --noipv6 --
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -16,7 +16,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv6-static-el7 --noipv6 
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authconfig --useshadow --passalgo=sha256 --kickstart
+authconfig --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -15,7 +15,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rhel9 --noipv6 
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authselect --useshadow --passalgo=sha256 --kickstart
+authselect --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -15,7 +15,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky8 --noipv6
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authselect --useshadow --passalgo=sha256 --kickstart
+authselect --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -15,7 +15,7 @@ network --device=00-f0-54-1a-7e-e0 --hostname snapshot-ipv4-dhcp-rocky9 --noipv6
 
 rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
-authselect --useshadow --passalgo=sha256 --kickstart
+authselect --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC 
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd


### PR DESCRIPTION
The default hash function should be more secure SHA512. NSA has recommended SHA512 since RHEL 5, so it's likely widely adopted. SHA256 is no longer considered supported and is prohibitted by some policies.

This is a cherry-pick from develop, as it was suggested at https://github.com/theforeman/foreman/pull/10206

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
