### PR TITLE
Fixes #38875 - Add empty state customization to TableIndexPage

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -229,7 +229,7 @@ export const Table = ({
               }))}
         </Tbody>
       </PFTable>
-      {results.length > 0 && !errorMessage && !emptyMessage && bottomPagination}
+      {results.length > 0 && !errorMessage && bottomPagination}
     </>
   );
 };

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -77,6 +77,9 @@ A page component that displays a table with data fetched from the API. It provid
 @param {function} {restrictedSearchQuery} - If included, normalize the search query to add this to all search queries to restrict search results without altering the search input value. Useful for limiting results to an initial selection.
 @param {boolean} {updateParamsByUrl} - If true, update pagination props from URL params. Default is true.
 @param {string} {bookmarksPosition} - The position of the bookmarks dropdown. Default is 'left', which means the menu will take up space to its right.
+@param {React.ReactNode} {customEmptyState} - Optional custom empty state component to display when there are no results
+@param {string} {emptyMessage} - Optional message to display in the default empty state when there are no results
+@param {Object} {emptyAction} - Optional action button for the empty state. Object with 'title' and 'onClick' properties
 */
 
 const TableIndexPage = ({
@@ -113,6 +116,9 @@ const TableIndexPage = ({
   restrictedSearchQuery,
   updateParamsByUrl,
   bookmarksPosition,
+  customEmptyState,
+  emptyMessage,
+  emptyAction,
   ouiaId,
 }) => {
   const history = useHistory();
@@ -335,6 +341,9 @@ const TableIndexPage = ({
             showCheckboxes={showCheckboxes}
             rowSelectTd={rowSelectTd}
             idColumn={idColumn}
+            customEmptyState={customEmptyState}
+            emptyMessage={emptyMessage}
+            emptyAction={emptyAction}
           />
         )}
       </PageSection>
@@ -399,6 +408,12 @@ TableIndexPage.propTypes = {
   restrictedSearchQuery: PropTypes.func,
   updateParamsByUrl: PropTypes.bool,
   bookmarksPosition: PropTypes.string,
+  customEmptyState: PropTypes.node,
+  emptyMessage: PropTypes.string,
+  emptyAction: PropTypes.shape({
+    title: PropTypes.string,
+    onClick: PropTypes.func,
+  }),
   ouiaId: PropTypes.string,
 };
 
@@ -435,6 +450,9 @@ TableIndexPage.defaultProps = {
   restrictedSearchQuery: noop,
   updateParamsByUrl: true,
   bookmarksPosition: 'left',
+  customEmptyState: null,
+  emptyMessage: null,
+  emptyAction: null,
   ouiaId: 'table',
 };
 


### PR DESCRIPTION
### What are the changes introduced in this pull request?

Goes with https://github.com/Katello/katello/pull/11547

This PR adds support for customizing the empty state in TableIndexPage by adding three new optional props:
- `customEmptyState`: Optional custom empty state component to fully replace the default
- `emptyMessage`: Optional message to display in the default empty state
- `emptyAction`: Optional action button object for the empty state (with `title` and `onClick` properties)

These props are passed through to the Table component to allow plugins and other consumers to provide more contextual empty states.

### Considerations taken when implementing this change?

- All three props are optional and backward compatible
- Props are documented in the JSDoc comments and PropTypes
- Props follow existing naming conventions in the component
- Implementation is minimal and doesn't change existing behavior when props are not provided

### What are the testing steps for this pull request?

1. Verify existing table pages still work without regression
2. Verify that passing `emptyMessage` shows custom message in empty state
3. Verify that passing `emptyAction` shows action button in empty state
4. Verify that passing `customEmptyState` fully replaces the default empty state

### Related issues

- Fixes #38875
- Related to Katello PR (to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>