### PR TITLE
Fixes #38747 - Load hostgroup data on page load

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -1,12 +1,15 @@
 //= require parameter_override
 var compute_resource_id = null;
 
+var isInitialLoad = true;
 $(document).on('ContentLoad', function() {
   var searchParams = new URLSearchParams(window.location.search);
-  if(searchParams.has('hostgroup_id')) {
+  if(searchParams.has('hostgroup_id') && isInitialLoad) {
     var param = searchParams.get('hostgroup_id');
     $('#host_hostgroup_id').val(param).trigger('change');
+    hostgroup_changed($('#host_hostgroup_id'));
   }
+  isInitialLoad=false;
   onHostEditLoad();
   const overrideButtons = document.querySelectorAll('[name=is_overridden_btn]');
   overrideButtons.forEach(button =>


### PR DESCRIPTION
To validate issue:

Scenario:
1. Go to Configure -> Host Groups
2. Click on first Host Group Actions -> Create Host
3. Host form is loaded like https://test.local/hosts/new?hostgroup_id=17
4. Hostgroup is selected in the form but no data from host group loaded.

Related change: https://github.com/theforeman/foreman/pull/10446

Expected:
On initial page visit if the hostgroup_id is passed through via parameter, the host group data is shown.

Tested also to make sure, the issue mentioned in the PR https://github.com/theforeman/foreman/pull/10446 is not back => page load does not freeze and does not load forever in a loop
Same, if I visit the 'create host' view form.



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
