### PR TITLE
Fixes #38237 - select2 search not working in modals

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -500,7 +500,11 @@ function activate_select2(container, allowClear ) {
           selectAllowClear = false;
         }
       }
+      var dropdownParent = $(document.body);
+      if ($(this).parents('.modal').length !== 0)
+        dropdownParent = $(this).parents('.modal');
       $(this).select2({
+        dropdownParent,
         language: langAttr,
         width: '100%',
         allowClear: selectAllowClear,

--- a/app/assets/javascripts/host_edit_interfaces.js
+++ b/app/assets/javascripts/host_edit_interfaces.js
@@ -27,7 +27,7 @@ function show_interface_modal(modal_content) {
   modal_window
     .find('.modal-title')
     .text(__('Interface') + ' ' + String(identifier));
-  modal_window.modal({ show: true });
+  modal_window.modal({ show: true , backdrop: 'static'});
 
   modal_window.find('a[rel="popover-modal"]').popover();
   activate_select2(modal_window);


### PR DESCRIPTION
This is a problem in the foreman-discovery plugin, but I thought its best to put it in core in case there are more places with this issue
I think its safe to assume that if its a select2 inside a modal the parent class name will be "modal"
` $(document.body);` is the default value in select2
https://select2.org/dropdown#dropdown-placement
to reproduce: When selecting the Provision option for a discovered host, the system prompts for "Select initial host properties" such as Host Group, Organization, and Location. However, when clicking on the dropdown menus for these fields and attempting to filter values by typing, the functionality does not work—essentially, input cannot be typed into the filter field.