### PR TITLE
Fixes #39002 - Handle nil hostgroup in GroupParameter search

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -196,8 +196,18 @@ module Hostext
         conditions = param_conditions(p)
         negate = param_conditions(n)
 
-        conditions += " AND " unless conditions.blank? || negate.blank?
-        conditions += " NOT(#{negate})" if negate.present?
+        # If we have parameters but no valid conditions (e.g., all GroupParameters have nil hostgroup),
+        # return no results instead of matching all hosts
+        return {:conditions => '1 = 0'} if conditions.blank? && negate.blank?
+
+        # If only the positive conditions are blank (orphaned), but we have negations,
+        # we need to negate from a base of "all hosts"
+        if conditions.blank? && negate.present?
+          conditions = "NOT(#{negate})"
+        elsif conditions.present? && negate.present?
+          conditions += " AND NOT(#{negate})"
+        end
+
         {:joins => :primary_interface, :conditions => conditions}
       end
 
@@ -274,7 +284,9 @@ module Hostext
             when 'OsParameter'
               conditions << "hosts.operatingsystem_id = #{param.reference_id}"
             when 'GroupParameter'
-              conditions << "hosts.hostgroup_id IN (#{param.hostgroup.subtree_ids.join(', ')})"
+              if param.hostgroup.present?
+                conditions << "hosts.hostgroup_id IN (#{param.hostgroup.subtree_ids.join(', ')})"
+              end
             when 'HostParameter'
               conditions << "hosts.id = #{param.reference_id}"
             when 'OrganizationParameter'

--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -271,6 +271,56 @@ module Hostext
         it { assert_includes(subject, built_status.host) }
         it { assert_not_includes(subject, build_failed_status.host) }
       end
+
+      context "search by parameters" do
+        let(:hostgroup) { FactoryBot.create(:hostgroup) }
+        let(:group_param) { FactoryBot.create(:hostgroup_parameter, name: 'test_param', value: 'test_value', hostgroup: hostgroup) }
+        let(:host_with_param) { FactoryBot.create(:host, hostgroup: hostgroup) }
+        let(:host_without_param) { FactoryBot.create(:host) }
+
+        setup do
+          group_param
+          host_with_param
+          host_without_param
+        end
+
+        test "can search hosts by GroupParameter value" do
+          result = Host.search_for("params.test_param = test_value")
+          assert_includes result, host_with_param
+          assert_not_includes result, host_without_param
+        end
+
+        test "handles orphaned GroupParameter with nil hostgroup gracefully" do
+          # Create an orphaned GroupParameter (bypassing validation)
+          orphaned_param = GroupParameter.new(name: 'orphaned_param', value: 'orphaned_value')
+          orphaned_param.save(validate: false)
+
+          # Search should not crash even with orphaned parameter
+          assert_nothing_raised do
+            Host.search_for("params.orphaned_param = orphaned_value")
+          end
+
+          # Should return empty results since no host has this orphaned param
+          result = Host.search_for("params.orphaned_param = orphaned_value")
+          assert_empty result
+        end
+
+        test "handles negated search with orphaned GroupParameter" do
+          # Create an orphaned GroupParameter with value 'f'
+          orphaned_param = GroupParameter.new(name: 'test_negation', value: 'f')
+          orphaned_param.save(validate: false)
+
+          # Search "not params.test_negation = f" should not crash with SQL syntax error
+          assert_nothing_raised do
+            Host.search_for("not params.test_negation = f")
+          end
+
+          # Since the orphaned param doesn't apply to any host, no host has test_negation=f,
+          # therefore all hosts match "not params.test_negation = f"
+          result = Host.search_for("not params.test_negation = f")
+          assert_equal Host.count, result.count
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR fixes a bug where the search_by_params method crashes with "undefined method 'subtree_ids' for nil:NilClass" when encountering orphaned GroupParameters (parameters whose hostgroup has been deleted or has a nil association).

The issue occurs when searching for hosts by parameters and the search encounters a GroupParameter with a nil hostgroup. This can happen due to the polymorphic nature of the Parameter model's reference_id column in the STI table design, where database-level foreign key constraints are not possible.

## Changes

1. **Added nil check in param_conditions** - Prevents crash when GroupParameter has nil hostgroup
2. **Handle negation with blank conditions** - Ensures valid SQL is generated when orphaned parameters are encountered in negated searches (e.g., `not params.foo = bar`)
3. **Added test coverage** - Tests for both normal and negated searches with orphaned parameters

## Manual Testing Steps

### Setup: Create an orphaned GroupParameter

```ruby
# In rails console
hostgroup = Hostgroup.create!(name: 'test_hg')
param = GroupParameter.create!(hostgroup: hostgroup, name: 'test_param', value: 'test_value')
host = Host::Managed.create!(name: 'test-host.example.com', hostgroup: hostgroup, managed: false)

# Now delete the hostgroup to create an orphaned parameter
hostgroup.destroy

# Verify the parameter still exists but has nil hostgroup
param.reload
param.hostgroup  # => nil
```

### Test Case 1: Normal search with orphaned parameter

```ruby
# This should NOT crash (would crash before the fix)
Host.search_for("params.test_param = test_value")
# Expected: Returns empty array (no hosts match since param is orphaned)
```

### Test Case 2: Negated search with orphaned parameter

```ruby
# Create orphaned parameter with value 'f'
orphaned = GroupParameter.new(name: 'test_negation', value: 'f')
orphaned.save(validate: false)

# This should NOT crash with SQL syntax error (would crash before the fix)
Host.search_for("not params.test_negation = f")
# Expected: Returns all hosts (since no host has test_negation=f)
```

### Test Case 3: Normal search with valid parameter

```ruby
# Create a valid hostgroup parameter
hg = Hostgroup.create!(name: 'valid_hg')
valid_param = GroupParameter.create!(hostgroup: hg, name: 'valid_param', value: 'valid_value')
valid_host = Host::Managed.create!(name: 'valid-host.example.com', hostgroup: hg, managed: false)

# This should work correctly
result = Host.search_for("params.valid_param = valid_value")
# Expected: Returns [valid_host]
result.should include(valid_host)
```

### Test Case 4: Reproduction of original bug (ForemanInventoryUpload)

The original bug occurred with this search query:
```ruby
Host.search_for("not params.host_registration_insights_inventory = f")
```

If any GroupParameters exist with nil hostgroups, this would previously crash with:
```
PG::SyntaxError: ERROR:  syntax error at or near ","
LINE 1: ...AND ((NOT COALESCE(, false)))...
```

After the fix, this search completes successfully.

## Automated Tests

Run the test suite:
```bash
bundle exec rails test test/models/concerns/hostext/search_test.rb
```

All 36 tests pass, including new tests for:
- Normal GroupParameter searches
- Orphaned GroupParameter handling
- Negated searches with orphaned parameters

Fixes https://projects.theforeman.org/issues/39002