### PR TITLE
Fixes #38910 - Return correct template kind without compute attrs

### DIFF
--- a/app/models/concerns/hostext/operating_system.rb
+++ b/app/models/concerns/hostext/operating_system.rb
@@ -37,10 +37,14 @@ module Hostext
       images = cr.try(:images)
 
       return [TemplateKind.friendly.find('finish')] if images.blank?
-      return [] if compute_attributes_empty?
 
-      uuid       = compute_attributes[cr.image_param_name]
-      image_kind = images.find_by_uuid(uuid).try(:user_data) ? 'user_data' : 'finish'
+      if compute_attributes_empty?
+        return [] unless image
+        image_kind = image.try(:user_data) ? 'user_data' : 'finish'
+      else
+        uuid       = compute_attributes[cr.image_param_name]
+        image_kind = images.find_by_uuid(uuid).try(:user_data) ? 'user_data' : 'finish'
+      end
 
       [TemplateKind.friendly.find(image_kind)]
     end

--- a/test/controllers/userdata_controller_test.rb
+++ b/test/controllers/userdata_controller_test.rb
@@ -6,7 +6,9 @@ class UserdataControllerTest < ActionController::TestCase
     let(:tax_location) { FactoryBot.create(:location) }
     let(:user_data_content) { 'template content user_data' }
     let(:cloud_init_content) { 'template content cloud-init' }
-    let(:user_data_template_kind) { FactoryBot.create(:template_kind, name: 'user_data') }
+    let(:user_data_template_kind) do
+      TemplateKind.where(name: 'user_data').first || FactoryBot.create(:template_kind, name: 'user_data')
+    end
     let(:cloud_init_template_kind) { FactoryBot.create(:template_kind, name: 'cloud-init') }
     let(:user_data_template) do
       FactoryBot.create(

--- a/test/fixtures/template_kinds.yml
+++ b/test/fixtures/template_kinds.yml
@@ -34,3 +34,7 @@ registration:
 public:
   name: public
   description: description for public template
+
+user_data:
+  name: user_data
+  description: description for user_data template

--- a/test/models/concerns/hostext/operating_system_test.rb
+++ b/test/models/concerns/hostext/operating_system_test.rb
@@ -47,6 +47,37 @@ module Hostext
         assert_equal [os_dt.provisioning_template], host.available_template_kinds('image')
       end
 
+      test "template_kinds returns user data kind for host without compute attributes" do
+        Foreman::Model::EC2.any_instance.stubs(:image_exists?).returns(true)
+        os_dt = FactoryBot.create(:os_default_template,
+          :template_kind => TemplateKind.friendly.find('finish'))
+        host  = FactoryBot.create(:host, :on_compute_resource,
+          :operatingsystem => os_dt.operatingsystem)
+        host.image = FactoryBot.create(
+          :image,
+          :uuid => 'abcde',
+          :compute_resource => host.compute_resource,
+          :user_data => true)
+        actual = host.template_kinds('image')
+        assert_equal [TemplateKind.friendly.find('user_data')], actual
+      end
+
+      test "template_kinds returns user data kind for host with compute attributes" do
+        Foreman::Model::EC2.any_instance.stubs(:image_exists?).returns(true)
+        os_dt = FactoryBot.create(:os_default_template,
+          :template_kind => TemplateKind.friendly.find('finish'))
+        host  = FactoryBot.create(:host, :on_compute_resource,
+          :operatingsystem => os_dt.operatingsystem)
+        host.image = FactoryBot.create(
+          :image,
+          :uuid => 'abcde',
+          :compute_resource => host.compute_resource,
+          :user_data => true)
+        host.compute_attributes = {:image_id => 'abcde'}
+        actual = host.template_kinds('image')
+        assert_equal [TemplateKind.friendly.find('user_data')], actual
+      end
+
       test "#render_template" do
         provision_template = @host.provisioning_template({:kind => "provision"})
         rendered_template = @host.render_template(template: provision_template)

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -126,6 +126,7 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
     image = images(:one)
     host = FactoryBot.build_stubbed(:host, :operatingsystem => image.operatingsystem, :image => image,
                              :compute_resource => image.compute_resource)
+    TemplateKind.where(name: "user_data").destroy_all # cleanup from fixtures
     prov_temp = FactoryBot.create(:provisioning_template, :template_kind => TemplateKind.create(:name => "user_data"))
     host.stubs(:provisioning_template).returns(prov_temp)
     attrs = {}


### PR DESCRIPTION
If `compute_attributes` are empty, we can still determine the template kind by examining the image that is attached to the host.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
