### PR TITLE
Fixes #38223 - host_edit when no inherit button creates error

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -8,9 +8,9 @@ $(document).on('ContentLoad', function() {
     $('#host_hostgroup_id').val(param).trigger('change');
   }
   onHostEditLoad();
-  document
-    .querySelector('[name=is_overridden_btn]')
-    .addEventListener('click', function(event) {
+  const overrideButtons = document.querySelectorAll('[name=is_overridden_btn]');
+  overrideButtons.forEach(button =>
+    button.addEventListener('click', function(event) {
       const item = event.target;
       var formControl = $(item)
         .closest('.input-group')
@@ -25,7 +25,8 @@ $(document).on('ContentLoad', function() {
             .trigger('change');
         }
       }
-    });
+    })
+  );
   if (window.location.href.includes('hostgroup')) {
     document.querySelector('form').addEventListener('submit', function() {
       // making sure inherited compute resource is included in the form


### PR DESCRIPTION
Follow up on https://github.com/theforeman/foreman/pull/10265
When editing a host, in foreman core without plugins, there is no inherit button on any of the fields, the causes this error:
Uncaught TypeError: document.querySelector(...) is null <anonymous> host_edit-a353532802cf651d1f8eaecab20ef1d6620e03c07c776b03559e9b18bebc15cf.js:1
for some reasons it makes it so the submit button redirects to the old details page, but still with the edit url
This causes the old details page to load on a loop