### PR TITLE
refs #38422 - Rename methods in Orchestration::Templates

### DIFF
--- a/app/models/concerns/orchestration/templates.rb
+++ b/app/models/concerns/orchestration/templates.rb
@@ -9,20 +9,20 @@ module Orchestration::Templates
   def queue_render_checks
     return if skip_orchestration?
     return unless managed?
-    return unless template
+    return unless template_to_render
 
     logger.debug "Scheduling render checks of template for #{self}"
 
-    queue.create name: _("Check renderability of template '%{name}'.") % { name: template.name },
+    queue.create name: _("Check renderability of template '%{name}'.") % { name: template_to_render.name },
       priority: 1, action: [self, :set_renderability]
   end
 
   def set_renderability
-    template.render(host: self)
+    template_to_render.render(host: self)
     true
   rescue => e
-    Foreman::Logging.exception("Error while rendering '#{template.name}' template", e)
-    failure _("Failed to render template '%{t}', error: %{e}") % { t: template.name, e: e }
+    Foreman::Logging.exception("Error while rendering '#{template_to_render.name}' template", e)
+    failure _("Failed to render template '%{t}', error: %{e}") % { t: template_to_render.name, e: e }
   end
 
   def del_renderability
@@ -31,16 +31,14 @@ module Orchestration::Templates
 
   private
 
-  def template
-    @template ||= provisioning_template(kind: kind)
-  end
+  def template_to_render
+    kind = case provision_method
+      when 'build'
+        'provision'
+      when 'image'
+        template_kinds('image').first&.name
+           end
 
-  def kind
-    case provision_method
-    when 'build'
-      'provision'
-    when 'image'
-      template_kinds('image').first&.name
-    end
+    @template_to_render ||= provisioning_template(kind: kind)
   end
 end


### PR DESCRIPTION
Original method names collide with the Orchestration::SshProvision module, causing an unexpected behavior when the script execution exits with a non-zero status.

refs 5295d856daf912b311c3f668d866795a6ca5c513
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
