### PR TITLE
Fixes #38895 - Modify the breadcrumbswitcher menu

### DIFF
--- a/test/integration/host_js_test.rb
+++ b/test/integration/host_js_test.rb
@@ -85,7 +85,7 @@ class HostJSTest < IntegrationTestWithJavascript
       host = FactoryBot.create(:host)
       visit host_details_page_path(host)
       find('.pf4-breadcrumb-switcher button').click
-      find('a', :text => @host.name).click
+      find("[data-item-name='#{@host.name}']").click
       find('h5', :text => @host.fqdn)
     end
 

--- a/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/BreadcrumbSwitcher/index.js
@@ -11,10 +11,10 @@ import {
   MenuList,
   MenuSearch,
   MenuItem,
-  Tooltip,
   Spinner,
   MenuSearchInput,
   Icon,
+  Truncate,
 } from '@patternfly/react-core';
 import { ExchangeAltIcon } from '@patternfly/react-icons';
 import { translate as __ } from '../../../common/I18n';
@@ -87,10 +87,9 @@ const BreadcrumbSwitcher = ({
         to={href}
         onClick={e => onResourceClick(e, href)}
         isSelected={isActive(href, id, name)}
+        data-item-name={name}
       >
-        <Tooltip content={__(name)}>
-          <span>{__(name)}</span>
-        </Tooltip>
+        <Truncate content={__(name)} position="middle" />
       </MenuItem>
     ));
   }


### PR DESCRIPTION
 * Show Module stream details in correct way using NSVC standard and truncated.

This fixes is related with https://github.com/Katello/katello/pull/11556
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
