### PR TITLE
Fixes #37691 - rename AuthSource Welcome var to fix translation

### DIFF
--- a/webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js
+++ b/webpack/assets/javascripts/react_app/components/AuthSource/Welcome.js
@@ -15,10 +15,10 @@ export const WelcomeAuthSource = ({ canCreate }) => {
       <FormattedMessage
         id="LDAP-providers"
         defaultMessage={__(
-          'The authentication process currently requires an LDAP provider, such as {FreeIPA}, {OpenLDAP} or {Microsoft}.'
+          'The authentication process currently requires an LDAP provider, such as {Free_IPA}, {OpenLDAP} or {Microsoft}.'
         )}
         values={{
-          FreeIPA: <em>FreeIPA</em>,
+          Free_IPA: <em>{__('FreeIPA')}</em>,
           OpenLDAP: <em>OpenLDAP</em>,
           Microsoft: <em>Microsoft&apos;s Active Directory</em>,
         }}


### PR DESCRIPTION
the theme plugin renames `FreeIPA` and adds spaces which breaks the formatter, so I renamed the variable name