### PR TITLE
Fixes #37589 - Store the BuildStatus in DB

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -779,11 +779,8 @@ autopart"', desc: 'to render the content of host partition table'
   end
   def get_status(type)
     status = host_statuses.detect { |s| s.type == type.to_s }
-    if status.nil?
-      host_statuses.new(:host => self, :type => type.to_s)
-    else
-      status
-    end
+    return status unless status.nil?
+    host_statuses.new(:host => self, :type => type.to_s)
   end
 
   def build_global_status(options = {})
@@ -952,7 +949,12 @@ autopart"', desc: 'to render the content of host partition table'
   end
 
   def refresh_build_status
-    get_status(HostStatus::BuildStatus).refresh
+    refresh_method = if new_record?
+                       'refresh'
+                     else
+                       'refresh!'
+                     end
+    get_status(HostStatus::BuildStatus).send(refresh_method)
   end
 
   def extract_params_from_object_ancestors(object)

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -474,6 +474,25 @@ class HostTest < ActiveSupport::TestCase
     assert_equal status, new_status
   end
 
+  test 'host #get_status(HostStatus::BuildStatus).to_status matches in DB stored "status' do
+    host = FactoryBot.build(:host)
+    host.build = false
+    status = host.get_status(HostStatus::BuildStatus)
+    original_status = status.to_status
+    status.save!
+    host.save!
+
+    assert_equal status.status, status.to_status
+
+    host.build = true
+    host.valid?
+
+    assert host.build?
+    status = host.get_status(HostStatus::BuildStatus)
+    assert_equal status.status, status.to_status
+    assert_not_equal original_status, status.to_status
+  end
+
   test 'host #get_status(type) only builds a new status once' do
     host = FactoryBot.build_stubbed(:host)
     status1 = host.get_status(HostStatus::BuildStatus)
@@ -518,7 +537,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test 'build status is updated on host validation' do
-    host = FactoryBot.build_stubbed(:host)
+    host = FactoryBot.build(:host)
     host.build = false
     host.valid?
     original_status = host.get_status(HostStatus::BuildStatus).to_status
@@ -808,7 +827,7 @@ class HostTest < ActiveSupport::TestCase
   end
 
   test "should allow build mode for unmanaged hosts" do
-    h = FactoryBot.build_stubbed(:host)
+    h = FactoryBot.build(:host)
     assert h.valid?
     h.build = true
     assert h.valid?


### PR DESCRIPTION
The method to refrsh the build status is called by before_validation and the BuildStatus object is able to determine the status correctly - but unfortunately, it is not stored on to the DB.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
