### PR TITLE
Fixes #37737 - expiration registration url param

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration_commands.rb
+++ b/app/controllers/concerns/foreman/controller/registration_commands.rb
@@ -13,10 +13,15 @@ module Foreman::Controller::RegistrationCommands
   end
 
   def registration_args
-    registration_params.except(*ignored_query_args)
-                       .transform_values! { |v| v == false ? v.to_s : v }
-                       .delete_if { |_, v| v.blank? }
-                       .permit!
+    params = registration_params
+    if jwt_expiration_param > 0
+      expires = Time.now.utc + jwt_expiration_param.hours
+      params = params.merge(expires_at_utc: expires.to_i)
+    end
+    params.except(*ignored_query_args)
+          .transform_values! { |v| v == false ? v.to_s : v }
+          .delete_if { |_, v| v.blank? }
+          .permit!
   end
 
   def insecure


### PR DESCRIPTION
Registration command does not show the expiration in any form, I would like to add this information into unused URL parameter as UNIX UTC epoch so consumers can tell if an existing registration command is expected to work on not.

We would like to bake this information into images created by image builder so users can tell if images are already expired and need to be rebuilt.

JWT spec specifies expiration it is relative tho which is not too useful for our use case. From what I saw, Foreman does not add any JWT expiration into the JSON.

I do not have development setup anymore, trying out blindly to see which tests will scream for an update.