### PR TITLE
Fixes #37647 - Make telemetry allowed_labels configurable

### DIFF
--- a/config/initializers/5_telemetry.rb
+++ b/config/initializers/5_telemetry.rb
@@ -125,4 +125,5 @@ allowed_labels = {
     'Widget',
   ],
 }
+allowed_labels.deep_merge!(SETTINGS[:telemetry][:allowed_labels]) if SETTINGS.dig(:telemetry, :allowed_labels)
 telemetry.add_allowed_tags!(allowed_labels)

--- a/config/settings.yaml.example
+++ b/config/settings.yaml.example
@@ -117,6 +117,14 @@
     :enabled: false
     # logging level as in Logger::LEVEL
     :level: 'DEBUG'
+  # Overwrite allowed_labels, if needed, for example:
+  # :allowed_labels:
+  #   :controller:
+  #     - '.*'
+  #   :action:
+  #     - 'index'
+  #   :class:
+  #     - '.*'
 
 #
 # Configure how many workers should dynflow use to handle incoming requests.


### PR DESCRIPTION
It might not be the best idea to put the lengthy list of classes to `settings.yaml`. As the list contains majority of classes either way, maybe we can have there simply:

    :class:
     - '.*'

?