### PR TITLE
Fixes #38795 - Settings - Update value from response

### DIFF
--- a/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueEdit.js
+++ b/webpack/assets/javascripts/react_app/components/SettingsTable/components/SettingValueEdit.js
@@ -59,8 +59,9 @@ const SettingValueEdit = ({ setting, updateSetting }) => {
     setLoading(false);
   };
 
-  const successCallback = submitValue => {
-    updateSetting(submitValue);
+  const successCallback = response => {
+    const responseValue = response?.data?.value;
+    updateSetting(responseValue);
 
     if (setting.name === SETTING_NEW_HOSTS_PAGE) {
       const bool = value === 'true';
@@ -92,7 +93,7 @@ const SettingValueEdit = ({ setting, updateSetting }) => {
       url: SETTING_UPDATE_PATH.replace(':id', setting.id),
       params: { ...setting, value: splitValue },
       key: `${setting.id}-EDIT`,
-      handleSuccess: () => successCallback(splitValue),
+      handleSuccess: response => successCallback(response),
       handleError: errorCallback,
       errorToast: error => {
         const msg =


### PR DESCRIPTION
String values are automatically trimmed on the backend [0]. The problem is that UI does not reflect the change, misleading the user into thinking the setting can start/end with a space.

[0] [app/models/setting#parse_string_value](https://github.com/theforeman/foreman/blob/develop/app/models/setting.rb#L149)

**How to test**

* Go to settings
* Set any string value to `   space-jam    `
* save
* Check the value of the field: It's `   space-jam    `
* Refresh the page, check the value of the field: `space jam`

With this fix, the value is updated based on the response value (processed by the backend)

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
