### PR TITLE
Fixes #38535 - image_exists? for Libvirt compute resource

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -262,6 +262,10 @@ module Foreman::Model
       self.class.terminate_connection(url)
     end
 
+    def image_exists?(uuid)
+      client.volumes.get(uuid) != nil
+    end
+
     protected
 
     def libvirt_connection_error

--- a/test/controllers/api/v2/images_controller_test.rb
+++ b/test/controllers/api/v2/images_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class Api::V2::ImagesControllerTest < ActionController::TestCase
+  setup do
+    Foreman::Model::Libvirt.any_instance.stubs(:image_exists?).returns(true)
+  end
+
   def valid_attrs
     { :name                => 'TestImage', :username => 'ec2-user', :uuid => 'abcdef', :password => "password",
       :operatingsystem_id  => Operatingsystem.first.id,

--- a/test/controllers/images_controller_test.rb
+++ b/test/controllers/images_controller_test.rb
@@ -4,6 +4,7 @@ class ImagesControllerTest < ActionController::TestCase
   setup do
     @image      = images(:one)
     @image.uuid = Foreman.uuid.to_s
+    Foreman::Model::Libvirt.any_instance.stubs(:image_exists?).returns(true)
   end
 
   test "should get index" do

--- a/test/factories/compute_resources.rb
+++ b/test/factories/compute_resources.rb
@@ -15,6 +15,7 @@ FactoryBot.define do
 
     trait :libvirt do
       provider { 'Libvirt' }
+      after(:build) { |cr| cr.stubs(:image_exists?).returns(true) }
     end
 
     trait :openstack do

--- a/test/models/image_test.rb
+++ b/test/models/image_test.rb
@@ -5,7 +5,7 @@ class ImageTest < ActiveSupport::TestCase
 
   test "image is invalid if uuid invalid" do
     image = FactoryBot.build(:image, :uuid => "bar")
-    ComputeResource.any_instance.stubs(:image_exists?).returns(false)
+    image.compute_resource.stubs(:image_exists?).returns(false)
     image.valid? # trigger validations
     assert image.errors.messages.key?(:uuid)
   end

--- a/test/unit/compute_resource_cleaner_test.rb
+++ b/test/unit/compute_resource_cleaner_test.rb
@@ -9,6 +9,7 @@ class ComputeResourceCleanerTest < ActiveSupport::TestCase
   let(:subject) { ComputeResourceCleaner.new(klass: klass) }
 
   setup do
+    Foreman::Model::Libvirt.any_instance.stubs(:image_exists?).returns(true)
     setup_compute_attrs
     setup_image
     setup_hostgroup


### PR DESCRIPTION
Add validation for the Image's path during create and update actions.

![Screenshot_20250627_090356](https://github.com/user-attachments/assets/f7f11d22-e901-4218-bb7d-6ace397c8017)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
