### PR TITLE
Fixes #38915 - Add Hooks for config_report

### DIFF
--- a/app/models/config_report.rb
+++ b/app/models/config_report.rb
@@ -1,4 +1,6 @@
 class ConfigReport < Report
+  include Foreman::ObservableModel
+
   METRIC = %w[applied restarted failed failed_restarts skipped pending].freeze
   BIT_NUM = 10
   MAX = (1 << BIT_NUM) - 1 # maximum value per metric
@@ -22,6 +24,23 @@ class ConfigReport < Report
 
   class << self
     delegate :model_name, :to => :superclass
+  end
+
+  set_crud_hooks :config_report
+
+  apipie :class do
+    name 'Configuration Report'
+    sections only: %w[all additional]
+    property :id, Integer, desc: "Numerical ID of the report"
+    property :origin, String, desc: "The origin of the report, e.g. 'Ansible'"
+    property :metrics, Hash, desc: "A hash of report metrics and their values"
+    property :host, 'Host', desc: "The host this report belongs to"
+    property :status, Hash, desc: "A key => value object where key is status metric name and value is the metric count"
+    property :reported_at, 'ActiveSupport::TimeWithZone', desc: "The time when the report was generated"
+  end
+
+  class Jail < Safemode::Jail
+    allow :id, :origin, :metrics, :host, :status, :reported_at
   end
 
   def self.import(report, proxy_id = nil)

--- a/test/models/config_report_test.rb
+++ b/test/models/config_report_test.rb
@@ -63,4 +63,13 @@ class ConfigReportTest < ActiveSupport::TestCase
     @report.save
     assert ConfigReport.with("pending").include?(@report)
   end
+
+  test 'hooks are defined' do
+    expected = [
+      'config_report_created.event.foreman',
+      'config_report_updated.event.foreman',
+      'config_report_destroyed.event.foreman',
+    ]
+    assert_same_elements expected, ConfigReport.event_subscription_hooks
+  end
 end


### PR DESCRIPTION
Hi, 

I need this feature and took the idea from https://github.com/theforeman/foreman_hooks/issues/65#issuecomment-3200468334 and added it myself.

Related issues:
https://github.com/theforeman/foreman_hooks/issues/65
https://community.theforeman.org/t/webhooks-config-report-event/40164
https://projects.theforeman.org/issues/38915

It successfully creates an output like this:

```json
{
  "object": {
    "id": 109937926,
    "host_id": 3660,
    "reported_at": "2025-12-02T10:09:41.000Z",
    "created_at": "2025-12-02T10:09:54.729Z",
    "updated_at": "2025-12-02T10:09:54.729Z",
    "status": {
      "applied": 0,
      "restarted": 0,
      "failed": 0,
      "failed_restarts": 0,
      "skipped": 0,
      "pending": 0
    },
    "metrics": {
      "resources": {
        "changed": 0,
        "corrective_change": 0,
        "failed": 0,
        "failed_to_restart": 0,
        "out_of_sync": 0,
        "restarted": 0,
        "scheduled": 0,
        "skipped": 0,
        "total": 1216
      },
      "time": {
        "anchor": 0.00019142299999999997,
        "augeas": 0.003895469,
        "catalog_application": 3.7994338759999664,
        "concat_file": 0.002022598,
        "concat_fragment": 0.0012733719999999996,
        "config_retrieval": 3.408054123000511,
        "convert_catalog": 0.4273544079997009,
        "exec": 0.023507800999999995,
        "fact_generation": 2.7382549280000603,
        "file": 0.783216828,
        "file_line": 0.005194125999999999,
        "filebucket": 0.000095783,
        "group": 0.001900466,
        "ini_setting": 0.003732358,
        "node_retrieval": 0.4268242799998916,
        "package": 0.32814015700000004,
        "plugin_sync": 0.9390982139993866,
        "schedule": 0.00029689,
        "service": 0.8839096619999998,
        "ssh_authorized_key": 0.011152982999999998,
        "sysctl": 0.0006136620000000001,
        "total": 12.490675675,
        "transaction_evaluation": 3.697348098000475,
        "user": 0.063793731
      },
      "changes": { "total": 0 },
      "events": { "failure": 0, "success": 0, "total": 0 }
    },
    "origin": "Puppet"
  },
  "event_name": "config_report_created.event.foreman",
  "webhook_id": 9,
  "context": {
    "remote_ip": "192.168.1.123",
    "request": "826f0669-d610-4d94-92b5-52b1283df2ca",
    "session": "826f0669-d610-4d94-92b5-52b1283df2ca",
    "user_login": "foreman_api_admin",
    "user_admin": true
  }
}
```

Unfortunately it is missing the hostname, which I need. I have to admit that don't know anything about ruby or the foreman codebase, so could you please help me to add the hostname and get this merged?

Let me know what you think.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
