### PR TITLE
Fixes #38793 - Fix CR VM json partial rendering

### DIFF
--- a/app/controllers/compute_resources_vms_controller.rb
+++ b/app/controllers/compute_resources_vms_controller.rb
@@ -21,7 +21,7 @@ class ComputeResourcesVmsController < ApplicationController
       format.html
       format.json do
         if @compute_resource.supports_vms_pagination?
-          render :partial => "compute_resources_vms/index/#{@compute_resource.provider.downcase}.json"
+          render :partial => "compute_resources_vms/index/#{@compute_resource.provider.downcase}", :formats => :json
         else
           render :json => _('JSON VM listing is not supported for this compute resource.'),
             :status => :not_implemented


### PR DESCRIPTION
The old code expected a template file to be stored as `app/views/compute_resources_vms/index/_EXAMPLE.json.erb`. However, in recent versions of rails this leads to a ["missing partials" error](https://stackoverflow.com/questions/71069354/rails-7-missing-partial). This breaks Foreman plugins that rely on this functionality.

The reason: rendering templates with `.` in the name is deprecated, see https://github.com/rails/rails/pull/39164.

~Besides fixing the code, the template files also needs to be renamed from `app/views/compute_resources_vms/index/_EXAMPLE.json.erb` to `app/views/compute_resources_vms/index/_EXAMPLE_json.erb`.~

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
