### PR TITLE
Fixes #38298 - pf5 tables css - search input and select all

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/SelectAllCheckbox/SelectAllCheckbox.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/SelectAllCheckbox/SelectAllCheckbox.scss
@@ -1,3 +1,4 @@
 .table-select-all-checkbox {
   font-weight: normal;
+  margin-bottom: 0;
 }

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.scss
@@ -12,6 +12,7 @@
       }
       .toolbar-search {
         flex-grow: 1;
+        display: block;
       }
       .table-toolbar-actions {
         padding-left: 16px;
@@ -39,7 +40,7 @@
       width: min-content;
     }
   }
-  .pf-c-table tr.pf-m-hoverable {
+  .pf-v5-c-table tr.pf-m-clickable {
     cursor: default;
   }
 }

--- a/webpack/assets/javascripts/react_app/components/SearchBar/SearchAutocomplete.js
+++ b/webpack/assets/javascripts/react_app/components/SearchBar/SearchAutocomplete.js
@@ -151,6 +151,8 @@ export const SearchAutocomplete = ({
     <Popper
       trigger={searchInput}
       popper={autocomplete}
+      triggerRef={searchWrapperRef}
+      popperRef={autocompleteRef}
       isVisible={isAutocompleteOpen}
       enableFlip={false}
     />


### PR DESCRIPTION
search input length became limited, causing too much space between it and the toolbar
select all "6 selected" had too much space and became higher than the search bar
added triggerRef so it wont wrap the autocomplete input in an extra div as that messes the css a bit
`table-select-all-checkbox ` got margin bottom from bootsrap, that was previously removed by pf css, but now wasnt removed. 
Also forgot to update the table classname in the pf5 pr for the cursor css 