### PR TITLE
Fixes #38767 - Add BMC Smart Proxy to host.smart_proxy_ids

### DIFF
--- a/app/models/concerns/hostext/smart_proxy.rb
+++ b/app/models/concerns/hostext/smart_proxy.rb
@@ -12,6 +12,7 @@ module Hostext
         ids << s.dhcp_id
         ids << s.tftp_id
         ids << s.dns_id
+        ids << s.bmc_id
       end
       ids << domain.dns_id if domain.present?
       ids << realm.realm_proxy_id if realm.present?

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3300,7 +3300,8 @@ class HostTest < ActiveSupport::TestCase
       host.subnet.tftp_id = 2
       host.subnet.dhcp_id = 3
       host.subnet.dns_id = 4
-      assert host.smart_proxy_ids, [1, 2, 3, 4]
+      host.subnet.bmc_id = 5
+      assert host.smart_proxy_ids, [1, 2, 3, 4, 5]
     end
 
     context 'from hostgroup' do


### PR DESCRIPTION
If a subnet has only a BMC proxy assigned,
this smart proxy will be ignored in the host.smart_proxies results.

This fix includes BMC proxies in the result.

Found during the testing of https://github.com/theforeman/foreman/pull/10561 (`power_action_v2` method)