### PR TITLE
Fixes #39045 - Use the correct httpboot proxy factory

### DIFF
--- a/test/factories/subnet.rb
+++ b/test/factories/subnet.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     end
 
     trait :httpboot do
-      association :httpboot, :factory => :template_smart_proxy
+      association :httpboot, :factory => :httpboot_smart_proxy
     end
 
     trait :dhcp do
@@ -86,7 +86,7 @@ FactoryBot.define do
     trait :proxies_for_snapshots do
       # ability to build more than one smart proxies with the same url or name for snapshot testing
       association :tftp, :ignore_validations, :factory => :template_smart_proxy, :name => "snapshot-proxy-tftp", :url => "http://localhost:8001"
-      association :httpboot, :ignore_validations, :factory => :template_smart_proxy, :name => "snapshot-proxy-httpboot", :url => "http://localhost:8002"
+      association :httpboot, :ignore_validations, :factory => :httpboot_smart_proxy, :name => "snapshot-proxy-httpboot", :url => "http://localhost:8002"
       association :dhcp, :ignore_validations, :factory => :dhcp_smart_proxy, :name => "snapshot-proxy-dhcp", :url => "http://localhost:8003"
       association :dns, :ignore_validations, :factory => :dns_smart_proxy, :name => "snapshot-proxy-dns", :url => "http://localhost:8004"
       association :bmc, :ignore_validations, :factory => :bmc_smart_proxy, :name => "snapshot-proxy-bmc", :url => "http://localhost:8005"


### PR DESCRIPTION
Fixes: 641c3f4a9bb5401a8ac06e70b925918125193957


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
