### PR TITLE
Fixes #38606 - Settings table UI fixes

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.js
@@ -7,6 +7,8 @@ import { translate as __ } from '../../common/I18n';
 import SettingValueCell from './components/SettingValueCell';
 import SettingNameCell from './components/SettingName';
 
+import './SettingsTable.scss';
+
 const TableHead = () => (
   <Thead>
     <Tr ouiaId="setting-table-heading-row">
@@ -20,18 +22,24 @@ const TableHead = () => (
 const ViewRows = ({ settings }) =>
   settings.map((data, index) => (
     <Tr key={index} ouiaId={`setting-table-heading-row-${index}`}>
-      <Td>
+      <Td width={30}>
         <SettingNameCell setting={data} />
       </Td>
-      <Td>
+      <Td width={35}>
         <SettingValueCell setting={data} index={index} />
       </Td>
-      <Td>{data.description}</Td>
+      <Td width={35}>{data.description}</Td>
     </Tr>
   ));
 
 const SettingsTable = ({ settings }) => (
-  <Table isStriped variant="compact" ouiaId="settings-table" borders>
+  <Table
+    isStriped
+    variant="compact"
+    ouiaId="settings-table"
+    borders
+    id="settings-table"
+  >
     <TableHead />
     <Tbody>
       <ViewRows settings={settings} />

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.scss
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.scss
@@ -1,0 +1,10 @@
+@import '../../common/variables';
+
+#settings-table {
+    .pf-v5-c-table__tr .pf-v5-c-table__td .setting-value{
+        overflow-wrap: anywhere;
+    }
+    .empty-value{
+        color: var(--pf-v5-global--Color--200);
+    }
+}

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/__tests__/__snapshots__/SettingsTable.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/__tests__/__snapshots__/SettingsTable.test.js.snap
@@ -3,6 +3,7 @@
 exports[`SettingsTableSnapshot should render 1`] = `
 <Table
   borders={true}
+  id="settings-table"
   isStriped={true}
   ouiaId="settings-table"
   variant="compact"

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValue.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValue.js
@@ -11,7 +11,15 @@ import {
 const innerCell = props => {
   const { setting } = props;
 
-  let field = <>{valueToString(setting)}</>;
+  let field = (
+    <div
+      className={
+        setting.value || setting.settingsType === 'boolean' ? '' : 'empty-value'
+      }
+    >
+      {valueToString(setting)}
+    </div>
+  );
 
   if (setting.value !== setting.default && hasDefault(setting))
     field = <strong>{field}</strong>;

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueCell.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueCell.js
@@ -23,20 +23,21 @@ const SettingValueCell = ({ setting, index }) => {
         <Flex
           justifyContent={{ default: 'justifyContentSpaceBetween' }}
           alignItems={{ default: 'alignItemsCenter' }}
-          flexWrap={{ default: 'nowrap' }}
         >
-          <FlexItem>
+          <FlexItem className="setting-value">
             <SettingValue setting={settingData} />
           </FlexItem>
           <FlexItem>
-            <Button
-              onClick={() => setEditingRow(true)}
-              variant="plain"
-              ouiaId={`edit-row-${index}-icon`}
-              id={setting.name}
-            >
-              <PencilAltIcon />
-            </Button>
+            {!setting.readonly && (
+              <Button
+                onClick={() => setEditingRow(true)}
+                variant="plain"
+                ouiaId={`edit-row-${index}-icon`}
+                id={setting.name}
+              >
+                <PencilAltIcon />
+              </Button>
+            )}
           </FlexItem>
         </Flex>
       )}

--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueEdit.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueEdit.js
@@ -72,6 +72,11 @@ const SettingValueEdit = ({ setting, updateSetting }) => {
   };
 
   const handleSubmit = () => {
+    if (value !== '' && value.trim() === '') {
+      setErrMsg(__('Invalid value'));
+      return;
+    }
+
     setLoading(true);
     setErrMsg(null);
 
@@ -91,9 +96,11 @@ const SettingValueEdit = ({ setting, updateSetting }) => {
       handleError: errorCallback,
       errorToast: error => {
         const msg =
+          error.response?.data?.error?.message ||
           // eslint-disable-next-line camelcase
-          error.response?.data?.error?.full_messages ??
-          error.response?.data?.error?.errors?.value[0];
+          error.response?.data?.error?.full_messages ||
+          error.response?.data?.error?.errors?.value[0] ||
+          error.response?.data?.errors?.value[0];
         setErrMsg(msg);
         return `${__('Error updating setting')}: ${msg}`;
       },


### PR DESCRIPTION
Fixes multiple UI/UX issues described bellow:

- Too long strings make text inputs in PF5 Settings overflow
- Readonly Setting shown as editable in new PF5 Settings
- Incorrectly handled error when Setting field data validation fails: "Error updating setting: undefined"
- It's possible to fill in " " in Settings even though it's not valid. Then it shows as " ".
- In PF5 Settings, empty fields are not visually distinguished from fields with value "Empty"
