### PR TITLE
Fixes #37758 - Delete host redirects to hosts list based on setting

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
@@ -12,7 +12,8 @@ import { POWER_REQURST_KEY } from '../DetailsCard/PowerStatus/constants';
 export const deleteHost = (
   hostName,
   compute,
-  destroyVmOnHostDelete
+  destroyVmOnHostDelete,
+  hostsIndexUrl
 ) => dispatch => {
   const successToast = () => sprintf(__('Host %s deleted'), hostName);
   const errorToast = ({ message }) => message;
@@ -44,7 +45,7 @@ export const deleteHost = (
             key: `${hostName}-DELETE`,
             successToast,
             errorToast,
-            handleSuccess: () => visit(foremanUrl('/hosts')),
+            handleSuccess: () => visit(foremanUrl(hostsIndexUrl)),
           })
         ),
       message: (

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -23,7 +23,10 @@ import { translate as __ } from '../../../common/I18n';
 import { selectKebabItems } from './Selectors';
 import { foremanUrl } from '../../../common/helpers';
 import { cancelBuild, deleteHost, isHostTurnOn } from './actions';
-import { useForemanSettings } from '../../../Root/Context/ForemanContext';
+import {
+  useForemanSettings,
+  useForemanHostsPageUrl,
+} from '../../../Root/Context/ForemanContext';
 import BuildModal from './BuildModal';
 import Slot from '../../common/Slot';
 
@@ -51,12 +54,15 @@ const ActionsBar = ({
   const [isBuildModalOpen, setBuildModal] = useState(false);
   const onKebabToggle = isOpen => setKebab(isOpen);
   const { destroyVmOnHostDelete } = useForemanSettings();
+  const hostsIndexUrl = useForemanHostsPageUrl();
   const registeredItems = useSelector(selectKebabItems, shallowEqual);
   const isHostActive = useSelector(isHostTurnOn);
 
   const dispatch = useDispatch();
   const deleteHostHandler = () =>
-    dispatch(deleteHost(hostName, computeId, destroyVmOnHostDelete));
+    dispatch(
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, hostsIndexUrl)
+    );
 
   const isConsoleDisabled = !(computeId && isHostActive);
   const determineTooltip = () => {

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -37,7 +37,10 @@ import {
   getPageStats,
 } from '../PF4/TableIndexPage/Table/helpers';
 import { deleteHost } from '../HostDetails/ActionsBar/actions';
-import { useForemanSettings } from '../../Root/Context/ForemanContext';
+import {
+  useForemanSettings,
+  useForemanHostsPageUrl,
+} from '../../Root/Context/ForemanContext';
 import { bulkDeleteHosts } from './BulkActions/bulkDelete';
 import BulkBuildHostModal from './BulkActions/buildHosts';
 import BulkReassignHostgroupModal from './BulkActions/reassignHostGroup';
@@ -177,8 +180,11 @@ const HostsIndex = () => {
 
   const dispatch = useDispatch();
   const { destroyVmOnHostDelete } = useForemanSettings();
+  const hostsIndexUrl = useForemanHostsPageUrl();
   const deleteHostHandler = ({ hostName, computeId }) =>
-    dispatch(deleteHost(hostName, computeId, destroyVmOnHostDelete));
+    dispatch(
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, hostsIndexUrl)
+    );
   const handleBulkDelete = () => {
     const bulkParams = fetchBulkParams();
     dispatch(


### PR DESCRIPTION
Test steps
1. All Hosts - Action - Delete on one of the hosts
2. All Hosts - click on one host  - click on kebab menu on the right - Delete
After deleting a host, the page should be redirected to the All Hosts page based on the setting of Show new host overview page.