### PR TITLE
Fixes #37591 - remove hand cursor from generic table

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
@@ -31,12 +31,15 @@
   }
   .pf-c-toolbar__group {
     flex-grow: 1;
-    &.pf-m-align-right{
+    &.pf-m-align-right {
       justify-content: flex-end;
     }
     &:first-child {
       margin-right: auto;
       width: min-content;
     }
+  }
+  .pf-c-table tr.pf-m-hoverable {
+    cursor: default;
   }
 }


### PR DESCRIPTION
isHoverable makes the row look clickable with a hand crursor, we only want the row to be highlighted on hover for readability 