### PR TITLE
Fixes #38458 - Host Registration - use --fail for curl

### DIFF
--- a/app/services/foreman/renderer/scope/macros/helpers.rb
+++ b/app/services/foreman/renderer/scope/macros/helpers.rb
@@ -171,7 +171,9 @@ module Foreman
             utility = Foreman.download_utilities.fetch(utility || 'curl')
             command = ["#{utility[:download_command]} #{url}"]
             command << "#{utility[:ca_cert]} #{ssl_ca_cert}" if ssl_ca_cert
+            command << "--fail" if utility[:fail]
             command << utility[:request_type_post] if params && utility[:request_type_post]
+
             if output_file
               command << "#{utility[:output_file]} #{output_file}"
             elsif utility[:output_pipe]

--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -132,7 +132,7 @@ register_host() {
   params << "packages=#{shell_escape(@packages)}" if @packages.present?
   params << "update_packages=#{@update_packages}" unless @update_packages.nil?
 -%>
-  <%= indent(2, skip1: true) { generate_web_request(utility: @download_utility, url: @registration_url, ssl_ca_cert: "$SSL_CA_CERT", headers: headers, params: params) } %>
+  <%= indent(2, skip1: true) { generate_web_request(utility: @download_utility, url: @registration_url, ssl_ca_cert: "$SSL_CA_CERT", output_file: "/root/registration_host_init.sh", headers: headers, params: params) } %>
 }
 
 echo "#"
@@ -156,7 +156,7 @@ register_katello_host(){
   params << "update_packages=#{@update_packages}" unless @update_packages.nil?
 -%>
   UUID=$(subscription-manager identity | grep --max-count 1 --only-matching '\([[:xdigit:]]\{8\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{4\}-[[:xdigit:]]\{12\}\)')
-  <%= indent(2, skip1: true) { generate_web_request(utility: @download_utility, url: @registration_url, ssl_ca_cert: "$KATELLO_SERVER_CA_CERT", headers: headers, params: params) } %>
+  <%= indent(2, skip1: true) { generate_web_request(utility: @download_utility, url: @registration_url, ssl_ca_cert: "$KATELLO_SERVER_CA_CERT", output_file: "/root/registration_host_init.sh", headers: headers, params: params) } %>
 }
 
 # Set up subscription-manager
@@ -165,11 +165,26 @@ register_katello_host(){
 subscription-manager register <%= '--force' if truthy?(@force) %> \
   --org='<%= @organization.label if @organization %>' \
   --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
-
-register_katello_host | bash
-<% else -%>
-register_host | bash
 <% end -%>
+
+# Update / create the host record in Foreman and fetch the host initial configuration script
+<%= plugin_present?('katello') ? "register_katello_host" : "register_host" %>
+
+curl_status=$?
+if [ $curl_status -ne 0 ]; then
+  echo "Failed to fetch the host initialization script."
+  echo "Please see the logs for more information."
+  cleanup_and_exit $curl_status
+fi
+
+bash /root/registration_host_init.sh
+init_conf_status=$?
+
+if [ $init_conf_status -ne 0 ]; then
+  echo "Host initialization script failed, see the logs for more information."
+  echo "You can access the script source by running 'cat /root/registration_host_init.sh'"
+  cleanup_and_exit $init_conf_status
+fi
 
 <% if truthy?(@setup_container_registry_certs) -%>
 <%= snippet('container_certs_setup') -%>

--- a/lib/foreman.rb
+++ b/lib/foreman.rb
@@ -54,6 +54,7 @@ module Foreman
         :insecure => '--insecure',
         :output_file => '--output',
         :request_type_post => '--request POST',
+        :fail => '--fail',
         :format_params => proc { |params| params.map { |param| "--data #{param}" } },
       },
       'wget' => {

--- a/test/unit/foreman/renderer/scope/macros/helpers_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/helpers_test.rb
@@ -116,6 +116,7 @@ class HelpersTest < ActiveSupport::TestCase
       url = "https://www.example.com/keys/client.asc"
       output_file = "/etc/apt/trusted.gpg.d/client1.asc"
       expected_request = "curl --silent --show-error https://www.example.com/keys/client.asc \\\n" \
+                         "  --fail \\\n" \
                          "  --output /etc/apt/trusted.gpg.d/client1.asc"
       assert_equal expected_request, scope.generate_web_request(utility: utility, url: url, output_file: output_file)
     end
@@ -128,6 +129,7 @@ class HelpersTest < ActiveSupport::TestCase
       params = ["host[build]=false", "host[organization_id]=1"]
       expected_request = "curl --silent --show-error https://www.example.com/register \\\n" \
                          "  --cacert /etc/ssl/custom_certs/ca_cert.crt \\\n" \
+                         "  --fail \\\n" \
                          "  --request POST \\\n" \
                          "  --header 'Authorization: Bearer my_token' \\\n" \
                          "  --data host[build]=false \\\n" \


### PR DESCRIPTION
When `register_host()` or `register_katello_host()` fails with `4xx`, the final exit status of the registration process is 0.

This can cause problems in CI or Ansible roles & playbooks. Using `--fail`, curl will return a non-zero code if the http response is not `200`. 
Wget has this as its default behavior, so no changes are needed.

## How to test
* Create a subnet that has a different IP range from the registered host
* Create a host group with the subnet
* generate command with activation key and the host group
* Try to register the host

Check the status code of the registration process, and verify that it is not zero.