### PR TITLE
Fixes #38614 - drop react-bootstrap pin

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "react-dnd-html5-backend": "^14.0.0",
     "react-dnd": "^14.0.2",
     "react-dom": "^16.8.1",
-    "react-bootstrap": "^0.32.0",
     "react-helmet": "^6.1.0",
     "react-intl": "^2.8.0",
     "react-loading-skeleton": "^1.1.2",


### PR DESCRIPTION
seems that it was pinned for test reasons, the tests look to pass without it