### PR TITLE
Fixes #38855 - Updated the parameter used by kexec

### DIFF
--- a/app/views/unattended/provisioning_templates/discovery/redhat_kexec.erb
+++ b/app/views/unattended/provisioning_templates/discovery/redhat_kexec.erb
@@ -51,7 +51,7 @@ require:
 "initram": "<%= @initrd_uri %>",
 <% if (@host.operatingsystem.name == 'Fedora' and @host.operatingsystem.major.to_i > 16) or
   (@host.operatingsystem.name != 'Fedora' and @host.operatingsystem.major.to_i >= 7) -%>
-  "append": "inst.ks=<%= foreman_url('provision', { static: 'yes' }) %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
+  "append": "inst.ks=<%= foreman_url('provision', { static: 'yes' }) %> inst.ks.sendmac <%= "ip=#{ip}::#{gw}:#{mask}:#{@host.name}::none nameserver=#{dns} ksdevice=bootif BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
 <% else -%>
   "append": "inst.ks=<%= foreman_url('provision', { static: 'yes' }) %> kssendmac nicdelay=5 <%= "ip=#{ip} netmask=#{mask} gateway=#{gw} dns=#{dns} ksdevice=#{mac} BOOTIF=#{bootif} nomodeset nokaslr " + options.compact.join(' ') %>",
 <% end -%>


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->

When provisioning rhel9+ via fdi using static network information, localhost.localdomain will be created on Satellite webUI

#### Steps to Reproduce:
- Setup satellite for provisioning (rhel9)
- FDI, using static network information
- Start the provisioning of rhel9

#### Actual behavior:
Initially, the content host will be created on Satellite, and once the VM reaches the rhsm call, a new entry will be created on satellite, called localhost.localdomain

#### Expected behavior:
The same content host entry should be used. During the rhsm call, the Content Host should already know the hostname, which is not the case.