### PR TITLE
Fixes #37903 - Correct XML syntax for Ansible password in Windows default provisioning

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -83,6 +83,9 @@ module Foreman
         "syspurpose_usage" => "Development/Test",
         "syspurpose_sla" => "Self-Support",
         "syspurpose_addons" => "first addon, second addon, third addon",
+        "ansible_user" => "win_ansible_user",
+        "create_ansible_user" => "true",
+        "ansible_ssh_pass" => "win_ansible_user_ssh_pass",
       }
       host_params.each_pair do |name, value|
         FactoryBot.build(:host_parameter, host: host, name: name, value: value)

--- a/app/views/unattended/provisioning_templates/provision/windows_default_provisioning.erb
+++ b/app/views/unattended/provisioning_templates/provision/windows_default_provisioning.erb
@@ -81,7 +81,7 @@ description: |
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>![CDATA[<%= host_param('ansible_ssh_pass') %>]]</Value>
+                            <Value><![CDATA[<%= host_param('ansible_ssh_pass') %>]]></Value>
                             <PlainText>true</PlainText>
                         </Password>
                         <Description>Ansible login service user</Description>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Windows_default_finish.windows10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Windows_default_finish.windows10_dhcp.snap.txt
@@ -45,6 +45,12 @@ w32tm /resync
 
 powershell /c "Get-NetConnectionProfile -InterfaceAlias \"Ethernet0\" | Set-NetConnectionProfile -NetworkCategory Private"
 
+powershell /c "set-localuser -name win_ansible_user -passwordneverexpires 1"
+powershell /c "Enable-PSRemoting"
+cmd /c "netsh advfirewall firewall add rule name="WinRM-HTTP" dir=in localport=5985 protocol=TCP action=allow"
+cmd /c winrm set winrm/config/service @{AllowUnencrypted="true"}
+cmd /c winrm set winrm/config/client/auth @{Basic="true"}
+cmd /c winrm set winrm/config/service/auth @{Basic="true"}
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Windows_default_provision.windows10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Windows_default_provision.windows10_dhcp.snap.txt
@@ -51,7 +51,19 @@
                     <Value>$1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0</Value>
                     <PlainText>false</PlainText>
                 </AdministratorPassword>
-                        </UserAccounts>
+                            <LocalAccounts>
+                    <LocalAccount wcm:action="add">
+                        <Password>
+                            <Value><![CDATA[win_ansible_user_ssh_pass]]></Value>
+                            <PlainText>true</PlainText>
+                        </Password>
+                        <Description>Ansible login service user</Description>
+                        <DisplayName>win_ansible_user</DisplayName>
+                        <Group>Administrators</Group>
+                        <Name>win_ansible_user</Name>
+                    </LocalAccount>
+	            </LocalAccounts>
+	                    </UserAccounts>
             <TimeZone>GMT Standard Time</TimeZone>
                         <OOBE>
                 <HideEULAPage>true</HideEULAPage>


### PR DESCRIPTION
… template correctly


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
