### PR TITLE
Fixes #37818 - Expand mail notification alert

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -84,7 +84,7 @@
             <%= render :partial => "users/mail_notifications", :locals => { :f => mail_form }  %>
           <% end %>
         <% else %>
-          <%= alert :class => 'alert-info', :header => '', :text => _("Notifications can't be assigned to this user."), :close => false %>
+          <%= alert :class => 'alert-info', :header => '', :text => _("You cannot assign notifications to this user. Grant the view_mail_notifications permission to the user first."), :close => false %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
The existing message doesn't really explain why a user can't assign mail notifications.

![view_mail_notifications](https://github.com/user-attachments/assets/4363e3ae-01a6-4b36-b9db-520827494643)

We had a situation where a user fixed this by adding broad administrative privileges. Instead, it would be more helpful to note which specific permission is missing.

To be honest, I don't know if the existing message is really displayed only in situations when view_mail_notifications is missing. There might be other situations when users see this message, in which case the proposed change would mislead them, but I don't know how to check for that.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
