### PR TITLE
Fixes #38037 - Update last login time for External Auth user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -337,6 +337,7 @@ class User < ApplicationRecord
         user.usergroups = new_usergroups.uniq
       end
 
+      user.post_successful_login
       user
     # not existing user and creating is disabled by settings
     elsif auth_source_name.nil?


### PR DESCRIPTION
This bug[1](https://projects.theforeman.org/issues/38037#fn1) has been reported previously in Satellite 6.2 and fixed in Satellite 6.3

 [1] https://bugzilla.redhat.com/show_bug.cgi?id=1460963

Later on it broke again by the PR below 5 years ago:

https://github.com/theforeman/foreman/pull/7155/files#diff-cfdccd0a9d5df5a43aaad2a35d36ebbe187c52ad5fdc9846fa189d04537adb6eL201
