### PR TITLE
Fixes #38926 - Add OS logo to hosts overview page

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -21,6 +21,10 @@ attributes :ip, :ip6, :last_report, :mac, :realm_id, :realm_name,
 attributes :organization_id, :organization_name
 attributes :location_id, :location_name
 
+node :operatingsystem_icon do |host|
+  icon(host.operatingsystem, size: "16x16", path: true) if host.operatingsystem
+end
+
 # for compatibility, :puppet_status was moved to host statuses
 attributes :configuration_status => :puppet_status
 

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.scss
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.scss
@@ -1,0 +1,5 @@
+.os-title-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/generalColumns.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/generalColumns.js
@@ -16,6 +16,7 @@ import { foremanUrl } from '../../../common/helpers';
 import RelativeDateTime from '../../common/dates/RelativeDateTime';
 import HostPowerStatus from './components/HostPowerStatus';
 import GlobalStatusIcon from '../../HostStatuses/Status/GlobalStatusIcon';
+import './core.scss';
 
 const generalColumns = [
   {
@@ -97,7 +98,16 @@ const generalColumns = [
   {
     columnName: 'os_title',
     title: __('OS'),
-    wrapper: hostDetails => hostDetails?.operatingsystem_name,
+    wrapper: hostDetails => {
+      const osIcon = hostDetails?.operatingsystem_icon;
+      const osName = hostDetails?.operatingsystem_name;
+      return (
+        <span className="os-title-wrapper">
+          {osIcon && <img src={osIcon} alt={`${osName} icon`} />}
+          <span>{osName}</span>
+        </span>
+      );
+    },
     isSorted: true,
     weight: 200,
   },


### PR DESCRIPTION
- Updated the Hosts API to return the operating system icon URL.
- Added OS icon to the new Hosts overview UI.
- Added supporting SCSS styles to align the icon properly.