### PR TITLE
Fixes #39023 - Add logging to Unattended#host_template

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -180,12 +180,15 @@ class UnattendedController < ApplicationController
     end
 
     error = host_verifier.errors.first
+    logger.debug("Could not verify host: #{error[:message]}")
     render_error(error[:message], { :status => error[:type] }.merge(error[:params]))
     false
   end
 
   def allowed_to_install?
-    @host.build? || spoof || Setting[:access_unattended_without_build]
+    allowed = @host.build? || spoof || Setting[:access_unattended_without_build]
+    logger.info("Host #{@host.name} is not allowed to install") unless allowed
+    allowed
   end
 
   # Reset realm OTP. This is run as a before_action for provisioning templates.


### PR DESCRIPTION
When a host fails to retrieve a template or is denied installation, it is currently difficult to diagnose why the request failed, especially when we don't share any details in the response.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
