### PR TITLE
Don't initialize interfaces with no subnet assigned

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
@@ -30,8 +30,9 @@ end
 network_options.push("--hostname #{@host.name}")
 
 # single stack
-network_options.push("--noipv6") if subnet4 && !subnet6
-network_options.push("--noipv4") if !subnet4 && subnet6
+network_options.push("--noipv4") unless subnet4
+network_options.push("--noipv6") unless subnet6
+network_options.push("--onboot=false") unless subnet4 || subnet6 || @iface.bond?
 
 # dual stack MTU check
 raise("IPv4 and IPv6 subnets have different MTU") if subnet4 && subnet6 && subnet4.mtu.present? && subnet6.mtu.present? && subnet4.mtu != subnet6.mtu


### PR DESCRIPTION
Interfaces marked as managed but that don't have a subnet assigned to them should include options to not start on boot like --noipv4 --noipv6 and onboot=false

This change will add those options to the interface configuration on network manager, based on how the interface is configured on foreman.