### PR TITLE
Fixes #37696 - Add convert2rhel fact to host reported data facet

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -85,6 +85,7 @@ module Hostext
       scoped_search :relation => :reported_data, :on => :cores, :rename => 'reported.cores', :only_explicit => true
       scoped_search :relation => :reported_data, :on => :disks_total, :rename => 'reported.disks_total', :only_explicit => true
       scoped_search :relation => :reported_data, :on => :kernel_version, :rename => 'reported.kernel_version', :only_explicit => true
+      scoped_search :relation => :reported_data, :on => :kernel_version, :rename => 'reported.convert2rhel', :only_explicit => true
       scoped_search :relation => :reported_data, :on => :bios_vendor, :rename => 'reported.bios_vendor'
       scoped_search :relation => :reported_data, :on => :bios_release_date, :rename => 'reported.bios_release_date'
       scoped_search :relation => :reported_data, :on => :bios_version, :rename => 'reported.bios_version'

--- a/app/models/host_facets/reported_data_facet.rb
+++ b/app/models/host_facets/reported_data_facet.rb
@@ -13,6 +13,7 @@ module HostFacets
         bios_vendor: parser.bios[:vendor],
         bios_release_date: parser.bios[:release_date],
         bios_version: parser.bios[:version],
+        convert2rhel: parser.convert2rhel,
       }.compact
       facet.save if facet.changed?
     end

--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -129,6 +129,10 @@ class FactParser
   def kernel_version
   end
 
+  # convert2rhel through Foreman
+  def convert2rhel
+  end
+
   # @return [Hash] bios information
   def bios
     {}

--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -117,6 +117,10 @@ module Katello
       facts['uname.release']
     end
 
+    def convert2rhel
+      facts['conversions.env.CONVERT2RHEL_THROUGH_FOREMAN'].to_i
+    end
+
     def bios
       {
         :vendor => facts['dmi::bios::all_records::vendor'],

--- a/app/views/api/v2/hosts/reported_data.json.rabl
+++ b/app/views/api/v2/hosts/reported_data.json.rabl
@@ -3,5 +3,5 @@ glue(@facet) do
 end
 
 child(@facet => :reported_data) do
-  attributes :boot_time, :cores, :sockets, :disks_total, :kernel_version, :bios_vendor, :bios_release_date, :bios_version
+  attributes :boot_time, :cores, :sockets, :disks_total, :kernel_version, :bios_vendor, :bios_release_date, :bios_version, :convert2rhel
 end

--- a/db/migrate/20240729192228_add_convert2rhel_to_host_facets.rb
+++ b/db/migrate/20240729192228_add_convert2rhel_to_host_facets.rb
@@ -1,0 +1,9 @@
+class AddConvert2rhelToHostFacets < ActiveRecord::Migration[6.1]
+  def up
+    add_column :host_facets_reported_data_facets, :convert2rhel, :int4
+  end
+
+  def down
+    remove_column :host_facets_reported_data_facets, :convert2rhel
+  end
+end


### PR DESCRIPTION
Convert2rhel creates a custom fact with an env variable, If it got converted through Satellite or through the Customer Portal. It looks like this:

```bash
[root@toledo8 ~]# cat /etc/rhsm/facts/convert2rhel.facts {
"conversions.version": "1",
"conversions.activity": "conversion",
"conversions.packages.0.nevra": "convert2rhel-0:2.0.0-1.el8.noarch",
"conversions.packages.0.signature": "RSA/SHA256, Thu May 30 13:31:33 2024, Key ID 199e2f91fd431d51",
"conversions.executed": "/usr/bin/convert2rhel",
"conversions.success": true,
"conversions.activity_started": "2024-07-11T17:28:54.281664Z",
"conversions.activity_ended": "2024-07-11T17:48:47.026664Z",
"conversions.source_os.id": "Cerulean Leopard",
"conversions.source_os.name": "AlmaLinux",
"conversions.source_os.version": "8.10",
"conversions.target_os.id": "Ootpa",
"conversions.target_os.name": "Red Hat Enterprise Linux",
"conversions.target_os.version": "8.10",
"conversions.env.CONVERT2RHEL_THROUGH_FOREMAN": "1", <- what we care about
"conversions.run_id": "null"
}
```

The env part of the fact is getting filtered out due to https://github.com/theforeman/foreman/blob/55d2a0d22a0fe738342804bcc4987fc24a3b0917/app/registries/foreman/settings/facts.rb#L23

We can see that the fact with this PR is present on the system when looking with pry:

```bash
[12] pry(main)> foo.reported_data
=> #<HostFacets::ReportedDataFacet:0x00007f6a30b9fb30
 id: 19,
 host_id: 18,
 boot_time: Thu, 11 Jul 2024 17:49:26.000000000 UTC +00:00,
 created_at: Mon, 29 Jul 2024 18:36:51.167876000 UTC +00:00,
 updated_at: Mon, 29 Jul 2024 19:30:23.632255000 UTC +00:00,
 virtual: true,
 sockets: 1,
 cores: 1,
 ram: 7953,
 disks_total: nil,
 kernel_version: "4.18.0-553.8.1.el8_10.x86_64",
 bios_vendor: nil,
 bios_release_date: nil,
 bios_version: nil,
 convert2rhel: 1>
```


The convert2rhel team wants that fact reported through RH cloud so they know if they should keep working on enhancing this process and to see how many people are using it.

Once this is in, I will make a PR to RH Cloud to add that into the report we send off.