### PR TITLE
Fixes #38340 - auto-set preseed netplan ids

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_generic_interface.erb
@@ -8,9 +8,11 @@ oses:
 - Ubuntu
 -%>
 <%- if @interface.identifier.blank? -%>
-    id0:
+    <%= @label %>:
+        <%- unless @interface.virtual? -%>
         match:
-          macaddress: "<%= @host.mac %>"
+          macaddress: "<%= @interface.mac %>"
+        <%- end -%>
 <%- else -%>
     <%= @interface.identifier %>:
 <%- end -%>

--- a/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/preseed_netplan_setup.erb
@@ -23,15 +23,15 @@ oses:
 <%#
 ##### Processing bond-interfaces #####
 -%>
-<%- found = false -%>
+<%- id = 0 -%>
 <%- @host.bond_interfaces.each do | bond | -%>
   <%- bonding_interfaces.push(bond.identifier) -%>
-  <%- if !found -%>
-  <%- found = true -%>
+  <%- if id == 0 -%>
     bonds:
   <%- end -%>
 <%- result= snippet('preseed_netplan_generic_interface', :variables => {
                   :interface => bond,
+                  :label => "bond#{id}",
                   :subnet => bond.subnet,
                   :subnet6 => bond.subnet6,
                   :dhcp => bond.subnet.nil? ? false : bond.subnet.dhcp_boot_mode?,
@@ -44,41 +44,43 @@ oses:
           <%- options.each do | option | -%>
           <%= option.gsub('=',': ') %>
           <%- end -%>
+  <%- id += 1 -%>
 <% end -%>
 <%#
 ##### Processing bridge interfaces #####
 -%>
-<%- found = false -%>
+<%- id = 0 -%>
 <%- @host.bridge_interfaces.each do | bridge | -%>
 <%- next if bonding_interfaces.include?(bridge.identifier) -%>
   <%- bridged_interfaces.push(bridge.identifier) -%>
-  <%- if !found -%>
-  <%- found = true -%>
+  <%- if id == 0 -%>
     bridges:
   <%- end -%>
 <%- result= snippet('preseed_netplan_generic_interface', :variables => {
                   :interface => bridge,
+                  :label => "bridge#{id}",
                   :subnet => bridge.subnet,
                   :subnet6 => bridge.subnet6,
                   :dhcp => bridge.subnet.nil? ? false : bridge.subnet.dhcp_boot_mode?,
                   :dhcp6 => bridge.subnet6.nil? ? false : bridge.subnet6.dhcp_boot_mode? }) -%>
   <%= result -%>
+  <%- id += 1 -%>
 <%- end -%>
 <%#
 ##### Processing vlan interfaces #####
 -%>
-<%- found = false -%>
+<%- id = 0 -%>
 <%- @host.managed_interfaces.each do | vlan | -%>
 <%- next if bonding_interfaces.include?(vlan.identifier) -%>
 <%- next if bridged_interfaces.include?(vlan.identifier) -%>
 <%- next if !vlan.virtual? -%>
   <%- vlans_interfaces.push(vlan.identifier) -%>
-  <%- if !found -%>
-  <%- found = true -%>
+  <%- if id == 0 -%>
     vlans:
   <%- end -%>
 <%- result= snippet('preseed_netplan_generic_interface', :variables => {
                   :interface => vlan,
+                  :label => "vlan#{id}",
                   :subnet => vlan.subnet,
                   :subnet6 => vlan.subnet6,
                   :dhcp => vlan.subnet.nil? ? false : vlan.subnet.dhcp_boot_mode?,
@@ -86,26 +88,28 @@ oses:
   <%= result -%>
         id: <%= vlan.tag %>
         link: <%= vlan.attached_to %>
+  <%- id += 1 -%>
 <%- end -%>
 <%#
 ##### Processing remaining interfaces (ethernets) #####
 -%>
-<%- found = false -%>
+<%- id = 0 -%>
 <%- @host.managed_interfaces.each do | interface | -%>
 <%- next if bonding_interfaces.include?(interface.identifier) -%>
 <%- next if bridged_interfaces.include?(interface.identifier) -%>
 <%- next if vlans_interfaces.include?(interface.identifier) -%>
   <%- interface_subnet = interface.subnet -%>
-  <%- if !found -%>
-  <%- found = true -%>
+  <%- if id == 0 -%>
     ethernets:
   <%- end -%>
 <%- result= snippet('preseed_netplan_generic_interface', :variables => {
                   :interface => interface,
+                  :label => "id#{id}",
                   :subnet => interface.subnet,
                   :subnet6 => interface.subnet6,
                   :dhcp => interface.subnet.nil? ? false : interface.subnet.dhcp_boot_mode?,
                   :dhcp6 => interface.subnet6.nil? ? false : interface.subnet6.dhcp_boot_mode? }) -%>
   <%= result -%>
+  <%- id += 1 -%>
 <%- end -%>
 <%- end -%>


### PR DESCRIPTION
Based on the name netplan types from https://netplan.readthedocs.io/en/latest/netplan-yaml/


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
