### PR TITLE
Fixes #37606 - Drop old CentOS installation media

### DIFF
--- a/app/controllers/api/v2/media_controller.rb
+++ b/app/controllers/api/v2/media_controller.rb
@@ -10,7 +10,7 @@ module Api
       PATH_INFO = <<~EOS
         The path to the medium, can be a URL or a valid NFS server (exclusive of the architecture).
 
-        for example http://mirror.centos.org/centos/$version/os/$arch
+        for example https://mirror.stream.centos.org/$version-stream/BaseOS/$arch/os
         where $arch will be substituted for the host\'s actual OS architecture and $version, $major and $minor
         will be substituted for the version of the operating system.
 

--- a/app/services/medium_providers/provider.rb
+++ b/app/services/medium_providers/provider.rb
@@ -4,7 +4,7 @@ module MediumProviders
   # Example:
   # provider = MyMediumProvider.new(centos_host)
   # provider.medium_uri
-  # => #<URI::HTTP http://mirror.centos.org/centos/7/os/x86_64>
+  # => #<URI::HTTP http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os>
   class Provider
     delegate :logger, :to => :Rails
 

--- a/app/views/media/_form.html.erb
+++ b/app/views/media/_form.html.erb
@@ -15,7 +15,7 @@
     <div class="tab-pane active" id="primary">
       <%= text_f f, :name %>
       <%= text_f f, :path, :size => "col-md-8", :help_block => _("The path to the medium, can be a URL or a valid NFS server (exclusive of the architecture).
-          for example <em>http://mirror.centos.org/centos/$version/os/$arch</em> where <strong>$arch</strong> will be substituted for the host's actual OS architecture and <strong>$version</strong>, <strong>$major</strong> and <strong>$minor</strong> will be substituted for the version of the operating system. Solaris and Debian media may also use <strong>$release</strong>.").html_safe %>
+          for example <em>https://mirror.stream.centos.org/$version-stream/BaseOS/$arch/os</em> where <strong>$arch</strong> will be substituted for the host's actual OS architecture and <strong>$version</strong>, <strong>$major</strong> and <strong>$minor</strong> will be substituted for the version of the operating system. Solaris and Debian media may also use <strong>$release</strong>.").html_safe %>
         <span id="nfs-section" <%= display?(!required_nfs?) %>>
           <%= text_f f, :media_path,  :size => "col-md-8", :help_inline => _("The NFS path to the media.") %>
           <%= text_f f, :config_path, :size => "col-md-8", :help_inline => _("The NFS path to the jumpstart control files.") %>

--- a/db/migrate/20240813141845_rename_centos_stream_mirror_to_centos.rb
+++ b/db/migrate/20240813141845_rename_centos_stream_mirror_to_centos.rb
@@ -1,0 +1,21 @@
+class RenameCentosStreamMirrorToCentos < ActiveRecord::Migration[6.1]
+  OLD_NAME = "CentOS Stream 9 mirror"
+  NEW_NAME = "CentOS mirror"
+
+  def up
+    # Name column isn't unique, so we can't just rename and catch
+    # ActiveRecord::RecordNotUnique
+    old = Medium.unscoped.where(name: OLD_NAME)
+    return unless old.exists?
+
+    if Medium.unscoped.where(name: NEW_NAME).exists?
+      logger.warn("Couldn't rename medium '#{OLD_NAME}' to '#{NEW_NAME}': already exists")
+    else
+      old.update_all(name: NEW_NAME)
+    end
+  end
+
+  def down
+    Medium.unscoped.where(name: NEW_NAME).update_all(name: OLD_NAME)
+  end
+end

--- a/db/seeds.d/100-installation_media.rb
+++ b/db/seeds.d/100-installation_media.rb
@@ -6,17 +6,7 @@ os_suse = Operatingsystem.unscoped.where(:type => "Suse") || Operatingsystem.uns
 Medium.without_auditing do
   [
     {
-      :name => "CentOS 7 mirror",
-      :os_family => "Redhat",
-      :path => "http://mirror.centos.org/centos/$major/os/$arch",
-    },
-    {
-      :name => "CentOS Stream",
-      :os_family => "Redhat",
-      :path => "http://mirror.centos.org/centos/$major-stream/BaseOS/$arch/os",
-    },
-    {
-      :name => "CentOS Stream 9 mirror",
+      :name => "CentOS mirror",
       :os_family => "Redhat",
       :path => "http://mirror.stream.centos.org/$major-stream/BaseOS/$arch/os",
     },


### PR DESCRIPTION
The host mirror.centos.org is gone now that CentOS < 9 is EOL. It includes a migration to simplify the name, but doesn't include migrations to remove old entries. That is up to the user because they may have modified them and still use them.