### PR TITLE
Fixes #38403 - Host Registration Form - Permission denied

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageSelectors.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPageSelectors.js
@@ -14,6 +14,9 @@ import {
 export const selectAPIStatusData = state =>
   selectAPIStatus(state, REGISTRATION_COMMANDS_DATA);
 
+export const selectApiDataResponseCode = state =>
+  selectAPIResponse(state, REGISTRATION_COMMANDS_DATA)?.response?.status;
+
 export const selectOrganizations = state =>
   selectAPIResponse(state, REGISTRATION_COMMANDS_DATA).organizations || [];
 

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/__tests__/fixtures.js
@@ -151,6 +151,7 @@ export const spySelector = selectors => {
   jest.spyOn(selectors, 'selectPluginData');
   jest.spyOn(selectors, 'selectAPIStatusCommand');
   jest.spyOn(selectors, 'selectCommand');
+  jest.spyOn(selectors, 'selectApiDataResponseCode');
 
   selectors.selectAPIStatusData.mockImplementation(() => STATUS.RESOLVED);
   selectors.selectOrganizations.mockImplementation(
@@ -165,6 +166,7 @@ export const spySelector = selectors => {
   selectors.selectPluginData.mockImplementation(() => {});
   selectors.selectAPIStatusCommand.mockImplementation(() => undefined);
   selectors.selectCommand.mockImplementation(() => '');
+  selectors.selectApiDataResponseCode.mockImplementation(() => null);
 };
 
 export const formData = {

--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/index.js
@@ -23,9 +23,11 @@ import {
 import { STATUS } from '../../../constants';
 import PageLayout from '../../common/PageLayout/PageLayout';
 import Slot from '../../../components/common/Slot';
+import PermissionDenied from '../../../components/PermissionDenied';
 
 import {
   selectAPIStatusData,
+  selectApiDataResponseCode,
   selectAPIStatusCommand,
   selectOrganizations,
   selectLocations,
@@ -61,6 +63,7 @@ const RegistrationCommandsPage = () => {
   // API statuses
   const apiStatusCommand = useSelector(selectAPIStatusCommand);
   const apiStatusData = useSelector(selectAPIStatusData);
+  const apiDataResponseCode = useSelector(selectApiDataResponseCode);
   const isLoading = apiStatusData === STATUS.PENDING;
   const isGenerating = apiStatusCommand === STATUS.PENDING;
 
@@ -188,6 +191,11 @@ const RegistrationCommandsPage = () => {
     // Disabled lint warning, need to check only hostgroup_id & operatingsystem_id
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, hostGroupId, operatingSystemId]);
+
+  // Do not show the form if the user is not authorized to register hosts
+  if (apiDataResponseCode === 403) {
+    return <PermissionDenied missingPermissions={['register_hosts']} />;
+  }
 
   return (
     <PageLayout


### PR DESCRIPTION
Do not display the registration form when the initial response is 401 or 403.

How to test:
With a user **without** `register_hosts` permission, try to access the `/hosts/register` page.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
