### PR TITLE
Fixes #38000 - Pagelet for HTTP Proxy form

### DIFF
--- a/app/views/http_proxies/_form.html.erb
+++ b/app/views/http_proxies/_form.html.erb
@@ -28,6 +28,8 @@
                                                      :spinner_id => 'test_connection_indicator',
                                                      :class => 'btn-default',
                                                      :spinner_class => nil) %>
+
+      <%= render_pagelets_for(:main_tab_fields, :subject => @http_proxy, :form => f) %>
     </div>
 
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @http_proxy %>


### PR DESCRIPTION
Allow the extension of the HTTP Proxy form from the plugins.

For https://github.com/Katello/katello/pull/11183