### PR TITLE
Fixes #38715 - generate report datepicker overlapping

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/DateTimePicker.js
@@ -92,10 +92,10 @@ class DateTimePicker extends React.Component {
           />
           <Popover
             position={placement}
-            className="container"
-            style={{ minWidth: '50em', width: '33%' }}
+            className="date-time-picker-popover"
             bodyContent={popover}
             onShown={() => this.setState({ hiddenValue: false })}
+            minWidth="500px"
           >
             <InputGroup.Addon className="date-time-picker-pf">
               <Icon type="fa" name="calendar" />

--- a/webpack/assets/javascripts/react_app/components/common/DateTimePicker/date-time-picker.scss
+++ b/webpack/assets/javascripts/react_app/components/common/DateTimePicker/date-time-picker.scss
@@ -54,3 +54,6 @@ span.clear-button {
 input.date-time-input {
   border-right: none;
 }
+.pf-v5-c-popover.date-time-picker-popover {
+  width: 33%;
+}


### PR DESCRIPTION
in templates/report_templates/X
the Generate at datepicker (opened by the button) is overlapping the timepicker

(cherry picked from commit de8bc53961995c5e48d2af8299be8e2bc642d114)
