### PR TITLE
Fixes #38222 - Add managed interface to ubuntu_autoinst4dhcp snapshot

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -184,6 +184,7 @@ module Foreman
         name: 'snapshot-ipv4-dhcp-ubuntu20',
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         interfaces: [ipv4_interface])
+      host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -24,6 +24,10 @@ autoinstall:
   locale: en_US.UTF-8
   network:
     version: 2
+    ethernets:
+      eth0:
+        dhcp4: true
+        dhcp6: false
   ssh:
     allow-pw: true
     install-server: true


### PR DESCRIPTION
The Ubuntu Autoinstall template-snapshot-host `ubuntu_autoinst4dhcp` doesn't set its `:managed_interfaces`. Therefore, the network configuration of the snapshot doesn't include the NIC setup. This PR fixes the issue and updates the template snapshot accordingly.
 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
