### PR TITLE
Host Orchestration - Renderability checks for templates

### DIFF
--- a/app/models/concerns/orchestration/templates.rb
+++ b/app/models/concerns/orchestration/templates.rb
@@ -1,0 +1,45 @@
+module Orchestration::Templates
+  extend ActiveSupport::Concern
+  include Orchestration::Common
+
+  included do
+    after_validation :queue_render_checks
+  end
+
+  def queue_render_checks
+    return if skip_orchestration?
+    return unless template
+
+    logger.debug "Scheduling render checks of template for #{self}"
+
+    queue.create name: _("Check renderability of template '%{name}'.") % { name: template.name },
+      priority: 1, action: [self, :set_renderability]
+  end
+
+  def set_renderability
+    template.render(host: self)
+    true
+  rescue => e
+    Foreman::Logging.exception("Error while rendering '#{template.name}' template", e)
+    failure _("Failed to render template '%{t}', error: %{e}") % { t: template.name, e: e }
+  end
+
+  def del_renderability
+    # No-op, we don't need to delete the rendered template
+  end
+
+  private
+
+  def template
+    @template ||= provisioning_template(kind: kind)
+  end
+
+  def kind
+    case provision_method
+    when 'build'
+      'provision'
+    when 'image'
+      template_kinds('image').first&.name
+    end
+  end
+end

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -310,6 +310,7 @@ class Host::Managed < Host::Base
   include Orchestration::PuppetCA
   include Orchestration::SshProvision
   include Orchestration::Realm
+  include Orchestration::Templates
   include HostTemplateHelpers
   delegate :require_ip4_validation?, :require_ip6_validation?, :to => :provision_interface
 

--- a/test/unit/orchestration/templates_test.rb
+++ b/test/unit/orchestration/templates_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class TemplatesTest < ActiveSupport::TestCase
+  setup do
+    @host = FactoryBot.build(:host, :managed)
+    @host.stubs(:skip_orchestration_for_testing?).returns(false)
+    @queue = @host.queue
+  end
+
+  test 'without template' do
+    @host.queue_render_checks
+    assert_equal 0, @queue.count
+  end
+
+  test 'with valid provisioning template' do
+    template = FactoryBot.build(:provisioning_template, template: "<%= @host.name %>")
+    @host.stubs(:provisioning_template).returns(template)
+    @host.queue_render_checks
+    assert_equal 1, @queue.count
+    assert @host.set_renderability
+  end
+
+  test 'with invalid provisioning template' do
+    template = FactoryBot.build(:provisioning_template, template: "<%= I WILL RAISE AN ERROR( %>")
+    @host.stubs(:provisioning_template).returns(template)
+    @host.queue_render_checks
+    assert_equal 1, @queue.count
+    refute @host.set_renderability
+  end
+end


### PR DESCRIPTION
The new `Orchestration::Templates` class verifies the host's readiness for the provisioning process and checks that all default os templates are renderable.

The `Orchestration::TFTP` was handling this use case partially, only for ['PXELinux', 'PXEGrub2', 'PXEGrub', 'iPXE'] kinds, leaving other template kinds from the list.

**How to reproduce the issue**

- Foreman + Smart Proxy, provisioning setup
- Assign PXELinux, PXEGrub2, and Kickstart Default templates to OS
- Ensure the Kickstart Default cannot be rendered (for example, with invalid ruby syntax).
- Provision a host

Without this PR, the host is provisioning, and the process is heading to later stages, where it will inevitably fail.

With this PR, the template render checks are the top 1 priority, so we don't waste time with other orchestration steps when the templates are invalid.
