### PR TITLE
Fixes #38473 - kwarg handling in notifications:clean

### DIFF
--- a/app/services/ui_notifications/clean_expired.rb
+++ b/app/services/ui_notifications/clean_expired.rb
@@ -1,6 +1,7 @@
 module UINotifications
   class CleanExpired
-    def initialize(blueprint: nil, group: nil, expired_at: Time.now.utc)
+    def initialize(blueprint: nil, group: nil, expired_at: nil)
+      expired_at ||= Time.now.utc
       @blueprint = blueprint.present? ? {:notification_blueprints => {:name => blueprint }} : nil
       @group = group.present? ? {:notification_blueprints => {:group => group}} : nil
       expired_at = expired_at.to_time if expired_at.is_a?(String)

--- a/lib/tasks/notifications_cleaner.rake
+++ b/lib/tasks/notifications_cleaner.rake
@@ -13,8 +13,8 @@ namespace :notifications do
   task :clean, [:time, :group, :blueprint] => :environment do |t, args|
     puts 'Starting expired notifications clean up...'
     begin
-      cleaner = UINotifications::CleanExpired.new({blueprint: args.blueprint, group: args.group,
-                                                   expired_at: args.time}.compact)
+      cleaner = UINotifications::CleanExpired.new(blueprint: args.blueprint, group: args.group,
+        expired_at: args.time)
       cleaner.clean!
       puts "Finished, cleaned #{cleaner.deleted_count} notifications"
     rescue => error


### PR DESCRIPTION
The hash was being interpreted as a single positional argument.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
