### PR TITLE
Fixes #38454 - Add container cert setup workflow to global registration

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -42,6 +42,7 @@ module Foreman::Controller::Registration
       update_packages: params['update_packages'],
       repo_data: repo_data,
       download_utility: params['download_utility'],
+      registration_host: registration_host,
     }
 
     params.permit(permitted)
@@ -107,6 +108,10 @@ module Foreman::Controller::Registration
 
   def context_urls
     { registration_url: registration_url }
+  end
+
+  def registration_host
+    registration_url.host
   end
 
   def setup_host_params

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -33,6 +33,7 @@ export LC_ALL=C LANG=C
 <%= "\n# Repository data: [#{@repo_data}]" if @repo_data.present? -%>
 <%= "\n# Force: [#{@force}]" unless @force.nil? -%>
 <%= "\n# Ignore subman errors: [#{@ignore_subman_errors}]" unless @ignore_subman_errors.nil? -%>
+<%= "\n# Set up container certs: [#{@setup_container_registry_certs}]" unless @setup_container_registry_certs.nil? -%>
 <%= "\n# Lifecycle environment id: [#{@lifecycle_environment_id}]" if @lifecycle_environment_id.present? -%>
 <%= "\n# Activation keys: [#{activation_keys}]" if activation_keys.present? -%>
 <%= "\n# Download utility: [#{@download_utility}]" unless @download_utility.nil? -%>
@@ -163,6 +164,9 @@ register_katello_host | bash
 register_host | bash
 <% end -%>
 
+<% if truthy?(@setup_container_registry_certs) -%>
+<%= snippet('container_certs_setup') -%>
+<% end -%>
 <%= snippet_if_exists('after_registration') -%>
 
 cleanup_and_exit

--- a/app/views/unattended/provisioning_templates/snippet/container_certs_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/container_certs_setup.erb
@@ -1,0 +1,45 @@
+<%#
+kind: snippet
+name: container_certs_setup
+model: ProvisioningTemplate
+snippet: true
+description: |
+  This snippet sets up SSL certificates for secure communication with the Foreman registry.
+-%>
+echo "#"
+echo "Running certificate setup for container registry"
+<% raise "Unable to determine registration hostname" if @registration_host.blank? %>
+hostname="<%= @registration_host %>"
+
+# Validate CA certificate
+ca_cert="/etc/pki/tls/certs/ca-bundle.crt"
+if [ ! -f "$ca_cert" ]; then
+  echo "Error: CA certificate not found at $ca_cert"
+  exit 1
+fi
+
+# Validate client key
+key_file=$(find /etc/pki/entitlement/ -name '*-key.pem' -type f -print -quit)
+if [ -z "$key_file" ]; then
+  echo "Error: Client key file not found in /etc/pki/entitlement/"
+  exit 1
+fi
+
+# Validate client certificate
+cert_file=$(find /etc/pki/entitlement/ -maxdepth 1 -type f -name '*.pem' -not -name '*-key.pem' -print -quit)
+if [ -z "$cert_file" ]; then
+  echo "Error: Client certificate file not found in /etc/pki/entitlement/"
+  exit 1
+fi
+
+# Create directory for certificates
+cert_dir="/etc/containers/certs.d/$hostname"
+echo "Creating $cert_dir directory"
+mkdir -p "$cert_dir" || { echo "Error: Failed to create directory $cert_dir"; exit 1; }
+
+# Perform linking if all checks pass
+ln -sf "$ca_cert" "$cert_dir/ca-bundle.crt"
+ln -sf "$key_file" "$cert_dir/client.key"
+ln -sf "$cert_file" "$cert_dir/client.cert"
+
+echo "Container certificate setup completed successfully."

--- a/test/unit/foreman/templates/snippets/container_certs_setup_test.rb
+++ b/test/unit/foreman/templates/snippets/container_certs_setup_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class ContainerCertsSetupTest < ActiveSupport::TestCase
+  def renderer
+    @renderer ||= Foreman::Renderer::SafeModeRenderer
+  end
+
+  def render_template(registration_host)
+    @snippet ||= Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'container_certs_setup.erb').read
+
+    source = OpenStruct.new(
+      name: 'Test',
+      content: @snippet
+    )
+
+    scope = Foreman::Renderer::Scope::Provisioning.new(
+      host: nil,
+      source: source,
+      variables: {
+       registration_host: registration_host,
+      })
+
+    renderer.render(source, scope)
+  end
+
+  test 'should render successfully with valid registration_host' do
+    registration_host = 'registry.example.com'
+    output = render_template(registration_host)
+    assert_includes output, 'hostname="registry.example.com"'
+    assert_includes output, "Create directory for certificates\ncert_dir=\"/etc/containers/certs.d/$hostname\""
+    assert_includes output, 'ln -sf "$ca_cert" "$cert_dir/ca-bundle.crt"'
+    assert_includes output, 'ln -sf "$key_file" "$cert_dir/client.key"'
+    assert_includes output, 'ln -sf "$cert_file" "$cert_dir/client.cert"'
+    assert_includes output, 'Container certificate setup completed successfully.'
+  end
+
+  test 'should raise error when registration_host is blank' do
+    assert_raises(RuntimeError, 'Unable to determine registration hostname') do
+      render_template(nil)
+    end
+  end
+end


### PR DESCRIPTION
This pull request introduces functionality for setting up SSL certificates for container registry communication during host registration. The changes include adding a new snippet for certificate setup and integrating it into the global registration process.

### Enhancements to container registry setup:

* **Provisioning template update**: Added a new conditional block in `app/views/unattended/provisioning_templates/registration/global_registration.erb` to invoke the `container_certs_setup` snippet if the `@setup_container_registry_certs` variable is truthy. This ensures the certificate setup process is executed during registration.
* **Container certificate setup snippet**: Introduced a new snippet in `app/views/unattended/provisioning_templates/snippet/container_certs_setup.erb` to handle SSL certificate setup for secure communication with the Foreman registry. This includes creating directories, linking CA certificates, and linking client keys and certificates.

### Template metadata additions:

* **Metadata inclusion**: Updated `app/views/unattended/provisioning_templates/registration/global_registration.erb` to include metadata for the `@setup_container_registry_certs` variable, ensuring its value is properly logged and handled during the provisioning process.


### Test the PR:
1. Checkout https://github.com/Katello/katello/pull/11402 for related katello changes.
2. Register a host to your foreman server using global registartion.
3. In the adavanced tab of the global registration form, check the `Set up ctainer registry certs` checkbox and generate registration command.
4. Run it on your host to register.
5. After registration, look at the /etc/containers/certs.d/ directory and make sure you see a directory named as foreman server.
6. The contents of the directory <foreman_server> should be soft links to ca-bundle.cert, entitlement cert and entitlement key.
7. You can test podman and flatpak(EL10) with this setup to verify.
8. You can also try re-registering and make sure the soft links are recreated to point to the new entitlement certs.
