### PR TITLE
Fixes #38051 - Fix built request to accept ipv6 hosts

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -214,11 +214,26 @@ class UnattendedController < ApplicationController
   # the form save)
   def update_ip
     ip = request.remote_ip
-    logger.debug "Built notice from #{ip}, current host ip is #{@host.ip}, updating" if @host.ip != ip
+    address = IPAddr.new(ip)
 
     # @host has been changed even if the save fails, so we have to change it back
+    if address.ipv4?
+      update_ip4(ip)
+    elsif address.ipv6? && !address.link_local?
+      update_ip6(ip)
+    end
+  end
+
+  def update_ip4(ip)
+    logger.debug "Built notice from #{ip}, current host ip is #{@host.ip}, updating" if @host.ip != ip
     old_ip = @host.ip
     @host.ip = old_ip unless @host.update({'ip' => ip})
+  end
+
+  def update_ip6(ip)
+    logger.debug "Built notice from #{ip}, current host ip is #{@host.ip6}, updating" if @host.ip6 != ip
+    old_ip = @host.ip6
+    @host.ip6 = old_ip unless @host.update({'ip6' => ip})
   end
 
   def ipxe_request?

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -373,6 +373,16 @@ class UnattendedControllerTest < ActionController::TestCase
       refute nic.build
     end
 
+    test "should accept built notifications over ipv6 and store the address" do
+      nic6 = '2001:db8::1234'
+      Setting[:update_ip_from_built_request] = true
+      @request.env["REMOTE_ADDR"] = nic6
+      post :built, params: { mac: @ub_host.primary_interface.mac }
+      assert_response :created
+      @ub_host.reload
+      assert_equal nic6, @ub_host.primary_interface.ip6
+    end
+
     test "should accept failed notifications" do
       @request.env["REMOTE_ADDR"] = @ub_host.ip
       post :failed


### PR DESCRIPTION
Built request should be able to accept built requests sent from IPv6 only machine. This pr makes sure `ip6` field is updated accordingly.