### PR TITLE
Fixes #37566 - Add UEFI Secure Boot Firmware to Libvirt

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -148,6 +148,9 @@ module Foreman::Model
       opts[:boot_order] = %w[hd]
       opts[:boot_order].unshift 'network' unless attr[:image_id]
 
+      firmware_type = opts.delete(:firmware_type).to_s
+      opts.merge!(process_firmware_attributes(opts[:firmware], firmware_type))
+
       vm = client.servers.new opts
       vm.memory = opts[:memory] if opts[:memory]
       vm
@@ -289,7 +292,9 @@ module Foreman::Model
         :display    => { :type     => display_type,
                          :listen   => Setting[:libvirt_default_console_address],
                          :password => random_password(console_password_length(display_type)),
-                         :port     => '-1' }
+                         :port     => '-1' },
+        :firmware   => 'automatic',
+        :firmware_features => { "secure-boot" => "no" }
       )
     end
 
@@ -325,6 +330,21 @@ module Foreman::Model
       if vol.capacity.to_s.empty? || /\A\d+G?\Z/.match(vol.capacity.to_s).nil?
         raise Foreman::Exception.new(N_("Please specify volume size. You may optionally use suffix 'G' to specify volume size in gigabytes."))
       end
+    end
+
+    # Generates Secure Boot settings for Libvirt based on the provided firmware type.
+    # The `secure_boot` setting is used to properly configure and display the Firmware in the `compute_attributes` form.
+    #
+    # @param firmware [String] The firmware type.
+    # @return [Hash] A hash with secure boot settings if applicable.
+    def generate_secure_boot_settings(firmware)
+      return {} unless firmware == 'uefi_secure_boot'
+
+      {
+        firmware_features: { 'secure-boot' => 'yes', 'enrolled-keys' => 'yes' },
+        loader_attributes: { 'secure' => 'yes' },
+        secure_boot: true,
+      }
     end
   end
 end

--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -50,6 +50,8 @@ module PxeLoaderSupport
       case pxe_loader
       when 'None'
         :none
+      when /SecureBoot/
+        :uefi_secure_boot
       when /UEFI/
         :uefi
       else

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -8,6 +8,13 @@
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2"} if new_vm && controller_name != "compute_attributes" %>
 
+<% firmware_type = new_vm ? 'automatic' : compute_resource.firmware_type(f.object.firmware, f.object.secure_boot) %>
+<%= field(f, :firmware, :disabled => !new_vm, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the host's PXE Loader. If no PXE Loader is selected, it defaults to BIOS."), :label_size => "col-md-2") do
+  compute_resource.firmware_types.collect do |type, name|
+    radio_button_f f, :firmware, {:checked => (firmware_type == type), :disabled => !new_vm, :value => type, :text => _(name) }
+  end.join(' ').html_safe
+end %>
+
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)

--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '>= 0.12.0'
+  gem 'fog-libvirt', '>= 0.13.0'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end

--- a/test/models/compute_resources/libvirt_test.rb
+++ b/test/models/compute_resources/libvirt_test.rb
@@ -270,4 +270,27 @@ class Foreman::Model::LibvirtTest < ActiveSupport::TestCase
       check_vm_attribute_names(cr)
     end
   end
+
+  describe '#generate_secure_boot_settings' do
+    before do
+      @cr = FactoryBot.build_stubbed(:libvirt_cr)
+    end
+
+    test "returns secure boot settings when firmware is 'uefi_secure_boot'" do
+      expected_sb_settings = {
+        firmware_features: { 'secure-boot' => 'yes', 'enrolled-keys' => 'yes' },
+        loader_attributes: { 'secure' => 'yes' },
+        secure_boot: true,
+      }
+
+      assert_equal expected_sb_settings, @cr.send(:generate_secure_boot_settings, 'uefi_secure_boot')
+    end
+
+    test "returns an empty hash for firmware types other than 'uefi_secure_boot'" do
+      assert_empty @cr.send(:generate_secure_boot_settings, 'uefi')
+      assert_empty @cr.send(:generate_secure_boot_settings, 'bios')
+      assert_empty @cr.send(:generate_secure_boot_settings, '')
+      assert_empty @cr.send(:generate_secure_boot_settings, nil)
+    end
+  end
 end

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -200,5 +200,9 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
     test 'defaults to bios firmware' do
       assert_equal :bios, DummyPxeLoader.firmware_type('Anything')
     end
+
+    test 'detects uefi_secure_boot firmware' do
+      assert_equal :uefi_secure_boot, DummyPxeLoader.firmware_type('Grub2 UEFI SecureBoot')
+    end
   end
 end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3313,6 +3313,11 @@ class HostTest < ActiveSupport::TestCase
       host = FactoryBot.build_stubbed(:host, :managed, :pxe_loader => "Grub2 UEFI")
       assert_equal :uefi, host.firmware_type
     end
+
+    test 'should be :uefi_secure_boot for host with uefi_secure_boot loader' do
+      host = FactoryBot.build_stubbed(:host, :managed, :pxe_loader => "Grub2 UEFI SecureBoot")
+      assert_equal :uefi_secure_boot, host.firmware_type
+    end
   end
 
   describe '#templates_used' do


### PR DESCRIPTION
Requires:
* https://github.com/fog/fog-libvirt/pull/155

This PR includes two commits:
1. Add firmware selection option for Libvirt VM creation.
2. Introduce a new firmware type for Secure Boot support.

When creating a new host in Foreman, after selecting `Libvirt` as the compute resource, a new option to select the VM's firmware will appear under the `Virtual Machine` tab.  See the screenshot below for a demonstration:

![image](https://github.com/user-attachments/assets/e0e4ef1b-6183-414c-816a-0ed3fd9d3ba5)

Notes:
1. For machines created through Foreman, `enrolled-keys` are enabled by default when Secure Boot is activated.
2. For existing VMs, Secure Boot status is determined by the `loader secure='yes'` setting. 

For more details: [community post](https://community.theforeman.org/t/seeking-input-on-secure-boot-usage-with-libvirt/39176).

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
