### PR TITLE
Fixes #38361 - Use the system's SSH instead of net/ssh for provisioning

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -43,11 +43,11 @@ module Orchestration::SshProvision
   def setSSHWaitForResponse
     logger.info "Starting SSH provisioning script - waiting for #{provision_host} to respond"
     if compute_resource.respond_to?(:key_pair) && compute_resource.key_pair.try(:secret)
-      credentials = { :key_data => [compute_resource.key_pair.secret] }
+      credentials = { :key_data => compute_resource.key_pair.secret }
     elsif vm.respond_to?(:password) && vm.password.present?
-      credentials = { :password => vm.password, :auth_methods => ["password", "keyboard-interactive"] }
+      credentials = { :password => vm.password }
     elsif image.respond_to?(:password) && image.password.present?
-      credentials = { :password => image.password, :auth_methods => ["password", "keyboard-interactive"] }
+      credentials = { :password => image.password }
     else
       raise ::Foreman::Exception.new(N_('Unable to find proper authentication method'))
     end

--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -1,113 +1,184 @@
-require 'timeout'
+require 'open3'
 
-class Foreman::Provision::Ssh
-  attr_reader :template, :uuid, :results, :address, :username, :options
+module Foreman
+  module Provision
+    class Ssh
+      # options: {
+      #   template: "/path/to/template",
+      #   uuid:     "uuid",
+      #   key_data: "private-key-content",
+      #   password: "string",
+      # }
+      def initialize(address, username = "root", options = {})
+        @username = username
+        @address  = address
+        @template = options.delete(:template) || raise("must provide a template")
+        @uuid     = options.delete(:uuid)     || "#{@address}-#{@username}"
+        @options  = options
+        @tmp_key_path = create_tmp_key
 
-  def initialize(address, username = "root", options = { })
-    @username = username
-    @address  = address
-    @template = options.delete(:template) || raise("must provide a template")
-    @uuid     = options.delete(:uuid)     || "#{address}-#{username}"
-    @options  = defaults.merge(options)
-
-    initiate_connection!
-  end
-
-  def deploy!
-    logger.debug "about to upload #{template} to remote system at #{remote_script}"
-    scp.upload(template, remote_script)
-    logger.debug "about to execute #{command}"
-    @results = ssh.run(command)
-    log_stdout
-    log_stderr
-    success?
-  end
-
-  private
-
-  def success?
-    return true if results.empty?
-    results.map(&:status).compact == [0]
-  end
-
-  def log_stdout
-    results.each do |r|
-      r.stdout.split("\n").each { |l| logger.debug l }
-    end
-  end
-
-  def log_stderr
-    results.each do |r|
-      r.stderr.split("\n").each { |l| logger.warn l }
-    end
-  end
-
-  def remote_script
-    "bootstrap-#{uuid}"
-  end
-
-  def command_prefix
-    (username == "root") ? "" : "sudo "
-  end
-
-  def command
-    # Use the users home to store the provision script since we can't reliably
-    # tell if other locations are writeable or executable by the user.
-    main_execution = "(chmod 0701 ./#{remote_script} && #{command_prefix} ./#{remote_script} ; echo $? >#{remote_script}.status) 2>&1"
-    "#{command_prefix} sh -c '#{main_execution} | tee #{remote_script}.log; exit $(cat #{remote_script}.status)'"
-  end
-
-  def defaults
-    {
-      :keys_only    => true,
-      :config       => false,
-      :auth_methods => %w(publickey),
-      :compression  => true,
-      :logger       => logger,
-    }
-  end
-
-  def logger
-    Rails.logger
-  end
-
-  def initiate_connection!
-    Timeout.timeout(Setting[:ssh_timeout].to_i) do
-      Timeout.timeout(8) do
-        ssh.run('pwd')
+        check_auth_options
+        establish_connection!
       end
-    rescue Errno::ECONNREFUSED
-      logger.debug "Connection refused for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Errno::EHOSTUNREACH
-      logger.debug "Host unreachable for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Net::SSH::Disconnect
-      logger.debug "Host dropping connections for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Net::SSH::ConnectionTimeout
-      logger.debug "Host timed out for #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Net::SSH::AuthenticationFailed
-      logger.debug "Auth failed for #{username} at #{address}, retrying"
-      sleep(2)
-      retry
-    rescue Timeout::Error
-      retry
-    rescue => e
-      Foreman::Logging.exception("SSH error", e)
+
+      def deploy!
+        upload_template
+
+        logger.debug "Executing #{main_command}"
+
+        begin
+          stdout, stderr, status = Open3.capture3(*ssh_cmd(main_command))
+          logger.debug(stdout) if stdout.presence
+          log_stderr(stderr)
+        ensure
+          cleanup_files
+        end
+
+        status.success?
+      end
+
+      private
+
+      def log_stderr(stderr)
+        return if stderr.empty?
+
+        stderr.split("\n").each { |l| logger.warn l }
+      end
+
+      # Attempt to connect to the remote host and run a simple command
+      def establish_connection!
+        start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+        logger.info "Establishing SSH connection to #{@address}"
+        logger.debug first_cmd(mask: true)
+
+        while (Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time) < Setting[:ssh_timeout].to_i
+          _stdout, stderr, status = Open3.capture3(*first_cmd)
+
+          if status.success?
+            logger.info "SSH connection successfully established to #{@address}"
+            break
+          else
+            logger.info "SSH connection to #{@address} failed. Retrying in 2 seconds..."
+            log_stderr(stderr)
+          end
+
+          sleep 2
+        end
+
+        unless status.success?
+          cleanup_files
+          raise "Failed to connect to #{@address} after #{Setting[:ssh_timeout]} seconds"
+        end
+      end
+
+      def command_prefix
+        (@username == "root") ? "" : "sudo "
+      end
+
+      # Use the users home to store the provision script since we can't reliably
+      # tell if other locations are writeable or executable by the user.
+      def main_command
+        main_execution = "(chmod 0500 #{remote_script} && #{command_prefix} #{remote_script} ; echo $? >#{remote_script}.status) 2>&1"
+        cleanup = "#{command_prefix} rm -f #{remote_script}"
+
+        "#{command_prefix} sh -c '#{main_execution} | tee #{remote_script}.log; #{cleanup}; exit $(cat #{remote_script}.status)'"
+      end
+
+      def logger
+        Rails.logger
+      end
+
+      def upload_template
+        logger.debug "Uploading template to remote system '#{@address}'"
+        logger.debug scp_cmd(mask: true)
+
+        stdout, stderr, status = Open3.capture3(*scp_cmd)
+
+        logger.debug stdout if stdout.present?
+        log_stderr(stderr)
+
+        return if status.success?
+
+        raise Foreman::Exception.new("Failed to upload '#{@template}' to remote system at #{@address}")
+      end
+
+      def passwd_cmd(mask: false)
+        return [] if @options[:password].empty?
+
+        value = mask ? '*****' : @options[:password]
+
+        [{'SSHPASS' => value }, "sshpass", "-e"]
+      end
+
+      def first_cmd(mask: false)
+        ssh_master_opts = ["-o ControlMaster=auto", "-o ControlPath=#{socket_file}", "-o ControlPersist=4m"]
+        [passwd_cmd(mask: mask), "ssh", (ssh_options + ssh_master_opts), @address, 'pwd'].flatten
+      end
+
+      def ssh_cmd(host_command, mask: false)
+        [passwd_cmd(mask: mask), "ssh", ssh_options, @address, host_command].flatten
+      end
+
+      def scp_cmd(mask: false)
+        [passwd_cmd(mask: mask), "scp", ssh_options, @template, "#{@username}@#{@address}:#{@remote_script}"].flatten
+      end
+
+      def ssh_options
+        opts = []
+
+        opts << "-o User=#{@username}"
+        opts << "-o ControlPath=#{socket_file}"
+        opts << "-o StrictHostKeychecking=no"
+        opts << "-o UserKnownHostsFile=/dev/null"
+        opts << "-o ConnectTimeout=4"
+        opts << "-o Compression=yes"
+        opts << "-o IdentityFile=#{@tmp_key_path}" if @options[:key_data].present?
+
+        methods = []
+        methods << 'publickey' if @options[:key_data].present?
+        methods << 'password' if @options[:password].present?
+
+        opts << "-o PreferredAuthentications=#{methods.join(',')}"
+
+        opts
+      end
+
+      def create_tmp_key
+        return if @options[:key_data].empty?
+
+        file = Tempfile.new("ssh-key-#{@uuid}")
+        file.write(@options[:key_data])
+        file.close
+        file.path
+      end
+
+      def check_auth_options
+        return if @options[:key_data].present? || @options[:password].present?
+
+        raise Foreman::Exception.new("Missing :key_data or :password options, no authentication method available")
+      end
+
+      def socket_file
+        @socket_file ||= begin
+          file = Tempfile.new("ssh-socket-#{@uuid}")
+          file.close
+          file.path
+        end
+      end
+
+      def cleanup_files
+        files = [socket_file]
+        files << @tmp_key_path if @options[:key_data].present?
+
+        `ssh -o ControlPath=#{socket_file} #{@address} -O exit`
+
+        FileUtils.rm_f(files)
+      end
+
+      def remote_script
+        @remote_script ||= "~/#{File.basename(@template)}"
+      end
     end
-  end
-
-  def ssh
-    Fog::SSH.new(address, username, options.merge(:timeout => 4))
-  end
-
-  def scp
-    Fog::SCP.new(address, username, options)
   end
 end


### PR DESCRIPTION
Ruby's net/ssh implementation fails to connect RHEL8 and RHEL8 with enabled FIPS.

To avoid problems in the future, use the system's SSH instead of Ruby's.

**Notes**
* `Foreman::Provision::Ssh` is used only in [core and deprecated plugins](https://github.com/search?q=org%3Atheforeman+Foreman%3A%3AProvision%3A%3ASsh&type=code); changes should not affect outsiders.
* If password and key are present in `options`, key takes precedence over the password.

Related PRs
* https://github.com/theforeman/foreman-packaging/pull/11946