### PR TITLE
Fixes #38552 - Fix example in Specify Matchers tooltip

### DIFF
--- a/app/views/lookup_keys/_values.html.erb
+++ b/app/views/lookup_keys/_values.html.erb
@@ -3,7 +3,7 @@
   <tr>
     <th colspan='2' class='col-md-5'><%= _('Attribute type') %>
       <span class="help-inline">
-        <%= popover("", _("Matcher is a combination of an attribute and its value, if they match, the value below would be provided.<br> You may use any attribute Foreman knows about, such as facts etc for example: <code> domain = example.com </code> or <code> is_virtual = true</code>."),
+        <%= popover("", _("Matcher is a combination of an attribute and its value, if they match, the value below would be provided.<br> You may use any attribute Foreman knows about, such as facts etc for example: <code>domain = example.com</code> or <code>hostgroup = webserver</code>."),
                     :title => _("Explain matchers")).html_safe %>
       </span></th>
     <% if is_param %>


### PR DESCRIPTION
Neither foreman_ansible nor foreman_puppet support "is_virtual" as example to filter hosts.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
