### PR TITLE
Fixes #38755 - Fix skip_failure option for foreman upgrade:run rake task

### DIFF
--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -35,7 +35,7 @@ namespace :upgrade do
 
     if task.skip_failure?
       Foreman::Logging.exception("Failed upgrade task: #{task.name}", e)
-      false
+      return false
     end
 
     true


### PR DESCRIPTION
Found while working on: https://github.com/Katello/katello/pull/11487#discussion_r2355640309