### PR TITLE
Fixes #38619 - Improve messaging in permissions:reset rake task

### DIFF
--- a/lib/tasks/reset_permissions.rake
+++ b/lib/tasks/reset_permissions.rake
@@ -1,6 +1,6 @@
 namespace :permissions do
   desc <<~END_DESC
-    Create or reset "admin" user permissions to defaults.  Alternatively, you may
+    Reset "admin" user permissions to defaults.  Alternatively, you may
     specify a username or password.
 
     Examples:
@@ -8,12 +8,15 @@ namespace :permissions do
       Reset to user: admin, password: HrbX7zQErrT6
 
       # foreman-rake permissions:reset username=bclark password=changeme
-      Reset to user: bclark, password: changeme
+      Reset existing user: bclark, password: changeme
   END_DESC
 
   task :reset => :environment do
     User.as_anonymous_admin do
-      user = User.where(:login => ENV["username"] || 'admin').first_or_create(:firstname => 'Admin', :lastname => 'User', :mail => Setting[:administrator])
+      username = ENV["username"] || 'admin'
+      created = !User.exists?(login: username)
+
+      user = User.where(:login => username).first_or_create(:firstname => 'Admin', :lastname => 'User', :mail => Setting[:administrator])
       src  = AuthSourceInternal.where(:type => "AuthSourceInternal").first_or_create
       src.update_attribute :name, "Internal"
       user.admin = true
@@ -21,7 +24,7 @@ namespace :permissions do
       password = ENV["password"] || User.random_password
       user.password = password
       if user.save
-        puts "Reset to user: #{user.login}, password: #{password}"
+        puts "#{created ? 'Created new user' : 'Reset to user'}: #{user.login}, password: #{password}"
         puts "WARNING: You need to change the password for hammer in ~/.hammer/cli.modules.d/foreman.yml manually!"
       else
         puts user.errors.full_messages.join(", ")


### PR DESCRIPTION
- this task should update password for any existing user
- If an attempt is made to reset password for a username that does not exist, the task will abort with an error message instead of creating a new user.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
