### PR TITLE
Fixes #39048 - Deprecate ForemanModal in core

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModal.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Modal } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import ModalContext from './ForemanModalContext';
 import ForemanModalHeader from './subcomponents/ForemanModalHeader';
 import ForemanModalFooter from './subcomponents/ForemanModalFooter';
 import { extractModalNodes } from './helpers';
+import { deprecate } from '../../common/DeprecationService';
 
 /**
  * A modal component that provides a standardized layout and context for modals in Foreman.
@@ -31,6 +32,10 @@ import { extractModalNodes } from './helpers';
   </ForemanModal>
 */
 const ForemanModal = props => {
+  useEffect(() => {
+    deprecate('ForemanModal', 'Modal from @patternfly/react-core', '3.20');
+  }, []);
+
   const {
     id,
     title,

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalActions.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalActions.js
@@ -6,17 +6,21 @@ import {
   SET_MODAL_STOP_SUBMITTING,
 } from './ForemanModalConstants';
 import { selectModalExists } from './ForemanModalSelectors';
+import { deprecate } from '../../common/DeprecationService';
 
 export const addModal = ({ id, isOpen = false, isSubmitting = false }) => (
   dispatch,
   getState
-) =>
+) => {
+  deprecate('ForemanModal', 'Modal from @patternfly/react-core', '3.20');
   dispatch({
     type: ADD_MODAL,
     payload: { id, isOpen, isSubmitting },
   });
+};
 
 const modalAction = actionType => ({ id }) => (dispatch, getState) => {
+  deprecate('ForemanModal', 'Modal from @patternfly/react-core', '3.20');
   if (!selectModalExists(getState(), id)) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalHooks.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/ForemanModalHooks.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { selectIsModalOpen } from './ForemanModalSelectors';
 import { setModalOpen, setModalClosed } from './ForemanModalActions';
 import ModalContext from './ForemanModalContext';
+import { deprecate } from '../../common/DeprecationService';
 
 // Because enzyme doesn't support useContext yet
 export const useModalContext = () => useContext(ModalContext);
@@ -11,6 +12,10 @@ export const useModalContext = () => useContext(ModalContext);
 // Make sure the id passed in matches the id prop of your <ForemanModal />.
 // Returns a variable that tells you the state and a function to toggle it.
 export const useForemanModal = ({ id, isOpen = false }) => {
+  useEffect(() => {
+    deprecate('ForemanModal', 'Modal from @patternfly/react-core', '3.20');
+  }, []);
+
   if (!id) throw new Error('useForemanModal: ID is required');
   const initialModalState = isOpen;
   const modalOpen = useSelector(state => selectIsModalOpen(state, id)) || false;

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/__snapshots__/ForemanModalActions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/__snapshots__/ForemanModalActions.test.js.snap
@@ -1,15 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ForemanModal actions creates the modal 1`] = `
-Object {
-  "payload": Object {
-    "id": "testModal",
-    "isOpen": false,
-    "isSubmitting": false,
-  },
-  "type": "ADD_MODAL",
-}
-`;
+exports[`ForemanModal actions creates the modal 1`] = `undefined`;
 
 exports[`ForemanModal actions should close modal 1`] = `
 Object {

--- a/webpack/assets/javascripts/react_app/components/ForemanModal/index.js
+++ b/webpack/assets/javascripts/react_app/components/ForemanModal/index.js
@@ -11,10 +11,15 @@ import ForemanModal from './ForemanModal';
 import ForemanModalHeader from './subcomponents/ForemanModalHeader';
 import ForemanModalFooter from './subcomponents/ForemanModalFooter';
 import reducer from './ForemanModalReducer';
+import { deprecate } from '../../common/DeprecationService';
 
 export const reducers = { foremanModals: reducer };
 
 const ConnectedForemanModal = props => {
+  useEffect(() => {
+    deprecate('ForemanModal', 'Modal from @patternfly/react-core', '3.20');
+  }, []);
+
   const { id, title } = props;
   const isOpen = useSelector(state => selectIsModalOpen(state, id));
   const isSubmitting = useSelector(state => selectIsModalSubmitting(state, id));


### PR DESCRIPTION
After removing all of the usages across foreman, this is last piece for deprecate ForemanModal and use only PatternFly Modals instead.