### PR TITLE
Fixes #37891 - Add enable-puppet8 parameter to provisioning templates

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -12,7 +12,7 @@ description: |
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-puppetlabs-repo') ||  host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+  aio_enabled = host_param_true?('enable-puppetlabs-repo') ||  host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -17,7 +17,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
 
 if host_param('run-puppet-in-installer-tags')
   puppet_tags = host_param('run-puppet-in-installer-tags')


### PR DESCRIPTION
Previously the enable-official-puppet8-repo parameter was added, but for users who supply their own packages (like Katello users) and still want to use AIO packaging need a parameter. Technically they could use enable-puppet5, enable-puppet6 or enable-puppet7 but this is inconsistent. It would be better to add a new version independent parameter, but this first aims for consistency.

Fixes: c35092bdba5d ("fixes #36939 - Allow for deployment of puppet 8")