### PR TITLE
Fixes #38605 - Reword note about compute resources

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -60,7 +60,8 @@
             <% end %>
             </tbody>
           </table>
-          <%= _('To enable a provider, either install the OS package (e.g. foreman-libvirt) or enable the bundler group for development setup (e.g. libvirt).') %>
+          <%= _('You can enable additional compute resources. For more information, see') %>
+          <%= link_to _('provisioning hosts'), external_link_path(type: 'docs', section: "Provisioning_Hosts", chapter: ""), :rel => "external" %>.
         </div>
         <div class="tab-pane" id="compute_resources">
           <% if @compute_resources.empty? %>


### PR DESCRIPTION
This patch rewords the note that is shown below the table of compute resources on the Administer > About page on the Available Providers tab.

* Remove "bundler" for development setups which not ideal for downstream products
* Remove "oVirt" which is deprecated (NOTE: When I first looked at it, it still referenced oVirt. This has been fixed by Leos via b777a65.)
* Recommend following the docs and using "foreman-installer" in favor of their package managers.

Without a chapter, the users will start at the beginning of the guide. There is no chapter that lists all virtualization platforms and cloud providers.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
