### PR TITLE
Fixes #37980 - Remove roles locked sort

### DIFF
--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -8,7 +8,7 @@
     <tr>
       <th class="col-md-2"><%= sort :name, :as => s_("Role|Name") %></th>
       <th class="col-md-8"><%= sort :description, :as => s_("Role|Description") %></th>
-      <th class="col-md-1"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
+      <th class="col-md-1"><%= s_("Role|Locked") %></th>
       <th><%= _('Actions') %></th>
     </tr>
   </thead>


### PR DESCRIPTION
In roles,
sorting by locked gives "unknown attribute 'locked' for Class." or, before foreman 3.5 - "Invalid search query: the field 'locked' in the order statement is not valid field for search"