### PR TITLE
Fixes #38696 - Add default node_options

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,4 +2,4 @@
 # If you wish to use a different server then the default, use e.g. `export RAILS_STARTUP='puma -w 3 -p 3000 --preload'`
 rails: [ -n "$RAILS_STARTUP" ] && env PRY_WARNING=1 $RAILS_STARTUP || [ -n "$BIND" ] && bin/rails server -b $BIND || env PRY_WARNING=1 bin/rails server
 
-webpack: env NODE_OPTIONS=${NODE_OPTIONS:---max-old-space-size=8096} NODE_ENV=${NODE_ENV:-development} npx webpack --config config/webpack.config.js --watch $WEBPACK_OPTS
+webpack: env NODE_OPTIONS="--max-old-space-size=8096 $NODE_OPTIONS" NODE_ENV=${NODE_ENV:-development} npx webpack --config config/webpack.config.js --watch $WEBPACK_OPTS

--- a/developer_docs/foreman_dev_setup.asciidoc
+++ b/developer_docs/foreman_dev_setup.asciidoc
@@ -102,7 +102,7 @@ Run the following command:
 gem install pg -v '{PG_VERSION}' -- --with-pg-config=/usr/pgsql-13/bin/pg_config
 ....
 
-*Good to Notice:* 
+*Good to Notice:*
 Foreman uses Bundler to install dependencies and get up and running. This is the preferred way to get Foreman if you want to benefit from the latest improvements. By using the git repository you can also upgrade more easily.
 
 [[Database]]
@@ -150,7 +150,7 @@ list of options that can be set in an .env file (as well as in the cli call):
 
 * `NOTIFICATIONS_POLLING` is the notification polling interval in ms.
 
-* `NODE_OPTIONS` is used for npm actions, when running plugin tests with `npm run test:plugins` we add `--max-old-space-size=8192` to the options, but it can be overridden by writing your own `NODE_OPTIONS`. It is also added for webpack compile (`foreman start webpack`).
+* `NODE_OPTIONS` is used for npm actions, when running plugin tests with `npm run test:plugins` we add `--max-old-space-size=8192` to the options, but it can be overridden by writing your own `NODE_OPTIONS`. It is also added for webpack compile (`foreman start webpack`). For more permanent setup of node options, please use the [.npmrc](https://docs.npmjs.com/cli/v8/configuring-npm/npmrc) local file (or the project file, if you want to share the option with everyone)
 
 
 === Resetting password

--- a/script/npm_test_plugin.js
+++ b/script/npm_test_plugin.js
@@ -20,8 +20,7 @@ var { allPluginDirs, skippedDirsKeys, dirsKeys } = filterPluginDirectories();
 const passedArgs = process.argv.slice(2);
 const coreConfigPath = path.resolve(__dirname, '../webpack/jest.config.js');
 const coreConfig = require(coreConfigPath);
-process.env.NODE_OPTIONS =
-  process.env.NODE_OPTIONS || '--max-old-space-size=8192';
+process.env.NODE_OPTIONS = '--max-old-space-size=8192 ' + (process.env.NODE_OPTIONS || '');
 
 const runTests = async () => {
   if (passedArgs[0] && passedArgs[0][0] !== '-') {


### PR DESCRIPTION
Make sure the NODE_OPTIONS field is overridable, but adds the
default values. I am using the fact that you can specify an option
twice, and only the last value will take precedence.