### PR TITLE
Fixes #38511 - Host form - Selecting the image resets the volume type

### DIFF
--- a/webpack/assets/javascripts/compute_resource/libvirt.js
+++ b/webpack/assets/javascripts/compute_resource/libvirt.js
@@ -84,9 +84,12 @@ export function imageSelected(item) {
           capacity.attr('value', `${capacityFromImage}G`);
         }
 
-        $('#storage_volumes .fields')
-          .find('#host_compute_attributes_volumes_attributes_0_format_type')
-          .select2('val', 'qcow2');
+        const volume = $('#storage_volumes .fields').find(
+          '#host_compute_attributes_volumes_attributes_0_format_type'
+        );
+
+        volume.val('qcow2');
+        volume.trigger('change');
       },
       error() {
         help.html(


### PR DESCRIPTION
**Steps to reproduce**
* Go to the host creation form
* Select Libvirt as a compute resource
* In the OS tab, switch from Networking to Image mode

:green_apple:  In the Virtual machine tab, check the volume type (correctly assigned to QCOW2)