### PR TITLE
Fixes #38318 - Fix template debian/suse ca-trust

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ca_registration.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ca_registration.erb
@@ -16,16 +16,21 @@ description: |
   if [ -f "$KATELLO_SERVER_CA_CERT" ]; then
     <%= save_to_file('"$KATELLO_SERVER_CA_CERT"', foreman_server_ca_cert) -%>
 
-    if [ -f /etc/debian_version ]; then
-      CA_TRUST_ANCHORS=/usr/local/share/ca-certificates/
+    . /etc/os-release
+
+    if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ]; then
+      # update-ca-certificates is picky and only looks at .crt files
+      CA_TRUST_ANCHOR_CERT=/usr/local/share/ca-certificates/katello-server-ca.crt
+    elif [ "$ID" = "sles" ] || [ "$ID_LIKE" = "suse" ] || [ "$ID_LIKE" = "suse opensuse" ]; then
+      CA_TRUST_ANCHOR_CERT=/etc/pki/trust/anchors/katello-server-ca.pem
     else
-      CA_TRUST_ANCHORS=/etc/pki/ca-trust/source/anchors
+      CA_TRUST_ANCHOR_CERT=/etc/pki/ca-trust/source/anchors/katello-server-ca.pem
     fi
 
     # Add the Katello CA certificate to the system-wide CA certificate store
-    cp $KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHORS
+    cp $KATELLO_SERVER_CA_CERT $CA_TRUST_ANCHOR_CERT
 
-    if [ -f /etc/debian_version ]; then
+    if [ "$ID" = "debian" ] || [ "$ID_LIKE" = "debian" ] || [ "$ID" = "sles" ] || [ "$ID_LIKE" = "suse" ] || [ "$ID_LIKE" = "suse opensuse" ]; then
       update-ca-certificates
     else
       update-ca-trust


### PR DESCRIPTION
Debian's `update-ca-certificates` tool needs the certificate-file to have file-extension 'crt'.

SUSE was not handled at all.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
