### PR TITLE
Fixes #38386 - encrypt setting when it includes credentials

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -45,6 +45,7 @@ class Setting < ApplicationRecord
   validates :value, :array_hostnames_ips => true, :if => proc { |s| ARRAY_HOSTNAMES.include? s.name }
   validates :value, :email => true, :if => proc { |s| EMAIL_ATTRS.include? s.name }
   before_save :clear_value_when_default
+  before_save :encrypt_url_if_password_present, :if => proc { |s| s.value.is_a?(String) && s.value.start_with?('http') }
   validate :validate_frozen_attributes
   before_validation :remove_whitespaces, :if => proc { |s| s.settings_type == "array" }
   # Custom validations are added from SettingManager class
@@ -282,5 +283,14 @@ class Setting < ApplicationRecord
 
   def remove_whitespaces
     self[:value] = value.each { |a| a.strip! if a.respond_to? :strip! }
+  end
+
+  def encrypt_url_if_password_present
+    uri = URI.parse(value)
+    return unless uri.userinfo&.include?(':')
+
+    self[:value] = encrypt_field(value)
+  rescue URI::InvalidURIError
+    errors.add(:value, _("Invalid URI '#{value}'"))
   end
 end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -384,4 +384,71 @@ class SettingTest < ActiveSupport::TestCase
       assert setting.valid?, "Can't update login_text setting with valid value #{value}"
     end
   end
+
+  context "when encryption key is expected" do
+    # Set the encryption key once for the context
+    before do
+      Setting.any_instance.expects(:encryption_key).at_least_once.returns('25d224dd383e92a7e0c82b8bf7c985e815f34cf5')
+    end
+
+    # Helper to initialize and save the setting
+    def create_setting(url)
+      setting = Setting.new(name: 'test_url', value: url)
+      setting.save!
+      setting
+    end
+
+    test 'encrypt URL setting when it contains password' do
+      url = 'http://user:pass@example.com'
+      setting = create_setting(url)
+
+      assert setting.is_decryptable?(setting.read_attribute(:value)), 'Expected URL to be encrypted'
+      assert_equal url, setting.value
+    end
+
+    test 'does not encrypt URL when userinfo does not contain password' do
+      url = 'http://user@example.com'
+      setting = create_setting(url)
+
+      refute setting.is_decryptable?(setting.read_attribute(:value)), 'Expected URL not to be encrypted'
+      assert_equal url, setting.value
+    end
+
+    test 'does not encrypt URL when URL does not have userinfo' do
+      url = 'http://example.com'
+      setting = create_setting(url)
+
+      refute setting.is_decryptable?(setting.read_attribute(:value)), 'Expected URL not to be encrypted'
+      assert_equal url, setting.value
+    end
+
+    test 'adds an error when URL is invalid' do
+      url = 'http://example.com/hello world'
+      setting = create_setting(url)
+
+      refute setting.is_decryptable?(setting.read_attribute(:value)), 'Expected URL not to be encrypted'
+      assert_includes setting.errors[:value], "Invalid URI '#{url}'"
+    end
+
+    test 'encrypt_url_if_password_present is not called if value does not start with http' do
+      setting = Setting.new(name: 'test_url', value: 'ftp://user:pass@example.com')
+
+      setting.expects(:encrypt_url_if_password_present).never
+      setting.save!
+    end
+
+    test 'encrypt_url_if_password_present is not called if value includes http but is not a URL' do
+      setting = Setting.new(name: 'test_url', value: 'my_http_proxy')
+
+      setting.expects(:encrypt_url_if_password_present).never
+      setting.save!
+    end
+
+    test 'encrypted? should return false when URL contains password' do
+      setting = Setting.new(name: 'test_url', value: 'http://user:pass@example.comjkjk')
+      setting.save!
+
+      assert_not setting.encrypted?, 'encrypted? should return false when URL contains password'
+    end
+  end
 end


### PR DESCRIPTION
In this PR, the setting (`http_proxy` for instance) value is encrypted only when it includes credentials, such as in `https://user:pa$$word@proxy.example.com`.

To test this PR, you first need to generate the following file: `/foreman/blob/develop/config/initializers/encryption_key.rb`.

See https://github.com/theforeman/foreman/blob/develop/config/initializers/encryption_key.rb.example.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
