### PR TITLE
[WIP] Investigate broken code reloading

### DIFF
--- a/app/registries/foreman/setting_manager.rb
+++ b/app/registries/foreman/setting_manager.rb
@@ -121,7 +121,7 @@ module Foreman
       #   end
       #
       def setting(name, default:, description:, type:, full_name: nil, collection: nil, encrypted: false, validate: nil, **options)
-        raise ::Foreman::Exception.new(N_("Setting '%s' is already defined, please avoid collisions"), name) if storage.key?(name.to_s)
+        Rails.logger.warn(format("Setting '%s' is already defined, please avoid collisions", name)) if storage.key?(name.to_s)
         raise ::Foreman::Exception.new(N_("Setting '%s' has an invalid type definition. Please use a valid type."), name) unless available_types.include?(type)
         storage[name.to_s] = {
           context: context_name,


### PR DESCRIPTION
I was working in Katello and found that `reload!` from the rails console is broken (not returning true) for a number of reasons. What's happening is (some) plugins call `Foreman::Plugin.register` at `reload!` time.

Foreman tasks and Katello do things differently from each other: Katello calls `Foreman::Plugin.register`  via a required file and won't be executed again on `reload!` whereas REX and ForemanTasks do invoke `register` on dev code reload.

https://github.com/Katello/katello/blob/87dc8cfc18dedbea67c59233392a6528e14a979e/lib/katello/engine.rb#L85

https://github.com/theforeman/foreman-tasks/blob/2760a7a5fa212d9d160dc02c4251b9b496110031/lib/foreman_tasks/engine.rb#L21

The fix here might not be the correct one, and I suppose the question is whether `Foreman:::Plugin.register` is meant to be used with dev code reloading or not. Will file an issue once a determination is made on how to address the problem.