### PR TITLE
Fixes #38219 - Update Ansible Tower API URL for AAP 2.5+ compatibility

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -70,6 +70,8 @@ module Foreman
         "enable-epel" => "true",
         "package_upgrade" => "true",
         "ansible_tower_provisioning" => "true",
+        "ansible_tower_api_url" => "https://host.example.com/api/controller/v2",
+        "ansible_job_template_id" => "20",
         "schedule_reboot" => "true",
         "fips_enabled" => "true",
         "force-puppet" => "true",

--- a/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_script.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_script.erb
@@ -11,8 +11,8 @@ description: |
 
 echo "Calling Ansible AWX/Tower provisioning callback..."
 <% if host_param('ansible_extra_vars') -%>
-/usr/bin/curl -v -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+/usr/bin/curl -v -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' <%= host_param('ansible_tower_api_url') %>/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
 <% else -%>
-/usr/bin/curl -v -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') %>" https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+/usr/bin/curl -v -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') %>" <%= host_param('ansible_tower_api_url') %>/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
 <% end -%>
 echo "DONE"

--- a/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_service.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ansible_tower_callback_service.erb
@@ -15,9 +15,9 @@ After=network-online.target
 [Service]
 Type=oneshot
 <% if host_param('ansible_extra_vars') -%>
-ExecStart=/usr/bin/curl -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' https://<%= host_param('ansible_tower_fqdn') %>/api/v2/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
+ExecStart=/usr/bin/curl -k -s -H 'Content-Type: application/json' --data '{"host_config_key":"<%= host_param('ansible_host_config_key') %>", "extra_vars": <%=host_param('ansible_extra_vars') %>}' <%= host_param('ansible_tower_api_url') %>/job_templates/<%= host_param('ansible_job_template_id') %>/callback/
 <% else -%>
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" https://<%= host_param('ansible_tower_fqdn') -%>/api/v2/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=<%= host_param('ansible_host_config_key') -%>" <%= host_param('ansible_tower_api_url') -%>/job_templates/<%= host_param('ansible_job_template_id') -%>/callback/
 <% end -%>
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 

--- a/db/migrate/20250309121956_rename_ansible_tower_fqdn_to_api_url.rb
+++ b/db/migrate/20250309121956_rename_ansible_tower_fqdn_to_api_url.rb
@@ -1,0 +1,19 @@
+class RenameAnsibleTowerFqdnToApiURL < ActiveRecord::Migration[7.0]
+  def up
+    Parameter.where(name: 'ansible_tower_fqdn').find_each do |parameter|
+      parameter.update(
+        name: 'ansible_tower_api_url',
+        value: "https://#{parameter.value}/api/controller/v2"
+      )
+    end
+  end
+
+  def down
+    Parameter.where(name: 'ansible_tower_api_url').find_each do |parameter|
+      parameter.update(
+        name: 'ansible_tower_fqdn',
+        value: URI(parameter.value).host
+      )
+    end
+  end
+end

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -227,7 +227,7 @@ cat << EOF-9f037ba1 > /root/ansible_provisioning_call.sh
 #!/bin/sh
 
 echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+/usr/bin/curl -v -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 echo "DONE"
 EOF-9f037ba1
 chmod +x /root/ansible_provisioning_call.sh

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -103,7 +103,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -103,7 +103,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -294,7 +294,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -294,7 +294,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -294,7 +294,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -294,7 +294,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -294,7 +294,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -177,7 +177,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -292,7 +292,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -291,7 +291,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/ansible_tower_callback_script.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/ansible_tower_callback_script.host4dhcp.snap.txt
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+/usr/bin/curl -v -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 echo "DONE"

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/ansible_tower_callback_service.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/ansible_tower_callback_service.host4dhcp.snap.txt
@@ -5,7 +5,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+ExecStart=/usr/bin/curl -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 ExecStartPost=/usr/bin/systemctl disable ansible-callback
 
 [Install]

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -240,7 +240,7 @@ echo "Performing initial puppet run for --tags no_such_tag"
 #!/bin/sh
 
 echo "Calling Ansible AWX/Tower provisioning callback..."
-/usr/bin/curl -v -k -s --data "host_config_key=" https:///api/v2/job_templates//callback/
+/usr/bin/curl -v -k -s --data "host_config_key=" https://host.example.com/api/controller/v2/job_templates/20/callback/
 echo "DONE"
 EOF-d592f4ed
     /bin/sh /tmp/ansible_provisioning_call.sh


### PR DESCRIPTION
AAP 2.5+ uses `/api/controller/v2` instead of `/api/v2`. This updates provisioning templates to use `ansible_tower_api_url` and includes a migration renaming `ansible_tower_fqdn`, appending the new API path.

(cherry picked from commit 2a81d51f7793f82bc5687952789e716b278083ff)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
