### PR TITLE
Fixes #38759 - Improve upgrade rake task error message

### DIFF
--- a/lib/tasks/upgrade.rake
+++ b/lib/tasks/upgrade.rake
@@ -31,7 +31,7 @@ namespace :upgrade do
   def run_task(task)
     Rake::Task[task.task_name].execute
   rescue => e
-    puts "Failed upgrade task: #{task.name}, see logs for more information."
+    puts "Failed upgrade task: #{task.name}, see '/var/log/foreman/production.log' for more information."
 
     if task.skip_failure?
       Foreman::Logging.exception("Failed upgrade task: #{task.name}", e)


### PR DESCRIPTION
Relates to "foreman-rake upgrade:run" rake task.

Problem:

- A common scenario is for the above task to be run via the `foreman-installer`, this happens with every foreman-installer run.
- The message tells users to: "..., see logs for more information."
- The `foreman-installer` very visibly tells users, for example: "The full log is at /var/log/foreman-installer/katello.log".

=> Users are not directed to the foreman production log, and will end up chasing ghosts.

Ideally we can point users equally explicitly to a specific place like `/var/log/foreman/production.log` as well, however this is only correct if [file based logging is configured on the foreman instance](https://docs.theforeman.org/nightly/Administering_Project/index-katello.html#configuring-logging-type-and-layout_admin).

So my question is: Is it possible to know the logging configuration from the rake task run, and make the message conditional on that?