### PR TITLE
Refs #38390 - Add warning if q.pending not empty

### DIFF
--- a/app/models/concerns/orchestration.rb
+++ b/app/models/concerns/orchestration.rb
@@ -159,10 +159,17 @@ module Orchestration
     end
 
     update_cache
-    # if we have no failures - we are done
-    return true if q.failed.empty? && q.pending.empty? && q.conflict.empty? && orchestration_errors?
 
-    logger.warn "Rolling back due to a problem: #{q.failed + q.conflict}"
+    if !q.failed.empty? || !q.conflict.empty?
+      logger.warn "Rolling back due to a problem: #{q.failed + q.conflict}"
+    elsif !q.pending.empty?
+      logger.warn "Rolling back due to unexpected pending task(s): #{q.pending}"
+    elsif !orchestration_errors?
+      logger.warn "Rolling back due to errors: #{errors}"
+    else
+      # if we have no failures - we are done
+      return true
+    end
     fail_queue(q)
 
     rollback


### PR DESCRIPTION
it resulted in a not communicated issue, if after processing q.pending, there were still tasks left (because new ones were added during processing the queue.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
