### PR TITLE
Fixes #38262 - Tweak the OIDC issuer message

### DIFF
--- a/app/services/sso/openid_connect.rb
+++ b/app/services/sso/openid_connect.rb
@@ -69,7 +69,7 @@ module SSO
       end
       unless payload.key?('iss') && (payload['iss'] == Setting['oidc_issuer'])
         logger.error "Invalid OIDC issuer received in JWT."
-        logger.debug "Received invalid OIDC issuer '#{payload['iss']}'"
+        logger.info "Received invalid OIDC issuer '#{payload['iss']}' but expected '#{Setting['oidc_issuer']}'"
         return false
       end
       true


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Show more info about OIDC issuer rejection so the user can compare what was received with what was expected. Make it an info level message because something didn't go as expected.
Example output:
```
2025-03-04T08:34:06 [I|app|7157e122] Filter chain halted as :require_login rendered or redirected
2025-03-04T08:34:06 [I|app|7157e122] Completed 302 Found in 3ms (ActiveRecord: 0.2ms | Allocations: 1366)
2025-03-04T08:34:07 [I|app|9fe06d70] Started GET "/users/extlogin" for 10.45.225.5 at 2025-03-04 08:34:07 -0500
2025-03-04T08:34:07 [I|app|9fe06d70] Processing by UsersController#extlogin as HTML
2025-03-04T08:34:07 [E|app|9fe06d70] Invalid OIDC issuer received in JWT.
2025-03-04T08:34:07 [I|app|9fe06d70] Received invalid OIDC issuer 'https://<RHBK_FQDN>:8443/realms/master' but expected 'https://<RHBK_FQDN>:8443/auth/realms/master'
2025-03-04T08:34:07 [I|app|9fe06d70] Redirected to https://<SAT_FQDN>/users/login
2025-03-04T08:34:07 [I|app|9fe06d70] Filter chain halted as :require_login rendered or redirected
```