### PR TITLE
Fixes #37644 - Pagination doesnt update between react pages

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Pagination/index.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/index.js
@@ -39,17 +39,19 @@ const Pagination = ({
     let nextPage = propsPage;
     let nextPerPage = propsPerPage;
     if (updateParamsByUrl) {
-      if (search !== undefined) {
+      if (search !== undefined && search.length) {
         const params = new URLSearchParams(search);
-        nextPage = Number(params.get('page'));
-        nextPerPage = Number(params.get('per_page'));
+        nextPage = Number(params.get('page') || getURIpage());
+        nextPerPage = Number(params.get('per_page') || getURIperPage());
       } else {
         nextPage = getURIpage();
         nextPerPage = getURIperPage();
       }
     }
-    setPerPage(current => nextPerPage || current || settingsPerPage);
-    setPage(current => nextPage || current);
+    setPerPage(
+      current => nextPerPage || propsPerPage || current || settingsPerPage
+    );
+    setPage(current => nextPage || propsPage || current);
   }, [search, propsPage, propsPerPage, settingsPerPage, updateParamsByUrl]);
 
   const paginationTitles = {
@@ -105,6 +107,7 @@ const Pagination = ({
   const cx = classNames('tfm-pagination', className, {
     'no-side-padding': noSidePadding,
   });
+
   return (
     <PF4Pagination
       titles={paginationTitles}


### PR DESCRIPTION
To recreate the bug: navigate to `models?search=&page=2&per_page=5` 
from the menu, go to audits,  then from the menu go to models
result is that the page will show page 1, per page 20 results from the api, but the pagination ui will show page 2, per page 5.
if the search is not empty, params.get('page') won't always be there, so the code sets the default value 