### PR TITLE
Fixes #39025 - Hide taxo params in API docs for taxo resources

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -163,10 +163,16 @@ module Api
       end
 
       def self.hide_taxonomy_options
+        prepend_before_action :drop_taxonomy_id_from_params
         resource_description do
           param :location_id, Integer, :show => false
           param :organization_id, Integer, :show => false
         end
+      end
+
+      def drop_taxonomy_id_from_params
+        params.delete(:location_id)
+        params.delete(:organization_id)
       end
     end
   end

--- a/app/controllers/concerns/api/v2/taxonomies_controller.rb
+++ b/app/controllers/concerns/api/v2/taxonomies_controller.rb
@@ -10,6 +10,8 @@ module Api::V2::TaxonomiesController
                                               medium_ids smart_proxy_ids environment_ids user_ids organization_ids realm_ids)
     before_action :params_match_database, :only => %w(create update)
     before_action :process_parameter_attributes, :only => %w(update)
+
+    hide_taxonomy_options
   end
 
   extend Apipie::DSL::Concern


### PR DESCRIPTION
Katello counterpart: https://github.com/Katello/katello/pull/11614