### PR TITLE
Fixes #38030 - Allow remote execution become any user

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -59,10 +59,10 @@ EOF
 
 <% if ssh_user != 'root' && host_param('remote_execution_effective_user_method') == 'sudo' -%>
 <% if @host.operatingsystem.family == 'Redhat' || @host.operatingsystem.family == 'Debian' -%>
-echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL" > /etc/sudoers.d/<%= ssh_user %>
+echo "<%= ssh_user %> ALL = (ALL) NOPASSWD : ALL" > /etc/sudoers.d/<%= ssh_user %>
 echo "Defaults:<%= ssh_user %> !requiretty" >> /etc/sudoers.d/<%= ssh_user %>
 <% elsif @host.operatingsystem.family == 'Suse' -%>
-echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL" >> /etc/sudoers
+echo "<%= ssh_user %> ALL = (ALL) NOPASSWD : ALL" >> /etc/sudoers
 echo "Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers
 <% end -%>
 <% end -%>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

This PR fix the sudoers.d/user_name configuration to allow the user to run playbooks with others users than root, for example:

```ansible
- name: Simple playbook demonstrating become and become_user
  hosts: all

  tasks:
    - name: Create a file as the root user (works well)
      ansible.builtin.file:
        path: /tmp/root_file.txt
        state: touch
      become: true
      become_user: root

    - name: Create a file as a different user (dont works, because the users is other than root)
      ansible.builtin.file:
        path: /tmp/www_data_file.txt
        state: touch
      become: true
      become_user: www-data
   ```
