### PR TITLE
Revert "Pin mocha to a lower version"

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,5 +1,5 @@
 group :test do
-  gem 'mocha', '~> 2.1', "<  2.4.3"
+  gem 'mocha', '~> 2.1'
   gem 'minitest', '~> 5.1'
   gem 'minitest-reporters', '~> 1.4', :require => false
   gem 'minitest-retry', '~> 0.0', :require => false


### PR DESCRIPTION
This reverts commit 75ac6568187719d114335381bfaf32d3dd266572.

Mocha 2.4.5+ is fine again


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
