### PR TITLE
Fixes #38904 - Fix build status on SSH error

### DIFF
--- a/app/models/concerns/orchestration/ssh_provision.rb
+++ b/app/models/concerns/orchestration/ssh_provision.rb
@@ -53,7 +53,10 @@ module Orchestration::SshProvision
     end
     self.client = Foreman::Provision::Ssh.new provision_host, image.try(:username), { :template => template_file.path, :uuid => uuid }.merge(credentials)
   rescue => e
-    failure _("Failed to login via SSH to %{name}: %{e}") % { :name => name, :e => e }, e
+    error_message = _("Failed to login via SSH to %{name}: %{e}") % { :name => name, :e => e }
+    self.build_errors = "#{build_errors}\n#{error_message}"
+    refresh_build_status
+    failure error_message, e
   end
 
   def delSSHWaitForResponse

--- a/app/models/host_status/build_status.rb
+++ b/app/models/host_status/build_status.rb
@@ -41,15 +41,15 @@ module HostStatus
     end
 
     def to_status(options = {})
-      if waiting_for_build?
-        if token_expired?
-          TOKEN_EXPIRED
-        else
-          PENDING
-        end
+      if build_errors?
+        BUILD_FAILED
       else
-        if build_errors?
-          BUILD_FAILED
+        if waiting_for_build?
+          if token_expired?
+            TOKEN_EXPIRED
+          else
+            PENDING
+          end
         else
           BUILT
         end


### PR DESCRIPTION
The PR changes the way the build status is calculated, so the build will be considered failed if errors present regardless the waiting condition. The second part is that the host is adding a build error once the SSH times out.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
