### PR TITLE
Fixes #38563 - replace pf4Table import in build modal to pf5

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/ErrorsTree/ErrorsTree.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/ErrorsTree/ErrorsTree.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { TableComposable, Tbody } from '@patternfly/react-table';
+import { Table, Tbody } from '@patternfly/react-table';
 import PropTypes from 'prop-types';
 import { ErrorsTreePrimaryRow } from './components/ErrorsTreePrimaryRow';
 import { ErrorsTreeSecondaryRow } from './components/ErrorsTreeSecondaryRow';
@@ -86,14 +86,14 @@ export const ErrorsTree = props => {
   };
 
   return (
-    <TableComposable
+    <Table
       ouiaId="errorsTreeTable"
       isTreeTable
       aria-label="Tree table"
       variant="compact"
     >
       <Tbody>{renderPrimaryRows(props.data)}</Tbody>
-    </TableComposable>
+    </Table>
   );
 };
 


### PR DESCRIPTION
In the new host details page, when a used clicks on "Build" the modal fails to open with this error:
Caused by components being added during the pf5 upgrade, and were missed between the time the pf5 pr opened and 
the pf5 pf merged
```
react.development.js:315 Warning: React.createElement: type is invalid -- expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `ErrorsTree`.
in ErrorsTree (created by BuildModal)
in SkeletonLoader (created by BuildModal)
in div (created by StackItem)
in StackItem (created by BuildModal)
in div (created by Stack)
```