### PR TITLE
Fixes #38472 - fix FiltersForm.test.js

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/FiltersForm/FiltersForm.test.js
+++ b/webpack/assets/javascripts/react_app/routes/FiltersForm/FiltersForm.test.js
@@ -78,7 +78,7 @@ const editProps = {
 };
 
 jest.mock('../../redux/API/API', () => ({
-  get: async url => {
+  get: url => {
     if (url === '/api/v2/roles?per_page=all&search=locked=false') {
       return {
         data: {


### PR DESCRIPTION
For some reason, anything that waits in react testing library, for that component, just doesnt stop waiting and also ignores the wait timeout
So waitFor/getBy just get stuck, using real and fake timers didnt change the out come
The minimum test is:
    render(
      <Provider store={store}>
        <FiltersForm {...editProps} />
      </Provider>
    );    
    await waitFor(() => screen.getByDisplayValue('test role for edit'), {
      timeout: 100,
    }); 
React testing library /react and /jest-dom didnt change in the last few months

IDK why this fixed it 