### PR TITLE
Fixes #38655 - Handle invalid scope filter in UI

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -104,10 +104,18 @@ class Authorizer
     return result if all_filters.any?(&:unlimited?)
 
     search_string = build_scoped_search_condition(all_filters.select(&:limited?))
-    find_options = ScopedSearch::QueryBuilder.build_query(resource_class.scoped_search_definition, search_string, options)
-    result[:where] << find_options[:conditions]
-    result[:includes].push(*find_options[:include])
-    result[:joins].push(*find_options[:joins])
+
+    begin
+      find_options = ScopedSearch::QueryBuilder.build_query(resource_class.scoped_search_definition, search_string, options)
+
+      result[:where] << find_options[:conditions]
+      result[:includes].push(*find_options[:include])
+      result[:joins].push(*find_options[:joins])
+    rescue ScopedSearch::QueryNotSupported => e
+      Foreman::Logging.logger('permissions').error N_("Scoped search query not supported: #{e.message}")
+      result[:where] << '1=0' unless user.admin?
+    end
+
     result
   end
 

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -112,7 +112,7 @@ class Authorizer
       result[:includes].push(*find_options[:include])
       result[:joins].push(*find_options[:joins])
     rescue ScopedSearch::QueryNotSupported => e
-      Foreman::Logging.logger('permissions').error N_("Scoped search query not supported: #{e.message}")
+      Foreman::Logging.logger('permissions').error "Scoped search query not supported: #{e.message}"
       result[:where] << '1=0' unless user.admin?
     end
 

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -348,6 +348,14 @@ class AuthorizerTest < ActiveSupport::TestCase
     end
   end
 
+  test "#find_collection returns no results for unsupported scoped search" do
+    permission = Permission.find_by_name('view_hosts')
+    auth = Authorizer.new(@user)
+
+    Filter.new(role: @role, permissions: [permission], search: 'invalid_field = raise-an-error').save(validate: false)
+    assert_empty auth.find_collection(Host::Managed, permission: :view_hosts)
+  end
+
   describe '#find_collection' do
     context 'using joined_on option' do
       test 'allows filtering on associations that do not match association class' do


### PR DESCRIPTION
Follow-up to Foreman Discovery PR [0], handling the case where the user has an invalid scope filter,
causing a never-ending redirect loop in the UI.

With new behavior user is redirected to the root with an error message describing the issue.

[0] https://github.com/theforeman/foreman_discovery/pull/661

Two cherry-picks:
* b49b89ad425c09ee35a9665ceff337ad3fcb96ad
* f5ee9b6183a266860ab0e979dc4acd18fc2289e5


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
