### PR TITLE
Fixes #38057 - Use ipv6 too for ssh provisioning

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -99,6 +99,6 @@ module Orchestration::SshProvision
 
   def provision_host
     # usually cloud compute resources provide IPs but virtualization do not
-    provision_interface.ip || provision_interface.fqdn
+    provision_interface.ip6 || provision_interface.ip || provision_interface.fqdn
   end
 end


### PR DESCRIPTION
We should also use IPv6 if available for ssh orchestration.