### PR TITLE
Fixes #38566 - Use if_exists: true on remove_index where needed

### DIFF
--- a/db/migrate/20100525094200_simplify_parameters.rb
+++ b/db/migrate/20100525094200_simplify_parameters.rb
@@ -1,8 +1,8 @@
 class SimplifyParameters < ActiveRecord::Migration[4.2]
   def up
-    remove_index  :parameters, [:host_id,      :type] if index_exists? :parameters, :host_id
-    remove_index  :parameters, [:hostgroup_id, :type] if index_exists? :parameters, :hostgroup_id
-    remove_index  :parameters, [:domain_id,    :type] if index_exists? :parameters, :domain_id
+    remove_index  :parameters, [:host_id,      :type], if_exists: true
+    remove_index  :parameters, [:hostgroup_id, :type], if_exists: true
+    remove_index  :parameters, [:domain_id,    :type], if_exists: true
 
     rename_column :parameters, :host_id, :reference_id if column_exists? :parameters, :host_id
     add_index     :parameters, [:reference_id, :type] if index_exists? :parameters, :reference_id

--- a/db/migrate/20120624081510_add_auditable_name_and_associated_name_to_audit.rb
+++ b/db/migrate/20120624081510_add_auditable_name_and_associated_name_to_audit.rb
@@ -6,7 +6,7 @@ class AddAuditableNameAndAssociatedNameToAudit < ActiveRecord::Migration[4.2]
   end
 
   def down
-    remove_index :audits, :id               if  index_exists?  :audits, :id
+    remove_index :audits, :id, if_exists: true
     remove_column :audits, :associated_name if  column_exists? :audits, :associated_name
     remove_column :audits, :auditable_name  if  column_exists? :audits, :auditable_name
   end

--- a/db/migrate/20130121130826_add_digest_to_messages.rb
+++ b/db/migrate/20130121130826_add_digest_to_messages.rb
@@ -1,6 +1,6 @@
 class AddDigestToMessages < ActiveRecord::Migration[4.2]
   def up
-    remove_index(:messages, :value) if index_exists?(:messages, :value)
+    remove_index(:messages, :value, if_exists: true)
     add_column :messages, :digest, :string, :limit => 40
     add_index :messages, :digest
   end

--- a/db/migrate/20130228145456_add_digest_to_sources.rb
+++ b/db/migrate/20130228145456_add_digest_to_sources.rb
@@ -1,6 +1,6 @@
 class AddDigestToSources < ActiveRecord::Migration[4.2]
   def up
-    remove_index(:sources, :value) if index_exists?(:sources, :value)
+    remove_index(:sources, :value, if_exists: true)
     add_column :sources, :digest, :string, :limit => 40
     add_index :sources, :digest
   end

--- a/db/migrate/20140805114754_add_unique_index_to_parameter.rb
+++ b/db/migrate/20140805114754_add_unique_index_to_parameter.rb
@@ -5,7 +5,7 @@ class AddUniqueIndexToParameter < ActiveRecord::Migration[4.2]
 
   def down
     # previous version, prior to #8366 and 20141112165600_add_type_to_parameter_index
-    remove_index :parameters, :column => [:reference_id, :name] if index_exists? :parameters, [:reference_id, :name], :unique => true
-    remove_index :parameters, :column => [:type, :reference_id, :name] if index_exists? :parameters, [:type, :reference_id, :name], :unique => true
+    remove_index :parameters, :column => [:reference_id, :name], :if_exists => true
+    remove_index :parameters, :column => [:type, :reference_id, :name], :if_exists => true
   end
 end

--- a/db/migrate/20150525081931_remove_duplicate_tokens.rb
+++ b/db/migrate/20150525081931_remove_duplicate_tokens.rb
@@ -1,14 +1,14 @@
 class RemoveDuplicateTokens < ActiveRecord::Migration[4.2]
   def up
     remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
-    remove_index :tokens, :host_id if index_exists? :tokens, :host_id
+    remove_index :tokens, :host_id, if_exists: true
     add_index :tokens, :host_id, :unique => true
     add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
   end
 
   def down
     remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
-    remove_index :tokens, :host_id if index_exists? :tokens, :host_id
+    remove_index :tokens, :host_id, if_exists: true
     add_index :tokens, :host_id
     add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
   end

--- a/db/migrate/20180613100703_add_type_to_token.rb
+++ b/db/migrate/20180613100703_add_type_to_token.rb
@@ -1,7 +1,7 @@
 class AddTypeToToken < ActiveRecord::Migration[5.1]
   def up
     remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
-    remove_index :tokens, :host_id if index_exists? :tokens, :host_id # was unique
+    remove_index :tokens, :host_id, if_exists: true # was unique
     add_index :tokens, :host_id
     add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
     add_column :tokens, :type, :string, default: 'Token::Build', null: false, index: true
@@ -12,7 +12,7 @@ class AddTypeToToken < ActiveRecord::Migration[5.1]
     change_column :tokens, :value, :string, limit: 255
     remove_column :tokens, :type
     remove_foreign_key :tokens, :column => :host_id if foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
-    remove_index :tokens, :host_id if index_exists? :tokens, :host_id
+    remove_index :tokens, :host_id, if_exists: true
     add_index :tokens, :host_id, :unique => true
     add_foreign_key :tokens, :hosts, :name => "tokens_host_id_fk" unless foreign_key_exists?(:tokens, name: "tokens_host_id_fk")
   end

--- a/db/migrate/20180715202514_optimize_indices.rb
+++ b/db/migrate/20180715202514_optimize_indices.rb
@@ -28,7 +28,7 @@ class OptimizeIndices < ActiveRecord::Migration[5.1]
     remove_index :hosts, :type
 
     # may be a leftover from when priority was changed to match
-    remove_index :lookup_values, name: "index_lookup_values_on_priority" if index_name_exists?(:lookup_values, "index_lookup_values_on_priority")
+    remove_index :lookup_values, name: "index_lookup_values_on_priority", if_exists: true
 
     # covered by [:type, :id]
     remove_index :nics, name: "index_by_type"
@@ -37,11 +37,11 @@ class OptimizeIndices < ActiveRecord::Migration[5.1]
     remove_index :notification_recipients, :user_id
 
     # These may be leftover from an old migration (20100525094200_simplify_parameters.rb)
-    remove_index :parameters, name: "index_parameters_on_domain_id_and_type" if index_name_exists?(:parameters, "index_parameters_on_domain_id_and_type")
-    remove_index :parameters, name: "index_parameters_on_hostgroup_id_and_type" if index_name_exists?(:parameters, "index_parameters_on_hostgroup_id_and_type")
-    remove_index :parameters, name: "index_parameters_on_host_id_and_type" if index_name_exists?(:parameters, "index_parameters_on_host_id_and_type")
+    remove_index :parameters, name: "index_parameters_on_domain_id_and_type", if_exists: true
+    remove_index :parameters, name: "index_parameters_on_hostgroup_id_and_type", if_exists: true
+    remove_index :parameters, name: "index_parameters_on_host_id_and_type", if_exists: true
     # Useless index, covered by [:type, :reference_id, :name] (no sense looking for reference_id with no type)
-    remove_index :parameters, [:reference_id, :type] if index_exists?(:parameters, [:reference_id, :type])
+    remove_index :parameters, [:reference_id, :type], if_exists: true
     # covered by [:type, :reference_id, :name]
     remove_index :parameters, :type
 


### PR DESCRIPTION
Instead of having a separate index_exists? call, this uses the if_exists parameter to offload it to the database. It saves a query and makes code easier to read.

Opening as a PR to see if this works. It came up in https://github.com/theforeman/jenkins-jobs/pull/525#issuecomment-2703939073 and when reading the code it surprised me.

Note: https://api.rubyonrails.org/v8.0.1/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-remove_column mentions that there's also an `if_exists` parameter on `remove_column` which could benefit from a similar approach.