### PR TITLE
Fixes #38209 - vmware Create controller select freezes the page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -177,6 +177,7 @@
           "unordered",
           "unprocessable",
           "unselect",
+          "unselecting",
           "unstyled",
           "virtualization",
           "vms",

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -25,8 +25,8 @@ class Select extends React.Component {
   attachEvent() {
     const { onChange } = this.props;
     $(this.select)
-      .off('change', onChange)
-      .on('change', onChange);
+      .off('select2:select select2:unselecting', onChange)
+      .on('select2:select select2:unselecting', onChange);
   }
 
   componentDidMount() {


### PR DESCRIPTION
after selecting, a change happens, but the select2 still thinks the select dropdown is open and prevents scroll, instead if we use the select2 events it doesnt happen. https://select2.org/programmatic-control/events
to reproduce create host -> Deploy On = vmware -> virtual machine tab -> select a cluster -> select "create controller"
after that the page cant be scrolled
