### PR TITLE
Fixes #38485 - Remove unused code in late_load.js

### DIFF
--- a/app/assets/javascripts/late_load.js
+++ b/app/assets/javascripts/late_load.js
@@ -20,8 +20,6 @@ function load_dynamic_javascripts(html) {
   }
   waitForAllLoaded().then(async function() {
     // parse html string
-    var template = document.createElement('template');
-    template.innerHTML = html;
     var doc = new DOMParser().parseFromString(html, 'text/html');
     var copyChildren = [...doc.head.children];
     const loadScript = async scripts => {


### PR DESCRIPTION
Left over, `template` is not used anywhere.
`var doc = new DOMParser().parseFromString(html, 'text/html');` parses the html instead