### PR TITLE
Fixes #39035 - Add dynflow_execution_plan_dependencies to schema dumper ignore list

### DIFF
--- a/config/initializers/dynflow.rb
+++ b/config/initializers/dynflow.rb
@@ -7,6 +7,7 @@ ActiveRecord::SchemaDumper.ignore_tables = [
   'dynflow_coordinator_records',
   'dynflow_delayed_plans',
   'dynflow_envelopes',
+  'dynflow_execution_plan_dependencies',
   'dynflow_execution_plans',
   'dynflow_output_chunks',
   'dynflow_schema_info',


### PR DESCRIPTION
I had some (well, just one) dynflow table show up in db/structure.sql which was awkward to say the least. Updated the ignore list to stop that

```
-- Name: dynflow_execution_plan_dependencies; Type: TABLE; Schema: public; Owner: -
CREATE TABLE public.dynflow_execution_plan_dependencies (
-- Name: dynflow_execution_plan_dependencies_blocked_by_uuid_index; Type: INDEX; Schema: public; Owner: -
CREATE INDEX dynflow_execution_plan_dependencies_blocked_by_uuid_index ON public.dynflow_execution_plan_dependencies USING btree (blocked_by_uuid);
-- Name: dynflow_execution_plan_dependencies_execution_plan_uuid_index; Type: INDEX; Schema: public; Owner: -
CREATE INDEX dynflow_execution_plan_dependencies_execution_plan_uuid_index ON public.dynflow_execution_plan_dependencies USING btree (execution_plan_uuid);
-- Name: dynflow_execution_plan_dependencies dynflow_execution_plan_dependencies_blocked_by_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
ALTER TABLE ONLY public.dynflow_execution_plan_dependencies
    ADD CONSTRAINT dynflow_execution_plan_dependencies_blocked_by_uuid_fkey FOREIGN KEY (blocked_by_uuid) REFERENCES public.dynflow_execution_plans(uuid) ON DELETE CASCADE;
-- Name: dynflow_execution_plan_dependencies dynflow_execution_plan_dependencies_execution_plan_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
ALTER TABLE ONLY public.dynflow_execution_plan_dependencies
    ADD CONSTRAINT dynflow_execution_plan_dependencies_execution_plan_uuid_fkey FOREIGN KEY (execution_plan_uuid) REFERENCES public.dynflow_execution_plans(uuid) ON DELETE CASCADE;
```

Recently added in dynflow => https://github.com/Dynflow/dynflow/commit/5538dd4c94b412a3445736fa057a9059ea8ff18a