### PR TITLE
Fixes #37774 - wait for the host page to render before editing again

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -529,6 +529,7 @@ class HostJSTest < IntegrationTestWithJavascript
       page.find(id).click
       assert page.has_no_selector?(id)
       click_button('Submit')
+      find('h5', :text => host.fqdn) # wait for the host page to load
 
       visit edit_host_path(host)
       switch_form_tab('Parameters')


### PR DESCRIPTION
Fixes: fe5c585bd98cb8612d7d401c96b0ed1dd7d5f63d


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
