### PR TITLE
Fixes #38169 - Fix operatingsystem race condition with concurrent registrations

### DIFF
--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -73,7 +73,13 @@ module Katello
           os_attributes[:name] = "CentOS"
         end
 
-        ::Operatingsystem.find_or_create_by(os_attributes)
+        os = ::Operatingsystem.find_by(os_attributes)
+        if os.blank?
+          created = ::Operatingsystem.create_or_find_by(os_attributes)
+          created.errors.any? ? ::Operatingsystem.find_by(os_attributes) : created
+        else
+          os
+        end
       end
     end
 

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -223,5 +223,18 @@ module Katello
 
       assert 'i386', parser.architecture.name
     end
+
+    def test_operatingsystem_race_condition_handling
+      existing_os = ::Operatingsystem.create(name: 'RedHat', major: '9', minor: '')
+      ::Operatingsystem.expects(:find_by).twice.returns(nil)
+      @facts['distribution.name'] = 'Red Hat Enterprise Linux'
+      @facts['distribution.version'] = '9'
+      @facts['distribution.id'] = 'Nine'
+
+      assert_nothing_raised do
+        parser.operatingsystem
+        existing_os.destroy
+      end
+    end
   end
 end


### PR DESCRIPTION
While testing concurrent Katello registrations in batches we see the following error leading to some hosts (2, 3 usually) with the same OS version failing to register:

```
PG::UniqueViolation: ERROR: duplicate key value violates unique constraint "index_operatingsystems_on_title"
DETAIL: Key (title)=(RedHat 9.2) already exists.
```

After these errors, the rest of registrations work without problems.
The error occurs with 50 concurrent registrations ~~but does not occur with >120 concurrent registrations.~~

This PR switches from `find_or_create_by` to `create_or_find_by`. Per the Active Record [documentation](https://apidock.com/rails/v7.0.0/ActiveRecord/Relation/create_or_find_by):

_Attempts to [create](https://apidock.com/rails/ActiveRecord/Relation/create) a record with the given attributes in a table that has a unique database constraint on one or several of its columns. If a row already exists with one or several of these unique constraints, the exception such an insertion would normally raise is caught, and the existing record with those attributes is found using #find_by!._

_This is similar to #find_or_create_by, but avoids the problem of stale reads between the SELECT and the INSERT, as that method needs to first query the table, then attempt to [insert](https://apidock.com/rails/ActiveRecord/Relation/insert) a row if none is found._

In our testing we found `create_or_find_by` would successfully avoid the unique constraint error, but then because

_This method will return a record if all given attributes are covered by unique constraints (unless the INSERT -> DELETE -> SELECT race condition is triggered), but if creation was attempted and failed due to validation errors it won’t be persisted, you get what [#create](https://apidock.com/rails/ActiveRecord/Relation/create) returns in such situation._

 the Rails validation for `:name` would cause it to return an unpersisted object with errors, and cause

```
ERROR: ERF42-2587 [Foreman::Exception]: Must provide an operating system 
```

We get around this with the second code change here, doing another `find_by`. 

With these two changes, Pablo says he ran the test 15 times and did not get any errors.


#### Considerations

The tradeoff with this solution is that you may end up with some (harmless) errors in your Postgres logs.

Another possible approach is to use `active_record_retry` from Katello: https://github.com/Katello/katello/blob/882b257afce348d1795db28fce81611543287b9e/app/lib/katello/util/support.rb#L96

But that would require moving that code to Foreman, and we have not yet tested that it would work as well as this.