### PR TITLE
Fixes #39070 - Update AreaChart to PatternFly5

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.fixtures.js
@@ -7,3 +7,26 @@ export const areaChartData = {
     ["Fedora 32", 1, 2]
   ]
 };
+
+/** Data with multiple points within the same minute - used to test that x-axis
+ * does not show duplicate date labels (regression test for double timestamps). */
+export const areaChartDataDenseSameMinute = {
+  yAxisLabel: "Reports",
+  data: [
+    [
+      "time",
+      1614449760, // Mar 3, 9:44 AM
+      1614449770, // +10s
+      1614449780, // +20s
+      1614449790, // +30s
+      1614449800, // +40s
+      1614449810, // +50s
+      1614449820, // +60s (next minute)
+      1614449880, // +2 min
+      1614449940, // +3 min
+      1614450000, // +4 min
+    ],
+    ["Config Retrieval", 1, 2, 1, 3, 2, 1, 2, 3, 1, 2],
+    ["Runtime", 0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+  ],
+};

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.scss
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.scss
@@ -1,0 +1,8 @@
+.area-chart-container {
+  width: 100%;
+  height: 100%;
+  min-width: 200px;
+  min-height: 200px;
+  margin: auto;
+  overflow: visible;
+}

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.test.js
@@ -1,0 +1,201 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AreaChart from './';
+import {
+  getXAxisTickValues,
+  formatAxisTick,
+  formatYAxisTick,
+} from './AreaChartLegend';
+import { areaChartData, areaChartDataDenseSameMinute } from './AreaChart.fixtures';
+
+jest.unmock('./');
+
+/** Build chartData shape from fixture (same as AreaChart does). */
+const buildChartData = fixture => {
+  const timeColumn = fixture.data.find(col => col[0] === 'time');
+  if (!timeColumn) return null;
+  const timestamps = timeColumn.slice(1);
+  const toMs = val => {
+    const n = Number(val);
+    return n >= 1e12 ? n : n * 1000;
+  };
+  const dates = timestamps.map(t => new Date(toMs(t)));
+  const series = fixture.data
+    .filter(col => col[0] !== 'time')
+    .map(col => ({
+      name: col[0],
+      data: col.slice(1).map((value, index) => ({
+        x: dates[index],
+        y: value ?? 0,
+        name: col[0],
+      })),
+    }));
+  return series.length > 0 ? series : null;
+};
+
+describe('formatYAxisTick', () => {
+  it('uses fixed decimals for typical values', () => {
+    expect(formatYAxisTick(0)).toBe('0.0');
+    expect(formatYAxisTick(12.345)).toBe('12.3');
+  });
+
+  it('uses scientific notation for very large magnitudes', () => {
+    expect(formatYAxisTick(1e21)).toBe('1.0e+21');
+    expect(formatYAxisTick(-1e21)).toBe('-1.0e+21');
+  });
+});
+
+describe('AreaChart', () => {
+  it('renders chart with valid data', () => {
+    const { container } = render(
+      <AreaChart
+        data={areaChartData.data}
+        yAxisLabel={areaChartData.yAxisLabel}
+      />
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no data provided', () => {
+    const { container } = render(<AreaChart data={null} />);
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('renders empty state when empty data array provided', () => {
+    const { container } = render(<AreaChart data={[]} />);
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('displays custom noDataMsg', () => {
+    const customMsg = 'Custom no data message';
+    render(<AreaChart data={null} noDataMsg={customMsg} />);
+
+    // Should display the custom message
+    expect(screen.getByText(customMsg)).toBeInTheDocument();
+  });
+
+  it('applies custom size to chart', () => {
+    const customSize = { width: 500, height: 300 };
+    const { container } = render(
+      <AreaChart data={areaChartData.data} size={customSize} />
+    );
+
+    // Chart receives size prop; SVG reflects chart dimensions
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('width', '500');
+    expect(svg).toHaveAttribute('height', '300');
+  });
+
+  it('renders with onclick callback and triggers it when legend item is clicked', () => {
+    const onClickMock = jest.fn();
+    render(<AreaChart data={areaChartData.data} onclick={onClickMock} />);
+
+    const legendButton = screen.getByRole('button', { name: 'CentOS 7.9' });
+    fireEvent.click(legendButton);
+
+    expect(onClickMock).not.toHaveBeenCalled();
+  });
+
+  it('calls onclick when data point is clicked', () => {
+    const onClickMock = jest.fn();
+    const { container } = render(
+      <AreaChart data={areaChartData.data} onclick={onClickMock} />
+    );
+
+    const chart = container.querySelector('svg');
+    expect(chart).toBeInTheDocument();
+
+    const path = chart.querySelector('path[class*="area"]');
+    if (path) {
+      fireEvent.click(path);
+      expect(onClickMock).toHaveBeenCalledWith({ id: expect.any(String) });
+    }
+  });
+
+  it('legend items are interactive (button role for accessibility)', () => {
+    render(<AreaChart data={areaChartData.data} />);
+
+    expect(screen.getByRole('button', { name: 'CentOS 7.9' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'CentOS 7.6' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Fedora 32' })).toBeInTheDocument();
+  });
+
+  it('clicking legend symbol toggles series visibility', () => {
+    const { container } = render(<AreaChart data={areaChartData.data} />);
+
+    const symbols = container.querySelectorAll('.area-chart-legend-symbol');
+    const labels = container.querySelectorAll('.area-chart-legend-label');
+
+    expect(symbols.length).toBeGreaterThanOrEqual(1);
+    expect(labels.length).toBeGreaterThanOrEqual(1);
+
+    const firstLabel = labels[0];
+    expect(firstLabel).toHaveAttribute('data-hidden', 'false');
+
+    fireEvent.click(symbols[0]);
+    expect(firstLabel).toHaveAttribute('data-hidden', 'true');
+
+    fireEvent.click(symbols[0]);
+    expect(firstLabel).toHaveAttribute('data-hidden', 'false');
+  });
+
+  it('renders chart with config timeseries (stacked)', () => {
+    const { container } = render(
+      <AreaChart
+        data={areaChartData.data}
+        config="timeseries"
+        yAxisLabel={areaChartData.yAxisLabel}
+      />
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders chart when xAxisDataLabel matches data column', () => {
+    const { container } = render(
+      <AreaChart
+        data={areaChartData.data}
+        xAxisDataLabel="time"
+        yAxisLabel={areaChartData.yAxisLabel}
+      />
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('handles missing xAxisDataLabel gracefully', () => {
+    const dataWithoutTime = [
+      ['nottime', 1614449768, 1614451500],
+      ['CentOS 7.9', 3, 5],
+    ];
+
+    render(
+      <AreaChart data={dataWithoutTime} xAxisDataLabel="time" />
+    );
+
+    // Should render empty state when time column is not found
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+  });
+
+  it('does not show duplicate x-axis labels when multiple data points fall within the same minute', () => {
+    const chartData = buildChartData(areaChartDataDenseSameMinute);
+    const tickValues = getXAxisTickValues(chartData, 6);
+
+    expect(tickValues).toBeDefined();
+    expect(tickValues.length).toBeGreaterThan(0);
+
+    const formattedLabels = tickValues.map(t => formatAxisTick(t));
+    const uniqueLabels = [...new Set(formattedLabels)];
+
+    expect(formattedLabels.length).toBe(uniqueLabels.length);
+    expect(formattedLabels).toEqual(uniqueLabels);
+  });
+});
+

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChartLegend.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChartLegend.js
@@ -1,0 +1,277 @@
+import React from 'react';
+import { ChartLabel, ChartPoint } from '@patternfly/react-charts';
+import { chart_color_black_500 as chartColorBlack500 } from '@patternfly/react-tokens';
+import './AreaChartLegend.scss';
+
+/** Process raw data into chart series. Backend may send Unix seconds or milliseconds. */
+export const processChartData = (data, xAxisDataLabel) => {
+  if (!data || data.length === 0) return null;
+  const timeColumn = data.find(col => col[0] === xAxisDataLabel);
+  if (!timeColumn) return null;
+  const timestamps = timeColumn.slice(1);
+  const toMs = val => {
+    const n = Number(val);
+    return n >= 1e12 ? n : n * 1000;
+  };
+  const dates = timestamps.map(t => new Date(toMs(t)));
+  const series = data
+    .filter(col => col[0] !== xAxisDataLabel)
+    .map(col => ({
+      name: col[0],
+      data: col.slice(1).map((value, index) => ({
+        x: dates[index],
+        y: value ?? 0,
+        name: col[0],
+      })),
+    }));
+  return series.length > 0 ? series : null;
+};
+
+export const getSeriesOpacity = isDimmedByHover => {
+  if (isDimmedByHover) return 0.35;
+  return 1;
+};
+
+// Use chart_color_black_500 for hidden symbol so ChartLegendTooltip skips this item (PatternFly convention).
+export const buildLegendData = (chartData, hiddenSeries) =>
+  chartData.map(series => {
+    const hidden = hiddenSeries.has(series.name);
+    return {
+      childName: series.name,
+      name: series.name,
+      ...(hidden && {
+        symbol: {
+          type: 'eyeSlash',
+          fill: chartColorBlack500.var,
+        },
+      }),
+    };
+  });
+
+export const getLegendEvents = (chartName, toggleSeries) => ({
+  target: `${chartName}-ChartLegend`,
+  eventHandlers: {
+    onClick: (evt, props) => {
+      if (props.datum?.name) toggleSeries(props.datum.name);
+      return [];
+    },
+    onMouseOver: () => [
+      { target: 'data', mutation: () => ({ style: { cursor: 'pointer' } }) },
+    ],
+    onMouseOut: () => [
+      { target: 'data', mutation: () => ({ style: { cursor: 'default' } }) },
+    ],
+  },
+});
+
+/** Format a timestamp for axis tick display (matches formatAxisTick output). */
+const formatTickForDedup = t => {
+  const date = t instanceof Date ? t : new Date(t >= 1e12 ? t : t * 1000);
+  return date.toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+};
+
+/** Sample x-axis tick values to avoid duplicate labels when many data points fall within the same minute.
+ * Returns up to maxTicks evenly-spaced timestamps, deduplicated by formatted label. */
+export const getXAxisTickValues = (chartData, maxTicks = 6) => {
+  if (!chartData?.[0]?.data?.length) return undefined;
+  const dates = chartData[0].data.map(d => d.x);
+  const unique = [
+    ...new Set(dates.map(d => (d instanceof Date ? d.getTime() : d))),
+  ].sort((a, b) => a - b);
+  // candidates: either all unique timestamps (if few enough), or maxTicks evenly-spaced
+  // samples across the range (indices 0, step, 2*step, ...) to avoid crowding the axis
+  const candidates =
+    unique.length <= maxTicks
+      ? unique.map(ms => new Date(ms))
+      : Array.from({ length: maxTicks }, (_, i) => {
+          const step = (unique.length - 1) / (maxTicks - 1);
+          const idx = Math.round(i * step);
+          return new Date(unique[idx]);
+        });
+  const seen = new Set();
+  return candidates.filter(d => {
+    const label = formatTickForDedup(d);
+    if (seen.has(label)) return false;
+    seen.add(label);
+    return true;
+  });
+};
+
+/** Get display text for tooltip; text may be string or array. */
+const getTooltipText = text => {
+  if (text == null) return '';
+  return Array.isArray(text) ? text.join(' ') : String(text);
+};
+
+/** Custom tick label anchored at end, with staggered vertical offset to prevent overlap.
+ * Wrapped in <g> with <title> for native tooltip on hover when labels are long or truncated. */
+/* eslint-disable react/prop-types */
+export const XAxisTickLabel = props => {
+  const {
+    style,
+    index = 0,
+    yAxisLabelOffset = -12,
+    dy: _dyIgnored,
+    text,
+    ...rest
+  } = props;
+  const cleanStyle =
+    style && typeof style === 'object' && !Array.isArray(style)
+      ? { ...style, verticalAnchor: undefined }
+      : style;
+  const staggerOffset = index % 2 === 1 ? 14 : 0;
+  const axisSpacing = 16;
+  const tooltipText = getTooltipText(text);
+  return (
+    <g>
+      {tooltipText && <title>{tooltipText}</title>}
+      <ChartLabel
+        {...rest}
+        text={text}
+        style={cleanStyle}
+        verticalAnchor="end"
+        textAnchor="end"
+        dy={yAxisLabelOffset + staggerOffset + axisSpacing}
+      />
+    </g>
+  );
+};
+/* eslint-enable react/prop-types */
+
+/** Compute y-axis tick values from chart data. */
+export const getYTickValues = (chartData, config, hiddenSeries) => {
+  if (!chartData?.length) return undefined;
+  let maxY = 0;
+  if (config === 'timeseries') {
+    const n = chartData[0].data.length;
+    for (let i = 0; i < n; i++) {
+      let sum = 0;
+      chartData.forEach(chartSeries => {
+        if (!hiddenSeries.has(chartSeries.name))
+          sum += chartSeries.data[i]?.y ?? 0;
+      });
+      maxY = Math.max(maxY, sum);
+    }
+  } else {
+    chartData
+      .filter(s => !hiddenSeries.has(s.name))
+      .forEach(s => {
+        s.data.forEach(point => {
+          maxY = Math.max(maxY, point.y ?? 0);
+        });
+      });
+  }
+  if (maxY <= 0) return [0, 0.5, 1.0];
+  const step = Math.max(0.1, Math.ceil((maxY / 4) * 10) / 10);
+  return [0, 1, 2, 3, 4, 5].map(i => Math.round(i * step * 10) / 10);
+};
+
+export const formatAxisTick = t => {
+  let date;
+  if (t instanceof Date) {
+    date = t;
+  } else if (typeof t === 'number' && t >= 1e9) {
+    const ms = t >= 1e12 ? t : t * 1000;
+    date = new Date(ms);
+  } else {
+    date = null;
+  }
+  return date
+    ? date.toLocaleString(undefined, {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+      })
+    : t;
+};
+
+/** Fixed decimals for normal range; scientific notation for very large magnitudes. */
+export const formatYAxisTick = t => {
+  const num = Number(t);
+  if (Math.abs(num) >= 1e21) {
+    return num.toExponential(1);
+  }
+  return num.toFixed(1);
+};
+
+export const formatTooltipTitle = datum => {
+  const x = datum?.x ?? datum?._x;
+  if (x == null) return '';
+  const date = x instanceof Date ? x : new Date(x >= 1e12 ? x : x * 1000);
+  const dateStr = date.toLocaleDateString(undefined, {
+    month: 'numeric',
+    day: 'numeric',
+  });
+  const timeStr = date.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return `${dateStr}, ${timeStr}`;
+};
+
+/* eslint-disable react/prop-types */
+export const InteractiveLegendSymbol = ({
+  datum,
+  setHoveredSeries,
+  toggleSeries,
+  ...rest
+}) => {
+  const handleClick = () => {
+    if (datum?.name && toggleSeries) {
+      toggleSeries(datum.name);
+    }
+  };
+  return (
+    <g
+      className="area-chart-legend-symbol"
+      onClick={handleClick}
+      onKeyDown={e => e.key === 'Enter' && handleClick()}
+      onMouseOver={() => datum?.name && setHoveredSeries(datum.name)}
+      onMouseOut={() => setHoveredSeries(null)}
+      role="button"
+      tabIndex={0}
+    >
+      <ChartPoint {...rest} datum={datum} />
+    </g>
+  );
+};
+
+export const InteractiveLegendLabel = ({
+  datum,
+  hiddenSeries,
+  hoveredSeries,
+  setHoveredSeries,
+  toggleSeries,
+  ...rest
+}) => {
+  const isHidden = datum?.name && hiddenSeries.has(datum.name);
+  const isHovered = datum?.name && hoveredSeries === datum.name;
+  const handleClick = () => {
+    if (datum?.name) toggleSeries(datum.name);
+  };
+  return (
+    <g
+      className="area-chart-legend-label"
+      data-hidden={isHidden}
+      data-hovered={isHovered}
+      onClick={handleClick}
+      onMouseOver={() => datum?.name && setHoveredSeries(datum.name)}
+      onMouseOut={() => setHoveredSeries(null)}
+      onKeyDown={e => e.key === 'Enter' && handleClick()}
+      role="button"
+      tabIndex={0}
+    >
+      <ChartLabel {...rest} />
+    </g>
+  );
+};
+/* eslint-enable react/prop-types */

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChartLegend.scss
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChartLegend.scss
@@ -1,0 +1,15 @@
+.area-chart-legend-symbol {
+  cursor: pointer;
+}
+
+.area-chart-legend-label {
+  cursor: pointer;
+
+  &[data-hidden='true'] {
+    opacity: 0.4;
+  }
+
+  &[data-hovered='true'] {
+    filter: brightness(1.1);
+  }
+}

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChartPropTypes.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChartPropTypes.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import { translate as __ } from '../../../../common/I18n';
+import { noop } from '../../../../common/helpers';
+
+export const areaChartPropTypes = {
+  data: PropTypes.arrayOf(PropTypes.array),
+  onclick: PropTypes.func,
+  noDataMsg: PropTypes.string,
+  config: PropTypes.oneOf(['timeseries']),
+  xAxisDataLabel: PropTypes.string,
+  yAxisLabel: PropTypes.string,
+  size: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number,
+  }),
+  unloadData: PropTypes.bool,
+  yAxisLabelOffset: PropTypes.number,
+  chartPadding: PropTypes.shape({
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number,
+    top: PropTypes.number,
+  }),
+  voronoiPadding: PropTypes.shape({
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+    right: PropTypes.number,
+    top: PropTypes.number,
+  }),
+};
+
+export const areaChartDefaultProps = {
+  data: null,
+  onclick: noop,
+  noDataMsg: __('No data available'),
+  config: 'timeseries',
+  xAxisDataLabel: 'time',
+  yAxisLabel: '',
+  size: undefined,
+  unloadData: false,
+  yAxisLabelOffset: -12,
+  chartPadding: undefined,
+  voronoiPadding: undefined,
+};

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/index.js
@@ -1,56 +1,286 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import { AreaChart as PfAreaChart } from 'patternfly-react';
-import { getAreaChartConfig } from '../../../../../services/charts/AreaChartService';
-import { noop } from '../../../../common/helpers';
-import { translate as __ } from '../../../../common/I18n';
+import React, {
+  useMemo,
+  useState,
+  useCallback,
+  useRef,
+  useEffect,
+} from 'react';
+import {
+  Chart,
+  ChartArea,
+  ChartAxis,
+  ChartGroup,
+  ChartStack,
+  ChartLegend,
+  ChartLegendTooltip,
+  ChartLabel,
+  ChartThemeColor,
+  createContainer,
+  getTheme,
+} from '@patternfly/react-charts';
 import MessageBox from '../../MessageBox';
+import {
+  processChartData,
+  getSeriesOpacity,
+  buildLegendData,
+  getLegendEvents,
+  getYTickValues,
+  getXAxisTickValues,
+  formatTooltipTitle,
+  formatAxisTick,
+  formatYAxisTick,
+  InteractiveLegendSymbol,
+  InteractiveLegendLabel,
+  XAxisTickLabel,
+} from './AreaChartLegend';
+import {
+  areaChartPropTypes,
+  areaChartDefaultProps,
+} from './AreaChartPropTypes';
+import './AreaChart.scss';
+
+const DEFAULT_HEIGHT = 250;
+const DEFAULT_WIDTH = 800;
+
+/** Left padding is computed from y-axis tick label width. */
+const CHART_PADDING_BASE = { bottom: 125, right: 170, top: 50 };
+const Y_AXIS_LABEL = 30;
+const DEFAULT_VORONOI_PADDING = {
+  top: 20,
+  left: 20,
+  right: 20,
+  bottom: 90,
+};
 
 const AreaChart = ({
   data,
   onclick,
   noDataMsg,
   config,
-  unloadData,
   xAxisDataLabel,
   yAxisLabel,
   size,
+  unloadData,
+  yAxisLabelOffset,
+  chartPadding,
+  voronoiPadding,
 }) => {
-  const chartConfig = getAreaChartConfig({
+  const chartData = useMemo(() => processChartData(data, xAxisDataLabel), [
     data,
-    config,
-    onclick,
-    yAxisLabel,
     xAxisDataLabel,
-    size,
+  ]);
+
+  const CursorVoronoiContainer = useMemo(
+    () => createContainer('voronoi', 'cursor'), // eslint-disable-line spellcheck/spell-checker
+    []
+  );
+
+  // Hooks must run before any early return (react-hooks/rules-of-hooks)
+  const [hiddenSeries, setHiddenSeries] = useState(() => new Set());
+  const [hoveredSeries, setHoveredSeries] = useState(null);
+  const toggleSeries = useCallback(name => {
+    setHiddenSeries(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
+
+  const multiTheme = useMemo(
+    () => ({
+      ...getTheme(ChartThemeColor.multi),
+      legend: {
+        ...getTheme(ChartThemeColor.multi).legend,
+        position: 'right',
+      },
+    }),
+    []
+  );
+  const colorScale = useMemo(
+    () =>
+      config === 'timeseries'
+        ? multiTheme.stack?.colorScale ?? multiTheme.chart?.colorScale ?? []
+        : multiTheme.group?.colorScale ?? multiTheme.chart?.colorScale ?? [],
+    [config, multiTheme]
+  );
+  const visibleSeriesWithIndex = useMemo(
+    () =>
+      chartData
+        ? chartData
+            .map((series, i) => ({ series, index: i }))
+            .filter(({ series }) => !hiddenSeries.has(series.name))
+        : [],
+    [chartData, hiddenSeries]
+  );
+
+  // Sample tick values to avoid duplicate labels when many data points fall within the same minute.
+  const tickValues = useMemo(() => getXAxisTickValues(chartData, 6), [
+    chartData,
+  ]);
+
+  const yTickValues = useMemo(
+    () => getYTickValues(chartData, config, hiddenSeries),
+    [chartData, config, hiddenSeries]
+  );
+
+  const containerRef = useRef(null);
+  const [observedSize, setObservedSize] = useState({
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
   });
 
-  if (chartConfig.data.columns.length) {
-    return <PfAreaChart {...chartConfig} unloadBeforeLoad={unloadData} />;
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect;
+      if (width > 0 && height > 0) {
+        setObservedSize({ width, height });
+      }
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  if (!chartData) {
+    return <MessageBox msg={noDataMsg} icontype="info" />;
   }
-  return <MessageBox msg={noDataMsg} icontype="info" />;
+
+  const chartHeight = size?.height ?? observedSize.height;
+  const chartWidth = size?.width ?? observedSize.width;
+  const maxTickLabelLen =
+    yTickValues?.length > 0
+      ? Math.max(...yTickValues.map(t => formatYAxisTick(t).length))
+      : formatYAxisTick(0).length;
+  const dynamicLeft = maxTickLabelLen * 8 + 50;
+  const padding = {
+    ...CHART_PADDING_BASE,
+    left: dynamicLeft,
+    ...chartPadding,
+  };
+  const chartName = 'area-chart';
+  const legendData = buildLegendData(chartData, hiddenSeries);
+  const legendEvents = getLegendEvents(chartName, toggleSeries);
+  const ChartWrapper = config === 'timeseries' ? ChartStack : ChartGroup;
+
+  return (
+    <div ref={containerRef} className="area-chart-container">
+      <Chart
+        name={chartName}
+        theme={multiTheme}
+        themeColor={ChartThemeColor.multi}
+        ariaDesc="Area chart"
+        containerComponent={
+          <CursorVoronoiContainer
+            cursorDimension="x"
+            labels={({ datum }) => {
+              const value =
+                datum.y0 !== undefined ? datum.y - datum.y0 : datum.y;
+              return formatYAxisTick(value);
+            }}
+            labelComponent={
+              <ChartLegendTooltip
+                legendData={legendData}
+                title={formatTooltipTitle}
+              />
+            }
+            mouseFollowTooltips
+            voronoiDimension="x"
+            voronoiPadding={{ ...DEFAULT_VORONOI_PADDING, ...voronoiPadding }}
+            constrainToVisibleArea
+          />
+        }
+        height={chartHeight}
+        width={chartWidth}
+        padding={padding}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        legendComponent={
+          <ChartLegend
+            dataComponent={
+              <InteractiveLegendSymbol
+                setHoveredSeries={setHoveredSeries}
+                toggleSeries={toggleSeries}
+              />
+            }
+            labelComponent={
+              <InteractiveLegendLabel
+                hiddenSeries={hiddenSeries}
+                hoveredSeries={hoveredSeries}
+                setHoveredSeries={setHoveredSeries}
+                toggleSeries={toggleSeries}
+              />
+            }
+          />
+        }
+        events={[
+          {
+            target: 'data',
+            eventHandlers: {
+              onClick: () => [
+                {
+                  target: 'data',
+                  // Victory passes datum to mutation; we don't control the props shape
+                  mutation: p => {
+                    if (onclick && p.datum?.name) onclick({ id: p.datum.name });
+                    return null;
+                  },
+                },
+              ],
+            },
+          },
+          legendEvents,
+        ]}
+      >
+        <ChartAxis
+          tickValues={tickValues}
+          tickFormat={formatAxisTick}
+          tickLabelComponent={
+            <XAxisTickLabel yAxisLabelOffset={yAxisLabelOffset} />
+          }
+          style={{ tickLabels: { angle: -45, verticalAnchor: 'end' } }}
+        />
+        <ChartAxis
+          dependentAxis
+          showGrid
+          label={yAxisLabel}
+          tickValues={yTickValues}
+          tickFormat={formatYAxisTick}
+          axisLabelComponent={
+            yAxisLabel ? (
+              <ChartLabel x={Y_AXIS_LABEL} dy={yAxisLabelOffset} />
+            ) : (
+              undefined
+            )
+          }
+        />
+        <ChartWrapper>
+          {visibleSeriesWithIndex.map(({ series, index }) => (
+            <ChartArea
+              key={series.name}
+              data={series.data}
+              name={series.name}
+              style={{
+                data: {
+                  fill: colorScale[index % colorScale.length] ?? undefined,
+                  opacity: getSeriesOpacity(
+                    hoveredSeries && hoveredSeries !== series.name
+                  ),
+                },
+              }}
+            />
+          ))}
+        </ChartWrapper>
+      </Chart>
+    </div>
+  );
 };
 
-AreaChart.propTypes = {
-  data: PropTypes.arrayOf(PropTypes.array),
-  onclick: PropTypes.func,
-  noDataMsg: PropTypes.string,
-  config: PropTypes.oneOf(['timeseries']),
-  unloadData: PropTypes.bool,
-  xAxisDataLabel: PropTypes.string,
-  yAxisLabel: PropTypes.string,
-  size: PropTypes.object,
-};
-
-AreaChart.defaultProps = {
-  data: null,
-  onclick: noop,
-  noDataMsg: __('No data available'),
-  config: 'timeseries',
-  unloadData: false,
-  xAxisDataLabel: 'time',
-  yAxisLabel: '',
-  size: undefined,
-};
+AreaChart.propTypes = areaChartPropTypes;
+AreaChart.defaultProps = areaChartDefaultProps;
 
 export default AreaChart;


### PR DESCRIPTION
Fixes: #39070

This PR updates the Area Chart to use PF5 components.

New images after latest Updates

**Before:**

<img width="847" height="739" alt="image" src="https://github.com/user-attachments/assets/dba1fbf8-b62f-422b-be25-50dd94802528" />


**After:**

<img width="962" height="723" alt="image" src="https://github.com/user-attachments/assets/d7207730-c264-40da-908d-e585ac4d2153" />



