### PR TITLE
Fixes #38053 - Remove syspurpose addons from Foreman

### DIFF
--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -201,7 +201,7 @@ module Foreman
           apipie :method, 'Returns an array of all possible host status classes sorted alphabetically by status name' do
             desc "Useful to generate a report on all host statuses."
             returns array_of: 'HostStatus', desc: 'Array of host status objects'
-            example "all_host_statuses # => [Katello::PurposeAddonsStatus, HostStatus::BuildStatus, ForemanOpenscap::ComplianceStatus, HostStatus::ConfigurationStatus, Katello::ErrataStatus, HostStatus::ExecutionStatus, Katello::PurposeRoleStatus, Katello::PurposeSlaStatus, Katello::SubscriptionStatus, Katello::PurposeStatus, Katello::TraceStatus, Katello::PurposeUsageStatus] "
+            example "all_host_statuses # => [HostStatus::BuildStatus, ForemanOpenscap::ComplianceStatus, HostStatus::ConfigurationStatus, Katello::ErrataStatus, HostStatus::ExecutionStatus, Katello::PurposeRoleStatus, Katello::PurposeSlaStatus, Katello::SubscriptionStatus, Katello::PurposeStatus, Katello::TraceStatus, Katello::PurposeUsageStatus] "
           end
           def all_host_statuses
             @all_host_statuses ||= HostStatus.status_registry.to_a.sort_by(&:status_name)
@@ -210,7 +210,7 @@ module Foreman
           apipie :method, 'Returns hash representing all statuses for a given host' do
             required :host, 'Host::Managed', desc: 'a host object to get the statuses for'
             returns object_of: Hash, desc: 'Hash representing all statuses for a given host'
-            example 'all_host_statuses(@host) # => {"Addons"=>0, "Build"=>1, "Compliance"=>0, "Configuration"=>0, "Errata"=>0, "Execution"=>1, "Role"=>0, "Service Level"=>0, "Subscription"=>0, "System Purpose"=>0, "Traces"=>0, "Usage"=>0}'
+            example 'all_host_statuses(@host) # => {"Build"=>1, "Compliance"=>0, "Configuration"=>0, "Errata"=>0, "Execution"=>1, "Role"=>0, "Service Level"=>0, "Subscription"=>0, "System Purpose"=>0, "Traces"=>0, "Usage"=>0}'
             example "<%- load_hosts.each_record do |host| -%>\n<%= host.name -%>, <%=   all_host_statuses(host)['Subscription'] %>\n<%- end -%>"
           end
           def all_host_statuses_hash(host)
@@ -220,7 +220,7 @@ module Foreman
           apipie :method, 'Returns hash representing all statuses for a given host in human-readable format' do
             required :host, 'Host::Managed', desc: 'a host object to get the statuses for'
             returns object_of: Hash, desc: 'Hash representing all statuses for a given host in human-readable format'
-            example 'all_host_statuses_labels(@host) # => {"Addons"=>"Unknown", "Build"=>"Installed", "Compliance"=>"Not applicable", "Configuration"=>"No reports", "Errata"=>"Security errata applicable", "Execution"=>"Last execution succeeded", "Role"=>"Unknown", "Service Level"=>"Unknown", "Subscription"=>"Simple Content Access", "System Purpose"=>"Unknown", "Traces"=>"No processes require restarting", "Usage"=>"Unknown"}'
+            example 'all_host_statuses_labels(@host) # => {"Build"=>"Installed", "Compliance"=>"Not applicable", "Configuration"=>"No reports", "Errata"=>"Security errata applicable", "Execution"=>"Last execution succeeded", "Role"=>"Unknown", "Service Level"=>"Unknown", "Subscription"=>"Simple Content Access", "System Purpose"=>"Unknown", "Traces"=>"No processes require restarting", "Usage"=>"Unknown"}'
             example "<%- load_hosts.each_record do |host| -%>\n<%= host.name -%>, <%=   all_host_statuses_labels(host)['Subscription'] %>\n<%- end -%>"
           end
           def all_host_statuses_labels_hash(host)

--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -82,7 +82,6 @@ module Foreman
         "syspurpose_role" => "Red Hat Enterprise Linux Server",
         "syspurpose_usage" => "Development/Test",
         "syspurpose_sla" => "Self-Support",
-        "syspurpose_addons" => "first addon, second addon, third addon",
         "ansible_user" => "win_ansible_user",
         "create_ansible_user" => "true",
         "ansible_ssh_pass" => "win_ansible_user_ssh_pass",

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_rhsm.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_rhsm.erb
@@ -19,12 +19,10 @@ test_on:
   sys_role = " --role '#{host_param('syspurpose_role')}'" if host_param('syspurpose_role')
   sys_usage = " --usage '#{host_param('syspurpose_usage')}'" if host_param('syspurpose_usage')
   sys_sla = " --sla '#{host_param('syspurpose_sla')}'" if host_param('syspurpose_sla')
-  sys_addons = " #{host_param('syspurpose_addons').split(',')
-                                                  .map { |add_on| "--addon '#{add_on.strip}'" }.join(" ")}" if host_param('syspurpose_addons')
 -%>
 <% if subman_registration -%>
 rhsm --organization="<%= subman_org %>" --activation-key="<%= subman_keys %>"<%= subman_hostname -%><%= subman_rhsm_baseurl -%><%= subman_insights -%>
 <% end -%>
 <%- if host_param('syspurpose_role') %>
-syspurpose<%= sys_role %><%= sys_usage %><%= sys_sla %><%= sys_addons %>
+syspurpose<%= sys_role %><%= sys_usage %><%= sys_sla %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -53,9 +53,6 @@ description: |
 
     syspurpose_sla                              Sets the system purpose SLA
 
-    syspurpose_addons                           Sets the system purpose add-ons. Separate multiple
-                                                values with commas.
-
   Set these parameters if you're using rhnreg_ks:
 
     spacewalk_host = <hostname>                 Hostname of Spacewalk server
@@ -98,7 +95,7 @@ description: |
   # Set up subscription-manager
   <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'provisioning' }).strip -%>
 
-  <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla') || host_param('syspurpose_addons')) -%>
+  <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla')) -%>
     # Avoid timeout accessing unreachable repo on air gapped infrastructure,
     #  assuming subscription-manager-syspurpose is installed in custom packages section.
     if ! rpm --query --quiet subscription-manager-syspurpose ; then
@@ -114,11 +111,6 @@ description: |
       <%- end -%>
       <%- if host_param('syspurpose_sla') -%>
         syspurpose set-sla "<%= host_param('syspurpose_sla') %>"
-      <%- end -%>
-      <%- if host_param('syspurpose_addons') -%>
-        <%- addons = host_param('syspurpose_addons').split(',')
-              .map { |add_on| "'#{add_on.strip}'" }.join(" ") %>
-        syspurpose add-addons <%= addons %>
       <%- end -%>
     else
       echo "Syspurpose CLI not found."

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -133,8 +133,6 @@ runcmd:
           syspurpose set-role "Red Hat Enterprise Linux Server"
           syspurpose set-usage "Development/Test"
           syspurpose set-sla "Self-Support"
-  
-          syspurpose add-addons 'first addon' 'second addon' 'third addon'
       else
         echo "Syspurpose CLI not found."
       fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -118,8 +118,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -181,8 +181,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -181,8 +181,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -181,8 +181,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -181,8 +181,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -181,8 +181,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -30,7 +30,7 @@ part /boot --fstype ext3 --size=100 --asprimary
 part /     --fstype ext3 --size=1024 --grow
 part swap  --recommended
 rhsm --organization="Org" --activation-key="key" --connect-to-insights
-syspurpose --role 'Red Hat Enterprise Linux Server' --usage 'Development/Test' --sla 'Self-Support' --addon 'first addon' --addon 'second addon' --addon 'third addon'
+syspurpose --role 'Red Hat Enterprise Linux Server' --usage 'Development/Test' --sla 'Self-Support'
 
 skipx
 text

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -179,8 +179,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -178,8 +178,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/kickstart_rhsm.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/kickstart_rhsm.rhel9_dhcp.snap.txt
@@ -1,2 +1,2 @@
 rhsm --organization="Org" --activation-key="key" --connect-to-insights
-syspurpose --role 'Red Hat Enterprise Linux Server' --usage 'Development/Test' --sla 'Self-Support' --addon 'first addon' --addon 'second addon' --addon 'third addon'
+syspurpose --role 'Red Hat Enterprise Linux Server' --usage 'Development/Test' --sla 'Self-Support'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -132,8 +132,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
         syspurpose set-role "Red Hat Enterprise Linux Server"
         syspurpose set-usage "Development/Test"
         syspurpose set-sla "Self-Support"
-
-        syspurpose add-addons 'first addon' 'second addon' 'third addon'
     else
       echo "Syspurpose CLI not found."
     fi


### PR DESCRIPTION
* In https://github.com/Katello/katello/pull/11196 we removed syspurpose addons from Katello. I didn't realize we had them in Foreman too which of course then broke QE tests. 
