### PR TITLE
Fixes #38624 - Adapt Registration Template to support OpenVox Agent

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -18,6 +18,7 @@ os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
 aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
+aio_openvox_enabled = host_param_true?('enable-openvox7') || host_param_true?('enable-openvox8')
 
 if host_param('run-puppet-in-installer-tags')
   puppet_tags = host_param('run-puppet-in-installer-tags')
@@ -35,6 +36,10 @@ elsif os_family == 'Windows'
   bin_path = 'C:\Program Files\Puppet Labs\Puppet\bin'
 elsif aio_enabled
   linux_package = 'puppet-agent'
+  etc_path = '/etc/puppetlabs/puppet'
+  bin_path = '/opt/puppetlabs/bin'
+elsif aio_openvox_enabled
+  linux_package = 'openvox-agent'
   etc_path = '/etc/puppetlabs/puppet'
   bin_path = '/opt/puppetlabs/bin'
 else
@@ -55,9 +60,10 @@ else
   yum -t -y install <%= linux_package %>
 fi
 <% elsif os_family == 'Suse' -%>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
+<% if aio_enabled -%>
 rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppet
+<% elsif aio_openvox_enabled -%>
+rpmkeys --import https://yum.voxpupuli.org/GPG-KEY-openvox.pub
 <% end -%>
 <% if @host.provision_method == 'image' -%>
 /usr/bin/zypper -n --gpg-auto-import-keys install <%= linux_package %>
@@ -111,7 +117,7 @@ puppet_unit=puppet
 <% if os_family == 'Freebsd' -%>
 echo 'puppet_enable="YES"' >>/etc/rc.conf
 <% end -%>
-<% unless aio_enabled -%>
+<% unless aio_enabled || aio_openvox_enabled -%>
 <% if os_family == 'Debian' -%>
 if [ -f "/etc/default/puppet" ]
 then


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Hi there!
I played around with registering OpenVox Agents for a bit and that's the necessary fix, that I had to do to make it work.

### Testing

- Make sure you have an activation key with either the 7 or 8 repo for one of the supported distros on hand
- Make sure you have the necessary host properties set (puppet_server, enable-openvox8)
- Then the global registration should work pretty much the same as with a Puppet Agent!

I hope I did everything correct, still not native with ruby 🙂 
Please do not hesitate to point out any improvements and I will fix it as soon as I have time. (or also if this doesn't fit the current implementation path totally fine with dropping it)

Thanks!