### PR TITLE
Fixes #37770 - hosts bottom pagination doesnt work

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -38,6 +38,9 @@ export const Table = ({
   children,
   bottomPagination,
 }) => {
+  const onPagination = newPagination => {
+    setParams({ ...params, ...newPagination });
+  };
   if (!bottomPagination)
     bottomPagination = (
       <Pagination
@@ -61,9 +64,6 @@ export const Table = ({
       ...params,
       order: `${Object.keys(columns)[index]} ${direction}`,
     });
-  };
-  const onPagination = newPagination => {
-    setParams({ ...params, ...newPagination });
   };
   const { pfSortParams } = useTableSort({
     allColumns: Object.keys(columns).map(k => columns[k].title),


### PR DESCRIPTION
In the new hosts index page, the bottom pagination didnt change the pages when clicked.
onPagination was used before it was defined so I moved it up