### PR TITLE
Fixes #38316 Keep the password value after an unsuccessful host creation

### DIFF
--- a/app/views/hosts/_operating_system.html.erb
+++ b/app/views/hosts/_operating_system.html.erb
@@ -22,10 +22,15 @@
 <% end %>
 
 <div id='root_password'>
+  <%
+    pass_keep_value = %w[clone create update].include?(action_name) && @host.root_pass_changed?
+    unset_value = %w[edit update].include?(action_name) && !@host.root_pass_changed?
+  %>
   <%= password_f f, :root_pass, :required => true,
-                 :unset => action_name == "edit", :keep_value => action_name == "clone",
-                 :placeholder => (@host.root_pass.empty?) ? nil : "**********",
-                 :help_inline => _("Password must be 8 characters or more.") + ((@host.root_pass_source.present?) ? " " + _("The password is currently set by %s.") % _(@host.root_pass_source) : "") %>
+                    :unset => unset_value,
+                    :keep_value => pass_keep_value,
+                    :placeholder => (@host.root_pass.empty?) ? nil : "**********",
+                    :help_inline => _("Password must be 8 characters or more.") + ((@host.root_pass_source.present?) ? " " + _("The password is currently set by %s.") % _(@host.root_pass_source) : "") %>
 </div>
 <!-- this section is used for displaying the provisioning scripts-->
 <div class="form-group">


### PR DESCRIPTION
**Steps to reproduce**
* Go to the Host UI form
* Fill in all the data, but leave the MAC address empty
* Submit the form

**Before**
* The root password is deleted

**With the fix**
* Password value is not reset
