### PR TITLE
Fixes #38416 - Hosts bulk action : Assign organization/ location

### DIFF
--- a/app/controllers/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/api/v2/hosts_bulk_actions_controller.rb
@@ -78,6 +78,32 @@ module Api
         end
       end
 
+      api :PUT, "/hosts/bulk/assign_taxonomy", N_("Assign organization/location")
+      param_group :bulk_host_ids
+      param :target_organization_id, :number, :desc => N_("ID of the organization to assign the hosts to")
+      param :target_location_id, :number, :desc => N_("ID of the location to assign the hosts to")
+      param :mismatch_setting_organization, :bool, N_("Fix organization on mismatch")
+      param :mismatch_setting_location, :bool, N_("Fix location on mismatch")
+      def assign_taxonomy
+        validate_taxonomy_settings
+        clear_current_taxonomy
+        find_editable_hosts
+
+        targets = Taxonomy.where(id: [params[:target_organization_id], params[:target_location_id]])
+        messages = targets.map do |tax|
+          tax_type = tax.type.downcase
+          BulkHostsManager.new(hosts: @hosts).assign_taxonomy(tax, params["mismatch_setting_#{tax_type}"])
+          tax_type == 'organization' ? _("Organization is set to %s.") % tax.name : _("Location is set to %s.") % tax.name
+        end
+
+        process_response(true, { :message => n_("Updated host: %{update}", "Updated hosts: %{update}",
+          @hosts.count) % { update: messages.join(" ") }})
+      rescue => e
+        render_error(:custom_error, :status => :unprocessable_entity, :locals => { :message => e.message})
+      ensure
+        restore_current_taxonomy
+      end
+
       protected
 
       def action_permission
@@ -97,6 +123,23 @@ module Api
 
       def find_editable_hosts
         find_bulk_hosts(:edit_hosts, params)
+      end
+
+      def clear_current_taxonomy
+        @context = Foreman::ThreadSession::Context.get
+        Foreman::ThreadSession::Context.set(user: @context[:user])
+      end
+
+      def restore_current_taxonomy
+        Foreman::ThreadSession::Context.set(**@context) if @context
+      end
+
+      def validate_taxonomy_settings
+        if [params[:mismatch_setting_organization], params[:mismatch_setting_location]].any? { |val| val == false }
+          raise _("Cannot update host(s) because of mismatch in settings.")
+        elsif [params[:mismatch_setting_organization], params[:mismatch_setting_location]].all? { |val| val.nil? }
+          raise _("At lease one of organization/location mismatch settings should be specified.")
+        end
       end
 
       def rebuild_config

--- a/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
+++ b/app/controllers/concerns/foreman/controller/taxonomy_multiple.rb
@@ -36,21 +36,12 @@ module Foreman::Controller::TaxonomyMultiple
     end
 
     taxonomy = Taxonomy.find_by_id(id)
-
-    if params[type][:optimistic_import] == 'yes'
-      @hosts.update_all("#{type}_id".to_sym => taxonomy.id)
-      # hosts location needs to be updated before import missing ids
-      taxonomy.import_missing_ids
-    else
-      if taxonomy.need_to_be_selected_ids.count == 0
-        @hosts.update_all("#{type}_id".to_sym => taxonomy.id)
-      else
-        error "Cannot update #{taxonomy.type} to #{taxonomy.name} because of mismatch in settings"
-        redirect_back_or_to helpers.current_hosts_path
-        return
-      end
+    begin
+      BulkHostsManager.new(hosts: @hosts).assign_taxonomy(taxonomy, params[type][:optimistic_import] == 'yes')
+      success "Updated hosts: Changed #{type.to_s.classify}"
+    rescue => e
+      error e.message
     end
-    success "Updated hosts: Changed #{type.to_s.classify}"
     redirect_back_or_to helpers.current_hosts_path
   end
 end

--- a/app/services/bulk_hosts_manager.rb
+++ b/app/services/bulk_hosts_manager.rb
@@ -38,4 +38,19 @@ class BulkHostsManager
     end
     all_fails
   end
+
+  # @param [Boolean] optimistic_import
+  #   either fix on mismatch or fail on mismatch
+  def assign_taxonomy(taxonomy, optimistic_import)
+    tax_type = taxonomy.type.downcase
+    if optimistic_import
+      @hosts.update_all("#{tax_type}_id".to_sym => taxonomy.id)
+      # hosts location needs to be updated before import missing ids
+      taxonomy.import_missing_ids
+    elsif taxonomy.need_to_be_selected_ids.empty?
+      @hosts.update_all("#{tax_type}_id".to_sym => taxonomy.id)
+    else
+      raise "Cannot update #{taxonomy.type.downcase} to #{taxonomy.name} because of mismatch in settings"
+    end
+  end
 end

--- a/config/initializers/f_foreman_permissions.rb
+++ b/config/initializers/f_foreman_permissions.rb
@@ -271,7 +271,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :"api/v2/hosts" => [:update, :disassociate, :forget_status],
                                     :"api/v2/interfaces" => [:create, :update, :destroy],
                                     :"api/v2/compute_resources" => [:associate],
-                                    :"api/v2/hosts_bulk_actions" => [:build, :reassign_hostgroup],
+                                    :"api/v2/hosts_bulk_actions" => [:build, :reassign_hostgroup, :assign_taxonomy],
                                   }
     map.permission :destroy_hosts, {:hosts => [:destroy, :multiple_actions, :reset_multiple, :multiple_destroy, :submit_multiple_destroy],
                                     :"api/v2/hosts" => [:destroy],

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -4,6 +4,7 @@ Foreman::Application.routes.draw do
     # new v2 routes that point to v2
     scope "(:apiv)", :module => :v2, :defaults => {:apiv => 'v2'}, :apiv => /v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       match 'hosts/bulk', :to => 'hosts_bulk_actions#bulk_destroy', :via => [:delete]
+      put 'hosts/bulk/assign_taxonomy', :to => 'hosts_bulk_actions#assign_taxonomy'
       match 'hosts/bulk/build', :to => 'hosts_bulk_actions#build', :via => [:put]
       match 'hosts/bulk/reassign_hostgroup', :to => 'hosts_bulk_actions#reassign_hostgroup', :via => [:put]
 

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -811,7 +811,7 @@ class HostsControllerTest < ActionController::TestCase
       :host_ids => Host.pluck('hosts.id'),
     }, session: set_session_user
     assert_redirected_to :controller => :hosts, :action => :index
-    assert flash[:error] == "Cannot update Location to Location 1 because of mismatch in settings"
+    assert_equal "Cannot update location to Location 1 because of mismatch in settings", flash[:error]
   end
   test "update multiple location does not update location of hosts if fails on pessimistic import" do
     @request.env['HTTP_REFERER'] = current_hosts_path
@@ -870,7 +870,7 @@ class HostsControllerTest < ActionController::TestCase
       :host_ids => Host.pluck('hosts.id'),
     }, session: set_session_user
     assert_redirected_to :controller => :hosts, :action => :index
-    assert_equal "Cannot update Organization to Organization 1 because of mismatch in settings", flash[:error]
+    assert_equal "Cannot update organization to Organization 1 because of mismatch in settings", flash[:error]
   end
   test "update multiple organization does not update organization of hosts if fails on pessimistic import" do
     @request.env['HTTP_REFERER'] = current_hosts_path

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
@@ -1,0 +1,257 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Modal,
+  Button,
+  MenuToggle,
+  SelectOption,
+  TextContent,
+  Text,
+} from '@patternfly/react-core';
+import { addToast } from '../../../ToastsList/slice';
+import { translate as __ } from '../../../../common/I18n';
+import { STATUS } from '../../../../constants';
+import {
+  selectAPIStatus,
+  selectAPIResponse,
+} from '../../../../redux/API/APISelectors';
+import {
+  BULK_ASSIGN_TAXONOMY_KEY,
+  bulkAssignTaxonomy,
+  fetchOrganizations,
+  fetchLocations,
+  ORGANIZATION_KEY,
+  LOCATION_KEY,
+} from './actions';
+import { foremanUrl } from '../../../../common/helpers';
+import { APIActions } from '../../../../redux/API';
+import {
+  HOSTS_API_PATH,
+  API_REQUEST_KEY,
+} from '../../../../routes/Hosts/constants';
+import TaxonomySelect from './TaxonomySelect';
+
+const BulkAssignTaxonomyModal = ({
+  isOpen,
+  closeModal,
+  selectedCount,
+  fetchBulkParams,
+}) => {
+  const dispatch = useDispatch();
+  const [organizationId, setOrganizationId] = useState('');
+  const [locationId, setLocationId] = useState('');
+  const [orgSelectOpen, setOrgSelectOpen] = useState(false);
+  const [locSelectOpen, setLocSelectOpen] = useState(false);
+  const [orgFixRadioChecked, setOrgFixRadioChecked] = useState(true);
+  const [locFixRadioChecked, setLocFixRadioChecked] = useState(true);
+  const organizations = useSelector(state =>
+    selectAPIResponse(state, ORGANIZATION_KEY)
+  );
+  const organizationStatus = useSelector(state =>
+    selectAPIStatus(state, ORGANIZATION_KEY)
+  );
+  const locations = useSelector(state =>
+    selectAPIResponse(state, LOCATION_KEY)
+  );
+  const locationStatus = useSelector(state =>
+    selectAPIStatus(state, LOCATION_KEY)
+  );
+  const hostUpdateStatus = useSelector(state =>
+    selectAPIStatus(state, BULK_ASSIGN_TAXONOMY_KEY)
+  );
+  const handleModalClose = () => {
+    setOrganizationId('');
+    setLocationId('');
+    setOrgFixRadioChecked(true);
+    setLocFixRadioChecked(true);
+    closeModal();
+  };
+
+  useEffect(() => {
+    dispatch(fetchOrganizations());
+    dispatch(fetchLocations());
+  }, [dispatch]);
+
+  const onOrgToggleClick = () => {
+    setOrgSelectOpen(!orgSelectOpen);
+  };
+  const toggleOrg = toggleRef => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onOrgToggleClick}
+      isExpanded={orgSelectOpen}
+      style={{ width: '95%' }}
+    >
+      {getSelectedLabel(organizationId, organizations)}
+    </MenuToggle>
+  );
+
+  const handleOrgSelect = (event, selection) => {
+    setOrganizationId(selection);
+    setOrgSelectOpen(false);
+  };
+
+  const onLocToggleClick = () => {
+    setLocSelectOpen(!locSelectOpen);
+  };
+  const toggleLoc = toggleRef => (
+    <MenuToggle
+      ref={toggleRef}
+      onClick={onLocToggleClick}
+      isExpanded={locSelectOpen}
+      style={{ width: '95%' }}
+    >
+      {getSelectedLabel(locationId, locations)}
+    </MenuToggle>
+  );
+
+  const handleLocSelect = (event, selection) => {
+    setLocationId(selection);
+    setLocSelectOpen(false);
+  };
+
+  const getSelectedLabel = (id, taxonomy) =>
+    taxonomy.results.find(t => t.id === id)?.name;
+
+  const handleError = error => {
+    const {
+      response: {
+        data: {
+          error: { message },
+        },
+      },
+    } = error;
+    dispatch(addToast({ type: 'danger', message }));
+    handleModalClose();
+  };
+
+  const handleSuccess = response => {
+    dispatch(
+      addToast({
+        type: 'success',
+        message: response.data.message,
+      })
+    );
+    dispatch(
+      APIActions.get({
+        key: API_REQUEST_KEY,
+        url: foremanUrl(HOSTS_API_PATH),
+      })
+    );
+    handleModalClose();
+  };
+
+  const handleSave = () => {
+    const requestBody = {
+      included: {
+        search: fetchBulkParams(),
+      },
+      target_location_id: locationId,
+      target_organization_id: organizationId,
+      mismatch_setting_location: locFixRadioChecked,
+      mismatch_setting_organization: orgFixRadioChecked,
+    };
+
+    dispatch(bulkAssignTaxonomy(requestBody, handleSuccess, handleError));
+  };
+
+  const modalActions = [
+    <Button
+      key="add"
+      ouiaId="bulk-assign-taxonomy-modal-add-button"
+      variant="primary"
+      onClick={handleSave}
+      isDisabled={
+        hostUpdateStatus === STATUS.PENDING ||
+        (organizationId === '' && locationId === '')
+      }
+      isLoading={hostUpdateStatus === STATUS.PENDING}
+    >
+      {__('Save')}
+    </Button>,
+    <Button
+      key="cancel"
+      ouiaId="bulk-assign-taxonomy-modal-cancel-button"
+      variant="link"
+      onClick={handleModalClose}
+    >
+      {__('Cancel')}
+    </Button>,
+  ];
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={handleModalClose}
+      onEscapePress={handleModalClose}
+      title={__('Change organization/location')}
+      width="50%"
+      position="top"
+      actions={modalActions}
+      id="bulk-assign-taxonomy-modal"
+      key="bulk-assign-taxonomy-modal"
+      ouiaId="bulk-assign-taxonomy-modal"
+    >
+      <TextContent>
+        <Text ouiaId="bulk-assign-taxonomy-options">
+          {__(
+            'Select organization/location to add hosts to. This change may affect all your selected hosts.'
+          )}
+        </Text>
+      </TextContent>
+      {organizations && organizationStatus === STATUS.RESOLVED && (
+        <TaxonomySelect
+          headerText={__('Select organization')}
+          taxonomy="organization"
+          isOpen={orgSelectOpen}
+          selected={organizationId}
+          onSelect={handleOrgSelect}
+          onOpenChange={isSelectOpen => setOrgSelectOpen(isSelectOpen)}
+          toggle={toggleOrg}
+          radioChecked={orgFixRadioChecked}
+          setRadioChecked={setOrgFixRadioChecked}
+        >
+          {organizations.results?.map(org => (
+            <SelectOption key={org.id} value={org.id}>
+              {org.name}
+            </SelectOption>
+          ))}
+        </TaxonomySelect>
+      )}
+      <hr />
+      {locations && locationStatus === STATUS.RESOLVED && (
+        <TaxonomySelect
+          headerText={__('Select location')}
+          taxonomy="location"
+          isOpen={locSelectOpen}
+          selected={locationId}
+          onSelect={handleLocSelect}
+          onOpenChange={isSelectOpen => setLocSelectOpen(isSelectOpen)}
+          toggle={toggleLoc}
+          radioChecked={locFixRadioChecked}
+          setRadioChecked={setLocFixRadioChecked}
+        >
+          {locations.results?.map(loc => (
+            <SelectOption key={loc.id} value={loc.id}>
+              {loc.name}
+            </SelectOption>
+          ))}
+        </TaxonomySelect>
+      )}
+    </Modal>
+  );
+};
+
+BulkAssignTaxonomyModal.propTypes = {
+  isOpen: PropTypes.bool,
+  closeModal: PropTypes.func,
+  selectedCount: PropTypes.number.isRequired,
+  fetchBulkParams: PropTypes.func.isRequired,
+};
+
+BulkAssignTaxonomyModal.defaultProps = {
+  isOpen: false,
+  closeModal: () => {},
+};
+
+export default BulkAssignTaxonomyModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/TaxonomySelect.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/TaxonomySelect.js
@@ -1,0 +1,83 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import { Bullseye, Radio, Select, Tooltip } from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
+import { translate as __ } from '../../../../common/I18n';
+
+const TaxonomySelect = ({
+  headerText,
+  taxonomy,
+  children,
+  radioChecked,
+  setRadioChecked,
+  ...selectProps
+}) => {
+  const taxonomyType =
+    taxonomy === 'organization' ? __('organization') : __('location');
+  const mismatchTip = (
+    <FormattedMessage
+      id={`bulk-assign-${taxonomy}-mismatch-tip`}
+      defaultMessage={__(
+        'A mismatch happens if there is a resource associated with a host, such as a domain or subnet, and at the same time not associated with the {taxonomy} you want to assign the host to. The option Fix on mismatch will add such a resource to the {taxonomy}, and is therefore the recommended choice. The option Fail on mismatch, on the other hand, will always result in an error message. For example, reassigning a host from one {taxonomy} to another will fail, even if there is no actual mismatch in settings.'
+      )}
+      values={{ taxonomy: taxonomyType }}
+    />
+  );
+
+  return (
+    <div style={{ marginTop: '1em' }}>
+      <h3>
+        {headerText}
+        <Tooltip position="right" content={mismatchTip}>
+          <OutlinedQuestionCircleIcon style={{ marginLeft: '4px' }} />
+        </Tooltip>
+      </h3>
+      <Select
+        id={`select-${taxonomy}`}
+        ouiaId={`select-${taxonomy}`}
+        shouldFocusToggleOnSelect
+        {...selectProps}
+      >
+        {children}
+      </Select>
+      <Bullseye>
+        <Radio
+          isChecked={radioChecked}
+          onChange={(_e, checked) => setRadioChecked(checked)}
+          name={`radioFixOnMismatch${taxonomy}`}
+          label={__('Fix on mismatch')}
+          id={`radio-fix-on-mismatch-${taxonomy}`}
+          ouiaId={`radio-fix-on-mismatch-${taxonomy}`}
+        />
+        <Radio
+          isChecked={!radioChecked}
+          onChange={(_e, checked) => setRadioChecked(!checked)}
+          name={`radioFailOnMismatch${taxonomy}`}
+          label={__('Fail on mismatch')}
+          id={`radio-fail-on-mismatch-${taxonomy}`}
+          ouiaId={`radio-fail-on-mismatch-${taxonomy}`}
+          style={{ marginLeft: '50px' }}
+        />
+      </Bullseye>
+    </div>
+  );
+};
+
+TaxonomySelect.propTypes = {
+  headerText: PropTypes.string,
+  taxonomy: PropTypes.string,
+  children: PropTypes.node,
+  radioChecked: PropTypes.bool,
+  setRadioChecked: PropTypes.func,
+};
+
+TaxonomySelect.defaultProps = {
+  headerText: '',
+  taxonomy: '',
+  children: [],
+  radioChecked: false,
+  setRadioChecked: undefined,
+};
+
+export default TaxonomySelect;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/actions.js
@@ -1,0 +1,41 @@
+import { APIActions } from '../../../../redux/API';
+import { foremanUrl } from '../../../../common/helpers';
+
+export const BULK_ASSIGN_TAXONOMY_KEY = 'BULK_ASSIGN_TAXONOMY';
+export const bulkAssignTaxonomy = (params, handleSuccess, handleError) => {
+  const url = foremanUrl(`/api/v2/hosts/bulk/assign_taxonomy`);
+  return APIActions.put({
+    key: BULK_ASSIGN_TAXONOMY_KEY,
+    url,
+    handleSuccess,
+    handleError,
+    params,
+  });
+};
+
+export const ORGANIZATION_KEY = 'ORGANIZATION';
+export const LOCATION_KEY = 'LOCATION';
+
+export const fetchOrganizations = () => {
+  const url = foremanUrl('/api/v2/organizations');
+  return APIActions.get({
+    key: ORGANIZATION_KEY,
+    url,
+    params: {
+      per_page: 'all',
+    },
+  });
+};
+
+export const fetchLocations = () => {
+  const url = foremanUrl('/api/v2/locations');
+  return APIActions.get({
+    key: LOCATION_KEY,
+    url,
+    params: {
+      per_page: 'all',
+    },
+  });
+};
+
+export default bulkAssignTaxonomy;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/index.js
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import { ForemanActionsBarContext } from '../../../../components/HostDetails/ActionsBar';
+import { useForemanModal } from '../../../../components/ForemanModal/ForemanModalHooks';
+import BulkAssignTaxonomyModal from './BulkAssignTaxonomyModal';
+
+const BulkAssignTaxonomyModalScene = () => {
+  const { selectedCount, fetchBulkParams } = useContext(
+    ForemanActionsBarContext
+  );
+  const { modalOpen, setModalClosed } = useForemanModal({
+    id: 'bulk-assign-taxonomy-modal',
+  });
+  return (
+    <BulkAssignTaxonomyModal
+      key="bulk-assign-taxonomy-modal"
+      selectedCount={selectedCount}
+      fetchBulkParams={fetchBulkParams}
+      isOpen={modalOpen}
+      closeModal={setModalClosed}
+    />
+  );
+};
+
+export default BulkAssignTaxonomyModalScene;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -5,10 +5,13 @@ import { Tr, Td, ActionsColumn } from '@patternfly/react-table';
 import {
   ToolbarItem,
   Divider,
-  MenuItem,
   Flex,
   FlexItem,
   Button,
+  Menu,
+  MenuItem,
+  MenuContent,
+  MenuList,
   Split,
   SplitItem,
   TextContent,
@@ -46,6 +49,7 @@ import {
 import { bulkDeleteHosts } from './BulkActions/bulkDelete';
 import BulkBuildHostModal from './BulkActions/buildHosts';
 import BulkReassignHostgroupModal from './BulkActions/reassignHostGroup';
+import BulkAssignTaxonomyModal from './BulkActions/assignTaxonomy';
 import { foremanUrl } from '../../common/helpers';
 import Slot from '../common/Slot';
 import forceSingleton from '../../common/forceSingleton';
@@ -214,6 +218,11 @@ const HostsIndex = () => {
         id: 'bulk-reassign-hg-modal',
       })
     );
+    dispatch(
+      addModal({
+        id: 'bulk-assign-taxonomy-modal',
+      })
+    );
   }, [dispatch]);
 
   const { setModalOpen: setHgModalOpen } = useForemanModal({
@@ -221,6 +230,9 @@ const HostsIndex = () => {
   });
   const { setModalOpen: setBuildModalOpen } = useForemanModal({
     id: 'bulk-build-hosts-modal',
+  });
+  const { setModalOpen: setTaxonomyModalOpen } = useForemanModal({
+    id: 'bulk-assign-taxonomy-modal',
   });
 
   const dropdownItems = [
@@ -233,12 +245,38 @@ const HostsIndex = () => {
       {__('Build management')}
     </MenuItem>,
     <MenuItem
-      itemId="reassign-hg-dropdown-item"
-      key="reassign-hg-dropdown-item"
-      onClick={setHgModalOpen}
+      itemId="host-affiliation-dropdown-item"
+      key="host-affiliation-dropdown-item"
       isDisabled={selectedCount === 0}
+      flyoutMenu={
+        <Menu
+          ouiaId="host-affiliation-dropdown-menu"
+          onSelect={() => setMenuOpen(false)}
+        >
+          <MenuContent>
+            <MenuList>
+              <MenuItem
+                itemId="reassign-hg-dropdown-item"
+                key="reassign-hg-dropdown-item"
+                onClick={setHgModalOpen}
+                isDisabled={selectedCount === 0}
+              >
+                {__('Host group')}
+              </MenuItem>
+              <MenuItem
+                itemId="assign-taxonomy-dropdown-item"
+                key="assign-taxonomy-dropdown-item"
+                onClick={setTaxonomyModalOpen}
+                isDisabled={selectedCount === 0}
+              >
+                {__('Organization/location')}
+              </MenuItem>
+            </MenuList>
+          </MenuContent>
+        </Menu>
+      }
     >
-      {__('Change host group')}
+      {__('Change associations')}
     </MenuItem>,
   ];
 
@@ -442,6 +480,7 @@ const HostsIndex = () => {
       >
         <BulkBuildHostModal key="bulk-build-hosts-modal" />
         <BulkReassignHostgroupModal key="bulk-reassign-hg-modal" />
+        <BulkAssignTaxonomyModal key="bulk-assign-taxonomy-modal" />
         <Slot id="_all-hosts-modals" multi />
       </ForemanActionsBarContext.Provider>
     </TableIndexPage>


### PR DESCRIPTION
Add `Assign organization/location` for new hosts page.

To test
Select hosts - Assign organization/location from Kebab menu.

Some test cases.
Prepare a testing environment with hosts, both registered and unregistered. Multiple organizations and locations.
1. Move one host/multiple hosts from a current organization to another.  Error message for registered hosts. 
2. Move one host/multiple hosts from a current location to another.
3. Move one host/multiple hosts from current org and current location to another org and another location.
Repeat above tests with Any Organization and Any Location context. 

Registered hosts are not allowed to change organization. All other cases should work.
Tests for registered hosts need https://github.com/Katello/katello/pull/11396.

![org1](https://github.com/user-attachments/assets/f994f724-4059-4f68-8ec0-b6f212c5c0df)


![org1](https://github.com/user-attachments/assets/f42b1ffb-9da0-4711-8e43-4c4059363891)
