### PR TITLE
Fixes #37915 - Give Toasts keys for ToastsList

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ToastsList/index.js
+++ b/webpack/assets/javascripts/react_app/components/ToastsList/index.js
@@ -18,8 +18,8 @@ const ToastsList = ({ railsMessages }) => {
   const messages = useSelector(selectToastsList);
 
   useEffect(() => {
-    railsMessages.forEach(({ message, type, key }) => {
-      dispatch(addToast({ message, type, key }));
+    railsMessages.forEach(({ message, type }) => {
+      dispatch(addToast({ message, type }));
     });
   }, [dispatch, railsMessages]);
 


### PR DESCRIPTION
toastProps key was sometimes empty, so it was overriding the key,  I moved the key prop to be after the spread so it wont get overriden but will take the toastProp key if its not empty.
This was causing this error:
react.development.js:315 Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ToastsList`
in Alert (created by ToastsList)

