### PR TITLE
Fixes #38469 - ensure test connection uses correct password

### DIFF
--- a/app/controllers/http_proxies_controller.rb
+++ b/app/controllers/http_proxies_controller.rb
@@ -24,12 +24,21 @@ class HttpProxiesController < ApplicationController
   end
 
   def test_connection
-    http_proxy = HttpProxy.new(http_proxy_params.merge(name: 'dummy'))
-    unless http_proxy.valid?
-      raise Foreman::Exception, http_proxy.errors.full_messages.join(', ')
+    if params[:http_proxy_id].present?
+      @http_proxy = HttpProxy.authorized(:edit_http_proxies).find(params[:http_proxy_id])
+      # Update attributes except password - preserve existing password
+      form_params = http_proxy_params.except(:password)
+      @http_proxy.attributes = form_params
+    else
+      @http_proxy = HttpProxy.new(http_proxy_params)
+    end
+    @http_proxy.name = 'dummy' # Required for validation
+
+    unless @http_proxy.valid?
+      raise Foreman::Exception, @http_proxy.errors.full_messages.join(', ')
     end
 
-    http_proxy.test_connection(params[:test_url])
+    @http_proxy.test_connection(params[:test_url])
 
     render :json => {:status => 'success', :message => _("HTTP Proxy connection successful.")}, :status => :ok
   rescue => e

--- a/app/views/http_proxies/_form.html.erb
+++ b/app/views/http_proxies/_form.html.erb
@@ -2,7 +2,7 @@
           :text => _("Please note that these HTTP proxy configurations are only used for requests
                       from Foreman or Foreman plugins. System-wide proxies must be configured at operating system level.") %>
 
-<%= form_for @http_proxy, :url => (@http_proxy.new_record? ? http_proxies_path : http_proxy_path(:id => @http_proxy)) do |f| %>
+<%= form_for @http_proxy, :url => (@http_proxy.new_record? ? http_proxies_path : http_proxy_path(:id => @http_proxy)), :html => {:data => {:id => @http_proxy.try(:id)}} do |f| %>
   <%= base_errors_for @http_proxy %>
   <ul class="nav nav-tabs" data-tabs="tabs">
     <li class="active"><a href="#primary" data-toggle="tab"><%= _("HTTP Proxy") %></a></li>

--- a/test/controllers/http_proxies_controller_test.rb
+++ b/test/controllers/http_proxies_controller_test.rb
@@ -72,4 +72,43 @@ class HttpProxiesControllerTest < ActionController::TestCase
     controller.expects(:render).with(:json => {:status => 'failure', :message => "some error"}, :status => :unprocessable_entity)
     controller.test_connection
   end
+
+  context 'test_connection with  existing proxy' do
+    test 'preserves password when empty password is provided' do
+      existing_proxy = FactoryBot.create(:http_proxy,
+        :name => 'existing_proxy',
+        :url => 'https://old.example.com:8080',
+        :username => 'olduser',
+        :password => 'oldpassword'
+      )
+
+      HttpProxy.any_instance.stubs(:test_connection).returns(true)
+
+      put :test_connection,
+        params: {
+          :http_proxy_id => existing_proxy.id,
+          :http_proxy => {
+            :name => 'updated_name',
+            :url => 'https://new.example.com:8080',
+            :username => 'newuser',
+            :password => '', # Empty password in form (disabled field)
+          },
+          :test_url => 'https://test.example.com',
+        },
+        session: set_session_user
+
+      assert_response :success
+      response_json = JSON.parse(@response.body)
+      assert_equal 'success', response_json['status']
+
+      # Verify that the existing proxy object used for testing still has original password
+      # but updated other attributes
+      assigns(:http_proxy).tap do |proxy|
+        assert_equal 'oldpassword', proxy.password, 'Password should be preserved from database'
+        assert_equal 'https://new.example.com:8080', proxy.url, 'URL should be updated from form'
+        assert_equal 'newuser', proxy.username, 'Username should be updated from form'
+        assert_equal 'dummy', proxy.name, 'Name should be set to dummy for validation'
+      end
+    end
+  end
 end

--- a/webpack/assets/javascripts/foreman_http_proxies.js
+++ b/webpack/assets/javascripts/foreman_http_proxies.js
@@ -8,7 +8,24 @@ import $ from 'jquery';
 import { notify, clear } from './foreman_toast_notifications';
 
 export function testConnection(item, url) {
-  const data = $('form').serialize();
+  // Get HTTP proxy ID for existing records, but only if password field is disabled
+  // If password field is enabled, user wants to test with new password from form
+  let httpProxyId = '';
+  const passwordField = $('#http_proxy_password');
+
+  if (passwordField.length > 0 && passwordField.prop('disabled')) {
+    // Password field is disabled, so use existing password from database
+    const formElement = $('form')[0];
+    httpProxyId = formElement.dataset.id || '';
+  }
+  // If password field is enabled, leave httpProxyId empty so controller uses form password
+
+  const serializedArray = $('form').serializeArray();
+  const formData = new URLSearchParams(
+    serializedArray.map(({ name, value }) => [name, value])
+  );
+  formData.append('http_proxy_id', httpProxyId);
+  const data = formData.toString();
 
   $('#test_connection_indicator').show();
   $(item).addClass('disabled');


### PR DESCRIPTION
The HTTP proxy page test connection feature currently only uses data that is in the form. One issue here is that, once an HTTP Proxy is saved and clicked into, the password form is disabled for security, which means no password is sent over.

This PR makes and update so that the test connection field reuses the password saved in the DB if the user is not trying to edit the password. If they do edit the password, the one in the text box gets used instead.