### PR TITLE
Fixes #38141 - Hide search submit button when not submittable

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SearchBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/index.js
@@ -62,7 +62,7 @@ const SearchBar = ({
         }
         onSearchChange={_onSearchChange}
         value={search}
-        onSearch={_onSearch}
+        onSearch={onSearch && _onSearch}
         disabled={disabled}
         error={error}
         name={name}


### PR DESCRIPTION
We already have this logic in `webpack/assets/javascripts/react_app/components/SearchBar/SearchAutocomplete.js` as well, this is an adjustment since  we added logic to the onSearch in `/SearchBar/index.js`.
Without this places with no onSeach (like the job wizard user inputs) will have a submit button that does nothing and adds an error in the console of onSeach being undefined.