### PR TITLE
Fixes #38732 - Deactivate /etc/grub.d/30_uefi-firmware in Debian 13

### DIFF
--- a/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
+++ b/app/views/unattended/provisioning_templates/finish/preseed_default_finish.erb
@@ -39,6 +39,11 @@ description: |
 /bin/hostname  <%= @host.shortname %>.<%= @host.domain %>
 <% end -%>
 
+<% if @host.operatingsystem.name == "Debian" && @host.operatingsystem.major.to_i >= 13 -%>
+echo "# Removed by Foreman" > /etc/grub.d/30_uefi-firmware
+/usr/sbin/grub-mkconfig -o /boot/grub/grub.cfg
+<% end -%>
+
 <% if @host.provision_method == 'image' && root_pass.present? -%>
 # Install the root password
 echo 'root:<%= root_pass -%>' | /usr/sbin/chpasswd -e

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -3,6 +3,7 @@
 
 
 
+
 # Select package manager for the OS (sets the $PKG_MANAGER* variables)
 if [ -z "$PKG_MANAGER" ]; then
   if [ -f /etc/os-release ] ; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -3,6 +3,7 @@
 
 
 
+
 # Select package manager for the OS (sets the $PKG_MANAGER* variables)
 if [ -z "$PKG_MANAGER" ]; then
   if [ -f /etc/os-release ] ; then


### PR DESCRIPTION
This GRUB2 configuration snippet contains the line `fwsetup --is-supported`, where the parameter `--is-supported` is not understood by older versions of GRUB2.  This may include GRUB2 from Foreman proxies.

This GRUB2 configuration snippet adds a menu entry in GRUB2 to enter the BIOS screen that is negligible.

To prevent the file from possibly being recreated by a package update (grub-common), we overwrite the content instead of removing it.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
