### PR TITLE
Fixes #39001 - Better output when kickstart syntax test fails

### DIFF
--- a/test/external/kickstart_syntax_test.rb
+++ b/test/external/kickstart_syntax_test.rb
@@ -26,7 +26,7 @@ class KickstartSyntaxTest < ActiveSupport::TestCase
     skip unless find_executable 'ksvalidator'
     output = `ksvalidator --version #{version} '#{file}' 2>&1`
     status = $CHILD_STATUS
-    assert_empty output.strip.sub(/Checking kickstart file [^ ]+/, '')
+    assert_empty output.strip.sub(/Checking kickstart file [^ ]+/, ''), "Tried file: #{file}, version: #{version}, ksvalidate failed with: #{output}"
     assert status.success?
   end
 end


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
