### PR TITLE
Fixes #38275 - Capsules index page may takes long time to load

### DIFF
--- a/app/controllers/smart_proxies_controller.rb
+++ b/app/controllers/smart_proxies_controller.rb
@@ -6,7 +6,10 @@ class SmartProxiesController < ApplicationController
   before_action :find_status, :only => [:ping, :tftp_server]
 
   def index
-    @smart_proxies = resource_base_search_and_page.includes(:features)
+    # Large content_counts data may cause slow page load, especially with eager load.
+    # So exclude this field since it is not used in index page.
+    needed_columns = SmartProxy.attribute_names.reject { |name| name == "content_counts" }
+    @smart_proxies = resource_base_search_and_page.select(needed_columns).preload(:features)
   end
 
   def show
@@ -144,7 +147,12 @@ class SmartProxiesController < ApplicationController
   end
 
   def resource_base
-    super.eager_load(:locations, :organizations)
+    # Preload appears to consume less memory (20k+ less alloctions) compared to eager load.
+    # Maybe because it prevented thousands of duplicate rows with table joins when using
+    # eager load.
+    # No signficant performance tradeoff is noticed when using preload, slightly faster
+    # view rendering is noticed in large data.
+    super.preload(:locations, :organizations)
   end
 
   def versions_mismatched?(proxy_versions_hash)


### PR DESCRIPTION
Capsules index page may takes up to 1 minute to load when there are many organizations and thousands of locations assigned to every capsules.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
