### PR TITLE
Fixes #37744: Line up Foreman and Katello registration data

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -140,7 +140,9 @@ register_katello_host(){
 <%= "      --data 'host[organization_id]=#{@organization.id}' \\\n" if @organization -%>
 <%= "      --data 'host[location_id]=#{@location.id}' \\\n" if @location -%>
 <%= "      --data 'host[hostgroup_id]=#{@hostgroup.id}' \\\n" if @hostgroup -%>
+<%= "      --data 'host[operatingsystem_id]=#{@operatingsystem.id}' \\\n" if @operatingsystem -%>
 <%= "      --data 'host[lifecycle_environment_id]=#{@lifecycle_environment_id}' \\\n" if @lifecycle_environment_id.present? -%>
+<%= "      --data host[interfaces_attributes][0][identifier]=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>
 <%= "      --data 'setup_insights=#{@setup_insights}' \\\n" unless @setup_insights.nil? -%>
 <%= "      --data 'setup_remote_execution=#{@setup_remote_execution}' \\\n" unless @setup_remote_execution.nil? -%>
 <%= "      --data remote_execution_interface=#{shell_escape(@remote_execution_interface)} \\\n" if @remote_execution_interface.present? -%>


### PR DESCRIPTION
Without the interface being created within Foreman, global registration with a REX interface selected failes on Katello instaces due to the interface not existing within Foreman.
Operatingsystem ID is now also included in register_katello_host to ensure data parity between both workflows.