### PR TITLE
Fixes #38762 - Capture exit codes from 'built' snippet

### DIFF
--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -94,11 +94,11 @@ trap - ERR
 if [[ $? == 0 ]] ; then
   echo "Host [<%= @host.name %>] successfully configured."
 else
-  echo "Host [<%= @host.name %>] successfully configured, but failed to set built status."
+  echo "ERROR: Host [<%= @host.name %>] configured, but failed to report status to Foreman." >&2
+  exit 1
 fi
 
 <% if plugin_present?('katello') -%>
-subscription-manager facts --update
 subscription-manager repos
 <% end -%>
 

--- a/app/views/unattended/provisioning_templates/snippet/built.erb
+++ b/app/views/unattended/provisioning_templates/snippet/built.erb
@@ -15,6 +15,7 @@ description: |
   url = foreman_url(endpoint)
   built_https = url.start_with?('https')
   curl_opts = ["-H 'Content-Type: text/plain'"]
+  curl_opts << "--fail"
   wget_opts = ["--header 'Content-Type: text/plain'"]
   if @body_file
     curl_opts << "--data @#{@body_file}"
@@ -45,7 +46,15 @@ elif [ -x /usr/bin/wget ]; then
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' '<%= url %>'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Alterator_default_finish.host4dhcp.snap.txt
@@ -35,16 +35,24 @@ EOF
 /sbin/chkconfig puppetd on
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -121,14 +121,22 @@ EOF-2929810d
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -121,14 +121,22 @@ EOF-2929810d
 # Runs during first boot, removes itself
 systemctl enable ansible-callback
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/XenServer_default_finish.host4dhcp.snap.txt
@@ -1,14 +1,22 @@
 #!/bin/bash
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 
 PATH=/usr/bin:/usr/sbin:/bin:/sbin:$PATH shutdown -r +1

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -177,16 +177,24 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 
 rm /etc/resolv.conf
 ]]>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -179,16 +179,24 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 
 rm /etc/resolv.conf
 ]]>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -334,29 +334,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -430,29 +430,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -334,29 +334,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -334,29 +334,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -334,29 +334,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -214,29 +214,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -332,29 +332,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -333,29 +333,45 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 if test -f /tmp/foreman_built; then
   echo "calling home: build is done!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 else
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
+    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'
   elif [ -x /usr/bin/wget ]; then
     /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/failed'
   else
     wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/failed'
   fi
+  FINAL_STATUS=$?
   
   if [ -x "$(command -v subscription-manager)" ] ; then
     subscription-manager facts --update
+    SUB_MAN_STATUS=$?
+  
+    if [ $FINAL_STATUS -eq 0 ]; then
+      FINAL_STATUS=$SUB_MAN_STATUS
+    fi
   fi
+  
+  (exit $FINAL_STATUS);
 fi
 
 sync

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -99,14 +99,22 @@ echo "Performing initial puppet run for --tags no_such_tag"
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -348,14 +348,22 @@ EOF-d592f4ed
 
 # UserData still needs to mark the build as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -103,14 +103,22 @@ systemctl enable puppet
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -103,14 +103,22 @@ systemctl enable puppet
 
 # UserData still needs wget to mark as finished
 if [ -x /usr/bin/curl ]; then
-  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --noproxy \* --silent 'http://foreman.example.com/unattended/built'
 elif [ -x /usr/bin/wget ]; then
   /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --no-proxy 'http://foreman.example.com/unattended/built'
 else
   wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
 fi
+FINAL_STATUS=$?
 
 if [ -x "$(command -v subscription-manager)" ] ; then
   subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
 fi
+
+(exit $FINAL_STATUS);
 


### PR DESCRIPTION
1. During registration, the host_initial_config_default template calls the 'built' snippet
2. This snippet runs `curl` to `/unattended/built` but does not record any failures.

Consequently, global registration was silently failing when the `/unattended/built` endpoint is unreachable, leaving the new host with pending build status.

This change should capture those exit codes (along with that of the subscription-manager facts update) and then correctly fail the registration.

To reproduce:

On dev boxes, enable the firewall and only block port 80:

sudo firewall-cmd --set-default-zone=trusted
sudo firewall-cmd --permanent --zone=trusted --add-rich-rule='rule family="ipv4" port port="80" protocol="tcp" reject'
sudo firewall-cmd --reload
sudo firewall-cmd --zone=trusted --list-all

(thanks to Gemini for those commands)

Now start your Foreman server.
Generate a registration command (insights = no) and register a host

Registration will succeed, but you will see a Build status of "Pending installation".

To reset:
subscription-manager clean on the host
Delete the host from Foreman

----

Check out the PR

Now, in rails console, mark seeds as needing run:
```
ForemanInternal.all.first.destroy
```

Now start your Foreman server and try again. You should see the output with nonzero exit code:

```
# Running [ip-10-0-168-72.rhos-01.prod.psi.rdu2.redhat.com] host initial configuration
/usr/sbin/restorecon
Refreshing subscription data
All local data refreshed
Successfully updated the system facts.
ERROR: Host [ip-10-0-168-72.rhos-01.prod.psi.rdu2.redhat.com] configured, but failed to report status to Foreman.
Host initialization script failed, see the logs for more information.
You can access the script source by running 'cat /root/registration_host_init.sh'
[root@ip-10-0-168-72 ~]# echo $?
1

```


