### PR TITLE
Fixes #37613 - compare parsed YAML results, not Strings

### DIFF
--- a/test/unit/foreman/renderer/scope/report_test.rb
+++ b/test/unit/foreman/renderer/scope/report_test.rb
@@ -93,18 +93,8 @@ class ReportScopeTest < ActiveSupport::TestCase
       expected_csv = "List,String,Number,Bool,Empty,Nil\n\"Val1,1,true\",Text,1,false,\"\",\"\"\n"
       assert_equal expected_csv, @scope.report_render(format: :csv)
 
-      expected_yaml = <<~OUT + "  Nil: \n"
-        ---
-        - List:
-          - Val1
-          - 1
-          - true
-          String: Text
-          Number: 1
-          Bool: false
-          Empty: ''
-      OUT
-      assert_equal expected_yaml, @scope.report_render(format: :yaml)
+      expected_yaml = [{"List" => ["Val1", 1, true], "String" => "Text", "Number" => 1, "Bool" => false, "Empty" => "", "Nil" => nil}]
+      assert_equal expected_yaml, YAML.safe_load(@scope.report_render(format: :yaml))
     end
   end
 end


### PR DESCRIPTION
depending on the libyaml version, it encodes `nil` differently and thus
the tests fail on newer versions as the *string* comparison fails.
if we parse the generated yaml back into a Hash, things compare just
fine again, without breaking the tests on older libyaml versions.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
