### PR TITLE
Fixes #38095 - don't chown /root during ssh key setup

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -57,7 +57,9 @@ EOF
   chmod 0700 <%= ssh_path %>
   chmod 0600 <%= ssh_path %>/authorized_keys
   chown -R <%= "#{ssh_user}:" %> <%= ssh_path %>
+<% if ssh_user != 'root' -%>
   chown -R <%= "#{ssh_user}:" %> <%= "~#{ssh_user}" %>
+<% end -%>
 
   # Restore SELinux context with restorecon, if it's available:
   command -v restorecon && restorecon -RvF <%= ssh_path %> || true


### PR DESCRIPTION
Setting up ssh keys on bootc hosts fails because `/root` cannot be modified due to the read-only nature.

I was going to skip this only for bootc hosts, but I could not think of a reason to do this at all. When would root not have access to `/root`? 

Maybe more of the ownership changing can be skipped for root, but this at least fixes the issue on bootc hosts.