### PR TITLE
Fixes #37433 - Add properly indented comment, to fix cloud-init yaml

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -70,6 +70,7 @@ module Foreman
         "syspurpose_usage" => "Development/Test",
         "syspurpose_sla" => "Self-Support",
         "syspurpose_addons" => "first addon, second addon, third addon",
+        "subscription_manager" => "true",
       }
       host_params.each_pair do |name, value|
         FactoryBot.build(:host_parameter, host: host, name: name, value: value)

--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -51,6 +51,7 @@ runcmd:
 <%= indent(2) { snippet 'epel' } -%>
 <% end -%>
 - |
+  # The first line must be indented correctly to keep YAML integrity
 <%= indent(2) { snippet 'redhat_register' } -%>
 - |
 <% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>

--- a/lib/tasks/snapshots.rake
+++ b/lib/tasks/snapshots.rake
@@ -34,6 +34,8 @@ namespace :snapshots do
       Foreman.settings.load
       Setting[:unattended_url] = "http://foreman.example.com"
       Setting[:foreman_url] = "http://foreman.example.com"
+      Setting[:ct_location] = "/usr/bin/cat"
+      Setting[:ct_arguments] = []
 
       User.current = FactoryBot.build(:user, :admin)
       admin = FactoryBot.create(:user, :admin, password: 'password123', auth_source: FactoryBot.create(:auth_source_ldap))

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -28,9 +28,149 @@ runcmd:
   /usr/sbin/hwclock --systohc
 - |
 - |
+  # The first line must be indented correctly to keep YAML integrity
   
   
   
+  
+    
+  
+    echo "##############################################################"
+    echo "################# SUBSCRIPTION MANAGER #######################"
+    echo "##############################################################"
+    echo
+    echo "Starting the subscription-manager registration process"
+  
+    # Set up subscription-manager
+    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+  if [ -z "$PKG_MANAGER" ]; then
+   
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+  fi
+  
+  # Define the path to rhsm.conf
+  RHSM_CFG=/etc/rhsm/rhsm.conf
+  
+  
+  
+  # Prepare subscription-manager
+  if ! [ -x "$(command -v subscription-manager)" ] ; then
+    $PKG_MANAGER_INSTALL subscription-manager
+  else
+    echo "subscription-manager is already installed!"
+    
+  fi
+  
+  # Check if rhsm.conf exists
+  if ! [ -f $RHSM_CFG ] ; then
+    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+      exit 1
+  fi
+  
+  
+  
+  # Configure subscription-manager
+  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+  subscription-manager config \
+    --server.hostname="subscription.rhsm.redhat.com" \
+    --server.port="443" \
+    --server.prefix="/subscription" \
+    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+    --rhsm.baseurl="https://cdn.redhat.com"
+  
+  # Older versions of subscription manager may not recognize
+  # report_package_profile and package_profile_on_trans options.
+  # So set them separately and redirect out & error to /dev/null
+  # to fail silently.
+  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+  
+  # Configuration for EL6
+  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+  else
+    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+  fi
+  
+  
+  # Restart yggdrasild if installed and running
+  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+  
+      # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+      #  assuming subscription-manager-syspurpose is installed in custom packages section.
+      if ! rpm --query --quiet subscription-manager-syspurpose ; then
+        $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+      fi
+  
+      if [ -f /usr/sbin/syspurpose ]; then
+  
+          syspurpose set-role "Red Hat Enterprise Linux Server"
+  
+  
+          syspurpose set-usage "Development/Test"
+  
+  
+          syspurpose set-sla "Self-Support"
+  
+  
+  
+          syspurpose add-addons 'first addon' 'second addon' 'third addon'
+  
+      else
+        echo "Syspurpose CLI not found."
+      fi
+    
+  
+    
+    
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-deb10" --org='Org' --activationkey='key'
+    
+  
+    
+  
+      
+  
+    
+  
+    
+  
+    
   
   
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -29,9 +29,149 @@ runcmd:
 - |
   rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 - |
+  # The first line must be indented correctly to keep YAML integrity
   
   
   
+  
+    
+  
+    echo "##############################################################"
+    echo "################# SUBSCRIPTION MANAGER #######################"
+    echo "##############################################################"
+    echo
+    echo "Starting the subscription-manager registration process"
+  
+    # Set up subscription-manager
+    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+  if [ -z "$PKG_MANAGER" ]; then
+   
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+  fi
+  
+  # Define the path to rhsm.conf
+  RHSM_CFG=/etc/rhsm/rhsm.conf
+  
+  
+  
+  # Prepare subscription-manager
+  if ! [ -x "$(command -v subscription-manager)" ] ; then
+    $PKG_MANAGER_INSTALL subscription-manager
+  else
+    echo "subscription-manager is already installed!"
+    
+  fi
+  
+  # Check if rhsm.conf exists
+  if ! [ -f $RHSM_CFG ] ; then
+    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+      exit 1
+  fi
+  
+  
+  
+  # Configure subscription-manager
+  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+  subscription-manager config \
+    --server.hostname="subscription.rhsm.redhat.com" \
+    --server.port="443" \
+    --server.prefix="/subscription" \
+    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+    --rhsm.baseurl="https://cdn.redhat.com"
+  
+  # Older versions of subscription manager may not recognize
+  # report_package_profile and package_profile_on_trans options.
+  # So set them separately and redirect out & error to /dev/null
+  # to fail silently.
+  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+  
+  # Configuration for EL6
+  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+  else
+    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+  fi
+  
+  
+  # Restart yggdrasild if installed and running
+  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+  
+      # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+      #  assuming subscription-manager-syspurpose is installed in custom packages section.
+      if ! rpm --query --quiet subscription-manager-syspurpose ; then
+        $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+      fi
+  
+      if [ -f /usr/sbin/syspurpose ]; then
+  
+          syspurpose set-role "Red Hat Enterprise Linux Server"
+  
+  
+          syspurpose set-usage "Development/Test"
+  
+  
+          syspurpose set-sla "Self-Support"
+  
+  
+  
+          syspurpose add-addons 'first addon' 'second addon' 'third addon'
+  
+      else
+        echo "Syspurpose CLI not found."
+      fi
+    
+  
+    
+    
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+    
+  
+    
+  
+      
+  
+    
+  
+    
+  
+    
   
   
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -28,9 +28,149 @@ runcmd:
   /usr/sbin/hwclock --systohc
 - |
 - |
+  # The first line must be indented correctly to keep YAML integrity
   
   
   
+  
+    
+  
+    echo "##############################################################"
+    echo "################# SUBSCRIPTION MANAGER #######################"
+    echo "##############################################################"
+    echo
+    echo "Starting the subscription-manager registration process"
+  
+    # Set up subscription-manager
+    # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+  if [ -z "$PKG_MANAGER" ]; then
+   
+  if [ -f /etc/os-release ] ; then
+    . /etc/os-release
+  fi
+  
+  if [ "${NAME%.*}" = 'FreeBSD' ]; then
+    PKG_MANAGER='pkg'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+    PKG_MANAGER='dnf'
+    if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+      PKG_MANAGER='yum'
+    elif [ -f /etc/system-release ]; then
+      PKG_MANAGER='yum'
+    fi
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  elif [ -f /etc/debian_version ]; then
+    PKG_MANAGER='apt-get'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  elif [ -f /etc/arch-release ]; then
+    PKG_MANAGER='pacman'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+    PKG_MANAGER='zypper'
+    PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+    PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  fi
+  fi
+  
+  # Define the path to rhsm.conf
+  RHSM_CFG=/etc/rhsm/rhsm.conf
+  
+  
+  
+  # Prepare subscription-manager
+  if ! [ -x "$(command -v subscription-manager)" ] ; then
+    $PKG_MANAGER_INSTALL subscription-manager
+  else
+    echo "subscription-manager is already installed!"
+    
+  fi
+  
+  # Check if rhsm.conf exists
+  if ! [ -f $RHSM_CFG ] ; then
+    echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+      exit 1
+  fi
+  
+  
+  
+  # Configure subscription-manager
+  test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+  subscription-manager config \
+    --server.hostname="subscription.rhsm.redhat.com" \
+    --server.port="443" \
+    --server.prefix="/subscription" \
+    --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+    --rhsm.baseurl="https://cdn.redhat.com"
+  
+  # Older versions of subscription manager may not recognize
+  # report_package_profile and package_profile_on_trans options.
+  # So set them separately and redirect out & error to /dev/null
+  # to fail silently.
+  subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+  subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+  
+  # Configuration for EL6
+  if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+    sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+  else
+    full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+    sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+  fi
+  
+  
+  # Restart yggdrasild if installed and running
+  systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+  
+      # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+      #  assuming subscription-manager-syspurpose is installed in custom packages section.
+      if ! rpm --query --quiet subscription-manager-syspurpose ; then
+        $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+      fi
+  
+      if [ -f /usr/sbin/syspurpose ]; then
+  
+          syspurpose set-role "Red Hat Enterprise Linux Server"
+  
+  
+          syspurpose set-usage "Development/Test"
+  
+  
+          syspurpose set-sla "Self-Support"
+  
+  
+  
+          syspurpose add-addons 'first addon' 'second addon' 'third addon'
+  
+      else
+        echo "Syspurpose CLI not found."
+      fi
+    
+  
+    
+    
+    
+      subscription-manager register --name="snapshot-ipv4-dhcp-ubuntu18" --org='Org' --activationkey='key'
+    
+  
+    
+  
+      
+  
+    
+  
+    
+  
+    
   
   
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -22,6 +22,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -85,6 +85,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv4-6-dhcp-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -85,6 +85,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -85,6 +85,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv4-static-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -85,6 +85,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv6-dhcp-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -85,6 +85,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv6-static-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -32,6 +32,145 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 
 
+  
+
+  echo "##############################################################"
+  echo "################# SUBSCRIPTION MANAGER #######################"
+  echo "##############################################################"
+  echo
+  echo "Starting the subscription-manager registration process"
+
+  # Set up subscription-manager
+  # Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -z "$PKG_MANAGER" ]; then
+ 
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+fi
+
+# Define the path to rhsm.conf
+RHSM_CFG=/etc/rhsm/rhsm.conf
+
+
+
+# Prepare subscription-manager
+if ! [ -x "$(command -v subscription-manager)" ] ; then
+  $PKG_MANAGER_INSTALL subscription-manager
+else
+  echo "subscription-manager is already installed!"
+  
+fi
+
+# Check if rhsm.conf exists
+if ! [ -f $RHSM_CFG ] ; then
+  echo "'$RHSM_CFG' not found, cannot configure subscription-manager"
+    exit 1
+fi
+
+
+
+# Configure subscription-manager
+test -f $RHSM_CFG.bak || cp $RHSM_CFG $RHSM_CFG.bak
+subscription-manager config \
+  --server.hostname="subscription.rhsm.redhat.com" \
+  --server.port="443" \
+  --server.prefix="/subscription" \
+  --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
+  --rhsm.baseurl="https://cdn.redhat.com"
+
+# Older versions of subscription manager may not recognize
+# report_package_profile and package_profile_on_trans options.
+# So set them separately and redirect out & error to /dev/null
+# to fail silently.
+subscription-manager config --rhsm.package_profile_on_trans=1 > /dev/null 2>&1 || true
+subscription-manager config --rhsm.report_package_profile=1 > /dev/null 2>&1 || true
+
+# Configuration for EL6
+if grep --quiet full_refresh_on_yum $RHSM_CFG; then
+  sed -i "s/full_refresh_on_yum\s*=.*$/full_refresh_on_yum = 1/g" $RHSM_CFG
+else
+  full_refresh_config="#config for on-premise management\nfull_refresh_on_yum = 1"
+  sed -i "/baseurl/a $full_refresh_config" $RHSM_CFG
+fi
+
+
+# Restart yggdrasild if installed and running
+systemctl try-restart yggdrasil >/dev/null 2>&1 || true
+
+    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
+    #  assuming subscription-manager-syspurpose is installed in custom packages section.
+    if ! rpm --query --quiet subscription-manager-syspurpose ; then
+      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
+    fi
+
+    if [ -f /usr/sbin/syspurpose ]; then
+
+        syspurpose set-role "Red Hat Enterprise Linux Server"
+
+
+        syspurpose set-usage "Development/Test"
+
+
+        syspurpose set-sla "Self-Support"
+
+
+
+        syspurpose add-addons 'first addon' 'second addon' 'third addon'
+
+    else
+      echo "Syspurpose CLI not found."
+    fi
+  
+
+  
+  
+  
+    subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
+  
+
+  
+
+    
+
+  
+
+  
+
+  
+
 
 
 


### PR DESCRIPTION
When there is more than two spaces indentation, the yaml generated by the template will be broken.

We need to make sure the first line starts with exactly two spaces.