### PR TITLE
Refs #38804 - Use preload instead of includes for subnet api

### DIFF
--- a/app/controllers/api/v2/subnets_controller.rb
+++ b/app/controllers/api/v2/subnets_controller.rb
@@ -20,7 +20,7 @@ module Api
       add_scoped_search_description_for(Subnet)
 
       def index
-        @subnets = resource_scope_for_index.includes(:tftp, :dhcp, :dns)
+        @subnets = resource_scope_for_index.preload(:tftp, :dhcp, :dns)
         @subnets = @subnets.network_reorder(params[:order]) if params[:order].present? && params[:order] =~ /\Anetwork( ASC| DESC)?\Z/
       end
 

--- a/test/controllers/api/v2/subnets_controller_test.rb
+++ b/test/controllers/api/v2/subnets_controller_test.rb
@@ -220,7 +220,7 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
     loc = FactoryBot.create(:location)
     FactoryBot.create(:subnet_ipv4, :organizations => [org], :locations => [loc])
     manager = roles(:manager)
-    role = manager.clone :name => "Clonned manager", :organizations => [org], :locations => [loc]
+    role = manager.clone :name => "Cloned manager", :organizations => [org], :locations => [loc]
     role.save!
     user = FactoryBot.create(:user, :organizations => [org], :locations => [loc], :default_organization_id => org.id,
                              :default_location_id => loc.id, :roles => [role])
@@ -228,5 +228,22 @@ class Api::V2::SubnetsControllerTest < ActionController::TestCase
       get :index, params: { :location_id => loc.id }
     end
     assert_response :success
+  end
+
+  test "index includes subnets without features" do
+    org = FactoryBot.create(:organization)
+    loc = FactoryBot.create(:location)
+    subnet = FactoryBot.create(:subnet_ipv4, :organizations => [org], :locations => [loc])
+    user = setup_user('view', 'subnets', "organization_id = #{org.id} AND location_id = #{loc.id}")
+    user.organizations << org
+    user.locations << loc
+
+    as_user user do
+      get :index
+    end
+
+    assert_response :success
+    data = ActiveSupport::JSON.decode(@response.body)
+    assert_include data['results'].map { |r| r['id'] }, subnet.id
   end
 end


### PR DESCRIPTION
Fixes https://github.com/theforeman/foreman/commit/740bc5c38f5901bb5903067b6d9056e10b66e61c
API flavor of https://github.com/theforeman/foreman/pull/10717

Should fix the failure observed in https://github.com/SatelliteQE/robottelo/pull/20097