### PR TITLE
Fixes #37769 - Point Subscription Manager to correct host

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -88,7 +88,7 @@ fi
      end
    elsif @subman_setup_scenario == 'provisioning'
      if plugin_present?('katello')
-       server_hostname = @host.content_source
+       server_hostname = @host.content_source.rhsm_url.host
        server_port = @host.content_source.rhsm_url.port
        server_prefix = @host.content_source.rhsm_url.path
        repo_ca_cert = "$KATELLO_SERVER_CA_CERT"


### PR DESCRIPTION
This fix points the subscription manager to the correct host for rhsm as it may not necessarily be the same as the content source.
