### PR TITLE
Fixes #38939 - host_param macro & transient host parameters

### DIFF
--- a/app/models/concerns/host_params.rb
+++ b/app/models/concerns/host_params.rb
@@ -21,7 +21,11 @@ module HostParams
     end
 
     def non_inherited_params_hash
-      params_to_hash(host_parameters.authorized(:view_params))
+      items = host_parameters.authorized(:view_params).to_a
+      # Add transient host parameters to the array
+      # :authorized removes records that are not saved in the db
+      items += host_parameters.reject(&:persisted?) if User.current.can?(:view_params)
+      params_to_hash(items.uniq(&:name))
     end
 
     def params_to_hash(params)

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -1128,13 +1128,14 @@ class HostsControllerTest < ActionController::TestCase
   describe '#template_used' do
     setup do
       @host.setBuild
-      ActiveRecord::Base.any_instance.expects(:destroy).never
-      ActiveRecord::Base.any_instance.expects(:save).never
       @attrs = host_attributes(@host)
       @attrs['hostgroup_id'] = hostgroups(:common).id
     end
 
     test 'returns templates with interfaces' do
+      ActiveRecord::Base.any_instance.expects(:destroy).never
+      ActiveRecord::Base.any_instance.expects(:save).never
+
       nic = FactoryBot.build(:nic_managed, :host => @host)
       @attrs[:interfaces_attributes] = nic.attributes.except 'updated_at', 'created_at', 'attrs'
       put :template_used, params: {:provisioning => 'build', :host => @attrs, :id => @host.id }, session: set_session_user, xhr: true
@@ -1142,14 +1143,37 @@ class HostsControllerTest < ActionController::TestCase
       assert_template :partial => '_provisioning'
     end
 
-    test 'returns templates with host parameters' do
-      @attrs[:host_parameters_attributes] = {'0' => {:name => 'foo', :value => 'bar'}}
-      put :template_used, params: {:provisioning => 'build', :host => @attrs }, session: set_session_user
+    test 'render templates with host parameters' do
+      template_kind = TemplateKind.find_by_name('provision')
+      template_with_error = FactoryBot.create :provisioning_template,
+        name: 'fail_without_hp_parameter',
+        template: "<% raise 'BOOOM' if host_param('transient-hp', '').empty? -%>",
+        template_kind: template_kind
+      os = FactoryBot.create(:operatingsystem, :with_archs, :with_os_defaults, provisioning_templates: [template_with_error])
+      host = FactoryBot.create(:host, :managed, operatingsystem: os)
+      attrs = host_attributes(host)
+
+      ActiveRecord::Base.any_instance.expects(:destroy).never
+      ActiveRecord::Base.any_instance.expects(:save).never
+
+      put :template_used, params: {:provisioning => 'build', :host => attrs }, session: set_session_user
       assert_response :success
       assert_template :partial => '_provisioning'
+      assert response.body.include? 'Templates rendered with errors'
+      assert response.body.include? 'BOOOM'
+
+      attrs[:host_parameters_attributes] = {'0' => {:name => 'transient-hp', :value => 'i-am-not-saved-in-db'}}
+      put :template_used, params: {:provisioning => 'build', :host => attrs }, session: set_session_user
+      assert_response :success
+      assert_template :partial => '_provisioning'
+      refute response.body.include? 'Templates rendered with errors'
+      refute response.body.include? 'BOOOM'
     end
 
     test 'shows templates for image provisioning' do
+      ActiveRecord::Base.any_instance.expects(:destroy).never
+      ActiveRecord::Base.any_instance.expects(:save).never
+
       image = compute_resources(:one).images.first
       @attrs[:compute_resource_id] = compute_resources(:one).id
       @attrs[:operatingsystem_id] = image.operatingsystem.id

--- a/test/models/concerns/host_params_test.rb
+++ b/test/models/concerns/host_params_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class HostParamsTest < ActiveSupport::TestCase
+  test 'shows global params' do
+    host = FactoryBot.build_stubbed(:host)
+
+    FactoryBot.create(:common_parameter, :name => 'test_param1', :value => 'test_value1')
+
+    assert_equal 'test_value1', host.host_params['test_param1']
+  end
+
+  test 'renders global params if template specified' do
+    host = FactoryBot.build_stubbed(:host)
+    # rubocop:disable Lint/InterpolationCheck
+    FactoryBot.create(:common_parameter, :name => 'test_param1', :value => '<%= "test_value1-#{@host.name}" %>')
+    # rubocop:enable Lint/InterpolationCheck
+
+    assert_equal "test_value1-#{host.name}", host.host_params['test_param1']
+  end
+
+  test 'transient host parameters in host_params' do
+    host = FactoryBot.build(:host)
+    hp = FactoryBot.build(:host_parameter, name: 'transient-hp', value: 'i-am-not-saved-in-db')
+    host.host_parameters << hp
+
+    assert host.host_params.key? hp.name
+    assert_equal hp.value, host.host_params[hp.name]
+
+    assert host.host_params_hash.key? hp.name
+    assert_equal hp.value, host.host_params_hash.dig(hp.name, :value)
+  end
+
+  test 'transient host params without :view_params permission' do
+    user_role = FactoryBot.create(:user_user_role)
+
+    as_user user_role.owner do
+      host = FactoryBot.build(:host)
+      hp = FactoryBot.build(:host_parameter, name: 'transient-hp', value: 'i-am-not-saved-in-db')
+      host.host_parameters << hp
+
+      refute host.host_params.key? hp.name
+      assert host.host_params.key? parameters(:common).name
+
+      refute host.host_params_hash.key? hp.name
+      assert host.host_params_hash.key? parameters(:common).name
+    end
+  end
+end

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -3381,24 +3381,6 @@ class HostTest < ActiveSupport::TestCase
     end
   end
 
-  describe 'HostParams module' do
-    test 'shows global params' do
-      host = FactoryBot.build_stubbed(:host)
-      FactoryBot.create(:common_parameter, :name => 'test_param1', :value => 'test_value1')
-
-      assert_equal 'test_value1', host.host_params['test_param1']
-    end
-
-    test 'renders global params if template specified' do
-      host = FactoryBot.build_stubbed(:host)
-      # rubocop:disable Lint/InterpolationCheck
-      FactoryBot.create(:common_parameter, :name => 'test_param1', :value => '<%= "test_value1-#{@host.name}" %>')
-      # rubocop:enable Lint/InterpolationCheck
-
-      assert_equal "test_value1-#{host.name}", host.host_params['test_param1']
-    end
-  end
-
   test "should find smart proxy ids" do
     host_1 = FactoryBot.create(:host, :with_tftp_orchestration)
     host_2 = FactoryBot.create(:host, :with_dns_orchestration)

--- a/test/unit/orchestration/templates_test.rb
+++ b/test/unit/orchestration/templates_test.rb
@@ -27,4 +27,21 @@ class TemplatesTest < ActiveSupport::TestCase
     assert_equal 1, @queue.count
     refute @host.set_renderability
   end
+
+  test 'with transient host parameter' do
+    template = FactoryBot.build :provisioning_template,
+      name: 'fail_without_hp_parameter',
+      template: "<% raise 'BOOOM' if host_param('transient-hp', '').empty? -%>"
+    @host.stubs(:provisioning_template).returns(template)
+
+    @host.queue_render_checks
+    assert_equal 1, @queue.count
+    refute @host.set_renderability
+
+    @host.clear_host_parameters_cache!
+    @host.host_parameters << FactoryBot.build(:host_parameter, name: 'transient-hp', value: 'i-am-not-saved-in-db')
+    @host.queue_render_checks
+    assert_equal 1, @queue.count
+    assert @host.set_renderability
+  end
 end


### PR DESCRIPTION
:host_param macro now allows rendering host parameters that are assigned to the host, but are not in the database.

### Background
Transient (new) host parameters associated with the host are not rendered in the template check action nor in the 'Orchestration:Templates' queue.

This behavior causes issues for image-based provisioning when the activation key is defined on the host level, rather than on the hostgroup.

### Fixed scenarios
* 'host_param' macro now renders all host parameters
* 'hosts#template_used' action now renders templates with all host parameters
* 'Orchestration::Templates' now renders templates with all host parameters

### How to test
**Preconditions**
* Assign the error-raising template to the host os
```erb
<% raise "BOOOM" if host_param('my-host-parameter', '').empty? -%>
<%= host_param('my-host-parameter') -%>
```

#### UI Host form
* Try the template render check (in _Operating System_ tab)
* It fails with `BOOOM` error
* In the `Parameters` tab, assign a new host parameter:
```
type: string
name: my-host-parameter
value: whatever you want
```
* Try the template check again; it's not failing.

#### Template orchestration check
The same logic, but this time submit the form.

#### Hammer (API)

```shell
hammer host create --location 'Default Location' --organization 'Default Organization' \
--hostgroup="libby-image-fedora42" --image="fedora42" --provision-method="image" --operatingsystem="Fedora 42" --name "hammer-01"
```
Fails with:

```
`Could not create the host:
 Failed to render template 'aaa_fail', error: BOOOM
```
Add ` --parameters "my-host-parameter=it-is-working"` and rerun it to make sure the host is correctly provisioned.


### Links
* Community RFC: https://community.theforeman.org/t/provisioning-hosts-doesnt-work-well-with-host-parameters/44334
* Original ticket: https://projects.theforeman.org/issues/38422#

---

### Notes
From the investigation in the RFC, there were three suggestions for fixes:

1. Change logic in the Orchestration queuing.
2. Allow rendering transient host params via `:host_parameter` macro.
3. Revert the `Orchestration::Templates` feature.

I chose a second approach simply for the safety & lower impact, I don't feel confident enough to alter the orchestration workflow. Plus, the second approach is more straightforward to cherry-pick, which we need.
The third option is a last resort, to be used only after we agree there is no hope.
