### PR TITLE
Fixes #32563 - Always provide iPXE bootstrap template

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -143,7 +143,7 @@ class UnattendedController < ApplicationController
   def render_ipxe_template
     return false unless ipxe_request?
 
-    if @host.nil? && params[:bootstrap]
+    if params[:bootstrap]
       render_intermediate_template
       return true
     end


### PR DESCRIPTION
Right now the iPXE bootstrap template can be only requested directly, not via the template proxy in foreman-proxy. This is due the implicit host lookup using the identity of the proxy.

However this template provides critical code to iPXE to make loading further boot stages possible, like the switch between installer or local disk. This means Foreman always needs to return the bootstrap script if requested.