### PR TITLE
Fixes #38078 - Correctly create a DB entry for settings test

### DIFF
--- a/test/unit/tasks/seeds_test.rb
+++ b/test/unit/tasks/seeds_test.rb
@@ -240,7 +240,7 @@ class SeedsTest < ActiveSupport::TestCase
     end
 
     test 'does not change value for existing setting' do
-      Setting[:instance_id] = Foreman.uuid
+      Setting.create(name: 'instance_id', value: Foreman.uuid)
       Setting.expects(:[]=).with(:instance_id, anything).never
       seed('190-instance_id.rb')
     end


### PR DESCRIPTION
In `test/unit/tasks/seeds_test.rb` the `test does not change value for existing setting` is failing because the DB setting is never created. Due to a bug in mocha (that 2.7.0 fixed) this was never uncovered.

Fixes: 02dd9831bd12 ("Fixes #36395 - move value setting to seed") (cherry picked from commit 2620245552250b038da003e38c6bd1df85f4fb5c)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
