### PR TITLE
Fixes #38282 - datatables pagination not working

### DIFF
--- a/app/assets/javascripts/proxy_status/logs.js
+++ b/app/assets/javascripts/proxy_status/logs.js
@@ -26,6 +26,7 @@ function changeFilterSelection(index) {
 
 function activateLogsDataTable() {
   $('#table-proxy-status-logs').dataTable({
+    pagingType: 'simple_numbers',
     dom: "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'i><'col-md-6'p>>",
     autoWidth: false,
     columnDefs: [{

--- a/webpack/assets/javascripts/foreman_tools.js
+++ b/webpack/assets/javascripts/foreman_tools.js
@@ -66,6 +66,7 @@ export function activateDatatables() {
   $('[data-table=inline]')
     .not('.dataTable')
     .DataTable({
+      pagingType: 'simple_numbers',
       language,
       dom: "<'row'<'col-md-6'f>r>t<'row'<'col-md-6'i><'col-md-6'p>>",
     });
@@ -76,6 +77,7 @@ export function activateDatatables() {
       const url = el.getAttribute('data-source');
 
       $(el).DataTable({
+        pagingType: 'simple_numbers',
         language,
         processing: true,
         serverSide: true,

--- a/webpack/assets/javascripts/foreman_tools.test.js
+++ b/webpack/assets/javascripts/foreman_tools.test.js
@@ -36,6 +36,7 @@ describe('activateDatatables', () => {
     $.fn.DataTable = jest.fn();
     tools.activateDatatables();
     expect($.fn.DataTable).toBeCalledWith({
+      pagingType: "simple_numbers",
       processing: true,
       serverSide: true,
       ordering: false,


### PR DESCRIPTION
This PR changes the pagination type of data tables to be numbers, instead being juts an input box where users can type a number:
Before: 
![image](https://github.com/user-attachments/assets/f17bacd0-3270-4e85-b1f5-f70c42a1dbb1)
After:
![image](https://github.com/user-attachments/assets/ee63b63e-d2c6-41b3-8cb8-d7305ebc94f3)
The issue is without this pr if a user clicks the "next" button nothing happens and there is an error in the console. 
I could not find what causes this (or even how we get the input pagination as its suppose to only happen if we install a datatables plug for pagination which we dont in foreman or foreman js)
so instead I changed the pagination type.
The error is: 
```
Uncaught TypeError: ((jQuery.event.special[handleObj.origType] || {}).handle || handleObj.handler).apply is not a function
    at HTMLLIElement.dispatch (jquery.js:5145:1)
    at elemData.handle (jquery.js:4949:1)
dispatch @ jquery.js:5145
elemData.handle @ jquery.js:4949
```

to test: we use data tables in edit role -> filters tab, or smart proxy -> logs tab