### PR TITLE
Fixes #38667 - Move ping widget to Foreman

### DIFF
--- a/app/views/about/index.html.erb
+++ b/app/views/about/index.html.erb
@@ -143,5 +143,7 @@
       <p><kbd>CTRL + SHIFT + F</kbd> <%= _("To focus the navigation search bar") %></p>
     </div>
   </div>
-  <%= slot('aboutFooterSlot', true) %>
+  <div id="backend-system-status" class="col-md-7">
+    <%= react_component('BackendSystemStatus', ping: ::Ping.ping) %>
+  </div>
 </div>

--- a/script/lint/lint_core_config.js
+++ b/script/lint/lint_core_config.js
@@ -23,6 +23,7 @@ module.exports = {
           'bool',
           'bootable',
           'Borderless',
+          'bss',
           'btns',
           'candlepin',
           'centos',

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/__tests__/BackendSystemStatus.test.js
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/__tests__/BackendSystemStatus.test.js
@@ -1,0 +1,112 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BackendSystemStatus } from '../index';
+
+const mockPingData = {
+  foreman: {
+    database: {
+      active: true,
+      duration_ms: '0'
+    },
+    cache: {
+      servers: [
+        {
+          status: 'ok',
+          duration_ms: '1'
+        }
+      ]
+    }
+  },
+  foreman_rh_cloud: {
+    services: {
+      advisor: {
+        status: 'FAIL',
+        message: '502 Bad Gateway'
+      },
+      vulnerability: {
+        status: 'ok',
+        duration_ms: '25'
+      }
+    },
+    status: 'FAIL'
+  }
+};
+
+const mockPingDataAllOK = {
+  foreman: {
+    database: {
+      active: true,
+      duration_ms: '0'
+    },
+    cache: {
+      servers: [
+        {
+          status: 'ok',
+          duration_ms: '1'
+        }
+      ]
+    }
+  }
+};
+
+describe('BackendSystemStatus', () => {
+  it('renders component structure with failed services correctly', () => {
+    const { container } = render(<BackendSystemStatus ping={mockPingData} />);
+    
+    // Basic structure
+    expect(screen.getByText('Backend system status')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Service name' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Info' })).toBeInTheDocument();
+    
+    // Service hierarchy
+    expect(screen.getAllByText('foreman')[0]).toBeInTheDocument();
+    expect(screen.getByText('database')).toBeInTheDocument();
+    expect(screen.getByText('cache')).toBeInTheDocument();
+    expect(screen.getByText('servers')).toBeInTheDocument();
+    
+    // Nested services
+    expect(screen.getAllByText('foreman_rh_cloud')[0]).toBeInTheDocument();
+    expect(screen.getByText('advisor')).toBeInTheDocument();
+    expect(screen.getByText('vulnerability')).toBeInTheDocument();
+    
+    // Status information
+    expect(screen.getByText('active')).toBeInTheDocument();
+    expect(screen.getAllByText('true')[0]).toBeInTheDocument();
+    expect(screen.getAllByText('duration (ms)')[0]).toBeInTheDocument();
+    expect(screen.getByText('FAIL')).toBeInTheDocument();
+    expect(screen.getByText('502 Bad Gateway')).toBeInTheDocument();
+    
+    // Warning icon due to failures
+    const warningIcon = container.querySelector('.pf-v5-c-icon__content.pf-m-warning');
+    expect(warningIcon).toBeInTheDocument();
+    
+    // CSS classes
+    const parentServiceElements = container.querySelectorAll('.service-name-parent');
+    expect(parentServiceElements.length).toBeGreaterThan(0);
+    
+    // OUIA attributes
+    const mainCard = container.querySelector('[data-ouia-component-id="backend-system-status"]');
+    expect(mainCard).toBeInTheDocument();
+  });
+
+  it('shows success status when all services are OK', () => {
+    const { container } = render(<BackendSystemStatus ping={mockPingDataAllOK} />);
+    
+    const successIcon = container.querySelector('.pf-v5-c-icon__content.pf-m-success');
+    expect(successIcon).toBeInTheDocument();
+  });
+
+  it('handles edge cases gracefully', () => {
+    // Empty data
+    const { rerender } = render(<BackendSystemStatus ping={{}} />);
+    expect(screen.getByText('Backend system status')).toBeInTheDocument();
+    const emptyTableRows = screen.getAllByRole('row');
+    expect(emptyTableRows).toHaveLength(1); // Only header row
+    
+    // Undefined prop
+    rerender(<BackendSystemStatus />);
+    expect(screen.getByText('Backend system status')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: 'Service name' })).toBeInTheDocument();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/__tests__/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/__tests__/helpers.test.js
@@ -1,0 +1,81 @@
+import { flattenPingResults, computeOverallStatus } from '../helpers';
+
+describe('flattenPingResults', () => {
+  it('handles various data structures correctly', () => {
+    // Simple nested structure
+    const simpleInput = {
+      foreman: {
+        database: { active: true, duration_ms: '0' }
+      }
+    };
+    const simpleResult = flattenPingResults(simpleInput);
+    expect(simpleResult).toEqual([{
+      serviceNameParts: ['foreman', 'database'],
+      data: { active: true, duration_ms: '0' }
+    }]);
+
+    // Array structures
+    const arrayInput = {
+      foreman: {
+        cache: {
+          servers: [
+            { status: 'ok', duration_ms: '1' },
+            { status: 'fail', duration_ms: '5' }
+          ]
+        }
+      }
+    };
+    const arrayResult = flattenPingResults(arrayInput);
+    expect(arrayResult).toHaveLength(2);
+    expect(arrayResult[0].serviceNameParts).toEqual(['foreman', 'cache', 'servers']);
+
+    // Nested services structure (skips 'services' key)
+    const nestedInput = {
+      foreman_rh_cloud: {
+        services: {
+          advisor: { status: 'FAIL', message: '502 Bad Gateway' },
+          vulnerability: { status: 'ok', duration_ms: '25' }
+        },
+        status: 'FAIL'
+      }
+    };
+    const nestedResult = flattenPingResults(nestedInput);
+    expect(nestedResult).toHaveLength(2);
+    expect(nestedResult[0].serviceNameParts).toEqual(['foreman_rh_cloud', 'advisor']);
+  });
+
+  it('handles edge cases', () => {
+    expect(flattenPingResults({})).toEqual([]);
+    expect(flattenPingResults({ simple: 'value', number: 42 })).toEqual([]);
+    expect(() => flattenPingResults(null)).toThrow();
+  });
+});
+
+describe('computeOverallStatus', () => {
+  it('returns correct status based on service health', () => {
+    // All OK
+    const okServices = [
+      { serviceNameParts: ['db'], data: { active: true } },
+      { serviceNameParts: ['cache'], data: { status: 'ok' } }
+    ];
+    expect(computeOverallStatus(okServices)).toBe('OK');
+
+    // Has failures
+    const failServices = [
+      { serviceNameParts: ['db'], data: { active: true } },
+      { serviceNameParts: ['api'], data: { status: 'FAIL' } }
+    ];
+    expect(computeOverallStatus(failServices)).toBe('FAIL');
+
+    // Case insensitive
+    const mixedCaseServices = [
+      { serviceNameParts: ['service'], data: { active: 'False' } }
+    ];
+    expect(computeOverallStatus(mixedCaseServices)).toBe('FAIL');
+
+    // Edge cases
+    expect(computeOverallStatus([])).toBe('Unknown');
+    expect(computeOverallStatus(null)).toBe('Unknown');
+    expect(computeOverallStatus([{ serviceNameParts: ['test'], data: { duration_ms: '10' } }])).toBe('OK');
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/__tests__/statusIcons.test.js
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/__tests__/statusIcons.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FailIcon, WarnIcon, OKIcon, StatusValue } from '../statusIcons';
+
+describe('StatusIcons', () => {
+  describe('Icon Components', () => {
+    it('renders all icon types with correct status classes', () => {
+      const { container: failContainer } = render(<FailIcon data-testid="fail-icon" />);
+      const { container: warnContainer } = render(<WarnIcon data-testid="warn-icon" />);
+      const { container: okContainer } = render(<OKIcon data-testid="ok-icon" />);
+      
+      expect(failContainer.querySelector('.pf-v5-c-icon__content.pf-m-danger')).toBeInTheDocument();
+      expect(warnContainer.querySelector('.pf-v5-c-icon__content.pf-m-warning')).toBeInTheDocument();
+      expect(okContainer.querySelector('.pf-v5-c-icon__content.pf-m-success')).toBeInTheDocument();
+      
+      // Test prop passing
+      expect(screen.getByTestId('fail-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('warn-icon')).toBeInTheDocument();
+      expect(screen.getByTestId('ok-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('StatusValue', () => {
+    it('renders success values with success icons', () => {
+      const successValues = ['OK', 'Ok', 'ok', 'true'];
+      
+      successValues.forEach((val) => {
+        const { container, unmount } = render(<StatusValue val={val} />);
+        
+        expect(screen.getByText(val)).toBeInTheDocument();
+        const icon = container.querySelector('.pf-v5-c-icon__content.pf-m-success');
+        expect(icon).toBeInTheDocument();
+        
+        unmount();
+      });
+    });
+
+    it('renders failure values with danger icons', () => {
+      const failureValues = ['FAIL', 'fail', 'false'];
+      
+      failureValues.forEach((val) => {
+        const { container, unmount } = render(<StatusValue val={val} />);
+        
+        expect(screen.getByText(val)).toBeInTheDocument();
+        const icon = container.querySelector('.pf-v5-c-icon__content.pf-m-danger');
+        expect(icon).toBeInTheDocument();
+        
+        unmount();
+      });
+    });
+
+    it('renders arbitrary text without icons and handles edge cases', () => {
+      const { container, rerender } = render(<StatusValue val="some random text" />);
+      
+      // Text without icon
+      expect(screen.getByText('some random text')).toBeInTheDocument();
+      const successIcon = container.querySelector('.pf-v5-c-icon__content.pf-m-success');
+      const dangerIcon = container.querySelector('.pf-v5-c-icon__content.pf-m-danger');
+      expect(successIcon).not.toBeInTheDocument();
+      expect(dangerIcon).not.toBeInTheDocument();
+      
+      // Numeric values
+      rerender(<StatusValue val="123" />);
+      expect(screen.getByText('123')).toBeInTheDocument();
+      
+      // CSS class application
+      rerender(<StatusValue val="OK" />);
+      const statusElement = container.querySelector('.bss-status-value');
+      expect(statusElement).toBeInTheDocument();
+      
+      // Edge cases
+      rerender(<StatusValue val="" />);
+      expect(container).toBeInTheDocument();
+      
+      rerender(<StatusValue />);
+      expect(container).toBeInTheDocument();
+      
+      // Object conversion
+      rerender(<StatusValue val={{ status: 'ok' }.toString()} />);
+      expect(container).toBeInTheDocument();
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/helpers.js
@@ -1,0 +1,63 @@
+/**
+ * Recursively traverses a nested object of service statuses and flattens it
+ * into an array of service objects suitable for rendering.
+ *
+ * @param {object} obj - The current object node in the data structure to process.
+ * @param {string[]} prefix - An array of parent keys, representing the path to the current node.
+ * @returns {Array<{serviceNameParts: string[], data: object}>} A flat array of service statuses.
+ * Each service has its name as an array of parts and its associated data payload.
+ *
+ * Example obj: {"foreman":{"database":{"active":true,"duration_ms":"0"},"cache":
+ * {"servers":[{"status":"ok","duration_ms":"1"}]}},"foreman_rh_cloud":{"services":{"advisor":
+ * {"status":"FAIL","message":"502 Bad Gateway"},"vulnerability":{"status":"ok","duration_ms":"25"}},
+ * "status":"FAIL"}
+ */
+export const flattenPingResults = (obj, prefix = []) => {
+  let results = [];
+
+  // BASE CASE
+  if (Object.hasOwn(obj, 'status') || Object.hasOwn(obj, 'active')) {
+    // EDGE CASE: Some parent objects have an overall 'status' key
+    // but also contain a nested 'services' object
+    if (Object.hasOwn(obj, 'services') && typeof obj.services === 'object') {
+      // This is a parent object, so we'll continue to the recursive step below
+    } else {
+      results.push({
+        serviceNameParts: prefix,
+        data: obj,
+      });
+      return results;
+    }
+  }
+
+  // RECURSIVE STEP
+  // eslint-disable-next-line no-unused-vars
+  for (const [key, value] of Object.entries(obj)) {
+    // We only recurse if the value is a non-null object (which includes arrays).
+    if (value && typeof value === 'object') {
+      // If the object we are currently iterating over is an array, we don't add
+      // its numeric index to the service name path.
+      // Also, don't add 'services'
+      const newPrefix =
+        key === 'services' || Array.isArray(obj) ? prefix : [...prefix, key];
+      results = results.concat(flattenPingResults(value, newPrefix));
+    }
+  }
+  return results;
+};
+
+export const computeOverallStatus = serviceStatuses => {
+  if (!serviceStatuses || serviceStatuses.length === 0) {
+    return 'Unknown';
+  }
+
+  const hasFailure = serviceStatuses.some(({ data }) => {
+    const dataStatus = String(data.status || '').toLowerCase();
+    const dataActive = String(data.active || '').toLowerCase();
+
+    // either of these will cause the .some above to fail
+    return dataStatus === 'fail' || dataActive === 'false';
+  });
+
+  return hasFailure ? 'FAIL' : 'OK';
+};

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/index.js
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/index.js
@@ -1,0 +1,120 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { Table, Thead, Tr, Th, Tbody, Td } from '@patternfly/react-table';
+import {
+  DescriptionList,
+  DescriptionListTerm,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  Card,
+  CardTitle,
+  CardBody,
+} from '@patternfly/react-core';
+import { computeOverallStatus, flattenPingResults } from './helpers';
+import { OKIcon, StatusValue, WarnIcon } from './statusIcons';
+import './index.scss';
+import { translate as __ } from '../../common/I18n';
+
+const NORMALIZED_TERMS = {
+  active: __('active'),
+  status: __('status'),
+  message: __('message'),
+  duration_ms: __('duration (ms)'),
+};
+
+const normalizeTerm = term => NORMALIZED_TERMS[term] ?? term;
+
+export const BackendSystemStatus = ({ ping }) => {
+  const serviceStatuses = useMemo(() => {
+    if (!ping) return [];
+    return flattenPingResults(ping);
+  }, [ping]);
+  const overallStatus = useMemo(() => computeOverallStatus(serviceStatuses), [
+    serviceStatuses,
+  ]);
+  const renderStatusIcon = () => {
+    switch (overallStatus) {
+      case 'OK':
+        return <OKIcon size="md" />;
+      case 'FAIL':
+        return <WarnIcon size="md" />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <Card ouiaId="backend-system-status" id="backend-system-status">
+      <CardTitle>
+        {renderStatusIcon()}
+        {__('Backend system status')}
+      </CardTitle>
+      <CardBody>
+        <Table
+          borders
+          isStriped
+          variant="compact"
+          ouiaId="backend-system-status-table"
+        >
+          <Thead>
+            <Tr ouiaId="bss-header-row">
+              <Th>{__('Service name')}</Th>
+              <Th>{__('Info')}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {serviceStatuses.map(({ serviceNameParts, data }, index) => {
+              // ex: ['foreman', 'cache', 'servers']
+              const finalPart = serviceNameParts[serviceNameParts.length - 1]; // 'servers'
+              const parentParts = serviceNameParts.slice(0, -1); // ['foreman', 'cache']
+
+              return (
+                <Tr key={`${finalPart}-${index}`} ouiaId="bss-table-row">
+                  <Td dataLabel="Service name">
+                    {/* Separator bullets are handled in CSS */}
+                    {parentParts.map(part => (
+                      <span key={part} className="service-name-parent">
+                        {part}
+                      </span>
+                    ))}
+                    <strong>{finalPart}</strong>
+                  </Td>
+                  <Td dataLabel="Info">
+                    <span className="bss-service-info">
+                      <DescriptionList
+                        isCompact
+                        isHorizontal
+                        isAutoColumnWidths
+                      >
+                        {Object.entries(data).map(([term, desc]) => (
+                          <DescriptionListGroup key={term}>
+                            <DescriptionListTerm>
+                              {normalizeTerm(term)}
+                            </DescriptionListTerm>
+                            <DescriptionListDescription>
+                              <StatusValue val={desc.toString()} />
+                            </DescriptionListDescription>
+                          </DescriptionListGroup>
+                        ))}
+                      </DescriptionList>
+                    </span>
+                  </Td>
+                </Tr>
+              );
+            })}
+          </Tbody>
+        </Table>
+      </CardBody>
+    </Card>
+  );
+};
+
+BackendSystemStatus.propTypes = {
+  ping: PropTypes.shape({}),
+};
+
+BackendSystemStatus.defaultProps = {
+  ping: {},
+};
+
+export default BackendSystemStatus;

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/index.scss
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/index.scss
@@ -1,0 +1,24 @@
+span.bss-service-info dl {
+  row-gap: 0;
+  margin-bottom: 0.3em;
+}
+
+.service-name-parent::after {
+  content: '•';
+  margin: 0 0.4em;
+  font-weight: normal;
+  /* This helps ensure the bullet is perfectly centered with the text */
+  vertical-align: middle;
+}
+
+#backend-system-status span.pf-v5-c-icon {
+  margin-right: 0.3em;
+}
+
+span.bss-status-value .pf-v5-c-icon {
+  margin-right: 0.3em;
+}
+
+span.service-name-parent {
+  color: var(--pf-v5-global--disabled-color--100);
+}

--- a/webpack/assets/javascripts/react_app/components/BackendSystemStatus/statusIcons.js
+++ b/webpack/assets/javascripts/react_app/components/BackendSystemStatus/statusIcons.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Icon } from '@patternfly/react-core';
+import {
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
+  CheckCircleIcon,
+} from '@patternfly/react-icons';
+
+export const FailIcon = props => (
+  <Icon status="danger" {...props}>
+    <ExclamationCircleIcon />
+  </Icon>
+);
+
+export const WarnIcon = props => (
+  <Icon status="warning" {...props}>
+    <ExclamationTriangleIcon />
+  </Icon>
+);
+
+export const OKIcon = props => (
+  <Icon status="success" {...props}>
+    <CheckCircleIcon />
+  </Icon>
+);
+
+export const StatusValue = ({ val }) => {
+  if (['OK', 'Ok', 'true', 'ok'].includes(val)) {
+    return (
+      <span className="bss-status-value">
+        <OKIcon />
+        {val}
+      </span>
+    );
+  }
+  if (['FAIL', 'fail', 'false'].includes(val)) {
+    return (
+      <span className="bss-status-value">
+        <FailIcon />
+        {val}
+      </span>
+    );
+  }
+  return val;
+};
+
+StatusValue.propTypes = {
+  val: PropTypes.oneOfType([PropTypes.string, PropTypes.shape({})]),
+};
+
+StatusValue.defaultProps = {
+  val: '',
+};

--- a/webpack/assets/javascripts/react_app/components/componentRegistry.js
+++ b/webpack/assets/javascripts/react_app/components/componentRegistry.js
@@ -40,6 +40,7 @@ import SettingsTable from './SettingsTable';
 import PersonalAccessTokens from './users/PersonalAccessTokens';
 import ClipboardCopy from './common/ClipboardCopy';
 import LabelIcon from './common/LabelIcon';
+import { BackendSystemStatus } from './BackendSystemStatus';
 import { WelcomeAuthSource } from './AuthSource/Welcome';
 import { WelcomeConfigReports } from './ConfigReports/Welcome';
 import { WelcomeArchitecture } from './Architectures/Welcome';
@@ -144,6 +145,7 @@ const coreComponents = [
   { name: 'JwtTokens', type: JwtTokens },
   { name: 'ClipboardCopy', type: ClipboardCopy },
   { name: 'LabelIcon', type: LabelIcon },
+  { name: 'BackendSystemStatus', type: BackendSystemStatus },
   {
     name: 'RelativeDateTime',
     type: RelativeDateTime,


### PR DESCRIPTION
Previously, Katello contributed a 'Backend System Status' widget on the Infrastructure > About page, which displayed results from calling `/katello/api/ping`. You could see the same results from calling `/api/ping` or `hammer ping` command.

This new component has several advantages over the previous one:

1. Katello's widget only displayed services from Katello. With this change, ping results from Foreman, Katello, and all other plugins are all correctly displayed on the widget.
2. If any plugins are added to Ping in the future, they should "just work"
3. This component does not need to make an API call, as the ping result can be directly passed from Foreman as props
4. This component uses modern Patternfly 5 and modern React code. It also looks better :)

(cherry picked from commit b044eab55ab968a0d5ef331dcc2638102ed84dfe)
