### PR TITLE
Refs #37936 - Correct documentation for invalidating multiple users token

### DIFF
--- a/app/controllers/api/v2/registration_tokens_controller.rb
+++ b/app/controllers/api/v2/registration_tokens_controller.rb
@@ -40,7 +40,7 @@ module Api
       end
 
       api :DELETE, "/registration_tokens", N_("Invalidate all registration tokens for multiple users")
-      param :search, String, :desc => N_("URL-encoded search query that selects users for which registration tokens will be invalidated. Search query example: id ^ (2, 4, 6)"), :required => true
+      param :search, String, :desc => N_("Search query that selects users for which registration tokens will be invalidated. Search query example: id ^ (2, 4, 6)"), :required => true
       description <<-DOC
       The users you specify will no longer be able to register hosts by using their JWTs.
       DOC


### PR DESCRIPTION
"URL encoding" is optional in sending curl command. So instead of removing it for hammer description, it is a better solution to remove it from curl description itself.
(cherry picked from commit [1ce151d])
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
