### PR TITLE
refs #37433 - Revert indentation for subscription_manager_setup

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -96,7 +96,7 @@ description: |
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-  <%= indent(2) { snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'provisioning' }).strip } -%>
+  <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'provisioning' }).strip -%>
 
   <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla') || host_param('syspurpose_addons')) -%>
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -38,91 +38,91 @@ runcmd:
     echo "Starting the subscription-manager registration process"
   
     # Set up subscription-manager
-      # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-    if [ -z "$PKG_MANAGER" ]; then
-      if [ -f /etc/os-release ] ; then
-        . /etc/os-release
+    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+  if [ -z "$PKG_MANAGER" ]; then
+    if [ -f /etc/os-release ] ; then
+      . /etc/os-release
+    fi
+    
+    if [ "${NAME%.*}" = 'FreeBSD' ]; then
+      PKG_MANAGER='pkg'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+      PKG_MANAGER='dnf'
+      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+        PKG_MANAGER='yum'
+      elif [ -f /etc/system-release ]; then
+        PKG_MANAGER='yum'
       fi
-      
-      if [ "${NAME%.*}" = 'FreeBSD' ]; then
-        PKG_MANAGER='pkg'
-        PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-        PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-        PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-      elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-        PKG_MANAGER='dnf'
-        if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-          PKG_MANAGER='yum'
-        elif [ -f /etc/system-release ]; then
-          PKG_MANAGER='yum'
-        fi
-        PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-        PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-        PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-      elif [ -f /etc/debian_version ]; then
-        PKG_MANAGER='apt-get'
-        PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-        PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-        PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-      elif [ -f /etc/arch-release ]; then
-        PKG_MANAGER='pacman'
-        PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-        PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-        PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-      elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-        PKG_MANAGER='zypper'
-        PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-        PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-        PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-      fi
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    elif [ -f /etc/debian_version ]; then
+      PKG_MANAGER='apt-get'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    elif [ -f /etc/arch-release ]; then
+      PKG_MANAGER='pacman'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+      PKG_MANAGER='zypper'
+      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
     fi
+  fi
+  
+  # Define the path to rhsm.conf
+  RHSM_CFG=/etc/rhsm/rhsm.conf
+  
+  
+  
+  # Prepare subscription-manager
+  if ! [ -x "$(command -v subscription-manager)" ] ; then
+    $PKG_MANAGER_INSTALL subscription-manager
+  else
+    echo "subscription-manager is already installed!"
     
-    # Define the path to rhsm.conf
-    RHSM_CFG=/etc/rhsm/rhsm.conf
-    
-    
-    
-    # Prepare subscription-manager
-    if ! [ -x "$(command -v subscription-manager)" ] ; then
-      $PKG_MANAGER_INSTALL subscription-manager
-    else
-      echo "subscription-manager is already installed!"
-      
-    fi
-    
-    # Check if rhsm.conf exists
-    if ! [ -f $RHSM_CFG ] ; then
-      echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-        exit 1
-    fi
-    
-    
-    # Configure subscription-manager
-    test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-    subscription-manager config \
-      --server.hostname="subscription.rhsm.redhat.com" \
-      --server.port="443" \
-      --server.prefix="/subscription" \
-      --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-      --rhsm.baseurl="https://cdn.redhat.com"
-    
-    # Older versions of subscription manager may not recognize
-    # report_package_profile and package_profile_on_trans options.
-    # So set them separately and redirect out & error to /dev/null
-    # to fail silently.
-    subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-    subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-    
-    # Configuration for EL6
-    if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-      sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-    else
-      full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-      sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-    fi
-    
-    # Restart yggdrasild if installed and running
-    systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+  fi
+  
+  # Check if rhsm.conf exists
+  if ! [ -f $RHSM_CFG ] ; then
+    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+      exit 1
+  fi
+  
+  
+  # Configure subscription-manager
+  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+  subscription-manager config \
+    --server.hostname="subscription.rhsm.redhat.com" \
+    --server.port="443" \
+    --server.prefix="/subscription" \
+    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+    --rhsm.baseurl="https://cdn.redhat.com"
+  
+  # Older versions of subscription manager may not recognize
+  # report_package_profile and package_profile_on_trans options.
+  # So set them separately and redirect out & error to /dev/null
+  # to fail silently.
+  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+  
+  # Configuration for EL6
+  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+  else
+    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+  fi
+  
+  # Restart yggdrasild if installed and running
+  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
       # Avoid timeout accessing unreachable repo on air gapped infrastructure,
       #  assuming subscription-manager-syspurpose is installed in custom packages section.
       if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -23,91 +23,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -86,91 +86,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -86,91 +86,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -86,91 +86,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -86,91 +86,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -86,91 +86,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -84,91 +84,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -83,91 +83,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -37,91 +37,91 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
   echo "Starting the subscription-manager registration process"
 
   # Set up subscription-manager
-    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
-  if [ -z "$PKG_MANAGER" ]; then
-    if [ -f /etc/os-release ] ; then
-      . /etc/os-release
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
     fi
-    
-    if [ "${NAME%.*}" = 'FreeBSD' ]; then
-      PKG_MANAGER='pkg'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
-    elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
-      PKG_MANAGER='dnf'
-      if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
-        PKG_MANAGER='yum'
-      elif [ -f /etc/system-release ]; then
-        PKG_MANAGER='yum'
-      fi
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
-    elif [ -f /etc/debian_version ]; then
-      PKG_MANAGER='apt-get'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
-    elif [ -f /etc/arch-release ]; then
-      PKG_MANAGER='pacman'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
-    elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
-      PKG_MANAGER='zypper'
-      PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
-      PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
-    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
   fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
   
-  # Define the path to rhsm.conf
-  RHSM_CFG=/etc/rhsm/rhsm.conf
-  
-  
-  
-  # Prepare subscription-manager
-  if ! [ -x "$(command -v subscription-manager)" ] ; then
-    $PKG_MANAGER_INSTALL subscription-manager
-  else
-    echo "subscription-manager is already installed!"
-    
-  fi
-  
-  # Check if rhsm.conf exists
-  if ! [ -f $RHSM_CFG ] ; then
-    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
-      exit 1
-  fi
-  
-  
-  # Configure subscription-manager
-  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
-  subscription-manager config \
-    --server.hostname="subscription.rhsm.redhat.com" \
-    --server.port="443" \
-    --server.prefix="/subscription" \
-    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
-  
-  # Older versions of subscription manager may not recognize
-  # report_package_profile and package_profile_on_trans options.
-  # So set them separately and redirect out & error to /dev/null
-  # to fail silently.
-  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
-  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
-  
-  # Configuration for EL6
-  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
-    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
-  else
-    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
-    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
-  fi
-  
-  # Restart yggdrasild if installed and running
-  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then


### PR DESCRIPTION
This reverts commit aa8f66f2f442602f48980fb037c003d13addc9ce.

The reverted change is breaking:
* provisioning of RHEL 8.y machines (https://issues.redhat.com/browse/SAT-27182)
* Templates with heredoc (https://projects.theforeman.org/issues/37741)
* Cloud-init templates with `subscription_manager_setup`

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
