### PR TITLE
Fixes #37651 - Fix error msg about invalid MAC appearing twice

### DIFF
--- a/app/validators/mac_address_validator.rb
+++ b/app/validators/mac_address_validator.rb
@@ -6,7 +6,10 @@ class MacAddressValidator < ActiveModel::EachValidator
   end
 
   def make_invalid(record, attribute)
-    record.errors.add(attribute, (options[:message] || _("is not a valid MAC address")))
+    # error message can already be present from the Net::Validations::normalize_mac method
+    if record.errors[attribute].blank?
+      record.errors.add(attribute, (options[:message] || _("is not a valid MAC address")))
+    end
     false
   end
 end


### PR DESCRIPTION
Currently when entering an invalid MAC address while editing a host's interface, the message shown is:
"'fa:16:3e:17:3e:19x' is not a valid MAC address and is not a valid MAC address"

This is because before the validation itself, another method normalize_mac is called, which also raises an error upon finding a MAC address invalid (foreman/app/models/nic/base.rb).

Since I found the method normalize_mac being used at multiple places, I did not want to alter the behavior of this method. Validation through the MacAddressValidator seems to be used only once, so I deemed more proper to edit the method there. Still, I am not certain if the two methods are equivalent as far as validation goes, so I just added a condition which prevents duplicating the error message if normalize_mac already threw an error.