### PR TITLE
Fixes #38731 - User taxonomy checks during permission checks

### DIFF
--- a/app/models/concerns/taxonomix.rb
+++ b/app/models/concerns/taxonomix.rb
@@ -249,7 +249,6 @@ module Taxonomix
       key = assoc_base + '_ids'
 
       next if (User.current.nil? || User.current.send(assoc.to_s).empty?) || (!new_record? && !send("#{key}_changed?"))
-
       allowed = taxonomy.authorized("assign_#{assoc}", taxonomy).pluck(:id).to_set.union(send("#{key}_was"))
       tried = send(key).to_set
 

--- a/app/models/filter.rb
+++ b/app/models/filter.rb
@@ -115,11 +115,35 @@ class Filter < ApplicationRecord
   end
 
   def search_condition
-    searches = [search]
-    searches << taxonomy_search
-    searches.compact!
-    searches.map! { |s| parenthesize(s) } if searches.size > 1
-    searches.join(' and ')
+    QueryBuilder.join('AND', [search, taxonomy_search])
+  end
+
+  def search_condition_for_user(user)
+    return search_condition unless granular?
+
+    parts = [search]
+    parts += taxonomy_search_condition_for_user(user, taxonomy_search)
+    QueryBuilder.join('AND', parts)
+  end
+
+  def taxonomy_search_condition_for_user(user, search = nil)
+    parts = []
+    if resource_taxable_by_organization?
+      parts << merge_taxonomy_search('organization_id', search, user.organization_and_child_ids)
+    end
+    if resource_taxable_by_location?
+      parts << merge_taxonomy_search('location_id', search, user.location_and_child_ids)
+    end
+    parts
+  end
+
+  def merge_taxonomy_search(key, search, user_ids)
+    ids = if search.nil? || !search.include?(key)
+            user_ids
+          else
+            search.scan(/\d+/).map(&:to_i) & user_ids
+          end
+    QueryBuilder.key_value_in(key, ids, :block)
   end
 
   def expire_topbar_cache
@@ -139,25 +163,15 @@ class Filter < ApplicationRecord
     orgs = build_taxonomy_search_string_from_ids('organization', organization_ids)
     locs = build_taxonomy_search_string_from_ids('location', location_ids)
 
-    taxonomies = [orgs, locs].reject { |t| t.blank? }
-    self.taxonomy_search = taxonomies.join(' and ').presence
+    self.taxonomy_search = QueryBuilder.join('AND', [orgs, locs])
   end
 
   def build_taxonomy_search_string_from_ids(name, ids)
-    return '' if ids.empty?
-    parenthesize("#{name}_id ^ (#{ids.join(',')})")
+    QueryBuilder.key_value_in("#{name}_id", ids || [])
   end
 
   def nilify_empty_searches
     self.search = nil if search.empty?
-  end
-
-  def parenthesize(string)
-    if string.blank? || (string.start_with?('(') && string.end_with?(')'))
-      string
-    else
-      "(#{string})"
-    end
   end
 
   # if we have 0 types, empty validation will set error, we can't have more than one type

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,6 +1,8 @@
 class Taxonomy < ApplicationRecord
   validates_lengths_from_database
 
+  after_create :assign_taxonomy_to_user
+
   include Authorizable
   include NestedAncestryCommon
   include TopbarCacheExpiry
@@ -8,7 +10,6 @@ class Taxonomy < ApplicationRecord
   serialize :ignore_types, Array
 
   before_create :assign_default_templates
-  after_create :assign_taxonomy_to_user
   before_validation :sanitize_ignored_types
 
   has_many :taxable_taxonomies, :dependent => :destroy
@@ -245,7 +246,7 @@ class Taxonomy < ApplicationRecord
 
   def assign_taxonomy_to_user
     return if User.current.nil? || User.current.admin
-    TaxableTaxonomy.create(:taxonomy_id => id, :taxable_id => User.current.id, :taxable_type => 'User')
+    User.current.public_send(self.class.to_s.downcase.pluralize) << self
   end
 
   def parent_id_does_not_escalate

--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -101,9 +101,9 @@ class Authorizer
     end
 
     result[:where] << { id: base_ids } if @base_collection.present?
-    return result if all_filters.any? { |f| f.search_condition.blank? }
 
     search_string = build_scoped_search_condition(all_filters)
+    return result if search_string.blank?
 
     begin
       find_options = ScopedSearch::QueryBuilder.build_query(resource_class.scoped_search_definition, search_string, options)
@@ -122,7 +122,32 @@ class Authorizer
   def build_scoped_search_condition(filters)
     raise ArgumentError if filters.blank?
 
-    filters.select { |f| f.search_condition.present? }.map { |f| "(#{f.search_condition})" }.join(' OR ')
+    if filters.all?(&:granular?)
+      # All the filters support granular filtering
+      #
+      # This means we can build a simplified query by OR-ing all the per-filter
+      # searches together and then AND-ing a single check for user's taxonomies
+
+      # Do not do any scoping if there's a filter which grants the permission universally
+      base_conditions = filters.any? { |f| f.taxonomy_search.nil? && f.search.nil? } ? [] : filters.map(&:search_condition)
+      tax_conditions = filters.first.taxonomy_search_condition_for_user(@user)
+
+      QueryBuilder.join(
+        'AND',
+        [
+          QueryBuilder.join('OR', base_conditions),
+          QueryBuilder.join('AND', tax_conditions),
+        ])
+    else
+      # At least one of the filters does not support granular filtering. This is
+      # probably the less common case
+      #
+      # This means we cannot take any shortcuts and need to build a query where
+      # the checks for user's taxonomies are evaluated for each filter
+      # individually
+      conditions = filters.map { |f| f.search_condition_for_user(@user) }
+      QueryBuilder.join('OR', conditions)
+    end
   end
 
   private

--- a/app/services/query_builder.rb
+++ b/app/services/query_builder.rb
@@ -1,0 +1,31 @@
+class QueryBuilder
+  class << self
+    def parenthesize(string, always: false)
+      if string.blank? || (!always && (string.start_with?('(') && string.end_with?(')')))
+        string
+      else
+        '(' + string + ')'
+      end
+    end
+
+    def join(conjunction, parts)
+      parts.reject!(&:blank?)
+      parts.map! { |s| parenthesize(s) } if parts.size > 1
+      parenthesize(parts.join(" #{conjunction} ").presence, always: true)
+    end
+
+    def key_value_in(key, values, on_empty = :nil)
+      values.reject!(&:blank?)
+      return "#{key} ^ (#{values.join(',')})" if values.any?
+
+      case on_empty
+      when :nil
+        nil
+      when :block
+        parenthesize("set? #{key} AND null? #{key}")
+      else
+        raise ArgumentError
+      end
+    end
+  end
+end

--- a/test/controllers/api/v2/roles_controller_test.rb
+++ b/test/controllers/api/v2/roles_controller_test.rb
@@ -221,7 +221,7 @@ class Api::V2::RolesControllerTest < ActionController::TestCase
       assert @org, updated_role.organizations.first
       assert @loc, updated_role.locations.first
       updated_filter = Filter.find_by :id => filter.id
-      assert_equal "(organization_id ^ (#{@org.id})) and (location_id ^ (#{@loc.id}))", updated_filter.taxonomy_search
+      assert_equal "((organization_id ^ (#{@org.id})) AND (location_id ^ (#{@loc.id})))", updated_filter.taxonomy_search
     end
   end
 

--- a/test/graphql/mutations/hosts/create_mutation_test.rb
+++ b/test/graphql/mutations/hosts/create_mutation_test.rb
@@ -285,6 +285,8 @@ module Mutations
         let(:context_user) do
           setup_user('create', 'hosts') do |user|
             user.roles << Role.find_by(name: 'Viewer')
+            user.organizations = [organization]
+            user.locations = [tax_location]
           end
         end
         let(:data) { result['data']['createHost']['host'] }
@@ -322,6 +324,8 @@ module Mutations
         let(:context_user) do
           setup_user('show', 'hosts') do |user|
             user.roles << Role.find_by(name: 'Viewer')
+            user.organizations = [organization]
+            user.locations = [tax_location]
           end
         end
 

--- a/test/integration/org_admin_js_test.rb
+++ b/test/integration/org_admin_js_test.rb
@@ -49,7 +49,7 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       within('#ms-domain_location_ids') do
         assert page.has_content? @loc1.name
         assert page.has_content? @loc2.name
-        assert page.has_content? @loc3.name
+        assert page.has_no_content? @loc3.name # User is not in loc3
       end
       select_option_of_multiselect(@loc1.name, select_id: 'domain_location_ids')
       select_option_of_multiselect(@loc2.name, select_id: 'domain_location_ids')
@@ -92,35 +92,12 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       select_option_of_multiselect(@loc2.name, select_id: 'domain_location_ids')
 
       switch_form_tab('Organizations')
-      ensure_selected_option_of_multiselect(@org1.name, select_id: 'domain_organization_ids')
       page.click_button 'Submit'
 
       wait_for_success_toast
       created_domain = Domain.unscoped.find_by_name(domain.name)
       # sets the only organization anyway
       assert_equal [@org1], created_domain.organizations
-    end
-
-    def test_org_admins_can_not_assign_location_which_they_do_not_belong_to
-      login_user(@user.login, 'changeme')
-      wait_for_ajax
-      visit new_domain_path
-      wait_for_ajax
-
-      domain = FactoryBot.build_stubbed(:domain)
-      page.fill_in 'domain[name]', :with => domain.name, :id => 'domain_name'
-      switch_form_tab('Organizations')
-      ensure_selected_option_of_multiselect(@org1.name, select_id: 'domain_organization_ids')
-
-      # once selection are driven by permissions only, this should not be possible
-      switch_form_tab('Locations')
-      select_option_of_multiselect(@loc3.name, select_id: 'domain_location_ids')
-      page.click_button 'Submit'
-
-      # this is partly buggy behavior based on fact user does not belong to location
-      # but has view + assign locations permission, this test describe this behavior
-      # which should change once org/loc selection is based on permissions entirely
-      assert page.has_content?("don't have access to specified organizations or locations")
     end
   end
 
@@ -167,7 +144,7 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       within('#ms-domain_location_ids') do
         assert page.has_content? @loc1.name
         assert page.has_content? @loc2.name
-        assert page.has_content? @loc3.name
+        assert page.has_no_content? @loc3.name # User is not in loc3
       end
       select_option_of_multiselect(@loc1.name, select_id: 'domain_location_ids')
       select_option_of_multiselect(@loc2.name, select_id: 'domain_location_ids')
@@ -266,7 +243,7 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       within('#ms-domain_location_ids') do
         assert page.has_content? @loc1.name
         assert page.has_content? @loc2.name
-        assert page.has_content? @loc3.name
+        assert page.has_no_content? @loc3.name # User is not a member of loc3
       end
       select_option_of_multiselect(@loc1.name, select_id: 'domain_location_ids')
       select_option_of_multiselect(@loc2.name, select_id: 'domain_location_ids')
@@ -317,9 +294,8 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       @invisible_domain_2 = FactoryBot.create(:domain, :organizations => [@org1], :locations => [@loc3])
     end
 
-    # this test illustrate the inconsistency results where user can assign resource to org but he/she can't
-    # switch to that org context so after assignment, the resource is not visible, assign_organizations defines
-    # what organizations can be assigned
+    # This test illustrates the consistency of results where user cannot assign resource to an org the user can't
+    # switch to, even though the user has the assign_organizations permission
     def test_org_admins_can_assign_resources_to_both_orgs_but_cant_switch_to_its_context
       login_user(@user.login, 'changeme')
       wait_for_ajax
@@ -338,7 +314,7 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       within('#ms-domain_location_ids') do
         assert page.has_content? @loc1.name
         assert page.has_content? @loc2.name
-        assert page.has_content? @loc3.name
+        assert page.has_no_content? @loc3.name
       end
       select_option_of_multiselect(@loc1.name, select_id: 'domain_location_ids')
       select_option_of_multiselect(@loc2.name, select_id: 'domain_location_ids')
@@ -346,19 +322,12 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
       switch_form_tab('Organizations')
       within('#ms-domain_organization_ids') do
         assert page.has_content? @org1.name
-        assert page.has_content? @org2.name
+        assert page.has_no_content? @org2.name
         assert page.has_content? @org3.name
 
         # current context is any organization
         assert page.has_no_content?('option[selected="selected"]')
       end
-      # select_option_of_multiselect(@org1.name, select_id: 'domain_organization_ids')
-      select_option_of_multiselect(@org2.name, select_id: 'domain_organization_ids')
-
-      page.click_button 'Submit'
-
-      # choosing only org that user does not belong to is forbidden
-      assert page.has_content?("You don't have permission create_domains with attributes that you have specified or you don't have access to specified organizations or locations")
 
       switch_form_tab('Organizations')
       # with org1 which user belongs to, submit passes but the organization selection is limited to user's list
@@ -397,9 +366,8 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
     end
 
     # this test illustrate the non-user without any organization assigned, they can't list or create anything
-    # but because of restrictions coming both from Taxonomix and Authorizable. Taxonomix prevents listing while
-    # Authorizable prevents creation. The information leaks through form, thanks to assign_organizations, names
-    # of organizations in form are visible
+    # because of the restrictions coming from Authorizable. It prevents both listing as well as creation.
+    # The information does not leak through form, names of organizations in form are not visible, despite assign_organizations
     def test_org_admins_can_assign_resources_to_both_orgs_but_cant_switch_to_its_context
       login_user(@user.login, 'changeme')
       wait_for_ajax
@@ -424,20 +392,9 @@ class OrgAdminJSTest < IntegrationTestWithJavascript
 
       switch_form_tab('Organizations')
       within('#ms-domain_organization_ids') do
-        assert page.has_content? @org1.name
-        assert page.has_content? @org2.name
+        assert page.has_no_content? @org1.name
+        assert page.has_no_content? @org2.name
       end
-      select_option_of_multiselect(@org1.name, select_id: 'domain_organization_ids')
-      select_option_of_multiselect(@org2.name, select_id: 'domain_organization_ids')
-      page.click_button 'Submit'
-
-      # choosing only org that user does not belong to is forbidden
-      assert page.has_content?("You don't have permission create_domains with attributes that you have specified or you don't have access to specified organizations or locations")
-
-      switch_form_tab('Organizations')
-      # with org1 which user belongs to, submit passes but the organization selection is limited to user's list
-      deselect_option_of_multiselect(@org1.name, select_id: 'domain_organization_ids')
-      deselect_option_of_multiselect(@org2.name, select_id: 'domain_organization_ids')
       page.click_button 'Submit'
 
       # can't create in any context either

--- a/test/models/concerns/taxonomix_test.rb
+++ b/test/models/concerns/taxonomix_test.rb
@@ -298,6 +298,14 @@ class TaxonomixTest < ActiveSupport::TestCase
     resource = FactoryBot.create(:domain, :organizations => [org1, org3])
     assert_includes resource.organizations, org3
 
+    # user is not a member of org2 so the user cannot assign org2 to any resource
+    as_user user do
+      resource.organization_ids = [org1, org2, org3].map(&:id)
+      refute resource.valid?
+      assert_equal "Invalid organizations selection, you must select at least one of yours and have 'assign_organizations' permission.", resource.errors[:organization_ids].first
+    end
+
+    user.organizations = [org1, org2]
     as_user user do
       resource.organization_ids = [org1, org2, org3].map(&:id)
       assert resource.save!

--- a/test/models/filter_test.rb
+++ b/test/models/filter_test.rb
@@ -84,16 +84,16 @@ class FilterTest < ActiveSupport::TestCase
 
   test "search string composition" do
     f = FactoryBot.build_stubbed :filter, :search => nil, :taxonomy_search => nil
-    assert_equal '', f.search_condition
+    assert_nil f.search_condition
 
     f = FactoryBot.build_stubbed :filter, :search => 'domain ~ test*', :taxonomy_search => nil
-    assert_equal 'domain ~ test*', f.search_condition
+    assert_equal '(domain ~ test*)', f.search_condition
 
     f = FactoryBot.build_stubbed :filter, :search => nil, :taxonomy_search => 'organization_id = 1'
-    assert_equal 'organization_id = 1', f.search_condition
+    assert_equal '(organization_id = 1)', f.search_condition
 
     f = FactoryBot.build_stubbed :filter, :search => 'domain ~ test*', :taxonomy_search => 'organization_id = 1'
-    assert_equal '(domain ~ test*) and (organization_id = 1)', f.search_condition
+    assert_equal '((domain ~ test*) AND (organization_id = 1))', f.search_condition
   end
 
   test "filter with a valid search string is valid" do
@@ -132,6 +132,101 @@ class FilterTest < ActiveSupport::TestCase
     location_test = FactoryBot.create(:location)
     f.role = FactoryBot.create(:role, :organizations => [organization_test], :locations => [location_test])
     f.save
-    assert_equal f.taxonomy_search, "(organization_id ^ (#{organization_test.id})) and (location_id ^ (#{location_test.id}))"
+    assert_equal f.taxonomy_search, "((organization_id ^ (#{organization_test.id})) AND (location_id ^ (#{location_test.id})))"
+  end
+
+  context '#search_condition_for_user' do
+    setup do
+      as_admin do
+        @user = FactoryBot.create(:user)
+        @org1 = FactoryBot.create(:organization)
+        @org2 = FactoryBot.create(:organization)
+        @loc1 = FactoryBot.create(:location)
+        @loc2 = FactoryBot.create(:location)
+        @user.organizations = [@org1, @org2]
+        @user.locations = [@loc1, @loc2]
+      end
+    end
+
+    test 'returns search_condition when filter is not granular' do
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Bookmark')
+      f.stub :granular?, false do
+        assert_equal f.search_condition, f.search_condition_for_user(@user)
+      end
+    end
+
+    test 'adds organization scope when resource is taxable by organization' do
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      f.stub :resource_taxable_by_location?, false do
+        expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id},#{@org2.id})))"
+        assert_equal expected, f.search_condition_for_user(@user)
+      end
+    end
+
+    test 'adds location scope when resource is taxable by location' do
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      f.stub :resource_taxable_by_organization?, false do
+        expected = "((name ~ test*) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
+        assert_equal expected, f.search_condition_for_user(@user)
+      end
+    end
+
+    test 'adds both organization and location scope when resource is taxable by both' do
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id},#{@org2.id})) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
+      assert_equal expected, f.search_condition_for_user(@user)
+    end
+
+    test 'works with nil search and only taxonomy scope' do
+      f = FactoryBot.build_stubbed(:filter, :search => nil, :resource_type => 'Domain')
+      expected = "((organization_id ^ (#{@org1.id},#{@org2.id})) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
+      assert_equal expected, f.search_condition_for_user(@user)
+    end
+
+    test 'works with existing taxonomy_search' do
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :taxonomy_search => "organization_id = #{@org1.id}", :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id})) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
+      assert_equal expected, f.search_condition_for_user(@user)
+    end
+
+    test 'works with conflicting existing taxonomy_search' do
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :taxonomy_search => "organization_id = 7", :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (set? organization_id AND null? organization_id) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
+      assert_equal expected, f.search_condition_for_user(@user)
+    end
+
+    test 'also covers nested organizations' do
+      skip('katello forbids having nested organizations') if ::Foreman::Plugin.installed?('katello')
+
+      sub_org = FactoryBot.create(:organization, parent_id: @org2.id)
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id},#{@org2.id},#{sub_org.id})) AND (location_id ^ (#{@loc1.id},#{@loc2.id})))"
+      assert_equal expected, f.search_condition_for_user(@user)
+    end
+
+    test 'also covers nested locations' do
+      sub_loc = FactoryBot.create(:location, parent_id: @loc2.id)
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id},#{@org2.id})) AND (location_id ^ (#{@loc1.id},#{@loc2.id},#{sub_loc.id})))"
+      assert_equal expected, f.search_condition_for_user(@user)
+    end
+
+    test 'handles user with no organizations' do
+      user_no_orgs = FactoryBot.create(:user)
+      user_no_orgs.organizations = []
+      user_no_orgs.locations = [@loc1]
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (set? organization_id AND null? organization_id) AND (location_id ^ (#{@loc1.id})))"
+      assert_equal expected, f.search_condition_for_user(user_no_orgs)
+    end
+
+    test 'handles user with no locations' do
+      user_no_locs = FactoryBot.create(:user)
+      user_no_locs.organizations = [@org1]
+      user_no_locs.locations = []
+      f = FactoryBot.build_stubbed(:filter, :search => 'name ~ test*', :resource_type => 'Domain')
+      expected = "((name ~ test*) AND (organization_id ^ (#{@org1.id})) AND (set? location_id AND null? location_id))"
+      assert_equal expected, f.search_condition_for_user(user_no_locs)
+    end
   end
 end

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -207,43 +207,47 @@ class AuthorizerTest < ActiveSupport::TestCase
   end
 
   test "#build_scoped_search_condition(filters) for one filter" do
-    auth    = Authorizer.new(FactoryBot.create(:user))
+    user = FactoryBot.create(:user)
+    auth    = Authorizer.new(user)
     filters = [FactoryBot.build_stubbed(:filter, :on_name_all)]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '(name ~ *)', result
+    assert_equal "(((name ~ *)) AND ((organization_id ^ (#{user.organization_ids.first})) AND (location_id ^ (#{user.location_ids.first}))))", result
   end
 
   test "#build_scoped_search_condition(filters) for more filters" do
-    auth    = Authorizer.new(FactoryBot.create(:user))
+    user = FactoryBot.create(:user)
+    auth    = Authorizer.new(user)
     filters = [FactoryBot.build_stubbed(:filter, :on_name_all), FactoryBot.build_stubbed(:filter, :on_name_starting_with_a)]
     result  = auth.build_scoped_search_condition(filters)
-
-    assert_equal '(name ~ *) OR (name ~ a*)', result
+    assert_equal result, "(((name ~ *) OR (name ~ a*)) AND ((organization_id ^ (#{user.organization_ids.first})) AND (location_id ^ (#{user.location_ids.first}))))"
   end
 
   test "#build_scoped_search_condition(filters) for filter" do
-    auth    = Authorizer.new(FactoryBot.create(:user))
+    user = FactoryBot.create(:user)
+    auth    = Authorizer.new(user)
     filters = [FactoryBot.build_stubbed(:filter)]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '', result
+    assert_equal "(((organization_id ^ (#{user.organization_ids.first})) AND (location_id ^ (#{user.location_ids.first}))))", result
   end
 
-  test "#build_scoped_search_condition(filters) for filter" do
-    auth    = Authorizer.new(FactoryBot.create(:user))
+  test "#build_scoped_search_condition(filters) for limited and unlimited filter" do
+    user = FactoryBot.create(:user)
+    auth    = Authorizer.new(user)
     filters = [FactoryBot.build_stubbed(:filter, :on_name_all), FactoryBot.build_stubbed(:filter)]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '(name ~ *)', result
+    assert_equal "(((organization_id ^ (#{user.organization_ids.first})) AND (location_id ^ (#{user.location_ids.first}))))", result
   end
 
   test "#build_scoped_search_condition(filters) for empty filter" do
-    auth    = Authorizer.new(FactoryBot.create(:user))
-    filters = [FactoryBot.build_stubbed(:filter, :search => '')]
+    user = FactoryBot.create(:user)
+    auth    = Authorizer.new(user)
+    filters = [FactoryBot.build_stubbed(:filter, :search => nil)]
     result  = auth.build_scoped_search_condition(filters)
 
-    assert_equal '', result
+    assert_equal "(((organization_id ^ (#{user.organization_ids.first})) AND (location_id ^ (#{user.location_ids.first}))))", result
   end
 
   test "#find_collection(Host, :permission => :view_hosts) with scoped_search join returns r/w resources" do
@@ -337,6 +341,57 @@ class AuthorizerTest < ActiveSupport::TestCase
           authorizer.find_collection(Host, permission: :view_hosts, joined_on: FactValue).to_a
         end
         assert_operator 0, :<, authorizer.find_collection(Host, permission: :view_hosts, joined_on: FactValue).count
+      end
+    end
+
+    context 'user taxonomy scoping' do
+      setup do
+        as_admin do
+          @org1 = FactoryBot.create(:organization)
+          @org2 = FactoryBot.create(:organization)
+          @loc1 = FactoryBot.create(:location)
+          @loc2 = FactoryBot.create(:location)
+          @user_role  = FactoryBot.create(:user_user_role)
+          @user       = @user_role.owner
+          @role       = @user_role.role
+        end
+      end
+
+      test 'user should not see resource from a different org' do
+        permission = Permission.find_by_name('view_domains')
+        domain = FactoryBot.create(:domain, organization_ids: [@org1.id])
+        FactoryBot.create(:filter, role: @role, permissions: [permission], search: "name = #{domain.name}")
+
+        assert_predicate (domain.organization_ids & @user.organization_ids), :empty?, 'user and domain do not share any organization'
+
+        User.current = @user
+        assert_empty ::Domain.unscoped.authorized(:view_domains)
+      end
+
+      test 'user should see resource in the same org' do
+        permission = Permission.find_by_name('view_domains')
+        domain = FactoryBot.create(:domain)
+        FactoryBot.create(:filter, role: @role, permissions: [permission], search: "name = #{domain.name}")
+
+        assert_predicate (domain.organization_ids & @user.organization_ids), :any?, 'user and domain share at least one organization'
+
+        User.current = @user
+        assert_equal [domain.id], ::Domain.unscoped.authorized(:view_domains).map(&:id)
+      end
+
+      test 'user should see resource in a child org' do
+        permission = Permission.find_by_name('view_domains')
+        child_org = FactoryBot.create(:organization)
+        child_org.parent_id = @user.organization_ids.first
+        child_org.save!
+
+        domain = FactoryBot.create(:domain, organization_ids: [child_org.id])
+        FactoryBot.create(:filter, role: @role, permissions: [permission], search: "name = #{domain.name}")
+
+        assert_predicate (domain.organization_ids & @user.organization_ids), :empty?, 'user and domain do not share any organization'
+
+        User.current = @user
+        assert_equal [domain.id], ::Domain.unscoped.authorized(:view_domains).map(&:id)
       end
     end
   end

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -1,0 +1,100 @@
+require 'test_helper'
+
+class QueryBuilderTest < ActiveSupport::TestCase
+  describe '#parenthesize' do
+    test 'returns empty string for blank input' do
+      assert_equal '', QueryBuilder.parenthesize('')
+      assert_nil QueryBuilder.parenthesize(nil)
+      assert_equal '   ', QueryBuilder.parenthesize('   ')
+    end
+
+    test 'returns same string if already parenthesized and always=false' do
+      assert_equal '(already parenthesized)', QueryBuilder.parenthesize('(already parenthesized)')
+      assert_equal '(test)', QueryBuilder.parenthesize('(test)')
+    end
+
+    test 'adds parentheses to non-parenthesized string' do
+      assert_equal '(test)', QueryBuilder.parenthesize('test')
+      assert_equal '(name = value)', QueryBuilder.parenthesize('name = value')
+    end
+
+    test 'adds parentheses when always=true even if already parenthesized' do
+      assert_equal '((already parenthesized))', QueryBuilder.parenthesize('(already parenthesized)', always: true)
+      assert_equal '(test)', QueryBuilder.parenthesize('test', always: true)
+    end
+
+    test 'handles strings that start with ( but do not end with )' do
+      assert_equal '((incomplete)', QueryBuilder.parenthesize('(incomplete')
+      assert_equal '(incomplete))', QueryBuilder.parenthesize('incomplete)')
+    end
+  end
+
+  describe '#join' do
+    test 'returns nil for empty array' do
+      assert_nil QueryBuilder.join('AND', [])
+      assert_nil QueryBuilder.join('OR', [])
+    end
+
+    test 'returns nil when all parts are blank' do
+      assert_nil QueryBuilder.join('AND', ['', nil, '   '])
+    end
+
+    test 'returns single part with parentheses when only one non-blank part' do
+      assert_equal '(test)', QueryBuilder.join('AND', ['test'])
+      assert_equal '(single)', QueryBuilder.join('OR', ['', 'single', nil])
+    end
+
+    test 'joins multiple parts with a conjunction' do
+      result = QueryBuilder.join('AND', ['name = value', 'status = active', 'foo ~ bar*'])
+      assert_equal '((name = value) AND (status = active) AND (foo ~ bar*))', result
+    end
+
+    test 'filters out blank parts and joins remaining' do
+      result = QueryBuilder.join('AND', ['name = value', '', 'status = active', nil, ''])
+      assert_equal '((name = value) AND (status = active))', result
+    end
+
+    test 'handles already parenthesized parts' do
+      result = QueryBuilder.join('AND', ['(name = value)', '(status = active)'])
+      assert_equal '((name = value) AND (status = active))', result
+    end
+  end
+
+  describe '#key_value_in' do
+    test 'returns formatted string for non-empty values array' do
+      result = QueryBuilder.key_value_in('organization_id', [1, 2, 3])
+      assert_equal 'organization_id ^ (1,2,3)', result
+    end
+
+    test 'returns formatted string for single value' do
+      result = QueryBuilder.key_value_in('user_id', [42])
+      assert_equal 'user_id ^ (42)', result
+    end
+
+    test 'returns formatted string for string values' do
+      result = QueryBuilder.key_value_in('name', ['admin', 'user'])
+      assert_equal 'name ^ (admin,user)', result
+    end
+
+    test 'returns nil for empty array when on_empty is :nil (default)' do
+      assert_nil QueryBuilder.key_value_in('organization_id', [])
+      assert_nil QueryBuilder.key_value_in('organization_id', [], :nil)
+    end
+
+    test 'returns blocking condition for empty array when on_empty is :block' do
+      result = QueryBuilder.key_value_in('organization_id', [], :block)
+      assert_equal '(set? organization_id AND null? organization_id)', result
+    end
+
+    test 'raises ArgumentError for invalid on_empty value' do
+      assert_raises ArgumentError do
+        QueryBuilder.key_value_in('organization_id', [], :invalid)
+      end
+    end
+
+    test 'handles mixed type values' do
+      result = QueryBuilder.key_value_in('mixed', [1, 'string', :symbol])
+      assert_equal 'mixed ^ (1,string,symbol)', result
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Additionally perform resource organization and location checks inside Authorizer, to prevent the RBAC system from allowing users to see resources outside of their organizations and locations.

# Background
Foreman currently has two mechanisms, which can be used to control what users can do - the permission system and user's orgnization/location membership. These two mechanisms were originally expected to work together. In Foreman, models come with a set of modules facilitating the plumbing between the model, user's taxonomies (`Taxonomix`) and the RBAC system (`Authorizable`) and a default scope. The default scope does two things - it sets up the scope in a way that honors current organization/location selection (coming from `Taxonomix`) as well as limiting the view to only organizations and locations of the current user. This is the usually followed by a call to `.authorized(permission)` (relying on `Authorizable` being included in the model), which loops in the RBAC system and further tightens what the user is allowed to do. While this approach nicely separates concerns, it can give misleading results if the two parts are used separately.

This changes the meaning of what user's membership in an organization or location means. Previously, this relationship only marked the user as a resource to be managed within that organization/location, just as subnets or domains are. With this change we would shift it from "a resource to me managed within the scope" to "an actor which manages other things within the scope". 

# Changes done here
Resource organization and location checks were added to the RBAC system. This makes the RBAC system (`Authorizable`, `Authorizer` and `#authorized(permission)`) one-stop solution for user permission checking.

From the user's point of view, this change should make dealing with permissions in Foreman more consistent as well as making it more intuitive by making organization and location membership set up firmer boundaries than it did previously.

This could also simplify certain workflows. Currently delegating control over a specific organization to a user involves cloning the default "Organization admin" role, setting organization on it, assigning the role to a user and assigning that user to that organization. After this change, this could be reduced to giving the user the default "Organization admin" role without cloning it and just assigning the user to the organization.

This should also benefit Katello, which in general omits the default scope and which scopes resources to organizations differently than Foreman.

# "Steps to reproduce"-styled example

## Vanilla Foreman
1. Have orgnizations `org1` and `org2`
2. Create a user `u`
3. Assign the user to `org1`
4. Create domain `d1` in `org1`
5. Create domain `d2` in `org2`
6. Create a custom role, do not set any taxonomies on the role, add `view_domains` permission to it, assign it to the user
7. In rails console:
```
User.current = User.find_by(login: 'u')
::Domain.unscoped.authorized(:view_domains).map(&:name)
```

Actual results:
Both `d1` and `d2` domains are found.

Expected results:
Only `d1` domain is found.

Note: On Foreman resources, there is a default scope that performs the organization and location scoping, hence the unscoped, but it is not part of authorization checks.

## Katello-flavor
1) Have orgnizations `org1` and `org2`
2) Create a user `u`
3) Assign the user to `org1`
4) Create product `p1` in `org1`
5) Create product `p2` in `org2`
6) Create a custom role, do not set any taxonomies on the role, add `view_products` permission to it, assign it to the user
7) In rails console:
```
User.current = User.find_by(login: 'u')
::Katello::Product.authorized(:view_products).map(&:name)
```


Actual results:
Both `p1` and `p2` products are found.

Expected results:
Only `p1` product is found.
