### PR TITLE
Fixes #37963 - Make SeedHelper.test_template_requirements public

### DIFF
--- a/lib/seed_helper.rb
+++ b/lib/seed_helper.rb
@@ -158,12 +158,6 @@ class SeedHelper
       model.errors.full_messages.join(';')
     end
 
-    private
-
-    def logger
-      Foreman::Logging.logger('app')
-    end
-
     def test_template_requirements(template_name, requirements)
       requirements.each do |r|
         plugin = Foreman::Plugin.find(r['plugin'])
@@ -177,6 +171,12 @@ class SeedHelper
         end
       end
       true
+    end
+
+    private
+
+    def logger
+      Foreman::Logging.logger('app')
     end
   end
 end


### PR DESCRIPTION
To allow using it from plugins seeding their own templates.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
