### PR TITLE
Fixes #38177 - remove select2('destroy') for non select2 item

### DIFF
--- a/app/assets/javascripts/lookup_keys.js
+++ b/app/assets/javascripts/lookup_keys.js
@@ -19,7 +19,6 @@ $(document).on('ContentLoad', function() {
     .on('submit', function() {
       build_match();
     });
-  $('.matcher_key').select2('destroy');
 });
 
 function select_first_tab() {


### PR DESCRIPTION
`.matcher_key` is very specifically not a select2 item. this causes error in the console and error with loading select2 for the rest of the page ( the page is `/salt/salt_variables/new`) 

` <%= select_tag '', nil, :class => 'matcher_key without_select2', :onchange => 'tfm.lookupKeys.matcherKeyChanged(this)' %>`
`activate_select2($(field).not('.matcher_key'));`