### PR TITLE
Fixes #38782 - Hosts - cancel build should not queue orchestration

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -242,6 +242,8 @@ class HostsController < ApplicationController
   end
 
   def cancelBuild
+    @host.skip_orchestration!
+
     if @host.built(false)
       respond_to do |format|
         format.html do


### PR DESCRIPTION
Cancelling the build host operation should not re-queue the Orchestration.