### PR TITLE
Fixes #37789 - Add snapshot tests for global_registration.erb

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -169,6 +169,17 @@ module Foreman
       define_host_params(host)
     end
 
+    def registration_template_default
+      Setting[:server_ca_file] = Rails.root.join('test/static_fixtures/certificates/example.com.crt')
+      Setting[:ssl_ca_file] =  Rails.root.join('test/static_fixtures/certificates/example2.com.crt')
+
+      host = FactoryBot.build(:host_for_snapshots, :with_rocky9,
+        name: 'snapshot-registration-template-default',
+        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
+        interfaces: [FactoryBot.build(:nic_for_snapshots, :with_v4_dhcp)])
+      define_host_params(host)
+    end
+
     private
 
     def files

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -2,6 +2,8 @@
 kind: registration
 name: Global Registration
 model: ProvisioningTemplate
+test_on:
+- registration_template_default
 description: |
   The registration template used to render OS agnostic script that any host can use to register to
   this Foreman instance. It is rendered as a response in the registration API endpoint. The resulting

--- a/test/unit/foreman/renderer/snapshots.yaml
+++ b/test/unit/foreman/renderer/snapshots.yaml
@@ -78,3 +78,4 @@ files:
   - finish/windows_default_finish.erb
   - script/windows_default_script.erb
   - snippet/windows_network.erb
+  - registration/global_registration.erb

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/registration/Global_Registration.registration_template_default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/registration/Global_Registration.registration_template_default.snap.txt
@@ -1,0 +1,168 @@
+#!/bin/sh
+
+# Make sure, all command output can be parsed (e.g. from subscription-manager)
+export LC_ALL=C LANG=C
+
+# Rendered with following template parameters:
+
+
+if ! [ $(id -u) = 0 ]; then
+  echo "Please run as root"
+  exit 1
+fi
+
+# Select package manager for the OS (sets the $PKG_MANAGER* variables)
+if [ -f /etc/os-release ] ; then
+  . /etc/os-release
+fi
+
+if [ "${NAME%.*}" = 'FreeBSD' ]; then
+  PKG_MANAGER='pkg'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
+  PKG_MANAGER='dnf'
+  if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
+    PKG_MANAGER='yum'
+  elif [ -f /etc/system-release ]; then
+    PKG_MANAGER='yum'
+  fi
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+elif [ -f /etc/debian_version ]; then
+  PKG_MANAGER='apt-get'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+elif [ -f /etc/arch-release ]; then
+  PKG_MANAGER='pacman'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
+  PKG_MANAGER='zypper'
+  PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
+  PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+fi
+
+
+SSL_CA_CERT=$(mktemp)
+cat << EOF > $SSL_CA_CERT
+-----BEGIN CERTIFICATE-----
+MIIFrTCCA5WgAwIBAgIJAOzdk0zTsuBPMA0GCSqGSIb3DQEBCwUAMF0xCzAJBgNV
+BAYTAlhYMRAwDgYDVQQIEwdFeGFtcGxlMRAwDgYDVQQHEwdFeGFtcGxlMRQwEgYD
+VQQKEwtFeGFtcGUgSW5jLjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMTcxMDA2
+MTMxMzMyWhcNMTgxMDA2MTMxMzMyWjBdMQswCQYDVQQGEwJYWDEQMA4GA1UECBMH
+RXhhbXBsZTEQMA4GA1UEBxMHRXhhbXBsZTEUMBIGA1UEChMLRXhhbXBlIEluYy4x
+FDASBgNVBAMTC2V4YW1wbGUuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC
+CgKCAgEAslMkcsSL4hhnTLBJ/ZD3qldyD+7qTE9cB5dk9MH0Vj2GEezPnnUYZ0Cu
+v0029+ZbwzOb7If8XzGxGU5tnqItZLfihrM3SKqshgJFaCjWEuLXfwRzHF2+jSk8
+mkG69Z0JtewIeQ7SqUReeZb4cV47Hag6gO5LVTnFXlHjGPrz98SH+Ho80XtIdmk0
+6fCzVXUZY+0EtXIul00LwnqsNc8UupuRpNC3VIG6ZCq5snwQ9Va1u+RP77nJlGQz
+bKh5/yYaMd9WU3LDREkY0kSzJzcqzzQzEJr1JAY1zmtm5+NLdU2LPZjMAU6UiuJ4
+ABNdHwlvUWQ0SyPDqH2pnaytFlHgAH3G6brOj51Jpp86hOa/3iJ+M6gGtbNcYshd
+LYTpr+kl34qri0677VQtpM3uVwM5om4rGrCGbhuse8DtMdOAv4jAvF79SrLGK5k+
+sCWxtPXGIJgt+AXS3HJev3lRGWjNm5yYL6fTwgjbWceh05hBGOro/fDFPyAOpCek
+KPqOhu/MpJz7x+48rBny0GIl/CsMqojQ8spFH1Xp9dKoV886ZdzDKMlvDYfSHrj4
+9A9aIOT3+W5VCsPMgSIrr0MFhv3bkIEGleo3IioHeLxIylW4FLl0D7AdXQeiqe99
+Y+Jf+w0FNoVlmykpcQ7qXmQTzHiG7VB+o3wOWaP3K7Sj0jpIjoUCAwEAAaNwMG4w
+CQYDVR0TBAIwADALBgNVHQ8EBAMCBeAwVAYDVR0RBE0wS4IPd3d3LmV4YW1wbGUu
+Y29tgg93d3cuZXhhbXBsZS5uZXSCD3d3dy5leGFtcGxlLm9yZ4cEwKgBAYcQIAEN
+uAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAgEAiirO6rvirqxB5nfziEdd
+Tn9BltiBDKg38MspsWSfSGJNHdmbZkBKhoJ89p9oewa8yOMqM3jrUjg2hn0J0nZG
+t4dXix3Y7jHswaqr15mJEoLFGflkiOIOVJc1efxlSweXmyC+x6O5gAarmWHb+T6B
+qxL/Z72N/Tua3foFQzlzR6lQ/++QglBHeBADtmZg6uPMPmWJ6iUA1OLpzW8cg4/0
+Q2UxKsD3WaN+37JbEJnNuuamCpCXoyHIpzxDccUKzmjAWOxUHuYuiOvSc55w4Ww3
+GXMmRgu6ElVxL938LgJfTnHTBZoN3TjAlWXTRMtLV+cUlUJhBA7wnDkZK9mfXvk8
+d7XCFq9WsRQ0B7+4raMt8fn7M20ckz5J9mnt3d1I8FQRluyTKOfzs7L++OP/AagD
+ZCUrI5IrxroWqrf6f65t0HyqNDJy3ZKK2drsaf+emR3X3GVeeWVV0RzhUaIu6NJS
+br7erBLX9J5s6ZrAf6LbbeKtF2x9AGF8SUYCCUNVAHQxf/fTBKQAtrB7BxOmZiY1
+fplNEWaMnDChPWlzdzmH+MsCAA5025+Sr7Eb/CS9wKZDV5z6FtqkQKPeZ/eHjtJV
+SylVI2XfadJwxM4gj6Jcq1L8LxURS/NpTinoXDd3xfkZYy3WrMNAsP6Cz6GvcU/n
+SBq3Hxpl4HptdDg+JyI1RIg=
+-----END CERTIFICATE-----
+
+-----BEGIN CERTIFICATE-----
+MIIFrTCCA5WgAwIBAgIJAOzdk0zTsuBPMA0GCSqGSIb3DQEBCwUAMF0xCzAJBgNV
+BAYTAlhYMRAwDgYDVQQIEwdFeGFtcGxlMRAwDgYDVQQHEwdFeGFtcGxlMRQwEgYD
+VQQKEwtFeGFtcGUgSW5jLjEUMBIGA1UEAxMLZXhhbXBsZS5jb20wHhcNMTcxMDA2
+MTMxMzMyWhcNMTgxMDA2MTMxMzMyWjBdMQswCQYDVQQGEwJYWDEQMA4GA1UECBMH
+RXhhbXBsZTEQMA4GA1UEBxMHRXhhbXBsZTEUMBIGA1UEChMLRXhhbXBlIEluYy4x
+FDASBgNVBAMTC2V4YW1wbGUuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIIC
+CgKCAgEAslMkcsSL4hhnTLBJ/ZD3qldyD+7qTE9cB5dk9MH0Vj2GEezPnnUYZ0Cu
+v0029+ZbwzOb7If8XzGxGU5tnqItZLfihrM3SKqshgJFaCjWEuLXfwRzHF2+jSk8
+mkG69Z0JtewIeQ7SqUReeZb4cV47Hag6gO5LVTnFXlHjGPrz98SH+Ho80XtIdmk0
+6fCzVXUZY+0EtXIul00LwnqsNc8UupuRpNC3VIG6ZCq5snwQ9Va1u+RP77nJlGQz
+bKh5/yYaMd9WU3LDREkY0kSzJzcqzzQzEJr1JAY1zmtm5+NLdU2LPZjMAU6UiuJ4
+ABNdHwlvUWQ0SyPDqH2pnaytFlHgAH3G6brOj51Jpp86hOa/3iJ+M6gGtbNcYshd
+LYTpr+kl34qri0677VQtpM3uVwM5om4rGrCGbhuse8DtMdOAv4jAvF79SrLGK5k+
+sCWxtPXGIJgt+AXS3HJev3lRGWjNm5yYL6fTwgjbWceh05hBGOro/fDFPyAOpCek
+KPqOhu/MpJz7x+48rBny0GIl/CsMqojQ8spFH1Xp9dKoV886ZdzDKMlvDYfSHrj4
+9A9aIOT3+W5VCsPMgSIrr0MFhv3bkIEGleo3IioHeLxIylW4FLl0D7AdXQeiqe99
+Y+Jf+w0FNoVlmykpcQ7qXmQTzHiG7VB+o3wOWaP3K7Sj0jpIjoUCAwEAAaNwMG4w
+CQYDVR0TBAIwADALBgNVHQ8EBAMCBeAwVAYDVR0RBE0wS4IPd3d3LmV4YW1wbGUu
+Y29tgg93d3cuZXhhbXBsZS5uZXSCD3d3dy5leGFtcGxlLm9yZ4cEwKgBAYcQIAEN
+uAAAAAAAAAAAAAAAATANBgkqhkiG9w0BAQsFAAOCAgEAiirO6rvirqxB5nfziEdd
+Tn9BltiBDKg38MspsWSfSGJNHdmbZkBKhoJ89p9oewa8yOMqM3jrUjg2hn0J0nZG
+t4dXix3Y7jHswaqr15mJEoLFGflkiOIOVJc1efxlSweXmyC+x6O5gAarmWHb+T6B
+qxL/Z72N/Tua3foFQzlzR6lQ/++QglBHeBADtmZg6uPMPmWJ6iUA1OLpzW8cg4/0
+Q2UxKsD3WaN+37JbEJnNuuamCpCXoyHIpzxDccUKzmjAWOxUHuYuiOvSc55w4Ww3
+GXMmRgu6ElVxL938LgJfTnHTBZoN3TjAlWXTRMtLV+cUlUJhBA7wnDkZK9mfXvk8
+d7XCFq9WsRQ0B7+4raMt8fn7M20ckz5J9mnt3d1I8FQRluyTKOfzs7L++OP/AagD
+ZCUrI5IrxroWqrf6f65t0HyqNDJy3ZKK2drsaf+emR3X3GVeeWVV0RzhUaIu6NJS
+br7erBLX9J5s6ZrAf6LbbeKtF2x9AGF8SUYCCUNVAHQxf/fTBKQAtrB7BxOmZiY1
+fplNEWaMnDChPWlzdzmH+MsCAA5025+Sr7Eb/CS9wKZDV5z6FtqkQKPeZ/eHjtJV
+SylVI2XfadJwxM4gj6Jcq1L8LxURS/NpTinoXDd3xfkZYy3WrMNAsP6Cz6GvcU/n
+SBq3Hxpl4HptdDg+JyI1RIg=
+-----END CERTIFICATE-----
+
+EOF
+
+cleanup_and_exit() {
+  rm -f $SSL_CA_CERT
+  exit $1
+}
+
+
+
+register_host() {
+  curl --silent --show-error  \
+    --cacert $SSL_CA_CERT \
+    --fail \
+    --request POST \
+    --output /root/registration_host_init.sh \
+    --header 'Authorization: Bearer ' \
+    --data host[name]=$(hostname --fqdn) \
+    --data host[build]=false \
+    --data host[managed]=false
+}
+
+echo "#"
+echo "# Running registration"
+echo "#"
+
+
+# Update / create the host record in Foreman and fetch the host initial configuration script
+register_host
+
+curl_status=$?
+if [ $curl_status -ne 0 ]; then
+  echo "Failed to fetch the host initialization script."
+  echo "Please see the logs for more information."
+  cleanup_and_exit $curl_status
+fi
+
+bash /root/registration_host_init.sh
+init_conf_status=$?
+
+if [ $init_conf_status -ne 0 ]; then
+  echo "Host initialization script failed, see the logs for more information."
+  echo "You can access the script source by running 'cat /root/registration_host_init.sh'"
+  cleanup_and_exit $init_conf_status
+fi
+
+
+cleanup_and_exit


### PR DESCRIPTION
In the course of #9808 @sbernhard and I were talking about adding snapshot tests for the Global Registration template. 

As adding sensible and reasonable tests for the Global Registration template with various variables set is not as easy as hoped in the beginning and to not block the original PR unnecessarily, I created this PR for adding snapshot tests for the Global Registration template.