### PR TITLE
Add webpack cache for development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ npm-debug.log
 mkmf.log
 .yardoc/
 webpack/assets/javascripts/all_react_app_exports.js
+.webpack_cache/

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -35,9 +35,9 @@ const shared = isPlugin => {
     ...sharedArr,
     {
       /*
-      have to use '@scalprum/core/index' in vendor.js entry otherwise we get 
+      have to use '@scalprum/core/index' in vendor.js entry otherwise we get
       Uncaught ReferenceError: __webpack_exports__ is not defined
-      but without need to "convert" @scalprum/core/index to @scalprum/core 
+      but without need to "convert" @scalprum/core/index to @scalprum/core
       so the shared context can find it
       */
       '@scalprum/react-core': {
@@ -96,12 +96,13 @@ const supportedLanguagesRE = new RegExp(
   `/(${supportedLanguages().join('|')})$`
 );
 
-const commonConfig = function() {
+const commonConfig = function(buildName = 'core') {
   var production =
     process.env.RAILS_ENV === 'production' ||
     process.env.NODE_ENV === 'production';
   const mode = production ? 'production' : 'development';
   const config = {};
+
   if (production) {
     config.devtool = 'source-map';
     config.optimization = {
@@ -109,9 +110,24 @@ const commonConfig = function() {
       splitChunks: false,
     };
   } else {
-    config.devtool = 'inline-source-map';
+    config.devtool = 'eval-cheap-module-source-map';
     config.optimization = {
       splitChunks: false,
+      removeAvailableModules: false,
+      removeEmptyChunks: false,
+    };
+
+    config.cache = {
+      type: 'filesystem',
+      maxAge: 604800000, // one week
+      version: '1.0',
+      cacheDirectory: path.resolve(root, '.webpack_cache'),
+      compression: false,
+      name: `${buildName}-${mode}`,
+      store: 'pack',
+      buildDependencies: {
+        config: [__filename],
+      },
     };
   }
   return {
@@ -201,7 +217,7 @@ const commonConfig = function() {
 };
 
 const coreConfig = function() {
-  var config = commonConfig();
+  var config = commonConfig('core');
   var manifestFilename = 'manifest.json';
   var bundleEntry = path.join(root, 'webpack/assets/javascripts/bundle.js');
   config.context = path.resolve(root);
@@ -280,7 +296,7 @@ const coreConfig = function() {
 const pluginConfig = function(plugin) {
   const pluginRoot = plugin.root;
   const pluginName = plugin.name.replace('-', '_'); // module federation doesnt like -
-  var config = commonConfig();
+  var config = commonConfig(pluginName);
   config.context = path.join(pluginRoot, 'webpack');
   config.entry = {};
 


### PR DESCRIPTION
I wanted to look at whether there were changes that could make rebuilds, and restarts faster in development. I did a series of testing and arrived at this change with these results:


  | Scenario              | No Cache | With Cache | Improvement          |
  |-----------------------|----------|------------|----------------------|
  | Cold Start            | ~112s    | ~112s      | 0% (no cache exists) |
  | Dev Rebuilds (Core)   | 9.1s     | 6.9s       | 24% faster           |
  | Dev Rebuilds (Plugin) | 1.6s     | 1.4s       | 16% faster           |
  | Dev Server Restart    | 128s     | 24s        | 81% faster           |


With moderate gains to rebuilds, and significant gains to server restarts.

Cold Start: No cache, first time the application boots, no changes.
Dev server restart: Server was started at least once, maybe some changes have been made, server is restarted.
