### PR TITLE
Fixes #38616 - expand nav item also when url has a query

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/LayoutHelper.js
@@ -2,6 +2,7 @@
 
 import { isEmpty } from 'lodash';
 import PropTypes from 'prop-types';
+import URI from 'urijs';
 import { translate as __ } from '../../common/I18n';
 import {
   removeLastSlashFromPath,
@@ -23,6 +24,12 @@ export const createInitialTaxonomy = (currentTaxonomy, availableTaxonomies) => {
 
 export const getCurrentPath = () =>
   removeLastSlashFromPath(window.location.pathname);
+
+export const cleanNavPath = href => {
+  if (!href) return href;
+  const uri = new URI(href);
+  return uri.pathname();
+};
 
 export const combineMenuItems = (data, displayNewHostsPage) => {
   const items = [];

--- a/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/Navigation.js
@@ -8,7 +8,7 @@ import {
   NavExpandable,
   NavItemSeparator,
 } from '@patternfly/react-core';
-import { getCurrentPath } from './LayoutHelper';
+import { getCurrentPath, cleanNavPath } from './LayoutHelper';
 import { NavigationSearch } from './NavigationSearch';
 import {
   useForemanOrganization,
@@ -114,7 +114,7 @@ const Navigation = ({
     groupedItems.some(({ groups }) =>
       groups.some(({ groupItems, title }) =>
         groupItems.some(({ href }) => {
-          if (href === pathFragment(getCurrentPath())) {
+          if (cleanNavPath(href) === pathFragment(getCurrentPath())) {
             setCurrentExpandedSecondary(title);
             return true;
           }


### PR DESCRIPTION
opening Reports > Config Management from navigation, causes the item to not be expanded, unlike all other menu items
For example (that works): Reports > report template

