### PR TITLE
Fixes #38216 - Use restrict Search query appropriately in table index

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -72,7 +72,7 @@ A page component that displays a table with data fetched from the API. It provid
 @param {string} {idColumn} - Not needed when passing children. The column name to use for RowSelectTd to pass to its selectOne function
 @param {function} {rowKebabItems} - Not needed when passing children. A function that takes a single result object and returns an array of kebab items to be displayed in the last column
 @param {function} {updateSearchQuery} - Pass in the updateSearchQuery function returned from useBulkSelect.
-@param {function} {restrictedSearchQuery} - If included, normalize the search query to add this to all search queries to restrict search results without altering the search input value. Useful for limiting results to an initial selection. 
+@param {function} {restrictedSearchQuery} - If included, normalize the search query to add this to all search queries to restrict search results without altering the search input value. Useful for limiting results to an initial selection.
 @param {boolean} {updateParamsByUrl} - If true, update pagination props from URL params. Default is true.
 @param {string} {bookmarksPosition} - The position of the bookmarks dropdown. Default is 'left', which means the menu will take up space to its right.
 */
@@ -117,7 +117,9 @@ const TableIndexPage = ({
   const urlParams = new URLSearchParams(historySearch);
   const urlParamsSearch = urlParams.get('search') || '';
   const search = updateParamsByUrl ? urlParamsSearch || getURIsearch() : '';
-  const defaultParams = { search: search || '' };
+  const defaultParams = {
+    search: (restrictedSearchQuery(search) ?? search) || '',
+  };
   if (updateParamsByUrl) {
     const urlPage = urlParams.get('page');
     const urlPerPage = urlParams.get('per_page');

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.test.js
@@ -19,7 +19,9 @@ const store = mockStore({
       },
     },
   },
-  autocomplete: { 'searchBar-testController': { url: '/test/', searchQuery: 'name=test' } },
+  autocomplete: {
+    'searchBar-testController': { url: '/test/', searchQuery: 'name=test' },
+  },
   foremanModals: {
     modal2: { isOpen: false },
   },
@@ -39,9 +41,9 @@ const props = {
   hasHelpPage: true,
   response: {
     response: {
-      search: "",
+      search: '',
       can_create: true,
-      results: [{item: 1}],
+      results: [{ item: 1 }],
       total: 1,
       per_page: 20,
       page: 1,
@@ -61,7 +63,7 @@ Object.defineProperty(window, 'location', {
   value: { href: '/test?search=name=test' },
 });
 describe('TableIndexPage', () => {
-  it('All props are shown', async () => {
+  test('All props are shown', async () => {
     render(
       <Provider store={store}>
         <TableIndexPage {...props} />
@@ -92,5 +94,15 @@ describe('TableIndexPage', () => {
     expect(screen.getByDisplayValue('name=test')).toBeInTheDocument();
     expect(screen.queryAllByText('Test Title')).toHaveLength(1);
     expect(screen.queryAllByText('Custom button')).toHaveLength(1);
+  });
+
+  test('Correct query is shown for restricted search query', async () => {
+    const restrictedSearch = jest.fn();
+    render(
+      <Provider store={store}>
+        <TableIndexPage restrictedSearchQuery={restrictedSearch} {...props} />
+      </Provider>
+    );
+    expect(restrictedSearch).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION

The Table Index page accepts a parameter called `restrictedSearchQuery`.  When the page with TableIndexPage component loads we want it further restrict the search results based on what `restrictedSearchQuery` returns. 
For example when you 

1. go to All Hosts page,
2. select a few hosts,
3. select a package to install
4. review the hosts and only install it on the selected hosts (you can unselect hosts here but the super set is confined to the hosts you selected in step 2) 

This already works but the bug occurs when we sort or change page numbers the selections reset. So for example if in step 1 you selected 10 out of 15 hosts and in the review stage you try to sort it by name, you would see 15 hosts. 

This PR sets the original search params to include the restricted query values. And there by correctly forces..

Steps to test

1. go to All Hosts page,
2. select a few hosts,
3. select a package to install
4. review the hosts and only install it on the selected hosts (you can unselect hosts here but the super set is confined to the hosts you selected in step 2) 
5. Sort / Change the page size

Before PR
You 'd see all hosts in the selected count

After PR
You 'd only see the selected hosts in the selected count

