### PR TITLE
CSP: Also allow data: for media_src

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -11,5 +11,6 @@
     :style_src   => ["'unsafe-inline'", "'self'"],
     :script_src  => ["'unsafe-eval'", "'unsafe-inline'", "'self'"],
     :img_src     => ["'self'", 'data:'],
+    :media_src   => ["'self'", 'data:'],
   }
 end


### PR DESCRIPTION
Currently CSP complains and doesn't load those "media" references because CSP for media_src defaults to default_src, which is "self" only. media_src also needs "data:" which is added through my commit / PR.
The error appears for example when being on a host.