### PR TITLE
refs #38361 - Remove net-scp & net-ssh from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,8 +27,6 @@ gem 'gettext_i18n_rails', '~> 1.8'
 gem 'rails-i18n', '~> 7.0'
 gem 'logging', '>= 1.8.0', '< 3.0.0'
 gem 'fog-core', '~> 2.1'
-gem 'net-scp'
-gem 'net-ssh'
 gem 'net-ldap', '>= 0.16.0'
 gem 'net-ping', :require => false
 gem 'activerecord-session_store', '>= 2.0.0', '< 3'


### PR DESCRIPTION
Foreman utilizes the system's SSH for provisioning; gems are no longer needed.

refs 1f0679fd380aee92483413c9361b6d24e3175e98

TODO: Foreman packaging

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
