### PR TITLE
Fixes #38819 - Clear host_owner on user[group] destroy

### DIFF
--- a/app/models/concerns/user_usergroup_common.rb
+++ b/app/models/concerns/user_usergroup_common.rb
@@ -1,4 +1,16 @@
 module UserUsergroupCommon
+  extend ActiveSupport::Concern
+
+  included do
+    after_destroy_commit :clear_host_owner_setting
+  end
+
+  def clear_host_owner_setting
+    return unless Setting[:host_owner] == id_and_type
+    setting = Foreman.settings.set_user_value('host_owner', '')
+    setting.save
+  end
+
   def ssh_authorized_keys
     ssh_keys.map(&:to_export)
   end

--- a/db/migrate/20251015113343_clear_host_owner_setting.rb
+++ b/db/migrate/20251015113343_clear_host_owner_setting.rb
@@ -1,0 +1,10 @@
+class ClearHostOwnerSetting < ActiveRecord::Migration[7.0]
+  def up
+    OwnerClassifier.classify_owner(Setting[:host_owner])
+  rescue ActiveRecord::RecordNotFound # maybe general rescue to clear at any error?
+    Foreman.settings.set_user_value('host_owner', '').save
+  end
+
+  def down
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3453,6 +3453,40 @@ class HostTest < ActiveSupport::TestCase
     assert_equal 'ens1.102', res.first.identifier
   end
 
+  context 'host_owner setting cleanup on destroy' do
+    setup do
+      User.current = users(:admin)
+    end
+
+    test 'destroying user as host_owner updates host owner suggestion' do
+      user = FactoryBot.create(:user)
+      Foreman.settings.set_user_value('host_owner', user.id_and_type).save
+
+      disable_orchestration
+      host = Host.new(:name => 'test-host')
+
+      assert_equal user, host.owner_suggestion
+
+      user.destroy
+
+      host2 = Host.new(:name => 'test-host-2')
+      assert_not_equal user, host2.owner_suggestion
+      assert_equal User.current, host2.owner_suggestion
+    end
+
+    test 'prevents destruction of host owner if set' do
+      user = FactoryBot.create(:user)
+      host = FactoryBot.create(:host)
+
+      host.owner = user
+      host.save
+
+      assert_raise(ActiveRecord::RecordNotDestroyed) { user.destroy! }
+
+      assert_equal user.id_and_type, host.owner.id_and_type
+    end
+  end
+
   private
 
   def setup_host_with_nic_parser(nic_attributes)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1337,4 +1337,57 @@ class UserTest < ActiveSupport::TestCase
     assert_equal ['one', 'two'], login_values
     assert_not_includes login_values, 'tHREE'
   end
+
+  context 'host_owner setting cleanup on destroy' do
+    setup do
+      @user = FactoryBot.create(:user)
+    end
+
+    test 'should clear host_owner setting when destroyed user is set as host_owner' do
+      Foreman.settings.set_user_value('host_owner', @user.id_and_type).save
+
+      @user.destroy
+
+      assert_nil Setting[:host_owner]
+    end
+
+    test 'should not clear host_owner setting when destroyed user is not set as host_owner' do
+      other_user = FactoryBot.create(:user)
+      Foreman.settings.set_user_value('host_owner', other_user.id_and_type).save
+
+      @user.destroy
+
+      assert_equal other_user.id_and_type, Setting[:host_owner]
+    end
+
+    test 'should handle destroy when host_owner setting is empty' do
+      Foreman.settings.set_user_value('host_owner', '').save
+
+      assert_nothing_raised do
+        @user.destroy
+      end
+    end
+
+    test 'should handle destroy when host_owner setting points to a usergroup' do
+      usergroup = FactoryBot.create(:usergroup)
+      Foreman.settings.set_user_value('host_owner', usergroup.id_and_type).save
+
+      @user.destroy
+
+      assert_equal usergroup.id_and_type, Setting[:host_owner]
+    end
+
+    test 'should not clear host_owner when user destroy is prevented by hosts' do
+      disable_orchestration
+      org = FactoryBot.create(:organization)
+      loc = FactoryBot.create(:location)
+      user = FactoryBot.create(:user, :organizations => [org], :locations => [loc])
+      Foreman.settings.set_user_value('host_owner', user.id_and_type).save
+      FactoryBot.create(:host, :owner => user, :organization => org, :location => loc)
+
+      user.destroy
+
+      assert_equal user.id_and_type, Setting[:host_owner]
+    end
+  end
 end

--- a/test/models/usergroup_test.rb
+++ b/test/models/usergroup_test.rb
@@ -418,4 +418,54 @@ class UsergroupTest < ActiveSupport::TestCase
 
     assert_equal expected, usergroup.to_export
   end
+
+  context 'host_owner setting cleanup on destroy' do
+    setup do
+      @usergroup = FactoryBot.create(:usergroup)
+    end
+
+    test 'should clear host_owner setting when destroyed usergroup is set as host_owner' do
+      Foreman.settings.set_user_value('host_owner', @usergroup.id_and_type).save
+
+      @usergroup.destroy
+
+      assert_nil Setting[:host_owner]
+    end
+
+    test 'should not clear host_owner setting when destroyed usergroup is not set as host_owner' do
+      other_usergroup = FactoryBot.create(:usergroup)
+      Foreman.settings.set_user_value('host_owner', other_usergroup.id_and_type).save
+
+      @usergroup.destroy
+
+      assert_equal other_usergroup.id_and_type, Setting[:host_owner]
+    end
+
+    test 'should handle destroy when host_owner setting is empty' do
+      Foreman.settings.set_user_value('host_owner', '').save
+
+      assert_nothing_raised do
+        @usergroup.destroy
+      end
+    end
+
+    test 'should handle destroy when host_owner setting points to a user' do
+      user = FactoryBot.create(:user)
+      Foreman.settings.set_user_value('host_owner', user.id_and_type).save
+
+      @usergroup.destroy
+
+      assert_equal user.id_and_type, Setting[:host_owner]
+    end
+
+    test 'should not clear host_owner when usergroup destroy is prevented by hosts' do
+      disable_orchestration
+      Foreman.settings.set_user_value('host_owner', @usergroup.id_and_type).save
+      FactoryBot.create(:host, :owner => @usergroup)
+
+      @usergroup.destroy
+
+      assert_equal @usergroup.id_and_type, Setting[:host_owner]
+    end
+  end
 end


### PR DESCRIPTION
This doesn't take into account the state when a user/group was already deleted, but the setting is still set to that user/group.

Should I add a migration for that or should we just mention in release notes that users should clear it manually in this case?

Ideally a migration should be present, but it seems like an overkill for such action...