### PR TITLE
Fixes #37610 - pass the unencrypted root_pass to crypt for grub_pass

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -152,8 +152,9 @@ module HostCommon
   end
 
   def crypt_passwords
-    self.root_pass = crypt_pass(self[:root_pass], :root)
-    self.grub_pass = crypt_pass(self[:grub_pass] || self[:root_pass], :grub)
+    root_pass = self[:root_pass]
+    self.root_pass = crypt_pass(root_pass, :root)
+    self.grub_pass = crypt_pass(self[:grub_pass] || root_pass, :grub)
   end
 
   def crypt_pass(unencrypted_pass, pass_kind)


### PR DESCRIPTION
self.root_pass can be already encrypted, and in the case of
Base64(-Windows) we do not reliably detect that. And even if, using B64
for GRUB wouldn't work anyway.

Fixes: 60d53c2621b3537e61e9082428ebb585f02fd3bc


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
