### PR TITLE
Fixes #38794 - Do not truncate dynflow tables

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -392,7 +392,7 @@ end
 
 class IntegrationTestWithJavascript < ActionDispatch::IntegrationTest
   def database_cleaner_strategy
-    :truncation
+    [:truncation, except: %w[dynflow_coordinator_records dynflow_schema_info]]
   end
 
   def before_setup


### PR DESCRIPTION
in JS integration tests to help with sporadically failing f_ansible tests like https://github.com/theforeman/foreman_ansible/actions/runs/18187928171/job/51776294929?pr=773

This could cause some tests to randomly fail due to dynflow's records being
wiped and dynflow reacting to that by terminating itself, along with the entire
process where the tests run.



