### PR TITLE
Fixes #38956 - Add cron rake tasks for recurring jobs

### DIFF
--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1269,6 +1269,39 @@ package installed and run (again in the *foreman* app folder):
 ----
 $ rake plugin:assets:precompile[foreman_plugin]
 ----
+
+[[scheduling-recurring-tasks]]
+=== Scheduling recurring tasks
+
+If your plugin needs periodic jobs (cleanup tasks, data refreshes, etc.), you can
+register rake tasks with Foreman’s cron framework instead of creating your own
+cron entries.
+
+The recommended place to do this is in your plugin’s `engine.rb`, inside the
+initializer where you register the plugin (`Foreman::Plugin.register`), just like
+other plugin configuration:
+
+[source,ruby]
+----
+module MyPlugin
+  class Engine < ::Rails::Engine
+    initializer 'my_plugin.register_plugin', before: :finisher_hook do
+      Foreman::Plugin.register :my_plugin do
+        # other plugin registration…
+
+        # Register recurring tasks
+        # These will be run when the corresponding cron/systemd timer runs
+        Foreman::Cron.register(:daily,  'my_plugin:cleanup')
+        Foreman::Cron.register(:weekly, 'my_plugin:rebuild_caches')
+      end
+    end
+  end
+end
+----
+
+This keeps cron registration alongside the rest of your plugin setup and matches
+how other plugin APIs are used from `engine.rb`.
+
 [[logging]]
 === Logging
 

--- a/lib/foreman/cron.rb
+++ b/lib/foreman/cron.rb
@@ -1,0 +1,75 @@
+require 'logger'
+require 'rake'
+
+module Foreman
+  module Cron
+    SUPPORTED_CADENCES = [:hourly, :daily, :weekly, :monthly].freeze
+
+    class << self
+      def register(cadence, task_name)
+        cadence = cadence.to_sym
+
+        unless SUPPORTED_CADENCES.include?(cadence)
+          logger.warn(
+            "Foreman::Cron[#{cadence}]: unknown cadence when registering #{task_name}, ignoring"
+          )
+          return
+        end
+
+        cadence_tasks = tasks_for(cadence)
+        cadence_tasks << task_name unless cadence_tasks.include?(task_name)
+      end
+
+      def run(cadence)
+        cadence = cadence.to_sym
+
+        cadence_tasks = tasks_for(cadence)
+        if cadence_tasks.empty?
+          logger.debug("Foreman::Cron[#{cadence}]: no tasks configured for this cadence")
+          return false
+        end
+
+        logger.info("Foreman::Cron[#{cadence}]: running #{cadence_tasks.size} task(s)")
+
+        failed_tasks = 0
+
+        cadence_tasks.each do |task_name|
+          failed_tasks += 1 unless run_task(cadence, task_name)
+        end
+
+        failed_tasks.positive?
+      end
+
+      private
+
+      def tasks
+        @tasks ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def tasks_for(cadence)
+        tasks[cadence.to_sym]
+      end
+
+      def run_task(cadence, task_name)
+        logger.info("Foreman::Cron[#{cadence}]: starting #{task_name}")
+
+        task = Rake::Task[task_name]
+        task.reenable
+        task.invoke
+
+        logger.info("Foreman::Cron[#{cadence}]: finished #{task_name}")
+        true
+      rescue StandardError => e
+        logger.error(
+          "Foreman::Cron[#{cadence}]: #{task_name} failed: #{e.class}: #{e.message}"
+        )
+        logger.debug(e.backtrace.join("\n")) if e.backtrace
+        false
+      end
+
+      def logger
+        @logger ||= Logger.new($stdout)
+      end
+    end
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -1,0 +1,41 @@
+require 'foreman/cron'
+
+# Register built-in recurring tasks for each cadence.
+# Plugins can also call Foreman::Cron.register(:daily, 'my_plugin:task').
+Foreman::Cron.register(:hourly, 'ldap:refresh_usergroups')
+
+Foreman::Cron.register(:daily,  'reports:daily')
+Foreman::Cron.register(:daily,  'db:sessions:clear')
+Foreman::Cron.register(:daily,  'reports:expire')
+Foreman::Cron.register(:daily,  'audits:expire')
+
+Foreman::Cron.register(:weekly, 'reports:weekly')
+Foreman::Cron.register(:weekly, 'notifications:clean')
+
+Foreman::Cron.register(:monthly, 'reports:monthly')
+
+namespace :cron do
+  desc 'Run hourly Foreman cron jobs'
+  task hourly: :environment do
+    failed = Foreman::Cron.run(:hourly)
+    raise "One or more hourly cron tasks failed" if failed
+  end
+
+  desc 'Run daily Foreman cron jobs'
+  task daily: :environment do
+    failed = Foreman::Cron.run(:daily)
+    raise "One or more daily cron tasks failed" if failed
+  end
+
+  desc 'Run weekly Foreman cron jobs'
+  task weekly: :environment do
+    failed = Foreman::Cron.run(:weekly)
+    raise "One or more weekly cron tasks failed" if failed
+  end
+
+  desc 'Run monthly Foreman cron jobs'
+  task monthly: :environment do
+    failed = Foreman::Cron.run(:monthly)
+    raise "One or more monthly cron tasks failed" if failed
+  end
+end

--- a/test/unit/foreman/cron_test.rb
+++ b/test/unit/foreman/cron_test.rb
@@ -1,0 +1,72 @@
+require 'test_helper'
+require 'foreman/cron'
+require 'logger'
+
+class Foreman::CronTest < ActiveSupport::TestCase
+  setup do
+    Foreman::Cron.instance_variable_set(:@tasks, nil)
+    Foreman::Cron.instance_variable_set(:@logger, Logger.new(nil))
+  end
+
+  test 'register adds task for valid cadence' do
+    Foreman::Cron.register(:daily, 'test:task')
+
+    tasks = Foreman::Cron.send(:tasks_for, :daily)
+    assert_includes tasks, 'test:task'
+  end
+
+  test 'register does not add duplicate tasks' do
+    Foreman::Cron.register(:daily, 'test:task')
+    Foreman::Cron.register(:daily, 'test:task')
+
+    tasks = Foreman::Cron.send(:tasks_for, :daily)
+    assert_equal 1, tasks.count('test:task')
+  end
+
+  test 'register ignores invalid cadence' do
+    Foreman::Cron.register(:invalid, 'test:task')
+
+    tasks = Foreman::Cron.send(:tasks_for, :invalid)
+    assert_empty(tasks)
+  end
+
+  test 'run returns false when all tasks succeed' do
+    Foreman::Cron.instance_variable_set(:@tasks, { daily: ['test:task'] })
+
+    task = mock('rake_task')
+    task.expects(:reenable).once
+    task.expects(:invoke).once
+    Rake::Task.stubs(:[]).with('test:task').returns(task)
+
+    result = Foreman::Cron.run(:daily)
+
+    assert_equal false, result
+  end
+
+  test 'run returns true when a task fails but continues executing others' do
+    Foreman::Cron.instance_variable_set(:@tasks, { daily: %w[first second] })
+
+    failing = mock('failing_task')
+    failing.expects(:reenable).once
+    failing.expects(:invoke).raises(StandardError.new('boom'))
+
+    succeeding = mock('succeeding_task')
+    succeeding.expects(:reenable).once
+    succeeding.expects(:invoke).once
+
+    Rake::Task.stubs(:[]).with('first').returns(failing)
+    Rake::Task.stubs(:[]).with('second').returns(succeeding)
+
+    result = Foreman::Cron.run(:daily)
+
+    assert_equal true, result
+  end
+
+  test 'run returns false when no tasks are configured' do
+    Foreman::Cron.instance_variable_set(:@tasks, { hourly: [] })
+
+    result = Foreman::Cron.run(:hourly)
+
+    assert_equal false, result
+  end
+end


### PR DESCRIPTION
Introduce `Foreman::Cron` with a hard-coded mapping from `hourly`/`daily`/`weekly`/`monthly` to existing rake tasks, and add `cron:hourly`, `cron:daily`, `cron:weekly` and `cron:monthly` rake tasks.

These serve as generic entrypoints for scheduling (e.g. systemd timers in foremanctl) instead of wiring individual tasks.

Related to: https://github.com/theforeman/foremanctl/pull/288#pullrequestreview-3472321405

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
