### PR TITLE
Refs #38825 - Remove HTTPS menuentries from GRUB2 configurations

### DIFF
--- a/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/autoyast_default_pxegrub2.erb
@@ -45,7 +45,6 @@ menuentry '<%= template_name %>' {
 subnet = @host.provision_interface.subnet || @host.provision_interface.subnet6
 if subnet && subnet.httpboot
   proxy_http_port = subnet.httpboot.httpboot_http_port
-  proxy_https_port = subnet.httpboot.httpboot_https_port
   # Workaround for "no DNS server configured" https://bugzilla.redhat.com/show_bug.cgi?id=1842509
   proxy_host = dns_lookup(subnet.httpboot.hostname)
 -%>
@@ -56,15 +55,6 @@ menuentry '<%= template_name %> EFI HTTP' --id efi_http {
 }
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
-<% end -%>
-
-<% if proxy_https_port -%>
-menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
-  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= kernel_options %>
-  <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
-}
-<% else -%>
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 <% end -%>
 
 <% end %>

--- a/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
+++ b/app/views/unattended/provisioning_templates/PXEGrub2/kickstart_default_pxegrub2.erb
@@ -62,7 +62,6 @@ menuentry '<%= template_name %>' {
 subnet = @host.provision_interface.subnet || @host.provision_interface.subnet6
 if subnet && subnet.httpboot
   proxy_http_port = subnet.httpboot.httpboot_http_port
-  proxy_https_port = subnet.httpboot.httpboot_https_port
   # Workaround for "no DNS server configured" https://bugzilla.redhat.com/show_bug.cgi?id=1842509
   proxy_host = dns_lookup(subnet.httpboot.hostname)
 -%>
@@ -73,15 +72,6 @@ menuentry '<%= template_name %> EFI HTTP' --id efi_http {
 }
 <% else -%>
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
-<% end -%>
-
-<% if proxy_https_port -%>
-menuentry '<%= template_name %> EFI HTTPS' --id efi_https {
-  <%= linuxcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @kernel %> <%= pxe_kernel_options %> <%= snippet("kickstart_kernel_options").strip %>
-  <%= initrdcmd %> (https,<%= proxy_host %>:<%= proxy_https_port %>)/httpboot/<%= @initrd %>
-}
-<% else -%>
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
 <% end -%>
 
 <% end %>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4and6dhcp.snap.txt
@@ -10,8 +10,6 @@ menuentry 'Kickstart default PXEGrub2' {
 
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
 
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4dhcp.snap.txt
@@ -10,8 +10,6 @@ menuentry 'Kickstart default PXEGrub2' {
 
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
 
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host4static.snap.txt
@@ -10,8 +10,6 @@ menuentry 'Kickstart default PXEGrub2' {
 
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
 
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6dhcp.snap.txt
@@ -10,8 +10,6 @@ menuentry 'Kickstart default PXEGrub2' {
 
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
 
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
-
 
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/PXEGrub2/Kickstart_default_PXEGrub2.host6static.snap.txt
@@ -10,8 +10,6 @@ menuentry 'Kickstart default PXEGrub2' {
 
 # Smart proxy does not have HTTPBoot feature with HTTP port enabled, skipping EFI HTTP boot menu entry
 
-# Smart proxy does not have HTTPBoot feature with HTTPS port enabled, skipping EFI HTTPS boot menu entry
-
 
 
 


### PR DESCRIPTION
HTTPS is not supported, only HTTP and TFTP (see
https://www.gnu.org/software/grub/manual/grub/grub.html#Device-syntax).


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
