### PR TITLE
Fixes #38333 - correct the TreeView prop name for checkboxes

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/ColumnSelector.js
@@ -187,7 +187,7 @@ const ColumnSelector = props => {
             </Button>,
           ]}
         >
-          <TreeView data={selectedColumns} onCheck={onCheck} hasChecks />
+          <TreeView data={selectedColumns} onCheck={onCheck} hasCheckboxes />
         </Modal>
       </div>
     </div>


### PR DESCRIPTION
Since the PF5 update, the Manage Columns modal is broken. It does not have any checkboxes; just the tree view. So you can't change anything.

This should fix it. Turns out `hasChecks` changed to `hasCheckboxes`. Not sure why the PF4 > PF5 codemod didn't catch that.
