### PR TITLE
Fixes #37602 - Fix broken host/hostgroup media association

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -558,10 +558,15 @@ autopart"', desc: 'to render the content of host partition table'
   end
 
   def inherited_attributes
-    inherited_attrs = %w{domain_id operatingsystem_id architecture_id compute_resource_id}
+    inherited_attrs = %w{domain_id operatingsystem_id compute_resource_id}
     inherited_attrs << "subnet_id" unless compute_provides?(:ip)
     inherited_attrs << "subnet6_id" unless compute_provides?(:ip6)
-    inherited_attrs.concat(%w{medium_id ptable_id pxe_loader}) unless image_build?
+
+    if managed?
+      inherited_attrs << "architecture_id"
+      inherited_attrs.concat(%w{medium_id ptable_id pxe_loader}) unless image_build?
+    end
+
     inherited_attrs
   end
 


### PR DESCRIPTION
Hostgroup with assigned Installation Media is used.
A host will be registered using HostRegistartion. During this process, the
Hostgroup was used and is assigned to the host. The host is using the
subscription-manager to register. This will create a new OS in foreman if
the OS doesn't currently exist. This new OS doesn’t have the installation
media assigned (because its a new OS).

Results:

- The new created Operatingsystem like AlmaLinux9 doesn't have
  a Installation Media.
- The used Hostgroup has different Operatingsystems and is using
  a Installation Media which is valid for the Operatingsystem is used in
  this Hostgroup.

The POST request during the HostRegistration process which assigns the
Hostgroup to the Host and should render the host_init_config Template
will fail with:

The system has been registered with ID: 21312a8f-1b6e-4302-ae9e-1a64b643c6f8
The registered system name is: myra-bergh.foreman.local
ERROR: Validation failed: Medium must belong to host's operating system
Notice:

This commit makes sure that the installation medium and some other
managed-host-related fields are only inherited for managed hosts.