### PR TITLE
Update style-loader to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "redux-mock-store": "^1.2.2",
     "sass": "~1.60.0",
     "sass-loader": "^13.3.2",
-    "style-loader": "^1.3.0",
+    "style-loader": "^4.0.0",
     "stylelint": "^9.3.0",
     "stylelint-config-standard": "^18.0.0",
     "tabbable": "^6.2.0",


### PR DESCRIPTION
This version doesn't have any dependencies which makes packaging easier.

Currently a draft to see how well this passes CI.