### PR TITLE
Fixes #37196 - Update breadcrumbs url generation logic for host

### DIFF
--- a/app/services/breadcrumbs_options.rb
+++ b/app/services/breadcrumbs_options.rb
@@ -30,9 +30,16 @@ class BreadcrumbsOptions
       class_name = ''
     end
 
+    # Use setting-aware path for hosts
+    url = if resource_name.downcase == 'host'
+            ApplicationHelper.current_hosts_path
+          else
+            resource_path(class_name) || resource_path(resource_name)
+          end
+
     {
       caption: _(Menu::Manager.get_resource_caption(controller.controller_name.to_s.downcase.pluralize.to_sym)),
-      url: resource_path(class_name) || resource_path(resource_name),
+      url: url,
     }
   end
 


### PR DESCRIPTION
## Fix breadcrumb links to respect 'Show new host overview page' setting

### Problem
When creating a new host (/hosts/new), the breadcrumb "All Hosts" link incorrectly points to /hosts instead of respecting the "Show new host overview page" setting which should redirect to /new/hosts.

### Solution
Updated **BreadcrumbsOptions.rb** to use **ApplicationHelper.current_hosts_path** for host resources, which automatically handles the new_hosts_page setting, ensuring breadcrumbs consistently link to the correct hosts page.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
