### PR TITLE
Fixes #38229 - Add new template snapshot host for Ubuntu

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -38,6 +38,10 @@ module Foreman
       new.ubuntu_autoinst4dhcp
     end
 
+    def self.ubuntu_autoinstmulti4dhcp
+      new.ubuntu_autoinstmulti4dhcp
+    end
+
     def self.rhel9_dhcp
       new.rhel9_dhcp
     end
@@ -189,6 +193,22 @@ module Foreman
         name: 'snapshot-ipv4-dhcp-ubuntu20',
         subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
         interfaces: [ipv4_interface])
+      host.define_singleton_method(:managed_interfaces) { interfaces }
+      define_host_params(host)
+    end
+
+    def ubuntu_autoinstmulti4dhcp
+      nic_a = FactoryBot.build(:nic_primary_and_provision, identifier: '',
+        mac: '00-f0-54-1a-7e-e0',
+        ip: '192.168.42.42')
+      nic_b = FactoryBot.build(:nic_managed, identifier: '',
+        mac: '00-f0-54-1a-7e-e1',
+        ip: '192.168.42.43')
+
+      host = FactoryBot.build(:host_for_snapshots_ipv4_dhcp_ubuntu20,
+        name: 'snapshot-ipv4-dhcp-ubuntu20',
+        subnet: FactoryBot.build(:subnet_ipv4_dhcp_for_snapshots),
+        interfaces: [nic_a, nic_b])
       host.define_singleton_method(:managed_interfaces) { interfaces }
       define_host_params(host)
     end

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -6,6 +6,7 @@ oses:
 - ubuntu
 test_on:
 - ubuntu_autoinst4dhcp
+- ubuntu_autoinstmulti4dhcp
 description: |
   The provisioning template for Autoinstall based distributions. To customize the installation,
   modify the host parameters

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinstmulti4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinstmulti4dhcp.snap.txt
@@ -1,0 +1,50 @@
+#cloud-config
+autoinstall:
+  version: 1
+  apt:
+    geoip: false
+    preserve_sources_list: false
+    primary:
+      - arches: [amd64, i386]
+        uri: http://archive.ubuntu.com/ubuntu
+      - arches: [default]
+        uri: http://ports.ubuntu.com/ubuntu-ports
+  user-data:
+    disable_root: false
+    fqdn: snapshot-ipv4-dhcp-ubuntu20
+    users:
+    - name: root
+      gecos: root
+      lock_passwd: false
+      hashed_passwd: $1$rtd8Ub7R$5Ohzuy8WXlkaK9cA2T1wb0
+  keyboard:
+    layout: us
+    toggle: null
+    variant: ''
+  locale: en_US.UTF-8
+  network:
+    version: 2
+    ethernets:
+      id0:
+        match:
+          macaddress: "00-f0-54-1a-7e-e0"
+        dhcp4: true
+        dhcp6: false
+      id1:
+        match:
+          macaddress: "00-f0-54-1a-7e-e1"
+        dhcp4: false
+        dhcp6: false
+  ssh:
+    allow-pw: true
+    install-server: true
+  updates: security
+  storage:
+    layout:
+      name: lvm
+
+  late-commands:
+
+  - wget --no-proxy http://foreman.example.com/unattended/finish -O /target/tmp/finish.sh
+  - curtin in-target -- chmod +x /tmp/finish.sh
+  - curtin in-target -- /tmp/finish.sh


### PR DESCRIPTION
This adds another machine `ubuntu_autoinstmulti4dhcp` in order to test a common NIC setup: No identifier is set and two NICs are provided. This aims on testing this part of the networking snippet: https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb#L10

This is a common scenario which is currently not covered by our snapshots and shows an issue with the current snippet.

I'm wondering whether we want to test different template/snippet scenarios by adding multiple snapshot hosts like I'm introducing with this PR. I did stumble across https://github.com/theforeman/foreman/pull/9516 which might make this more elegant by transitioning to traits.





<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
