### PR TITLE
Refs #37733 - Improve formatting of the new Host Ansible Role audit

### DIFF
--- a/app/helpers/audits_helper.rb
+++ b/app/helpers/audits_helper.rb
@@ -43,6 +43,8 @@ module AuditsHelper
   def audit_title(audit)
     type_name = audited_type audit
     case type_name
+      when 'Host Ansible Role'
+        audit.associated_name + " / " + id_to_label("ansible_role_id", audit.audited_changes["ansible_role_id"], audit: audit)
       when 'Puppet Class'
         (id_to_label audit.audited_changes.keys[0], audit.audited_changes.values[0], audit: audit).to_s
       else


### PR DESCRIPTION
Improving the new host ansible role audits.

From:

![image](https://github.com/user-attachments/assets/714f8ce9-7d71-494c-b550-1924e790f452)

To:

![image](https://github.com/user-attachments/assets/7fac3464-baf1-41bd-a384-3c4d07c27a8d)

Requires https://github.com/theforeman/foreman_ansible/pull/729 to be merged.