### PR TITLE
Fixes #38360 - Add RAM to reported_data output

### DIFF
--- a/app/views/api/v2/hosts/reported_data.json.rabl
+++ b/app/views/api/v2/hosts/reported_data.json.rabl
@@ -3,5 +3,5 @@ glue(@facet) do
 end
 
 child(@facet => :reported_data) do
-  attributes :boot_time, :cores, :sockets, :disks_total, :kernel_version, :bios_vendor, :bios_release_date, :bios_version
+  attributes :boot_time, :cores, :sockets, :ram, :disks_total, :kernel_version, :bios_vendor, :bios_release_date, :bios_version
 end

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.js
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { TableText } from '@patternfly/react-table';
 import { UserIcon, UsersIcon } from '@patternfly/react-icons';
+import { number_to_human_size as NumberToHumanSize } from 'number_helpers';
 import { translate as __ } from '../../../common/I18n';
 import forceSingleton from '../../../common/forceSingleton';
 import RelativeDateTime from '../../common/dates/RelativeDateTime';
@@ -163,7 +164,12 @@ const reportedDataColumns = [
   {
     columnName: 'ram',
     title: __('RAM'),
-    wrapper: hostDetails => hostDetails?.reported_data?.ram,
+    wrapper: hostDetails => {
+      if (!hostDetails?.reported_data?.ram) return null;
+      return NumberToHumanSize(hostDetails.reported_data.ram * 1024 * 1024, {
+        strip_insignificant_zeros: true,
+      });
+    },
     isSorted: false,
     weight: 1300,
   },
@@ -177,7 +183,12 @@ const reportedDataColumns = [
   {
     columnName: 'disks_total',
     title: __('Total disk space'),
-    wrapper: hostDetails => hostDetails?.reported_data?.disks_total,
+    wrapper: hostDetails => {
+      if (!hostDetails?.reported_data?.disks_total) return null;
+      return NumberToHumanSize(hostDetails.reported_data.disks_total, {
+        strip_insignificant_zeros: true,
+      });
+    },
     isSorted: false,
     weight: 1500,
   },


### PR DESCRIPTION
Add RAM to reported_data output so the ram column on the new hosts page shows the memory correctly.

![ram](https://github.com/user-attachments/assets/755e8d25-f250-4e6c-8170-f5488ca737a7)
