### PR TITLE
Fixes #38866 - Set manage_repos=1 in rhsm.conf

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/subscription_manager_setup.erb
@@ -110,7 +110,8 @@ subscription-manager config \
   --server.port="<%= server_port %>" \
   --server.prefix="<%= server_prefix %>" \
   --rhsm.repo_ca_cert="<%= repo_ca_cert %>" \
-  --rhsm.baseurl="<%= rhsm_baseurl %>"
+  --rhsm.baseurl="<%= rhsm_baseurl %>" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -104,7 +104,8 @@ runcmd:
     --server.port="443" \
     --server.prefix="/subscription" \
     --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-    --rhsm.baseurl="https://cdn.redhat.com"
+    --rhsm.baseurl="https://cdn.redhat.com" \
+    --rhsm.manage_repos=1
   
   # Older versions of subscription manager may not recognize
   # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -89,7 +89,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -154,7 +154,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -154,7 +154,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -154,7 +154,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -154,7 +154,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -154,7 +154,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -152,7 +152,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -153,7 +153,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub_discovery.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/pxegrub_discovery.host4dhcp.snap.txt
@@ -1,4 +1,0 @@
-# http://projects.theforeman.org/issues/15997
-title Foreman Discovery Image - not supported with Grub 1.x
-  kernel boot/fdi-image/vmlinuz0 rootflags=loop root=live:/fdi.iso rootfstype=auto ro rd.live.image acpi=force rd.luks=0 rd.md=0 rd.dm=0 rd.lvm=0 rd.bootif=0 rd.neednet=0 nokaslr nomodeset proxy.url=http://foreman.example.com proxy.type=foreman BOOTIF=01-$net_default_mac
-  initrd boot/fdi-image/initrd0.img

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -103,7 +103,8 @@ subscription-manager config \
   --server.port="443" \
   --server.prefix="/subscription" \
   --rhsm.repo_ca_cert="/etc/rhsm/ca/redhat-uep.pem" \
-  --rhsm.baseurl="https://cdn.redhat.com"
+  --rhsm.baseurl="https://cdn.redhat.com" \
+  --rhsm.manage_repos=1
 
 # Older versions of subscription manager may not recognize
 # report_package_profile and package_profile_on_trans options.


### PR DESCRIPTION
Any RHEL 8.4+  AMIs launched in cloud, would have auto_registration enabled and hence, as they are not expected to consume content directly from redhat cdn or a satellite\katello\foreman, The manage_repos option is by default set to 0 or disabled.

In order to register such a system back with a satellite\foreman\katello instance, it's important that we force manage_repos to be enabled ( set to 1 ) so that, after the registration the systems can see and consume repos from the parent satellite\katello\foreman instance and complete the post-registration steps as well.
