### PR TITLE
Fixes #39037 - use assert_equal_arrays when comparing CR taxonomies

### DIFF
--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -451,7 +451,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     new_organizations = [Organization.first, Organization.second, Organization.third]
     put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:organization_ids => new_organizations.map { |org| org.id } } }
     assert_response :success
-    assert_equal JSON.parse(@response.body)['organizations'].map { |org| org['name'] }.sort, new_organizations.map { |org| org.name }, "Can't update libvirt compute resource with orgs #{new_organizations}"
+    assert_equal_arrays JSON.parse(@response.body)['organizations'].map { |org| org['name'] }, new_organizations.map { |org| org.name }, "Can't update libvirt compute resource with orgs #{new_organizations}"
   end
 
   test "should not create with same name" do
@@ -528,7 +528,7 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
       libvirt_with_locs = @valid_libvirt_with_org_loc.clone.update(:location_ids => locs.map { |loc| loc.id })
       post :create, params: { :compute_resource => libvirt_with_locs }
       assert_response :created
-      assert_equal JSON.parse(@response.body)['locations'].map { |loc| loc['name'] }, locs.map { |loc| loc.name }, "Can't create libvirt compute resource with locs #{locs}"
+      assert_equal_arrays JSON.parse(@response.body)['locations'].map { |loc| loc['name'] }, locs.map { |loc| loc.name }, "Can't create libvirt compute resource with locs #{locs}"
     end
 
     test "should create libvirt compute resource with orgs" do
@@ -536,14 +536,14 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
       libvirt_with_orgs = @valid_libvirt_attrs.clone.update(:organization_ids => orgs.map { |org| org.id })
       post :create, params: { :compute_resource => libvirt_with_orgs }
       assert_response :created
-      assert_equal JSON.parse(@response.body)['organizations'].map { |org| org['name'] }, orgs.map { |org| org.name }, "Can't create libvirt compute resource with orgs #{orgs}"
+      assert_equal_arrays JSON.parse(@response.body)['organizations'].map { |org| org['name'] }, orgs.map { |org| org.name }, "Can't create libvirt compute resource with orgs #{orgs}"
     end
 
     test "should update libvirt compute resource with locs" do
       new_locations = Array.new(3) { FactoryBot.create(:location, :organization_ids => [@organization.id]) }
       put :update, params: { :id => compute_resources(:mycompute).id, :compute_resource => {:location_ids => new_locations.map { |loc| loc.id } } }
       assert_response :success
-      assert_equal JSON.parse(@response.body)['locations'].map { |loc| loc['name'] }, new_locations.map { |loc| loc.name }, "Can't update libvirt compute resource with locs #{new_locations}"
+      assert_equal_arrays JSON.parse(@response.body)['locations'].map { |loc| loc['name'] }, new_locations.map { |loc| loc.name }, "Can't update libvirt compute resource with locs #{new_locations}"
     end
 
     test "should not create libvirt compute resource with invalid name" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -150,8 +150,8 @@ class ActiveSupport::TestCase
     assert_equal num_of_queries, queries.size, "Expected #{num_of_queries} queries, but got #{queries.size}"
   end
 
-  def assert_equal_arrays(array1, array2)
-    assert_equal array1.sort, array2.sort
+  def assert_equal_arrays(array1, array2, msg = nil)
+    assert_equal array1.sort, array2.sort, msg
   end
 end
 


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
