### PR TITLE
Fixes #38213 Unattended#built - IP detection of host behind proxy

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -163,7 +163,7 @@ class UnattendedController < ApplicationController
 
   def load_host_details
     query_params = params
-    query_params[:ip] = request.remote_ip
+    query_params[:ip] = host_ip
     query_params[:mac_list] = Foreman::UnattendedInstallation::MacListExtractor.new.extract_from_env(request.env, params: params)
     query_params[:built] = ['built', 'failed'].include? action_name
 
@@ -171,8 +171,7 @@ class UnattendedController < ApplicationController
   end
 
   def verify_found_host(needs_token = true)
-    host_verifier = Foreman::UnattendedInstallation::HostVerifier.new(@host, request_ip: request.remote_ip,
-                                                                             for_host_template: (action_name == 'host_template'))
+    host_verifier = Foreman::UnattendedInstallation::HostVerifier.new(@host, request_ip: host_ip, for_host_template: (action_name == 'host_template'))
 
     if host_verifier.valid?
       logger.debug "Found #{@host}"
@@ -213,7 +212,7 @@ class UnattendedController < ApplicationController
   # doesn't know the IP in advance (and has been given a fake one just to make
   # the form save)
   def update_ip
-    ip = request.remote_ip
+    ip = host_ip
     address = IPAddr.new(ip)
 
     # @host has been changed even if the save fails, so we have to change it back
@@ -246,5 +245,13 @@ class UnattendedController < ApplicationController
 
   def spoof
     @spoof ||= @host.present? && (params.key?(:spoof) || params.key?(:hostname))
+  end
+
+  def host_ip
+    return request.remote_ip unless params[:url]
+
+    # The call is from external proxy
+    # We need to get the original (host's) IP, not the proxy
+    request.env["HTTP_X_FORWARDED_FOR"].split(",").first
   end
 end

--- a/test/controllers/unattended_controller_test.rb
+++ b/test/controllers/unattended_controller_test.rb
@@ -58,6 +58,13 @@ class UnattendedControllerTest < ActionController::TestCase
       assert_response :success
     end
 
+    test "should get a kickstart even if we are behind a smart proxy" do
+      @request.env["HTTP_X_FORWARDED_FOR"] = "#{@rh_host.ip}, 192.0.2.66"
+      @request.env["REMOTE_ADDR"] = "127.0.0.1"
+      get :host_template, params: { :kind => 'provision' }
+      assert_response :success
+    end
+
     test "should get a foreman CA refresh for a host" do
       get :host_template, params: { kind: 'public', id: 'foreman_ca_refresh' }
       assert_response :success


### PR DESCRIPTION
Fix the issue of detecting the host's IP
when communicating through the external smart proxy.

**How to test**
* Foreman with external smart proxy
* Register host through the external proxy
* Check that the built status has been set correctly.
