### PR TITLE
Create a workflow to label test-breaking PRs

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,0 +1,17 @@
+name: Label an issue 'test-breaking' when a 'test-breaking' comment is added to a PR
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    if: github.event.comment.body == 'test-breaking'
+    steps:
+      - run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          LABELS: test-breaking


### PR DESCRIPTION
This PR creates a new GH workflow. When a comment `test-breaking` is added to a PR, it sets label `test-breaking` to that PR.

A new label needs to be created in this repo before this PR is merged.

### Reason:
In my team, we've identified a **problem**: often, a PR breaks our tests, be it an API change, UI change, or whatever not-that-important change that gives QE hard time in the process of finding a failure, identifying a change, investigating whether the change was intended and fixing the test in Robottelo. Most often, it seems, this is caused by WebUI locators changes.
We have proposed this **solution**: there will be an optional label for foreman and foreman-plugin repos that developers should set when they expect some change will break tests, especially WebUI. The QEs then should prefer to look at these PRs to change the tests before they get broken.