### PR TITLE
Fixes #38959 - autoyast NTP config

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_default.erb
@@ -122,16 +122,16 @@ description: |
     <%- if host_param('ntp-server').respond_to?(:join) -%>
     <%- host_param('ntp-server').each do |ntp| -%>
     <ntp_server>
-     <iburst config:type="boolean">false</iburst>
+     <iburst config:type="boolean">true</iburst>
      <address><%= ntp %></address>
-     <offline config:type="boolean">true</offline>
+     <offline config:type="boolean">false</offline>
     </ntp_server>
     <%- end -%>
     <%- else -%>
     <ntp_server>
-     <iburst config:type="boolean">false</iburst>
+     <iburst config:type="boolean">true</iburst>
      <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
-     <offline config:type="boolean">true</offline>
+     <offline config:type="boolean">false</offline>
     </ntp_server>
     <%- end -%>
    </ntp_servers>

--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -111,15 +111,15 @@ description: |
       <%- host_param('ntp-server').each do |ntp| -%>
       <ntp_server>
         <address><%= ntp %></address>
-        <iburst config:type="boolean">false</iburst>
-        <offline config:type="boolean">true</offline>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">false</offline>
       </ntp_server>
       <%- end -%>
       <%- else -%>
       <ntp_server>
         <address><%= host_param('ntp-server') || '2.opensuse.pool.ntp.org' %></address>
-        <iburst config:type="boolean">false</iburst>
-        <offline config:type="boolean">true</offline>
+        <iburst config:type="boolean">true</iburst>
+        <offline config:type="boolean">false</offline>
       </ntp_server>
       <%- end -%>
     </ntp_servers>


### PR DESCRIPTION
We did some tests and found out, that configuration of the 2 settings work better to configure the NTP. 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
