### PR TITLE
Fixes #37821 - Fix RegistrationCommandsPage tests

### DIFF
--- a/webpack/assets/javascripts/react_app/mockRequests.js
+++ b/webpack/assets/javascripts/react_app/mockRequests.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { MockAdapter } from '@theforeman/test';
 
-export const mock = () => new MockAdapter(axios);
+export const mock = new MockAdapter(axios);
 const methods = {
   GET: 'onGet',
   POST: 'onPost',
@@ -15,9 +15,6 @@ export const mockRequest = ({
   data = null,
   status = 200,
   response = null,
-}) =>
-  mock()
-    [methods[method]](url, data)
-    .reply(status, response);
+}) => mock[methods[method]](url, data).reply(status, response);
 
-export const mockReset = () => mock().reset();
+export const mockReset = () => mock.reset();

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js
@@ -1,14 +1,10 @@
 /* eslint-disable promise/prefer-await-to-then */
 import { submitForm } from './forms';
-import { mockReset } from '../../../mockRequests';
 
 describe('form actions', () => {
   beforeEach(() => {
     document.head.innerHTML = `<meta name="csrf-param" content="authenticity_token" />
      <meta name="csrf-token" content="token123" />`;
-  });
-  afterEach(() => {
-    mockReset();
   });
 
   it('SubmitForm must include an object item/values', () => {

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
@@ -28,7 +28,24 @@ Object {
       },
     ],
   ],
-  "state": Object {},
+  "state": Object {
+    "apiReducer": Object {
+      "REGISTRATION_COMMANDS": Object {
+        "payload": Object {
+          "url": "/hosts/register",
+        },
+        "response": null,
+        "status": "PENDING",
+      },
+      "REGISTRATION_COMMANDS_DATA": Object {
+        "payload": Object {
+          "url": "/hosts/register/data",
+        },
+        "response": null,
+        "status": "PENDING",
+      },
+    },
+  },
 }
 `;
 
@@ -49,6 +66,16 @@ Object {
       },
     ],
   ],
-  "state": Object {},
+  "state": Object {
+    "apiReducer": Object {
+      "REGISTRATION_COMMANDS_DATA": Object {
+        "payload": Object {
+          "url": "/hosts/register/data",
+        },
+        "response": null,
+        "status": "PENDING",
+      },
+    },
+  },
 }
 `;

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/integration.test.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/integration.test.js
@@ -1,16 +1,19 @@
 import React from 'react';
 import { Router } from 'react-router-dom';
-import thunk from 'redux-thunk'
+import thunk from 'redux-thunk';
 import IntegrationTestHelper from '../../../../common/IntegrationTestHelper';
 import history from '../../../../history';
-import * as selectors from '../RegistrationCommandsPageSelectors'
-import RegistrationCommandsPage from '../index'
+import * as selectors from '../RegistrationCommandsPageSelectors';
+import RegistrationCommandsPage from '../index';
 import { APIMiddleware } from '../../../../redux/API';
 import apiReducer from '../../../../redux/API/APIReducer';
-import { spySelector } from './fixtures'
+import * as apiHelpers from '../../../../redux/API/APIHelpers';
+import { spySelector } from './fixtures';
 import ForemanContext from '../../../../Root/Context/ForemanContext';
 
-jest.mock('../../../../components/common/Slot', () => () => (<></>));
+jest.mock('../../../../redux/API/API');
+
+jest.mock('../../../../components/common/Slot', () => () => <></>);
 jest
   .spyOn(ForemanContext, 'useForemanOrganization')
   .mockReturnValue({ id: 3, title: 'ACME' });
@@ -18,34 +21,55 @@ jest
   .spyOn(ForemanContext, 'useForemanLocation')
   .mockReturnValue({ id: 4, title: 'munich' });
 
+jest.spyOn(apiHelpers, 'getApiResponse').mockReturnValue({ data: {} });
 
 spySelector(selectors);
 
+const reducers = {
+  apiReducer,
+};
 describe('RegistrationCommandsPage integration', () => {
   it('generate command', () => {
-    const integrationTestHelper = new IntegrationTestHelper(apiReducer, [thunk,
+    const integrationTestHelper = new IntegrationTestHelper(reducers, [
+      thunk,
       APIMiddleware,
     ]);
-    const component = integrationTestHelper.mount(<Router history={history}>
-      <RegistrationCommandsPage />
-    </Router>);
+    const component = integrationTestHelper.mount(
+      <Router history={history}>
+        <RegistrationCommandsPage />
+      </Router>
+    );
     integrationTestHelper.takeStoreAndLastActionSnapshot('rendered');
 
-    const submitBtn = component.find('#generate_btn').at(0)
-    const commandField = component.find('.pf-v5-c-clipboard-copy__expandable-content pre')
+    const submitBtn = component.find('#generate_btn').at(0);
+    const commandField = component.find(
+      '.pf-v5-c-clipboard-copy__expandable-content pre'
+    );
 
     expect(submitBtn.hasClass('pf-m-disabled')).toBe(false);
     expect(commandField.length).toBe(0);
 
     // check that only current Org and Loc are selectable
-    const organizationSelectOptions = component.find('#reg_organization').find('FormSelectOption');
+    const organizationSelectOptions = component
+      .find('#reg_organization')
+      .find('FormSelectOption');
     expect(organizationSelectOptions.length).toBe(2);
-    expect(organizationSelectOptions.findWhere((n) => n.prop('value') === 1).length).toBe(0);
-    expect(organizationSelectOptions.findWhere((n) => n.prop('value') === 3).length).toBe(2);
-    const locationSelectOptions = component.find('#reg_location').find('FormSelectOption');
+    expect(
+      organizationSelectOptions.findWhere(n => n.prop('value') === 1).length
+    ).toBe(0);
+    expect(
+      organizationSelectOptions.findWhere(n => n.prop('value') === 3).length
+    ).toBe(2);
+    const locationSelectOptions = component
+      .find('#reg_location')
+      .find('FormSelectOption');
     expect(locationSelectOptions.length).toBe(2);
-    expect(locationSelectOptions.findWhere((n) => n.prop('value') === 2).length).toBe(0);
-    expect(locationSelectOptions.findWhere((n) => n.prop('value') === 4).length).toBe(2);
+    expect(
+      locationSelectOptions.findWhere(n => n.prop('value') === 2).length
+    ).toBe(0);
+    expect(
+      locationSelectOptions.findWhere(n => n.prop('value') === 4).length
+    ).toBe(2);
 
     submitBtn.simulate('click');
     integrationTestHelper.takeStoreAndLastActionSnapshot('generated command');


### PR DESCRIPTION
`export const mock = () => new MockAdapter(axios);` was moved to be a function because it caused webpack issues, but we exclude this file from ExportAll. There should only be one MockAdapter.
one of the issues of having multiple instances of the mockAdapter is this error:
```
        throw new Error(process.env.NODE_ENV === "production" ? formatProdErrorMessage(14) : "When called with an action of type " + (actionType ? "\"" + String(actionType) + "\"" : '(unknown type)') + ", the slice reducer for key \"" + _key + "\" returned undefined. " + "To ignore an action, you must explicitly return the previous state. " + "If you want this reducer to hold no value, you can return null instead of undefined.");
              ^

Error: When called with an action of type "REGISTRATION_COMMANDS_FAILURE", the slice reducer for key "reducerSpy" returned undefined. To ignore an action, you must explicitly return the previous state. If you want this reducer to hold no value, you can return null instead of undefined.
```

webpack/assets/javascripts/react_app/redux/actions/common/forms.test.js didnt use mocks anymore so it doesnt need to reset them.
