### PR TITLE
Fixes #38303 - the host count depends on the organization

### DIFF
--- a/app/services/host_counter.rb
+++ b/app/services/host_counter.rb
@@ -21,7 +21,14 @@ class HostCounter
 
   def cache(&block)
     delay = Rails.env.test? ? 0 : 2.minutes
-    Rails.cache.fetch("hosts_count/#{@association}/#{User.current.id}", expires_in: delay, &block)
+    # If we are on /organizations or /locations, this allows to display the
+    # count for hosts not in the current organization & location.
+    org, loc = if %w[organization location].include?(@association.to_s)
+                 ["all", "all"]
+               else
+                 [Organization.current&.id || "all", Location.current&.id || "all"]
+               end
+    Rails.cache.fetch("hosts_count/org_#{org}/loc_#{loc}/#{@association}/#{User.current.id}", expires_in: delay, &block)
   end
 
   def counted_hosts

--- a/test/unit/host_counter_test.rb
+++ b/test/unit/host_counter_test.rb
@@ -47,17 +47,31 @@ class HostCounterTest < ActiveSupport::TestCase
 
     setup do
       FactoryBot.create(:host, :model => model, :location => loc1, :organization => org1)
+      FactoryBot.create(:host, :model => model, :location => loc1, :organization => org1)
+      FactoryBot.create(:host, :model => model, :location => loc1, :organization => org1)
       FactoryBot.create(:host, :model => model, :location => loc2, :organization => org2)
     end
 
     test 'it should count only hosts in user location/organization' do
-      assert_equal 2, hosts_count(:model)[model]
+      assert_equal 4, hosts_count(:model)[model]
+
+      Taxonomy.as_taxonomy(org1, loc1) do
+        assert_equal 3, hosts_count(:model)[model]
+      end
 
       Taxonomy.as_taxonomy(nil, loc1) do
-        assert_equal 1, hosts_count(:model)[model]
+        assert_equal 3, hosts_count(:model)[model]
       end
 
       Taxonomy.as_taxonomy(org1, nil) do
+        assert_equal 3, hosts_count(:model)[model]
+      end
+
+      Taxonomy.as_taxonomy(org2, nil) do
+        assert_equal 1, hosts_count(:model)[model]
+      end
+
+      Taxonomy.as_taxonomy(nil, loc2) do
         assert_equal 1, hosts_count(:model)[model]
       end
 
@@ -66,10 +80,15 @@ class HostCounterTest < ActiveSupport::TestCase
       end
     end
 
-    test 'it should count hosts associated to location/organization even though current location/organization is set' do
+    test 'it should count hosts associated to organization even though current organization is set' do
       Taxonomy.as_taxonomy(org1, loc2) do
-        assert_equal 2, hosts_count(:organization).hosts_count.count
-        assert_equal 2, hosts_count(:location).hosts_count.count
+        assert_equal 4, hosts_count(:organization).hosts_count.values.sum
+      end
+    end
+
+    test 'it should count hosts associated to location even though current location is set' do
+      Taxonomy.as_taxonomy(org1, loc2) do
+        assert_equal 4, hosts_count(:location).hosts_count.values.sum
       end
     end
   end


### PR DESCRIPTION
If a user is in multiple organizations the host count which is displayed on different UI pages depends on the selected organization.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
