### PR TITLE
Fixes #38839 - Kickstart dynamic partition table fails on UEFI systems

### DIFF
--- a/app/views/unattended/partition_tables_templates/kickstart_dynamic.erb
+++ b/app/views/unattended/partition_tables_templates/kickstart_dynamic.erb
@@ -44,7 +44,20 @@ fi
 cat <<EOF > /tmp/diskpart.cfg
 zerombr
 clearpart --all --initlabel
-part /boot --fstype ext4 --size 200 --asprimary
+EOF
+
+if [ -d /sys/firmware/efi ]; then
+    cat <<EOF >> /tmp/diskpart.cfg
+part /boot/efi --fstype efi --size=600 --asprimary
+part /boot --fstype ext4 --size=1024
+EOF
+else
+    cat <<EOF >> /tmp/diskpart.cfg
+part /boot --fstype ext4 --size=1024 --asprimary
+EOF
+fi
+
+cat <<EOF >> /tmp/diskpart.cfg
 part swap --size "$SWAP_MEMORY"
 part / --fstype ext4 --size 1024 --grow
 EOF


### PR DESCRIPTION
### Problem Summary

When provisioning UEFI hosts with the **Kickstart dynamic** partition table, the installation fails during partitioning with the following error message:

```
Failed to find a suitable stage1 device: EFI System Partition cannot be of type ext4.
EFI System Partition must be mounted on one of /boot/efi.
```

This occurs because the `%pre` section of the template only generates `/boot`, `/`, and `swap` partitions, but does not create `/boot/efi`.  
As a result, Anaconda cannot find a valid EFI System Partition (ESP) and aborts the installation.

### Modifications in this PR

#### Add UEFI Detection and ESP Creation
- The template now checks for the existence of `/sys/firmware/efi` to determine if the system is booted in UEFI mode.
- If UEFI is detected:
  - Create a 600 MiB EFI System Partition:
    ```
    part /boot/efi --fstype=efi --size=600
    ```
- If BIOS mode is detected:
  - Keep the existing layout (`/boot` 200 MiB, ext4).