### PR TITLE
Fixes #38208 - Http proxy test connection error

### DIFF
--- a/app/controllers/http_proxies_controller.rb
+++ b/app/controllers/http_proxies_controller.rb
@@ -24,7 +24,7 @@ class HttpProxiesController < ApplicationController
   end
 
   def test_connection
-    http_proxy = HttpProxy.new({name: 'dummy'}.update(http_proxy_params))
+    http_proxy = HttpProxy.new(http_proxy_params.merge(name: 'dummy'))
     unless http_proxy.valid?
       raise Foreman::Exception, http_proxy.errors.full_messages.join(', ')
     end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Steps to reproduce:
1. Create and save a http proxy. 
2. Go to the http proxy and hit Test connection.
3. Without PR, you'll see this error:
![Screenshot from 2025-02-12 03-51-26](https://github.com/user-attachments/assets/ba233e88-519b-4e9e-8bb6-58827caeac4b)
4. Checkout this PR and try Test connection again.
