### PR TITLE
Fixes #38338 - Align host status icons

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/AggregateStatusCard.js
@@ -92,12 +92,7 @@ const AggregateStatusCard = ({
         <CardTitle>
           <span>
             <span style={{ marginRight: '0.5rem' }}>{__('Host status')}</span>
-            {!isOKState && (
-              <StatusIcon
-                statusNumber={global}
-                style={{ position: 'relative', top: '2px' }}
-              />
-            )}
+            {!isOKState && <StatusIcon statusNumber={global} />}
           </span>
         </CardTitle>
         <CardBody style={{ height: '129px' }}>

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusIcon.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/StatusIcon.js
@@ -15,49 +15,52 @@ import {
   WARNING_STATUS_STATE,
 } from './Constants';
 
-const StatusIcon = ({ statusNumber, label, style }) => {
-  switch (statusNumber) {
-    case OK_STATUS_STATE:
-      return (
-        <span className="status-success" style={style}>
-          <Icon isInline>
-            <CheckCircleIcon />
-          </Icon>
-          {label}
-        </span>
-      );
-    case WARNING_STATUS_STATE:
-      return (
-        <span className="status-warning" style={style}>
-          <Icon isInline>
-            <ExclamationTriangleIcon />
-          </Icon>
-          {label}
-        </span>
-      );
-
-    case ERROR_STATUS_STATE:
-      return (
-        <span className="status-error" style={style}>
-          <Icon isInline>
-            <ExclamationCircleIcon />
-          </Icon>
-          {label}
-        </span>
-      );
-    case NA_STATUS_STATE:
-      return (
-        <span className="disabled" style={style}>
-          <Icon isInline>
-            <BanIcon />
-          </Icon>
-          {label}
-        </span>
-      );
-    default:
-      return null;
-  }
-};
+const StatusIcon = ({ statusNumber, label }) => (
+  <span className="host-status-icon-container">
+    {(() => {
+      switch (statusNumber) {
+        case OK_STATUS_STATE:
+          return (
+            <span className="status-success">
+              <Icon isInline>
+                <CheckCircleIcon />
+              </Icon>
+              {label}
+            </span>
+          );
+        case WARNING_STATUS_STATE:
+          return (
+            <span className="status-warning">
+              <Icon isInline>
+                <ExclamationTriangleIcon />
+              </Icon>
+              {label}
+            </span>
+          );
+        case ERROR_STATUS_STATE:
+          return (
+            <span className="status-error">
+              <Icon isInline>
+                <ExclamationCircleIcon />
+              </Icon>
+              {label}
+            </span>
+          );
+        case NA_STATUS_STATE:
+          return (
+            <span className="disabled">
+              <Icon isInline>
+                <BanIcon />
+              </Icon>
+              {label}
+            </span>
+          );
+        default:
+          return null;
+      }
+    })()}
+  </span>
+);
 
 StatusIcon.propTypes = {
   label: PropTypes.string,

--- a/webpack/assets/javascripts/react_app/components/HostDetails/Status/styles.scss
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/Status/styles.scss
@@ -7,19 +7,32 @@
     }
   }
 }
+.host-status-icon-container {
+  .disabled {
+    color: var(--pf-v5-global--disabled-color--200);
+    .pf-v5-c-icon {
+      margin-right: 4px;
+    }
+  }
 
-.disabled {
-  color: var(--pf-v5-global--disabled-color--200);
-}
+  .status-success {
+    color: var(--pf-v5-global--success-color--100);
+    .pf-v5-c-icon {
+      margin-right: 4px;
+    }
+  }
 
-.status-success {
-  color: var(--pf-v5-global--success-color--100);
-}
+  .status-error {
+    color: var(--pf-v5-global--danger-color--100);
+    .pf-v5-c-icon {
+      margin-right: 4px;
+    }
+  }
 
-.status-error {
-  color: var(--pf-v5-global--danger-color--100);
-}
-
-.status-warning {
-  color: var(--pf-v5-global--warning-color--100);
+  .status-warning {
+    color: var(--pf-v5-global--warning-color--100);
+    .pf-v5-c-icon {
+      margin-right: 4px;
+    }
+  }
 }


### PR DESCRIPTION
Purpose of the PR:

This PR resolves an issue where the host status card on the host details page displayed icons that were out of vertical alignment with the numbers. The issue was caused during the PF5 migration, and I have adjusted the alignment of the icons to ensure proper vertical alignment.

Screenshots:

Before: 
![rhel9b-fedora-example-com-04-01-2025_12_58_PM](https://github.com/user-attachments/assets/069c1125-26b8-438a-af2a-b8fe6c007ba1)

After: 
![image](https://github.com/user-attachments/assets/a0ce6b19-26b1-4f45-b283-a975b8481f8a)

