### PR TITLE
Fixes #37800 - Don't apply the compute profile when updating host

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -159,7 +159,6 @@ module Api
         @all_parameters = true
 
         @host.attributes = host_attributes(host_params, @host)
-        apply_compute_profile(@host) if (params[:host] && params[:host][:compute_attributes].present?) || @host.compute_profile_id_changed?
 
         process_response @host.save
       rescue InterfaceTypeMapper::UnknownTypeException => e


### PR DESCRIPTION
For the details, please see the [upstream RFC](https://community.theforeman.org/t/rfc-dont-apply-the-compute-profile-when-updating-the-host/39278).