### PR TITLE
Fixes #39033 - Add global css override for PF lists and labels

### DIFF
--- a/app/assets/stylesheets/patternfly_and_overrides.scss
+++ b/app/assets/stylesheets/patternfly_and_overrides.scss
@@ -348,3 +348,30 @@ span.btn-action a {
 span.btn-action.btn-primary a {
   color: #fff;
 }
+
+.pf-v5-c-menu ul {
+  /* override bootstrap-sass
+  ul, ol {
+    margin-top: 0px;
+    margin-bottom: 10px;
+  }*/
+  margin-bottom: 0;
+}
+
+label[class^='pf-v5'],
+[class^='pf-v5'] label {
+  /* override  
+    patternfly-sass
+    label {
+      font-weight: 600;
+    }
+    bootstrap-sass
+    label {
+      display: inline-block;
+      max-width: 100%;
+      margin-bottom: 5px;
+      font-weight: 700;
+    } */
+  margin-bottom: 0;
+  font-weight: normal;
+}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/SelectAllCheckbox/SelectAllCheckbox.scss
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/SelectAllCheckbox/SelectAllCheckbox.scss
@@ -1,4 +1,0 @@
-.table-select-all-checkbox {
-  font-weight: normal;
-  margin-bottom: 0;
-}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/SelectAllCheckbox/index.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/SelectAllCheckbox/index.js
@@ -9,8 +9,6 @@ import {
 import { translate as __ } from '../../../../../common/I18n';
 import { noop } from '../../../../../common/helpers';
 
-import './SelectAllCheckbox.scss';
-
 const SelectAllCheckbox = ({
   selectNone,
   selectDefault,
@@ -140,7 +138,6 @@ const SelectAllCheckbox = ({
           ouiaId="select-all-checkbox-dropdown-toggle"
           splitButtonItems={[
             <DropdownToggleCheckbox
-              className="table-select-all-checkbox"
               key="table-select-all-checkbox"
               ouiaId="select-all-checkbox-dropdown-toggle-checkbox"
               aria-label="Select all"


### PR DESCRIPTION
bootstrap-sass and patternfly-sass add global rules to all ul, and label. We end up overriding them everytime we add a PF5 component that contains these elements. instead of doing it individually, we should apply a global rule for it.