### PR TITLE
Fixes #38281 - Refactor handling of `:include_blank` in `form_select_f`

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -442,7 +442,7 @@ module FormHelper
 
   def form_select_f(f, attr, array, select_options = {}, html_options = {})
     addClass html_options, "form-control"
-    include_blank = select_options.delete(:include_blank)
+    include_blank = select_options[:include_blank]
     if include_blank
       addClass html_options, "include_blank"
       blank_value = include_blank.is_a?(TrueClass) ? nil : include_blank
@@ -450,6 +450,7 @@ module FormHelper
         array = array.to_a.dup
         blank_option = [blank_value, nil]
         array.insert(0, blank_option)
+        select_options.delete(:include_blank)
       end
       html_options['data-placeholder'] = blank_value || html_options[:placeholder]
     elsif html_options[:placeholder]


### PR DESCRIPTION
Ensure proper handling of `include_blank` in both cases:
when `array` is an array of options, and when `array` is a string of HTML options.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
