### PR TITLE
Fixes #TBFL - Taxonomy-level permission enforcement

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,7 +6,7 @@ module Api
     include Foreman::Controller::BruteforceProtection
 
     before_action :load_settings
-    before_action :set_default_response_format, :authorize, :set_taxonomy
+    before_action :set_default_response_format, :authorize, :set_taxonomy, :authorize_in_taxonomy_scope
     before_action :check_media_type
     before_action :assign_lone_taxonomies, :only => :create
     before_action :add_info_headers, :set_gettext_locale
@@ -218,6 +218,15 @@ module Api
       end
 
       unless authorized
+        deny_access
+        return false
+      end
+
+      true
+    end
+
+    def authorize_in_taxonomy_scope
+      unless authorized_in_taxonomy_scope
         deny_access
         return false
       end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -67,7 +67,7 @@ class ApplicationController < ActionController::Base
       render :json => { :error => "Authentication error" }, :status => :unauthorized
       return
     end
-    authorized ? true : deny_access
+    authorized_in_taxonomy_scope ? true : deny_access
   end
 
   def deny_access

--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -45,6 +45,10 @@ module Foreman::Controller::Authentication
     User.current.allowed_to?(path_to_authenticate)
   end
 
+  def authorized_in_taxonomy_scope
+    User.current.allowed_to_in_taxonomy_scope?(path_to_authenticate)
+  end
+
   def path_to_authenticate
     Foreman::AccessControl.normalize_path_hash(params.slice(:controller, :action, :id, :user_id))
   end

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -8,6 +8,7 @@ module Foreman::Controller::SmartProxyAuth
     def add_smart_proxy_filters(actions, options = {})
       skip_before_action :require_login, :check_user_enabled, :only => actions, :raise => false
       skip_before_action :authorize, :only => actions
+      skip_before_action :authorize_in_taxonomy_scope, :only => actions
       skip_before_action :verify_authenticity_token, :only => actions
       skip_before_action :set_taxonomy, :only => actions, :raise => false
       skip_before_action :session_expiry, :update_activity_time, :only => actions

--- a/app/helpers/authorize_helper.rb
+++ b/app/helpers/authorize_helper.rb
@@ -19,7 +19,7 @@ module AuthorizeHelper
     permission      = options.delete(:permission) || [action, controller_name.split('/').last].join('_')
 
     if object.nil?
-      user.allowed_to?({ :controller => controller_name, :action => action, :id => id, :user_id => user_id }) rescue false
+      user.allowed_to_in_taxonomy_scope?({ :controller => controller_name, :action => action, :id => id, :user_id => user_id }) rescue false
     else
       authorizer = options.delete(:authorizer) || Authorizer.new(user)
       authorizer.can?(permission, object) rescue false

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -143,11 +143,16 @@ class Role < ApplicationRecord
   # * a parameter-like Hash (eg. :controller => 'projects', :action => 'edit')
   # * a permission Symbol (eg. :edit_project)
   def allowed_to?(action)
-    if action.is_a?(Hash) || action.is_a?(ActionController::Parameters)
-      allowed_actions.include? Foreman::AccessControl.path_hash_to_string(action)
-    else
-      allowed_permissions.include? action
-    end
+    action_allowed?(action, allowed_permissions)
+  end
+
+  def allowed_to_in_taxonomy_scope?(action)
+    public_permission_names = Foreman::AccessControl.public_permissions.map(&:name)
+    return true if action_allowed?(action, public_permission_names)
+
+    allowed_to?(action) &&
+      allowed_to_in_taxonomy?(action, Organization.current, organization_ids) &&
+      allowed_to_in_taxonomy?(action, Location.current, location_ids)
   end
 
   # options can have following keys
@@ -281,6 +286,35 @@ class Role < ApplicationRecord
   end
 
   private
+
+  def allowed_to_in_taxonomy?(action, current_taxonomy, taxonomy_ids)
+    # If current_taxonomy is unset, the user is in Any context. In that case we
+    # can skip doing taxonomy-based checks on permissions. Either the user has
+    # the permission or not, which should already be covered by #allowed_to?(action).
+    return true if current_taxonomy.nil?
+
+    # If the role is is not assigned to any taxonomy, it is considered to be
+    # globally applicable - it grants the permission in all taxonomies
+    return true if taxonomy_ids.empty?
+
+    # This intentionally checks only for directly assigned taxonomies. In other
+    # words, this intentionally skips checks for taxonomy inheritance.
+    return false unless taxonomy_ids.include?(current_taxonomy.id)
+
+    filters.any? do |filter|
+      action_allowed?(action, filter.permissions.pluck(:name))
+    end
+  end
+
+  def action_allowed?(action, permissions)
+    permissions = permissions.map(&:to_sym)
+    if action.is_a?(Hash) || action.is_a?(ActionController::Parameters)
+      action = Foreman::AccessControl.path_hash_to_string(action)
+      permissions = permissions.flat_map { |perm| Foreman::AccessControl.allowed_actions(perm) }
+    end
+
+    permissions.include?(action)
+  end
 
   def sync_inheriting_filters
     filters.find_each do |f|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -443,6 +443,16 @@ class User < ApplicationRecord
     cached_roles.detect { |role| role.allowed_to?(action) }.present?
   end
 
+  def allowed_to_in_taxonomy_scope?(action)
+    return false if disabled?
+    return true if admin?
+    if action.is_a?(Hash) || action.is_a?(ActionController::Parameters)
+      action = Foreman::AccessControl.normalize_path_hash(action)
+      return true if editing_self?(action)
+    end
+    cached_roles.detect { |role| role.allowed_to_in_taxonomy_scope?(action) }.present?
+  end
+
   def logged?
     true
   end

--- a/app/registries/menu/item.rb
+++ b/app/registries/menu/item.rb
@@ -39,7 +39,7 @@ module Menu
     end
 
     def authorized?
-      User.current.allowed_to?(url_hash.slice(:controller, :action, :id))
+      User.current.allowed_to_in_taxonomy_scope?(url_hash.slice(:controller, :action, :id))
     rescue => error
       Foreman::Logging.exception("Error while evaluating permissions", error)
       false

--- a/app/views/common/403.html.erb
+++ b/app/views/common/403.html.erb
@@ -7,7 +7,7 @@
   </div>
   <h1><%= _("Permission denied") %></h1>
   <p>
-    <%= _("You are not authorized to perform this action.") %></br>
+    <%= _("You are not authorized to perform this action in the context of current Organization and Location.") %></br>
     <%= _("Please request one of the required permissions listed below from a Foreman administrator:") %></br>
     <%= content_tag(:ul, permissions.join.html_safe, class: 'list-unstyled') %>
   </p>

--- a/test/models/role_test.rb
+++ b/test/models/role_test.rb
@@ -440,4 +440,88 @@ class RoleTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe '#allowed_to_in_taxonomy_scope?' do
+    setup do
+      @permission = :view_domains
+      @action = { controller: "domains", action: "index" }
+      @o1 = FactoryBot.create(:organization)
+      @o2 = FactoryBot.create(:organization)
+      @l1 = FactoryBot.create(:location)
+      @l2 = FactoryBot.create(:location)
+      @role = FactoryBot.create(:role,
+        filters: [FactoryBot.create(:filter, permissions: [Permission.find_by(name: @permission)])],
+        organizations: [@o1],
+        locations: [@l1])
+    end
+
+    it 'allows all public permissions implicitly' do
+      blank_role = FactoryBot.create(:role)
+      assert_predicate blank_role.permissions, :empty?
+      Foreman::AccessControl.public_permissions.each do |permission|
+        assert blank_role.allowed_to_in_taxonomy_scope?(permission.name)
+      end
+    end
+
+    it 'does nothing when taxonomies are unset' do
+      assert @role.allowed_to?(@permission) # A sanity check
+      assert @role.allowed_to_in_taxonomy_scope?(@permission)
+
+      assert @role.allowed_to?(@action) # A sanity check
+      assert @role.allowed_to_in_taxonomy_scope?(@action)
+    end
+
+    it 'does nothing when Organization is not set on the role' do
+      @role.organizations = []
+      assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      Taxonomy.as_taxonomy(@o1, nil) do
+        assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+      Taxonomy.as_taxonomy(@o2, nil) do
+        assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+
+    it 'passes in the right Organization' do
+      Taxonomy.as_taxonomy(@o1, nil) do
+        assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+
+    it 'fails in the wrong Organization' do
+      Taxonomy.as_taxonomy(@o2, nil) do
+        refute @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+
+    it 'only honors direct role-taxonomy assignment' do
+      o3 = FactoryBot.create(:organization, parent: @o1)
+      Taxonomy.as_taxonomy(o3, nil) do
+        refute @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+
+    it 'does nothing when Location is not set on the role' do
+      @role.locations = []
+      assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      Taxonomy.as_taxonomy(nil, @l1) do
+        assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+      Taxonomy.as_taxonomy(nil, @l2) do
+        assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+
+    it 'passes in the right Location' do
+      Taxonomy.as_taxonomy(nil, @l1) do
+        assert @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+
+    it 'fails in the wrong Location' do
+      Taxonomy.as_taxonomy(nil, @l2) do
+        refute @role.allowed_to_in_taxonomy_scope?(@permission)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I might be away from work for a couple of weeks, so I'm opening this as a draft for the time being to remember what I wanted to do here and hopefully spark some discussion in the meantime.

# TL; DR
If a role has organizations or locations assigned, the permissions granted by that role apply only in the context of those organizations/locations.

# "Steps to reproduce"-styled example
1. Create organization `Allowed`
2. Create organization `Forbidden`
3. Clone the `Organization admin` role into `Allowed Organization admin` and assign the clone to organization `Allowed`
5. Create a user
    1. Assign it to both organizations
    2. Assign the role to it
6. Create a subnet an assign it to organization `Forbidden`
7. Log in as the user

## Behaviour before the changes:
1. The user can freely pick both organizations
2. The user sees the `Infrastructure > Subnets` menu item in both organizations (and any)
3. The user can go to `Infrastructure > Subnets` in both organizations (and any)
4. The user doesn't see any subnets, because the "second level" inside the page filters out the subnet in the forbidden organization

## Behaviour after the changes:
1. The user can freely pick both organizations
2. The user sees the `Infrastructure > Subnets` menu item in organization `Allowed` and in any
    1. The user does not see the menu item in `Forbidden` organization
3. The user can go to `Infrastructure > Subnets` in in organization `Allowed` and in any
    1. When navigating to /subnets in `Forbidden` organization, the user gets an error page stating that the user does not have `view_subnets` permission in the current organization and location scope


# Background
Foreman comes with a RBAC system that can be leveraged to have fine-grained control over which actions can be performed by users. The essential model is that individual permissions are linked to roles, users are assigned to roles and users are granted permissions through their roles.

Roles can be assigned to organizations and locations. There is an assumption that if a role is assigned to a taxonomy (organization or location) it applies only in the scope of that taxonomy - a clone of `Organization admin` role assigned to organization `Allowed` should grant permissions over the entirety of the `Allowed` organization, but not outside of it. This is supported by [documentation](https://docs.theforeman.org/nightly/Administering_Project/index-foreman-el.html#Creating_an_organization_Specific_Manager_Role_admin). This holds, as long as the user is assigned to _the same and no other_ organization.

Users, same as Roles, can be assigned to organizations and locations too. Problems (or at least undefined behaviour) arise when there is a mismatch between the taxonomies of the User and the taxonomies of the User's roles.

The permissions are enforced at two different levels. In layman's terms, one is when accessing pages, the other is about what gets shown inside those pages.

The tricky thing here is that the page-access level is not taxonomy-aware, the check is really just "does the user have the required permission, through _any_ of their roles?".

In the model sitatuion outlined above, the expectation people seem to have is that in this case, the user should not be able to do anything in organization `Forbidden`. The user probably should still have an option to select both organizations in the organization picker, after all, they're still a member of both of them, but they shouldn't be able to navigate to any pages there. What really happens is that the user can go to pages in organization `Forbidden`, but then the second level _should_ kick in and filter out the things the user is not allowed to see - in this case, they shouldn't see anything.

# Changes introduced here
In this PR, I'm adding a set of helpers to make the page-access level checks taxonomy-aware and switching over to them. This affects what menu items show in the navigation as well as enforcing those permissions more strictly when accessing pages.

The taxonomy-awareness is implemented in a relatively straightforward way. Roles without taxonomies grant their permissions globally, roles with taxonomies grant them only within those taxonomies. When the permission checks are done, the role's taxonomies are taken into consideration and compared against current taxonomies. In here I deliberately chose to ignore taxonomy inheritance - if a role is expected to grant permissions in a child organization, it should be assigned to the child organization directly.

Note:
This soft-depends on https://github.com/theforeman/foreman/pull/10370 . That PR removes one case that would otherwise have to be covered as well - without that PR, individual filters can be configured to override organization and location scoping configured on the role.

# But why?
1. The new behaviour seems to be more in-line with what people intuitively expect.
2. The current two-level does not cover all cases
    1. In some cases, the in-page level does not support taxonomy-based filtering and while those cases could be fixed on their own, it felt better to address this at a more fundamental level


# TODOs
- [x] put together an RFC on discourse and ideally present this at the community demo ahead of time
- [ ] check how this plays with plugins, especially katello

# Open questions
- [ ] instead of new helpers and gradual roll-out with explicit changes, should we just change what the old helpers do?
