### PR TITLE
Fixes #38601 - replace react-ellipsis-with-tooltip

### DIFF
--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -19,7 +19,6 @@ module.exports = [
   'react-dnd-html5-backend',
   'react-debounce-input',
   'react-diff-view',
-  'react-ellipsis-with-tooltip',
   'react-onclickoutside',
   'react-password-strength',
   'react-router-dom',

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "react-dnd": "^14.0.2",
     "react-dom": "^16.8.1",
     "react-bootstrap": "^0.32.0",
-    "react-ellipsis-with-tooltip": "^1.0.8",
     "react-helmet": "^6.1.0",
     "react-intl": "^2.8.0",
     "react-loading-skeleton": "^1.1.2",

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/Breadcrumb.js
@@ -6,8 +6,8 @@ import {
   BreadcrumbItem,
   TextContent,
   Text,
+  Truncate,
 } from '@patternfly/react-core';
-import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
 import './Breadcrumbs.scss';
 
 const Breadcrumb = ({
@@ -40,9 +40,7 @@ const Breadcrumb = ({
         if (!icon && !itemTitle) return null;
 
         const inner = active ? (
-          <EllipsisWithTooltip placement="bottom">
-            {itemTitle}
-          </EllipsisWithTooltip>
+          <Truncate content={itemTitle} tooltipPosition="bottom" />
         ) : (
           itemTitle
         );

--- a/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/BreadcrumbBar/components/__snapshots__/Breadcrumb.test.js.snap
@@ -43,11 +43,10 @@ exports[`Breadcrumbs renders breadcrumbs menu 1`] = `
     key="2"
   >
      
-    <EllipisWithTooltip
-      placement="bottom"
-    >
-      active child
-    </EllipisWithTooltip>
+    <Truncate
+      content="active child"
+      tooltipPosition="bottom"
+    />
   </BreadcrumbItem>
 </Breadcrumb>
 `;
@@ -65,11 +64,10 @@ exports[`Breadcrumbs renders h1 title 1`] = `
     key="0"
   >
      
-    <EllipisWithTooltip
-      placement="bottom"
-    >
-      title
-    </EllipisWithTooltip>
+    <Truncate
+      content="title"
+      tooltipPosition="bottom"
+    />
   </BreadcrumbItem>
 </Breadcrumb>
 `;
@@ -102,11 +100,10 @@ exports[`Breadcrumbs renders title override 1`] = `
     key="1"
   >
      
-    <EllipisWithTooltip
-      placement="bottom"
-    >
-      override title
-    </EllipisWithTooltip>
+    <Truncate
+      content="override title"
+      tooltipPosition="bottom"
+    />
   </BreadcrumbItem>
 </Breadcrumb>
 `;

--- a/webpack/assets/javascripts/react_app/components/common/table/formatters/ellipsisCellFormatter.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/formatters/ellipsisCellFormatter.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import EllipsisWithTooltip from 'react-ellipsis-with-tooltip';
+import { Truncate } from '@patternfly/react-core';
 import cellFormatter from './cellFormatter';
 
-export default value =>
-  cellFormatter(<EllipsisWithTooltip>{value || ''}</EllipsisWithTooltip>);
+export default value => cellFormatter(<Truncate content={value || ''} />);


### PR DESCRIPTION
since this removes the package its best to first merge the (unopened katello and templates prs)
before (grey) & after (black)
<img width="571" height="171" alt="Screenshot From 2025-07-22 11-35-37" src="https://github.com/user-attachments/assets/9a505bed-e617-4995-889f-92386d721ccb" />
<img width="571" height="171" alt="Screenshot From 2025-07-22 11-31-55" src="https://github.com/user-attachments/assets/e50e2d9a-5630-4b28-8ccb-2a04fb723d59" />
