### PR TITLE
Fixes #38700 - run github js test on js scripts

### DIFF
--- a/.github/workflows/js_tests.yml
+++ b/.github/workflows/js_tests.yml
@@ -1,12 +1,5 @@
 name: JavaScript
-on:
-  pull_request:
-    paths:
-      - 'webpack/**'
-      - 'package.json'
-      - '.github/workflows/js_tests.yml'
-      - '.eslintrc'
-      - '.eslintignore'
+on: pull_request
 
 permissions:
   contents: read

--- a/script/npm_test_plugin.js
+++ b/script/npm_test_plugin.js
@@ -20,7 +20,8 @@ var { allPluginDirs, skippedDirsKeys, dirsKeys } = filterPluginDirectories();
 const passedArgs = process.argv.slice(2);
 const coreConfigPath = path.resolve(__dirname, '../webpack/jest.config.js');
 const coreConfig = require(coreConfigPath);
-process.env.NODE_OPTIONS = '--max-old-space-size=8192 ' + (process.env.NODE_OPTIONS || '');
+process.env.NODE_OPTIONS = `--max-old-space-size=8192 ${process.env
+  .NODE_OPTIONS || ''}`;
 
 const runTests = async () => {
   if (passedArgs[0] && passedArgs[0][0] !== '-') {


### PR DESCRIPTION
lint was not run on a pr that was changing `script/npm_test_plugin.js` so now tests fail in other prs