### PR TITLE
Fixes #38650 Fixing an Operating System entry when installing Satellite

### DIFF
--- a/app/models/operatingsystems/redhat.rb
+++ b/app/models/operatingsystems/redhat.rb
@@ -54,7 +54,7 @@ class Redhat < Operatingsystem
   def shorten_description(description)
     return "" if description.blank?
     s = description.dup
-    s.gsub!('Red Hat Enterprise Linux', 'RHEL')
+    s.gsub!('Red Hat Enterprise Linux', 'RedHat')
     s.gsub!('release', '')
     s.gsub!(/\(.+?\)/, '')
     s.squeeze! " "


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

Please, review the issue [SAT-36540](https://issues.redhat.com/browse/SAT-36540) for the complete information, with additional screenshot.

Thank you!
Waldirio

