### PR TITLE
Fixes #37584 - Host details - Fix append domain setting

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/index.js
@@ -54,7 +54,7 @@ const HostDetails = ({
   location: { hash },
   history,
 }) => {
-  const { displayFqdnForHosts, displayNewHostsPage } = useForemanSettings();
+  const { displayNewHostsPage } = useForemanSettings();
   const { response, status } = useAPI(
     'get',
     `/api/hosts/${id}?show_hidden_parameters=true`,
@@ -124,9 +124,7 @@ const HostDetails = ({
                     : ({ caption }) => <a href={hostsIndexUrl}>{caption}</a>,
                 },
                 {
-                  caption: displayFqdnForHosts
-                    ? response.name
-                    : response.name?.replace(`.${response.domain_name}`, ''),
+                  caption: response.display_name,
                 },
               ]}
             />
@@ -151,12 +149,7 @@ const HostDetails = ({
                           headingLevel="h5"
                           size="2xl"
                         >
-                          {displayFqdnForHosts
-                            ? response.name
-                            : response.name?.replace(
-                                `.${response.domain_name}`,
-                                ''
-                              )}
+                          {response.display_name}
                         </Title>
                       )}
                     </SkeletonLoader>


### PR DESCRIPTION
It doesn't work for hosts with long names like
meh-3-3.vms.meh.meh.foreman.com, and for hosts
without domain (unmanaged hosts).
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
