### PR TITLE
Fixes #38029 - Update subscription_manager_setup to use correct URLs for load-balanced smart proxies

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -88,11 +88,11 @@ fi
      end
    elsif @subman_setup_scenario == 'provisioning'
      if plugin_present?('katello')
-       server_hostname = @host.content_source.rhsm_url.host
+       server_hostname = @host.content_source.registration_url.host
        server_port = @host.content_source.rhsm_url.port
        server_prefix = @host.content_source.rhsm_url.path
        repo_ca_cert = "$KATELLO_SERVER_CA_CERT"
-       rhsm_baseurl = @host.content_source.pulp_content_url
+       rhsm_baseurl = @host.content_source.load_balancer_pulp_content_url
      else
        server_hostname = "subscription.rhsm.redhat.com"
        server_port = "443"


### PR DESCRIPTION
The `subscription_manager_setup` snippet, when used in provisioning, was setting the wrong URLs for subscription-manager for load-balanced smart proxy setups. This attempts to fix this by using `registration_url`, which should correctly reflect the load balancer FQDN when the smart proxy is set up correctly with load balancing, and will reflect the smart proxy FQDN when it's not.

Goes with https://github.com/Katello/katello/pull/11229
