### PR TITLE
Fixes #38740 - correct grid system to 12 items

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/TaxonomyDropdown.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/components/TaxonomySwitcher/TaxonomyDropdown.js
@@ -130,7 +130,7 @@ const TaxonomyDropdown = ({ taxonomyType, currentTaxonomy, taxonomies }) => {
           isDisabled={title === currentTaxonomy}
         >
           <Grid hasGutter>
-            <GridItem span={10} style={{ textAlign: 'left' }}>
+            <GridItem span={11} style={{ textAlign: 'left' }}>
               {title}
             </GridItem>
             <GridItem span={1}>


### PR DESCRIPTION
The grid system was defined with only 11 items instead of the intended 12. Updated to match the standard 12-item grid layout.

Fixes 97ec33f ("Fixes #28810 - changes to Any organization & Any location taxonomy's names")
