### PR TITLE
Fixes #38509 - Failed to load some Fog compute classes

### DIFF
--- a/lib/fog_extensions.rb
+++ b/lib/fog_extensions.rb
@@ -36,6 +36,9 @@ if Foreman::Model::Vmware.available?
   require 'fog/vsphere'
   require 'fog/vsphere/models/compute/cluster'
   require 'fog/vsphere/models/compute/network'
+  require 'fog/vsphere/models/compute/datastore'
+  require 'fog/vsphere/models/compute/storage_pod'
+  require 'fog/vsphere/models/compute/resource_pool'
   require 'fog/vsphere/models/compute/server'
   Fog::Vsphere::Compute::Server.include FogExtensions::Vsphere::Server
 


### PR DESCRIPTION
Fog classes are loaded on demand when API is called to the Vcenter. If the API is not yet being called since the last application restart, then loading cached compute resource data will fail with uninitialized constant error.

For more information about this issue please refer to the following links:

https://community.theforeman.org/t/foreman-1-20-2-vmware-sporadic-http-500-when-querying-api-compute-resources-api/13907

https://github.com/theforeman/foreman/pull/6803

https://github.com/fog/fog-vsphere/pull/267