### PR TITLE
Fixes #38972 - Use FQDN for BMC connection target

### DIFF
--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -19,6 +19,7 @@ module Nic
       raise Foreman::Exception.new(N_('Unable to find a proxy with BMC feature')) if proxy.nil?
       args = {
         :host_ip => ip,
+        :fqdn => fqdn,
         :url => proxy.url,
         :user => username,
         :password => password_unredacted,

--- a/app/services/proxy_api/bmc.rb
+++ b/app/services/proxy_api/bmc.rb
@@ -3,7 +3,7 @@ module ProxyAPI
     SUPPORTED_BOOT_DEVICES = %w[disk cdrom pxe bios]
 
     def initialize(args)
-      @target = args[:host_ip] || '127.0.0.1'
+      @target = args[:fqdn].presence || args[:host_ip] || '127.0.0.1'
       @url = args[:url] + "/bmc"
       @provider = args[:bmc_provider]
       super args

--- a/test/models/nics/bmc_test.rb
+++ b/test/models/nics/bmc_test.rb
@@ -62,22 +62,24 @@ class BMCTest < ActiveSupport::TestCase
   context 'with bmc_credentials_accessible => false' do
     setup do
       Setting[:bmc_credentials_accessible] = false
-      host = FactoryBot.build(:host, :managed)
-      @bmc_nic = FactoryBot.build_stubbed(:nic_bmc, :host => host, :provider => 'IPMI', :username => "user", :password => 'secret', :subnet => subnets(:one))
+      domain = FactoryBot.build(:domain, :name => 'example.com')
+      host = FactoryBot.build(:host, :managed, :domain => domain)
+      @bmc_nic = FactoryBot.build_stubbed(:nic_bmc, :host => host, :provider => 'IPMI', :username => "user", :password => 'secret', :subnet => subnets(:one), :name => 'bmc', :domain => domain)
     end
 
     test 'BMC password is redacted in ENC output' do
       assert_nil @bmc_nic.to_export['password']
     end
 
-    test 'BMC password is hidden in #password' do
+    test 'password is hidden and fqdn is correctly constructed' do
       assert_nil @bmc_nic.password
       assert_equal 'secret', @bmc_nic.password_unredacted
+      assert_equal 'bmc.example.com', @bmc_nic.fqdn
     end
 
-    test '#proxy instantiates ProxyAPI with password' do
+    test '#proxy instantiates ProxyAPI with correct password and fqdn' do
       @bmc_nic.expects(:bmc_proxy).returns(FactoryBot.create(:bmc_smart_proxy))
-      ProxyAPI::BMC.expects(:new).with(has_entry(:password => 'secret'))
+      ProxyAPI::BMC.expects(:new).with(has_entries(:password => 'secret', :fqdn => 'bmc.example.com'))
       @bmc_nic.proxy
     end
 

--- a/test/services/proxy_api/bmc_test.rb
+++ b/test/services/proxy_api/bmc_test.rb
@@ -1,0 +1,75 @@
+require 'test_helper'
+
+class ProxyAPI::BMCTest < ActiveSupport::TestCase
+  def setup
+    @url = 'https://proxy.example.com:8443'
+    @options = { url: @url, host_ip: '192.168.1.1', fqdn: 'bmc.example.com', bmc_provider: 'Redfish' }
+    @bmc_api = ProxyAPI::BMC.new(@options)
+  end
+
+  test 'initialize should set target to fqdn if present' do
+    assert_equal 'bmc.example.com', @bmc_api.instance_variable_get(:@target)
+  end
+
+  test 'initialize should set target to host_ip if fqdn is not present' do
+    options = { url: @url, host_ip: '192.168.1.1' }
+    bmc_api = ProxyAPI::BMC.new(options)
+    assert_equal '192.168.1.1', bmc_api.instance_variable_get(:@target)
+  end
+
+  test 'initialize should set target to 127.0.0.1 if fqdn and host_ip are not present' do
+    options = { url: @url }
+    bmc_api = ProxyAPI::BMC.new(options)
+    assert_equal '127.0.0.1', bmc_api.instance_variable_get(:@target)
+  end
+
+  test 'power_on should call put with correct arguments' do
+    @bmc_api.expects(:put).with({ bmc_provider: 'Redfish', action: 'on' }, '/bmc.example.com/chassis/power/on').returns('fake response').once
+    @bmc_api.expects(:parse).with('fake response').returns({ 'result' => true })
+    assert @bmc_api.power_on({})
+  end
+
+  test 'power_off should call put with correct arguments' do
+    @bmc_api.expects(:put).with({ bmc_provider: 'Redfish', action: 'off' }, '/bmc.example.com/chassis/power/off').returns('fake response').once
+    @bmc_api.expects(:parse).with('fake response').returns({ 'result' => true })
+    assert @bmc_api.power_off({})
+  end
+
+  test 'power_status should call get with correct arguments' do
+    expected_path = '/bmc.example.com/chassis/power/status'
+    expected_query = { bmc_provider: 'Redfish' }
+    @bmc_api.expects(:get).with(expected_path, query: expected_query).returns('fake response')
+    @bmc_api.expects(:parse).with('fake response').returns({ 'result' => 'on' })
+    assert_equal 'on', @bmc_api.power_status({})
+  end
+
+  test 'lan_ip should call get and return the result' do
+    expected_path = '/bmc.example.com/lan/ip'
+    expected_query = { bmc_provider: 'Redfish' }
+    @bmc_api.expects(:get).with(expected_path, query: expected_query).returns('fake response')
+    @bmc_api.expects(:parse).with('fake response').returns({ 'result' => '192.168.1.100' })
+    assert_equal '192.168.1.100', @bmc_api.lan_ip({})
+  end
+
+  test 'boot_pxe should call boot with correct device' do
+    args = { reboot: true }
+    expected_args = { function: 'bootdevice', device: 'pxe', reboot: true, bmc_provider: 'Redfish' }
+    @bmc_api.expects(:put).with(expected_args, '/bmc.example.com/chassis/config/bootdevice/pxe').returns('{}')
+    @bmc_api.boot_pxe(args)
+  end
+
+  test 'method_missing should raise NoMethodError for invalid methods' do
+    assert_raise(NoMethodError) { @bmc_api.invalid_method({}) }
+  end
+
+  test 'respond_to_missing? should be true for valid dynamic methods' do
+    assert_respond_to @bmc_api, :power_on
+    assert_respond_to @bmc_api, :boot_disk
+    assert_respond_to @bmc_api, :identify_off
+    assert_respond_to @bmc_api, :lan_mac
+  end
+
+  test 'respond_to_missing? should be false for invalid dynamic methods' do
+    assert !@bmc_api.respond_to?(:invalid_method), "Should not respond to :invalid_method"
+  end
+end


### PR DESCRIPTION
Description:
Bug  [#38972](https://projects.theforeman.org/issues/38972)  is caused by the following:

Even though the FQDN is configured in Foreman's BMC interface settings, Foreman  invariably specifies the IP address in the :host parameter when using the Smart Proxy BMC API.

This PR fixes this item.

Modifications in this PR
- Fixed so that the configured FQDN is used.
In app/models/nic/bmc.rb, adding :fqdn to args allows the FQDN to be obtained from the models class instance. In app/services/proxy_api/bmc.rb, if an FQDN is set for the BMC interface, it is used as the connection target in preference to the IP address.

As this change also requires updates on the smart-proxy side, we created the following related ticket & PRs:

Ticket
Bug [#38973](https://projects.theforeman.org/issues/38973)  IP address not retrieved when using SSH API of BMC

PR
[#933](https://github.com/theforeman/smart-proxy/pull/933)

All two PRs (one in Foreman and one in smart-proxy) are ready for review.
Your feedback would be greatly appreciated.

Verification Contents:
1) I set the FQDN for the BMC interface in the Foreman Web UI and confirmed that operations such as turning the IPMI, Redfish, and SSH providers on and off were successful.
2) The Smart Proxy source code contains logic for the "Shell" BMC interface. However, since the Foreman web UI lacks a user interface to utilize this functionality, we conducted a code review to confirm that the current fix (related to FQDN processing) does not adversely affect or regress this "Shell" logic.
