### PR TITLE
Refs #39006 - validate more cloud-config files

### DIFF
--- a/test/external/cloudinit_syntax_test.rb
+++ b/test/external/cloudinit_syntax_test.rb
@@ -3,7 +3,12 @@ require 'mkmf'
 require 'English'
 
 class CloudInitSyntaxTest < ActiveSupport::TestCase
-  files = Dir.glob('test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/*')
+  files = Dir.glob('test/unit/foreman/renderer/snapshots/ProvisioningTemplate/*/*').select do |f|
+    content = File.read(f)
+    # coreos and rancheros have own cloud-init implementations, which we can't validate using
+    # the original cloud-init tooling
+    content.match?(/^#cloud-config/) && !content.match?(/coreos:/) && !content.match?(/rancher:/)
+  end
 
   files.each do |file|
     test file do
@@ -18,7 +23,6 @@ class CloudInitSyntaxTest < ActiveSupport::TestCase
     skip unless find_executable 'cloud-init'
     output = `./script/cloud-init-validate '#{file}' 2>&1`
     status = $CHILD_STATUS
-    assert_empty output.strip
-    assert status.success?
+    assert status.success?, "cloud-init-validate result:\n#{output.strip}"
   end
 end


### PR DESCRIPTION
- Not all snapshots live in the cloud-init folder
- Only assert success, not empty output, to ignore deprecation warnings



<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
