### PR TITLE
Fixes #37947 - install katello-host-tools by default

### DIFF
--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -73,7 +73,7 @@ if command -v subscription-manager &>/dev/null; then
   subscription-manager refresh
 fi
 
-<% if host_param_true?('redhat_install_host_tools') -%>
+<% if host_param_true?('redhat_install_host_tools', true) -%>
 <%= install_packages('katello-host-tools') -%>
 <% end -%>
 


### PR DESCRIPTION
The default parameter if katello-host-tools should be installed is true according to [1].

[1] https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/snippet/redhat_register.erb#L81


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
