### PR TITLE
Fixes #37834 - Set Firmware selection correct

### DIFF
--- a/app/models/compute_resource.rb
+++ b/app/models/compute_resource.rb
@@ -439,11 +439,23 @@ class ComputeResource < ApplicationRecord
   # @param firmware_type [String] The firmware type based on the provided PXE Loader.
   # @return [Hash] A hash containing the processed firmware attributes.
   def process_firmware_attributes(firmware, firmware_type)
-    firmware = resolve_automatic_firmware(firmware, firmware_type)
+    attrs = {}
 
-    attrs = generate_secure_boot_settings(firmware)
-    attrs[:firmware] = normalize_firmware_type(firmware)
-    attrs
+    # The `firmware_type` flag is set through `host_compute_attrs(host)` and only used
+    # during host creation via the orchestration process.
+    # If not set, the method may be used for validation, preview, or UI-related logic
+    # without performing any real provisioning actions.
+    # The normalization should only be used during host creation, otherwise the firmware is set
+    # to the initial firmware value so that the UI can display the correct value.
+
+    if firmware_type.present?
+      firmware = resolve_automatic_firmware(firmware, firmware_type)
+      attrs[:firmware] = normalize_firmware_type(firmware)
+    else
+      attrs[:firmware] = firmware || 'automatic'
+    end
+
+    attrs.merge!(generate_secure_boot_settings(firmware))
   end
 
   protected

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -8,8 +8,10 @@
 <% checked = params[:host] && params[:host][:compute_attributes] && params[:host][:compute_attributes][:start] || '1' %>
 <%= checkbox_f f, :start, { :checked => (checked == '1'), :help_inline => _("Power ON this machine"), :label => _('Start'), :label_size => "col-md-2"} if new_vm && controller_name != "compute_attributes" %>
 
-<% firmware_type = new_vm ? 'automatic' : compute_resource.firmware_type(f.object.firmware, f.object.secure_boot) %>
-<%= field(f, :firmware, :disabled => !new_vm, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the host's PXE Loader. If no PXE Loader is selected, it defaults to BIOS."), :label_size => "col-md-2") do
+<%
+  firmware_type = compute_resource.firmware_type(f.object.firmware, f.object.secure_boot)
+%>
+<%= field(f, :firmware, :disabled => !new_vm, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the PXE loader of the host. If no PXE loader is selected, firmware defaults to BIOS."), :label_size => "col-md-2") do
   compute_resource.firmware_types.collect do |type, name|
     radio_button_f f, :firmware, {:checked => (firmware_type == type), :disabled => !new_vm, :value => type, :text => _(name) }
   end.join(' ').html_safe

--- a/app/views/compute_resources_vms/form/vmware/_base.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_base.html.erb
@@ -7,8 +7,10 @@
 </div>
 <%= text_f f, :memory_mb, :class => "col-md-2", :label => _("Memory (MB)") %>
 
-<% firmware_type = new_vm ? 'automatic' : compute_resource.firmware_type(f.object.firmware, f.object.secure_boot) %>
-<%= field(f, :firmware, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the PXE Loader. If no PXE Loader is selected, it defaults to BIOS."), :label_size => "col-md-2") do
+<%
+  firmware_type = compute_resource.firmware_type(f.object.firmware, f.object.secure_boot)
+%>
+<%= field(f, :firmware, :label => _('Firmware'), :label_help => _("Choose 'Automatic' to set the firmware based on the PXE loader of the host. If no PXE loader is selected, firmware defaults to BIOS."), :label_size => "col-md-2") do
   compute_resource.firmware_types.collect do |type, name|
     radio_button_f f, :firmware, { :checked => (firmware_type == type), :disabled => !new_vm, :value => type, :text => _(name) }
   end.join(' ').html_safe

--- a/test/models/compute_resource_test.rb
+++ b/test/models/compute_resource_test.rb
@@ -469,4 +469,45 @@ class ComputeResourceTest < ActiveSupport::TestCase
       assert_equal 'bios', @cr.send(:resolve_automatic_firmware, 'automatic', nil)
     end
   end
+
+  describe '#process_firmware_attributes' do
+    before do
+      @cr = compute_resources(:vmware)
+    end
+
+    test "returns 'automatic' when firmware is nil and firmware_type is not present" do
+      attr_exp = { :firmware => "automatic" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, nil, nil)
+    end
+
+    test "returns 'bios' when firmware is 'automatic' and firmware_type is 'bios'" do
+      attr_exp = { :firmware => "bios" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, 'automatic', 'bios')
+    end
+
+    test "returns 'automatic' when firmware is 'automatic' and firmware_type is not present" do
+      attr_exp = { :firmware => "automatic" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, 'automatic', nil)
+    end
+
+    test "returns 'uefi' when firmware is 'uefi' and firmware_type is not present" do
+      attr_exp = { :firmware => "uefi" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, 'uefi', nil)
+    end
+
+    test "returns 'efi' when firmware is 'automatic' and firmware_type is 'uefi'" do
+      attr_exp = { :firmware => "efi" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, 'automatic', 'uefi')
+    end
+
+    test "returns 'uefi_secure_boot' with secure boot flag when firmware is 'uefi_secure_boot' and firmware_type is not present" do
+      attr_exp = { :secure_boot => true, :firmware => "uefi_secure_boot" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, 'uefi_secure_boot', nil)
+    end
+
+    test "returns 'efi' with secure boot flag when firmware is 'uefi_secure_boot' and firmware_type is 'uefi_secure_boot'" do
+      attr_exp = { :secure_boot => true, :firmware => "efi" }
+      assert_equal attr_exp, @cr.send(:process_firmware_attributes, 'uefi_secure_boot', 'uefi_secure_boot')
+    end
+  end
 end

--- a/test/models/compute_resources/vmware_test.rb
+++ b/test/models/compute_resources/vmware_test.rb
@@ -254,9 +254,9 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
       @cr = FactoryBot.build_stubbed(:vmware_cr)
     end
 
-    test "defaults to BIOS firmware when no firmware is provided" do
+    test "defaults to automatic firmware when no firmware is provided" do
       args = HashWithIndifferentAccess.new
-      expected_firmware = { firmware: "bios" }
+      expected_firmware = { firmware: "automatic" }
 
       assert_equal expected_firmware, @cr.parse_args(args)
     end
@@ -288,7 +288,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
         }
       )
       # All keys must be symbolized
-      attrs_out = { :cpus => "1", :interfaces => [{ :type => "VirtualVmxnet3", :network => "network-17", :_delete => "" }], :volumes => [{ :size_gb => "1", :_delete => "" }], :firmware => "bios" }
+      attrs_out = { :cpus => "1", :interfaces => [{ :type => "VirtualVmxnet3", :network => "network-17", :_delete => "" }], :volumes => [{ :size_gb => "1", :_delete => "" }], :firmware => "automatic" }
       assert_equal attrs_out, @cr.parse_args(attrs_in)
     end
 
@@ -319,7 +319,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
           },
         }
       )
-      attrs_out = {:cpus => "1", :interfaces => [{:type => "VirtualVmxnet3", :network => "network-17", :_delete => ""}], :volumes => [{:size_gb => "1", :_delete => ""}], :firmware => "bios" }
+      attrs_out = {:cpus => "1", :interfaces => [{:type => "VirtualVmxnet3", :network => "network-17", :_delete => ""}], :volumes => [{:size_gb => "1", :_delete => ""}], :firmware => "automatic" }
       assert_equal attrs_out, @cr.parse_args(attrs_in)
     end
 
@@ -366,7 +366,7 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
             :_delete => "",
           },
         ],
-        :firmware => "bios",
+        :firmware => "automatic",
       }
       assert_equal attrs_out, @cr.parse_args(attrs_in)
     end
@@ -390,9 +390,21 @@ class Foreman::Model::VmwareTest < ActiveSupport::TestCase
         assert_equal attrs_out, @cr.parse_args(attrs_in)
       end
 
-      test 'chooses BIOS firmware when no pxe loader is set and firmware is automatic' do
+      test 'chooses EFI firmware with secure boot flag when pxe loader is set to UEFI SecureBoot and firmware is automatic' do
+        attrs_in = HashWithIndifferentAccess.new(:firmware_type => :uefi_secure_boot, 'firmware' => 'automatic')
+        attrs_out = {:firmware => "efi", :secure_boot => true}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+
+      test 'chooses UEFI firmware when no pxe loader is set and firmware is UEFI' do
+        attrs_in = HashWithIndifferentAccess.new('firmware' => 'uefi')
+        attrs_out = {:firmware => "uefi"}
+        assert_equal attrs_out, @cr.parse_args(attrs_in)
+      end
+
+      test 'chooses automatic firmware when no pxe loader is set and firmware is automatic' do
         attrs_in = HashWithIndifferentAccess.new('firmware' => 'automatic')
-        attrs_out = {:firmware => "bios"}
+        attrs_out = {:firmware => "automatic"}
         assert_equal attrs_out, @cr.parse_args(attrs_in)
       end
     end


### PR DESCRIPTION
Without this PR, its is currently really broken. Without this PR, it does always! show 'Automatic' - except while editing hosts. For new/edit of Compute Profile or in the Create Host page - always 'Automatic' is shown. A user would never know what is really configured. This is because of [1].

If you create a host later, 'Automatic' is always displayed, regardless of which firmware is selected in the Compute Profile.

This change makes sure, that the selected firmware on the Compute Profile is the one which was saved previously and represents the value from the database while editing a existing Compute Profile.

The trick is to extend the new_vm() method with a "dry-run" parameter. dry-run is normally set to "true" as the new_vm() method is used at the compute_profile and hosts page for showing the form. The firmware modification should only be done in case the vm is later on really saved.

[1] https://github.com/theforeman/foreman/pull/10321/files#diff-c88b347f9af46e109987241498e9db3c776cc76433ffe3ba6f58ae1d8a74b9adR11


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
