### PR TITLE
Fixes #37805 - Add possibility to display message when table is empty

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -19,6 +19,7 @@ import { getColumnHelpers } from './helpers';
 
 export const Table = ({
   columns,
+  emptyMessage,
   errorMessage,
   getActions,
   isDeleteable,
@@ -133,10 +134,10 @@ export const Table = ({
               </Td>
             </Tr>
           )}
-          {!isPending && !errorMessage && results.length === 0 && (
+          {!isPending && results.length === 0 && !errorMessage && (
             <Tr ouiaId="table-empty">
               <Td colSpan={100}>
-                <EmptyPage />
+                <EmptyPage message={{ type: 'empty', text: emptyMessage }} />
               </Td>
             </Tr>
           )}
@@ -177,7 +178,7 @@ export const Table = ({
             })}
         </Tbody>
       </TableComposable>
-      {results.length > 0 && !errorMessage && bottomPagination}
+      {results.length > 0 && !errorMessage && !emptyMessage && bottomPagination}
     </>
   );
 };
@@ -190,6 +191,7 @@ Table.propTypes = {
     perPage: PropTypes.number,
     order: PropTypes.string,
   }).isRequired,
+  emptyMessage: PropTypes.string,
   errorMessage: PropTypes.string,
   getActions: PropTypes.func,
   isDeleteable: PropTypes.bool,
@@ -210,6 +212,7 @@ Table.propTypes = {
 
 Table.defaultProps = {
   children: null,
+  emptyMessage: null,
   errorMessage: null,
   isDeleteable: false,
   itemCount: 0,

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
@@ -179,6 +179,7 @@ describe('Table', () => {
           setParams={setParams}
           refreshData={refreshData}
           results={[]}
+          errorMessage="Empty test"
           isDeleteable={true}
           url="/users"
           isPending={false}
@@ -186,7 +187,7 @@ describe('Table', () => {
       </Provider>
     );
     expect(screen.queryAllByText('items')).toHaveLength(0);
-    expect(screen.queryAllByText('No Results')).toHaveLength(2);
+    expect(screen.queryAllByText('Empty test')).toHaveLength(1);
     expect(screen.queryAllByText('Loading...')).toHaveLength(0);
   });
   test('show empty state while loading', () => {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/92f9708a-f4f2-4c9f-88f1-4a7fba8c4b70)

After adding a custom message:
![image](https://github.com/user-attachments/assets/d4e52f73-7364-4d43-9002-cb9b22bfecb1)
![image](https://github.com/user-attachments/assets/bb35f983-6bf9-437b-a927-a5a4b363c974)

This PR is needed for [Fixes #37630 - Display basic list of hosts on the new job_invocations page](https://github.com/theforeman/foreman_remote_execution/pull/913)
