### PR TITLE
Fixes #38155 - Use auto instead of dhcp for ipv6 interfaces

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -122,7 +122,6 @@ keyboard <%= host_param('keyboard') || 'us' %>
       variables: {
         iface: iface,
         host: @host,
-        use_slaac: host_param_true?('use-slaac'),
         static: @static,
         static6: @static6
       }

--- a/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_ovirt.erb
@@ -60,7 +60,6 @@ liveimg --url=<%= liveimg_url %>
         variables: {
           iface: iface,
           host: @host,
-          use_slaac: false,
           static: @static,
           static6: @static6
           }

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_ifcfg_generic_interface.erb
@@ -22,7 +22,7 @@ BOOTPROTO="<%= @dhcp ? 'dhcp' : 'none' -%>"
 <%- end -%>
 <%- if @interface.ip6.present? -%>
 <%=   "IPV6INIT=yes" %>
-<%=   "IPV6_AUTOCONF=#{host_param_true?('use-slaac') ? 'yes' : 'no'}" %>
+<%=   "IPV6_AUTOCONF=yes" %>
 <%=   "IPV6ADDR=#{@interface.ip6}" %>
 <%-   if !@subnet6.nil? && @subnet6.gateway.present? -%>
 <%=     "IPV6_DEFAULTGW=#{@subnet6.gateway}" %><%= '%$real' if @subnet6.gateway.match(/^fe80:/) %>

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -52,7 +52,7 @@ description: |
       options.push("ks=#{foreman_url('provision', static6: '1').gsub("&", "\\\\&")}")
     else
       options.push("ks=#{foreman_url('provision').gsub("&", "\\\\&")}", "kssendmac", "ks.sendmac")
-    end  
+    end
   end
 
   # networking credentials
@@ -84,11 +84,7 @@ description: |
       end
     end
   elsif subnet6 && subnet6.dhcp_boot_mode? && rhel_compatible && major >= 7
-    if host_param_true?("use-slaac")
-      options.push("ip=auto6")
-    else
-      options.push("ip=dhcp6")
-    end
+    options.push("ip=auto6")
   elsif subnet6 && !subnet6.dhcp_boot_mode?
     raise("Static IPv6 provisioning works on RHEL7 or newer") if rhel_compatible && major < 7
     gw = subnet6.gateway ? "[#{subnet6.gateway}]" : ""

--- a/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
@@ -8,7 +8,7 @@ description: |
   Generates network directive for a given interface. It is not expected to be used directly.
 -%>
 <%#
-  # Variables: iface, host, use_slaac, static, static6
+  # Variables: iface, host, static, static6
 -%>
 <%if @iface.managed? -%>
 <%
@@ -61,11 +61,7 @@ if subnet6
     network_options.push("--ipv6=#{@iface.ip6}/#{subnet6.cidr}")
     network_options.push("--ipv6gateway=#{subnet6.gateway}")
   elsif subnet6.dhcp_boot_mode?
-    if @use_slaac
-      network_options.push("--ipv6 auto")
-    else
-      network_options.push("--ipv6 dhcp")
-    end
+    network_options.push("--ipv6 auto")
   end
 
   nameservers.concat(subnet6.dns_servers)

--- a/test/unit/foreman/templates/snippets/kickstart_network_interface_test.rb
+++ b/test/unit/foreman/templates/snippets/kickstart_network_interface_test.rb
@@ -5,7 +5,7 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
     @renderer ||= Foreman::Renderer::SafeModeRenderer
   end
 
-  def render_template(iface, host:, use_slaac:, static:, static6:)
+  def render_template(iface, host:, static:, static6:)
     @snippet ||= File.read(Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'kickstart_network_interface.erb'))
 
     source = OpenStruct.new(
@@ -20,7 +20,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       variables: {
         iface: iface,
         host: host,
-        use_slaac: use_slaac,
         static: static,
         static6: static6,
       })
@@ -43,7 +42,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         @host.managed_interfaces.first,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -57,7 +55,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -78,7 +75,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -103,7 +99,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -125,7 +120,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -145,7 +139,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -163,7 +156,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: true,
         static6: false
       )
@@ -185,7 +177,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -205,7 +196,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: true
       )
@@ -227,13 +217,12 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
 
       assert_not_nil(ipv6_match = /--ipv6 ([^ ]*)/.match(actual))
-      assert_match(/dhcp/, ipv6_match[1])
+      assert_match(/auto/, ipv6_match[1])
     end
 
     test 'should use auto ipv6 configuration' do
@@ -246,7 +235,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: true,
         static: false,
         static6: false
       )
@@ -267,7 +255,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -288,7 +275,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -309,7 +295,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )
@@ -342,7 +327,6 @@ class KickstartNetworkInterfaceTest < ActiveSupport::TestCase
       actual = render_template(
         iface,
         host: @host,
-        use_slaac: false,
         static: false,
         static6: false
       )


### PR DESCRIPTION
option `dhcp` does not use Router Advertisements to configure the network. 