### PR TITLE
Fixes #38790 - Add ouiaId prop to TableIndexPage and Table

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -43,6 +43,7 @@ export const Table = ({
   childrenOutsideTbody, // Expandable table rows are each a Tbody so they cant be inside the Tbody
   onExpandAll,
   areAllRowsExpanded,
+  ouiaId,
 }) => {
   const onPagination = newPagination => {
     setParams({ ...params, ...newPagination });
@@ -117,7 +118,7 @@ export const Table = ({
       />
       <PFTable
         variant="compact"
-        ouiaId="table"
+        ouiaId={ouiaId}
         isStriped
         isExpandable={childrenOutsideTbody}
       >
@@ -260,6 +261,7 @@ Table.propTypes = {
   childrenOutsideTbody: PropTypes.bool,
   onExpandAll: PropTypes.func,
   areAllRowsExpanded: PropTypes.bool,
+  ouiaId: PropTypes.string,
 };
 
 Table.defaultProps = {
@@ -282,4 +284,5 @@ Table.defaultProps = {
   childrenOutsideTbody: false,
   onExpandAll: null,
   areAllRowsExpanded: false,
+  ouiaId: 'table',
 };

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -111,6 +111,7 @@ const TableIndexPage = ({
   restrictedSearchQuery,
   updateParamsByUrl,
   bookmarksPosition,
+  ouiaId,
 }) => {
   const history = useHistory();
   const { location: { search: historySearch } = {} } = history || {};
@@ -296,6 +297,7 @@ const TableIndexPage = ({
               perPage,
             }}
             setParams={setParamsAndAPI}
+            ouiaId={ouiaId}
             bottomPagination={
               <Pagination
                 key="table-bottom-pagination-yes"
@@ -391,6 +393,7 @@ TableIndexPage.propTypes = {
   restrictedSearchQuery: PropTypes.func,
   updateParamsByUrl: PropTypes.bool,
   bookmarksPosition: PropTypes.string,
+  ouiaId: PropTypes.string,
 };
 
 TableIndexPage.defaultProps = {
@@ -426,6 +429,7 @@ TableIndexPage.defaultProps = {
   restrictedSearchQuery: noop,
   updateParamsByUrl: true,
   bookmarksPosition: 'left',
+  ouiaId: 'table',
 };
 
 export default TableIndexPage;


### PR DESCRIPTION
#### What are the changes introduced in this pull request?

Introduces an ouiaId prop to both TableIndexPage and Table, allowing pages to set a stable and unique data-ouia-component-id for testing. The default behavior remains unchanged, with ouiaId defaulting to "table" to preserve backward compatibility.

#### Considerations taken when implementing this change?

The implementation ensures backward compatibility by keeping the default ouiaId value as "table".

#### What are the testing steps for this pull request?

- Render a page using TableIndexPage without passing ouiaId and verify the table still renders with data-ouia-component-id="table".
- Render a page using TableIndexPage with a custom ouiaId and verify the table renders with the provided value.
