### PR TITLE
Fixes #38002 - Fix typo in Linux host_init_config default template

### DIFF
--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -15,7 +15,7 @@ description: |
   This template is used during the host registration to perform the initial host configuration. After the host
   is created by starting the registration, the registration script asks for the host init config script, that
   is rendered based on this template. It is rendered for the specific host therefore it contains instructions
-  specific for the OS of the host. It's content can differ based on any parameters applicable for the host.
+  specific for the OS of the host. Its content can differ based on any parameters applicable for the host.
 
   It deploys the CA certificate so any later communication with the Foreman is TLS secured. Then it
   performs initial steps, such as puppet deployment, remote execution SSH key configuration etc. At the end


### PR DESCRIPTION
The template "Linux host_init_config default" has a typo in its description section:

~~~
description: |
This template is used during the host registration to perform the initial host configuration. After the host
is created by starting the registration, the registration script asks for the host init config script, that
is rendered based on this template. It is rendered for the specific host therefore it contains instructions
specific for the OS of the host. It's content can differ based on any parameters applicable for the host.
~~~

The sentence beginning "It's content can differ based on any parameters applicable for the host." has an apostrophe in the "It's" - grammatically this should be "Its" and the apostrophe/quote mark renders the rest of the script as one long string (it is all 'yellow' in the template editor)

This PR just changes `It's` to `Its`. 

Before: 

![before](https://github.com/user-attachments/assets/f795c6df-a540-4409-8240-1e83d65f9df7)

After: 

![after](https://github.com/user-attachments/assets/e4ab431c-f2b9-40b2-a107-2b60aebb7f60)
