### PR TITLE
Fixes #37675 - Change All Hosts kebab menu to match design

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/ActionKebab.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/ActionKebab.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import { Dropdown, KebabToggle } from '@patternfly/react-core';
+import { Menu, MenuToggle, Popper } from '@patternfly/react-core';
+import { EllipsisVIcon } from '@patternfly/react-icons';
 
 /**
  * Generate a button or a dropdown of buttons
@@ -8,31 +9,48 @@ import { Dropdown, KebabToggle } from '@patternfly/react-core';
  * @param  {Object} action action to preform when the button is click can be href with data-method or Onclick
  * @return {Function} button component or splitbutton component
  */
-export const ActionKebab = ({ items }) => {
-  const [isOpen, setIsOpen] = useState(false);
+export const ActionKebab = ({ items, menuOpen, setMenuOpen }) => {
+  const containerRef = React.useRef();
   if (!items.length) return null;
+  const menu = (
+    <Menu
+      containsFlyout
+      ouiaId="hosts-index-actions-kebab"
+      id="hosts-index-actions-kebab"
+      onSelect={() => setMenuOpen(false)}
+    >
+      {items}
+    </Menu>
+  );
+
+  const menuToggle = (
+    <MenuToggle
+      variant="plain"
+      aria-label="plain kebab"
+      onClick={() => setMenuOpen(prev => !prev)}
+      isExpanded={menuOpen}
+    >
+      <EllipsisVIcon />
+    </MenuToggle>
+  );
+
   return (
-    <>
-      {items.length > 0 && (
-        <Dropdown
-          ouiaId="action-buttons-dropdown"
-          toggle={
-            <KebabToggle
-              aria-label="toggle action dropdown"
-              onToggle={setIsOpen}
-            />
-          }
-          isOpen={isOpen}
-          isPlain
-          dropdownItems={items}
-        />
-      )}
-    </>
+    <div ref={containerRef}>
+      <Popper
+        trigger={menuToggle}
+        popper={menu}
+        appendTo={containerRef.current || undefined}
+        isVisible={menuOpen}
+        popperMatchesTriggerWidth={false}
+      />
+    </div>
   );
 };
 
 ActionKebab.propTypes = {
   items: PropTypes.arrayOf(PropTypes.node),
+  menuOpen: PropTypes.bool.isRequired,
+  setMenuOpen: PropTypes.func.isRequired,
 };
 
 ActionKebab.defaultProps = {

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/TableRowActions/core.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/TableRowActions/core.js
@@ -1,0 +1,45 @@
+import forceSingleton from '../../../common/forceSingleton';
+
+const coreTableRowActionsRegistry = forceSingleton(
+  'coreTableRowActionsRegistry',
+  () => ({})
+);
+
+// Unlike the column registry which is collecting objects that describe table columns,
+// here we collect an object containing a single getActions funtion, which returns an array of kebab action items.
+export const registerGetActions = ({
+  pluginName,
+  getActionsFunc,
+  tableName = 'hosts',
+}) => {
+  if (!coreTableRowActionsRegistry[pluginName])
+    coreTableRowActionsRegistry[pluginName] = {};
+  coreTableRowActionsRegistry[pluginName][tableName] = {
+    getActions: getActionsFunc,
+  };
+};
+
+export const registeredTableRowActions = ({ tableName = 'hosts' }) => {
+  const result = {};
+  Object.keys(coreTableRowActionsRegistry).forEach(pluginName => {
+    if (coreTableRowActionsRegistry[pluginName]?.[tableName]) {
+      result[pluginName] = coreTableRowActionsRegistry[pluginName][tableName];
+    }
+  });
+  // { katello: { getActions: [Function: getActions] } }
+  return result;
+};
+
+export const getActions = (hostDetailsResult, { tableName = 'hosts' } = {}) => {
+  const result = [];
+  const allGetActionsFuncs = registeredTableRowActions({ tableName });
+  Object.values(allGetActionsFuncs).forEach(
+    ({ getActions: getActionsFunc }) => {
+      if (typeof getActionsFunc !== 'function') return;
+      result.push(...getActionsFunc(hostDetailsResult));
+    }
+  );
+  return result;
+};
+
+export default getActions;

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -76,14 +76,22 @@ export const Table = ({
     setSelectedItem({ id, name });
     setDeleteModalOpen(true);
   };
-  const actions = ({ can_delete: canDelete, id, name, ...item }) =>
+  const actions = ({
+    can_delete: canDelete,
+    can_edit: canEdit,
+    id,
+    name,
+    ...item
+  }) =>
     [
       isDeleteable && {
         title: __('Delete'),
         onClick: () => onDeleteClick({ id, name }),
         isDisabled: !canDelete,
       },
-      ...((getActions && getActions({ id, name, canDelete, ...item })) ?? []),
+      ...((getActions &&
+        getActions({ id, name, canDelete, canEdit, ...item })) ??
+        []),
     ].filter(Boolean);
   const RowSelectTd = rowSelectTd;
   return (


### PR DESCRIPTION
- [x] Main kebab menu
- [x] Single-host table row kebab

This PR updates the kebab menus in the All Hosts page to match existing designs.

The design calls for a fly-out menu like this:
![image](https://github.com/user-attachments/assets/5b2193fd-2b10-4316-9306-dbef4fd7edd1)

The problem is that the Patternfly `<Dropdown>` component does not support this fly-out menu style. Per the [Patternfly documentation](https://v4-archive.patternfly.org/v4/components/navigation#flyout), it seems the only way to accomplish this was with a `<Menu>` component, and switch all the `DropdownItem`s to `MenuItem`s.

`Menu` does not handle its own open/closed state, so I had to introduce a new state and handlers for this. I use it both directly here in Foreman, and also in the `ForemanActionsBarContext` so that [Katello can close its own submenu](https://github.com/Katello/katello/pull/11089) when the user clicks on something. `Menu` also doesn't handle its own positioning and apparently offers no easy way to pair with its `MenuToggle`, so ~~I was forced to do some manual CSS there as well.~~
