### PR TITLE
Fixes #38998 - Deprecate pf3 select form field

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Spinner } from 'patternfly-react';
 
+import { deprecate } from '../../../common/DeprecationService';
 import { translate as __ } from '../../../common/I18n';
 import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
@@ -30,6 +31,11 @@ class Select extends React.Component {
   }
 
   componentDidMount() {
+    deprecate(
+      'Select',
+      'Select or TypeaheadSelect from @patternfly/react-core or @patternfly/react-templates',
+      '3.20'
+    );
     if (this.props.useSelect2) {
       this.initializeSelect2();
       this.attachEvent();


### PR DESCRIPTION
depends on https://github.com/theforeman/foreman/pull/10817

No longer used anywhere and there are alternatives.

Checked that its not used in:
* templates (only use these input types: 'plain', 'search', 'date','resource')
* react_form_input
* InputFactory
* FormField
* 
