### PR TITLE
Fixes #37830 - remove @theforeman/vendor-dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@theforeman/eslint-plugin-foreman": "^13.1.0",
     "@theforeman/eslint-plugin-rules": "^13.1.0",
     "@theforeman/test": "^13.1.0",
-    "@theforeman/vendor-dev": "^13.1.0",
     "@types/jest": "<27.0.0",
     "argv-parse": "^1.0.1",
     "babel-eslint": "^10.0.0",


### PR DESCRIPTION
We used to import babel and eslint config from it but now we import it from other libraries (and soon will not import it but have it in foreman core).
So @theforeman/vendor-dev is not used in foreman at all.
