### PR TITLE
Fixes #38886 - Bump fog-libvirt to 0.14.0

### DIFF
--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,4 +1,4 @@
 group :libvirt do
-  gem 'fog-libvirt', '>= 0.13.0'
+  gem 'fog-libvirt', '>= 0.14.0'
   gem 'ruby-libvirt', '~> 0.5', :require => 'libvirt'
 end


### PR DESCRIPTION
Packaging: https://github.com/theforeman/foreman-packaging/commit/42668c7734de6227e2c046976511cc531cef09a2 
fog libvirt change: https://github.com/fog/fog-libvirt/commit/c4b2ae909b24ae960511ef27e2536ea72544483c