### PR TITLE
Fixes #38580 - Update foreman dev setup doc

### DIFF
--- a/developer_docs/foreman_dev_setup.asciidoc
+++ b/developer_docs/foreman_dev_setup.asciidoc
@@ -22,7 +22,7 @@ Fedora ships with a too new Ruby. It's recommended to install https://github.com
 sudo dnf install rbenv ruby-build-rbenv nodejs
 echo 'eval "$(rbenv init -)"' >> ~/.bashrc
 source ~/.bashrc
-rbenv install 2.7.6
+rbenv install 3.0.7
 ....
 
 https://github.com/rvm/rvm[RVM] can also be used.
@@ -33,7 +33,7 @@ By default EL8 ships with older versions, but newer modules are available:
 
 [source, bash]
 ....
-dnf module enable ruby:2.7
+dnf module enable ruby:3.0
 dnf module enable postgresql:12
 dnf module enable nodejs:14
 ....
@@ -73,11 +73,11 @@ cp config/database.yml.example config/database.yml
 git remote add upstream git@github.com:theforeman/foreman.git
 ....
 
-If you're using rbenv, now you can configure it to locally use Ruby 2.7:
+If you're using rbenv, now you can configure it to locally use Ruby 3.0:
 
 [source, bash]
 ....
-rbenv local 2.7.6
+rbenv local 3.0.7
 ....
 
 Now you can install the dependencies:


### PR DESCRIPTION
- Update Ruby version from 2.7 to 3.0.x

Ruby 3.0+ is the preferred version for Rails 7.0.x and provides better performance and compatibility.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
