### PR TITLE
Fixes #38694 - Handle filter search correctly in find_bulk_hosts

### DIFF
--- a/app/controllers/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/api/v2/hosts_bulk_actions_controller.rb
@@ -136,7 +136,7 @@ module Api
       private
 
       def find_deletable_hosts
-        find_bulk_hosts(:destroy_hosts, params)
+        find_bulk_hosts(:destroy_hosts, included: params)
       end
 
       def find_editable_hosts

--- a/app/controllers/concerns/api/v2/bulk_hosts_extension.rb
+++ b/app/controllers/concerns/api/v2/bulk_hosts_extension.rb
@@ -11,7 +11,7 @@ module Api::V2::BulkHostsExtension
     # works on a structure of param_group bulk_params and transforms it into a list of systems
     bulk_params[:included] ||= {}
     bulk_params[:excluded] ||= {}
-    search_param = bulk_params[:included][:search] || bulk_params[:search]
+    search_param = bulk_params[:included][:search]
 
     if !params[:install_all] && bulk_params[:included][:ids].blank? && search_param.nil?
       render_error :custom_error, :status => :bad_request, :locals => { :message => _('No hosts have been specified') }

--- a/test/controllers/concerns/bulk_hosts_extension_test.rb
+++ b/test/controllers/concerns/bulk_hosts_extension_test.rb
@@ -77,6 +77,18 @@ class BulkHostsExtensionTest < ActiveSupport::TestCase
     assert_includes result, @host3
   end
 
+  def test_search_with_set_search
+    bulk_params = {
+      :included => {
+        :ids => [@host1.id],
+      },
+      :search => "bugfix",
+    }
+    result = @controller.find_bulk_hosts(@edit, bulk_params)
+
+    assert_equal result, [@host1]
+  end
+
   def test_no_hosts_specified
     bulk_params = {
       :included => {},


### PR DESCRIPTION
Host related search is set in `bulk_params[:included][:search]`. 
`bulk_params[:search]` is meant for the filter search on current page.