### PR TITLE
Fixes #38252 - Handle boolean searchable_value displayed as true/false in search field

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -171,6 +171,12 @@ module Hostext
 
       def search_by_params(key, operator, value)
         key_name = key.sub(/^.*\./, '')
+
+        if Parameter.find_by(name: key_name)&.key_type == 'boolean'
+          # boolean value is saved as 't'/'f' in searchable_value column
+          value = value.chr
+        end
+
         condition = sanitize_sql_for_conditions(["name = ? and searchable_value #{operator} ?", key_name, value_to_sql(operator, value)])
         p = Parameter.where(condition).reorder(:priority)
         return {:conditions => '1 = 0'} if p.blank?

--- a/app/models/concerns/parameter_search.rb
+++ b/app/models/concerns/parameter_search.rb
@@ -10,6 +10,11 @@ module ParameterSearch
       key_name = key.sub(/^.*\./, '')
       parameters_relation = parameter_relation_symbol
 
+      if Parameter.find_by(name: key_name)&.key_type == 'boolean'
+        # boolean value is saved as 't'/'f' in searchable_value column
+        value = value.chr
+      end
+
       conditions = sanitize_sql_for_conditions(
         ["parameters.name = ? and parameters.searchable_value #{operator} ?", key_name, value_to_sql(operator, value)]
       )

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -1965,6 +1965,30 @@ class HostTest < ActiveSupport::TestCase
       results = Host.search_for(%{params.#{parameter.name} = "#{parameter.searchable_value}"})
       assert results.include?(host)
     end
+
+    test "can search hosts by boolean parameter" do
+      host = FactoryBot.create(:host, :managed)
+      parameter = CommonParameter.create(:name => "test_param", :value => "true", :parameter_type => 'boolean')
+      results = Host.search_for("params.#{parameter.name} = true")
+      assert results.include?(host)
+      results = Host.search_for("params.#{parameter.name} = t")
+      assert results.include?(host)
+      results = Host.search_for("params.#{parameter.name} = false")
+      assert_empty results
+      results = Host.search_for("params.#{parameter.name} = f")
+      assert_empty results
+
+      host2 = FactoryBot.create(:host, :managed)
+      HostParameter.create(:name => "test_param", :value => "false", :parameter_type => 'boolean', :reference_id => host2.id)
+      results = Host.search_for("params.#{parameter.name} = true")
+      assert_same_elements results, [host]
+      results = Host.search_for("params.#{parameter.name} = t")
+      assert_same_elements results, [host]
+      results = Host.search_for("params.#{parameter.name} = false")
+      assert_same_elements results, [host2]
+      results = Host.search_for("params.#{parameter.name} = f")
+      assert_same_elements results, [host2]
+    end
   end
 
   test "can search hosts by current_user" do

--- a/test/models/parameter_test.rb
+++ b/test/models/parameter_test.rb
@@ -135,4 +135,20 @@ class ParameterTest < ActiveSupport::TestCase
       assert parameter.valid?, "Can't create parameter with valid name #{name}"
     end
   end
+
+  test "should allow search by boolean parameter" do
+    hg1 = FactoryBot.create(:hostgroup)
+    hg2 = FactoryBot.create(:hostgroup)
+    GroupParameter.create(:name => "dev", :value => "true", :parameter_type => 'boolean', :reference_id => hg1.id)
+    GroupParameter.create(:name => "dev", :value => "false", :parameter_type => 'boolean', :reference_id => hg2.id)
+
+    results = Hostgroup.search_for("params.dev = true")
+    assert_same_elements results, [hg1]
+    results = Hostgroup.search_for("params.dev = t")
+    assert_same_elements results, [hg1]
+    results = Hostgroup.search_for("params.dev = false")
+    assert_same_elements results, [hg2]
+    results = Hostgroup.search_for("params.dev = f")
+    assert_same_elements results, [hg2]
+  end
 end


### PR DESCRIPTION
`searchable_value` is a text field in DB. So boolean value is saved as `t` and `f` in the DB instead of `true` and `false`.

**Test Steps**
Hosts - Content Hosts, and in the search field, you can add a query

**Before**
`params.host_registration_insights = f` and `params.host_registration_insights = false`
Both "false" and "f" will be presented automatically on Satellite . But you get accurate response only when selecting "f".

If you don't see `params.host_registration_insights = false`  displayed on your server, just add a global parameter with `string` type and `false` value.

**After**
Both `params.host_registration_insights = false` or `params.host_registration_insights = f` would work with the same result.
