### PR TITLE
Fixes #38840 - Always verify auth token and expire session except for smart proxies

### DIFF
--- a/app/controllers/concerns/foreman/controller/authentication.rb
+++ b/app/controllers/concerns/foreman/controller/authentication.rb
@@ -36,7 +36,9 @@ module Foreman::Controller::Authentication
       backup_session_content { reset_session }
       inline_warning _('User account is disabled, please contact your administrator')
       redirect_to main_app.login_users_path
+      return false
     end
+    true
   end
 
   def authorized

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -2,7 +2,6 @@ module Foreman::Controller::Session
   extend ActiveSupport::Concern
 
   def session_expiry
-    Rails.logger.info "session_expiry"
     return if ignore_api_request?
     if session[:expires_at].blank? || (Time.at(session[:expires_at]).utc - Time.now.utc).to_i < 0
       session[:original_uri] = request.fullpath unless api_request?
@@ -38,7 +37,7 @@ module Foreman::Controller::Session
     else
       sso = get_sso_method
       if sso.nil? || !sso.support_expiration?
-        inline_warning _("Your session has expired, please login again")
+        inline_warning _("Your session has expired; please log in again")
         redirect_to main_app.login_users_path
       else
         redirect_to sso.expiration_url

--- a/app/controllers/concerns/foreman/controller/session.rb
+++ b/app/controllers/concerns/foreman/controller/session.rb
@@ -2,6 +2,7 @@ module Foreman::Controller::Session
   extend ActiveSupport::Concern
 
   def session_expiry
+    Rails.logger.info "session_expiry"
     return if ignore_api_request?
     if session[:expires_at].blank? || (Time.at(session[:expires_at]).utc - Time.now.utc).to_i < 0
       session[:original_uri] = request.fullpath unless api_request?

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -32,12 +32,18 @@ module Foreman::Controller::SmartProxyAuth
       return true
     end
 
-    require_login
-    unless User.current
+    # if we reach this, the requestor is a user and not a smart proxy
+    require_user_login
+  end
+
+  def require_user_login
+    unless require_login && User.current.present? && check_user_enabled
       render_error 'access_denied', :status => :forbidden unless performed? && api_request?
       return false
     end
-    authorize
+    authorize && verify_authenticity_token && set_taxonomy
+    session_expiry
+    update_activity_time
   end
 
   # Filter requests to only permit from hosts with a registered smart proxy

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -38,11 +38,11 @@ module Foreman::Controller::SmartProxyAuth
 
   def require_user_login
     verify_authenticity_token
-    unless require_login && User.current.present? && check_user_enabled
+    if require_login == false || User.current.blank? || check_user_enabled == false
       render_error 'access_denied', :status => :forbidden unless performed? && api_request?
       return false
     end
-    return false unless authorize && set_taxonomy
+    return false if (authorize == false || set_taxonomy == false)
     session_expiry
     update_activity_time
     true

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -20,7 +20,6 @@ module Foreman::Controller::SmartProxyAuth
 
   # Permits registered Smart Proxies or a user with permission
   def require_smart_proxy_or_login(features = nil)
-    Rails.logger.info "require_smart_proxy_or_login"
     features = features.call if features.respond_to?(:call)
     allowed_smart_proxies = if features.blank?
                               SmartProxy.unscoped.all
@@ -29,33 +28,28 @@ module Foreman::Controller::SmartProxyAuth
                             end
 
     if !Setting[:restrict_registered_smart_proxies] || auth_smart_proxy(allowed_smart_proxies)
-      Rails.logger.info "set_admin_user"
       set_admin_user
       return true
     end
 
     # if we reach this, the requestor is a user and not a smart proxy
-    Rails.logger.info "requestor is a user and not a smart proxy"
     require_user_login
   end
 
   def require_user_login
-    Rails.logger.info "require_user_login"
+    verify_authenticity_token
     unless require_login && User.current.present? && check_user_enabled
       render_error 'access_denied', :status => :forbidden unless performed? && api_request?
       return false
     end
-    Rails.logger.info "after require_login && check_user_enabled"
-    authorize && verify_authenticity_token && set_taxonomy
-    Rails.logger.info "after authorize && verify_authenticity_token && set_taxonomy"
+    return false unless authorize && set_taxonomy
     session_expiry
-    Rails.logger.info "after session_expiry"
     update_activity_time
+    true
   end
 
   # Filter requests to only permit from hosts with a registered smart proxy
   def auth_smart_proxy(proxies = SmartProxy.unscoped.all)
-    Rails.logger.info "auth_smart_proxy"
     request_hosts = nil
     if request.ssl?
       # If we have the client certficate in the request environment we can extract the dn and sans from there

--- a/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
+++ b/app/controllers/concerns/foreman/controller/smart_proxy_auth.rb
@@ -20,6 +20,7 @@ module Foreman::Controller::SmartProxyAuth
 
   # Permits registered Smart Proxies or a user with permission
   def require_smart_proxy_or_login(features = nil)
+    Rails.logger.info "require_smart_proxy_or_login"
     features = features.call if features.respond_to?(:call)
     allowed_smart_proxies = if features.blank?
                               SmartProxy.unscoped.all
@@ -28,26 +29,33 @@ module Foreman::Controller::SmartProxyAuth
                             end
 
     if !Setting[:restrict_registered_smart_proxies] || auth_smart_proxy(allowed_smart_proxies)
+      Rails.logger.info "set_admin_user"
       set_admin_user
       return true
     end
 
     # if we reach this, the requestor is a user and not a smart proxy
+    Rails.logger.info "requestor is a user and not a smart proxy"
     require_user_login
   end
 
   def require_user_login
+    Rails.logger.info "require_user_login"
     unless require_login && User.current.present? && check_user_enabled
       render_error 'access_denied', :status => :forbidden unless performed? && api_request?
       return false
     end
+    Rails.logger.info "after require_login && check_user_enabled"
     authorize && verify_authenticity_token && set_taxonomy
+    Rails.logger.info "after authorize && verify_authenticity_token && set_taxonomy"
     session_expiry
+    Rails.logger.info "after session_expiry"
     update_activity_time
   end
 
   # Filter requests to only permit from hosts with a registered smart proxy
   def auth_smart_proxy(proxies = SmartProxy.unscoped.all)
+    Rails.logger.info "auth_smart_proxy"
     request_hosts = nil
     if request.ssl?
       # If we have the client certficate in the request environment we can extract the dn and sans from there
@@ -75,10 +83,21 @@ module Foreman::Controller::SmartProxyAuth
       request_hosts = [request.remote_ip] if request_hosts.empty?
     end
     return false unless request_hosts
+    Rails.logger.info request_hosts
 
     hosts = Hash[proxies.map { |p| [URI.parse(p.url).host, p] }]
-    allowed_hosts = hosts.keys.push(*Setting[:trusted_hosts])
-    logger.debug { "Verifying request from #{request_hosts.inspect} against #{allowed_hosts.inspect}" }
+
+    # For loopback addresses in non-SSL mode, only match against trusted_hosts,
+    # not registered smart proxy URLs. This prevents local processes from
+    # impersonating smart proxies while still allowing explicit trusted_hosts entries.
+    remote_ip = IPAddr.new(request.remote_ip) rescue nil
+    if !request.ssl? && remote_ip&.loopback?
+      allowed_hosts = Setting[:trusted_hosts]
+      logger.debug { "Verifying loopback request from #{request_hosts.inspect} against trusted_hosts only: #{allowed_hosts.inspect}" }
+    else
+      allowed_hosts = hosts.keys.push(*Setting[:trusted_hosts])
+      logger.debug { "Verifying request from #{request_hosts.inspect} against #{allowed_hosts.inspect}" }
+    end
 
     if (host = detect_matching_host(allowed_hosts, request_hosts))
       @detected_proxy = hosts[host] if host

--- a/test/controllers/locations_controller_test.rb
+++ b/test/controllers/locations_controller_test.rb
@@ -78,7 +78,7 @@ class LocationsControllerTest < ActionController::TestCase
 
     # session is reset, redirected to login, but org id remains
     assert_redirected_to "/users/login"
-    assert_match /Your session has expired, please login again/, flash[:inline][:warning]
+    assert_match /Your session has expired; please log in again/, flash[:inline][:warning]
     assert_equal session[:location_id], taxonomies(:location1).id
   end
 

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -90,7 +90,7 @@ class OrganizationsControllerTest < ActionController::TestCase
 
     # session is reset, redirected to login, but org id remains
     assert_redirected_to "/users/login"
-    assert_match /Your session has expired, please login again/, flash[:inline][:warning]
+    assert_match /Your session has expired; please log in again/, flash[:inline][:warning]
     assert_equal session[:organization_id], taxonomies(:organization1).id
   end
 

--- a/test/controllers/smart_proxy_auth_test.rb
+++ b/test/controllers/smart_proxy_auth_test.rb
@@ -12,7 +12,12 @@ class SmartProxyAuthApiTest < ActionController::TestCase
 
     @controller.stubs(:auth_smart_proxy).returns(false)
     @controller.stubs(:require_login).returns(true)
+    @controller.stubs(:check_user_enabled).returns(true)
     @controller.stubs(:authorize).returns(true)
+    @controller.stubs(:verify_authenticity_token).returns(true)
+    @controller.stubs(:set_taxonomy).returns(true)
+    @controller.stubs(:session_expiry).returns(true)
+    @controller.stubs(:update_activity_time).returns(true)
 
     assert @controller.send(:require_smart_proxy_or_login)
   end
@@ -41,11 +46,53 @@ class SmartProxyAuthApiTest < ActionController::TestCase
 
     @controller.stubs(:auth_smart_proxy).returns(false)
     @controller.stubs(:require_login).returns(true)
+    @controller.stubs(:check_user_enabled).returns(true)
     @controller.stubs(:authorize).returns(true)
+    @controller.stubs(:verify_authenticity_token).returns(true)
+    @controller.stubs(:set_taxonomy).returns(true)
+    @controller.stubs(:session_expiry).returns(true)
+    @controller.stubs(:update_activity_time).returns(true)
 
     assert_raise ArgumentError, 'test' do
       @controller.send(:require_smart_proxy_or_login, proc { raise ArgumentError, 'test' })
     end
+  end
+
+  def test_require_user_login_calls_all_required_filters
+    User.current = users(:admin)
+
+    @controller.expects(:require_login).returns(true)
+    @controller.expects(:check_user_enabled).returns(true)
+    @controller.expects(:authorize).returns(true)
+    @controller.expects(:verify_authenticity_token).returns(true)
+    @controller.expects(:set_taxonomy).returns(true)
+    @controller.expects(:session_expiry).returns(true)
+    @controller.expects(:update_activity_time).returns(true)
+
+    assert @controller.send(:require_user_login)
+  end
+
+  def test_require_user_login_fails_when_user_current_is_nil
+    User.current = nil
+
+    @controller.stubs(:require_login).returns(true)
+    @controller.stubs(:check_user_enabled).returns(true)
+    @controller.stubs(:performed?).returns(false)
+    @controller.expects(:render_error).with('access_denied', status: :forbidden)
+
+    refute @controller.send(:require_user_login)
+  end
+
+  def test_require_user_login_does_not_render_error_when_already_performed_for_api
+    User.current = nil
+
+    @controller.stubs(:require_login).returns(true)
+    @controller.stubs(:check_user_enabled).returns(true)
+    @controller.stubs(:performed?).returns(true)
+    @controller.stubs(:api_request?).returns(true)
+    @controller.expects(:render_error).never
+
+    refute @controller.send(:require_user_login)
   end
 
   def test_certificate_with_dn_permits_access
@@ -204,7 +251,12 @@ class SmartProxyAuthWebUITest < ActionController::TestCase
 
     @controller.stubs(:auth_smart_proxy).returns(false)
     @controller.stubs(:require_login).returns(true)
+    @controller.stubs(:check_user_enabled).returns(true)
     @controller.stubs(:authorize).returns(true)
+    @controller.stubs(:verify_authenticity_token).returns(true)
+    @controller.stubs(:set_taxonomy).returns(true)
+    @controller.stubs(:session_expiry).returns(true)
+    @controller.stubs(:update_activity_time).returns(true)
 
     assert @controller.send(:require_smart_proxy_or_login)
   end

--- a/test/controllers/smart_proxy_auth_test.rb
+++ b/test/controllers/smart_proxy_auth_test.rb
@@ -237,6 +237,22 @@ class SmartProxyAuthApiTest < ActionController::TestCase
     Setting[:trusted_hosts] = ['2001:db8:cafe::/48']
     refute @controller.send(:auth_smart_proxy)
   end
+
+  def test_non_ssl_loopback_does_not_match_proxy_urls
+    # Ensure non-SSL loopback requests don't match against registered proxy URLs
+    Resolv.any_instance.expects(:getnames).with('127.0.0.1').returns(['localhost'])
+    @request.env['REMOTE_ADDR'] = '127.0.0.1'
+    @request.stubs(:ssl?).returns(false)
+
+    # Proxy registered with localhost URL
+    proxy = FactoryBot.create(:smart_proxy, :url => 'http://localhost:8443')
+    SmartProxy.expects(:unscoped).returns(stub(all: [proxy]))
+
+    # trusted_hosts is empty - should NOT match
+    Setting[:trusted_hosts] = []
+
+    refute @controller.send(:auth_smart_proxy)
+  end
 end
 
 class SmartProxyAuthWebUITest < ActionController::TestCase


### PR DESCRIPTION
~~RH Cloud change: https://github.com/theforeman/foreman_rh_cloud/pull/1119~~

Note that the changed lines take place _after_ this
```
if !Setting[:restrict_registered_smart_proxies] || auth_smart_proxy(allowed_smart_proxies)
      set_admin_user
      return true
    end
```

so they should only apply to requests coming from users (not smart proxies).

### To test

Set idle timeout setting to 1 minute
Set your hammer to use sessions:
```
$ cat ~/.hammer/cli.modules.d/foreman.yml
:foreman:
  :use_sessions: true
```

Then run
```
hammer auth login basic
```

enter username/password

Wait >1 minute
`hammer organization list` -- should not list organizations. Should instead ask you for username/password.


