### PR TITLE
Fixes #38647: kickstart default drop EOL conditions

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -63,15 +63,13 @@ description: |
   is_fedora = @host.operatingsystem.name == 'Fedora'
   os_major = @host.operatingsystem.major.to_i
   os_minor = @host.operatingsystem.minor.to_i
-  realm_compatible = (@host.operatingsystem.name == 'Fedora' && os_major >= 20) || (rhel_compatible && os_major >= 7)
   # safemode renderer does not support unary negation
   proxy_uri = host_param('http-proxy') ? "http://#{host_param('http-proxy')}:#{host_param('http-proxy-port')}" : nil
   proxy_string = proxy_uri ? " --proxy=#{proxy_uri}" : ''
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
   salt_enabled = host_param('salt_master') ? true : false
   chef_enabled = @host.respond_to?(:chef_proxy) && @host.chef_proxy
-  section_end = (rhel_compatible && os_major <= 5) ? '' : '%end'
-  use_ntp = host_param_true?('use-ntp', (is_fedora && os_major < 16) || (rhel_compatible && os_major <= 6))
+  use_ntp = host_param_true?('use-ntp')
   iface = @host.provision_interface
   appstream_present = false
   use_rhsm = (@host.operatingsystem.name == 'RedHat' || @host.operatingsystem.name == 'RHEL') && os_major >= 9
@@ -88,7 +86,7 @@ if plugin_present?('katello')
 # Content Source: <%= @host.content_source %>
 <% end -%>
 
-<% if (is_fedora && os_major < 29) || (rhel_compatible && os_major <= 7) -%>
+<% if rhel_compatible && os_major <= 7 -%>
 install
 <% end -%>
 <%
@@ -138,7 +136,7 @@ rootpw --iscrypted <%= root_pass %>
 <% if host_param_true?('disable-firewall') -%>
 firewall --disable
 <% else -%>
-firewall --<%= os_major >= 6 ? 'service=' : '' %>ssh
+firewall --service=ssh
 <% end -%>
 <%# Kdump -%>
 <% if host_param('kdump-options').present? -%>
@@ -169,7 +167,7 @@ timesource --ntp-server <%= host_param('ntp-server') %>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 <% end -%>
 
-<% if realm_compatible && @host.realm && @host.realm.realm_type == 'Active Directory' -%>
+<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'Active Directory' -%>
 # One-time password will be requested at install time. Otherwise, $HOST[OTP] is used as a placeholder value.
 realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.realm %>
 <% end -%>
@@ -178,16 +176,7 @@ realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.real
 repo --name="Server-Mysql"
 <% end -%>
 
-<% if @host.operatingsystem.name == 'Fedora' && os_major <= 16 -%>
-# Bootloader exception for Fedora 16:
-bootloader --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %> <%= ks_console %>" <%= grub_pass %>
-part biosboot --fstype=biosboot --size=1
-<% else -%>
 bootloader --location=mbr --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %>" <%= grub_pass %>
-<% if os_major == 5 -%>
-key --skip
-<% end -%>
-<% end -%>
 
 <% if @dynamic -%>
 %include /tmp/diskpart.cfg
@@ -226,13 +215,13 @@ wget
 <% if host_param('additional-packages').present? -%>
 <%= host_param('additional-packages').split(" ").join("\n") %>
 <% end -%>
-<%= section_end %>
+%end
 
 <% if @dynamic -%>
 %pre --log=/tmp/install.pre.dynamic.log
 <%= snippet_if_exists(template_name + " custom pre") %>
 <%= @host.diskLayout %>
-<%= section_end %>
+%end
 <% end -%>
 
 %post --nochroot
@@ -248,7 +237,7 @@ cp -va /etc/resolv.conf /mnt/sysimage/etc/resolv.conf
 
 chvt 1
 ) 2>&1 | tee /mnt/sysimage/root/install.postnochroot.log
-<%= section_end %>
+%end
 
 <%#
 Main post script, if it fails the last post is still executed.
@@ -329,21 +318,17 @@ chvt 6
 chvt 1
 <% end -%>
 ) 2>&1 | tee /root/install.post.log
-<%= section_end %>
+%end
 
 # copy %pre log files into chroot
 %post --nochroot
 cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
-<%= section_end %>
+%end
 
 <%#
 The last post section halts Anaconda to prevent endless loop in case HTTP request fails
 %>
-<% if (is_fedora && os_major < 20) || (rhel_compatible && os_major < 7) -%>
-%post
-<% else -%>
 %post --erroronfail --log=/root/install-callhome.post.log
-<% end -%>
 
 <%= snippet 'eject_cdrom' -%>
 
@@ -356,4 +341,4 @@ else
 fi
 
 sync
-<%= section_end %>
+%end


### PR DESCRIPTION
Kickstart default template, remove conditions related to EOL OSes:

* EL5 - EOL 30 Nov 2020
* EL6 - EOL 30 Jun 2024
* Fedora <= 28 - EOL 28 May 2019
* Fedora <= 19 - EOL 06 Jan 2015
* Fedora <= 16 - EOL 12 Feb 2013
* ~~OracleLinux 7 supports only latest~~ ([still supported](https://blogs.oracle.com/linux/post/extend-your-os-upgrade-timeline-oracle-linux-7s-extended-support-with-expanded-coverage))