### PR TITLE
Basic usage report implementation with reports

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -15,7 +15,7 @@ class ApplicationRecord < ActiveRecord::Base
   end
 
   class Jail < Safemode::Jail
-    allow :id, :name, :present?
+    allow :id, :name, :present?, :created_at
   end
 
   self.abstract_class = true

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -56,7 +56,7 @@ class Domain < ApplicationRecord
     prop_group :basic_model_props, ApplicationRecord, meta: { example: 'example.com' }
     property :fullname, String, desc: 'User name for this domain, e.g. "Primary domain for our company"'
   end
-  class Jail < Safemode::Jail
+  class Jail < Jail
     allow :id, :name, :fullname
   end
 

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -214,7 +214,7 @@ class SmartProxy < ApplicationRecord
     property :httpboot_https_port, Integer, desc: 'Returns proxy port for HTTPS boot'
     property :httpboot_https_port!, Integer, desc: 'Same as httpboot_https_port, but raises Foreman::Exception if no port is set'
   end
-  class Jail < ::Safemode::Jail
-    allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port, :httpboot_http_port!, :httpboot_https_port!, :url
+  class Jail < Jail
+    allow :hostname, :httpboot_http_port, :httpboot_https_port, :httpboot_http_port!, :httpboot_https_port!, :url, :feature_details
   end
 end

--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -122,6 +122,7 @@ module Foreman
         :outofsync_interval,
         :default_puppet_environment,
         :update_ip_from_built_request,
+        :lab_features,
       ]
 
       DEFAULT_ALLOWED_LOADERS = Foreman::Renderer::Scope::Macros::Loaders::LOADERS.map(&:first)
@@ -138,7 +139,7 @@ module Foreman
         :allowed_generic_helpers, :allowed_host_helpers, :allowed_loaders
 
       def allowed_helpers
-        allowed_generic_helpers + allowed_host_helpers + allowed_loaders
+        allowed_generic_helpers + allowed_host_helpers + allowed_loaders + [:load_any_resource]
       end
     end
   end

--- a/app/services/foreman/renderer/scope/macros/loaders.rb
+++ b/app/services/foreman/renderer/scope/macros/loaders.rb
@@ -70,6 +70,11 @@ module Foreman
             end
           end
 
+          def load_any_resource(resource:, permission:, search: '', batch: nil)
+            model = resource.constantize
+            load_resource(klass: model, search: search, permission: permission, batch: batch)
+          end
+
           private
 
           # returns a batched relation, use either
@@ -88,7 +93,8 @@ module Foreman
             base = base.limit(limit) unless limit.nil?
             base = base.where(where) unless where.nil?
             base = base.select(select) unless select.nil?
-            base.in_batches(of: batch)
+            base = base.in_batches(of: batch) unless batch.nil?
+            base
           end
         end
       end

--- a/app/views/unattended/report_templates/usage_report.erb
+++ b/app/views/unattended/report_templates/usage_report.erb
@@ -1,0 +1,17 @@
+<%#
+name: Usage report
+snippet: false
+model: ReportTemplate
+-%>
+
+<%- report_row(item: 'SmartProxy', data: load_smart_proxies(batch: nil).size) -%>
+<%- report_row(item: 'SmartProxy_creation', data: load_smart_proxies(batch: nil).map{|p| p.created_at} ) -%>
+<%- report_row(item: 'SmartProxy_feature_details', data: load_smart_proxies(batch: nil).map{|p| p.feature_details } ) -%>
+<%- report_row(item: 'Experimental', data: global_setting(:lab_features) ) -%>
+
+<%- report_row(item: 'Users', data: load_users(batch: nil).size) -%>
+<%- report_row(item: 'Users', data: load_users(batch: nil, search: 'admin = false').size) -%>
+
+<%- report_row(item: 'AnyResource', data: load_any_resource(resource: 'User', permission: 'view_users', batch: nil, search: 'admin = false').size) -%>
+
+<%= report_render -%>


### PR DESCRIPTION
This is a base implementation of usage report as a report template. 

It shows what changes are required to helpers framework to become suitable for aggregation reports.