### PR TITLE
Fixes #38159 - Cache classes for apipie:cache task

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,7 @@ Foreman::Application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  config.cache_classes = Foreman.in_rake?('apipie:cache')
 
   # Eager load is set for all environments
   config.eager_load = true


### PR DESCRIPTION
During `apipie:cache` task, Apipie reloads classes, but since Zeitwerk changes in Foreman, we don't have code reloading in functional state, especially with any plugin enabled.