### PR TITLE
Fixes #38272 - Use .presence for ip6 address

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -99,6 +99,6 @@ module Orchestration::SshProvision
 
   def provision_host
     # usually cloud compute resources provide IPs but virtualization do not
-    provision_interface.ip6 || provision_interface.ip || provision_interface.fqdn
+    provision_interface.ip6.presence || provision_interface.ip.presence || provision_interface.fqdn
   end
 end


### PR DESCRIPTION
Stems from the fact that ip6 is defined as an empty string here: https://github.com/theforeman/foreman/blob/bc335dcd2709ee85b20c0af079f06768527c53d2/app/models/concerns/orchestration/ssh_provision.rb#L102C28-L102C36