### PR TITLE
Fixes #38391 - Allow displaying all host interfaces through API

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -362,15 +362,15 @@ module Api
           end
           # map interface types
           params[:interfaces_attributes] = params[:interfaces_attributes].map do |nic_attr|
-            interface_attributes(nic_attr, allow_nil_type: host.nil?)
+            interface_attributes(nic_attr)
           end
         end
         params = host.apply_inherited_attributes(params) if host
         params
       end
 
-      def interface_attributes(params, allow_nil_type: false)
-        params[:type] = InterfaceTypeMapper.map(params[:type]) if params.has_key?(:type) || allow_nil_type
+      def interface_attributes(params)
+        params[:type] = InterfaceTypeMapper.map(params[:type]) if params.has_key?(:type) || params[:id].nil?
         params
       end
 

--- a/app/models/nic/base.rb
+++ b/app/models/nic/base.rb
@@ -346,8 +346,7 @@ module Nic
     end
 
     def validate_updating_types
-      sti_type = type || 'Nic::Base'
-      errors.add(:type, _("can't be changed once the interface is saved")) if persisted? && (self.class.name != sti_type)
+      errors.add(:type, _("can't be changed once the interface is saved")) if persisted? && (self.class.name != type)
     end
 
     def mac_addresses_for_provisioning

--- a/db/migrate/20250527151609_change_base_interface_type.rb
+++ b/db/migrate/20250527151609_change_base_interface_type.rb
@@ -1,0 +1,11 @@
+class ChangeBaseInterfaceType < ActiveRecord::Migration[7.0]
+  def up
+    allowed_types = Nic::Base.allowed_types.map(&:name)
+    Nic::Base.where.not(type: allowed_types)
+                   .or(Nic::Base.where(type: nil))
+                   .update_all(type: 'Nic::Managed')
+  end
+
+  def down
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -317,6 +317,16 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal Nic::BMC,     last_record.interfaces.find_by_mac('00:11:22:33:44:01').class
   end
 
+  test "should provide a default type for interfaces" do
+    disable_orchestration
+
+    post :create, params: { :host => basic_attrs.merge!(:interfaces_attributes => nics_attrs << {:mac => '00:11:22:33:44:03'}) }
+    assert_response :created
+    assert_equal 3, last_record.interfaces.count
+
+    assert_equal Nic::Managed, last_record.interfaces.find_by_mac('00:11:22:33:44:03').class
+  end
+
   test "should create interfaces sent in a hash" do
     disable_orchestration
     hash_nics_attrs = nics_attrs.inject({}) do |hash, item|


### PR DESCRIPTION
Currently, when you add an interfce to an existing host, for example
with
```
hammer host interface create --host <hostname> --identifier test --managed false
```
and the try to GET request to display the interfaces with
```
curl --request GET --insecure --user admin:changeme https://`hostname -f`/api/v2/hosts/10/enc
```
you get an error about undefined method `to_export`. For details see the
linked issue.

The default class of the interface without provided type seems to be
`Nic::Base`. We need to provide a valid interface type as a default to
ensure that every interface has a valid type and can be exported.