### PR TITLE
refs #38422 - template_kinds if compute_attributes_empty?

### DIFF
--- a/app/models/concerns/hostext/operating_system.rb
+++ b/app/models/concerns/hostext/operating_system.rb
@@ -35,13 +35,14 @@ module Hostext
       cr_id  = compute_resource_id || hostgroup&.compute_resource_id
       cr     = ComputeResource.find_by_id(cr_id)
       images = cr.try(:images)
-      if images.blank?
-        [TemplateKind.friendly.find('finish')]
-      else
-        uuid       = compute_attributes[cr.image_param_name]
-        image_kind = images.find_by_uuid(uuid).try(:user_data) ? 'user_data' : 'finish'
-        [TemplateKind.friendly.find(image_kind)]
-      end
+
+      return [TemplateKind.friendly.find('finish')] if images.blank?
+      return [] if compute_attributes_empty?
+
+      uuid       = compute_attributes[cr.image_param_name]
+      image_kind = images.find_by_uuid(uuid).try(:user_data) ? 'user_data' : 'finish'
+
+      [TemplateKind.friendly.find(image_kind)]
     end
 
     def templates_used


### PR DESCRIPTION
During the host provisioning, especially in the case of an image-based case with Katello, the host object is saved multiple times, hitting the orchestration in multiple moments/states of the host.

Added safeguard helps to prevent failures.

refs 5295d856daf912b311c3f668d866795a6ca5c513


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
