### PR TITLE
Refs #38885 - Avoid validation errors when generating snapshots

### DIFF
--- a/lib/tasks/snapshots.rake
+++ b/lib/tasks/snapshots.rake
@@ -34,7 +34,9 @@ namespace :snapshots do
       Foreman.settings.load
       Setting[:unattended_url] = "http://foreman.example.com"
       Setting[:foreman_url] = "http://foreman.example.com"
-      Setting[:ct_location] = "/usr/bin/cat"
+      # The ct_location setting is protected by a validation and cat is not an allowed value.
+      # Use SETTINGS directly to mimic a direct change to settings.yaml
+      SETTINGS[:ct_location] = "/usr/bin/cat"
       Setting[:ct_arguments] = []
 
       User.current = FactoryBot.build(:user, :admin)


### PR DESCRIPTION
To generate snapshots, we need `ct_location` to be `/usr/bin/cat` to avoid the dependency on `ct`, but setting `Setting[:ct_location]` is forbidden by the validation.

Instead we can adjust `SETTINGS[:ct_location]` which avoids validation and is also what the user would do by editing `settings.yaml`.

Fixes: 49dd22221ed4ba4d7687e3e7406d8ae975a2ffa9


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
