### PR TITLE
Fixes #38725 - Add host backlink to interface object

### DIFF
--- a/app/views/api/v2/interfaces/main.json.rabl
+++ b/app/views/api/v2/interfaces/main.json.rabl
@@ -2,7 +2,7 @@ object @interface
 
 extends "api/v2/interfaces/base"
 
-attributes :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :domain_id, :domain_name, :created_at, :updated_at,
+attributes :subnet_id, :subnet_name, :subnet6_id, :subnet6_name, :domain_id, :domain_name, :host_id, :host_name, :created_at, :updated_at,
   :managed, :identifier
 
 node do |interface|


### PR DESCRIPTION
The interface show api(https://apidocs.theforeman.org/foreman/3.4/apidoc/v2/interfaces/show.html), does not include the host backlink(host_id, host_name).
As host can have many interface objects, it make sense to provide host backlink to the interface object.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
