### PR TITLE
Fixes #37640 - Apply Loc/Org filter to Host Registration form

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
@@ -11,9 +11,9 @@ Object {
             "hostgroupId": undefined,
             "insecure": false,
             "jwtExpiration": 4,
-            "locationId": undefined,
+            "locationId": 4,
             "operatingsystemId": undefined,
-            "organizationId": undefined,
+            "organizationId": 3,
             "packages": "",
             "repoData": Array [],
             "setupInsights": "",
@@ -39,8 +39,8 @@ Object {
         "payload": Object {
           "key": "REGISTRATION_COMMANDS_DATA",
           "params": Object {
-            "location_id": undefined,
-            "organization_id": undefined,
+            "location_id": 4,
+            "organization_id": 3,
           },
           "url": "/hosts/register/data",
         },

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
@@ -164,11 +164,19 @@ export const formData = {
       id: 1,
       name: 'Default Organization',
     },
+    {
+      id: 3,
+      name: 'ACME',
+    },
   ],
   locations: [
     {
       id: 2,
       name: 'Default Location',
+    },
+    {
+      id: 4,
+      name: 'munich',
     },
   ],
 };

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/integration.test.js
@@ -8,8 +8,16 @@ import RegistrationCommandsPage from '../index'
 import { APIMiddleware } from '../../../../redux/API';
 import apiReducer from '../../../../redux/API/APIReducer';
 import { spySelector } from './fixtures'
+import ForemanContext from '../../../../Root/Context/ForemanContext';
 
 jest.mock('../../../../components/common/Slot', () => () => (<></>));
+jest
+  .spyOn(ForemanContext, 'useForemanOrganization')
+  .mockReturnValue({ id: 3, title: 'ACME' });
+jest
+  .spyOn(ForemanContext, 'useForemanLocation')
+  .mockReturnValue({ id: 4, title: 'munich' });
+
 
 spySelector(selectors);
 
@@ -28,6 +36,16 @@ describe('RegistrationCommandsPage integration', () => {
 
     expect(submitBtn.hasClass('pf-m-disabled')).toBe(false);
     expect(commandField.length).toBe(0);
+
+    // check that only current Org and Loc are selectable
+    const organizationSelectOptions = component.find('#reg_organization').find('FormSelectOption');
+    expect(organizationSelectOptions.length).toBe(2);
+    expect(organizationSelectOptions.findWhere((n) => n.prop('value') === 1).length).toBe(0);
+    expect(organizationSelectOptions.findWhere((n) => n.prop('value') === 3).length).toBe(2);
+    const locationSelectOptions = component.find('#reg_location').find('FormSelectOption');
+    expect(locationSelectOptions.length).toBe(2);
+    expect(locationSelectOptions.findWhere((n) => n.prop('value') === 2).length).toBe(0);
+    expect(locationSelectOptions.findWhere((n) => n.prop('value') === 4).length).toBe(2);
 
     submitBtn.simulate('click');
     integrationTestHelper.takeStoreAndLastActionSnapshot('generated command');

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -64,8 +64,14 @@ const RegistrationCommandsPage = () => {
   const isGenerating = apiStatusCommand === STATUS.PENDING;
 
   // Form data
-  const organizations = useSelector(selectOrganizations);
-  const locations = useSelector(selectLocations);
+  let organizations = useSelector(selectOrganizations);
+  if (currentOrganization !== undefined) {
+    organizations = organizations.filter(f => f.id === currentOrganization.id);
+  }
+  let locations = useSelector(selectLocations);
+  if (currentLocation !== undefined) {
+    locations = locations.filter(f => f.id === currentLocation.id);
+  }
   const hostGroups = useSelector(selectHostGroups);
   const operatingSystems = useSelector(selectOperatingSystems);
   const operatingSystemTemplate = useSelector(selectOperatingSystemTemplate);


### PR DESCRIPTION
Select organization A. Then go to Register Host page and Select organization B in the Host Registration form and choose a smart-proxy that belongs to B. Choose activation key and click generate. That gives you an error because organizations are not matching. The curl command fails to render.

Fixed it by not allowing to choose other locations/organizations than the one selected for Foreman previously. If no location/organization is selected in Foreman, any organization can be selected in the Host Registration form. 

![bug](https://github.com/theforeman/foreman/assets/71487468/f856ff30-538c-4de2-a520-8b213223a229)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
