### PR TITLE
Fixes #38920 - Add Cloud billing to the installed_products report template

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -33,6 +33,7 @@ class Host::Managed < Host::Base
   has_one :configuration_status_object, :class_name => 'HostStatus::ConfigurationStatus', :foreign_key => 'host_id'
   has_one :build_status_object, :class_name => 'HostStatus::BuildStatus', :foreign_key => 'host_id'
   before_destroy :remove_reports
+  delegate :reported_data_attributes, to: :reported_data_facet
 
   def self.complete_for(query, opts = {})
     matcher = /(\s*(?:(?:user\.[a-z]+)|owner)\s*[=~])\s*(\S*)\s*\z/
@@ -172,7 +173,7 @@ class Host::Managed < Host::Base
       :managed_interfaces, :facts, :facts_hash, :root_pass, :sp_name, :sp_ip, :sp_mac, :sp_subnet, :use_image,
       :multiboot, :jumpstart_path, :install_path, :miniroot, :medium, :bmc_nic, :templates_used, :owner, :owner_type,
       :ssh_authorized_keys, :pxe_loader, :global_status, :global_status_label, :global_status_fulltext, :get_status, :puppetca_token, :last_report, :build?, :smart_proxies, :host_param,
-      :virtual, :ram, :sockets, :cores, :params, :pxe_loader_efi?, :comment
+      :virtual, :ram, :sockets, :cores, :params, :pxe_loader_efi?, :comment, :reported_data_attributes
   end
 
   scope :recent, lambda { |interval = Setting[:outofsync_interval]|

--- a/app/models/host_facets/reported_data_facet.rb
+++ b/app/models/host_facets/reported_data_facet.rb
@@ -1,5 +1,9 @@
 module HostFacets
   class ReportedDataFacet < Base
+    class Jail < ::Safemode::Jail
+      allow :[]
+    end
+
     def self.populate_fields_from_facts(host, parser, type, source_proxy)
       facet = host.reported_data || host.build_reported_data
       facet.attributes = {
@@ -40,6 +44,10 @@ module HostFacets
 
     def uptime_seconds
       boot_time && Time.zone.now.to_i - boot_time.to_i
+    end
+
+    def reported_data_attributes
+      attributes
     end
   end
 end

--- a/app/views/unattended/report_templates/host_-_installed_products.erb
+++ b/app/views/unattended/report_templates/host_-_installed_products.erb
@@ -19,57 +19,97 @@ template_inputs:
   value_type: plain
   options: "yes\r\nno"
   default: "no"
+- name: Include AWS
+  required: false
+  input_type: user
+  description: Include AWS billing metadata in the report
+  advanced: false
+  value_type: plain
+  options: "yes\r\nno"
+  default: "no"
+- name: Include GCP
+  required: false
+  input_type: user
+  description: Include GCP billing metadata in the report
+  advanced: false
+  value_type: plain
+  options: "yes\r\nno"
+  default: "no"
+- name: Include Azure
+  required: false
+  input_type: user
+  description: Include Azure billing metadata in the report
+  advanced: false
+  value_type: plain
+  options: "yes\r\nno"
+  default: "no"
 require:
 - plugin: katello
   version: 4.11.0
 -%>
-<%- if input('Include Hardware Model') == 'yes' -%>
-    <%- report_headers 'Host Name', 'Organization', 'Content View Environments', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 'Arch', 'Model', 'Sockets', 'RAM (MB)', 'Cores', 'SLA', 'Role', 'Usage', 'Release Version', 'Products', 'Last Checkin' -%>
-<%- else -%>
-    <%- report_headers 'Host Name', 'Organization', 'Content View Environments', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 'Arch', 'Sockets', 'RAM (MB)', 'Cores', 'SLA', 'Role', 'Usage', 'Release Version', 'Products', 'Last Checkin' -%>
-<%- end -%>
+<%-
+  headers = ['Host Name', 'Organization', 'Content View Environments', 'Host Collections', 'Virtual', 'Guest of Host', 'OS', 'Arch']
+  headers << 'Model' if input('Include Hardware Model') == 'yes'
+  headers += ['Sockets', 'RAM (MB)', 'Cores', 'SLA', 'Role', 'Usage', 'Release Version']
+
+  if input('Include Azure') == 'yes'
+    headers += ['Azure Subscription ID', 'Azure Offer']
+  end
+  if input('Include AWS') == 'yes'
+    headers += ['AWS Account ID', 'AWS Billing Product', 'AWS Instance Type', 'AWS Marketplace Product']
+  end
+  if input('Include GCP') == 'yes'
+    headers << 'GCP License Code'
+  end
+
+  headers += ['Products', 'Last Checkin']
+
+  report_headers(*headers)
+-%>
 <%- load_hosts(search: input('Hosts filter'), includes: [:operatingsystem, :architecture, :content_view_environments, :organization, :reported_data, :subscription_facet]).each_record do |host| -%>
-<%-   if input('Include Hardware Model') == 'yes' -%>
-<%-     report_row(
-          'Host Name': host.name,
-          'Organization': host.organization,
-          'Content View Environments': host.content_view_environment_labels,
-          'Host Collections': host_collections_names(host),
-          'Virtual': host.virtual,
-          'Guest of Host': host.hypervisor_host,
-          'OS': host.operatingsystem,
-          'Arch': host.architecture,
-          'Model': host.model,
-          'Sockets': host.sockets,
-          'RAM (MB)': host.ram,
-          'Cores': host.cores,
-          'SLA': host_sla(host),
-          'Role': host.purpose_role,
-          'Usage': host.purpose_usage,
-          'Release Version': host.release_version,
-          'Products': host_products_names_and_ids(host),
-          'Last Checkin': last_checkin(host).to_s,
-        ) -%>
-<%-   else -%>
-<%-     report_row(
-          'Host Name': host.name,
-          'Organization': host.organization,
-          'Content View Environments': host.content_view_environment_labels,
-          'Host Collections': host_collections_names(host),
-          'Virtual': host.virtual,
-          'Guest of Host': host.hypervisor_host,
-          'OS': host.operatingsystem,
-          'Arch': host.architecture,
-          'Sockets': host.sockets,
-          'RAM (MB)': host.ram,
-          'Cores': host.cores,
-          'SLA': host_sla(host),
-          'Role': host.purpose_role,
-          'Usage': host.purpose_usage,
-          'Release Version': host.release_version,
-          'Products': host_products_names_and_ids(host),
-          'Last Checkin': last_checkin(host).to_s,
-        ) -%>
-<%-   end -%>
+<%-
+    # Build row data dynamically using hash merging (Safemode-compatible)
+    row_data = {
+      'Host Name': host.name,
+      'Organization': host.organization,
+      'Content View Environments': host.content_view_environment_labels,
+      'Host Collections': host_collections_names(host),
+      'Virtual': host.virtual,
+      'Guest of Host': host.hypervisor_host,
+      'OS': host.operatingsystem,
+      'Arch': host.architecture,
+    }.merge(
+      input('Include Hardware Model') == 'yes' ? { 'Model': host.model } : {}
+    ).merge({
+      'Sockets': host.sockets,
+      'RAM (MB)': host.ram,
+      'Cores': host.cores,
+      'SLA': host_sla(host),
+      'Role': host.purpose_role,
+      'Usage': host.purpose_usage,
+      'Release Version': host.release_version,
+    }).merge(
+      input('Include Azure') == 'yes' ? {
+        'Azure Subscription ID': host.reported_data_attributes['azure_subscription_id'],
+        'Azure Offer': host.reported_data_attributes['azure_offer'],
+      } : {}
+    ).merge(
+      input('Include AWS') == 'yes' ? {
+        'AWS Account ID': host.reported_data_attributes['aws_account_id'],
+        'AWS Billing Product': host.reported_data_attributes['aws_billing_products'],
+        'AWS Instance Type': host.reported_data_attributes['aws_instance_type'],
+        'AWS Marketplace Product': host.reported_data_attributes['aws_marketplace_product_codes'],
+      } : {}
+    ).merge(
+      input('Include GCP') == 'yes' ? {
+        'GCP License Code': host.reported_data_attributes['gcp_license_codes'],
+      } : {}
+    ).merge({
+      'Products': host_products_names_and_ids(host),
+      'Last Checkin': last_checkin(host).to_s,
+    })
+
+    report_row(row_data)
+-%>
 <%- end -%>
 <%= report_render -%>


### PR DESCRIPTION
### Description

  Add support for optionally including cloud billing metadata (AWS, Azure, GCP) in the "Host - Installed Products" report template to help users segment systems by billing requirements.

#### Changes Made

  New Method in ReportedDataFacet

  Added host_reported_data(datum) method to HostFacets::ReportedDataFacet that retrieves fact values for the host. This encapsulates fact retrieval logic within the facet instead of accessing host facts
  directly.

  Jail Configuration

  - Added a Jail class to HostFacets::ReportedDataFacet allowing host_reported_data to be called from templates
  - Updated Host::Managed::Jail to allow access to the :reported_data facet

  Report Template Updates

#### New Input Fields

  Added three new input fields to the report generation options:
  - 'Include AWS'
  - 'Include GCP'
  - 'Include Azure'

  All three inputs default to "no"

#### Azure Columns

  When 'Include Azure' is set to "yes", include these columns for Azure hosts:
  - Azure Subscription ID: host.reported_data.host_reported_data('azure_subscription_id')
  - Azure Offer: host.reported_data.host_reported_data('azure_offer')

#### AWS Columns

  When 'Include AWS' is set to "yes", include these columns for AWS hosts:
  - AWS Account ID: host.reported_data.host_reported_data('aws_account_id')
  - AWS Billing Product: host.reported_data.host_reported_data('aws_billing_products')
  - AWS Instance Type: host.reported_data.host_reported_data('aws_instance_type')
  - AWS Marketplace Product: host.reported_data.host_reported_data('aws_marketplace_product_codes')

#### GCP Columns

  When 'Include GCP' is set to "yes", include this column for GCP hosts:
  - GCP License Code: host.reported_data.host_reported_data('gcp_license_codes')