### PR TITLE
Fixes #38539 - ComputeResourceCache - rescue error when reading invalid cache

### DIFF
--- a/app/services/compute_resource_cache.rb
+++ b/app/services/compute_resource_cache.rb
@@ -31,7 +31,13 @@ class ComputeResourceCache
 
   def read(key)
     logger.debug "Reading from compute resource cache: #{key}"
-    Rails.cache.read(cache_key + key.to_s, cache_options)
+
+    begin
+      Rails.cache.read(cache_key + key.to_s, cache_options)
+    rescue StandardError => e
+      Foreman::Logging.exception('Failed to read from compute resource cache', e)
+      nil
+    end
   end
 
   def write(key, value)

--- a/test/unit/compute_resource_cache_test.rb
+++ b/test/unit/compute_resource_cache_test.rb
@@ -42,6 +42,14 @@ class ComputeResourceCacheTest < ActiveSupport::TestCase
       cache.write(:write_test, message)
       assert_equal message, cache.read(:write_test)
     end
+
+    test 'it does not raise an error when the cache is not available' do
+      cache.write(:err_key, 'val1')
+      assert_equal 'val1', cache.cache(:err_key)
+
+      Rails.cache.expects(:read).raises(StandardError)
+      assert_equal 'fresh', cache.cache(:err_key) { 'fresh' }
+    end
   end
 
   context 'with caching disabled' do


### PR DESCRIPTION
Rescuing an error in the method allows the cache method to continue and retrieve a fresh, uncached value.

**Fixed issue, steps to reproduce**
* Foreman running in **production mode**
* Create a VMware compute resource
* Assign a compute profile to it
* Restart Rails
* Run `hammer compute-profile info --id 1`
```
=>
undefined class/module Fog::Vsphere::Compute::ResourcePool
```
(or go to compute profile detail in UI and check the logs)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
