### PR TITLE
Fixes #38744 - Allow open redirects for action controller

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -105,6 +105,8 @@ module Foreman
     # Rails 7.0 changed this to true
     config.active_record.verify_foreign_keys_for_fixtures = false
     config.active_record.automatic_scope_inversing = false
+    # Open redirects are necessary for container pull over a DNS alias set as an allowed hostname
+    config.action_controller.raise_on_open_redirects = false
 
     # Setup additional routes by loading all routes file from routes directory
     Dir["#{Rails.root}/config/routes/**/*.rb"].each do |route_file|


### PR DESCRIPTION
I'm opening this as a draft PR to address [38744](https://projects.theforeman.org/issues/38744) /[ SAT-36036](https://issues.redhat.com/browse/SAT-36036). I'm still in the process of investigating if there's a less ham-fisted way to fix open redirects when pulling a container image since this is ostensibly a security feature for the application. I'm hoping we can have a little discussion about this change.

Testing steps (requires Katello):

1. Add a DNS alias to your environment:

- Modifying `/etc/hosts` is a good option. Add a line like `x.x.x.x address.example.com alias.example.com`. Message Quinn James (me) if you'd like a way to do this "properly" without loopback.
2. Change foreman's `config/settings.yaml` file and add the following:
```
# Configure hostnames for ActionDispatch::HostAuthorization
# Only hostnames are supported. Regular expressions and IP addresses/ranges are not.
# https://guides.rubyonrails.org/v6.1/configuring.html#configuring-middleware
:hosts:  
  - alias.example.com 
```
3. Run `podman login alias.example.com --tls-verify=false`. It should work.
4. Run `podman push XXXXXX alias.example.com/org_label/product_label/repo_name --tls-verify=false`. It should work.
5. Run `podman pull alias.example.com/org_label/product_label/repo_name --tls-verify=false`. It should fail with a 500 internal server error.
6. Rerun the above step after pulling this PR. It should succeed.