### PR TITLE
Fixes #38573 - Add `enable-puppet-aio` to puppet templates

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -12,7 +12,7 @@ description: |
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('enable-puppetlabs-repo') ||  host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+  aio_enabled = host_param_true?('enable-puppetlabs-repo') ||  host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet-aio', true)
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -17,7 +17,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
-aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5') || host_param_true?('enable-puppet-aio', true)
 
 if host_param('run-puppet-in-installer-tags')
   puppet_tags = host_param('run-puppet-in-installer-tags')

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -73,14 +73,10 @@ runcmd:
 
 - |
   apt-get update
-  apt-get install -y puppet
+  apt-get install -y puppet-agent
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -90,11 +86,6 @@ runcmd:
   EOF
   
   
-  if [ -f "/etc/default/puppet" ]
-  then
-  /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-  fi
-  /usr/bin/puppet agent --enable
   
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
@@ -102,7 +93,7 @@ runcmd:
   # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
   # or set a full puppet run by setting "run-puppet-in-installer" = true
   echo "Performing initial puppet run for --tags no_such_tag"
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
   systemctl enable puppet
 
 phone_home:

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -289,17 +289,13 @@ runcmd:
 
 - |
   if [ -f /usr/bin/dnf ]; then
-    dnf -y install puppet
+    dnf -y install puppet-agent
   else
-    yum -t -y install puppet
+    yum -t -y install puppet-agent
   fi
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -319,7 +315,7 @@ runcmd:
   # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
   # or set a full puppet run by setting "run-puppet-in-installer" = true
   echo "Performing initial puppet run for --tags no_such_tag"
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 phone_home:
   url: http://foreman.example.com/unattended/built

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -73,14 +73,10 @@ runcmd:
 
 - |
   apt-get update
-  apt-get install -y puppet
+  apt-get install -y puppet-agent
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -90,11 +86,6 @@ runcmd:
   EOF
   
   
-  if [ -f "/etc/default/puppet" ]
-  then
-  /bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-  fi
-  /usr/bin/puppet agent --enable
   
   # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
   export FACTER_is_installer=true
@@ -102,7 +93,7 @@ runcmd:
   # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
   # or set a full puppet run by setting "run-puppet-in-installer" = true
   echo "Performing initial puppet run for --tags no_such_tag"
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
   systemctl enable puppet
 
 phone_home:

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -20,10 +20,6 @@ apt-get -y install puppet >/dev/null 2>/dev/null
 
 cat > /etc/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
@@ -25,17 +25,13 @@ pkg upgrade -y > /root/install/pkg_upgrade.txt
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -55,7 +51,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -285,17 +285,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -315,7 +311,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -49,14 +49,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -66,11 +62,6 @@ certname        = snapshot-ipv4-dhcp-deb10
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
@@ -78,7 +69,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -49,14 +49,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -66,11 +62,6 @@ certname        = snapshot-ipv4-dhcp-ubuntu18
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
@@ -78,7 +69,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -141,17 +141,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -171,7 +167,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -143,17 +143,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -173,7 +169,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -253,17 +253,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -283,7 +279,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -349,17 +349,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -379,7 +375,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -253,17 +253,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -283,7 +279,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -253,17 +253,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -283,7 +279,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -253,17 +253,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -283,7 +279,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -138,17 +138,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -168,7 +164,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -251,17 +251,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -281,7 +277,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -252,17 +252,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -282,7 +278,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet.conf.host4dhcp.snap.txt
@@ -1,8 +1,4 @@
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/puppet_setup.host4dhcp.snap.txt
@@ -1,15 +1,11 @@
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -29,4 +25,4 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -63,17 +63,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -93,7 +89,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -298,17 +298,13 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 if [ -f /usr/bin/dnf ]; then
-  dnf -y install puppet
+  dnf -y install puppet-agent
 else
-  yum -t -y install puppet
+  yum -t -y install puppet-agent
 fi
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -328,7 +324,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -67,14 +67,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -84,11 +80,6 @@ certname        = snapshot-ipv4-dhcp-deb10
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
@@ -96,7 +87,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -67,14 +67,10 @@ echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
 apt-get update
-apt-get install -y puppet
+apt-get install -y puppet-agent
 
-cat > /etc/puppet/puppet.conf << EOF
+cat > /etc/puppetlabs/puppet/puppet.conf << EOF
 [main]
-vardir = /var/lib/puppet
-logdir = /var/log/puppet
-rundir = /var/run/puppet
-ssldir = \$vardir/ssl
 
 [agent]
 pluginsync      = true
@@ -84,11 +80,6 @@ certname        = snapshot-ipv4-dhcp-ubuntu18
 EOF
 
 
-if [ -f "/etc/default/puppet" ]
-then
-/bin/sed -i 's/^START=no/START=yes/' /etc/default/puppet
-fi
-/usr/bin/puppet agent --enable
 
 # export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
 export FACTER_is_installer=true
@@ -96,7 +87,7 @@ export FACTER_is_installer=true
 # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
 # or set a full puppet run by setting "run-puppet-in-installer" = true
 echo "Performing initial puppet run for --tags no_such_tag"
-/usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+/opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 systemctl enable puppet
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -67,17 +67,13 @@ runcmd:
 
 - |
   if [ -f /usr/bin/dnf ]; then
-    dnf -y install puppet
+    dnf -y install puppet-agent
   else
-    yum -t -y install puppet
+    yum -t -y install puppet-agent
   fi
   
-  cat > /etc/puppet/puppet.conf << EOF
+  cat > /etc/puppetlabs/puppet/puppet.conf << EOF
   [main]
-  vardir = /var/lib/puppet
-  logdir = /var/log/puppet
-  rundir = /var/run/puppet
-  ssldir = \$vardir/ssl
   
   [agent]
   pluginsync      = true
@@ -97,7 +93,7 @@ runcmd:
   # You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
   # or set a full puppet run by setting "run-puppet-in-installer" = true
   echo "Performing initial puppet run for --tags no_such_tag"
-  /usr/bin/puppet agent --config /etc/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
+  /opt/puppetlabs/bin/puppet agent --config /etc/puppetlabs/puppet/puppet.conf --onetime --tags no_such_tag  --no-daemonize
 
 
 phone_home:


### PR DESCRIPTION
As older versions of puppet fall off the support matrix, this should help clean up the various parameters folks set.