### PR TITLE
Fixes #38453 - Manage columns pre-selects boxes of displayed columns

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/helpers.js
@@ -1,3 +1,5 @@
+import { DEFAULT_USER_COLUMNS } from '../PF4/TableIndexPage/Table/helpers';
+
 const getCheckedStateForCategory = (category = { children: [] }) => {
   // return true if all children are checked
   // return null if some children are checked
@@ -25,7 +27,7 @@ export const categoriesFromFrontendColumnData = ({
   registeredColumns,
   userId,
   controller = 'hosts',
-  userColumns = ['name'],
+  userColumns = DEFAULT_USER_COLUMNS,
   hasPreference = false,
   contextData = {},
 }) => {


### PR DESCRIPTION
5 default columns are displayed on host index page after users login.

**Before**
1. Clicks 'Manage columns,' and checks the box for 1 column
2. Only 1 column is displayed on the page. The 1 column has replaced the default columns.

**After**
Default columns are pre-selected when Manage columns modal is open.
