### PR TITLE
Fixes #37587 - cast page and perPage to Number

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -102,8 +102,8 @@ module Api
       end
 
       def metadata_per_page
-        @per_page ||= Setting[:entries_per_page] if params[:per_page].blank?
-        @per_page ||= params[:per_page] == 'all' ? metadata_total : params[:per_page].to_i
+        @per_page ||= Setting[:entries_per_page].to_i if params[:per_page].blank?
+        @per_page ||= params[:per_page] == 'all' ? metadata_total.to_i : params[:per_page].to_i
       end
 
       # For the purpose of ADDING/REMOVING associations in CHILD node on POST/PUT payload

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -141,14 +141,16 @@ const TableIndexPage = ({
       can_create: canCreate,
       results,
       total,
-      per_page: perPage,
-      page,
+      per_page: respPerPage,
+      page: respPage,
       subtotal,
       message: errorMessage,
     },
     status = STATUS.PENDING,
     setAPIOptions,
   } = response;
+  const page = Number(respPage);
+  const perPage = Number(respPerPage);
 
   const memoDefaultSearchProps = useMemo(
     () => getControllerSearchProps(controller),


### PR DESCRIPTION
New All Hosts page - On the bulk packages wizard, you get this error when you choose anything except 'Upgrade all' and then advance to the next wizard step (the packages table):

```
Warning: Failed prop type: Invalid prop `perPage` of type `string` supplied to `Pagination`, expected `number`.
    in Pagination (created by TableIndexPage)
    in TableIndexPage (created by BulkPackagesTable)
    in BulkPackagesTable (created by BulkPackagesUpgradeTable)
```

`page` and `perPage` being strings also cause the Pagination component to do crazy things like go from page 1 > 2 > 21 when you press the next page button.

This casts them to Numbers in TableIndexPage. I also added some `.to_i`s in the backend - I'm not sure they made a difference, but think they should stay so that things are more consistent.
