### PR TITLE
Fixes #38068 - Consistently use errors.add

### DIFF
--- a/app/controllers/usergroups_controller.rb
+++ b/app/controllers/usergroups_controller.rb
@@ -37,7 +37,7 @@ class UsergroupsController < ApplicationController
       process_error
     end
   rescue Foreman::CyclicGraphException => e
-    @usergroup.errors[:usergroups] << e.record.errors[:base].join(' ')
+    @usergroup.errors.add(:usergroups, e.record.errors[:base].join(' '))
     process_error
   rescue => e
     external_usergroups_error(@usergroup, e)

--- a/app/models/compute_resources/foreman/model/ec2.rb
+++ b/app/models/compute_resources/foreman/model/ec2.rb
@@ -122,9 +122,9 @@ module Foreman::Model
       super
       errors[:user].empty? && errors[:password].empty? && regions
     rescue Fog::AWS::Compute::Error => e
-      errors[:base] << e.message
+      errors.add(:base, e.message)
     rescue Excon::Error::Socket => e
-      errors[:base] << e.message
+      errors.add(:base, e.message)
     end
 
     def console(uuid)

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -78,7 +78,7 @@ module Foreman::Model
       errors[:url].empty? && hypervisor
     rescue => e
       disconnect rescue nil
-      errors[:base] << e.message
+      errors.add(:base, e.message)
     end
 
     def new_nic(attr = {})

--- a/app/models/compute_resources/foreman/model/openstack.rb
+++ b/app/models/compute_resources/foreman/model/openstack.rb
@@ -91,7 +91,7 @@ module Foreman::Model
       super
       errors[:user].empty? && errors[:password] && tenants
     rescue => e
-      errors[:base] << e.message
+      errors.add(:base, e.message)
     end
 
     def available_images

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -470,7 +470,7 @@ module Foreman::Model
         errors.delete(:datacenter)
       end
     rescue => e
-      errors[:base] << e.message
+      errors.add(:base, e.message)
     end
 
     def parse_args(args)

--- a/app/services/host_build_status.rb
+++ b/app/services/host_build_status.rb
@@ -56,6 +56,6 @@ class HostBuildStatus
 
   def fail!(type, message, id = nil)
     @state = false
-    @errors[type] << {:message => message, :edit_id => id}
+    @errors.add(type, {:message => message, :edit_id => id})
   end
 end


### PR DESCRIPTION
Using `errors[:field] << 'the error'` is deprecated in favor of `errors.add(:field, 'the error')`. Instances found using:

    rg 'errors\[.+\]\s+<<'