### PR TITLE
Fixes #38529 - Correctly set line breaks in reports

### DIFF
--- a/app/services/foreman/renderer/scope/macros/base.rb
+++ b/app/services/foreman/renderer/scope/macros/base.rb
@@ -416,14 +416,17 @@ module Foreman
             example 'join_with_line_break(values) # => 1\n2\n3 for CSV,JSON,YAML'
           end
           def join_with_line_break(array)
+            # Normalize elements of the array to end with "\n" if they do
+            # not do already.
+            array.map! { |str| str.end_with?("\n") ? str : "#{str}\n" }
             case report_format.mime_type
-            when 'text/csv'
-              array.join("\n")
-            when 'application/json', 'text/yaml'
-              array.join("\\n")
+            when 'text/csv', 'application/json', 'text/yaml'
+              array.join
             when 'text/html'
               array.map! { |str| CGI.escapeHTML(str) }
-              array.join("<br>").html_safe
+              # Replace all "\n" in the string with "\n<br>"
+              array.map! { |str| str.gsub("\n", "\n<br>") }
+              array.join.html_safe
             end
           end
 


### PR DESCRIPTION
The line breaks in reports are currently incorrect for various reasons:

In 'text/csv' they get doubled, in application/json' and 'text/yaml' an additional string '\\n' is added and in 'text/html' HTML line breaks (<br>) are only added for each array element. But the strings in the array can contain further line breaks that are not considered.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
