### PR TITLE
Fixes #37901 - Set root password through Cloudinit deployments

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -39,6 +39,12 @@ hostname: <%= @host.name %>
 fqdn: <%= @host %>
 manage_etc_hosts: true
 users: []
+<% if root_pass.present? -%>
+chpasswd:
+  expire: False
+  users:
+  - {name: root, password: <%= root_pass -%>}
+<% end -%>
 runcmd:
 - |
 <%= indent(2) { snippet 'fix_hosts' } -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -4,6 +4,10 @@ hostname: snapshot-ipv4-dhcp-deb10
 fqdn: snapshot-ipv4-dhcp-deb10
 manage_etc_hosts: true
 users: []
+chpasswd:
+  expire: False
+  users:
+  - {name: root, password: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0}
 runcmd:
 - |
   echo "" > /etc/hostname

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -4,6 +4,10 @@ hostname: snapshot-ipv4-dhcp-el7
 fqdn: snapshot-ipv4-dhcp-el7
 manage_etc_hosts: true
 users: []
+chpasswd:
+  expire: False
+  users:
+  - {name: root, password: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0}
 runcmd:
 - |
   echo "" > /etc/hostname

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -4,6 +4,10 @@ hostname: snapshot-ipv4-dhcp-ubuntu18
 fqdn: snapshot-ipv4-dhcp-ubuntu18
 manage_etc_hosts: true
 users: []
+chpasswd:
+  expire: False
+  users:
+  - {name: root, password: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0}
 runcmd:
 - |
   echo "" > /etc/hostname


### PR DESCRIPTION
When deploying a system via Cloud-init and Userdata, in VMware, the root password set on the deployed system is the same as the root password of the VM template.

Say,

* Root password in VM template is password@123
* When creating the system, I mentioned my root password as qwerty@123 and then submitted the system build.
* Once the system comes up, It will still have the root password set as password@123 but NOT what we expected it to be i.e. qwerty@123

 We do change it for other types of deployments i.e. via templates [Kickstart Default Finish](https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb#L37-L40) or [Kickstart Default Userdata](https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb#L29-L32) but not for Cloudinit default e.g.

```
# grep root_pass app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb -B3 -A1

<%# Cloud instances frequently have incorrect hosts data %>
<%= snippet 'fix_hosts' %>

<% if @host.provision_method == 'image' && root_pass.present? -%>
# Install the root password
echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
<% end -%>
```

The same method can be applied for Cloudinit as well