### PR TITLE
Fixes #37768 - Respect the updateParamsByUrl param

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -116,7 +116,7 @@ const TableIndexPage = ({
   const { location: { search: historySearch } = {} } = history || {};
   const urlParams = new URLSearchParams(historySearch);
   const urlParamsSearch = urlParams.get('search') || '';
-  const search = urlParamsSearch || getURIsearch();
+  const search = updateParamsByUrl ? urlParamsSearch || getURIsearch() : '';
   const defaultParams = { search: search || '' };
   if (updateParamsByUrl) {
     const urlPage = urlParams.get('page');


### PR DESCRIPTION
This updates TableIndexPage not to use URL params for the initial search, if you haven't passed the `updateParamsByUrl` prop.

Without this the host search was bleeding into the searches on the Packages and Errata wizards.