### PR TITLE
FIXES #37867 - remote_execution_ssh_keys sudoers permissions

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -61,9 +61,11 @@ EOF
 <% if @host.operatingsystem.family == 'Redhat' || @host.operatingsystem.family == 'Debian' -%>
 echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL" > /etc/sudoers.d/<%= ssh_user %>
 echo "Defaults:<%= ssh_user %> !requiretty" >> /etc/sudoers.d/<%= ssh_user %>
+chmod 440 /etc/sudoers.d/<%= ssh_user %>
 <% elsif @host.operatingsystem.family == 'Suse' -%>
 echo "<%= ssh_user %> ALL = (root) NOPASSWD : ALL" >> /etc/sudoers
 echo "Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers
+chmod 440 /etc/sudoers.d/<%= ssh_user %>
 <% end -%>
 <% end -%>
 else


### PR DESCRIPTION
**Description of problem:**
Provision template doesn't assign right file permissions to /etc/sudoers.d/rexuser for non-root users making it unusable. 

**How reproducible:**
Always

**Is this issue a regression from an earlier version:**
No

**Steps to Reproduce:**
1. Generate the curl registration command using `--setup-remote-execution true`
2. Register the Content Host using provided curl command

**Actual behavior:**
File permissions are invalid:
~~~
[root@pafernan-6158cli ~]# ls -l /etc/sudoers.d/                                       
total 4                                                                               
-rw-r--r--. 1 root root 65 Sep 30 17:45 rexuser
~~~

**Expected behavior:**
File permissions are valid
~~~
[root@pafernan-6158cli ~]# ls -l /etc/sudoers.d/
total 4
-rw-------. 1 root root 65 Sep 30 18:27 rexuser
~~~

**Business Impact / Additional info:**
Remote execution for non-root users doesn't work
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
