### PR TITLE
Fixes #39038 - fix action button handling for mulitple buttons with hash input

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -255,7 +255,8 @@ module ApplicationHelper
     end
 
     # multiple buttons
-    primary = args.delete_at(0).html_safe
+    primary = args.delete_at(0)
+    primary = (primary.is_a?(Hash) ? primary[:content] : primary).html_safe
     primary = content_tag(:span, primary, :class => 'btn btn-sm btn-default') if primary !~ /btn/
 
     content_tag(:div, :class => "btn-group") do

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -198,4 +198,42 @@ class ApplicationHelperTest < ActionView::TestCase
       ::Foreman::Plugin.app_metadata_registry.instance_variable_get(:@plugin_metadata).delete(:test_plugin_mixed)
     end
   end
+
+  describe 'action_buttons' do
+    test 'returns nil when no arguments provided' do
+      result = action_buttons
+      assert_nil result
+    end
+
+    test 'returns single button' do
+      result = action_buttons('Edit')
+      assert_match /Edit/, result
+      assert_match /<span.*btn/, result
+    end
+
+    test 'returns single button from hash' do
+      result = action_buttons({ content: 'Edit' })
+      assert_match /Edit/, result
+      assert_match /<span.*btn/, result
+    end
+
+    test 'returns dropdown for multiple buttons' do
+      result = action_buttons('Edit', 'Delete', 'Clone')
+      assert_match /btn-group/, result
+      assert_match /dropdown-menu/, result
+      assert_match /dropdown-toggle/, result
+    end
+
+    test 'renders dropdown for multiple buttons from hash' do
+      items = [
+        { content: 'Edit', options: { class: 'primary' } },
+        { content: 'Delete', options: { class: 'danger' } },
+        { content: 'Clone', options: { class: 'warning' } },
+      ]
+      result = action_buttons(*items)
+      assert_match /btn-group/, result
+      assert_match /<li class="danger">Delete<\/li>/, result
+      assert_match /<li class="warning">Clone<\/li>/, result
+    end
+  end
 end


### PR DESCRIPTION
the two button scenario did not account for the possibility of args being a hash.

to check:
- have a setup with foreman_ansible
- create a non admin user with Viewer and Remote Execution User roles
- with this user go to /hostgroups
