### PR TITLE
Fix validation error handling for Hardware Models form

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -13,7 +13,7 @@ class ModelsController < ApplicationController
     if @model.save
       process_success :success_redirect => '/models'
     else
-      process_error
+      redirect_to new_model_path, alert: @model.errors.full_messages.to_sentence
     end
   end
 


### PR DESCRIPTION
This is to redirect to `/models/new` on validation failure instead of rendering at `/models`. Also ensures validation errors like "can't be blank" are displayed properly.
