### PR TITLE
Fixes #38232 - Fix GRUB2 loader commands for Debian/Ubuntu

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -19,7 +19,7 @@ description: |
   os_major = @host.operatingsystem.major.to_i
   os_name  = @host.operatingsystem.name
 
-  if (os_name == 'Ubuntu' && os_major > 12) || (os_name == 'Debian' && os_major > 8)
+  if (os_name == 'Ubuntu' && os_major > 12 && os_major < 24) || (os_name == 'Debian' && os_major > 8 && os_major < 13)
     efi_suffix = 'efi'
   else
     efi_suffix = ''

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2_autoinstall.erb
@@ -19,7 +19,13 @@ test_on:
 #   System locale
 #
 <%
-  efi_suffix = 'efi'
+  os_major = @host.operatingsystem.major.to_i
+
+  if (os_major > 12 && os_major < 24)
+    efi_suffix = 'efi'
+  else
+    efi_suffix = ''
+  end
 -%>
 
 set default=0


### PR DESCRIPTION
Back in time, GRUB2 is using `linux` and `initrd` loader commands to load the kernel and initrd into ram on legacy BIOS. Later, `linuxefi` and `initrdefi` loader commands have been added to do the same on UEFI platforms as some kind of interim solution. These out-of-tree patches have been added by the vendors.

First vendors [1] started now to drop patches for `linuxefi`/`initrdefi` loader commands support, `linux`/`initrd` of course also work under UEFI then.

Thus, we need to adapt preseed templates to render correct templates with supported loader commands.

[1]:https://salsa.debian.org/grub-team/grub/-/commit/5cf01c9d98bda554ac2460a6e68e34743a19328f


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
