### PR TITLE
Fixes #38067 - Replace deprecated wget "-Y off"

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/preseed_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/preseed_default.erb
@@ -168,4 +168,4 @@ d-i finish-install/reboot_in_progress note
 
 <%= snippet_if_exists(template_name + " custom post") -%>
 
-d-i preseed/late_command string wget -Y off <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget --no-proxy <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -72,6 +72,6 @@ autoinstall:
 <%= indent(2) { snippet_if_exists(template_name + " custom root") } -%>
   late-commands:
 <%= indent(2) { snippet 'preseed_autoinstall_clevis_tang_wrapper' if host_param('disk_enc_tang_servers') && os_major >= 22 } %>
-  - wget -Y off <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /target/tmp/finish.sh
+  - wget --no-proxy <%= @static ? "'#{foreman_url('finish', static: 'true')}'" : foreman_url('finish') %> -O /target/tmp/finish.sh
   - curtin in-target -- chmod +x /tmp/finish.sh
   - curtin in-target -- /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.debian4dhcp.snap.txt
@@ -78,4 +78,4 @@ d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 
 
-d-i preseed/late_command string wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget --no-proxy http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Preseed_default.ubuntu4dhcp.snap.txt
@@ -78,4 +78,4 @@ d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 
 
-d-i preseed/late_command string wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh
+d-i preseed/late_command string wget --no-proxy http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh && in-target chmod +x /tmp/finish.sh && in-target /tmp/finish.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -34,6 +34,6 @@ autoinstall:
 
   late-commands:
 
-  - wget -Y off http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh
+  - wget --no-proxy http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh
   - curtin in-target -- chmod +x /tmp/finish.sh
   - curtin in-target -- /tmp/finish.sh


### PR DESCRIPTION
As the parameter is not part of the manpage anymore [1] (but still supported for backward compatibility reasons [2]) this might confuse people.

Correct parameter would be `wget --no-proxy`.

[1]:http://git.savannah.gnu.org/cgit/wget.git/commit/?id=0734d8dd3744825c4db56ef0f50bcff111efa18e [2]:http://git.savannah.gnu.org/cgit/wget.git/commit/?id=e3acbd2aaf2c1a6556b20243781f4e4b83dbd2a2


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
