### PR TITLE
Fixes #39016 - Use unique IDs as React keys for table rows

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -575,10 +575,10 @@ const HostsIndex = () => {
           }
           isPending={status === STATUS.PENDING}
         >
-          {results?.map((result, rowIndex) => {
+          {results?.map(result => {
             const rowActions = getActions(result);
             return (
-              <Tr key={rowIndex} ouiaId={`table-row-${rowIndex}`} isClickable>
+              <Tr key={result.id} ouiaId={`table-row-${result.id}`} isClickable>
                 {
                   <RowSelectTd
                     rowData={result}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -195,12 +195,12 @@ export const Table = ({
           )}
           {!childrenOutsideTbody &&
             (children ||
-              results.map((result, rowIndex) => {
+              results.map(result => {
                 const rowActions = actions(result);
                 return (
                   <Tr
-                    key={rowIndex}
-                    ouiaId={`table-row-${rowIndex}`}
+                    key={result[idColumn] || result.id}
+                    ouiaId={`table-row-${result[idColumn] || result.id}`}
                     isClickable
                   >
                     {showCheckboxes && (

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.test.js
@@ -215,4 +215,105 @@ describe('Table', () => {
     expect(screen.queryAllByText('No Results')).toHaveLength(0);
     expect(screen.queryAllByText('Loading...')).toHaveLength(1);
   });
+
+  test('uses result.id as React key for table rows', () => {
+    const { container } = render(
+      <Provider store={store}>
+        <Table
+          columns={columns}
+          params={{ page: 1, perPage: 10, order: '' }}
+          setParams={setParams}
+          refreshData={refreshData}
+          results={results}
+          url="/users"
+          isPending={false}
+        />
+      </Provider>
+    );
+
+    // Find all table rows (excluding header row)
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(2);
+
+    // Verify first row uses result.id as key
+    expect(rows[0]).toHaveAttribute('data-ouia-component-id', 'table-row-1');
+
+    // Verify second row uses result.id as key
+    expect(rows[1]).toHaveAttribute('data-ouia-component-id', 'table-row-2');
+  });
+
+  test('uses idColumn prop for React key when provided', () => {
+    const customResults = [
+      { custom_id: 'abc-123', name: 'John Doe', email: 'johndoe@example.com', role: 'Admin' },
+      { custom_id: 'xyz-456', name: 'Jane Smith', email: 'janesmith@example.com', role: 'User' },
+    ];
+
+    const { container } = render(
+      <Provider store={store}>
+        <Table
+          columns={columns}
+          params={{ page: 1, perPage: 10, order: '' }}
+          setParams={setParams}
+          refreshData={refreshData}
+          results={customResults}
+          idColumn="custom_id"
+          url="/users"
+          isPending={false}
+        />
+      </Provider>
+    );
+
+    const rows = container.querySelectorAll('tbody tr');
+    expect(rows).toHaveLength(2);
+
+    // Verify rows use custom_id as key
+    expect(rows[0]).toHaveAttribute('data-ouia-component-id', 'table-row-abc-123');
+    expect(rows[1]).toHaveAttribute('data-ouia-component-id', 'table-row-xyz-456');
+  });
+
+  test('keys remain stable when results are reordered', () => {
+    const sortedResults = [
+      { id: 2, name: 'Jane Smith', email: 'janesmith@example.com', role: 'User' },
+      { id: 1, name: 'John Doe', email: 'johndoe@example.com', role: 'Admin' },
+    ];
+
+    const { container, rerender } = render(
+      <Provider store={store}>
+        <Table
+          columns={columns}
+          params={{ page: 1, perPage: 10, order: '' }}
+          setParams={setParams}
+          refreshData={refreshData}
+          results={results}
+          url="/users"
+          isPending={false}
+        />
+      </Provider>
+    );
+
+    // Check initial order
+    let rows = container.querySelectorAll('tbody tr');
+    expect(rows[0]).toHaveAttribute('data-ouia-component-id', 'table-row-1');
+    expect(rows[1]).toHaveAttribute('data-ouia-component-id', 'table-row-2');
+
+    // Re-render with sorted results
+    rerender(
+      <Provider store={store}>
+        <Table
+          columns={columns}
+          params={{ page: 1, perPage: 10, order: 'name desc' }}
+          setParams={setParams}
+          refreshData={refreshData}
+          results={sortedResults}
+          url="/users"
+          isPending={false}
+        />
+      </Provider>
+    );
+
+    // After sort, keys should follow the data
+    rows = container.querySelectorAll('tbody tr');
+    expect(rows[0]).toHaveAttribute('data-ouia-component-id', 'table-row-2');
+    expect(rows[1]).toHaveAttribute('data-ouia-component-id', 'table-row-1');
+  });
 });


### PR DESCRIPTION
### Purpose

Fixes a bug where CVE column values would duplicate or disappear when sorting the hosts table. The root cause was using array index (`rowIndex`) as React keys instead of unique identifiers, causing React to reuse component instances across different data rows during sorting.

### Changes

1. **HostsIndex component**: Changed row key from `key={rowIndex}` to `key={result.id}`
2. **Generic Table component**: Changed row key from `key={rowIndex}` to `key={result[idColumn] || result.id}` to support custom ID columns
3. **Added unit tests**: Three new tests verify that keys use unique IDs and remain stable when results are reordered

### Testing Prerequisites

- Foreman instance with IoP (Insights on Premise) mode enabled
- At least 5 hosts registered in the system
- Hosts should have varying CVE data (some with CVE counts, some without)

### Testing Scenarios

#### Before Fix (Buggy Behavior)
1. Navigate to Hosts index page with 5+ hosts
2. Wait for at least one host to load CVE data (shows a number instead of '-')
3. Click Name column header to sort
4. **Bug**: CVE count appears in multiple rows or disappears
5. Sort again → values continue to duplicate/disappear randomly

#### After Fix (Expected Behavior)
1. Navigate to Hosts index page with 5+ hosts
2. Note which host shows a CVE count (e.g., "host-alpha" shows '5')
3. Click Name column header to sort ascending
4. **Expected**: Only "host-alpha" still shows '5', in its new sorted position
5. Sort by Name descending → ascending → descending again
6. **Expected**: CVE count stays with "host-alpha" through all sorts
7. Sort by other columns (IP address, OS, etc.)
8. **Expected**: CVE values always stay with the correct hosts

#### Unit Tests
```bash
npm test -- Table.test.js
```

All 11 tests should pass, including 3 new tests:
- ✓ uses result.id as React key for table rows
- ✓ uses idColumn prop for React key when provided
- ✓ keys remain stable when results are reordered

### Technical Details

React's reconciliation algorithm uses keys to track which component instances correspond to which data. When we used `rowIndex` as the key:

1. Initial state: Row 0 (key=0) → Host A
2. After sort: Row 0 (key=0) → Host C
3. React sees same key (0) with different data
4. React **reuses** the existing component instance from Host A for Host C
5. Child components (like CVECountCell) maintain stale state from Host A
6. CVE data shows incorrectly for Host C

With unique IDs as keys:
1. Initial: Row 0 (key=1) → Host A
2. After sort: Row 0 (key=3) → Host C
3. React sees different key (3 vs 1)
4. React **destroys** Host A's component and **creates** new one for Host C
5. Fresh component state, correct CVE data displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)