### PR TITLE
Fixes #38569 - improves error handling while updating built status

### DIFF
--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -91,14 +91,7 @@ fi
 trap - ERR
 <%= snippet 'built' %>
 
-if [[ $? == 0 ]] ; then
-  echo "Host [<%= @host.name %>] successfully configured."
-else
-  echo "Host [<%= @host.name %>] successfully configured, but failed to set built status."
-fi
-
 <% if plugin_present?('katello') -%>
-subscription-manager facts --update
 subscription-manager repos
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/snippet/built.erb
+++ b/app/views/unattended/provisioning_templates/snippet/built.erb
@@ -39,13 +39,19 @@ EOF
 -%>
 <% end -%>
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null <%= curl_opts.join(' ') %> --silent '<%= url %>'
+  /usr/bin/curl -o /dev/null <%= curl_opts.join(' ') %> --silent --show-error '<%= url %>'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method <%= method %> <%= wget_opts.join(' ') %> '<%= url %>'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' '<%= url %>'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [<%= @host.name %>] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [<%= @host.name %>]."
 fi
+

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -35,16 +35,22 @@ EOF
 /sbin/chkconfig puppetd on
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
 fi
+
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -112,14 +112,20 @@ EOF-2929810d
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-deb10] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-deb10]."
 fi
+
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -112,14 +112,20 @@ EOF-2929810d
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-ubuntu18] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-ubuntu18]."
 fi
+
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer_default_finish.host4dhcp.snap.txt
@@ -1,14 +1,20 @@
 #!/bin/bash
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
 fi
+
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -177,16 +177,22 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
 fi
+
 
 rm /etc/resolv.conf
 ]]>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -179,16 +179,22 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
 fi
+
 
 rm /etc/resolv.conf
 ]]>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -329,29 +329,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-6-dhcp-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-6-dhcp-el7]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-6-dhcp-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-6-dhcp-el7]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -425,29 +425,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -329,29 +329,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-static-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-static-el7]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-static-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-static-el7]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -329,29 +329,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv6-dhcp-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv6-dhcp-el7]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv6-dhcp-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv6-dhcp-el7]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -329,29 +329,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv6-static-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv6-static-el7]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv6-static-el7] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv6-static-el7]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -212,29 +212,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-rhel9] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-rhel9]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-rhel9] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-rhel9]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -327,29 +327,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-rocky8] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-rocky8]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-rocky8] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-rocky8]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -326,29 +326,41 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-rocky9] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-rocky9]."
   fi
+  
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
   
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
+  if [[ $? == 0  ]] ; then
+    echo "Host [snapshot-ipv4-dhcp-rocky9] successfully configured."
+    if [ -x "$(command -v subscription-manager)" ] ; then
+      subscription-manager facts --update
+    fi
+  else
+    echo "Failed to set built status for host [snapshot-ipv4-dhcp-rocky9]."
   fi
+  
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -99,14 +99,20 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
 fi
+
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -343,14 +343,20 @@ EOF-d592f4ed
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-el7] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-el7]."
 fi
+
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -103,14 +103,20 @@ systemctl enable puppet
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-deb10] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-deb10]."
 fi
+
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -103,14 +103,20 @@ systemctl enable puppet
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent --show-error 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
 
-if [ -x "$(command -v subscription-manager)" ] ; then
-  subscription-manager facts --update
+if [[ $? == 0  ]] ; then
+  echo "Host [snapshot-ipv4-dhcp-ubuntu18] successfully configured."
+  if [ -x "$(command -v subscription-manager)" ] ; then
+    subscription-manager facts --update
+  fi
+else
+  echo "Failed to set built status for host [snapshot-ipv4-dhcp-ubuntu18]."
 fi
+
 


### PR DESCRIPTION
Since https://github.com/theforeman/foreman/commit/cd049d53d98c992ddf466bb21fc894b51fd70aa8 had landed in foreman 3.12+, Users have started reporting a rather weird post-registration issue, specifically for the Global registration effort.

When access to port 80 is disabled, then 
* Any system trying to register with foreman will be completed. 
* It will seem that everything went fine, but actually the system would remain in pending installation state. 
* And after 24 hours, the same build status for the host would show up as Token Expired ( as it should be).

This started happening after the implementation of one extra `subscription-manager facts --update` within the [built](https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/snippet/built.erb#L49-L51) snippet via the same commit mentioned above.

So now, even if due to the unavailability of port 80 i.e., http access to foreman, the built completion update via curl would fail, it will fail silently but then as the sub-man facts --update command is executed, it would change the exit code of the snippet execution to be 0 i.e success.

Hence, here in https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb#L91-L98 , Global Reg would never show as failed. It will always show successful.

This PR attempts to improve couple of things.

1. Add `--show-error` along with `--slient` flag to curl, So that the error is not silent and actually displayed to the end-user.
2. Remove the redundant `sub-man facts --update` from host_init_config as that is already part of the built snippet and will be called anyway. 
3. Remove the [final part of the error handling from the host_init_config](https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb#L94-L98) and put it within the built snippet instead. 


With the PR changes, Now the behavior is like this:

With port 80 blocked:

~~~
Refreshing subscription data
All local data refreshed
curl: (7) Failed to connect to foreman-instance-fqdn port 80: No route to host
Failed to set built status for host [dhclient-host-fqdn].
..
..
~~~

With port 80 allowed:

~~~
Refreshing subscription data
All local data refreshed
Host [dhclient-host-fqdn] successfully configured.
Successfully updated the system facts.
..
..
~~~

NOTE: The blank line at the end of the built snippet is important or else, that create a problem [here](https://github.com/theforeman/foreman/blob/develop/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb#L39) when the template is rendered. 

Without the blank line:

~~~
  fi  exit 1
}
~~~

With the blank line:

~~~
  fi
  exit 1
}
~~~
