### PR TITLE
[3.11] Test against correct Katello version

### DIFF
--- a/.github/workflows/foreman.yml
+++ b/.github/workflows/foreman.yml
@@ -139,6 +139,7 @@ jobs:
     with:
       plugin: katello
       plugin_repository: Katello/katello
+      plugin_version: KATELLO-4.13
       foreman_version: ${{ github.ref }}
       postgresql_container: ghcr.io/theforeman/postgresql-evr
       test_existing_database: false


### PR DESCRIPTION
If the plugin_version is not specified, it will test against the default branch.