### PR TITLE
Refs #37904 - move css import packages to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,13 +23,23 @@
   },
   "dependencies": {
     "@module-federation/utilities": "^1.7.0",
+    "@patternfly/patternfly": "^5.4.2",
     "@theforeman/vendor": "^15.0.0",
+    "bootstrap-sass": "^3.4.3",
+    "datatables.net-bs": "1.13.5",
+    "dsmorse-gridster": "^0.8.0",
     "graphql-tag": "^2.11.0",
     "intl": "~1.2.5",
     "jed": "^1.1.1",
     "js-cookie": "^3.0.5",
+    "multiselect": "~0.9.12",
     "os-browserify": "^0.3.0",
-    "react-intl": "^2.8.0"
+    "patternfly-react-extensions": "^3.0.15",
+    "patternfly-react": "^2.40.0",
+    "patternfly": "^3.59.5",
+    "react-diff-view": "^2.6.0",
+    "react-intl": "^2.8.0",
+    "select2": "4.0.12"
   },
   "devDependencies": {
     "@apollo/react-testing": "^4.0.0",

--- a/webpack/assets/javascripts/react_app/common/scss/vendor-core.scss
+++ b/webpack/assets/javascripts/react_app/common/scss/vendor-core.scss
@@ -9,7 +9,6 @@
 @import '~select2/src/scss/core.scss';
 @import "~dsmorse-gridster/dist/jquery.gridster";
 @import "~datatables.net-bs/css/dataTables.bootstrap.css";
-@import "~@redhat-cloud-services/frontend-components/index.css";
 
 // patternfly v3
 @import '~patternfly-react/dist/sass/_patternfly-react.scss';


### PR DESCRIPTION
Packaging was not happy 
https://github.com/theforeman/foreman-packaging/pull/12124
```
ERROR in ./webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIcon.scss (../../../../usr/lib/node_modules/css-loader/dist/cjs.js!../../../../usr/lib/node_modules/sass-loader/dist/cjs.js!./webpack/assets/javascripts/react_app/components/Layout/components/ImpersonateIcon/ImpersonateIcon.scss)
Module build failed (from ../../../../usr/lib/node_modules/sass-loader/dist/cjs.js):
Can't find stylesheet to import.
```