### PR TITLE
Fixes #37834 - Set Firmware selection correct

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -148,8 +148,11 @@ module Foreman::Model
       opts[:boot_order] = %w[hd]
       opts[:boot_order].unshift 'network' unless attr[:image_id]
 
-      firmware_type = opts.delete(:firmware_type).to_s
-      opts.merge!(process_firmware_attributes(opts[:firmware], firmware_type))
+      source = opts.delete(:source).to_s
+      unless source == 'compute_profile'
+        firmware_type = opts.delete(:firmware_type).to_s
+        opts.merge!(process_firmware_attributes(opts[:firmware], firmware_type))
+      end
 
       vm = client.servers.new opts
       vm.memory = opts[:memory] if opts[:memory]

--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -481,8 +481,13 @@ module Foreman::Model
 
       args.except!(:hardware_version) if args[:hardware_version] == 'Default'
 
-      firmware_type = args.delete(:firmware_type).to_s
-      args.merge!(process_firmware_attributes(args[:firmware], firmware_type))
+      source = args.delete(:source).to_s
+
+      unless source == 'compute_profile'
+        firmware_type = args.delete(:firmware_type).to_s
+        args.merge!(process_firmware_attributes(args[:firmware], firmware_type))
+      end
+
       args[:virtual_tpm] = validate_tpm_compatibility(args[:virtual_tpm], args[:firmware])
 
       args.reject! { |k, v| v.nil? }

--- a/app/views/compute_attributes/_form.html.erb
+++ b/app/views/compute_attributes/_form.html.erb
@@ -4,7 +4,7 @@
   <%= select_f f, :compute_profile_id, ComputeProfile.all, :id, :name, {}, :disabled => true, :label => _('Compute profile'), :label_size => "col-md-2" %>
   <%= select_f f, :compute_resource_id, ComputeResource.all, :id, :to_label, {}, :disabled => true, :label => _('Compute resource'), :label_size => "col-md-2" %>
 
-  <%= fields_for 'compute_attribute[vm_attrs]', @set.compute_resource.new_vm(@set.vm_attrs) do |f2| %>
+  <%= fields_for 'compute_attribute[vm_attrs]', @set.compute_resource.new_vm(@set.vm_attrs.merge(:source => 'compute_profile')) do |f2| %>
     <%= render :partial => "compute_form",
                :locals => { :f => f2, :compute_resource => @set.compute_resource, :selected_cluster => @set.vm_attrs['cluster'] } %>
   <% end %>

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -8,8 +8,11 @@
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2"} if new_vm && controller_name != "compute_attributes" %>
 
-<% firmware_type = new_vm ? 'automatic' : compute_resource.firmware_type(f.object.firmware, f.object.secure_boot) %>
-<%= field(f, :firmware, :disabled => !new_vm, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the host's PXE Loader. If no PXE Loader is selected, it defaults to BIOS."), :label_size => "col-md-2") do
+<%
+  firmware_type = compute_resource.firmware_type(f.object.firmware, f.object.secure_boot)
+  firmware_help_block = _("If firmware on the compute profile is set to 'Automatic', the firmware above has already been pre-selected based on the PXE loader. If you set firmware to 'Automatic', Foreman will base the firmware on the PXE loader unless you select it manually.") if new_vm && controller_name != 'compute_attributes'
+%>
+<%= field(f, :firmware, :disabled => !new_vm, :label => _('Firmware'), :help_block => firmware_help_block, :label_help => _("Choose 'Automatic' to set the firmware based on the PXE loader of the host. If no PXE loader is selected, firmware defaults to BIOS."), :label_size => "col-md-2") do
   compute_resource.firmware_types.collect do |type, name|
     radio_button_f f, :firmware, {:checked => (firmware_type == type), :disabled => !new_vm, :value => type, :text => _(name) }
   end.join(' ').html_safe

--- a/app/views/compute_resources_vms/form/vmware/_base.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_base.html.erb
@@ -7,8 +7,11 @@
 </div>
 <%= text_f f, :memory_mb, :class => "col-md-2", :label => _("Memory (MB)") %>
 
-<% firmware_type = new_vm ? 'automatic' : compute_resource.firmware_type(f.object.firmware, f.object.secure_boot) %>
-<%= field(f, :firmware, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the PXE Loader. If no PXE Loader is selected, it defaults to BIOS."), :label_size => "col-md-2") do
+<%
+  firmware_type = compute_resource.firmware_type(f.object.firmware, f.object.secure_boot)
+  firmware_help_block = _("If firmware on the compute profile is set to 'Automatic', the firmware above has already been pre-selected based on the PXE loader. If you set firmware to 'Automatic', Foreman will base the firmware on the PXE loader unless you select it manually.") if new_vm && controller_name != 'compute_attributes'
+%>
+<%= field(f, :firmware, :label => _('Firmware'), :help_block => firmware_help_block, :label_help => _("Choose 'Automatic' to set the firmware based on the PXE loader of the host. If no PXE loader is selected, firmware defaults to BIOS."), :label_size => "col-md-2") do
   compute_resource.firmware_types.collect do |type, name|
     radio_button_f f, :firmware, { :checked => (firmware_type == type), :disabled => !new_vm, :value => type, :text => _(name) }
   end.join(' ').html_safe


### PR DESCRIPTION
Without this PR, its is currently really broken. Without this PR, it does always! show 'Automatic' - except while editing hosts. For new/edit of Compute Profile or in the Create Host page - always 'Automatic' is shown. A user would never know what is really configured. This is because of [1].

If you create a host later, 'Automatic' is always displayed, regardless of which firmware is selected in the Compute Profile.

This change makes sure, that the selected firmware on the Compute Profile is the one which was saved previously and represents the value from the database while editing a existing Compute Profile.

On the Create Host page, it's a little bit more difficult, because the firmware is automatically chosed by the Compute Profile firmware and the PXE Loader field. To solve this and make it understandable for the user, a corresponding help message is shown while creating a host.

[1] https://github.com/theforeman/foreman/pull/10321/files#diff-c88b347f9af46e109987241498e9db3c776cc76433ffe3ba6f58ae1d8a74b9adR11


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
