### PR TITLE
Fixes #38362 - Host Form - Removal of arch resets ptable & medium

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -429,6 +429,7 @@ function architecture_selected(element) {
     },
     success: function(request) {
       $('#os_select').html(request);
+      os_selected($('.host-architecture-os-select'));
     },
   });
 }


### PR DESCRIPTION
How to test
* Go to the new Host (or host group) form
* Switch to OS tab
* Select Architecture, OS, Medium & partition table
* Unselect architecture

**BEFORE**
Medium & partition table are still selected.

**After**
Medium & partition table are unselected together with OS.