### PR TITLE
Fixes #38173 - Permit use of arrays for multiple timesources

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/freebsd_(mfsbsd)_finish.erb
@@ -33,7 +33,11 @@ echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config
 /bin/hostname <%= @host.name %>
 cp /usr/share/zoneinfo/<%= host_param('time-zone') || 'UTC' %> /etc/localtime
 adjkerntz -a
-ntpdate <%= host_param('ntp-server') || '0.freebsd.pool.ntp.org' %>
+<% if host_param('ntp-server').respond_to?(:join) -%>
+ntpdate <%= host_param('ntp-server').first %>
+<% else -%>
+ntpdate <%= host_param('ntp-server') || '2.freebsd.pool.ntp.org' %>
+<% end -%>
 
 mkdir /root/install/
 freebsd-update fetch > /root/install/freebsd-update_fetch.txt

--- a/app/views/unattended/provisioning_templates/finish/junos_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/junos_default_finish.erb
@@ -23,8 +23,14 @@ system {
         <% end -%>
     }
     ntp {
-        boot-server <%= host_param('ntp-server') || '0.pool.ntp.org' %>;
-        server <%= host_param('ntp-server') || '0.pool.ntp.org' %>;
+<% if host_param('ntp-server').respond_to?(:join) -%>
+        boot-server <%= host_param('ntp-server').first %>;
+        server <%= host_param('ntp-server').first %>;
+<% else -%>
+<%# no known subdomain for Junos at ntp.org -%>
+        boot-server <%= host_param('ntp-server') || '2.pool.ntp.org' %>;
+        server <%= host_param('ntp-server') || '2.pool.ntp.org' %>;
+<% end -%>
     }
     login {
         message "This device was provisioned by using The Foreman!\nSee http://theforeman.org/ for further information.\n";

--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -102,7 +102,11 @@ description: |
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
       <peer>
-        <address><%= host_param('ntp-server') || '0.opensuse.pool.ntp.org' %></address>
+        <%- if host_param('ntp-server').respond_to?(:join) -%>
+        <address><%= host_param('ntp-server').first %></address>
+        <%- else -%>
+        <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
+        <%- end -%>
         <initial_sync config:type="boolean">true</initial_sync>
         <options></options>
         <type>server</type>
@@ -115,11 +119,21 @@ description: |
   <ntp-client>
    <ntp_policy>auto</ntp_policy>
    <ntp_servers config:type="list">
+    <%- if host_param('ntp-server').respond_to?(:join) -%>
+    <%- host_param('ntp-server').each do |ntp| -%>
     <ntp_server>
      <iburst config:type="boolean">false</iburst>
-     <address><%= host_param('ntp-server') || '0.opensuse.pool.ntp.org' %></address>
+     <address><%= ntp %></address>
      <offline config:type="boolean">true</offline>
     </ntp_server>
+    <%- end -%>
+    <%- else -%>
+    <ntp_server>
+     <iburst config:type="boolean">false</iburst>
+     <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
+     <offline config:type="boolean">true</offline>
+    </ntp_server>
+    <%- end -%>
    </ntp_servers>
    <ntp_sync>systemd</ntp_sync>
    </ntp-client>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -107,11 +107,21 @@ description: |
   <ntp-client>
     <ntp_policy>auto</ntp_policy>
     <ntp_servers config:type="list">
+      <%- if host_param('ntp-server').respond_to?(:join) -%>
+      <%- host_param('ntp-server').each do |ntp| -%>
       <ntp_server>
-        <address><%= host_param('ntp-server') || '0.opensuse.pool.ntp.org' %></address>
+        <address><%= ntp %></address>
         <iburst config:type="boolean">false</iburst>
         <offline config:type="boolean">true</offline>
       </ntp_server>
+      <%- end -%>
+      <%- else -%>
+      <ntp_server>
+        <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
+        <iburst config:type="boolean">false</iburst>
+        <offline config:type="boolean">true</offline>
+      </ntp_server>
+      <%- end -%>
     </ntp_servers>
     <ntp_sync>15</ntp_sync>
   </ntp-client>
@@ -120,7 +130,11 @@ description: |
     <configure_dhcp config:type="boolean">false</configure_dhcp>
     <peers config:type="list">
       <peer>
-        <address><%= host_param('ntp-server') || '0.opensuse.pool.ntp.org' %></address>
+        <%- if host_param('ntp-server').respond_to?(:join) -%>
+        <address><%= host_param('ntp-server').first %></address>
+        <%- else -%>
+        <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
+        <%- end -%>
         <initial_sync config:type="boolean">true</initial_sync>
         <options></options>
         <type>server</type>

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -41,7 +41,7 @@ description: |
   - skip-puppet-setup: boolean (default=false)
   - salt_master: string (default=undef)
   - ntp-pools: array (default=undef)
-  - ntp-server: string (default=undef)
+  - ntp-server: string (default=undef), an array is permitted for multiple servers
   - bootloader-append: string (default="nofb quiet splash=quiet")
   - disable-firewall: boolean (default=false)
   - kdump-options: string (default=undef)
@@ -153,15 +153,28 @@ authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downca
 <% end -%>
 <%# Timezone + NTP -%>
 <% if rhel_compatible && os_major < 9 -%>
-timezone --utc <%= host_param('time-zone') || 'UTC' %> <%= host_param('ntp-server') ? "--ntpservers #{host_param('ntp-server')}" : '' %>
+<%# RHEL < 9: Use legacy timezone command with --ntpservers -%>
+<% if host_param('ntp-server').respond_to?(:join) -%>
+timezone --ntpservers <%= host_param('ntp-server').join(',') %> --utc <%= host_param('time-zone') || 'UTC' %>
+<% elsif host_param('ntp-server') -%>
+timezone --ntpservers <%= host_param('ntp-server') %> --utc <%= host_param('time-zone') || 'UTC' %>
 <% else -%>
+timezone --utc <%= host_param('time-zone') || 'UTC' %>
+<% end -%>
+<% else -%>
+<%# RHEL >= 9: Use timezone + timesource commands -%>
 timezone --utc <%= host_param('time-zone') || 'UTC' %>
 <% if host_param('ntp-pools') -%>
 <% host_param('ntp-pools').each do |ntppool| -%>
 timesource --ntp-pool <%= ntppool %>
 <% end -%>
-<% elsif host_param('ntp-server') -%>
-timesource --ntp-server <%= host_param('ntp-server') %>
+<% elsif host_param('ntp-server').respond_to?(:join) -%>
+<% host_param('ntp-server').each do |ntpserver| -%>
+timesource --ntp-server <%= ntpserver %>
+<% end -%>
+<% else -%>
+<%# too many possible OS vendors to easily pick a default subdomain for ntp.org -%>
+timesource --ntp-server <%= host_param('ntp-server') || '2.pool.ntp.org' %>
 <% end -%>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/provision/preseed_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/preseed_default.erb
@@ -97,7 +97,12 @@ d-i time/zone string <%= host_param('time-zone') || 'UTC' %>
 
 # NTP
 d-i clock-setup/ntp boolean true
-d-i clock-setup/ntp-server string <%= host_param('ntp-server') || '0.debian.pool.ntp.org' %>
+<% if host_param('ntp-server').respond_to?(:join) -%>
+# host_param('ntp-server') is an array, but preseed only permits one value
+d-i clock-setup/ntp-server string <%= host_param('ntp-server').first %>
+<% else -%>
+d-i clock-setup/ntp-server string <%= host_param('ntp-server') || '2.debian.pool.ntp.org' %>
+<% end -%>
 
 # Set alignment for automatic partitioning
 # Choices: cylinder, minimal, optimal

--- a/app/views/unattended/provisioning_templates/provision/xenserver_default_answerfile.erb
+++ b/app/views/unattended/provisioning_templates/provision/xenserver_default_answerfile.erb
@@ -31,7 +31,13 @@ description: |
 <% subnet.dns_servers.each do |nameserver| -%>
   <name-server><%= nameserver %></name-server>
 <% end -%>
-  <ntp-server><%= host_param('ntp-server') || 'pool.ntp.org' %></ntp-server>
+<% if host_param('ntp-server').respond_to?(:join) -%>
+<% host_param('ntp-server').each do |srv| -%>
+  <ntp-server><%= srv  %></ntp-server>
+<% end -%>
+<% else -%>
+  <ntp-server><%= host_param('ntp-server') || '2.xenserver.pool.ntp.org' %></ntp-server>
+<% end -%>
   <timezone><%= host_param('time-zone') || 'UTC' %></timezone>
   <time-config-method>ntp</time-config-method>
   <script stage="installation-complete" type="url">

--- a/app/views/unattended/provisioning_templates/snippet/ntp.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ntp.erb
@@ -21,12 +21,20 @@ echo "Updating system time"
 <% if os_family == 'Debian' -%>
   <% if ntp_server -%>
     <% if @host.operatingsystem.name == "Ubuntu" -%>
+      <%- if ntp_server.respond_to?(:join) -%>
+      sed -i -E 's/^[[:space:]]*#?\s*NTP=.*/NTP=<%= ntp_server.first %>/' /etc/systemd/timesyncd.conf
+      <%- else -%>
       sed -i -E 's/^[[:space:]]*#?\s*NTP=.*/NTP=<%= ntp_server %>/' /etc/systemd/timesyncd.conf
+      <%- end -%>
       systemctl enable --now systemd-timesyncd
       timedatectl set-ntp true
     <% else -%>
       apt-get install -y chrony
+      <%- if ntp_server.respond_to?(:join) -%>
+      sed -i -E 's|^pool .*|server <%= ntp_server.first %> iburst|' /etc/chrony/chrony.conf
+      <%- else -%>
       sed -i -E 's|^pool .*|server <%= ntp_server %> iburst|' /etc/chrony/chrony.conf
+      <%- end -%>
       systemctl enable --now chrony
     <% end -%>
   <% end -%>
@@ -38,8 +46,12 @@ echo "Updating system time"
   -%>
   <% if use_ntp -%>
     yum -y install ntpdate
-    <% if host_param('ntp-server') -%>
-      /usr/sbin/ntpdate -sub <%= host_param('ntp-server') %>
+    <% if ntp-server -%>
+      <% if ntp_server.respond_to?(:join) -%>
+    /usr/sbin/ntpdate -sub <%= ntp-server.first %>
+      <% else -%>
+    /usr/sbin/ntpdate -sub <%= ntp-server %>
+      <% end -%>
     <% end -%>
     systemctl enable --now ntpd
   <% else -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -19,7 +19,7 @@ firewall --service=ssh
 %addon com_redhat_kdump --disable
 %end
 authconfig --useshadow --passalgo=sha512 --kickstart
-timezone --utc UTC --ntpservers first.ntp.server
+timezone --ntpservers first.ntp.server --utc UTC
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -19,7 +19,7 @@ firewall --service=ssh
 %addon com_redhat_kdump --disable
 %end
 authconfig --useshadow --passalgo=sha512 --kickstart
-timezone --utc UTC --ntpservers first.ntp.server
+timezone --ntpservers first.ntp.server --utc UTC
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -19,7 +19,7 @@ firewall --service=ssh
 %addon com_redhat_kdump --disable
 %end
 authconfig --useshadow --passalgo=sha512 --kickstart
-timezone --utc UTC --ntpservers first.ntp.server
+timezone --ntpservers first.ntp.server --utc UTC
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -19,7 +19,7 @@ firewall --service=ssh
 %addon com_redhat_kdump --disable
 %end
 authconfig --useshadow --passalgo=sha512 --kickstart
-timezone --utc UTC --ntpservers first.ntp.server
+timezone --ntpservers first.ntp.server --utc UTC
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -19,7 +19,7 @@ firewall --service=ssh
 %addon com_redhat_kdump --disable
 %end
 authconfig --useshadow --passalgo=sha512 --kickstart
-timezone --utc UTC --ntpservers first.ntp.server
+timezone --ntpservers first.ntp.server --utc UTC
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -18,7 +18,7 @@ firewall --service=ssh
 %addon com_redhat_kdump --disable
 %end
 authselect --useshadow --passalgo=sha512 --kickstart
-timezone --utc UTC --ntpservers first.ntp.server
+timezone --ntpservers first.ntp.server --utc UTC
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 


### PR DESCRIPTION
I'm unclear how best to test this.

My site offers multiple on site NTP servers on different names depending on location.  This permits them to bring hosts down for maintenance without significant interruption.