### PR TITLE
allow pip to break system packages when installin pykickstart

### DIFF
--- a/.github/workflows/foreman.yml
+++ b/.github/workflows/foreman.yml
@@ -115,7 +115,7 @@ jobs:
         if: contains(matrix.task, 'compile')
       - name: Install external test dependencies
         run: |
-          pip3 install pykickstart
+          pip3 install --break-system-packages pykickstart
           sudo apt-get -qq -y install --no-install-recommends grub-common
         if: contains(matrix.task, 'external')
       - name: Prepare test env

--- a/.github/workflows/foreman.yml
+++ b/.github/workflows/foreman.yml
@@ -21,7 +21,7 @@ concurrency:
 jobs:
   setup_matrix:
     name: Setup matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.build_matrix.outputs.matrix }}
     steps:
@@ -32,7 +32,7 @@ jobs:
   rubocop:
     name: Rubocop
     needs: setup_matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       BUNDLE_WITHOUT: assets:console:development:dynflow_sidekiq:ec2:journald:jsonp:libvirt:openid:openstack:ovirt:redis:service:telemetry:vmware
     steps:
@@ -47,7 +47,7 @@ jobs:
 
   tests:
     name: "${{ matrix.task }} - Ruby ${{ matrix.ruby }} and Node ${{ matrix.node }} on PostgreSQL ${{ matrix.postgresql }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - setup_matrix
       - rubocop
@@ -146,7 +146,7 @@ jobs:
   result:
     if: always()
     name: Test suite
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs:
       - tests
       - katello


### PR DESCRIPTION
Ubuntu 24.04 by default protects system packages, which is good, but in
CI we just don't care enough to create a venv.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
