### PR TITLE
Fixes #38001 - Basic test for table sortings

### DIFF
--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -8,7 +8,7 @@
     <tr>
       <th class="col-md-2"><%= sort :name, :as => s_("Role|Name") %></th>
       <th class="col-md-8"><%= sort :description, :as => s_("Role|Description") %></th>
-      <th class="col-md-1"><%= sort :locked, :as => s_("Role|Locked"), :default => "DESC" %></th>
+      <th class="col-md-1"><%= s_("Role|Locked") %></th>
       <th><%= _('Actions') %></th>
     </tr>
   </thead>

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -103,6 +103,32 @@ class ActionDispatch::IntegrationTest
     assert_breadcrumb_text(title_text)
     (assert first(:link, new_link_text).visible?, "#{new_link_text} is not visible") if new_link_text
     (assert find('.autocomplete-search button').visible?, "Search button is not visible") if has_search
+    assert_sortable_table index_path
+  end
+
+  def assert_sortable_table(index_path)
+    visit index_path
+    if page.has_selector?('table')
+      if page.has_selector?(:css, ".pf-c-table")
+        th_with_sort = "//th/button"
+      else
+        th_with_sort = "//th/a"
+      end
+      len = page.all(:xpath, th_with_sort).length
+      (0..len - 1).each do |i|
+        th = page.all(:xpath, th_with_sort)[i]
+        th_text = th.text
+        th.click
+        sort_by = page.all(:xpath, th_with_sort)[i]
+        assert(
+          sort_by[:class].include?('ascending') ||
+          sort_by[:class].include?('descending') ||
+          sort_by["aria-sort"] == 'ascending' ||
+          sort_by["aria-sort"] == 'descending',
+          "sort by #{th_text} does not have 'ascending' or 'descending' class"
+        )
+      end
+    end
   end
 
   def assert_breadcrumb_text(text)


### PR DESCRIPTION
Relies on: https://github.com/theforeman/foreman/pull/10368 as without it the test will fail with:
```
#<ActionController::RoutingError: No route matches [GET] "/favicon.ico">
[MinitestRetry] retry 'test_0001_index page' count: 3,  msg: ActiveModel::UnknownAttributeError: unknown attribute 'locked' for Class.
    app/controllers/roles_controller.rb:25:in `index'
```
Tests that clicking on the sort in react and rb tables in index pages doesnt break the page, and also that the tables appears sorted.
Does not test that the sorting work as some tables have different ways of sorting so the search query wont always be `order_by=some_header`