### PR TITLE
Fixes #37720 - Execute insights registration with empty input

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/insights.erb
+++ b/app/views/unattended/provisioning_templates/snippet/insights.erb
@@ -13,6 +13,6 @@ echo '# Installing Insights client'
 echo '#'
 
 yum install -y insights-client
-insights-client --register
+insights-client --register < /dev/null
 
 <% end -%>


### PR DESCRIPTION
When using global registration method to register a system and setup_insights is set to true, The registration process will terminate immediately after completing the execution of "insights-client --register" and the host never exists from build mode.

Based on the recent internal discussions, It's happening because of how we execute the whole `register_katello_host` function i.e. straightaway pipe it to bash. The current working hypothesis is that insights-client somehow hijacks the pipe that is used to pass the inner script into bash. Hence, we need to find a way to feed the whole function in some different way to bash and execute it.

The best way to do so is to pass the function content as a `virtual file` directly to bash instead of piping it e.g.

instead of

```
register_katello_host | bash
```

we can do

```
bash <(register_katello_host)
```

And that allows the execution to be completed without any issues.

Further investigation reveals that something in the insights-client is perhaps eating the stdin and  we can rather work it around by sending an empty input to the insights-client command and doing the job i.e. 

```
insights-client --register < /dev/null
```
