### PR TITLE
Refs #38978 - Add @patternfly/react-templates to vendor.js

### DIFF
--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -47,6 +47,7 @@ module.exports = [
   '@patternfly/react-tokens',
   '@patternfly/react-styles',
   '@patternfly/react-charts',
+  '@patternfly/react-templates',
 
   /**
    * ace-builds related


### PR DESCRIPTION
Forgot to add it when I added the package. adding it to webpack.vendor makes it available for plugins 