### PR TITLE
Fixes #38736 - yggdrasild not enabled

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
+++ b/app/views/unattended/provisioning_templates/registration/remote_execution_pull_setup.erb
@@ -69,7 +69,9 @@ else
 fi
 
 YGGDRASIL_SERVICE=yggdrasil.service
-systemctl cat $YGGDRASIL_SERVICE >/dev/null 2>/dev/null || YGGDRASIL_SERVICE=yggdrasild.service
+if ! systemctl list-unit-files "$YGGDRASIL_SERVICE" | grep -q "^$YGGDRASIL_SERVICE"; then
+    YGGDRASIL_SERVICE="yggdrasild.service"
+fi
 
 # start the yggdrasild service
 if systemctl is-enabled $YGGDRASIL_SERVICE 2>/dev/null && [ -n "$YGGDRASIL_RESTART_DELAY" ] && [ "$YGGDRASIL_RESTART_DELAY" -gt 0 ]; then


### PR DESCRIPTION
yggdrasild systemctl service (the old version with 'd' at the end') did not start during host provisioning.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
