### PR TITLE
Use WF to label PRs breaks-robottelo on comment

### DIFF
--- a/.github/workflows/test-breaking.yaml
+++ b/.github/workflows/test-breaking.yaml
@@ -1,0 +1,14 @@
+name: Label a PR `breaks-robottelo` on appropriate comment
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  breaks-robottelo:
+    uses: theforeman/actions/.github/workflows/breaks-robottelo.yml@v0
+    permissions:
+      pull-requests: write
+    with:
+      repo: ${{ github.repository }}
+      issue: ${{ github.event.issue.number }}
+    secrets:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is a workflow that uses https://github.com/theforeman/actions/pull/69 to add `breaks-robottelo` label to a PR when a comment `/label breaks-robottelo` is added to it.

### Reason:

In my team, we've identified a problem: often, a PR breaks our tests, be it an API change, UI change, or whatever not-that-important change that gives QE hard time in the process of finding a failure, identifying a change, investigating whether the change was intended and fixing the test in Robottelo. Most often, it seems, this is caused by WebUI locators changes.
We have proposed this solution: there will be an optional label for foreman and foreman-plugin repos that developers should set when they expect some change will break tests, especially WebUI. The QEs then should prefer to look at these PRs to change the tests before they get broken.