### PR TITLE
Fixes #39057 - Remove exit calls from recurring rake tasks

### DIFF
--- a/lib/tasks/audits.rake
+++ b/lib/tasks/audits.rake
@@ -17,6 +17,7 @@ END_DESC
 
 namespace :audits do
   task :expire => :environment do
+    next unless before_date
     audits = get_audits_without_templates
     puts "Deleting audits older than #{before_date}. This might take a few minutes..."
     TaxableTaxonomy.where(taxable_type: "Audited::Audit", taxable: audits).delete_all
@@ -25,6 +26,7 @@ namespace :audits do
   end
 
   task :anonymize => :environment do
+    next unless before_date
     puts "Anonymizing audits older than #{before_date}. This might take a few minutes..."
 
     count = get_audits_without_templates.where.not(remote_address: nil)
@@ -66,8 +68,8 @@ namespace :audits do
   def before_date
     days = ENV['days'] || Setting[:audits_period]
     if days.blank?
-      puts "The interval for keeping the Audits is not defined in the settings, exiting..."
-      exit 0
+      puts "The interval for keeping the Audits is not defined in the settings, skipping..."
+      return nil
     end
     @before_date ||= days.to_i.days.ago
   end

--- a/lib/tasks/reports.rake
+++ b/lib/tasks/reports.rake
@@ -80,8 +80,7 @@ namespace :reports do
     env = ENV['environment']
     unless env.empty?
       unless (e = Environment.find_by_name(env))
-        $stdout.puts "Unable to find puppet environment=#{env}"
-        exit 1
+        raise "Unable to find puppet environment=#{env}"
       end
       options[:env] = e if e
     end
@@ -89,8 +88,7 @@ namespace :reports do
     unless ENV['fact'].empty?
       name, value = ENV['fact'].split(":")
       if name.empty? || value.empty?
-        $stdout.puts "invalid fact #{ENV['fact']}"
-        exit 1
+        raise "Invalid fact #{ENV['fact']}"
       end
       options[:factname] = name
       options[:factvalue] = value


### PR DESCRIPTION
Replace `exit()` with early returns and exceptions to prevent aborting
the entire `cron:*` task sequence when run via systemd timers.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
