### PR TITLE
Fixes #37878 - expose hidden_value attribute when creating parameters

### DIFF
--- a/app/controllers/api/v2/parameters_controller.rb
+++ b/app/controllers/api/v2/parameters_controller.rb
@@ -64,6 +64,7 @@ module Api
           param :name, String, :required => true
           param :value, String, :required => true
           param :parameter_type, Parameter::KEY_TYPES, :desc => N_("Type of value"), :required => true
+          param :hidden_value, :bool, :desc => N_("Should the value be hidden")
         end
       end
 

--- a/test/controllers/api/v2/parameters_controller_test.rb
+++ b/test/controllers/api/v2/parameters_controller_test.rb
@@ -419,5 +419,12 @@ class Api::V2::ParametersControllerTest < ActionController::TestCase
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_equal parameter.hidden_value, show_response['value']
     end
+
+    test "should create hidden host parameter" do
+      assert_difference('@host.parameters.count') do
+        post :create, params: { :host_id => @host.to_param, :parameter => { :name => 'secret', :value => '123', :hidden_value => true } }
+      end
+      assert_response :created
+    end
   end
 end


### PR DESCRIPTION

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
