### PR TITLE
Fixes #38660 - user jwt page ui warnings

### DIFF
--- a/webpack/assets/javascripts/react_app/components/users/JwtTokens/JwtTokens.js
+++ b/webpack/assets/javascripts/react_app/components/users/JwtTokens/JwtTokens.js
@@ -27,7 +27,7 @@ const JwtTokens = ({ userId }) => {
               <Button
                 ouiaId="invalidate-jwt-token-button"
                 variant="primary"
-                isSmall
+                size="sm"
                 onClick={() =>
                   dispatch(
                     openConfirmModal({
@@ -61,7 +61,7 @@ const JwtTokens = ({ userId }) => {
 };
 
 JwtTokens.propTypes = {
-  userId: PropTypes.string.isRequired,
+  userId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };
 
 export default JwtTokens;


### PR DESCRIPTION
isSmall was a propname in pf4 and is not in pf5
```
checkPropTypes.js:20 Warning: Failed prop type: Invalid prop `userId` of type `number` supplied to `JwtTokens`, expected `string`.
in JwtTokens (created by I18nProviderWrapper(JwtTokens))

Warning: React does not recognize the `isSmall` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `issmall` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
in button (created by ButtonBase)
in ButtonBase (created by Button)
in Button (created by JwtTokens)
in td (created by JwtTokens)
in tr (created by JwtTokens)
in tbody (created by JwtTokens)
in table (created by JwtTokens)
in JwtTokens (created by I18nProviderWrapper(JwtTokens))
```