### PR TITLE
Refs #36547 - explicitly stringify major/minor for Ubuntu

### DIFF
--- a/app/services/puppet_fact_parser.rb
+++ b/app/services/puppet_fact_parser.rb
@@ -6,8 +6,8 @@ class PuppetFactParser < FactParser
 
     if orel.present?
       if os_name =~ /ubuntu/i
-        major = os_major_version
-        minor = os_minor_version
+        major = os_major_version.to_s
+        minor = os_minor_version.to_s
       else
         major, minor = orel.split('.', 2)
         major = major.to_s.gsub(/\D/, '')


### PR DESCRIPTION
We stringify these anyway on save, but here it's also used for
searching, and that fails to find the existing OS when searching with
minor=nil.

When the existing OS is not found, a new one is created, but that fails
to save as the name/major/minor combination already exists and that
breaks fact uploads.

Fixes: d690fa772475adc612ca11f6bd3a0209a8133126


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
