### PR TITLE
refs #38423 - Use host_params for new Host in Hosts#template_used

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -616,7 +616,7 @@ class HostsController < ApplicationController
   # we don't need any has_many relation to determine what proxies are used and the view
   # renders only resulting templates set so the rest of form is unaffected
   def template_used
-    host = params[:id] ? Host::Base.readonly.find(params[:id]) : Host.new
+    host = params[:id] ? Host::Base.readonly.find(params[:id]) : Host.new(host_params)
     kind = params.delete(:provisioning)
     host.attributes = host_attributes_for_templates(host)
     templates = host.available_template_kinds(kind)

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1142,7 +1142,7 @@ class HostsControllerTest < ActionController::TestCase
     end
 
     test 'returns templates with host parameters' do
-      @attrs[:host_parameters_attributes] = {'0' => {:name => 'foo', :value => 'bar', :id => '34'}}
+      @attrs[:host_parameters_attributes] = {'0' => {:name => 'foo', :value => 'bar'}}
       put :template_used, params: {:provisioning => 'build', :host => @attrs }, session: set_session_user
       assert_response :success
       assert_template :partial => '_provisioning'


### PR DESCRIPTION
Initializing a new Host without `host_params` leads to insufficient data required for correct rendering.

For example, in Katello, the `content_facet` has not been initialized, and the template was reporting a false render error.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
