### PR TITLE
[3.16] Fixes #38735 - Translate setting descriptions in UI

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/SettingsTable.js
@@ -28,7 +28,7 @@ const ViewRows = ({ settings }) =>
       <Td width={35}>
         <SettingValueCell setting={data} index={index} />
       </Td>
-      <Td width={35}>{data.description}</Td>
+      <Td width={35}>{__(data.description)}</Td>
     </Tr>
   ));
 


### PR DESCRIPTION
This PR backports #10681 to `3.16-stable`

Prior to the rewrite to React and PF5 the descriptions were translated.
This restores that behavior.

Fixes: b1b8ae615514 ("Fixes #38255 - settings page table update to pf5")
(cherry picked from commit 9579d0d6bc5c80737c99e5ea33a2390cf7c6a1fd)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
