### PR TITLE
Fixes #38300 - add support for multiple architectures on pxe loader iPXE chain UEFI

### DIFF
--- a/app/models/concerns/pxe_loader_support.rb
+++ b/app/models/concerns/pxe_loader_support.rb
@@ -6,7 +6,7 @@ module PxeLoaderSupport
     :PXELinux => /^(pxelinux.*|PXELinux (BIOS|UEFI))$/,
     :PXEGrub => /^(grub\/|Grub UEFI).*/,
     :PXEGrub2 => /(^Grub2 (BIOS|UEFI|ELF).*|\/?grub2\/)/,
-    :iPXE => /^((iPXE|http.*\/ipxe-).*|ipxe\.efi|undionly\.kpxe)$/,
+    :iPXE => /^((iPXE|http.*\/ipxe-).*|ipxe(-.*)?\.efi|undionly\.kpxe)$/,
   }.with_indifferent_access.freeze
 
   # preference order is defined in Operatingsystem#template_kinds
@@ -34,7 +34,7 @@ module PxeLoaderSupport
         "iPXE Embedded" => nil, # renders directly as foreman_url('iPXE')
         "iPXE UEFI HTTP" => "http://#{httpboot_host}/httpboot/ipxe-#{precision}.efi",
         "iPXE Chain BIOS" => "undionly-ipxe.0",
-        "iPXE Chain UEFI" => "ipxe.efi",
+        "iPXE Chain UEFI" => "ipxe-#{precision}.efi",
       }.freeze
     end
 

--- a/test/models/concerns/pxe_loader_support_test.rb
+++ b/test/models/concerns/pxe_loader_support_test.rb
@@ -127,6 +127,16 @@ class PxeLoaderSupportTest < ActiveSupport::TestCase
       assert_equal :iPXE, @subject.pxe_loader_kind(@host)
     end
 
+    test "iPXE is found for iPXE Chain UEFI" do
+      @host.pxe_loader = "iPXE Chain UEFI"
+      assert_equal :iPXE, @subject.pxe_loader_kind(@host)
+    end
+
+    test "iPXE is found for ipxe-x64.efi" do
+      @host.pxe_loader = "ipxe-x64.efi"
+      assert_equal :iPXE, @subject.pxe_loader_kind(@host)
+    end
+
     test "iPXE is found for undionly.kpxe filename" do
       @host.pxe_loader = 'undionly.kpxe'
       assert_equal :iPXE, @subject.pxe_loader_kind(@host)


### PR DESCRIPTION
Hello 👋 

This MR adds architecture precision to the ipxe binary allowing more than one architecture booting with foreman using ipxe chain uefi.

Regards,
Lisa