### PR TITLE
Fixes #38761 - Override max-height for Manage Columns modal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ColumnSelector/column-selector.scss
+++ b/webpack/assets/javascripts/react_app/components/ColumnSelector/column-selector.scss
@@ -12,10 +12,14 @@
   padding-top: 0px
 }
 
-#btn-select-columns{
+#btn-select-columns {
   @media (max-width: 1530px) {
     .columns-selector-text {
       display: none;
     }
   }
+}
+
+div [data-ouia-component-id="manage-columns-modal"].pf-v5-c-modal-box {                                                                                                                                        
+  max-height: calc(100% - 128px);                                                                                                                                                          
 }


### PR DESCRIPTION
This fixes a height issue for the Manage Columns modal, both on the new All Hosts and legacy UI All Hosts page. Previously the bottom of the modal would extend partially offscreen.
