### PR TITLE
Fixes #38706 - choose httpboot grub2 menuentry

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -148,6 +148,7 @@ class Host::Managed < Host::Base
     property :ssh_authorized_keys, array_of: String, desc: 'Returns an array of host owner\'s SSH authorized keys'
     property :pxe_loader, String, desc: 'Returns name of PXE loader, e.g. PXELinux BIOS'
     property :pxe_build?, one_of: [true, false], desc: 'Returns true if this host provision method is build, meaning network based provisioning, false otherwise'
+    property :uses_httpboot?, one_of: [true, false], desc: 'Returns true if this host is using the PXE Loader \'UEFI HTTP\' or \'UEFI HTTPs\', false otherwise'
     property :global_status, Integer, desc: 'Returns numerical representation of the host status'
     property :multiboot, String, desc: 'Returns path to multiboot loader'
     property :miniroot, String, desc: 'Returns path to the initial RAM disk for this host'
@@ -167,7 +168,7 @@ class Host::Managed < Host::Base
     allow :id, :name, :created_at, :diskLayout, :puppet_server, :puppet_ca_server, :operatingsystem, :os, :ptable, :hostgroup,
       :url_for_boot, :hostgroup, :compute_resource, :domain, :ip, :ip6, :mac, :shortname, :architecture,
       :model, :certname, :capabilities, :provider, :subnet, :subnet6, :token, :location, :organization, :provision_method,
-      :image_build?, :pxe_build?, :otp, :realm, :nil?, :indent, :primary_interface,
+      :image_build?, :pxe_build?, :uses_httpboot?, :otp, :realm, :nil?, :indent, :primary_interface,
       :provision_interface, :interfaces, :bond_interfaces, :bridge_interfaces, :interfaces_with_identifier,
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
@@ -743,6 +744,11 @@ autopart"', desc: 'to render the content of host partition table'
 
   def pxe_build?
     provision_method == 'build'
+  end
+
+  def uses_httpboot?(secure: false)
+    return pxe_loader.to_s.include?("UEFI HTTPS") if secure
+    pxe_loader.to_s.include?("UEFI HTTP")
   end
 
   def validate_media?

--- a/app/models/operatingsystem.rb
+++ b/app/models/operatingsystem.rb
@@ -267,8 +267,8 @@ class Operatingsystem < ApplicationRecord
     return default_boot_filename if host.nil? || host.pxe_loader.nil?
     return host.foreman_url('iPXE') if host.pxe_loader == 'iPXE Embedded'
     architecture = host.arch.nil? ? '' : host.arch.bootfilename_efi
-    if host.subnet&.httpboot? && host.pxe_loader =~ /UEFI HTTP/
-      if host.pxe_loader =~ /HTTPS/
+    if host.subnet&.httpboot? && host.uses_httpboot?
+      if host.uses_httpboot?(secure: true)
         port = host.subnet.httpboot.httpboot_https_port!
       else
         port = host.subnet.httpboot.httpboot_http_port!
@@ -276,7 +276,7 @@ class Operatingsystem < ApplicationRecord
       hostname = URI.parse(host.subnet.httpboot.url).hostname
       self.class.all_loaders_map(architecture, "#{hostname}:#{port}")[host.pxe_loader]
     else
-      raise(::Foreman::Exception.new(N_("HTTP UEFI boot requires proxy with httpboot feature"))) if host.pxe_loader =~ /UEFI HTTP/
+      raise(::Foreman::Exception.new(N_("HTTP UEFI boot requires proxy with httpboot feature"))) if host.uses_httpboot?
       self.class.all_loaders_map(architecture)[host.pxe_loader]
     end
   end

--- a/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
@@ -32,15 +32,8 @@ description: |
   kernel_options = "ramdisk_size=65536 install=#{@mediapath} autoyast=#{foreman_url('provision')} textmode=1 #{http_proxy_string}"
 -%>
 
-set default=<%= host_param('default_grub_install_entry') || 0 %>
-set timeout=<%= host_param('loader_timeout') || 10 %>
-
-menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> <%= kernel_options %>
-  <%= initrdcmd %> <%= @initrd %>
-}
-
 <%
+fallback_grub_install_entry = "0"
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1811561 and https://bugzilla.redhat.com/show_bug.cgi?id=1842893
 subnet = @host.provision_interface.subnet || @host.provision_interface.subnet6
 if subnet && subnet.httpboot
@@ -48,7 +41,21 @@ if subnet && subnet.httpboot
   proxy_https_port = subnet.httpboot.httpboot_https_port
   # Workaround for "no DNS server configured" https://bugzilla.redhat.com/show_bug.cgi?id=1842509
   proxy_host = dns_lookup(subnet.httpboot.hostname)
+
+  if proxy_https_port && @host.uses_httpboot?(secure: true)
+    fallback_grub_install_entry = "efi_https"
+  elsif proxy_http_port && @host.uses_httpboot?
+    fallback_grub_install_entry = "efi_http"
+  end
+end
 -%>
+set default=<%= host_param('default_grub_install_entry', fallback_grub_install_entry) %>
+set timeout=<%= host_param('loader_timeout') || 10 %>
+
+menuentry '<%= template_name %>' {
+  <%= linuxcmd %> <%= @kernel %> <%= kernel_options %>
+  <%= initrdcmd %> <%= @initrd %>
+}
 <% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
   <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= kernel_options %>
@@ -66,7 +73,5 @@ menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 <% end -%>
-
-<% end %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -49,15 +49,8 @@ test_on:
   end
 -%>
 
-set default=<%= host_param('default_grub_install_entry') || 0 %>
-set timeout=<%= host_param('loader_timeout') || 10 %>
-
-menuentry '<%= template_name %>' {
-  <%= linuxcmd %> <%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-  <%= initrdcmd %> <%= @initrd %>
-}
-
 <%
+fallback_grub_install_entry = "0"
 # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1811561 and https://bugzilla.redhat.com/show_bug.cgi?id=1842893
 subnet = @host.provision_interface.subnet || @host.provision_interface.subnet6
 if subnet && subnet.httpboot
@@ -65,7 +58,22 @@ if subnet && subnet.httpboot
   proxy_https_port = subnet.httpboot.httpboot_https_port
   # Workaround for "no DNS server configured" https://bugzilla.redhat.com/show_bug.cgi?id=1842509
   proxy_host = dns_lookup(subnet.httpboot.hostname)
+
+  if proxy_https_port && @host.uses_httpboot?(secure: true)
+    fallback_grub_install_entry = "efi_https"
+  elsif proxy_http_port && @host.uses_httpboot?
+    fallback_grub_install_entry = "efi_http"
+  end
+end
 -%>
+set default=<%= host_param('default_grub_install_entry', fallback_grub_install_entry) %>
+set timeout=<%= host_param('loader_timeout') || 10 %>
+
+menuentry '<%= template_name %>' {
+  <%= linuxcmd %> <%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
+  <%= initrdcmd %> <%= @initrd %>
+}
+
 <% if proxy_http_port -%>
 menuentry '<%= template_name %> EFI HTTP' --id efi_http {
   <%= linuxcmd %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
@@ -83,7 +91,5 @@ menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 <% end -%>
-
-<% end %>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/preseed_default_pxegrub2.erb
@@ -24,13 +24,49 @@ description: |
   else
     efi_suffix = ''
   end
+
+  fallback_grub_install_entry = "0"
+  # Workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1811561 and https://bugzilla.redhat.com/show_bug.cgi?id=1842893
+  subnet = @host.provision_interface.subnet || @host.provision_interface.subnet6
+  if subnet && subnet.httpboot
+    proxy_http_port = subnet.httpboot.httpboot_http_port
+    proxy_https_port = subnet.httpboot.httpboot_https_port
+    # Workaround for "no DNS server configured" https://bugzilla.redhat.com/show_bug.cgi?id=1842509
+    proxy_host = dns_lookup(subnet.httpboot.hostname)
+
+    if proxy_https_port && @host.uses_httpboot?(secure: true)
+      fallback_grub_install_entry = "efi_https"
+    elsif proxy_http_port && @host.uses_httpboot?
+      fallback_grub_install_entry = "efi_http"
+    end
+  end
+
+  kernel_options = "interface=auto url=#{foreman_url('provision')} ramdisk_size=10800 root=/dev/rd/0 rw auto"
 -%>
-set default=0
+set default=<%= host_param('default_grub_install_entry', fallback_grub_install_entry) %>
 set timeout=<%= host_param('loader_timeout') || 10 %>
 
 menuentry '<%= template_name %>' {
-  linux<%= efi_suffix %>  <%= @kernel %> interface=auto url=<%= foreman_url('provision')%> ramdisk_size=10800 root=/dev/rd/0 rw auto <%= snippet("preseed_kernel_options").strip %>
+  linux<%= efi_suffix %>  <%= @kernel %> <%= kernel_options %> <%= snippet("preseed_kernel_options").strip %>
   initrd<%= efi_suffix %> <%= @initrd %>
 }
+
+<% if proxy_http_port -%>
+menuentry '<%= template_name %> EFI HTTP' --id efi_http {
+  linux<%= efi_suffix %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @kernel %> <%= kernel_options %> <%= snippet("preseed_kernel_options").strip %>
+  initrd<%= efi_suffix %> (http,<%= proxy_host %>:<%= proxy_http_port %>)/httpboot/<%= @initrd %>
+}
+<% else -%>
+# Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
+<% end -%>
+
+<% if proxy_https_port -%>
+menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
+  linux<%= efi_suffix %>(https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= kernel_options %> <%= snippet("preseed_kernel_options").strip %>
+  initrd<%= efi_suffix %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
+}
+<% else -%>
+# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
+<% end -%>
 
 <%= snippet_if_exists(template_name + " custom menu") %>

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -2184,6 +2184,26 @@ class HostTest < ActiveSupport::TestCase
     assert host.require_ip6_validation?
   end
 
+  test 'uses_httpboot? returns false for pxe lodaer Grub2 UEFI without HTTP' do
+    host = FactoryBot.build_stubbed(:host, :managed, :pxe_loader => "Grub2 UEFI")
+    refute host.uses_httpboot?
+  end
+
+  test 'uses_httpboot? returns true for Grub2 UEFI HTTP pxe loader' do
+    host = FactoryBot.build_stubbed(:host, :managed, :pxe_loader => "Grub2 UEFI HTTP")
+    assert host.uses_httpboot?
+  end
+
+  test 'uses_httpboot? returns true for Grub2 UEFI HTTPS pxe loader' do
+    host = FactoryBot.build_stubbed(:host, :managed, :pxe_loader => "Grub2 UEFI HTTPS")
+    assert host.uses_httpboot?
+  end
+
+  test 'uses_httpboot? returns true for Grub2 UEFI HTTPS pxe loader with enabled secure check' do
+    host = FactoryBot.build_stubbed(:host, :managed, :pxe_loader => "Grub2 UEFI HTTPS")
+    assert host.uses_httpboot?(secure: true)
+  end
+
   test "test tokens are not created until host is saved" do
     class Host::Test < Host::Base
       def lookup_value_match

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
@@ -13,5 +13,3 @@ menuentry 'Kickstart default PXEGrub2' {
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 
 
-
-

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
@@ -13,5 +13,3 @@ menuentry 'Kickstart default PXEGrub2' {
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 
 
-
-

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -13,5 +13,3 @@ menuentry 'Kickstart default PXEGrub2' {
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 
 
-
-

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
@@ -13,5 +13,3 @@ menuentry 'Kickstart default PXEGrub2' {
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 
 
-
-

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -13,5 +13,3 @@ menuentry 'Kickstart default PXEGrub2' {
 # Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 
 
-
-

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.debian4dhcp.snap.txt
@@ -9,4 +9,8 @@ menuentry 'Preseed default PXEGrub2' {
   initrdefi boot/debian-mirror-2De7fzShMmxe-initrd.gz
 }
 
+# Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
+
+# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
+
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Preseed_default_PXEGrub2.ubuntu4dhcp.snap.txt
@@ -9,4 +9,8 @@ menuentry 'Preseed default PXEGrub2' {
   initrdefi boot/ubuntu-mirror-siJBlGH2vpRc-initrd.gz
 }
 
+# Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
+
+# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
+
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
