### PR TITLE
Fixes #39014 - Ensure User.current can be reloaded via rails console

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,10 +33,6 @@ if File.exist?(File.expand_path('../Gemfile.in', __dir__))
   require 'bundler_ext'
   Bundler.ui = Bundler::UI::Silent.new if Rails.env.production?
   BundlerExt.system_require(File.expand_path('../Gemfile.in', __dir__), :all)
-
-  class Foreman::Consoletie < Rails::Railtie
-    console { Foreman.setup_console }
-  end
 else
   # If you have a Gemfile, require the gems listed there
   # Note that :default, :test, :development and :production groups
@@ -44,22 +40,28 @@ else
   if defined?(Bundler)
     Bundler.ui = Bundler::UI::Silent.new if Rails.env.production?
 
-    class Foreman::Consoletie < Rails::Railtie
-      console do
-        begin
-          Bundler.require(:console)
-        rescue LoadError
-          # no action, logs a warning in setup_console only
-        end
-        Foreman.setup_console
-      end
-    end
     Bundler.require(*Rails.groups)
     optional_bundler_groups = %w[assets ec2 fog libvirt openstack vmware redis]
     optional_bundler_groups.each do |group|
       Bundler.require(group)
     rescue LoadError
       # ignoring intentionally
+    end
+  end
+end
+
+class Foreman::Consoletie < Rails::Railtie
+  console do |app|
+    begin
+      Bundler.require(:console) if defined?(Bundler) && !defined?(BundlerExt)
+    rescue LoadError
+      # no action, logs a warning in setup_console only
+    end
+
+    Foreman.setup_console
+
+    app.reloader.to_prepare do
+      Foreman.setup_console
     end
   end
 end


### PR DESCRIPTION
Attempting to fix this:

Before
```
bundle exec rails c
pry(main)> reload!
pry(main)> User.current.class.object_id == User.object_id
=> false
pry(main)> t = ForemanTasks.async_task(Actions::Katello::ContentView::Publish, Katello::ContentView.last)
2026-01-20T16:01:20 [I|bac|] Task {label: , execution_plan_id: 9b388334-3f6c-499c-99b9-f8fca175ccd8} state changed: pending
ArgumentError: Unable to set current User, expected class 'User', got #<User id: 2, login: "foreman_console_admin", firstname: "Console", lastname: "Admin", mail: nil, admin: true, last_login_on: nil, auth_source_id: 2, created_at: "2026-01-19 17:10:04.461786000 +0000", updated_at: "2026-01-19 17:10:04.461786000 +0000", password_hash: nil, password_salt: nil, locale: nil, avatar_hash: nil, default_organization_id: 1, default_location_id: 2, lower_login: "foreman_console_admin", mail_enabled: false, timezone: nil, description: nil, disabled: false, ui_compact_mode: false, password: nil>
from /home/vagrant/foreman/app/models/concerns/foreman/thread_session.rb:73:in `current='
```

After
```
bundle exec rails c
pry(main)> reload!
pry(main)> User.current.class.object_id == User.object_id
=> true
```