### PR TITLE
Fixes #38519 - Pass cloud-init users as a list

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -38,7 +38,7 @@ description: |
 hostname: <%= @host.name %>
 fqdn: <%= @host %>
 manage_etc_hosts: true
-users: {}
+users: []
 runcmd:
 - |
 <%= indent(2) { snippet 'fix_hosts' } -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -3,7 +3,7 @@
 hostname: snapshot-ipv4-dhcp-deb10
 fqdn: snapshot-ipv4-dhcp-deb10
 manage_etc_hosts: true
-users: {}
+users: []
 runcmd:
 - |
   echo "" > /etc/hostname

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -3,7 +3,7 @@
 hostname: snapshot-ipv4-dhcp-el7
 fqdn: snapshot-ipv4-dhcp-el7
 manage_etc_hosts: true
-users: {}
+users: []
 runcmd:
 - |
   echo "" > /etc/hostname

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -3,7 +3,7 @@
 hostname: snapshot-ipv4-dhcp-ubuntu18
 fqdn: snapshot-ipv4-dhcp-ubuntu18
 manage_etc_hosts: true
-users: {}
+users: []
 runcmd:
 - |
   echo "" > /etc/hostname


### PR DESCRIPTION
The dict type is deprecated and list should be used for users config:

```
cloud-init[962]: 2025-06-13 06:01:11,556 - lifecycle.py[DEPRECATED]: 'users' of type <class 'dict'> is deprecated in 22.2 and scheduled to be removed in 27.2. Use 'users' as a list.
```