### PR TITLE
Fixes #39029 - Unattended::HostFinder - track search method

### DIFF
--- a/app/controllers/unattended_controller.rb
+++ b/app/controllers/unattended_controller.rb
@@ -167,12 +167,15 @@ class UnattendedController < ApplicationController
     query_params[:mac_list] = Foreman::UnattendedInstallation::MacListExtractor.new.extract_from_env(request.env, params: params)
     query_params[:built] = ['built', 'failed'].include? action_name
 
-    @host = Foreman::UnattendedInstallation::HostFinder.new(query_params: query_params).search
+    host_finder = Foreman::UnattendedInstallation::HostFinder.new(query_params: query_params)
+    @host = host_finder.search
+    @host_search_paths = host_finder.search_paths
   end
 
   def verify_found_host(needs_token = true)
     host_verifier = Foreman::UnattendedInstallation::HostVerifier.new(@host, request_ip: request.remote_ip,
-                                                                             for_host_template: (action_name == 'host_template'))
+                                                                             for_host_template: (action_name == 'host_template'),
+                                                                             search_paths: @host_search_paths)
 
     if host_verifier.valid?
       logger.debug "Found #{@host}"

--- a/app/services/foreman/unattended_installation/host_finder.rb
+++ b/app/services/foreman/unattended_installation/host_finder.rb
@@ -3,17 +3,18 @@ require 'ipaddr'
 module Foreman
   module UnattendedInstallation
     class HostFinder
-      attr_reader :query_params
+      attr_reader :query_params, :search_paths
 
       def initialize(options = {})
         @query_params = options[:query_params]
+        @search_paths = []
       end
 
       # lookup for a host based on the ip address and if possible by a mac address(as sent by anaconda)
       # if the host was found than its record will be in @host
       # if the host doesn't exists, it will return 404 and the requested method will not be reached.
       def search
-        host = find_host_by_spoof || find_host_by_token
+        host = find_host_by_spoof || find_host_by_hostname || find_host_by_token
         host ||= find_host_by_ip_or_mac unless token_from_params.present?
 
         host
@@ -22,9 +23,17 @@ module Foreman
       private
 
       def find_host_by_spoof
-        host = Host.authorized('view_hosts').joins(:primary_interface).where(nics: {ip: query_params['spoof']}).first if query_params['spoof'].present?
-        host ||= Host.authorized('view_hosts').find_by_name(query_params['hostname']) if query_params['hostname'].present?
-        @spoof = host.present?
+        return unless query_params[:spoof]
+        host = Host.authorized('view_hosts').joins(:primary_interface).where(nics: {ip: query_params[:spoof]}).first
+        add_search_path(:spoof, query_params[:spoof])
+        host
+      end
+
+      def find_host_by_hostname
+        return unless query_params[:hostname]
+
+        host = Host.authorized('view_hosts').find_by_name(query_params[:hostname])
+        add_search_path(:hostname, query_params[:hostname])
         host
       end
 
@@ -41,7 +50,7 @@ module Foreman
 
       def find_host_by_token
         return unless (token = token_from_params)
-
+        add_search_path(:token, '[redacted]')
         return Host.for_token_when_built(token).first if query_params[:built]
 
         Host.for_token(token).first
@@ -58,8 +67,10 @@ module Foreman
         hosts = Host.joins(:provision_interface).order(:created_at)
         # filter the records either by mac or by the IP address
         if mac_list.empty?
+          add_search_path(:ip, ip)
           hosts = hosts.where(:nics => { :ip => ip }).or(hosts.where(:nics => { :ip6 => ip }))
         else
+          add_search_path(:mac, mac_list.join(', '))
           hosts = hosts.where("lower(nics.mac) IN (?)", mac_list)
         end
 
@@ -69,6 +80,10 @@ module Foreman
 
         # We return the last host and reload it since it is readonly because of associations.
         hosts.last.reload
+      end
+
+      def add_search_path(name, value)
+        @search_paths << "#{name}: #{value}"
       end
     end
   end

--- a/app/services/foreman/unattended_installation/host_verifier.rb
+++ b/app/services/foreman/unattended_installation/host_verifier.rb
@@ -3,10 +3,11 @@ module Foreman
     class HostVerifier
       attr_reader :errors, :host, :request_ip, :for_host_template, :controller_name
 
-      def initialize(host, request_ip:, for_host_template:, needs_token: true)
+      def initialize(host, request_ip:, for_host_template:, search_paths:, needs_token: true)
         @host = host
         @errors = []
         @for_host_template = for_host_template
+        @search_paths = search_paths
         @request_ip = request_ip
         @controller_name = 'unattended'
         @needs_token = needs_token
@@ -41,11 +42,10 @@ module Foreman
 
       def host_found?
         return true if host.present?
-
         errors << {
-          message: N_("%{controller}: unable to find a host that matches the request from %{addr}"),
+          message: N_("%{controller}: unable to find a host that matches the request from %{addr}. Search paths: %{search_paths}"),
           type: :not_found,
-          params: { addr: request_ip, controller: controller_name },
+          params: { controller: controller_name, addr: request_ip, search_paths: @search_paths.join(',') },
         }
 
         false

--- a/test/unit/foreman/unattended_installation/host_finder_test.rb
+++ b/test/unit/foreman/unattended_installation/host_finder_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class Foreman::UnattendedInstallation::HostFinderTest < ActiveSupport::TestCase
+  subject { Foreman::UnattendedInstallation::HostFinder }
+  let(:host) { FactoryBot.create(:host, :managed, build: true) }
+
+  context 'search' do
+    it 'finds a host by spoof' do
+      finder = subject.new(query_params: { spoof: host.ip })
+
+      assert_equal host, finder.search
+      assert_equal(["spoof: #{host.ip}"], finder.search_paths)
+    end
+
+    it 'finds a host by hostname' do
+      finder = subject.new(query_params: { hostname: host.name })
+
+      assert_equal host, finder.search
+      assert_equal(["hostname: #{host.name}"], finder.search_paths)
+    end
+
+    it 'finds a host by token' do
+      finder = subject.new(query_params: { token: host.token.value })
+
+      assert_equal host, finder.search
+      assert_equal(["token: [redacted]"], finder.search_paths)
+    end
+
+    it 'finds a host by mac address' do
+      mac_list = [host.mac, '00:53:66:ab:66:67']
+      finder = subject.new(query_params: { mac_list: mac_list, ip: host.ip })
+
+      assert_equal host, finder.search
+      assert_equal(["mac: #{mac_list.join(', ')}"], finder.search_paths)
+    end
+
+    it 'finds a host by ip address' do
+      finder = subject.new(query_params: { ip: host.ip })
+
+      assert_equal host, finder.search
+      assert_equal(["ip: #{host.ip}"], finder.search_paths)
+    end
+
+    it 'searchs by spoof, hostname and mac address' do
+      mac_list = [host.mac, '00:53:66:ab:66:67']
+      params = { spoof: '127.0.66.66', hostname: 'invalid-hostname', mac_list: mac_list, ip: host.ip }
+      finder = subject.new(query_params: params)
+
+      assert_equal host, finder.search
+      assert_equal(["spoof: 127.0.66.66", "hostname: invalid-hostname", "mac: #{mac_list.join(', ')}"], finder.search_paths)
+    end
+
+    it 'searchs by spoof, hostname and ip address' do
+      params = { spoof: '127.0.66.66', hostname: 'invalid-hostname', ip: host.ip }
+      finder = subject.new(query_params: params)
+
+      assert_equal host, finder.search
+      assert_equal(["spoof: 127.0.66.66", "hostname: invalid-hostname", "ip: #{host.ip}"], finder.search_paths)
+    end
+
+    it 'skips search by ip & mac when token is present' do
+      params = { token: host.token.value, ip: host.ip, mac_list: [host.mac] }
+      finder = subject.new(query_params: params)
+
+      assert_equal host, finder.search
+      assert_equal(["token: [redacted]"], finder.search_paths)
+    end
+  end
+end

--- a/test/unit/foreman/unattended_installation/host_verifier_test.rb
+++ b/test/unit/foreman/unattended_installation/host_verifier_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class Foreman::UnattendedInstallation::HostVerifierTest < ActiveSupport::TestCase
+  subject { Foreman::UnattendedInstallation::HostVerifier }
+
+  context 'host_found?' do
+    it 'error message includes search method when host is not found' do
+      search_paths = ["spoof: 127.0.0.1", "hostname: test-hostname", "token: [redacted]", "ip: 127.0.0.1", "mac: 00:00:00:00:00:00, 00:00:00:00:00:01"]
+
+      search_paths.each do |search_path|
+        verifier = subject.new(nil, search_paths: [search_path], request_ip: '127.0.0.1', for_host_template: false)
+        refute verifier.valid?
+        error = verifier.errors.first
+
+        refute_nil error
+        assert_equal :not_found, error[:type]
+        assert_includes error[:message], "search_paths"
+        assert_equal search_path, error.dig(:params, :search_paths)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In UnattendedController, it was previously unclear which attribute Foreman was using to identify a host when a 404 occurred.

By tracking the search_method in HostFinder,
UnattendedController provides a more actionable error message.