### PR TITLE
Fixes #38382 - TableIndexPage improvements

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -40,7 +40,7 @@ export const Table = ({
   idColumn,
   children,
   bottomPagination,
-  childrenOutsideTbody, // Expendable table rows are each a Tbody so they cant be inside the Tbody
+  childrenOutsideTbody, // Expandable table rows are each a Tbody so they cant be inside the Tbody
 }) => {
   const onPagination = newPagination => {
     setParams({ ...params, ...newPagination });
@@ -113,11 +113,19 @@ export const Table = ({
         url={url}
         refreshData={refreshData}
       />
-      <PFTable variant="compact" ouiaId="table" isStriped>
+      <PFTable
+        variant="compact"
+        ouiaId="table"
+        isStriped
+        isExpandable={childrenOutsideTbody}
+      >
         <Thead>
           <Tr ouiaId="table-header">
             {showCheckboxes && (
               <Th aria-label="checkbox-header" key="checkbox-th" />
+            )}
+            {childrenOutsideTbody && (
+              <Th aria-label="expansion-carat" key="expansion-carat" />
             )}
             {columnNamesKeys.map(k => (
               <Th


### PR DESCRIPTION
Goes with https://github.com/Katello/katello/pull/11364

To use Patternfly expandable table rows, each Tr must be enclosed in a Tbody. The `childrenOutsideTbody` prop of `<Table>` tried to address this, but there are a couple more changes needed.

1. When `childrenOutsideTbody` is passed, indicating use of expandable table rows, also render another column header for the expansion column. This way the column names do not get shifted incorrectly.
2. Pass the `isExpandable` prop to PFTable. This will tell Patternfly to properly render shading of table rows.

~~Also, this PR fixes some issues with pagination by allowing you to control both top and bottom pagination from outside TableIndexPage.~~

