### PR TITLE
Fixes #38220 - page scroll freeze in host edit unselect arch

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -507,7 +507,15 @@ function activate_select2(container, allowClear ) {
         formatNoMatches: __('No matches found'),
         placeholder: selectAllowClear? placeholder || '' : { id: '-1', text: '' },
       });
+      $(this).on("select2:clear", function (evt) {
+        $(this).on("select2:opening.cancelOpen", function (evt) {
+          evt.preventDefault();
+          
+          $(this).off("select2:opening.cancelOpen");
+        });
+      });
     });
+
 }
 
 function setError(field, text) {

--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -36,17 +36,19 @@ $(document).on('ContentLoad', function() {
   update_default_compute_resource($('.hostgroup-select').val());
 });
 $(document)
-  .on('change', '.hostgroup-select', function(evt) {
+  .on('select2:select select2:unselecting', '.hostgroup-select', function(evt) {
     hostgroup_changed(evt.target);
-  }).on('change', '.host-form-compute-resource-handle', function(evt) {
+  }).on('select2:select select2:unselecting', '.host-form-compute-resource-handle', function(evt) {
     computeResourceSelected(evt.target);
-  }).on('change', '.host-taxonomy-select', function(evt) {
+  }).on('select2:select select2:unselecting', '.host-taxonomy-select', function(evt) {
     update_form(evt.target);
-  }).on('change', '.host-architecture-select', function(evt) {
+  }).on('select2:select select2:unselecting', '#host_architecture_id', function(evt) {
     architecture_selected(evt.target);
-  }).on('change', '.host-architecture-os-select', function(evt) {
+  }).on('select2:select select2:unselecting', '#hostgroup_architecture_id', function(evt) {
+    architecture_selected(evt.target);
+  }).on('select2:select select2:unselecting', '.host-architecture-os-select', function(evt) {
     os_selected(evt.target);
-  }).on('change', '.host-os-media-select', function(evt) {
+  }).on('select2:select select2:unselecting', '.host-os-media-select', function(evt) {
     medium_selected(evt.target);
   });
 
@@ -599,7 +601,7 @@ function build_provision_method_selected() {
     $('#host_compute_attributes_template').select2('readonly',false);
 }
 $(document).on(
-  'change',
+  'select2:select select2:unselecting',
   '#host_provision_method_build',
   build_provision_method_selected
 );
@@ -622,12 +624,12 @@ function image_provision_method_selected() {
   }
 }
 $(document).on(
-  'change',
+  'select2:select select2:unselecting',
   '#host_provision_method_image',
   image_provision_method_selected
 );
 
-$(document).on('change', '.interface_domain', function() {
+$(document).on('select2:select select2:unselecting', '.interface_domain', function() {
     interface_domain_selected(this);
     clearIpField(this, '.interface_ip');
     clearIpField(this, '.interface_ip6');

--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -1,6 +1,6 @@
 
 <%= select_f f, :architecture_id, accessible_resource(f.object, :architecture), :id, :to_label, {:include_blank => true},
-    {:onchange => 'architecture_selected(this);', :'data-url' => method_path('architecture_selected'), :'data-type' =>  controller_name.singularize == 'compute_resources_vm' ? 'host' : controller_name.singularize,
+    {:'data-url' => method_path('architecture_selected'), :'data-type' =>  controller_name.singularize == 'compute_resources_vm' ? 'host' : controller_name.singularize,
     :help_inline => :indicator, :required => true} %>
 
 <span id="os_select">


### PR DESCRIPTION
Go to create host page, OS tab, select Architecture, unselect Architecture, try to scroll down, cant scroll down.
same solution as in https://github.com/theforeman/foreman/pull/10440
also `.host-architecture-select` doesnt exist which might be why there was the extra `:onchage` in `app/views/hosts/_operating_system.html.erb`, changed to select by id