### PR TITLE
Fixes #38713 - Support IPv6 literal addresses in RSS URL

### DIFF
--- a/app/services/ui_notifications/rss_notifications_checker.rb
+++ b/app/services/ui_notifications/rss_notifications_checker.rb
@@ -78,7 +78,7 @@ module UINotifications
 
     def load_rss_feed
       uri = URI.parse(@url)
-      ::Foreman::HttpProxy::NetHttpExt.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
+      ::Foreman::HttpProxy::NetHttpExt.start(uri.hostname, uri.port, :use_ssl => uri.scheme == 'https') do |http|
         request = Net::HTTP::Get.new(uri.request_uri)
         request.initialize_http_header({"User-Agent" => rss_user_agent})
         result = http.request(request)


### PR DESCRIPTION
When using an IPv6 literal address such as `http://[2001:db8::1]/rss.xml` it breaks.

```
Failed to open TCP connection to [2001:db8::1]:80 (getaddrinfo: Name or service not known)
```

Easiest reproducer: `FOREMAN_RSS_URL='http://[2001:db8::1]/rss.xml' rake rss:create_notifications`

I don't expect anyone to want to do this, but I was looking for more cases similar to https://github.com/Katello/katello/pull/11432.