### PR TITLE
Fixes #38078 - Correctly create a DB entry for settings test

### DIFF
--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -240,7 +240,7 @@ class SeedsTest < ActiveSupport::TestCase
     end
 
     test 'does not change value for existing setting' do
-      Setting[:instance_id] = Foreman.uuid
+      Setting.create(name: 'instance_id', value: Foreman.uuid)
       Setting.expects(:[]=).with(:instance_id, anything).never
       seed('190-instance_id.rb')
     end


### PR DESCRIPTION
In `test/unit/tasks/seeds_test.rb` the `test does not change value for existing setting` is failing because the DB setting is never created.  Due to a bug in mocha (that 2.7.0 fixed) this was never uncovered.

Fixes: 02dd9831bd12 ("Fixes #36395 - move value setting to seed")