### PR TITLE
Fixes #38976 - Queue Orchestration::Templates only for Host::Managed

### DIFF
--- a/app/models/concerns/orchestration/templates.rb
+++ b/app/models/concerns/orchestration/templates.rb
@@ -7,6 +7,9 @@ module Orchestration::Templates
   end
 
   def queue_render_checks
+    # Skip if the host class is not supported
+    # (for example Host::Discovered from foreman_discovery)
+    return unless instance_of? Host::Managed
     return if skip_orchestration?
     return unless managed?
     return unless template

--- a/test/unit/orchestration/templates_test.rb
+++ b/test/unit/orchestration/templates_test.rb
@@ -44,4 +44,14 @@ class TemplatesTest < ActiveSupport::TestCase
     assert_equal 1, @queue.count
     assert @host.set_renderability
   end
+
+  test 'orchestration is queued for Host::Managed class only' do
+    template = FactoryBot.build(:provisioning_template, template: "<%= @host.name %>")
+
+    @host.stubs(:provisioning_template).returns(template)
+    @host.stubs(:instance_of?).with(Host::Managed).returns(false)
+    @host.queue_render_checks
+
+    assert_equal 0, @queue.count
+  end
 end


### PR DESCRIPTION
The Orchestration::Templates should not run for other classes, such as Host::Discovered from the foreman_discovery plugin.