### PR TITLE
Fixes #38932 - Allow users to purge all audit types

### DIFF
--- a/lib/tasks/audits.rake
+++ b/lib/tasks/audits.rake
@@ -59,7 +59,11 @@ namespace :audits do
 
   def get_audits_without_templates
     User.as_anonymous_admin do
-      Audited::Audit.up_until(before_date).where.not(auditable_type: %w(ReportTemplate Ptable ProvisioningTemplate JobTemplate))
+      if ENV.key?('AUDITS_PURGE_INCLUDE_TEMPLATES')
+        Audited::Audit.up_until(before_date)
+      else
+        Audited::Audit.up_until(before_date).where.not(auditable_type: %w(ReportTemplate Ptable ProvisioningTemplate JobTemplate))
+      end
     end
   end
 

--- a/lib/tasks/audits.rake
+++ b/lib/tasks/audits.rake
@@ -11,6 +11,7 @@ desc <<~END_DESC
     Example:
       rake audits:expire # expires all audits older then 90 days
       rake audits:expire days=7 # expires all audits older then 7 days
+      AUDITS_PURGE_INCLUDE_TEMPLATES=yes rake audits:expire # expires all audits older then 90 days, including templates
       rake audits:anonymize days=7 # anonymizes all audits older then 7 days
 
 END_DESC
@@ -61,7 +62,11 @@ namespace :audits do
 
   def get_audits_without_templates
     User.as_anonymous_admin do
-      Audited::Audit.up_until(before_date).where.not(auditable_type: %w(ReportTemplate Ptable ProvisioningTemplate JobTemplate))
+      if Foreman::Cast.to_bool(ENV['AUDITS_PURGE_INCLUDE_TEMPLATES'])
+        Audited::Audit.up_until(before_date)
+      else
+        Audited::Audit.up_until(before_date).where.not(auditable_type: %w(ReportTemplate Ptable ProvisioningTemplate JobTemplate))
+      end
     end
   end
 


### PR DESCRIPTION
The various template types are excluded from foreman-rake audits:clean because they're also used to show diffs to older versions. These can build up over time and users need a way to clean these up.

This introduces the `AUDITS_PURGE_INCLUDE_TEMPLATES` environment variable to purge all audit types.

Currently untested so this is a draft.