### PR TITLE
refs #38361 - Selinux issues with SSH provisioning

### DIFF
--- a/app/services/foreman/provision/ssh.rb
+++ b/app/services/foreman/provision/ssh.rb
@@ -121,7 +121,7 @@ module Foreman
       end
 
       def scp_cmd(mask: false)
-        [passwd_cmd(mask: mask), "scp", ssh_options, @template, "#{@username}@#{@address}:#{@remote_script}"].flatten
+        [passwd_cmd(mask: mask), "scp", ssh_options, @template, "#{@username}@#{@address}:#{remote_script}"].flatten
       end
 
       def ssh_options
@@ -160,11 +160,7 @@ module Foreman
       end
 
       def socket_file
-        @socket_file ||= begin
-          file = Tempfile.new("ssh-socket-#{@uuid}")
-          file.close
-          file.path
-        end
+        @socket_file ||= "~/.ssh/ssh-socket-#{@uuid}"
       end
 
       def cleanup_files
@@ -177,7 +173,7 @@ module Foreman
       end
 
       def remote_script
-        @remote_script ||= "~/#{File.basename(@template)}"
+        @remote_script ||= "/tmp/#{File.basename(@template)}"
       end
     end
   end


### PR DESCRIPTION
The original 'Use the system's SSH instead of net/ssh for provisioning' commit introduced issues with SELinux policies, making the SSH connection impossible in the production environment.

Fixed issues:
 - Rails creates the SSH socket file in the correct SSH directory.
 - The SSH private key is added using ssh-add instead of being stored in a file.

refs 617b25d30c0ca379ff27c79ba6751b7b404174b5


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
