### PR TITLE
Fixes #37780 - Simplify help text for disk partition field

### DIFF
--- a/app/views/hosts/provision_method/build/_form.html.erb
+++ b/app/views/hosts/provision_method/build/_form.html.erb
@@ -8,5 +8,5 @@
 
 
   <%= textarea_f f, :disk, :size => "col-md-8", :rows => "4",
-           :help_block => _("What ever text(or ERB template) you use in here, would be used as your OS disk layout options If you want to use the partition table option, delete all of the text from this field") %>
+           :help_block => _("Text (or ERB template) to be used as your OS disk layout options. Leave empty if you want to use the partition table option") %>
 </div>


### PR DESCRIPTION
Previously it was rather long and missing spacing/punctuation.