### PR TITLE
Fixes #38322 - compact ui setting for tables

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -675,3 +675,13 @@ td .dropdown-menu > li > a.disabled:focus {
 span.btn a.disabled {
  color: #8b8d8f;
 }
+
+.compact-ui {
+  td.pf-v5-c-table__td {
+    padding-top: 2px;
+    padding-bottom: 2px;
+    > button {
+      padding:0;
+    }
+  }
+}

--- a/app/controllers/api/v2/users_controller.rb
+++ b/app/controllers/api/v2/users_controller.rb
@@ -63,6 +63,7 @@ module Api
         param :role_ids, Array, :require => false
         param :mail_enabled, :bool, :desc => N_("Enable user's email")
         param_group :taxonomies, ::Api::V2::BaseController
+        param :ui_compact_mode, :bool, :desc => N_("Use compact UI")
       end
 
       def_param_group :user do

--- a/app/controllers/concerns/foreman/controller/parameters/user.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/user.rb
@@ -19,6 +19,7 @@ module Foreman::Controller::Parameters::User
           :password_confirmation,
           :timezone,
           :disabled,
+          :ui_compact_mode,
           :user_mail_notifications_attributes => [user_mail_notification_params_filter]
 
         filter.permit do |ctx|

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -414,7 +414,7 @@ module ApplicationHelper
       docUrl: documentation_url,
       location: Location.current && { id: Location.current.id, title: Location.current.title },
       organization: Organization.current && { id: Organization.current.id, title: Organization.current.title },
-      user: User.current&.attributes&.slice('id', 'login', 'firstname', 'lastname', 'admin'),
+      user: User.current&.attributes&.slice('id', 'login', 'firstname', 'lastname', 'admin', 'ui_compact_mode'),
       user_settings: {
         lab_features: Setting[:lab_features],
       },

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -268,6 +268,10 @@ module LayoutHelper
     "pf-m-redhat-font foreman-theme"
   end
 
+  def all_body_css_classes
+    body_css_classes + ' ' + (User.current&.ui_compact_mode ? 'compact-ui' : '')
+  end
+
   private
 
   def table_css_classes(classes = '')

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -35,8 +35,7 @@
     <%= yield(:head) %>
   </head>
 
-  <body class='<%= body_css_classes %>'>
-  
+  <body class='<%= all_body_css_classes %>'>
     <%= javascript_include_tag("/webpack/#{get_webpack_chunk('vendor', 'js')}") %>
     <%= javascript_include_tag("/webpack/#{get_webpack_chunk('bundle', 'js')}") %>
     <%= javascript_include_tag("/webpack/#{get_webpack_chunk('reactExports', 'js')}") %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -21,6 +21,7 @@
     <% if @editing_self %>
       <li><a href='#jwt_tokens' data-toggle='tab'><%= _('Registration Tokens') %></a></li>
     <% end %>
+    <li><a href='#ui_preferences' data-toggle='tab'><%= _('UI Preferences') %></a></li>
     <%= render_tab_header_for(:main_tabs, :subject => @user, :form => f) %>
   </ul>
 
@@ -142,6 +143,10 @@
     <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @user,
                :html_options => user_taxonomies_html_options(@user)
     %>
+    
+    <div class='tab-pane' id='ui_preferences'>
+      <%= checkbox_f f, :ui_compact_mode, :label => _("Compact table mode"),  :label_help => _("Will show table rows with less space between items") %>
+    </div>
     <%= render_tab_content_for(:main_tabs, :subject => @user, :form => f) %>
   </div>
 

--- a/db/migrate/20250328153630_add_ui_compact_mode_to_user.rb
+++ b/db/migrate/20250328153630_add_ui_compact_mode_to_user.rb
@@ -1,0 +1,5 @@
+class AddUICompactModeToUser < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :ui_compact_mode, :boolean, :default => false
+  end
+end


### PR DESCRIPTION
Created a user setting (and category) for compact mode, made it generic incase we find more places to reduce padding, but calling it "compact tables" setting add later adding more compact settings is also an option.
I put it in the UI context in case we need to use but its not needed for the ui changes in this PR.
![image](https://github.com/user-attachments/assets/e7ef6e98-b780-4737-a3a3-2e496e2fe37d)

Added a all_body_css_classes cause it made sense to add it in a ruby file instead of the html, I cant add things to body_css_classes  cause it gets overriden by the theme plugin (yes a better name for body_css_classes was foreman_css_class_name but its too late :upside_down_face: )
