### PR TITLE
Dynamically determine the version based on git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+VERSION export-subst

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,7 @@ actions:
     - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foreman/foreman.logrotate -O foreman.logrotate"
     - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foreman/foreman.cron.d -O foreman.cron.d"
     - "wget https://raw.githubusercontent.com/theforeman/foreman-packaging/rpm/develop/packages/foreman/foreman/foreman.tmpfiles -O foreman.tmpfiles"
-  get-current-version: "sed 's/-develop//' VERSION"
+  get-current-version: "git describe --abbrev=0 | sed 's/-develop//'"
 
 jobs:
   - job: copr_build

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-3.15.0-develop
+$Format:%(describe)$

--- a/app/services/foreman/version.rb
+++ b/app/services/foreman/version.rb
@@ -7,9 +7,11 @@ module Foreman
     def initialize(givenversion = nil)
       if givenversion
         @version = givenversion
+      elsif File.exist?(File.join(root, '.git'))
+        command = ['git', '--git-dir', File.join(root, '.git'), 'describe']
+        @version = IO.popen(command) { |f| f.readline }.chomp
       else
-        root = File.expand_path(File.dirname(__FILE__) + "/../../..")
-        @version = File.read(root + "/VERSION").chomp # or fail if not found
+        @version = File.read(File.join(root, "VERSION")).chomp # or fail if not found
       end
       @major, @minor, @build = @version.scan(/\d+/)
       @short = "#{@major}.#{@minor}"
@@ -25,6 +27,13 @@ module Foreman
 
     def to_s
       @version
+    end
+
+    private
+
+    # Find the rails root. This is undefined in very early init
+    def root
+      Rails.root || File.join(__dir__, '..', '..', '..')
     end
   end
 end

--- a/lib/tasks/pkg.rake
+++ b/lib/tasks/pkg.rake
@@ -20,11 +20,10 @@ namespace :pkg do
 
   desc 'Generate package source tar.bz2, supply ref=<tag> for tags'
   task :generate_source do
-    File.exist?('pkg') || FileUtils.mkdir('pkg')
+    FileUtils.mkdir_p('pkg')
     ref = ENV['ref'] || 'HEAD'
     name = 'foreman'
-    version = `git show #{ref}:VERSION`.chomp
-    raise "can't find VERSION from #{ref}" if version.empty?
+    version = `git describe --abbrev=0 #{ref}`.chomp
     filename = "pkg/#{name}-#{version}.tar.bz2"
     `git archive --prefix=#{name}-#{version}/ #{ref} | bzip2 -9 > #{filename}`
     raise 'Failed to generate the source archive' if $CHILD_STATUS != 0


### PR DESCRIPTION
This takes an effort to avoid maintaining the VERSION file in git but instead rely on git to provide the version based on tags.

The next step is to modify code that relies on the content of this file.

The version shown at runtime now determined by calling out to git. This could be made a bit more robust but should suffice for a first version.

For the archive export it uses --abbrev=0 to remove the specific git commit and only show the latest tag it was based on. This makes the filename predictable, which is needed for our nightly package building. This requires a procedure change to start tagging develop versions when we branch to be useful.

Packit also uses the VERSION file and is replaced with git describe as well. This will fail until we push the tags at branching points.

The final step it takes is to replace VERSION with some string that git will replace on export, as it's told to via an attribute.

Currently a draft because I intend to submit an RFC and link to this.