### PR TITLE
Refs #36999 - Force host-passthrough CPU model for libvirt

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -282,6 +282,7 @@ module Foreman::Model
 
     def vm_instance_defaults
       super.merge(
+        :cpu        => { mode: 'host-passthrough' },
         :memory     => 2048.megabytes,
         :nics       => [new_nic],
         :volumes    => [new_volume].compact,


### PR DESCRIPTION
If the :cpu option is not specified, fog-libvirt uses the default configured CPU model on the libvirt host. This is often qemu64 and that lacks some features you generally want. host-passthrough is recommended by libvirt so this opts into that.

Technically it duplicates the default that fog-libvirt already sets, but if you leave the hash empty then it falls back to the host default.

Users can override the value via the API, but I think that's fine.