### PR TITLE
Fixes #37583 - remove coffee-rails

### DIFF
--- a/bundler.d/assets.rb
+++ b/bundler.d/assets.rb
@@ -6,6 +6,4 @@ group :assets do
   gem 'execjs', '>= 1.4.0', '< 3.0'
   gem 'terser', '~> 1.1'
   gem 'sass-rails', '~> 6.0'
-  # this one is a dependecy for x-editable-rails
-  gem 'coffee-rails', '~> 5.0.0'
 end


### PR DESCRIPTION
Usage was removed here: https://github.com/theforeman/foreman/pull/7775 and I didnt find any usage of it now in foreman+katello and their plugins