### PR TITLE
Fixes #38799 - Allow ForemanContext app_metadata to be extended from plugins

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -407,7 +407,7 @@ module ApplicationHelper
     params.slice(*permitted.concat([:locale, :search, :per_page])).permit!
   end
 
-  def app_metadata
+  def core_app_metadata
     {
       UISettings: ui_settings,
       version: SETTINGS[:version].short,
@@ -419,6 +419,12 @@ module ApplicationHelper
         lab_features: Setting[:lab_features],
       },
     }.compact
+  end
+
+  def app_metadata
+    core_app_metadata.merge(
+      ::Foreman::Plugin.app_metadata_registry.all_plugin_metadata
+    )
   end
 
   def ui_settings

--- a/app/registries/foreman/plugin.rb
+++ b/app/registries/foreman/plugin.rb
@@ -32,6 +32,7 @@ module Foreman #:nodoc:
     DEFAULT_REGISTRIES = {
       fact_importer: 'Foreman::Plugin::FactImporterRegistry',
       fact_parser: 'Foreman::Plugin::FactParserRegistry',
+      app_metadata: 'Foreman::Plugin::AppMetadataRegistry',
       report_scanner: 'Foreman::Plugin::ReportScannerRegistry',
       report_origin: 'Foreman::Plugin::ReportOriginRegistry',
       medium_providers: 'Foreman::Plugin::MediumProvidersRegistry',

--- a/app/registries/foreman/plugin/app_metadata_registry.rb
+++ b/app/registries/foreman/plugin/app_metadata_registry.rb
@@ -1,0 +1,22 @@
+module Foreman
+  class Plugin
+    class AppMetadataRegistry
+      def initialize
+        @plugin_metadata = {}.with_indifferent_access
+      end
+
+      def register(plugin_name, data = {})
+        unless data.is_a?(Hash) || data.respond_to?(:to_h)
+          Rails.logger.warn "AppMetadataRegistry: data for plugin #{plugin_name} is not a hash or compatible type; registration skipped."
+          return
+        end
+        @plugin_metadata[plugin_name] = data.is_a?(Hash) ? data : data.to_h
+        Rails.logger.info "Registered app metadata for plugin #{plugin_name}"
+      end
+
+      def all_plugin_metadata
+        @plugin_metadata
+      end
+    end
+  end
+end

--- a/developer_docs/foreman-context.asciidoc
+++ b/developer_docs/foreman-context.asciidoc
@@ -33,12 +33,12 @@ const { id, title } = useForemanOrganization();
 const { id, login, firstname, lastname, admin } = useForemanUser();
 ```
 
-## How to add a value to the context
+## How to add a value to the core context
 
-Keys and values are set in the `app_metadata` method of `/application_helper.rb`.
+Keys and values are set in the `core_app_metadata` method of `/application_helper.rb`.
 The `app_metadata` object is passed down and becomes ForemanContext.
 
-If you add a new value to `app_metadata`, it will also be useful to add a new custom hook in `webpack/assets/javascripts/react_app/ReactApp/Context/ForemanContext.js`
+If you add a new value to `core_app_metadata`, it will also be useful to add a new custom hook in `webpack/assets/javascripts/react_app/ReactApp/Context/ForemanContext.js`
 so that the value can be easily consumed on the front end.
 For example, Adding a new hook:
 ```js
@@ -46,3 +46,25 @@ For example, Adding a new hook:
 
 export const useForemanFeature = () => useForemanContext().feature;
 ```
+
+## Adding a value to the context from a plugin
+
+To add a value to the context from a plugin, the plugin must register the data like so:
+
+```ruby
+Foreman::Plugin.register :plugin_name do
+  ...
+  ::Foreman::Plugin.app_metadata_registry.register(:plugin_name, {
+    context_key: 'context value',
+  })
+end
+```
+
+The value will then be in ForemanContext under the `:plugin_name` namespace:
+
+```js
+import { useForemanContext } from 'foremanReact/Root/Context/ForemanContext';
+...
+useForemanContext().metadata?.plugin_name?.context_key
+```
+

--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/helpers.js
@@ -8,12 +8,26 @@ const getCheckedStateForCategory = (category = { children: [] }) => {
   return false;
 };
 
+export const checkColumnRelevancy = (isRelevantFunc, contextData) => {
+  let result = true;
+  if (typeof isRelevantFunc === 'function') {
+    try {
+      result = isRelevantFunc(contextData);
+    } catch (e) {
+      // If isRelevantFunc throws, treat the column as not relevant
+      result = false;
+    }
+  }
+  return result;
+};
+
 export const categoriesFromFrontendColumnData = ({
   registeredColumns,
   userId,
   controller = 'hosts',
   userColumns = ['name'],
   hasPreference = false,
+  contextData = {},
 }) => {
   // need to build an object like
   // {
@@ -57,6 +71,7 @@ export const categoriesFromFrontendColumnData = ({
       columnName,
       title,
       isRequired,
+      isRelevant,
     } = registeredColumns[column];
     if (tableName !== controller) return;
     const category = categories.find(cat => cat.key === categoryKey);
@@ -72,14 +87,18 @@ export const categoriesFromFrontendColumnData = ({
       });
     }
     const categoryIndex = categories.findIndex(cat => cat.key === categoryKey);
-    categories[categoryIndex].children.push({
-      name: title,
-      key: columnName,
-      checkProps: {
-        checked: isRequired || userColumns.includes(columnName),
-        disabled: isRequired ?? null,
-      },
-    });
+    const shouldShowColumn = checkColumnRelevancy(isRelevant, contextData);
+
+    if (shouldShowColumn) {
+      categories[categoryIndex].children.push({
+        name: title,
+        key: columnName,
+        checkProps: {
+          checked: isRequired || userColumns.includes(columnName),
+          disabled: isRequired ?? null,
+        },
+      });
+    }
   });
   categories.forEach(category => {
     category.checkProps.checked = getCheckedStateForCategory(category);

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -45,6 +45,7 @@ import { deleteHost } from '../HostDetails/ActionsBar/actions';
 import {
   useForemanSettings,
   useForemanHostsPageUrl,
+  useForemanContext,
 } from '../../Root/Context/ForemanContext';
 import { bulkDeleteHosts } from './BulkActions/bulkDelete';
 import {
@@ -97,6 +98,7 @@ const HostsIndex = () => {
     apiOptions,
     defaultParams,
   });
+  const contextData = useForemanContext();
 
   const {
     response: {
@@ -143,16 +145,17 @@ const HostsIndex = () => {
   const columns = filterColumnDataByUserPreferences(
     isLoading,
     userColumns,
-    allColumns
+    allColumns,
+    contextData
   );
   const [columnNamesKeys, keysToColumnNames] = getColumnHelpers(columns);
-
   const columnSelectData = categoriesFromFrontendColumnData({
     registeredColumns: allColumns,
     userId: currentUserId,
     tableName: 'hosts',
     userColumns,
     hasPreference,
+    contextData,
   });
 
   const { pageRowCount } = getPageStats({ total, page, perPage });

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/helpers.js
@@ -1,3 +1,5 @@
+import { checkColumnRelevancy } from '../../../ColumnSelector/helpers';
+
 export const getPageStats = ({ total, page, perPage }) => {
   // logic adapted from patternfly so that we can know the number of items per page
   const lastPage = Math.ceil(total / perPage) ?? 0;
@@ -63,12 +65,17 @@ export const DEFAULT_USER_COLUMNS = [
 export const filterColumnDataByUserPreferences = (
   isLoading,
   columnNames = isLoading ? [] : DEFAULT_USER_COLUMNS,
-  allColumnData
+  allColumnData,
+  contextData
 ) => {
   const filteredColumns = {};
   columnNames.forEach(key => {
     if (allColumnData[key]) {
-      filteredColumns[key] = allColumnData[key];
+      const shouldShowColumnInTable = checkColumnRelevancy(
+        allColumnData[key]?.isRelevant,
+        contextData
+      );
+      if (shouldShowColumnInTable) filteredColumns[key] = allColumnData[key];
     }
   });
   return filteredColumns;

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -47,7 +47,8 @@ A page component that displays a table with data fetched from the API. It provid
 @param {Object}{columns} - Not needed when passing children. An object of objects representing the columns to be displayed in the table, keys should be the same as in the api response
 @param {string} columns[].title - the title of the column, translated
 @param {function} columns[].wrapper - a function that returns a React component to be rendered in the column
-@param {boolean} columns[].isSorted - whether or not the column is sorted
+@param {boolean} columns[].isSorted - whether or not the column is sortable by its columnName. Only works if ORDER BY <columnName> will work.
+@param {function} columns[].isRelevant - optional function that takes in ForemanContext and returns a boolean. The column will be hidden from the column selector if isRelevant returns false. If the isRelevant key is omitted, columns are always relevant.
 @param {string}{controller} - the name of the controller for the API
 @param {boolean} {creatable} - whether or not to show create button
 @param {Array<Object>} {customActionButtons} - an array of custom action buttons to be displayed in the toolbar


### PR DESCRIPTION
Foreman provides a React context, `ForemanContext`, that can be used anywhere in the React tree, including by plugins. This makes it easy to use data from the backend without the need for an API request. See https://github.com/theforeman/foreman/blob/develop/developer_docs/foreman-context.asciidoc

The actual data is set in `application_helper.rb` in Foreman. However, until now it was not possible for plugins to add to this data. With this PR, a procedure is introduced for plugins to register their app metadata during the plugin registration process.

For an example of use, see the Companion PR: https://github.com/theforeman/foreman_rh_cloud/pull/1116
