### PR TITLE
Fixes #39004 - Update ForemanContext mock to include all metadata

### DIFF
--- a/webpack/core_test_setup.js
+++ b/webpack/core_test_setup.js
@@ -5,24 +5,68 @@ ace.config.set('modePath', '');
 ace.config.set('themePath', '');
 
 jest.mock('jed');
-jest.mock('./assets/javascripts/react_app/Root/Context/ForemanContext', () => ({
-  getForemanContext: () => ({
-    context: { metadata: { version: 'mocked_version' } },
-  }),
-  useForemanContext: () => ({ metadata: { version: 'mocked_version' } }),
-  useForemanVersion: () => 'mocked_version',
-  useForemanSettings: () => ({ perPage: 5 }),
-  useForemanDocUrl: () => '/url',
-  useForemanLocation: () => ({ title: 'location' }),
-  useForemanOrganization: () => ({ title: 'organization' }),
-  useForemanUser: () => ({ login: 'user' }),
-  getHostsPageUrl: displayNewHostsPage =>
-    displayNewHostsPage ? '/new/hosts' : '/hosts',
-  useForemanSetContext: () => jest.fn(),
-  useForemanHostsPageUrl: () => '/hosts',
-  useForemanPermissions: () =>
-    new Set(['test_permission_one', 'test_permission_two']),
-}));
+jest.mock('./assets/javascripts/react_app/Root/Context/ForemanContext', () => {
+  const originalModule = jest.requireActual(
+    './assets/javascripts/react_app/Root/Context/ForemanContext'
+  );
+  const permissionsSet = new Set([
+    'test_permission_one',
+    'test_permission_two',
+  ]);
+  const metadata = {
+    UISettings: {
+      perPage: 20,
+      destroyVmOnHostDelete: false,
+      labFeatures: false,
+      safeMode: true,
+      displayFqdnForHosts: true,
+      displayNewHostsPage: true,
+      displayNewHostDetailsPage: true,
+    },
+    docUrl: 'TEST_DOC_URL',
+    location: {
+      id: 2,
+      title: 'Default Location',
+    },
+    organization: {
+      id: 1,
+      title: 'Default Organization',
+    },
+    user: {
+      id: 4,
+      login: 'admin',
+      firstname: 'Admin',
+      lastname: 'User',
+      admin: true,
+      ui_compact_mode: false,
+    },
+    user_settings: {
+      lab_features: false,
+    },
+    permissions: permissionsSet,
+    version: 'mocked_version',
+  };
+  return {
+    ...originalModule,
+    getForemanContext: () => ({
+      context: {
+        metadata,
+      },
+    }),
+    useForemanContext: () => ({ metadata }),
+    useForemanVersion: () => metadata.version,
+    useForemanSettings: () => metadata.UISettings,
+    useForemanDocUrl: () => metadata.docUrl,
+    useForemanLocation: () => metadata.location,
+    useForemanOrganization: () => metadata.organization,
+    useForemanUser: () => metadata.user,
+    getHostsPageUrl: displayNewHostsPage =>
+      displayNewHostsPage ? '/new/hosts' : '/hosts',
+    useForemanSetContext: () => jest.fn(),
+    useForemanHostsPageUrl: () => '/hosts',
+    useForemanPermissions: () => metadata.permissions,
+  };
+});
 jest.mock('./assets/javascripts/react_app/common/I18n');
 jest.mock('./assets/javascripts/foreman_tools', () => ({
   foremanUrl: url => url,


### PR DESCRIPTION
Mocking just ` useForemanContext: () => ({ metadata }),` partially and then relying on the in file selectors doesnt work, so we should mock all. 
tested on these plugins:
foreman_ansible
foreman_bootdisk
foreman_discovery
foreman_openscap
foreman_remote_execution
foreman_templates
foreman_virt_who_configure
foreman_webhooks
foreman-tasks