### PR TITLE
Fixes #38644 - call sub-man unregister once with force option

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -162,7 +162,7 @@ register_katello_host(){
 # Set up subscription-manager
 <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'registration' }).strip -%>
 
-subscription-manager register <%= '--force' if truthy?(@force) %> \
+subscription-manager register \
   --org='<%= @organization.label if @organization %>' \
   --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
 


### PR DESCRIPTION
Currently global registration calls sub-man unregister twice with `Force` option.
```
 <% if truthy?(@force) -%>
      # Unregister host and remove all local system and subscription data
      if [ -x "$(command -v subscription-manager)" ] ; then
        subscription-manager unregister || true
        subscription-manager clean
      fi
```

and
 ```
subscription-manager register <%= '--force' if truthy?(@force) %> \
  --org='<%= @organization.label if @organization %>' \
  --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
```

Based on the [manual](https://github.com/candlepin/subscription-manager/blob/83a8b05934bd536d890e0f3d313d6256a1ffed28/man/subscription-manager.8#L241), this commit removes the implicit unregister.