### PR TITLE
Fixes #38321 - taxonomy rb tests randomly failing

### DIFF
--- a/test/integration/location_js_test.rb
+++ b/test/integration/location_js_test.rb
@@ -13,9 +13,11 @@ class LocationJSTest < IntegrationTestWithJavascript
     assert_new_button(locations_path, "New Location", new_location_path)
     fill_in "location_name", :with => "Raleigh"
     click_button "Submit"
-    assert_current_path step2_location_path(Location.unscoped.order(:id).last)
+    # wait for submit to finish
+    page.all('.breadcrumb-item div', text: 'Edit Raleigh')
+    assert_current_path step2_location_path(Location.find_by(name: "Raleigh"))
     click_link "Proceed to Edit"
-    assert_current_path edit_location_path(Location.unscoped.order(:id).last)
+    assert_current_path edit_location_path(Location.find_by(name: "Raleigh"))
     assert_breadcrumb_text('Edit')
   end
 end

--- a/test/integration/organization_js_test.rb
+++ b/test/integration/organization_js_test.rb
@@ -13,9 +13,11 @@ class OrganizationJSTest < IntegrationTestWithJavascript
     assert_new_button(organizations_path, "New Organization", new_organization_path)
     fill_in "organization_name", :with => "Finance"
     click_button "Submit"
-    assert_current_path step2_organization_path(Organization.unscoped.order(:id).last)
+    # wait for submit to finish
+    page.all('.breadcrumb-item div', text: 'Edit Finance')
+    assert_current_path step2_organization_path(Organization.find_by(name: "Finance"))
     click_link "Proceed to Edit"
-    assert_current_path edit_organization_path(Organization.unscoped.order(:id).last)
+    assert_current_path edit_organization_path(Organization.find_by(name: "Finance"))
     assert_breadcrumb_text('Edit')
   end
 


### PR DESCRIPTION
In ci some times the org test, some times the loc test and sometimes both fail.
The reason seems to be `taxonomy.unscoped.order(:id).last` run before `  def create   if @taxonomy.save`  the save happens.
```
retry 'test_0002_create new page when some hosts are NOT assigned a organization - click Proceed to Edit' count: 3, msg: expected "/organizations/447626439-Finance/step2" to equal "/organizations/447626438-Organization%201/step2"

Error: Failure: test_0002_create new page when some hosts are NOT assigned a organization - click Proceed to Edit
```