### PR TITLE
Refs #36999 - Force host-passthrough CPU model for libvirt

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -282,6 +282,7 @@ module Foreman::Model
 
     def vm_instance_defaults
       super.merge(
+        :cpu        => { mode: 'host-passthrough' },
         :memory     => 2048.megabytes,
         :nics       => [new_nic],
         :volumes    => [new_volume].compact,


### PR DESCRIPTION
If the :cpu option is not specified, fog-libvirt uses the default configured CPU model on the libvirt host. This is often qemu64 and that lacks some features you generally want. host-passthrough is recommended by libvirt so this opts into that.

Technically it duplicates the default that fog-libvirt already sets, but if you leave the hash empty then it falls back to the host default.

(cherry picked from commit 3b9957fe97bd0e34c06c9e57b1131aa63069751e)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
