### PR TITLE
Implement a default database URL

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,13 @@
 # Load the rails application
 require File.expand_path('application', __dir__)
 
+# https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+ENV['DATABASE_URL'] ||= case Rails.env
+                       when 'production'
+                         'postgresql://'
+                       else
+                         "postgresql:///foreman-#{Rails.env}"
+                       end
+
 # Initialize the rails application
 Foreman::Application.initialize!

--- a/developer_docs/foreman_dev_setup.asciidoc
+++ b/developer_docs/foreman_dev_setup.asciidoc
@@ -68,7 +68,6 @@ sudo -u postgres createuser --createdb $USER
 git clone https://github.com/{GITHUB_USER}/foreman.git -b develop
 cd foreman
 cp config/settings.yaml.example config/settings.yaml
-cp config/database.yml.example config/database.yml
 git remote add upstream git@github.com:theforeman/foreman.git
 ....
 
@@ -106,8 +105,6 @@ Foreman uses Bundler to install dependencies and get up and running. This is the
 
 [[Database]]
 == Setting the database
-It is important that config/database.yml is set to use the correct database in the “development” block.
-Rails (and subsequently Foreman) will use these connection settings under “development” to manage the database it uses and setup the necessary schema.
 
 Set up database schema:
 [source, ruby]

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -5,7 +5,6 @@ namespace :db do
     Make a dump of your database
 
     Foreman will make a dump of your database at the provided location, or it will put it in #{File.expand_path('../../db', __dir__)} if no destination file is provided.
-    A valid config/database.yml file with the database details is needed to perform this operation.
 
     Available conditions:
       * destination => path to dump output file (defaults to #{File.expand_path('../../db', __dir__)}/foreman.EPOCH.sql)
@@ -73,7 +72,6 @@ namespace :db do
     Import a database dump
 
     Foreman will import a database from the provided location.
-    A valid config/database.yml file with the database details is needed to perform this operation.
 
     Available conditions:
       * file => database dump file path


### PR DESCRIPTION
This implements a default database URL, which is `postgresql://` for production and `postgresql:///foreman-$ENV` otherwise. That means using a unix socket to connect to, which implies the username and doesn't need any password. When no database name is given (like in production) PostgreSQL assumes one that matches the username.

By doing this, there is no need for a config/database.yml file which simplifies setup.

I'm not sure if this is a good idea or not. It'll still be needed for remote DBs and in case you need to override the pool size. It does make development and testing easier.