### PR TITLE
Fixes #38769 - Host form - accept hostgroup_id & host[hostgroup_id] params

### DIFF
--- a/app/assets/javascripts/host_edit.js
+++ b/app/assets/javascripts/host_edit.js
@@ -4,9 +4,10 @@ var compute_resource_id = null;
 var isInitialLoad = true;
 $(document).on('ContentLoad', function() {
   var searchParams = new URLSearchParams(window.location.search);
-  if(searchParams.has('hostgroup_id') && isInitialLoad) {
-    var param = searchParams.get('hostgroup_id');
-    $('#host_hostgroup_id').val(param).trigger('change');
+  var hostGroupId = searchParams.get('hostgroup_id') || searchParams.get('host[hostgroup_id]');
+
+  if(hostGroupId && isInitialLoad) {
+    $('#host_hostgroup_id').val(hostGroupId).trigger('change');
     hostgroup_changed($('#host_hostgroup_id'));
   }
   isInitialLoad=false;


### PR DESCRIPTION
In the UI Host Form, sometimes the hostgroup_id param is used, sometimes it's the host[hostgroup_id] parameter.

This fix makes sure both params are used and the form is properly (re)loading the data from the host group.

**How to test**
* Go to the host groups page, create a host from the host group -> check all fields are loaded
* Go to discovered hosts (need foreman_discovery), click on provision, select the host group, and _customize_. See the form

Related Foreman Discovery PR: https://github.com/theforeman/foreman_discovery/pull/668/files