### PR TITLE
refs #38655 - Don't translate log message in authorizer.rb

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -112,7 +112,7 @@ class Authorizer
       result[:includes].push(*find_options[:include])
       result[:joins].push(*find_options[:joins])
     rescue ScopedSearch::QueryNotSupported => e
-      Foreman::Logging.logger('permissions').error N_("Scoped search query not supported: #{e.message}")
+      Foreman::Logging.logger('permissions').error "Scoped search query not supported: #{e.message}"
       result[:where] << '1=0' unless user.admin?
     end
 


### PR DESCRIPTION
refs b49b89ad425c09ee35a9665ceff337ad3fcb96ad


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
