### PR TITLE
Fixes #38272 - Use .presence for ip6 address (Cherry-pick to 3.14)

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -99,6 +99,6 @@ module Orchestration::SshProvision
 
   def provision_host
     # usually cloud compute resources provide IPs but virtualization do not
-    provision_interface.ip6 || provision_interface.ip || provision_interface.fqdn
+    provision_interface.ip6.presence || provision_interface.ip.presence || provision_interface.fqdn
   end
 end


### PR DESCRIPTION
We cannot use regular `||` method on `ip6` and `ip` fields, since the value can be an empty string.

(cherry picked from commit cd26ededa8fe0942fcebe037824f402d976824b0)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
