### PR TITLE
Fixes #37627 - Only update repositories once in global registration

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -81,8 +81,6 @@ gpgcheck=0
 EOF
   if [ x$PKG_MANAGER = xdnf -o x$PKG_MANAGER = xyum ]; then
     mv -f /tmp/foreman_registration.repo /etc/yum.repos.d/foreman_registration<%= index %>.repo
-    echo "Building yum metadata cache, this may take a few minutes"
-    $PKG_MANAGER makecache
   else
     zypper --quiet --non-interactive addrepo /tmp/foreman_registration.repo
   fi
@@ -98,13 +96,18 @@ elif [ -f /etc/debian_version ]; then
     curl --silent --show-error --output /etc/apt/trusted.gpg.d/client<%= index %>.asc <%= shell_escape repo_gpg_key_url %>
   fi
 <% end -%>
-  apt-get update
-
 else
   echo "Unsupported operating system, can't add repository."
   cleanup_and_exit 1
 fi
 <% end -%>
+
+if [ x$PKG_MANAGER = xdnf -o x$PKG_MANAGER = xyum ]; then
+  echo "Building yum metadata cache, this may take a few minutes"
+  $PKG_MANAGER makecache
+elif [ -f /etc/debian_version ]; then
+  apt-get update
+fi
 <% end -%>
 
 register_host() {

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -72,13 +72,13 @@ name=foreman_register<%= index %>
 baseurl=<%= shell_escape repo %>
 enabled=1
 type=rpm-md
-EOF
 <% if repo_gpg_key_url.present? -%>
-  echo gpgcheck=1 >> /tmp/foreman_registration.repo
-  echo gpgkey=<%= shell_escape repo_gpg_key_url %> >> /tmp/foreman_registration.repo
+gpgcheck=1
+gpgkey=<%= shell_escape repo_gpg_key_url %>
 <% else -%>
-  echo gpgcheck=0 >> /tmp/foreman_registration.repo
+gpgcheck=0
 <% end -%>
+EOF
   if [ x$PKG_MANAGER = xdnf -o x$PKG_MANAGER = xyum ]; then
     mv -f /tmp/foreman_registration.repo /etc/yum.repos.d/foreman_registration<%= index %>.repo
     echo "Building yum metadata cache, this may take a few minutes"


### PR DESCRIPTION
Rather than doing this for each repository, it is now performed once.

It also simplifies writing out the repo file to make the write atomic. Right now it doesn't use `save_to_file`, but that could simplify it even further.