### PR TITLE
Fixes #37838 - Remove redundant translation call

### DIFF
--- a/app/views/compute_resources_vms/show/_vmware.html.erb
+++ b/app/views/compute_resources_vms/show/_vmware.html.erb
@@ -12,7 +12,7 @@
       <% @vm.disks.each do |vol| %>
         <tr>
           <td><%= _("Disk '%s'") % vol[:label] %></td>
-          <td><%= _("%{capacity}") % { :capacity => number_to_human_size(vol[:capacity])} %></td>
+          <td><%= number_to_human_size(vol[:capacity]) %></td>
         </tr>
       <% end %>
       <% @vm.partitions.each do |part| %>


### PR DESCRIPTION
This was translating an interpolation string, which doesn't do anything and can only introduce problems.

Fixes: 00de05fdcab40f887b5bb3860bada3ec1d236ae9 ("Fixes #36518 - show disk/partitions of vsphere host")