### PR TITLE
Refs #38622 - Fix current_host_details_path usage

### DIFF
--- a/app/views/hosts/console/log.html.erb
+++ b/app/views/hosts/console/log.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <% search_bar(_("Generated %s ago") % time_ago_in_words(@console['timestamp'])) %>
   <% if @host && authorized_for(hash_for_host_path(@host)) %>
-    <%= title_actions(link_to(_("Back to host"), current_host_details_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default')) %>
+    <%= title_actions(link_to(_("Back to host"), current_host_details_path(@host), :title => _("Back to host"), :class => 'btn btn-default')) %>
   <% end %>
   <% title "#{@console[:name]}" %>
 </div>

--- a/app/views/hosts/console/spice.html.erb
+++ b/app/views/hosts/console/spice.html.erb
@@ -2,7 +2,7 @@
 <%= title_actions(
         button_group(link_to(_("Ctrl-Alt-Del"), "#", :id => "sendCtrlAltDelButton", :onclick => 'tfm.spice.sendCtrlAltDel()', :class => "btn btn-default"),
                      if @host && authorized_for(hash_for_host_path(@host))
-                       link_to(_("Back to host"), current_host_details_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default')
+                       link_to(_("Back to host"), current_host_details_path(@host), :title => _("Back to host"), :class => 'btn btn-default')
                      end
         ),
         documentation_button("7.1NoVNC",

--- a/app/views/hosts/console/vmrc.html.erb
+++ b/app/views/hosts/console/vmrc.html.erb
@@ -14,7 +14,7 @@
                   :disable_with => "<i class='fa fa-spinner fa-spin'></i> #{_('Opening VMRC Console')}..."
                 }) %>
     <% if @host && authorized_for(hash_for_host_path(@host)) %>
-      <%= link_to(_("Back to host"), current_host_details_path(:id => @host), :title => _('Back to host'), :class => 'btn btn-default btn-lg') %>
+      <%= link_to(_("Back to host"), current_host_details_path(@host), :title => _('Back to host'), :class => 'btn btn-default btn-lg') %>
     <% end %>
   </div>
 </div>

--- a/app/views/hosts/console/vnc.html.erb
+++ b/app/views/hosts/console/vnc.html.erb
@@ -2,7 +2,7 @@
 <%= title_actions(
         button_group(link_to("Ctrl-Alt-Del", "#", :id => "sendCtrlAltDelButton", :class => "btn btn-default"),
                      if @host && authorized_for(hash_for_host_path(@host))
-                       link_to(_("Back to host"), current_host_details_path(:id => @host), :title => _("Back to host"), :class => 'btn btn-default')
+                       link_to(_("Back to host"), current_host_details_path(@host), :title => _("Back to host"), :class => 'btn btn-default')
                      end
         ),
         documentation_button("7.1NoVNC",


### PR DESCRIPTION
Follow up for https://github.com/theforeman/foreman/pull/10629

Without this, the page with the console throws:
<img width="639" height="439" alt="Screenshot-1754655456148" src="https://github.com/user-attachments/assets/13dec215-a9d1-443c-b716-b9afa547a042" />
