### PR TITLE
Fixes #37824 - Hide taxonomies from parts of api documentation

### DIFF
--- a/app/controllers/api/v2/architectures_controller.rb
+++ b/app/controllers/api/v2/architectures_controller.rb
@@ -3,6 +3,8 @@ module Api
     class ArchitecturesController < V2::BaseController
       include Foreman::Controller::Parameters::Architecture
 
+      hide_taxonomy_options
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy}
 

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -168,6 +168,13 @@ module Api
         render options.merge(:template => "api/v2/errors/#{error}",
           :layout => 'api/v2/layouts/error_layout')
       end
+
+      def self.hide_taxonomy_options
+        resource_description do
+          param :location_id, Integer, :show => false
+          param :organization_id, Integer, :show => false
+        end
+      end
     end
   end
 end

--- a/app/controllers/api/v2/external_usergroups_controller.rb
+++ b/app/controllers/api/v2/external_usergroups_controller.rb
@@ -4,6 +4,8 @@ module Api
       include Api::Version2
       include Foreman::Controller::Parameters::ExternalUsergroup
 
+      hide_taxonomy_options
+
       before_action :find_resource, :only => [:show, :update, :destroy, :refresh]
       before_action :find_required_nested_object, :only => [:index, :show, :create]
       after_action :refresh_external_usergroup, :only => [:create, :update, :destroy]

--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V2
     class SettingsController < V2::BaseController
+      hide_taxonomy_options
+
       before_action :find_resource, :only => %w{show update}
 
       def_param_group :setting_params do

--- a/app/controllers/api/v2/usergroups_controller.rb
+++ b/app/controllers/api/v2/usergroups_controller.rb
@@ -3,6 +3,8 @@ module Api
     class UsergroupsController < V2::BaseController
       include Foreman::Controller::Parameters::Usergroup
 
+      hide_taxonomy_options
+
       before_action :find_optional_nested_object
       before_action :find_resource, :only => %w{show update destroy}
 


### PR DESCRIPTION
Some resources like user groups, external user groups, and architectures are not scoped by taxonomies, yet the the api endpoints associated with these resources accept the `organization-id` and `location-id` options. I didn't observe any effect of these options on the api call, except for when trying to create an external user group and providing either organization-id or location-id, which causes the action to fail with an error appearing in the logs:
`undefined method external_usergroups for #<{Organization/Location}: ...`

I have not, however, found any simple way of fixing this. All `Api::V2` controllers inherit from `Api::V2::BaseController`, where the taxonomy options are added through the `resource_description` method from Apipie. While this method can be overridden in child classes, there appears to be no way (at least I have not found such a way) of removing a parameter once it is added.

The most correct solution would be of course to create a child class inheriting from BaseController, provide the resource description with taxonomy options there, and then have all taxonomy-scoped resource controllers inherit from it. The problem is that there are many plugins in which the controllers inherit from BaseController that would all need to be updated as well. I see too much potential for breaking because of a relatively harmless bug, so in my opinion the risk is not worth to fix the issue this way.

Hence, I propose a partial solution. Hide the taxonomy options from the API documentation of the relevant resources. Hammer can also be updated to not display options with the `show => false` flag set.

This would not completely solve the issue but in my opinion has the best effort/result/risk reduction ratio.
