### PR TITLE
Fixes #38217 - Set autocomplete attribute on name inputs

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -2,7 +2,10 @@ module FormHelper
   def text_f(f, attr, options = {})
     field(f, attr, options) do
       addClass options, "form-control"
-      options[:focus_on_load] = true if options[:focus_on_load].nil? && attr.to_s == 'name'
+      if attr.to_s == 'name'
+        options[:focus_on_load] ||= true
+        options[:autocomplete] ||= "section-#{f.object_name} name"
+      end
       f.text_field attr, options
     end
   end


### PR DESCRIPTION
to prevent a password manager from suggesting saved credentials in various name fields.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
