### PR TITLE
Fixes #38178 - Add linuxefi/initrdefi wrapper to GRUB2 templates

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -15,22 +15,20 @@ description: |
 #
 # This file was deployed via '<%= template_name %>' template
 
-<%
-  os_major = @host.operatingsystem.major.to_i
-  os_name  = @host.operatingsystem.name
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
 
-  if (os_name == 'Ubuntu' && os_major > 12) || (os_name == 'Debian' && os_major > 8)
-    efi_suffix = 'efi'
-  else
-    efi_suffix = ''
-  end
--%>
 set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options").strip %>
-  initrd<%= efi_suffix %> <%= @initrd %>
+  linuxefi  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options").strip %>
+  initrdefi <%= @initrd %>
 }
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
@@ -18,16 +18,21 @@ test_on:
 # lang = en_US
 #   System locale
 #
-<%
-  efi_suffix = 'efi'
--%>
+
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
 
 set default=0
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %> <%= @kernel %> root=/dev/rd/0 rw auto <%= snippet('preseed_kernel_options_autoinstall', variables: {add_userdata_quotes: true}).strip %>
-  initrd<%= efi_suffix %> <%= @initrd %>
+  linuxefi <%= @kernel %> root=/dev/rd/0 rw auto <%= snippet('preseed_kernel_options_autoinstall', variables: {add_userdata_quotes: true}).strip %>
+  initrdefi <%= @initrd %>
 }
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/pxegrub2_global_default.erb
@@ -7,6 +7,14 @@ description: |
   The output is deployed on the host's subnet TFTP proxy.
   Do not associate or change the name.
 -%>
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
+
 default=<%= global_setting("default_pxe_item_global", "local") %>
 timeout=20
 echo Default PXE global template entry is set to '<%= global_setting("default_pxe_item_global", "local") %>'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/PXEGrub2_global_default.host4dhcp.snap.txt
@@ -1,3 +1,11 @@
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
+
 default=local
 timeout=20
 echo Default PXE global template entry is set to 'local'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
@@ -1,6 +1,14 @@
 #
 # This file was deployed via 'Preseed default PXEGrub2' template
 
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
+
 set default=0
 set timeout=10
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -1,6 +1,14 @@
 #
 # This file was deployed via 'Preseed default PXEGrub2' template
 
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
+
 set default=0
 set timeout=10
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2_Autoinstall.ubuntu_autoinst4dhcp.snap.txt
@@ -11,6 +11,14 @@
 #   System locale
 #
 
+# Wrapper for deprecated linuxefi/initrdefi commands
+function linuxefi {
+  linux $*
+}
+function initrdefi {
+  initrd $*
+}
+
 set default=0
 set timeout=10
 


### PR DESCRIPTION
Back in time, GRUB2 is using `linux` and `initrd` commands to load the kernel and initrd into ram on legacy BIOS. Later, `linuxefi` and `initrdefi` commands have been added to do the same on UEFI platforms.

However, it looks like that `linuxefi` and `initrdefi` commands are deprecated and distributions like Ubuntu started to remove them starting with 24.04.

In case of Secure Boot [1] and Ubuntu 24.04 - putting corresponding shim+GRUB2 binaries in bootloader universe directory - the network boot is not working anymore because of used `linuxefi/initrdefi` commands in the involved GRUB2 configuration templates.

In order fix this we can simply add wrapper functions to provide `linuxefi`/`initrdefi` as commands.

[1]:https://github.com/theforeman/foreman/pull/9864

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
