### PR TITLE
Fixes #38543 - Make the new hosts overview page default

### DIFF
--- a/config/initializers/f_foreman_settings_general.rb
+++ b/config/initializers/f_foreman_settings_general.rb
@@ -54,7 +54,7 @@ Foreman::SettingManager.define(:foreman) do
     setting('new_hosts_page',
       type: :boolean,
       description: N_("Whether or not to show the new overview page for All Hosts"),
-      default: false,
+      default: true,
       full_name: N_('Show New Host Overview Page'))
     setting('display_fqdn_for_hosts',
       type: :boolean,

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -218,7 +218,7 @@ class HostsControllerTest < ActionController::TestCase
     assert_difference('Host.unscoped.count', -1) do
       delete :destroy, params: { :id => @host.name }, session: set_session_user
     end
-    assert_redirected_to hosts_url
+    assert_redirected_to new_hosts_index_page_url
   end
 
   test "when host is not saved after setBuild, the flash should inform it" do
@@ -434,13 +434,13 @@ class HostsControllerTest < ActionController::TestCase
 
   test 'multiple without hosts' do
     post :update_multiple_hostgroup, session: set_session_user
-    assert_redirected_to hosts_url
+    assert_redirected_to new_hosts_index_page_url
     assert_equal "No hosts selected", flash[:error]
 
     # now try to pass an invalid id
     post :update_multiple_hostgroup, params: { :host_ids => [-1], :host_names => ["no.such.host"] }, session: set_session_user
 
-    assert_redirected_to hosts_url
+    assert_redirected_to new_hosts_index_page_url
     assert_equal "No hosts were found with that id, name or query filter", flash[:error]
   end
 
@@ -777,6 +777,7 @@ class HostsControllerTest < ActionController::TestCase
     end
 
     def multiple_hosts_submit_request(method, ids, success, params = {})
+      Setting[:new_hosts_page] = false
       post :"submit_multiple_#{method}", params: params.merge({:host_ids => ids}), session: set_session_user
       assert_response :found
       assert_redirected_to current_hosts_path
@@ -810,7 +811,7 @@ class HostsControllerTest < ActionController::TestCase
       :location => {:id => location.id, :optimistic_import => "no"},
       :host_ids => Host.pluck('hosts.id'),
     }, session: set_session_user
-    assert_redirected_to :controller => :hosts, :action => :index
+    assert_redirected_to new_hosts_index_page_path
     assert flash[:error] == "Cannot update Location to Location 1 because of mismatch in settings"
   end
   test "update multiple location does not update location of hosts if fails on pessimistic import" do
@@ -845,7 +846,7 @@ class HostsControllerTest < ActionController::TestCase
         :host_ids => Host.pluck('hosts.id'),
       }, session: set_session_user
     end
-    assert_redirected_to :controller => :hosts, :action => :index
+    assert_redirected_to new_hosts_index_page_path
     assert_equal "Updated hosts: Changed Location", flash[:success]
   end
   test "update multiple location imports taxable_taxonomies rows if succeeds on optimistic import" do
@@ -869,7 +870,7 @@ class HostsControllerTest < ActionController::TestCase
       :organization => {:id => organization.id, :optimistic_import => "no"},
       :host_ids => Host.pluck('hosts.id'),
     }, session: set_session_user
-    assert_redirected_to :controller => :hosts, :action => :index
+    assert_redirected_to new_hosts_index_page_path
     assert_equal "Cannot update Organization to Organization 1 because of mismatch in settings", flash[:error]
   end
   test "update multiple organization does not update organization of hosts if fails on pessimistic import" do
@@ -901,7 +902,7 @@ class HostsControllerTest < ActionController::TestCase
       :organization => {:id => organization.id, :optimistic_import => "yes"},
       :host_ids => Host.pluck('hosts.id'),
     }, session: set_session_user
-    assert_redirected_to :controller => :hosts, :action => :index
+    assert_redirected_to new_hosts_index_page_path
     assert_equal "Updated hosts: Changed Organization", flash[:success]
   end
   test "update multiple organization succeeds with search" do
@@ -914,7 +915,7 @@ class HostsControllerTest < ActionController::TestCase
       organization: {id: organization2.id, optimistic_import: 'yes'},
       search: 'domain ~ example',
     }, session: set_session_user
-    assert_redirected_to :controller => :hosts, :action => :index
+    assert_redirected_to new_hosts_index_page_path
     assert_equal "Updated hosts: Changed Organization", flash[:success]
 
     hosts = hosts.map(&:reload)

--- a/test/integration/dashboard_test.rb
+++ b/test/integration/dashboard_test.rb
@@ -7,6 +7,7 @@ class DashboardIntegrationTest < IntegrationTestWithJavascript
   def setup
     Dashboard::Manager.reset_user_to_default(users(:admin))
     Setting[:outofsync_interval] = 35
+    Setting[:new_hosts_page] = false
   end
 
   def assert_dashboard_link(text)

--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -21,6 +21,7 @@ class HostJSTest < IntegrationTestWithJavascript
     as_admin { @host = FactoryBot.create(:host, :managed) }
     Fog.mock!
     Foreman::Model::Libvirt.any_instance.stubs(:hypervisor).returns(Fog::Libvirt::Compute::Node.new(:cpus => 4))
+    Setting[:new_hosts_page] = false
   end
 
   after do

--- a/test/integration/host_test.rb
+++ b/test/integration/host_test.rb
@@ -9,6 +9,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   test "index page with search" do
+    Setting[:new_hosts_page] = false
     visit current_hosts_path(search: "name = #{@host.name}")
     assert page.has_link?('Export', href: current_hosts_path(format: 'csv', search: "name = #{@host.name}"))
   end
@@ -23,6 +24,7 @@ class HostIntegrationTest < ActionDispatch::IntegrationTest
 
   describe "create new host page" do
     test "tabs are present" do
+      Setting[:new_hosts_page] = false
       assert_new_button(current_hosts_path, "Create Host", new_host_path)
       assert page.has_link?("Host", :href => "#primary")
       assert page.has_link?("Interfaces", :href => "#network")


### PR DESCRIPTION
Enable the new hosts overview page by default.