### PR TITLE
Pin fog-libvirt to 0.12.0

### DIFF
--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '>= 0.9.0'
+  gem 'fog-libvirt', '>= 0.9.0', '!= 0.12.1'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end


### PR DESCRIPTION
test_3_11_stable is failing since it is pulling in fog-libvirt 0.12.1 which is breaking some tests. Let's just pin 3.11 to 0.12.0 which was passing previously.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
