### PR TITLE
Fixes #39053 - allow logout redirect to external site

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -202,7 +202,7 @@ class UsersController < ApplicationController
       session.clear
       inline_success _("Logged out - See you soon")
     end
-    redirect_to sso_logout_path || login_users_path
+    redirect_to(sso_logout_path || login_users_path, allow_other_host: true)
   end
 
   def extlogout


### PR DESCRIPTION
If user sets login_delegation_logout_redirect to somewhere else, the redirect is stopped as unsafe
