### PR TITLE
Fixes #37580 - Auto-import new GPG keys on SLES

### DIFF
--- a/app/services/foreman/renderer/scope/macros/host_template.rb
+++ b/app/services/foreman/renderer/scope/macros/host_template.rb
@@ -173,7 +173,7 @@ module Foreman
               <<~CMD
                 #{banner}
                 zypper refresh
-                zypper -n install #{packages}
+                zypper -n --gpg-auto-import-keys install #{packages}
               CMD
             else
               raise UnsupportedOS.new

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -60,7 +60,7 @@ rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
 rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppet
 <% end -%>
 <% if @host.provision_method == 'image' -%>
-/usr/bin/zypper -n install <%= linux_package %>
+/usr/bin/zypper -n --gpg-auto-import-keys install <%= linux_package %>
 <% end -%>
 <% elsif os_family == 'Windows' -%>
 $puppet_agent_msi = "${env:TEMP}\<%= windows_package %>"

--- a/app/views/unattended/provisioning_templates/snippet/saltstack_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/saltstack_setup.erb
@@ -22,7 +22,7 @@ else
   yum -t -y install salt-minion
 fi
 <% elsif @host.operatingsystem.family == 'Suse' -%>
-  /usr/bin/zypper -n install salt-minion
+  /usr/bin/zypper -n --gpg-auto-import-keys install salt-minion
 <% end -%>
 
 cat > <%= etc_path %>/minion.d/minion.conf << EOF

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -294,7 +294,7 @@ class HostTemplateTest < ActiveSupport::TestCase
       @scope.instance_variable_set('@host', host)
       command = @scope.install_packages('pkg1')
 
-      assert_includes command, 'zypper -n install pkg1'
+      assert_includes command, 'zypper -n --gpg-auto-import-keys install pkg1'
     end
   end
 


### PR DESCRIPTION
I recently introduced a change in foreman-rex to automatically import GPG keys on SLES, making it behave the same as EL distros.

This PR introduces the same change to snippets calling zypper in this repo.