### PR TITLE
Fixes #38192 - Separate the Satellite Inventory Plugin from "host_registration_insights" parameter

### DIFF
--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -13,6 +13,7 @@ module Api
         param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in. Operating system must have a `host_init_config` template assigned")
         param :smart_proxy_id, :number, desc: N_("ID of the Smart Proxy. This Proxy must have enabled both the 'Templates' and 'Registration' features")
         param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems")
+        param :setup_insights_inventory, :bool, desc: N_("Set 'host_registration_insights_inventory' parameter for the host. If it is set to true, insights data about the host will be uploaded to console.redhat.com during report generation")
         param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
         param :jwt_expiration, :number, desc: N_("Expiration of the authorization token (in hours), 0 means 'unlimited'.")
         param :insecure, :bool, desc: N_("Enable insecure argument for the initial curl/wget")

--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -24,6 +24,7 @@ module Api
       param :operatingsystem_id, :number, desc: N_("ID of the Operating System to register the host in. Takes precedence over the `operatingsystem` parameter")
       param :operatingsystem, String, desc: N_("Title of the Operating System to register the host in")
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems")
+      param :setup_insights_inventory, :bool, desc: N_("Set 'host_registration_insights_inventory' parameter for the host. If it is set to true, insights data about the host will be uploaded to console.redhat.com during report generation")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
       param :packages, String, desc: N_("Packages to install on the host when registered. Can be set by `host_packages` parameter, example: `pkg1 pkg2`")
       param :update_packages, :bool, desc: N_("Update all packages on the host")
@@ -85,6 +86,7 @@ module Api
         end
       end
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems")
+      param :setup_insights_inventory, :bool, desc: N_("Set 'host_registration_insights_inventory' parameter for the host. If it is set to true, insights data about the host will be uploaded to console.redhat.com during report generation")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
       def host
         begin

--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -37,6 +37,7 @@ module Foreman::Controller::Registration
       hostgroup: hostgroup,
       operatingsystem: operatingsystem,
       setup_insights: ActiveRecord::Type::Boolean.new.deserialize(params['setup_insights']),
+      setup_insights_inventory: ActiveRecord::Type::Boolean.new.deserialize(params['setup_insights_inventory']),
       setup_remote_execution: ActiveRecord::Type::Boolean.new.deserialize(params['setup_remote_execution']),
       packages: params['packages'],
       update_packages: params['update_packages'],
@@ -113,6 +114,7 @@ module Foreman::Controller::Registration
     clean_host_params
 
     setup_host_param('host_registration_insights', params['setup_insights'])
+    setup_host_param('host_registraton_insights_inventory', params['setup_insights_inventory'])
     setup_host_param('host_registration_remote_execution', params['setup_remote_execution'])
     setup_host_param('host_packages', params['packages'], 'string')
     setup_host_param('host_update_packages', params['update_packages'])
@@ -120,7 +122,7 @@ module Foreman::Controller::Registration
 
   def clean_host_params
     names = ['host_registration_insights', 'host_registration_remote_execution',
-             'host_packages', 'host_update_packages']
+             'host_packages', 'host_update_packages', 'host_registraton_insights_inventory']
 
     HostParameter.where(host: @host, name: names).destroy_all
   end

--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -79,6 +79,7 @@ module Foreman
         "subscription_manager_org" => "Org",
         "activation_key" => "key",
         "host_registration_insights" => "true",
+        "host_registraton_insights_inventory" => "true",
         "syspurpose_role" => "Red Hat Enterprise Linux Server",
         "syspurpose_usage" => "Development/Test",
         "syspurpose_sla" => "Self-Support",

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -67,6 +67,10 @@ apt-get -y update
 
 <% end -%>
 
+<% if host_param_true?('host_registraton_insights_inventory') -%>
+echo '{"insights_inventory_enabled": "true"}' > /etc/rhsm/facts/insights-inventory.facts
+<% end -%>
+
 <% if plugin_present?('katello') -%>
 if command -v subscription-manager &>/dev/null; then
   echo "Refreshing subscription data"

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -25,6 +25,7 @@ export LC_ALL=C LANG=C
 <%= "\n# Host group: [#{@hostgroup.title}]" if @hostgroup -%>
 <%= "\n# Operating system: [#{@operatingsystem}]" if @operatingsystem -%>
 <%= "\n# Setup Insights: [#{@setup_insights}]" unless @setup_insights.nil? -%>
+<%= "\n# setup_insights_inventory: [#{@setup_insights_inventory}]" unless @setup_insights_inventory.nil? -%>
 <%= "\n# Setup remote execution: [#{@setup_remote_execution}]" unless @setup_remote_execution.nil? -%>
 <%= "\n# Setup remote execution pull: [#{@setup_remote_execution_pull}]" unless @setup_remote_execution_pull.nil? -%>
 <%= "\n# Remote execution interface: [#{@remote_execution_interface}]" if @remote_execution_interface.present? -%>
@@ -119,6 +120,7 @@ register_host() {
   params << "host[operatingsystem_id]=#{@operatingsystem.id}" if @operatingsystem
   params << "host[interfaces_attributes][0][identifier]=#{shell_escape(@remote_execution_interface)}" if @remote_execution_interface.present?
   params << "setup_insights=#{@setup_insights}" unless @setup_insights.nil?
+  params << "setup_insights_inventory=#{@setup_insights_inventory}" unless @setup_insights_inventory.nil?
   params << "setup_remote_execution=#{@setup_remote_execution}" unless @setup_remote_execution.nil?
   params << "remote_execution_interface=#{shell_escape(@remote_execution_interface)}" if @remote_execution_interface.present?
   params << "packages=#{shell_escape(@packages)}" if @packages.present?
@@ -141,6 +143,7 @@ register_katello_host(){
   params << "host[hostgroup_id]=#{@hostgroup.id}" if @hostgroup
   params << "host[lifecycle_environment_id]=#{@lifecycle_environment_id}" if @lifecycle_environment_id.present?
   params << "setup_insights=#{@setup_insights}" unless @setup_insights.nil?
+  params << "setup_insights_inventory=#{@setup_insights_inventory}" unless @setup_insights_inventory.nil?
   params << "setup_remote_execution=#{@setup_remote_execution}" unless @setup_remote_execution.nil?
   params << "remote_execution_interface=#{shell_escape(@remote_execution_interface)}" if @remote_execution_interface.present?
   params << "setup_remote_execution_pull=#{@setup_remote_execution_pull}" unless @setup_remote_execution_pull.nil?

--- a/db/seeds.d/180-common_parameters.rb
+++ b/db/seeds.d/180-common_parameters.rb
@@ -1,6 +1,7 @@
 CommonParameter.without_auditing do
   params = [
     { name: "host_registration_insights", key_type: "boolean", value: false },
+    { name: "host_registraton_insights_inventory", key_type: "boolean", value: false },
     { name: "host_registration_remote_execution", key_type: "boolean", value: true },
     { name: "host_packages", key_type: "string", value: "" },
   ]

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -301,6 +301,36 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
       end
     end
 
+    context 'setup_insights_inventory' do
+      test 'without param' do
+        params = { setup_insights_inventory: '' }.merge(host_params)
+        post :host, params: params, session: set_session_user
+        assert_response :success
+
+        host = Host.find_by(name: params[:host][:name]).reload
+        assert_nil HostParameter.find_by(host: host, name: 'host_registraton_insights_inventory')
+      end
+
+      test 'with setup_insights_inventory = true' do
+        params = { setup_insights_inventory: 'true' }.merge(host_params)
+        post :host, params: params, session: set_session_user
+        assert_response :success
+
+        host = Host.find_by(name: params[:host][:name]).reload
+        assert HostParameter.find_by(host: host, name: 'host_registraton_insights_inventory').value
+      end
+
+      test 'with setup_insights_inventory = false' do
+        params = { setup_insights_inventory: 'false' }.merge(host_params)
+
+        post :host, params: params, session: set_session_user
+        assert_response :success
+
+        host = Host.find_by(name: params[:host][:name]).reload
+        refute HostParameter.find_by(host: host, name: 'host_registraton_insights_inventory').value
+      end
+    end
+
     context 'setup_remote_execution' do
       test 'without param' do
         params = { setup_remote_execution: '' }.merge(host_params)

--- a/test/controllers/registration_commands_controller_test.rb
+++ b/test/controllers/registration_commands_controller_test.rb
@@ -74,6 +74,7 @@ class RegistrationCommandsControllerTest < ActionController::TestCase
 
       before do
         CommonParameter.where(name: 'host_registration_insights').destroy_all
+        CommonParameter.where(name: 'host_registraton_insights_inventory').destroy_all
         CommonParameter.where(name: 'setup_remote_execution').destroy_all
       end
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/__snapshots__/integration.test.js.snap
@@ -18,6 +18,7 @@ Object {
             "packages": "",
             "repoData": Array [],
             "setupInsights": "",
+            "setupInsightsInventory": "",
             "setupRemoteExecution": "",
             "smartProxyId": undefined,
             "updatePackages": false,

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/Advanced.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/Advanced.test.js.snap
@@ -5,9 +5,11 @@ exports[`RegistrationCommandsPage - Advanced renders 1`] = `
   <ConfigParams
     configParams={Object {}}
     handleInsights={[Function]}
+    handleInsightsInventory={[Function]}
     handleRemoteExecution={[Function]}
     isLoading={false}
     setupInsights=""
+    setupInsightsInventory=""
     setupRemoteExecution=""
   />
   <Packages

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/ConfigParams.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/components/__snapshots__/ConfigParams.test.js.snap
@@ -82,5 +82,45 @@ exports[`RegistrationCommandsPage fields - ConfigParams renders 1`] = `
       />
     </FormSelect>
   </FormGroup>
+  <FormGroup
+    fieldId="registration_setup_insights_inventory"
+    label="Setup Insights Inventory"
+    labelIcon={
+      <LabelIcon
+        text="If set to \`Yes\`, Insights data about this host will be included in the scheduled report generation and upload or via a manual run of the action. The inherited value is based on the \`host_registraton_insights_inventory\` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level."
+      />
+    }
+  >
+    <FormSelect
+      className="without_select2"
+      id="registration_setup_insights_inventory"
+      isDisabled={false}
+      isIconSprite={false}
+      isRequired={true}
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      ouiaId="registration_setup_insights_inventory"
+      ouiaSafe={true}
+      validated="default"
+      value=""
+    >
+      <FormSelectOption
+        key="0"
+        label="Inherit from host parameter (no)"
+        value=""
+      />
+      <FormSelectOption
+        key="1"
+        label="Yes (override)"
+        value={true}
+      />
+      <FormSelectOption
+        key="2"
+        label="No (override)"
+        value={false}
+      />
+    </FormSelect>
+  </FormGroup>
 </Fragment>
 `;

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
@@ -29,7 +29,9 @@ export const advancedComponentProps = {
   configParams: {},
   setupRemoteExecution: '',
   setupInsights: '',
+  setupInsightsInventory: '',
   handleInsights: () => {},
+  handleInsightsInventory: () => {},
   handleRemoteExecution: () => {},
   jwtExpiration: '',
   handleJwtExpiration: () => {},
@@ -59,8 +61,10 @@ export const configParamsProps = {
   configParams: {},
   setupRemoteExecution: '',
   setupInsights: '',
+  setupInsightsInventory: '',
   handleRemoteExecution: () => {},
   handleInsights: () => {},
+  handleInsightsInventory: () => {},
   isLoading: false,
 };
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Advanced.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/Advanced.js
@@ -11,7 +11,9 @@ const Advanced = ({
   configParams,
   setupRemoteExecution,
   setupInsights,
+  setupInsightsInventory,
   handleInsights,
+  handleInsightsInventory,
   handleRemoteExecution,
   jwtExpiration,
   handleJwtExpiration,
@@ -29,7 +31,9 @@ const Advanced = ({
       configParams={configParams}
       setupRemoteExecution={setupRemoteExecution}
       setupInsights={setupInsights}
+      setupInsightsInventory={setupInsightsInventory}
       handleInsights={handleInsights}
+      handleInsightsInventory={handleInsightsInventory}
       handleRemoteExecution={handleRemoteExecution}
       isLoading={isLoading}
     />
@@ -62,7 +66,9 @@ Advanced.propTypes = {
   configParams: PropTypes.object,
   setupRemoteExecution: PropTypes.string,
   setupInsights: PropTypes.string,
+  setupInsightsInventory: PropTypes.string,
   handleInsights: PropTypes.func.isRequired,
+  handleInsightsInventory: PropTypes.func.isRequired,
   handleRemoteExecution: PropTypes.func.isRequired,
   jwtExpiration: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   handleJwtExpiration: PropTypes.func.isRequired,
@@ -80,6 +86,7 @@ Advanced.defaultProps = {
   configParams: {},
   setupRemoteExecution: '',
   setupInsights: '',
+  setupInsightsInventory: '',
   jwtExpiration: 4,
   packages: '',
   updatePackages: false,

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/components/fields/ConfigParams.js
@@ -14,8 +14,10 @@ const ConfigParams = ({
   configParams,
   setupRemoteExecution,
   setupInsights,
+  setupInsightsInventory,
   handleRemoteExecution,
   handleInsights,
+  handleInsightsInventory,
   isLoading,
 }) => {
   const options = (value = '') => {
@@ -83,6 +85,30 @@ const ConfigParams = ({
           options(configParams?.host_registration_insights)}
         </FormSelect>
       </FormGroup>
+      <FormGroup
+        label={__('Setup Insights Inventory')}
+        fieldId="registration_setup_insights_inventory"
+        labelIcon={
+          <LabelIcon
+            text={__(
+              'If set to `Yes`, Insights data about this host will be included in the scheduled report generation and upload or via a manual run of the action. The inherited value is based on the `host_registraton_insights_inventory` parameter. It can be inherited e.g. from host group, operating system, organization. When overridden, the selected value will be stored on host parameter level.'
+            )}
+          />
+        }
+      >
+        <FormSelect
+          ouiaId="registration_setup_insights_inventory"
+          value={setupInsightsInventory}
+          onChange={v => handleInsightsInventory(v)}
+          className="without_select2"
+          id="registration_setup_insights_inventory"
+          isDisabled={isLoading}
+          isRequired
+        >
+          {/* eslint-disable-next-line camelcase */
+          options(configParams?.host_registraton_insights_inventory)}
+        </FormSelect>
+      </FormGroup>
     </>
   );
 };
@@ -91,8 +117,10 @@ ConfigParams.propTypes = {
   configParams: PropTypes.object,
   setupRemoteExecution: PropTypes.string.isRequired,
   setupInsights: PropTypes.string.isRequired,
+  setupInsightsInventory: PropTypes.string.isRequired,
   handleRemoteExecution: PropTypes.func.isRequired,
   handleInsights: PropTypes.func.isRequired,
+  handleInsightsInventory: PropTypes.func.isRequired,
   isLoading: PropTypes.bool.isRequired,
 };
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -89,6 +89,7 @@ const RegistrationCommandsPage = () => {
   const [insecure, setInsecure] = useState(false);
   const [setupRemoteExecution, setSetupRemoteExecution] = useState('');
   const [setupInsights, setSetupInsights] = useState('');
+  const [setupInsightsInventory, setSetupInsightsInventory] = useState('');
   const [jwtExpiration, setJwtExpiration] = useState(4);
   const [packages, setPackages] = useState('');
   const [updatePackages, setUpdatePackages] = useState(false);
@@ -132,6 +133,7 @@ const RegistrationCommandsPage = () => {
       insecure,
       setupRemoteExecution,
       setupInsights,
+      setupInsightsInventory,
       jwtExpiration,
       packages,
       repoData,
@@ -315,7 +317,9 @@ const RegistrationCommandsPage = () => {
                   configParams={configParams}
                   setupRemoteExecution={setupRemoteExecution}
                   setupInsights={setupInsights}
+                  setupInsightsInventory={setupInsightsInventory}
                   handleInsights={setSetupInsights}
+                  handleInsightsInventory={setSetupInsightsInventory}
                   handleRemoteExecution={setSetupRemoteExecution}
                   jwtExpiration={jwtExpiration}
                   handleJwtExpiration={setJwtExpiration}


### PR DESCRIPTION
* Adding a new parameter called host_registration_inventory_plugin to allow the host to be included/excluded from inventory upload
* Added some unit tests

#### What are the changes introduced in this pull request?
  * Goes along with https://github.com/theforeman/foreman_rh_cloud/pull/947
  * Adding a new parameter called   host_registration_inventory_plugin to allow the host to be included/excluded from inventory upload
  * Added some unit tests
  * Updated Javascript test snapshots

#### What are the testing steps for this pull request?
* Check out PR
* Register a host with the parameter set to false or true
* Check the host parameter to see if the value is reflected during the global registration