### PR TITLE
Fixes #37731 - Display correct network at the host/edit page while importing the host

### DIFF
--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -344,8 +344,6 @@ $(document).on('click', '.managed-flag', function() {
   update_interface_table();
 });
 
-var providerSpecificNICInfo = null;
-
 function nic_info(form) {
   var info = '';
   var virtual_types = ['Nic::Bond', 'Nic::Bridge'];

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -691,7 +691,7 @@ module Foreman::Model
         interface_attrs = {}
         interface_attrs[:compute_attributes] = {}
         interface_attrs[:mac] = interface.mac
-        interface_attrs[:compute_attributes][:network] = network.name
+        interface_attrs[:compute_attributes][:network] = network.id
         interface_attrs[:compute_attributes][:type] = interface.type.to_s.split('::').last
         hsh[index.to_s] = interface_attrs
       end

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -631,7 +631,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
           "0" => { :vol => 1, :size_gb => 4 },
           "1" => { :vol => 2, :size_gb => 4 },
         },
-        :interfaces_attributes => {"0" => {:compute_attributes => {:network => "Testnetwork", :type => "VirtualVmxnet3"}, :mac => "00:50:56:84:f1:b1"}},
+        :interfaces_attributes => {"0" => {:compute_attributes => {:network => "dvportgroup-123456", :type => "VirtualVmxnet3"}, :mac => "00:50:56:84:f1:b1"}},
         :scsi_controllers => [
           {
             :type => "VirtualLsiLogicController",

--- a/test/unit/compute_resource_host_importer_test.rb
+++ b/test/unit/compute_resource_host_importer_test.rb
@@ -41,7 +41,7 @@ class ComputeResourceHostImporterTest < ActiveSupport::TestCase
 
       test 'imports the VM with all parameters' do
         expected_compute_attributes = {
-          'network' => 'network1',
+          'network' => 'dvportgroup-123456',
           'type' => 'VirtualE1000',
         }
 


### PR DESCRIPTION
During importing a host from the compute resources, the network was being displayed incorrectly In the host/edit in the interfaces tab, under the column Type, This PR fixes 2 things: 
1. The network being displayed as "Physical" instead of the network name
2. Incorrect network being displayed (This happens because we were selecting the network by network name instead of the network id)

Note: This PR only fixes incorrect network being fetch while importing a host. Revisiting the host/edit post import is not being covered here. We will cover that in a separate PR 