### PR TITLE
fixes #38624 update puppet.conf and puppet_setup snippets - more work needed

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/eol_puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/eol_puppet.conf.erb
@@ -1,12 +1,11 @@
 <%#
 kind: snippet
-name: puppet.conf
+name: eol_puppet.conf
 model: ProvisioningTemplate
 snippet: true
 description: |
-  Generates a puppet.conf file which is required for the puppet agent bootstraping.
-  The puppet server and CA is configured based on the host configuration. It supports
-  Puppet 5 and newer.
+  legacy snippet in deprecation generates a puppet.conf file which is required for the puppet agent bootstraping.
+  The puppet server and CA is configured based on the host configuration. It supports Perforce Puppet legacy versionis.
 -%>
 <%
   os_family = @host.operatingsystem.family

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -12,7 +12,7 @@ description: |
   os_family = @host.operatingsystem.family
   os_name   = @host.operatingsystem.name
 
-  aio_enabled = host_param_true?('openvox_version') ||  host_param_true?('enable_openvox_repo') 
+  aio_enabled = host_param_true?('openvox-version') ||  host_param_true?('enable-openvox-repo') 
   aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
 
   if os_family == 'Windows'

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -1,0 +1,57 @@
+<%#
+kind: snippet
+name: puppet.conf
+model: ProvisioningTemplate
+snippet: true
+description: |
+  snippet generates a puppet.conf file which is required for the puppet agent bootstraping.
+  The puppet server and CA is configured based on the host configuration.
+  It support Voxpupuli OpenVox configuration management software  
+-%>
+<%
+  os_family = @host.operatingsystem.family
+  os_name   = @host.operatingsystem.name
+
+  aio_enabled = host_param_true?('openvox_version') ||  host_param_true?('enable_openvox_repo') 
+  aio_available = os_family == 'Debian' || os_family == 'Redhat' || os_name == 'SLES'
+
+  if os_family == 'Windows'
+    var_dir = 'C:\ProgramData\PuppetLabs\puppet\cache'
+    log_dir = 'C:\ProgramData\PuppetLabs\puppet\var\log'
+    run_dir = 'C:\ProgramData\PuppetLabs\puppet\var\run'
+    ssl_dir = 'C:\ProgramData\PuppetLabs\puppet\etc\ssl'
+  else
+    if @host.operatingsystem.family == 'Freebsd'
+      var_dir = '/var/puppet'
+    else
+      var_dir = '/var/lib/puppet'
+    end
+    log_dir = '/var/log/puppet'
+    run_dir = '/var/run/puppet'
+    ssl_dir = '\$vardir/ssl'
+  end
+-%>
+[main]
+certname        = <%= @host.certname %>
+<%- unless host_param('dns_alt_names').to_s.empty? -%>
+dns_alt_names = <%= host_param('dns_alt_names') %>
+<%- end -%>
+<% unless aio_enabled && aio_available -%>
+vardir = <%= var_dir %>
+logdir = <%= log_dir %>
+rundir = <%= run_dir %>
+<%- if host_puppet_server.present? -%>
+server          = <%= host_puppet_server %>
+<%- end -%>
+ssldir = <%= ssl_dir %>
+<% end -%>
+
+[agent]
+<%- if host_puppet_environment.present? -%>
+environment     = <%= host_puppet_environment %>
+<%- end -%>
+report          = true
+runinternal     = 1800
+<%- if host_puppet_ca_server.present? -%>
+ca_server       = <%= host_puppet_ca_server %>
+<%- end -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -148,6 +148,48 @@ if [ -f "/etc/sysconfig/puppet" ]
 then
 /usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= host_puppet_server %>/ /etc/sysconfig/puppet
 fi
+<%#
+IMPORTANT NOTE: Setting "run-puppet-in-installer" is UNSUPPORTED!
+
+The default mode of operation in Foreman is only to set up Puppet, but to not run it inside the installer environment.
+Running Puppet inside the installer can cause various hard to diagnose errors, many of them resulting from the fact that
+services are not started inside the installer.
+
+If you are aware of the downsides, you can trigger a Puppet run inside the installer by setting the variable
+run-puppet-in-installer to true.
+
+Note, that this is an *unsupported mode of operation* and not supported by Foreman at all. You have been warned!
+%>
+<% if host_param_true?('run-puppet-in-installer') -%>
+<% if (os_name == 'Ubuntu' && os_major >= 15) || (os_name == 'Debian' && os_major >= 8) -%>
+# Puppet tries to detect the init system by checking the presence of the directory /run/systemd/system. That detection
+# fails in a chroot environment like the one the installer provides. See Puppet tickets PA-136 and PUP-5577
+#
+# We work around that here until it gets fixed in Puppet (probably never for Puppet 3.x)
+mkdir -p /run/systemd/system
+<% end -%>
+<% end -%>
+# export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
+<% if os_family == 'Windows' -%>
+$env:FACTER_is_installer = $TRUE
+
+# passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
+# You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
+# or set a full puppet run by setting "run-puppet-in-installer" = true
+$puppet_agent_args = @(
+  "agent",
+  "--config", "<%= etc_path %>\puppet.conf",
+  "--onetime",
+  <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : "\"--tags #{puppet_tags}\"," %>
+  <%= host_puppet_server.blank? ? '' : "\"--server #{host_puppet_server}\"," %>
+  "--no-daemonize"
+)
+Start-Process '<%= bin_path %>\puppet' -ArgumentList $puppet_agent_args -Wait -NoNewWindow
+<% else -%>
+export FACTER_is_installer=true
+# passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
+# You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
+# or set a full puppet run by setting "run-puppet-in-installer" = true
 <% if host_param_true?('run-puppet-in-installer') || @full_puppet_run -%>
 echo "Performing initial full puppet run"
 <% else -%>

--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -17,6 +17,7 @@ os_family = @host.operatingsystem.family
 os_major  = @host.operatingsystem.major.to_i
 os_name   = @host.operatingsystem.name
 
+# EOL Code block - Remove when perforce puppet obsoleted
 aio_enabled = host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-puppet8') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppet7') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppet6') || host_param_true?('enable-puppetlabs-puppet5-repo') || host_param_true?('enable-puppet5')
 
 if host_param('run-puppet-in-installer-tags')
@@ -42,6 +43,35 @@ else
   etc_path = '/etc/puppet'
   bin_path = '/usr/bin'
 end
+
+# Logic to support openvox
+# for windows support openvox-version must be set to a specific package version not major version as with Linux
+aio_enabled = host_param_true?('openvox-version') || host_param_true?('enable-openbox-repo')
+
+if host_param('run-puppet-in-installer-tags')
+  puppet_tags = host_param('run-puppet-in-installer-tags')
+else
+  puppet_tags = 'no_such_tag'
+end
+
+if os_family == 'Freebsd'
+  freebsd_package = 'openvox-agent8'
+  etc_path = '/usr/local/etc/puppet'
+  bin_path = '/usr/local/bin'
+elsif os_family == 'Windows'
+  windows_package = "openvox-agent-host_param('openvox-version')-#{@host.architecture}.msi"
+  etc_path = 'C:\ProgramData\PuppetLabs\puppet\etc'
+  bin_path = 'C:\Program Files\Puppet Labs\Puppet\bin'
+elsif aio_enabled
+  linux_package = 'openvox-agent'
+  etc_path = '/etc/puppetlabs/puppet'
+  bin_path = '/opt/puppetlabs/bin'
+else
+  linux_package = os_family == 'Suse' ? 'rubygem-openvox' : 'openvox'
+  etc_path = '/etc/puppet'
+  bin_path = '/usr/bin'
+end
+
 -%>
 <% if os_family == 'Debian' -%>
 apt-get update
@@ -55,9 +85,8 @@ else
   yum -t -y install <%= linux_package %>
 fi
 <% elsif os_family == 'Suse' -%>
-<% if host_param_true?('enable-puppetlabs-repo') || host_param_true?('enable-official-puppet8-repo') || host_param_true?('enable-official-puppet7-repo') || host_param_true?('enable-puppetlabs-puppet6-repo') || host_param_true?('enable-puppetlabs-puppet5-repo') -%>
-rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppetlabs
-rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppet
+<% if host_param_true?('openvox-version') || host_param_true?('enable-openvox-repo') -%>
+rpmkeys --import https://yum.voxpupuli.org/GPG-KEY-openvox.pub
 <% end -%>
 <% if @host.provision_method == 'image' -%>
 /usr/bin/zypper -n --gpg-auto-import-keys install <%= linux_package %>
@@ -100,13 +129,9 @@ EOF
 <% end -%>
 
 <% if os_family == 'Redhat' -%>
-<% if os_major > 6 -%>
 puppet_unit=puppet
 /usr/bin/systemctl list-unit-files | grep -q puppetagent && puppet_unit=puppetagent
 /usr/bin/systemctl enable ${puppet_unit}
-<% else -%>
-/sbin/chkconfig --level 345 puppet on
-<% end -%>
 <% end -%>
 <% if os_family == 'Freebsd' -%>
 echo 'puppet_enable="YES"' >>/etc/rc.conf
@@ -123,50 +148,6 @@ if [ -f "/etc/sysconfig/puppet" ]
 then
 /usr/bin/sed -ie s/^PUPPET_SERVER=.*/PUPPET_SERVER=<%= host_puppet_server %>/ /etc/sysconfig/puppet
 fi
-<% end -%>
-<% end -%>
-<%#
-IMPORTANT NOTE: Setting "run-puppet-in-installer" is UNSUPPORTED!
-
-The default mode of operation in Foreman is only to set up Puppet, but to not run it inside the installer environment.
-Running Puppet inside the installer can cause various hard to diagnose errors, many of them resulting from the fact that
-services are not started inside the installer.
-
-If you are aware of the downsides, you can trigger a Puppet run inside the installer by setting the variable
-run-puppet-in-installer to true.
-
-Note, that this is an *unsupported mode of operation* and not supported by Foreman at all. You have been warned!
-%>
-<% if host_param_true?('run-puppet-in-installer') -%>
-<% if (os_name == 'Ubuntu' && os_major >= 15) || (os_name == 'Debian' && os_major >= 8) -%>
-# Puppet tries to detect the init system by checking the presence of the directory /run/systemd/system. That detection
-# fails in a chroot environment like the one the installer provides. See Puppet tickets PA-136 and PUP-5577
-#
-# We work around that here until it gets fixed in Puppet (probably never for Puppet 3.x)
-mkdir -p /run/systemd/system
-<% end -%>
-<% end -%>
-# export a custom fact called 'is_installer' to allow detection of the installer environment in Puppet modules
-<% if os_family == 'Windows' -%>
-$env:FACTER_is_installer = $TRUE
-
-# passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-# You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
-# or set a full puppet run by setting "run-puppet-in-installer" = true
-$puppet_agent_args = @(
-  "agent",
-  "--config", "<%= etc_path %>\puppet.conf",
-  "--onetime",
-  <%= host_param_true?('run-puppet-in-installer') || @full_puppet_run ? '' : "\"--tags #{puppet_tags}\"," %>
-  <%= host_puppet_server.blank? ? '' : "\"--server #{host_puppet_server}\"," %>
-  "--no-daemonize"
-)
-Start-Process '<%= bin_path %>\puppet' -ArgumentList $puppet_agent_args -Wait -NoNewWindow
-<% else -%>
-export FACTER_is_installer=true
-# passing a non-existent tag like "no_such_tag" to the puppet agent only initializes the node
-# You can select specific tag(s) with the "run-puppet-in-installer-tags" parameter
-# or set a full puppet run by setting "run-puppet-in-installer" = true
 <% if host_param_true?('run-puppet-in-installer') || @full_puppet_run -%>
 echo "Performing initial full puppet run"
 <% else -%>
@@ -182,5 +163,4 @@ systemctl enable puppet
 <% end -%>
 <% if @host.provision_method == 'image' -%>
 <%= bin_path %>/puppet resource service puppet ensure=running
-<% end -%>
 <% end -%>


### PR DESCRIPTION
non-breaking changes to fix start to fix #38624
only updates puppet.conf and the puppet_setup snippet to maintain legacy compatibility for Satellite / older uses, while giving a platform to fix forward and grow by obsoleting old snippet template at the right time.

Aligns to foreman-puppet (puppet-puppet) module format (which can be built on and developed) and removes old parameters from the older puppet versions no longer relevant.

creates 2 new parameters for openxvox repo and version allowing a global param to set the installer version or a host param as versions later than 8 come out, and allows safe phase out of puppetlabs repos

Has a concept for supporting the windows packages - need help fixing the format of the variable before merge.

If this work is acceptable I can combine it with https://github.com/theforeman/foreman/pull/10630 and progress the additional templates and any migrations needed to make this work.

