### PR TITLE
Fixes #38036 - Add lxc* pattern to IGNORED_INTERFACES list

### DIFF
--- a/config/initializers/f_foreman_settings_facts.rb
+++ b/config/initializers/f_foreman_settings_facts.rb
@@ -38,6 +38,7 @@ Foreman::SettingManager.define(:foreman) do
       'br-int',
       'vif*',
       'cali*',
+      'lxc*',
     ].freeze
 
     setting('create_new_host_when_facts_are_uploaded',


### PR DESCRIPTION
Using some Kubernetes platforms with Cilium as the CNI will cause the node hosts to have lots of container interfaces with `lxc` as a prefix. If these nodes are registered to Foreman/Satellite, the facts for the hosts interfaces will become very large and cause performance issues when loading the host page in the Satellite/Foreman WebUI . Add interfaces with `lxc*` pattern to list of `IGNORED_INTERFACES`. Trivial one-line change. 
 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
