### PR TITLE
Fixes #37978 - CVE-2024-8553 - Forbid strings as loader macros argument

### DIFF
--- a/test/unit/foreman/renderer/scope/macros/loader_macros_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/loader_macros_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class LoaderMacrosTest < ActiveSupport::TestCase
+  setup do
+    template = OpenStruct.new(
+      name: 'Test',
+      template: 'Test'
+    )
+    source = Foreman::Renderer::Source::Database.new(
+      template
+    )
+    @scope = Class.new(Foreman::Renderer::Scope::Base) do
+      include Foreman::Renderer::Scope::Macros::Base
+    end.send(:new, source: source)
+  end
+
+  describe '#load_resources' do
+    it 'should accept custom selects' do
+      @scope.load_hosts(select: :id)
+      @scope.load_hosts(select: [:id, :name])
+    end
+
+    it 'should reject unacceptable selects' do
+      assert_raises(ArgumentError) { @scope.load_hosts(select: 'a string value') }
+      assert_raises(ArgumentError) { @scope.load_hosts(select: {:key => :value}) }
+      assert_raises(ArgumentError) { @scope.load_hosts(select: [:mixed, 'array']) }
+      error = assert_raises(ArgumentError) { @scope.load_hosts(select: 7) }
+      assert_match /Value of 'select'/, error.message
+      assert_match /load_hosts/, error.message
+      assert_match /Symbol or Array of Symbols/, error.message
+    end
+
+    it 'should accept custom joins' do
+      @scope.load_hosts(joins: :interfaces)
+      @scope.load_hosts(joins: {:interfaces => :subnet})
+      @scope.load_hosts(joins: [:interfaces, :domain])
+    end
+
+    it 'should reject unacceptable joins' do
+      assert_raises(ArgumentError) { @scope.load_hosts(joins: 'a string value') }
+      assert_raises(ArgumentError) { @scope.load_hosts(joins: [:mixed, 'array']) }
+      error = assert_raises(ArgumentError) { @scope.load_hosts(joins: 7) }
+      assert_match /Value of 'joins'/, error.message
+      assert_match /load_hosts/, error.message
+      assert_match /Symbol, Hash or Array of Symbols/, error.message
+    end
+  end
+end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
