### PR TITLE
Fixes #37714 - inherit overrides deploy on in hostgroup

### DIFF
--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -30,6 +30,7 @@ class HostgroupsController < ApplicationController
     @hostgroup = Hostgroup.new(:parent_id => @parent.id)
 
     load_vars_for_ajax
+    @hostgroup.compute_resource_id = @parent.compute_resource_id
     @hostgroup.locations = @parent.locations
     @hostgroup.organizations = @parent.organizations
     # Clone any parameters as well
@@ -101,11 +102,12 @@ class HostgroupsController < ApplicationController
   def load_vars_for_ajax
     return unless @hostgroup.present?
 
-    @architecture    = @hostgroup.architecture
-    @operatingsystem = @hostgroup.operatingsystem
-    @domain          = @hostgroup.domain
-    @subnet          = @hostgroup.subnet
-    @realm           = @hostgroup.realm
+    @compute_resource_id = @hostgroup.compute_resource_id
+    @architecture        = @hostgroup.architecture
+    @operatingsystem     = @hostgroup.operatingsystem
+    @domain              = @hostgroup.domain
+    @subnet              = @hostgroup.subnet
+    @realm               = @hostgroup.realm
   end
 
   def users_in_ancestors
@@ -144,11 +146,12 @@ class HostgroupsController < ApplicationController
   def inherit_parent_attributes
     return unless @parent.present?
 
-    @hostgroup.architecture       ||= @parent.architecture
-    @hostgroup.operatingsystem    ||= @parent.operatingsystem
-    @hostgroup.domain             ||= @parent.domain
-    @hostgroup.subnet             ||= @parent.subnet
-    @hostgroup.realm              ||= @parent.realm
+    @hostgroup.compute_resource_id ||= @parent.compute_resource_id
+    @hostgroup.architecture        ||= @parent.architecture
+    @hostgroup.operatingsystem     ||= @parent.operatingsystem
+    @hostgroup.domain              ||= @parent.domain
+    @hostgroup.subnet              ||= @parent.subnet
+    @hostgroup.realm               ||= @parent.realm
   end
 
   def reset_explicit_attributes

--- a/app/helpers/hostgroups_helper.rb
+++ b/app/helpers/hostgroups_helper.rb
@@ -37,4 +37,11 @@ module HostgroupsHelper
       sort_by { |member| member[:priority] }.
       map { |member_hash| member_hash[value_key] }
   end
+
+  def hostgroup_inherited_by_default?(field, hostgroup)
+    return false if hostgroup.ancestry.nil?
+    return false if params[:action] == 'clone'
+    return true unless params[:hostgroup]
+    !params[:hostgroup][field]
+  end
 end

--- a/app/views/hostgroups/_form.html.erb
+++ b/app/views/hostgroups/_form.html.erb
@@ -26,8 +26,16 @@
       <%= text_f f, :name %>
       <%= textarea_f f, :description, :rows => :auto %>
 
-      <%= select_f f, :compute_resource_id, accessible_resource(@hostgroup, :compute_resource), :id, :to_label,
-          { :include_blank => blank_or_inherit_f(f, :compute_resource, blank_value: _('Bare Metal')) },
+      <%= select_f f, :compute_resource_id, 
+          accessible_resource(@hostgroup, :compute_resource), 
+          :id, 
+          :to_label,
+          { 
+            :disable_button_enabled => hostgroup_inherited_by_default?(:compute_resource_id, @hostgroup),
+            :disable_button => _(HostsAndHostgroupsHelper::INHERIT_TEXT),
+            :user_set => user_set?(:compute_resource_id),
+            :include_blank => _('Bare Metal'),
+          },
           { :label => _('Deploy on'),
             :help_inline => :indicator } %>
 


### PR DESCRIPTION
if the hostgroup parent has a compute resource, the child hostgroup cant be set to have "bare metal", since empty value ("bare metal") = inherit.
In this pr I managed to make it work similarly to the host page, which is not perfect.
I added on top of `submit_with_all_params` to just reuse existing logic and not building new one.