### PR TITLE
Fixes #38653 - Fix settings show endpoint

### DIFF
--- a/app/controllers/api/v2/settings_controller.rb
+++ b/app/controllers/api/v2/settings_controller.rb
@@ -5,6 +5,11 @@ module Api
 
       before_action :find_resource, :only => %w{show update}
 
+      def find_resource
+        @setting = resource_scope.find(params[:id])
+        raise ActiveRecord::RecordNotFound if @setting.nil?
+      end
+
       def_param_group :setting_params do
         property :id, String, desc: N_('Alias for setting name')
         property :name, String, desc: N_('Setting unique name')

--- a/test/controllers/api/v2/settings_controller_test.rb
+++ b/test/controllers/api/v2/settings_controller_test.rb
@@ -81,6 +81,11 @@ class Api::V2::SettingsControllerTest < ActionController::TestCase
       show_response = ActiveSupport::JSON.decode(@response.body)
       assert_include show_response.keys, 'updated_at'
     end
+
+    test "return 404 for non-existent setting" do
+      get :show, params: { :id => 'non_existent_setting' }
+      assert_response :not_found
+    end
   end
 
   test "should not update setting" do


### PR DESCRIPTION
- There was issue related to the api, in settings when we try to find a setting by id and if there is no setting with that id, it gives nil(which causes issue on the output) rather than raising exception.

hammer settings info --id 1
Before:-

output:- undefined method `name' for nil:NilClass

After Fix:-

output:- Resource setting not found by id '1'


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
