### PR TITLE
Update developer docs to work on Fedora 40+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ config/hooks
 *.csv
 .envrc
 node_modules
+vendor/bundle
 vendor/ruby
 public/webpack
 .env*

--- a/developer_docs/foreman_dev_setup.asciidoc
+++ b/developer_docs/foreman_dev_setup.asciidoc
@@ -55,8 +55,9 @@ Use the following steps to set up PostgreSQL on RPM based distributions:
 
 [source, bash]
 ....
-sudo dnf install postgresql
+sudo dnf install postgresql-server
 sudo postgresql-setup --initdb
+sudo systemctl enable --now postgresql
 sudo -u postgres createuser --createdb $USER
 ....
 


### PR DESCRIPTION
On Fedora 40 bundler installs by default to vendor/bundle and this ignores the directory. While installing it was also noticed that postgresql-server is the real server package and that the server needs to be running. For simplicity it's configured to always start on boot.

cc @ColeHiggins2