### PR TITLE
Fixes #38439 - Correctly handle incorrect content type of API request

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -7,6 +7,7 @@ module Api
 
     before_action :load_settings
     before_action :set_default_response_format, :authorize, :set_taxonomy
+    before_action :check_media_type
     before_action :assign_lone_taxonomies, :only => :create
     before_action :add_info_headers, :set_gettext_locale
     before_action :session_expiry, :update_activity_time
@@ -118,6 +119,12 @@ module Api
 
     def api_request?
       true
+    end
+
+    def check_media_type
+      if (request.post? || request.put?) && request.media_type != "application/json"
+        render_error(:unsupported_media_type, :status => :unsupported_media_type)
+      end
     end
 
     protected

--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -42,7 +42,6 @@ module Api
       end
 
       before_action :setup_has_many_params, :only => [:create, :update]
-      before_action :check_media_type
 
       layout 'api/v2/layouts/index_layout', :only => :index
 
@@ -155,12 +154,6 @@ module Api
         model_name = controller_name.singularize
         append_array_of_ids(params[model_name]) # wrapped params
         append_array_of_ids(params)             # unwrapped params
-      end
-
-      def check_media_type
-        if (request.post? || request.put?) && request.media_type != "application/json"
-          render_error(:unsupported_media_type, :status => :unsupported_media_type)
-        end
       end
 
       def render_error(error, options = { })

--- a/test/controllers/api/v2/organizations_controller_test.rb
+++ b/test/controllers/api/v2/organizations_controller_test.rb
@@ -7,6 +7,16 @@ class Api::V2::OrganizationsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:organizations)
   end
 
+  # assign_lone_taxonomies causes internal server error in case the content is not JSON and contains
+  # organization data should it be called before the media type check.
+  # We must make sure the media type check is performed before assign_lone_taxonomies is called.
+  test "handles unsupported content type" do
+    @request.env['CONTENT_TYPE'] = 'application/x-www-form-urlencoded'
+    @controller.expects(:assign_lone_taxonomies).never
+    post :create, params: { :organization => { :name => 'new org' } }
+    assert_response 415
+  end
+
   test "index respects taxonomies" do
     org1 = FactoryBot.create(:organization)
     org2 = FactoryBot.create(:organization)


### PR DESCRIPTION
Right now, the call of assign_lone_taxonomies in api/base_controller before the call of check_content_type in api/v2/base_controller causes an internal server error when trying to create an organization and providing incorrect content type. Calling check_content_type before assign_lone_taxonomies handles the incorrect type and provides helpful error message instead of ISE.