### PR TITLE
Fixes #37760 - Update pagination component to default to false for URL pagination

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Pagination/index.js
+++ b/webpack/assets/javascripts/react_app/components/Pagination/index.js
@@ -150,7 +150,7 @@ Pagination.defaultProps = {
   perPage: null,
   noSidePadding: false,
   variant: PaginationVariant.bottom,
-  updateParamsByUrl: true,
+  updateParamsByUrl: false,
 };
 
 export default Pagination;


### PR DESCRIPTION
The updateParamsByUrl is true by default in the component. As a result the effect here: https://github.com/theforeman/foreman/blob/aa2a03c106af65a2ad139641d2875559a2dc45c7/webpack/assets/javascripts/react_app/components/Pagination/index.js#L47 sets page to default value of 1.
https://github.com/theforeman/foreman/blob/aa2a03c106af65a2ad139641d2875559a2dc45c7/webpack/assets/javascripts/react_app/common/urlHelpers.js#L29

I saw some usages of Pagination component and we seem to be passing this. In places where we don't, like Katello Table wrapper , this value will now default to false and pagination will work based on the current value of page.

To test:
Create some test data for CV UI.
```
100.times do |i|
  cv1 = cv.dup  
  cv1.label='test'+i.to_s  
  cv1.name = 'test'+i.to_s  
  cv1.save!
end 
```
Go to Content View page.
Try moving around pages of results using the pagination component on top and bottom of table.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
