### PR TITLE
Fixes #37623 - Use html format in react controller to allow for ics domains

### DIFF
--- a/app/controllers/react_controller.rb
+++ b/app/controllers/react_controller.rb
@@ -4,6 +4,6 @@ class ReactController < ApplicationController
 
   def index
     response.headers['X-Request-Path'] = request.path
-    render 'react/index'
+    render("react/index", formats: [:html])
   end
 end

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -13,6 +13,14 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_link?('Export', href: current_hosts_path(format: 'csv', search: "name = #{@host.name}"))
   end
 
+  describe "view host page" do
+    test "host with .ics extension" do
+      domain = FactoryBot.create(:domain, name: 'example.ics')
+      host = FactoryBot.create(:host, domain: domain)
+      visit host_details_page_path(host)
+    end
+  end
+
   describe "create new host page" do
     test "tabs are present" do
       assert_new_button(current_hosts_path, "Create Host", new_host_path)


### PR DESCRIPTION
Credit to @hao-yu for finding the fix. If you have a host with a domain extension .ics the all hosts pages fails to render the host (even the legacy UI) because rails is trying to ics as a format.

Testing steps:

1. Register a host with a name like foo.example.ics
2. Try to view the host in the UI and watch it fail
3. Apply PR
4. View the host and see that it shows up

Screenshots before and after:
![Screenshot 2024-07-03 at 12-01-12 Action Controller Exception caught](https://github.com/theforeman/foreman/assets/1518655/f0551e2c-6436-419f-bdf7-36fce2574cbf)
![Screenshot 2024-07-03 at 12-02-58 rhel8 croberts ics](https://github.com/theforeman/foreman/assets/1518655/6e1c12fd-8723-4c62-b366-23d5d4a43a46)

Based on my understanding, I think it should not break anything because there is only one view in react directory:
```
ls -lrt /usr/share/foreman/app/views/react/
total 0
-rw-r--r--. 1 root root 0 Jan 31 16:40 index.html.erb
```