### PR TITLE
Fixes #37964 - Increase foreman.socket's Backlog option to INT_MAX

### DIFF
--- a/extras/systemd/foreman.socket
+++ b/extras/systemd/foreman.socket
@@ -7,7 +7,8 @@ ListenStream=3000
 # Socket options matching Puma defaults
 NoDelay=true
 ReusePort=true
-Backlog=1024
+# Match systemd v254+'s default because EL9 has 252
+Backlog=4294967295
 
 [Install]
 WantedBy=sockets.target


### PR DESCRIPTION
Ever since 3e38815694272ef06d11efd63ffa29e9c1834c62 we've shipped with Backlog=1024. That value was taken somewhere from the internet and it sort of made sense. The default back then was 128, which was often a bottleneck. Why 1024, that's a good question.

Taking a step back, I wrote a [long analysis](https://issues.redhat.com/browse/SAT-6776#comment-25982829) which can be summarized:

systemd < 254 uses SOMAXCONN as a default for Backlog=, which is a constant defined by libc. glibc < 2.31 defaults to 128 while >= 2.31 uses 4096 to match the Linux kernel's net.core.somaxconn. systemd >= 254 defaults to INT_MAX (4294967295) for Backlog= and will be capped by the kernel's net.core.somaxconn value.

Linux < 5.4 defaults to 128 for net.core.somaxconn while >= 5.4 defaults to 4096.

EL 9 ships with Linux 5.14, glibc 2.34 and systemd 252. That makes me think it defaults to 4096 for Backlog=, but is also hard capped. Setting it to INT_MAX (like systemd 254+) should solely leave it to the kernel's net.core.somaxconn, making it easier for users to tune their system.