### PR TITLE
Remove pry-byebug from development group

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -11,7 +11,6 @@ group :development do
   gem 'byebug'
   gem 'pry'
   gem 'pry-rails'
-  gem 'pry-byebug'
   gem 'pry-doc'
   gem 'pry-stack_explorer'
   gem 'pry-remote' # will not work when running via foreman

--- a/developer_docs/foreman_dev_setup.asciidoc
+++ b/developer_docs/foreman_dev_setup.asciidoc
@@ -142,7 +142,9 @@ In order to run Foreman you can use the following command inside your git reposi
 bundle exec foreman start
 ....
 
-You can also run Foreman in two separate processes - frontend and rails. This way when you need to restart Foreman (for code reload) you don't have to wait for webpack build:
+You can also run Foreman in two separate processes - frontend and rails.
+This way when you need to restart Foreman (for code reload) you don't have to wait for webpack build. 
+Additionally, this allows you to use interactive tools which bind to the console such as [pry](https://github.com/pry/pry) or [byebug](https://github.com/deivid-rodriguez/byebug).
 [source, bash]
 ....
 # Rails


### PR DESCRIPTION
Apparently `pry-byebug` conflicts with `remote-pry`, rendering `remote-pry` completely unusable. With both gems enabled, `binding.remote_pry` correctly waits for a connection from a client. However, once the connection is established, it gets immediately closed again and pry attaches to the server's console instead of letting the remote client have the session. If the server is running under foreman (as in ddollar/foreman), which redirects stdin/stdout, the pry session terminates immediately as its input is closed.

Edit: To make things worse, the pry session launched this way does not put you to the place where you actually invoked pry but it gives you a session somewhere in the depths of pry-remote's own internals.

Before:
```
# Logs
[pry-remote] Waiting for client on druby://127.0.0.1:9876

# pry-remote
$ echo '"Hello"' | bundle exec pry-remote && echo done
done

# Logs, continued
[pry-remote] Client received, starting remote session
[pry-remote] Remote session terminated
[pry-remote] Ensure stop service

Frame number: 0/106

From: /Users/aruzicka/vcs/foreman/foreman/vendor/ruby/3.1.0/gems/pry-remote-0.1.8/lib/pry-remote.rb:321 Object#remote_pry:

    319: def remote_pry(host = PryRemote::DefaultHost, port = PryRemote::DefaultPort, options = {})
    320:   PryRemote::Server.new(self, host, port, options).run
 => 321: end

[1] pry(#<Binding>)>
```

After:
```
# Logs
[pry-remote] Waiting for client on druby://127.0.0.1:9876

# pry-remote
$ echo '"Hello"' | bundle exec pry-remote && echo done

Frame number: 0/91

From: /Users/aruzicka/vcs/foreman/foreman/app/controllers/api/v2/hosts_controller.rb:41 Api::V2::HostsController#index:

    40:       def index
 => 41: require 'pry-remote'; binding.remote_pry
-----B<-----SNIP-----B<-----
    62:       end

[1] pry(#<Api::V2::HostsController>)> "Hello"
=> "Hello"
[2] pry(#<Api::V2::HostsController>)> done

# Logs
[pry-remote] Client received, starting remote session
[pry-remote] Remote session terminated
[pry-remote] Ensure stop service
```

To test:
1) Place `require 'pry-remote'; binding.remote_pry` somewhere in the code
2) Hit that codepath
3) From a different terminal, run `pry-remote`