### PR TITLE
Fixes #38331 - CardTemplate should have cardId as string

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Templates/CardItem/CardTemplate/index.js
@@ -25,7 +25,8 @@ const CardTemplate = ({
   const { cardExpandStates, dispatch, registerCard } = useContext(
     CardExpansionContext
   );
-  const cardId = header;
+  const cardId =
+    typeof header === 'string' || header instanceof String ? header : ouiaId;
   const [dropdownVisibility, setDropdownVisibility] = useState(false);
   const isExpanded = expandable && cardExpandStates[`${cardId}`] === true;
   const onDropdownToggle = isOpen => setDropdownVisibility(isOpen);


### PR DESCRIPTION
`CardTemplate` should have `cardId` as string which is used by `cardExpandStates`.

![image](https://github.com/user-attachments/assets/638f7dd7-9cc5-4d8e-9203-328b20d7cc03)

Blocks https://github.com/Katello/katello/pull/11356.
