### PR TITLE
Fixes #38551 - Add NTP-server host parameter for Debian/Ubuntu

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ntp.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ntp.erb
@@ -6,25 +6,45 @@ snippet: true
 description: |
   The snippet configuring the system time using a given NTP server
   It respects the following parameters:
+
+  Parameters:
   - use-ntp: boolean (default depends on OS release)
   - ntp-server: string (default=undef)
 -%>
 <%
-rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
-is_fedora = @host.operatingsystem.name == 'Fedora'
+os_family = @host.operatingsystem.family
 os_major = @host.operatingsystem.major.to_i
-use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 6))
+ntp_server = host_param('ntp-server')
 -%>
 
 echo "Updating system time"
-<% if use_ntp -%>
-yum -y install ntpdate
-  <% if host_param('ntp-server') -%>
-/usr/sbin/ntpdate -sub <%= host_param('ntp-server') %>
+<% if os_family == 'Debian' -%>
+  <% if ntp_server -%>
+    <% if @host.operatingsystem.name == "Ubuntu" -%>
+      sed -i -E 's/^[[:space:]]*#?\s*NTP=.*/NTP=<%= ntp_server %>/' /etc/systemd/timesyncd.conf
+      systemctl enable --now systemd-timesyncd
+      timedatectl set-ntp true
+    <% else -%>
+      apt-get install -y chrony
+      sed -i -E 's|^pool .*|server <%= ntp_server %> iburst|' /etc/chrony/chrony.conf
+      systemctl enable --now chrony
+    <% end -%>
   <% end -%>
-systemctl enable --now ntpd
-<% else -%>
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
+<% elsif os_family == 'Redhat' -%>
+  <%
+  rhel_compatible = @host.operatingsystem.family == 'Redhat' && @host.operatingsystem.name != 'Fedora'
+  is_fedora = @host.operatingsystem.name == 'Fedora'
+  use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 6))
+  -%>
+  <% if use_ntp -%>
+    yum -y install ntpdate
+    <% if host_param('ntp-server') -%>
+      /usr/sbin/ntpdate -sub <%= host_param('ntp-server') %>
+    <% end -%>
+    systemctl enable --now ntpd
+  <% else -%>
+    systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  <% end -%>
 <% end -%>
-/usr/sbin/hwclock --systohc
+[ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -23,9 +23,7 @@ runcmd:
 - |
   
   echo "Updating system time"
-  systemctl enable --now chronyd
-  /usr/bin/chronyc -a makestep
-  /usr/sbin/hwclock --systohc
+    [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 - |
   
   # Select package manager for the OS (sets the $PKG_MANAGER* variables)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -23,9 +23,9 @@ runcmd:
 - |
   
   echo "Updating system time"
-  systemctl enable --now chronyd
-  /usr/bin/chronyc -a makestep
-  /usr/sbin/hwclock --systohc
+          systemctl enable --now chronyd
+      /usr/bin/chronyc -a makestep
+    [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 - |
   rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 - |

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -23,9 +23,7 @@ runcmd:
 - |
   
   echo "Updating system time"
-  systemctl enable --now chronyd
-  /usr/bin/chronyc -a makestep
-  /usr/sbin/hwclock --systohc
+    [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 - |
   
   # Select package manager for the OS (sets the $PKG_MANAGER* variables)

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -7,9 +7,9 @@
 
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -69,9 +69,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv4-6-dhcp-el7 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -69,9 +69,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv4-dhcp-el7 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -69,9 +69,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv4-static-el7 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -69,9 +69,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv6-dhcp-el7 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -69,9 +69,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv6-static-el7 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -70,9 +70,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv4-dhcp-rhel9 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -67,9 +67,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv4-dhcp-rocky8 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -68,9 +68,9 @@ chvt 3
 logger "Starting anaconda snapshot-ipv4-dhcp-rocky9 postinstall"
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -21,9 +21,9 @@ EOF
 
 
 echo "Updating system time"
-systemctl enable --now chronyd
-/usr/bin/chronyc -a makestep
-/usr/sbin/hwclock --systohc
+        systemctl enable --now chronyd
+    /usr/bin/chronyc -a makestep
+  [ -f /usr/sbin/hwclock ] && /usr/sbin/hwclock --systohc
 
 
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm


### PR DESCRIPTION
Before, the `ntp.erb` template ignored NTP parameters for Debian/Ubuntu and did actually not set any NTP for these operating systems.

This PR adds an implementation that sets the NTP for those operating systems. It uses `timesyncd` for Ubuntu and `chrony` for Debian, as Debian does not have `timesyncd` installed by default.

We also make sure that the template does not fail in case the `hwclock` binary is not present (which is the case for example on Ubuntu 24.04)

1: https://projects.theforeman.org/issues/38551

