### PR TITLE
Fixes #37767 - Fixes User search filter for 'auth_source_type'.

### DIFF
--- a/app/models/auth_sources/auth_source_ldap.rb
+++ b/app/models/auth_sources/auth_source_ldap.rb
@@ -39,7 +39,7 @@ class AuthSourceLdap < AuthSource
 
   before_validation :strip_ldap_attributes
   before_validation :sanitize_use_netgroups
-  after_initialize :set_defaults
+  after_initialize :set_defaults, if: :new_record?
 
   scoped_search :on => :name, :complete_value => :true
 


### PR DESCRIPTION
If LDAP Authentication source is added in `Administer > Authentication Sources` then User search filter fails for `auth_source_type` as it cannot find attributes to set default values for them. Since LDAP auth source is not initialized in User page it fails the condition set_defaults after initialize. To prevent this, set defaults only if its a new record and not when there already exists some AuthSourceLdap object.