### PR TITLE
Fixes #37912 - Correct Puppet server in Windows default user data template

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/windows_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/windows_default_user_data.erb
@@ -50,7 +50,7 @@ identity:
         - "<%= powershell %> -Command \"invoke-webrequest -Uri <%= host_param('win_puppet_source') %> -OutFile C:\\puppet-agent-latest.msi\""
         - "<%= powershell %> -Command \"md C:\\ProgramData\\PuppetLabs\\puppet\\etc\""
         - "<%= powershell %> -Command \"echo \"[main]\" | out-file C:\\ProgramData\\PuppetLabs\\puppet\\etc\\puppet.conf -encoding utf8\""
-        - "<%= powershell %> -Command \"echo \"server=http://<%= foreman_server_fqdn %>:8000/unattended/built?token=cae2cc74-1394-4acb-ad16-1011020b9bbe\" | add-content C:\\ProgramData\\PuppetLabs\\puppet\\etc\\puppet.conf -encoding utf8\""
+        - "<%= powershell %> -Command \"echo \"server=<%= host_puppet_server %>\" | add-content C:\\ProgramData\\PuppetLabs\\puppet\\etc\\puppet.conf -encoding utf8\""
         - "<%= powershell %> -Command \"echo \"autoflush=true\" | add-content C:\\ProgramData\\PuppetLabs\\puppet\\etc\\puppet.conf -encoding utf8\""
         - "<%= powershell %> -Command \"start /wait \"\" msiexec /qn /norestart /i C:\\puppet-agent-latest.msi PUPPET_MASTER_SERVER=<%= @host.puppet_server %>\""
         - "<%= powershell %> -Command \"sdelete.exe -accepteula -p 2 C:\\puppet-agent-latest.msi\""


### PR DESCRIPTION
It should use the `host_puppet_server` macro to determine the Puppet server for a given host, not some unattended URL with a hardcoded token.

Fixes: 6470fc41cd46 ("Fixes #36161 - Add windows default user data template")

@nadjaheitmann could you take a look?