### PR TITLE
Fixes #38523 - Host Form - Improvements for resolved templates

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -620,8 +620,18 @@ class HostsController < ApplicationController
     kind = params.delete(:provisioning)
     host.attributes = host_attributes_for_templates(host)
     templates = host.available_template_kinds(kind)
+
     return not_found if templates.empty?
-    render :partial => 'provisioning', :locals => { :templates => templates }
+
+    rendered_errors = {}
+    ok_tmpl, err_tmpl = templates.partition do |t|
+      t.render(host: host)
+    rescue => e
+      rendered_errors[t.id] = e.message
+      false
+    end
+
+    render partial: 'provisioning', locals: { ok_tmpl: ok_tmpl, err_tmpl: err_tmpl, rendered_errors: rendered_errors }
   end
 
   def preview_host_collection

--- a/app/views/hosts/_provisioning.html.erb
+++ b/app/views/hosts/_provisioning.html.erb
@@ -1,12 +1,36 @@
+<% if ok_tmpl.any? %>
 <div class="alert alert-success alert-dismissable">
-  <%= icon_text("ok", "",:kind => "pficon") %>
+  <%= icon_text('ok', "", :kind => "pficon") %>
   <%= alert_close %>
-  <h4><%= _('Templates resolved for this operating system') %></h4>
-  <% templates.sort{|t,x| t.template_kind <=> x.template_kind}.each do |tmplt| %>
-      <div class="form-group">
-        <div class="control-label col-md-8"> <%= tmplt.template_kind %>
-          <%= link_to_if_authorized h(tmplt), hash_for_edit_provisioning_template_path(:id => tmplt.to_param, :auth_object => tmplt, :permission => 'edit_provisioning_templates'), :rel=>"external" %>
-        </div>
-    </div>
+  <h4 class="alert-heading"><%= _('Templates resolved for this operating system') %></h4>
+
+  <ul>
+  <% ok_tmpl.sort{|t,x| t.template_kind <=> x.template_kind}.each do |t| %>
+    <li>
+      <%= t.template_kind %>:
+      <%= link_to_if_authorized h(t), hash_for_edit_provisioning_template_path(id: t.to_param, auth_object: t, permission: 'edit_provisioning_templates'), rel: "external", target: "_blank" %>
+    </li>
   <% end %>
+  </ul>
 </div>
+<% end %>
+
+<% if err_tmpl.any? %>
+<div class="alert alert-danger alert-dismissable">
+  <%= icon_text('error-circle-o', "", :kind => "pficon") %>
+  <%= alert_close %>
+  <h4 class="alert-heading"><%= _('Templates rendered with errors') %></h4>
+
+  <ul>
+  <% err_tmpl.sort{|t,x| t.template_kind <=> x.template_kind}.each do |t| %>
+    <li>
+      <div>
+        <%= t.template_kind %>:
+        <%= link_to_if_authorized h(t), hash_for_edit_provisioning_template_path(id: t.to_param, auth_object: t, permission: 'edit_provisioning_templates'), rel: "external", target: "_blank" %>
+      </div>
+      <pre><%= rendered_errors[t.id] %></pre>
+    </li>
+  <% end %>
+  </ul>
+</div>
+<% end %>


### PR DESCRIPTION
Add a render check for assigned templates in the `HostsController#template_used` action. 
It's only an informative UI change; the results do not block the provisioning process.

UI changes
* Split the box into `success` and `error`. Show only if relevant.
* Add `target='_blank'` to links
* A little bit of formatting.

In addition to https://github.com/theforeman/foreman/pull/10540 (not dependent)

## Before
![ui-before](https://github.com/user-attachments/assets/0e8874ac-48f1-4079-a54f-8802d2939b97)

## After
![ut-after2](https://github.com/user-attachments/assets/72b2cc89-c49d-4159-91d3-968a4ba4075c)
