### PR TITLE
Fixes #39046 - Set the "wrong" subnet to nil when using dualstack fal…

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_kernel_options.erb
@@ -58,10 +58,12 @@ description: |
   # networking credentials
   if subnet4 && subnet6
     if dual_stack_fallback == 'IPv4'
-      subnet6 = false
+      subnet6 = nil
     elsif dual_stack_fallback == 'IPv6'
-      subnet4 = false
+      subnet4 = nil
     else
+      # Dracut does not support dual stack
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1008076
       raise("Dual-stack provisioning not supported, set parameter 'dual_stack_provision_fallback'")
     end
   end


### PR DESCRIPTION
…lback

Before 93ac254d954c46924a78860f86678ff81139fe89 the subnet was used as a safeguard, where nil and false worked, but with safe navigation this fails as `false.nic_delay` is called and that's not a thing.

Fixes: b7ee77a7a387afa48e4baabf54efec8f2763e2d3
Fixes: 93ac254d954c46924a78860f86678ff81139fe89


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
