### PR TITLE
Fixes #38329 - Avoid frozen string modification

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -23,9 +23,9 @@ module Api
 
     rescue_from NoMethodError do |error|
       Foreman::Logging.exception("Action failed", error)
-      message = _("Internal Server Error: the server was unable to finish the request. ")
-      message << _("This may be caused by unavailability of some required service, incorrect API call or a server-side bug. ")
-      message << _("There may be more information in the server's logs.")
+      message = _("Internal Server Error: the server was unable to finish the request. " \
+        "This may be caused by unavailability of some required service, incorrect API call or a server-side bug. " \
+        "There may be more information in the server's logs.")
       render_error 'custom_error', :status => :internal_server_error, :locals => { :message => message }
     end
 

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -492,7 +492,7 @@ class HostsController < ApplicationController
     message = ''
     all_fails.each_pair do |key, values|
       unless values.empty?
-        message << ((n_("%{config_type} rebuild failed for host: %{host_names}.",
+        message += ((n_("%{config_type} rebuild failed for host: %{host_names}.",
           "%{config_type} rebuild failed for hosts: %{host_names}.",
           values.count) % {:config_type => _(key), :host_names => values.map(&:to_label).to_sentence})) + " "
       end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -461,7 +461,7 @@ module FormHelper
 
   def link_to_add_fields_classes(options = {})
     classes = "btn btn-default #{options[:class]}"
-    classes << ' btn-primary' if options.fetch(:primary_button, true)
+    classes += ' btn-primary' if options.fetch(:primary_button, true)
     classes
   end
 end

--- a/app/services/foreman/plugin/role_lock.rb
+++ b/app/services/foreman/plugin/role_lock.rb
@@ -70,7 +70,7 @@ module Foreman
 
       def generate_name(prefix, original_name, num = nil)
         new_name = "#{prefix} #{original_name}"
-        num ? new_name << " #{num}" : new_name
+        num ? "#{new_name} #{num}" : new_name
       end
 
       def last_role_num(role, role_name)

--- a/app/services/foreman/renderer/scope/report.rb
+++ b/app/services/foreman/renderer/scope/report.rb
@@ -121,7 +121,7 @@ module Foreman
         end
 
         def report_render_html
-          html = ""
+          html = +""
 
           html << "<html><head><title>#{@template_name}</title><style>#{html_style}</style></head><body><table><thead><tr>"
           html << @report_headers.map { |header| "<th>#{ERB::Util.html_escape(header)}</th>" }.join('')

--- a/app/validators/pxe_template_name_validator.rb
+++ b/app/validators/pxe_template_name_validator.rb
@@ -5,7 +5,7 @@ class PxeTemplateNameValidator < ActiveModel::EachValidator
       tmpl = ProvisioningTemplate.find_global_default_template value, template_kind
       unless tmpl
         msg = _('is invalid. No provisioning template with name "%{name}" and kind "%{kind}" found. ') % { :name => value, :kind => template_kind }
-        msg << _('Consult "Provisioning Templates" page to see what templates are available.')
+        msg += _('Consult "Provisioning Templates" page to see what templates are available.')
         record.errors.add(attribute, msg)
       end
     end

--- a/app/views/unattended/report_templates/host_-_last_checkin.erb
+++ b/app/views/unattended/report_templates/host_-_last_checkin.erb
@@ -41,7 +41,7 @@ require:
 -%>
 <%- include_unknown_search = input('Include unknown') == 'true' ? ' or null? last_checkin' : '' %>
 <%- search = "(last_checkin < \"#{input('Interval')} ago\"#{include_unknown_search})" -%>
-<%- search << "and #{input('Host filter')}" if input('Host filter').present? -%>
+<%- search += "and #{input('Host filter')}" if input('Host filter').present? -%>
 <%- report_headers('Name', 'IP', 'IPv6', 'Last Checkin') -%>
 <%- load_hosts(search: search, preload: [ :subscription_facet, :interfaces ]).each_record do |host| -%>
 <%-   report_row(

--- a/lib/tasks/backup.rake
+++ b/lib/tasks/backup.rake
@@ -23,7 +23,7 @@ namespace :db do
     backup_dir  = File.expand_path('../../db', __dir__)
     backup_name = ENV['destination'] || File.join(backup_dir, "foreman.#{Time.now.to_i}")
     unless ENV["destination"].present?
-      backup_name << '.sql'
+      backup_name += '.sql'
     end
 
     if ENV['tables'].present?

--- a/test/controllers/api/v2/base_controller_subclass_test.rb
+++ b/test/controllers/api/v2/base_controller_subclass_test.rb
@@ -124,9 +124,9 @@ class Api::V2::TestableControllerTest < ActionController::TestCase
   test "should have server error message" do
     get :new
     assert_response 500
-    msg = "Internal Server Error: the server was unable to finish the request. "
-    msg << "This may be caused by unavailability of some required service, incorrect API call or a server-side bug. "
-    msg << "There may be more information in the server's logs."
+    msg = "Internal Server Error: the server was unable to finish the request. " \
+      "This may be caused by unavailability of some required service, incorrect API call or a server-side bug. " \
+      "There may be more information in the server's logs."
     assert_equal JSON.parse(response.body)['error']['message'], msg
   end
 


### PR DESCRIPTION
When dealing with frozen strings, `<<` breaks. Using `+=` unfreezes the string and is thus safer.

    [1] pry(main)> msg = 'x'.freeze
    => "x"
    [2] pry(main)> msg.frozen?
    => true
    [3] pry(main)> msg << 'y'
    FrozenError: can't modify frozen String: "x" (FrozenError)
    from (pry):3:in `__pry__'
    [4] pry(main)> msg += 'y'
    => "xy"
    [5] pry(main)> msg.frozen?
    => false

This an attempt at solving the spurious error:

    FrozenError: can't modify frozen String: ""

But it's also very likely this comes from a library somewhere.