### PR TITLE
Add Trusted Platform Model (TPM) support to libvirt provider.

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -298,8 +298,7 @@ module Foreman::Model
                          :password => random_password(console_password_length(display_type)),
                          :port     => '-1' },
         :firmware   => 'automatic',
-        :firmware_features => { "secure-boot" => "no" },
-        :tpm        => false
+        :firmware_features => { "secure-boot" => "no" }
       )
     end
 

--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -298,7 +298,8 @@ module Foreman::Model
                          :password => random_password(console_password_length(display_type)),
                          :port     => '-1' },
         :firmware   => 'automatic',
-        :firmware_features => { "secure-boot" => "no" }
+        :firmware_features => { "secure-boot" => "no" },
+        :tpm        => false
       )
     end
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -19,7 +19,7 @@ end %>
 
 <%= checkbox_f f, :tpm, { :help_inline => _("Trusted Platform Module"),
                           :label => _('TPM'),
-                          :label_help => _("Add Trusted Plratform Module (TPM) to Virtual Machine."),
+                          :label_help => _("Add Trusted Platform Module (TPM) to Virtual Machine."),
                           :label_size => "col-md-2",
                           :disabled => !new_vm %>
 

--- a/app/views/compute_resources_vms/form/libvirt/_base.html.erb
+++ b/app/views/compute_resources_vms/form/libvirt/_base.html.erb
@@ -17,6 +17,12 @@
   end.join(' ').html_safe
 end %>
 
+<%= checkbox_f f, :tpm, { :help_inline => _("Trusted Platform Module"),
+                          :label => _('TPM'),
+                          :label_help => _("Add Trusted Plratform Module (TPM) to Virtual Machine."),
+                          :label_size => "col-md-2",
+                          :disabled => !new_vm %>
+
 <%
    arch ||= nil ; os ||= nil
    images = possible_images(compute_resource, arch, os)


### PR DESCRIPTION
Qemu does not limit the firmware that TPM can run with. On x86-64 this works with both UEFI & Bios. This is also the 
same for other architectures.

Fixes Issue: 
       https://projects.theforeman.org/issues/38892

Awaiting PR from fog-libvirt:
        https://github.com/fog/fog-libvirt/pull/185
         https://github.com/fog/fog-libvirt/issues/178

Testing requires system using libvirt cluster.

Signed-off-by: Jerone Young <jyoung@redhat.com>

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
