### PR TITLE
Fixes #38418 - Pin spring to 4.2.1 in development

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -20,7 +20,8 @@ group :development do
 
   gem 'bullet', '>= 6.1.0'
   gem "parallel_tests"
-  gem 'spring', '~> 4.0'
+  # TODO: https://projects.theforeman.org/issues/38419
+  gem 'spring', '4.2.1'
   gem 'benchmark-ips', '>= 2.8.2'
   gem 'foreman'
   gem('bootsnap', :require => false)


### PR DESCRIPTION
Spring v4.3.0, in combination with Ruby 3.0.7 and Rails 7, is causing an error that blocks the Rails start.

Error: method_missing: undefined method root
for Rails::Application:Class (NoMethodError)

One solution could be to upgrade Ruby to 3.1.7,
but that doesn't work on the latest Fedora 42 [1].

And upgrading to 3.2.z is not feasible due to some gems limiting Ruby versions to < 3.2 (safe-render, I think).

External issues:
[0] https://github.com/rails/spring/issues/737
[1] https://github.com/rbenv/ruby-build/discussions/2529


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
