### PR TITLE
Fixes #38370 - Allow deleting hosts with null statuses

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -29,6 +29,7 @@ class Host::Managed < Host::Base
 
   belongs_to :image
   has_many :host_statuses, -> { where.not(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
+  has_many :host_null_statuses, -> { where(type: nil) }, :class_name => 'HostStatus::Status', :foreign_key => 'host_id', :inverse_of => :host, :dependent => :destroy
   has_one :configuration_status_object, :class_name => 'HostStatus::ConfigurationStatus', :foreign_key => 'host_id'
   has_one :build_status_object, :class_name => 'HostStatus::BuildStatus', :foreign_key => 'host_id'
   before_destroy :remove_reports


### PR DESCRIPTION
By some to me unknown way, some hosts can end up with a type null host status. When trying to delete such host in the UI, you get the following error:

```
Could not delete the host:
PG::ForeignKeyViolation: ERROR: update or delete on table "hosts" violates foreign key constraint "host_status_hosts_host_id_fk" on table "host_status"
DETAIL: Key (id)=(3724) is still referenced from table "host_status".
```

The ideal solution would be to find out why a null host status  is sometimes created and remove the cause, however; there are already exists a lot of deployments with large number of hosts associated with such status, and removing the cause would not help these deployments. Because of this, I believe it is beneficial to implement a workaround: delete all type null statuses associated with the host before deleting the host itself.