### PR TITLE
Fixes #38171 - Add index on audit to speed up action queries and sorting for latest records

### DIFF
--- a/db/migrate/20250129162644_add_index_to_audits_for_actions.rb
+++ b/db/migrate/20250129162644_add_index_to_audits_for_actions.rb
@@ -1,0 +1,6 @@
+class AddIndexToAuditsForActions < ActiveRecord::Migration[7.0]
+  def change
+    add_index :audits, [:auditable_type, :auditable_id, :action, :created_at],
+      name: 'index_audits_on_auditable_action_created_at'
+  end
+end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Add an index to audit table that includes :auditable_type, :auditable_id, :action for quicker querying for particular action on a resource. Also added :created_at to make sorting quicker when we need to check newer records.
The index is specifically helpful for a usecase we have around fetching the latest sync audit record.

https://github.com/Katello/katello/pull/11294