### PR TITLE
Fixes #38381 - fix image-based provisioning on VMware

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -591,6 +591,9 @@ module Foreman::Model
         "resource_pool" => [args[:cluster], args[:resource_pool]],
         "boot_order" => [:disk],
         "annotation" => args[:annotation],
+        "virtual_tpm" => args[:virtual_tpm],
+        "firmware" => args[:firmware],
+        "secure_boot" => args[:secure_boot],
       }
 
       opts['transform'] = (args[:volumes].first[:thin] == 'true') ? 'sparse' : 'flat' unless args[:volumes].empty?
@@ -858,7 +861,7 @@ module Foreman::Model
     # @param firmware [String] The firmware type.
     # @return [Hash] A hash with secure boot settings if applicable.
     def generate_secure_boot_settings(firmware)
-      firmware == 'uefi_secure_boot' ? { "secure_boot" => true } : {}
+      firmware == 'uefi_secure_boot' ? { secure_boot: true } : {}
     end
 
     # Validates TPM compatibility based on the firmware type and virtual TPM setting.

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -1071,7 +1071,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
     end
 
     test "returns secure boot settings when firmware is 'uefi_secure_boot'" do
-      assert_equal({ "secure_boot" => true }, @cr.send(:generate_secure_boot_settings, 'uefi_secure_boot'))
+      assert_equal({ secure_boot: true }, @cr.send(:generate_secure_boot_settings, 'uefi_secure_boot'))
     end
 
     test "returns an empty hash for firmware types other than 'uefi_secure_boot'" do


### PR DESCRIPTION
Add SecureBoot and VirtualTPM options for image-based provisioning on VMware

Requiers: https://github.com/fog/fog-vsphere/pull/309


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
