### PR TITLE
Remove grub templates

### DIFF
--- a/db/migrate/20251229071811_remove_grub_template.rb
+++ b/db/migrate/20251229071811_remove_grub_template.rb
@@ -1,0 +1,27 @@
+class RemoveGrubTemplate < ActiveRecord::Migration[7.0]
+  def up
+    template_kind = TemplateKind.find_by(name: 'PXEGrub')
+    return unless template_kind
+
+    template_kind.os_default_templates.destroy_all
+
+    templates = Template.where(template_kind_id: template_kind.id)
+    if templates.any?
+      template_ids = templates.pluck(:id)
+
+      # Delete template_combinations to bypass EnsureNotUsedBy(:hostgroups) callback
+      TemplateCombination.where(provisioning_template_id: template_ids).destroy_all
+
+      # Unlock templates to bypass check_if_template_is_locked callback
+      templates.update_all(locked: false)
+
+      templates.destroy_all
+    end
+
+    template_kind.destroy!
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Cannot restore removed PXEGrub template"
+  end
+end

--- a/test/migrate/remove_pxe_grub_template_kind_test.rb
+++ b/test/migrate/remove_pxe_grub_template_kind_test.rb
@@ -1,0 +1,109 @@
+require 'test_helper'
+require Rails.root.join('db/migrate/20251229071811_remove_grub_template.rb')
+
+class RemoveGrubTemplateTest < ActiveSupport::TestCase
+  let(:migration) { RemoveGrubTemplate.new }
+
+  setup do
+    @pxe_grub_kind = TemplateKind.find_or_create_by!(name: 'PXEGrub')
+
+    @template = ProvisioningTemplate.create!(
+      name: 'Test PXEGrub Template',
+      template: 'test template content',
+      template_kind: @pxe_grub_kind,
+      snippet: false,
+      locked: true
+    )
+  end
+
+  test "removes PXEGrub template kind and all templates" do
+    assert TemplateKind.exists?(name: 'PXEGrub')
+    assert Template.exists?(id: @template.id)
+
+    migration.up
+
+    assert_not TemplateKind.exists?(name: 'PXEGrub')
+    assert_not Template.exists?(id: @template.id)
+  end
+
+  test "removes locked templates" do
+    assert @template.locked?
+
+    migration.up
+
+    assert_not Template.exists?(id: @template.id)
+  end
+
+  test "removes os_default_templates associated with PXEGrub kind" do
+    os = FactoryBot.create(:operatingsystem)
+    os_default = OsDefaultTemplate.create!(
+      operatingsystem: os,
+      template_kind: @pxe_grub_kind,
+      provisioning_template: @template
+    )
+
+    assert OsDefaultTemplate.exists?(id: os_default.id)
+
+    migration.up
+
+    assert_not OsDefaultTemplate.exists?(id: os_default.id)
+    assert Operatingsystem.exists?(id: os.id)
+  end
+
+  test "removes template_combinations (hostgroup associations)" do
+    hostgroup = FactoryBot.create(:hostgroup)
+    combination = TemplateCombination.create!(
+      provisioning_template: @template,
+      hostgroup: hostgroup
+    )
+
+    assert TemplateCombination.exists?(id: combination.id)
+
+    migration.up
+
+    assert_not TemplateCombination.exists?(id: combination.id)
+    assert_not Template.exists?(id: @template.id)
+    assert Hostgroup.exists?(id: hostgroup.id)
+  end
+
+  test "templates with hostgroup associations cannot be deleted without bypass" do
+    hostgroup = FactoryBot.create(:hostgroup)
+    combination = TemplateCombination.create!(
+      provisioning_template: @template,
+      hostgroup: hostgroup
+    )
+
+    assert TemplateCombination.exists?(id: combination.id)
+
+    assert_raises(ActiveRecord::RecordNotDestroyed) do
+      @template.destroy!
+    end
+
+    assert Template.exists?(id: @template.id)
+    assert TemplateCombination.exists?(id: combination.id)
+  end
+
+  test "removes multiple PXEGrub templates" do
+    template2 = ProvisioningTemplate.create!(
+      name: 'Test PXEGrub Template 2',
+      template: 'test content 2',
+      template_kind: @pxe_grub_kind,
+      snippet: false,
+      locked: true
+    )
+
+    assert_equal 2, Template.where(template_kind_id: @pxe_grub_kind.id).count
+
+    migration.up
+
+    assert_not Template.exists?(id: @template.id)
+    assert_not Template.exists?(id: template2.id)
+    assert_not TemplateKind.exists?(name: 'PXEGrub')
+  end
+
+  test "migration is irreversible" do
+    assert_raises(ActiveRecord::IrreversibleMigration) do
+      migration.down
+    end
+  end
+end


### PR DESCRIPTION
It's a followup step on https://github.com/theforeman/foreman/pull/10698 , which removed PXEGrub support.
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
