### PR TITLE
Fixes #35379 - Kickstart callback home in the first boot service

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -310,6 +310,13 @@ sed -e 's/DEFAULTKERNEL=kernel-uek/DEFAULTKERNEL=kernel/g' -i /etc/sysconfig/ker
 <%= snippet 'insights' if host_param_true?('host_registration_insights') && os_major < 9 -%>
 <%= snippet 'disk_enc_clevis_tang' if host_param('disk_enc_tang_servers') -%>
 
+# Prepare first-boot service
+<%= save_to_file('/etc/systemd/system/first_boot_service.service', snippet('first_boot_service')) %>
+<%= save_to_file('/root/first_boot_script.sh', snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' })) %>
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 <% if host_param_true?('use_graphical_installer') -%>
@@ -332,10 +339,7 @@ The last post section halts Anaconda to prevent endless loop in case HTTP reques
 
 <%= snippet 'eject_cdrom' -%>
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  <%= indent(2, skip1: true, skip_content: 'EOF') { snippet('built', :variables => { :endpoint => 'built', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   <%= indent(2, skip1: true, skip_content: 'EOF') { snippet('built', :variables => { :endpoint => 'failed', :method => 'POST', :body_file => '/root/install.post.log' }) } -%>
 fi

--- a/app/views/unattended/provisioning_templates/snippet/first_boot_service.erb
+++ b/app/views/unattended/provisioning_templates/snippet/first_boot_service.erb
@@ -1,0 +1,20 @@
+<%#
+kind: snippet
+name: first_boot_service
+model: ProvisioningTemplate
+snippet: true
+description: |
+  Post replacement service
+-%>
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -317,6 +317,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -332,28 +372,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -413,6 +413,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -428,28 +468,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -317,6 +317,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -332,28 +372,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -317,6 +317,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -332,28 +372,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -317,6 +317,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -332,28 +372,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -196,6 +196,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -211,28 +251,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -315,6 +315,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -330,28 +370,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -316,6 +316,46 @@ systemctl enable ansible-callback
 
 
 
+# Prepare first-boot service
+cat << EOF-782969c0 > /etc/systemd/system/first_boot_service.service
+[Unit]
+Description=Initial setup callback
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+ExecStart=/bin/bash /root/first_boot_script.sh
+Type=oneshot
+ExecStartPost=/usr/bin/systemctl disable first_boot_service
+
+[Install]
+WantedBy=multi-user.target
+EOF-782969c0
+cat << EOF-76fe21d9 > /root/first_boot_script.sh
+if [ -x /usr/bin/curl ]; then
+  /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
+elif [ -x /usr/bin/wget ]; then
+  /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
+else
+  wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
+fi
+FINAL_STATUS=$?
+
+if [ -x "$(command -v subscription-manager)" ] ; then
+  subscription-manager facts --update
+  SUB_MAN_STATUS=$?
+
+  if [ $FINAL_STATUS -eq 0 ]; then
+    FINAL_STATUS=$SUB_MAN_STATUS
+  fi
+fi
+
+(exit $FINAL_STATUS);
+EOF-76fe21d9
+
+systemctl enable first_boot_service
+chmod +x /root/first_boot_script.sh
+
 touch /tmp/foreman_built
 
 chvt 1
@@ -331,28 +371,7 @@ cp -vf /tmp/*.pre.*.log /mnt/sysimage/root/
 %post --erroronfail --log=/root/install-callhome.post.log
 
 
-if test -f /tmp/foreman_built; then
-  echo "calling home: build is done!"
-  if [ -x /usr/bin/curl ]; then
-    /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/built'
-  elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -q -O /dev/null --method POST --header 'Content-Type: text/plain' --body-file=/root/install.post.log --no-proxy 'http://foreman.example.com/unattended/built'
-  else
-    wget -q -O /dev/null --header 'Content-Type: text/plain' 'http://foreman.example.com/unattended/built'
-  fi
-  FINAL_STATUS=$?
-  
-  if [ -x "$(command -v subscription-manager)" ] ; then
-    subscription-manager facts --update
-    SUB_MAN_STATUS=$?
-  
-    if [ $FINAL_STATUS -eq 0 ]; then
-      FINAL_STATUS=$SUB_MAN_STATUS
-    fi
-  fi
-  
-  (exit $FINAL_STATUS);
-else
+if ! [ -f /tmp/foreman_built ]; then
   echo "calling home: build failed!"
   if [ -x /usr/bin/curl ]; then
     /usr/bin/curl -o /dev/null -H 'Content-Type: text/plain' --fail --data @/root/install.post.log --noproxy \* --silent 'http://foreman.example.com/unattended/failed'


### PR DESCRIPTION
Follow up to https://github.com/theforeman/foreman/pull/9677 (credits @Dyrkon )

Move the callback home with the facts update to the first boot service.
* The callback now really means done & running.
* Subscription manager reports facts from the running system

Tested with CentOS Stream 10