### PR TITLE
Fixes #37742 - Exclude rhn-client-tools for subman upgrade

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -65,7 +65,7 @@ if ! [ -x "$(command -v subscription-manager)" ] ; then
 else
   echo "subscription-manager is already installed!"
   <% if @subman_setup_scenario == 'registration' -%>
-    $PKG_MANAGER_UPGRADE subscription-manager > /dev/null 2>&1
+    $PKG_MANAGER_UPGRADE --setopt=exclude=rhn-client-tools subscription-manager > /dev/null 2>&1
   <% end %>
 fi
 


### PR DESCRIPTION
* Prevent rhn-client-tools from obsoleting subscription-manager by adding `--setopt=exclude=rhn-client-tools` during an upgrade
* Ensure subscription-manager upgrades correctly without being replaced by rhn-client-tools


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
