### PR TITLE
Fix save_to_file to be indentation independent

### DIFF
--- a/test/static_fixtures/interpolated_text.txt
+++ b/test/static_fixtures/interpolated_text.txt
@@ -1,0 +1,2 @@
+foo: bar
+baz: $INTERPOLATED

--- a/test/static_fixtures/script.txt
+++ b/test/static_fixtures/script.txt
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+echo "Calling Ansible AWX/Tower provisioning callback..."
+/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+echo "DONE"

--- a/test/unit/foreman/renderer/renderers_shared_tests.rb
+++ b/test/unit/foreman/renderer/renderers_shared_tests.rb
@@ -138,7 +138,10 @@ module RenderersSharedTests
     test "should render a save_to_file macro" do
       source = OpenStruct.new(content: '<%= save_to_file("/etc/puppet/puppet.conf", "[main]\nserver=example.com\n") %>')
       assert_nothing_raised do
-        assert_equal("cat << EOF-728d4ec4 > /etc/puppet/puppet.conf\n[main]\nserver=example.com\nEOF-728d4ec4", renderer.render(source, @scope))
+        actual = renderer.render(source, @scope)
+        assert_match /[main]/, actual
+        assert_match /server=example.com/, actual
+        assert_match /\/etc\/puppet\/puppet.conf/, actual
       end
     end
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -186,13 +186,12 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-9f037ba1 > /root/ansible_provisioning_call.sh
-#!/bin/sh
-
-echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-echo "DONE"
-EOF-9f037ba1
+cat /dev/null > /root/ansible_provisioning_call.sh
+echo "#!/bin/sh" >> /root/ansible_provisioning_call.sh
+echo "" >> /root/ansible_provisioning_call.sh
+echo "echo \"Calling Ansible AWX/Tower provisioning callback...\"" >> /root/ansible_provisioning_call.sh
+echo "/usr/bin/curl -v -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /root/ansible_provisioning_call.sh
+echo "echo \"DONE\"" >> /root/ansible_provisioning_call.sh
 chmod +x /root/ansible_provisioning_call.sh
 /root/ansible_provisioning_call.sh
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -56,20 +56,19 @@ allow-hotplug $real
 iface $real inet dhcp
 EOF
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -56,20 +56,19 @@ allow-hotplug $real
 iface $real inet dhcp
 EOF
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -249,20 +249,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -249,20 +249,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -249,20 +249,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -249,20 +249,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -249,20 +249,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -130,20 +130,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -247,20 +247,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -246,20 +246,19 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-cat << EOF-2929810d > /etc/systemd/system/ansible-callback.service
-[Unit]
-Description=Provisioning callback to Ansible Tower
-Wants=network-online.target
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-ExecStartPost=/usr/bin/systemctl disable ansible-callback
-
-[Install]
-WantedBy=multi-user.target
-EOF-2929810d
+cat /dev/null > /etc/systemd/system/ansible-callback.service
+echo "[Unit]" >> /etc/systemd/system/ansible-callback.service
+echo "Description=Provisioning callback to Ansible Tower" >> /etc/systemd/system/ansible-callback.service
+echo "Wants=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "After=network-online.target" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Service]" >> /etc/systemd/system/ansible-callback.service
+echo "Type=oneshot" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStart=/usr/bin/curl -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /etc/systemd/system/ansible-callback.service
+echo "ExecStartPost=/usr/bin/systemctl disable ansible-callback" >> /etc/systemd/system/ansible-callback.service
+echo "" >> /etc/systemd/system/ansible-callback.service
+echo "[Install]" >> /etc/systemd/system/ansible-callback.service
+echo "WantedBy=multi-user.target" >> /etc/systemd/system/ansible-callback.service
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -199,13 +199,12 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 
-    cat << EOF-d592f4ed > /tmp/ansible_provisioning_call.sh
-#!/bin/sh
-
-echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
-echo "DONE"
-EOF-d592f4ed
+    cat /dev/null > /tmp/ansible_provisioning_call.sh
+echo "#!/bin/sh" >> /tmp/ansible_provisioning_call.sh
+echo "" >> /tmp/ansible_provisioning_call.sh
+echo "echo \"Calling Ansible AWX/Tower provisioning callback...\"" >> /tmp/ansible_provisioning_call.sh
+echo "/usr/bin/curl -v -k -s --data \"host_config_key=\" https:///api/v2/job_templates//callback/" >> /tmp/ansible_provisioning_call.sh
+echo "echo \"DONE\"" >> /tmp/ansible_provisioning_call.sh
     /bin/sh /tmp/ansible_provisioning_call.sh
 
 # UserData still needs to mark the build as finished


### PR DESCRIPTION
Heredoc notation is very sensitive to leading spaces.
This implementation makes the `save_to_file` macro safe for indentation.