### PR TITLE
Fixes #37877 - Make the config file compatible with 0.2.z and 0.4.z

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
+++ b/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
@@ -54,10 +54,13 @@ if [ -f $CONFIGTOML ]; then
     cat <<EOF > $CONFIGTOML
 # yggdrasil global configuration settings written by katello-pull-transport-migrate
 broker = ["mqtts://$SERVER_NAME:1883"]
+server = ["mqtts://$SERVER_NAME:1883"]
 cert-file = "$CERT_FILE"
 key-file = "$KEY_FILE"
 ca-root = ["$CA_FILE"]
 log-level = "error"
+data-host = ""
+path-prefix = "yggdrasil"
 EOF
 
 else
@@ -65,23 +68,29 @@ else
     exit 1
 fi
 
-# start the yggdrasild service
-if systemctl is-enabled yggdrasild 2>/dev/null && [ -n "$YGGDRASIL_RESTART_DELAY" ] && [ "$YGGDRASIL_RESTART_DELAY" -gt 0 ]; then
-    systemd-run --on-active="$YGGDRASIL_RESTART_DELAY" --collect --no-block systemctl restart yggdrasild
-else
-    echo "Starting yggdrasild..."
-    systemctl try-restart yggdrasild
-    systemctl enable --now yggdrasild
+YGGDRASIL_SERVICE=yggdrasil.service
+systemctl cat $YGGDRASIL_SERVICE >/dev/null 2>/dev/null || YGGDRASIL_SERVICE=yggdrasild.service
 
-    # check status of yggdrasild and fail if it is not running
+# start the yggdrasild service
+if systemctl is-enabled $YGGDRASIL_SERVICE 2>/dev/null && [ -n "$YGGDRASIL_RESTART_DELAY" ] && [ "$YGGDRASIL_RESTART_DELAY" -gt 0 ]; then
+    systemd-run --on-active="$YGGDRASIL_RESTART_DELAY" --collect --no-block systemctl restart $YGGDRASIL_SERVICE
+else
+    echo "Starting $YGGDRASIL_SERVICE..."
+    systemctl try-restart $YGGDRASIL_SERVICE
+    systemctl enable --now $YGGDRASIL_SERVICE
+
+    # check status of $YGGDRASIL_SERVICE and fail if it is not running
     # possible failure reason: incorrect protocol (should be tcp:// or mqtt://) or port (should be 1883)
     # also, cert-file and key-file must be valid
     # and broker must be running on the server
-    yggdrasil status
+    # yggdrasil-0.2.z provides a dedicated status subcommand, newer yggdrasil doesn't have anything like that
+    if which yggdrasil >/dev/null 2>/dev/null; then
+        yggdrasil status
+    fi
 
-    if ! systemctl is-active --quiet yggdrasild; then
+    if ! systemctl is-active --quiet $YGGDRASIL_SERVICE; then
         echo ""
-        echo "yggdrasild failed to start! Check configuration in $CONFIGTOML and make sure the broker is running on the server."
+        echo "$YGGDRASIL_SERVICE failed to start! Check configuration in $CONFIGTOML and make sure the broker is running on the server."
         exit $?
     fi
 fi


### PR DESCRIPTION
- `broker` is an array of mqtt servers used by 0.2
- `server` is an array of mqtt servers used by 0.4
- `data-host` needs to be set to an empty string to override certain compile-time defaults set in RHEL and CentOS Stream
- `prefix` needs to be set to the value we expect to override certain compile-time defaults set in RHEL and CentOS Stream

`broker` and `server` can be set at both once, each will be honored by their respective versions

`data-host` and `prefix` can be set both at once on our build of yggdrasil they'll just duplicate the defaults, on RHEL/CentOS Stream they'll act as overrides

TODOs:
- [x] things in packaging
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
