### PR TITLE
Fixes #38688 - Drop redundant realm check in provisioning

### DIFF
--- a/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
+++ b/app/views/unattended/provisioning_templates/cloud_init/cloud_init_default.erb
@@ -54,7 +54,7 @@ runcmd:
 - |
 <%= indent(2) { snippet 'redhat_register' } -%>
 <% end -%>
-<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<% if @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 - |
 <%= indent(2) { snippet 'freeipa_register' } %>
 <% end -%>

--- a/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/kickstart_default_finish.erb
@@ -49,7 +49,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 
 <%= snippet 'redhat_register' %>
 
-<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<% if @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -45,7 +45,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 
 <% end -%>
 <%= snippet_if_exists(template_name + " custom snippet") %>
-<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -169,7 +169,7 @@ timesource --ntp-server <%= host_param('ntp-server') %>
 services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,openibd,avahi-daemon,avahi-dnsconfd,hidd,hplip,pcscd
 <% end -%>
 
-<% if realm_compatible && host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'Active Directory' -%>
+<% if realm_compatible && @host.realm && @host.realm.realm_type == 'Active Directory' -%>
 # One-time password will be requested at install time. Otherwise, $HOST[OTP] is used as a placeholder value.
 realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.realm %>
 <% end -%>
@@ -268,7 +268,7 @@ logger "Starting anaconda <%= @host %> postinstall"
 
 <%= snippet 'redhat_register' if rhel_compatible && !use_rhsm -%>
 
-<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<% if @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/kickstart_default_user_data.erb
@@ -41,7 +41,7 @@ echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e
 
 <%= snippet 'redhat_register' %>
 
-<% if host_enc['parameters']['realm'] && @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
+<% if @host.realm && (@host.realm.realm_type == 'FreeIPA' || @host.realm.realm_type == 'Red Hat Identity Management') -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_default_user_data.erb
@@ -31,7 +31,7 @@ description: |
 echo 'Acquire::http::Proxy "<%= proxy_uri %>";' >> /etc/apt/apt.conf
 <% end -%>
 
-<% if host_enc['parameters']['realm'] && @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
+<% if @host.realm && @host.realm.realm_type == 'FreeIPA' -%>
 <%= snippet 'freeipa_register' %>
 <% end -%>
 


### PR DESCRIPTION
The provisioning templates use some variation of:

```ruby
if host_enc['parameters']['realm'] && @host.realm
```

This requires the full ENC to be rendered for no good reason: the realm parameter is equivalent to `@host.realm&.name` (https://github.com/theforeman/foreman/blob/c28ab6ff1cd0b8fe77b853a5bfbd70ef86508af9/app/models/host_info_providers/static_info.rb#L54-L55). Since name is mandatory and we already check for `@host.realm` anyway we can drop the redundant check.

Cherry pick of https://github.com/theforeman/foreman/pull/10659.