### PR TITLE
Fixes #38426 - Fix prop type and usage of areAllRowsOnPageSelected

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -179,7 +179,10 @@ const HostsIndex = () => {
           pageRowCount,
         }}
         totalCount={total}
-        areAllRowsOnPageSelected={areAllRowsOnPageSelected()}
+        areAllRowsOnPageSelected={
+          !Array.isArray(areAllRowsOnPageSelected()) &&
+          !!areAllRowsOnPageSelected()
+        } // returns array if all rows selected
         areAllRowsSelected={areAllRowsSelected()}
       />
     </ToolbarItem>


### PR DESCRIPTION
I'm not sure about this change.

_Ensure `areAllRowsOnPageSelected` is always treated as a boolean to avoid issues when it was sometimes passed as an array._