### PR TITLE
Fixes #38417 - HostDetail safemode-rendering

### DIFF
--- a/app/controllers/concerns/foreman/controller/template_rendering.rb
+++ b/app/controllers/concerns/foreman/controller/template_rendering.rb
@@ -13,7 +13,7 @@ module Foreman
       end
 
       def safe_render(template)
-        renderer = params.delete('force_safemode') ? Foreman::Renderer::SafeModeRenderer : Foreman::Renderer
+        renderer = Foreman::Cast.to_bool(params.delete('force_safemode')) ? Foreman::Renderer::SafeModeRenderer : Foreman::Renderer
 
         render plain: template.render(renderer: renderer, host: @host, params: params).html_safe
       rescue StandardError => error


### PR DESCRIPTION
`force_safemode` parameter not correctly handled.

### Test

1. disable SafeMode Rendering in Settings
2. attach an 'unsafe' template to a host
3. on host's Detail-page open the template (Modal-box)
4. switch `safe mode off` to off

Expected: template is rendered

### Background

Modal-Box requests: `/unattended/finish?force_safemode=false&hostname=host`
`force_safemode` parameter had not been cast to a boolean.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
