### PR TITLE
Fixes #38172 - Permit use of NTP Pools in kickstart

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -89,6 +89,7 @@ module Foreman
         "ansible_ssh_pass" => "win_ansible_user_ssh_pass",
         "remote_desktop" => "true",
         "realm" => "true",
+        "ntp-pools" => ['first.ntp-pool', 'second.ntp-pool'],
       }
       host_params.each_pair do |name, value|
         FactoryBot.build(:host_parameter, host: host, name: name, value: value)

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -38,6 +38,7 @@ description: |
   - enable-official-puppet8-repo: boolean (default=false)
   - skip-puppet-setup: boolean (default=false)
   - salt_master: string (default=undef)
+  - ntp-pools: array (default=undef)
   - ntp-server: string (default=undef)
   - bootloader-append: string (default="nofb quiet splash=quiet")
   - disable-firewall: boolean (default=false)
@@ -156,7 +157,11 @@ authconfig --useshadow --passalgo=<%= @host.operatingsystem.password_hash.downca
 timezone --utc <%= host_param('time-zone') || 'UTC' %> <%= host_param('ntp-server') ? "--ntpservers #{host_param('ntp-server')}" : '' %>
 <% else -%>
 timezone --utc <%= host_param('time-zone') || 'UTC' %>
-<% if host_param('ntp-server') -%>
+<% if host_param('ntp-pools') -%>
+<% host_param('ntp-pools').each do |ntppool| -%>
+timesource --ntp-pool <%= ntppool %>
+<% end -%>
+<% elsif host_param('ntp-server') -%>
 timesource --ntp-server <%= host_param('ntp-server') %>
 <% end -%>
 <% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -17,6 +17,8 @@ rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
 authselect --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC
+timesource --ntp-pool first.ntp-pool
+timesource --ntp-pool second.ntp-pool
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -17,6 +17,8 @@ rootpw --iscrypted $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
 firewall --service=ssh
 authselect --useshadow --passalgo=sha512 --kickstart
 timezone --utc UTC
+timesource --ntp-pool first.ntp-pool
+timesource --ntp-pool second.ntp-pool
 
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 


### PR DESCRIPTION
I'll confess I have no idea how to test this.