### PR TITLE
Fixes #38735 - Translate setting descriptions in UI

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.js
@@ -28,7 +28,7 @@ const ViewRows = ({ settings }) =>
       <Td width={35}>
         <SettingValueCell setting={data} index={index} />
       </Td>
-      <Td width={35}>{data.description}</Td>
+      <Td width={35}>{__(data.description)}</Td>
     </Tr>
   ));
 


### PR DESCRIPTION
It should shows Satellite word instead of Foreman, replaces the word Foreman with its translation