### PR TITLE
[CP 3.13] Fixes #38223 - host_edit when no inherit button creates error

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -9,9 +9,9 @@ $(document).ready(function() {
 });
 $(document).on('ContentLoad', function() {
   onHostEditLoad();
-  document
-    .querySelector('[name=is_overridden_btn]')
-    .addEventListener('click', function(event) {
+  const overrideButtons = document.querySelectorAll('[name=is_overridden_btn]');
+  overrideButtons.forEach(button =>
+    button.addEventListener('click', function(event) {
       const item = event.target;
       var formControl = $(item)
         .closest('.input-group')
@@ -26,7 +26,8 @@ $(document).on('ContentLoad', function() {
             .trigger('change');
         }
       }
-    });
+    })
+  );
   if (window.location.href.includes('hostgroup')) {
     document.querySelector('form').addEventListener('submit', function() {
       // making sure inherited compute resource is included in the form


### PR DESCRIPTION
(cherry picked from commit c97a40e1631a3c6642cba47658787ece8a1c95ef)
https://github.com/theforeman/foreman/pull/10447

When editing a host, in foreman core without plugins, there is no inherit button on any of the fields, the causes this error:
Uncaught TypeError: document.querySelector(...) is null host_edit-a353532802cf651d1f8eaecab20ef1d6620e03c07c776b03559e9b18bebc15cf.js:1
for some reasons it makes it so the submit button redirects to the old details page, but still with the edit url
This causes the old details page to load on a loop

This is a bug when users have the old hosts details page as default,
We might want to cp it in 3.13, to work around a user can go to the details page and/or delete the the /edit from the url, or just set up to use the new page