### PR TITLE
Fixes #39056 - Update CounterInput component to PF5

### DIFF
--- a/test/integration/compute_profile_js_test.rb
+++ b/test/integration/compute_profile_js_test.rb
@@ -59,7 +59,7 @@ class ComputeProfileJSTest < IntegrationTestWithJavascript
     assert click_button("Submit")
     visit compute_profile_path(selected_profile)
     assert click_link(compute_resources(:mycompute).to_s)
-    assert_equal  "2048 MB", find_field('compute_attribute_vm_attrs_memory').value
+    assert_equal  "2048", find_field('compute_attribute_vm_attrs_memory').value
     assert_equal  "1", find_field('compute_attribute_vm_attrs_cpus').value
   end
 

--- a/webpack/assets/javascripts/react_app/components/MemoryAllocationInput/MemoryAllocationInput.js
+++ b/webpack/assets/javascripts/react_app/components/MemoryAllocationInput/MemoryAllocationInput.js
@@ -1,9 +1,7 @@
-import RCInputNumber from 'rc-input-number';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { sprintf, translate as __ } from '../../common/I18n';
 import { DEFAULT_MEMORY_MB, MB_FORMAT, BYTES_PER_MB } from './constants';
-import '../common/forms/NumericInput.scss';
+import CounterInput from '../common/forms/CounterInput/CounterInput';
 import { noop } from '../../common/helpers';
 
 const MemoryAllocationInput = ({
@@ -18,55 +16,38 @@ const MemoryAllocationInput = ({
   setError,
   setWarning,
 }) => {
-  const [valueMB, setValueMB] = useState(value / BYTES_PER_MB);
-
-  useEffect(() => {
-    const valueBytes = valueMB * BYTES_PER_MB;
-    if (maxValue && valueBytes > maxValue) {
-      setWarning(null);
-      setError(
-        sprintf(
-          __('Specified value is higher than maximum value %s'),
-          `${maxValue / BYTES_PER_MB} ${MB_FORMAT}`
-        )
-      );
-    } else if (recommendedMaxValue && valueBytes > recommendedMaxValue) {
-      setError(null);
-      setWarning(
-        sprintf(
-          __('Specified value is higher than recommended maximum %s'),
-          `${recommendedMaxValue / BYTES_PER_MB} ${MB_FORMAT}`
-        )
-      );
-    } else {
-      setWarning(null);
-    }
-  }, [valueMB, recommendedMaxValue, maxValue, setError, setWarning]);
+  const [valueMB, setValueMB] = useState(Math.round(value / BYTES_PER_MB));
 
   const handleChange = v => {
-    if (v === valueMB + 1) {
-      v = valueMB * 2;
-    } else if (v === valueMB - 1) {
-      v = Math.floor(valueMB / 2);
-    }
     setValueMB(v);
     onChange(v * BYTES_PER_MB);
   };
-
+  const handlePlus = () => {
+    handleChange(valueMB * 2);
+  };
+  const handleMinus = () => {
+    handleChange(Math.floor(valueMB / 2));
+  };
   return (
     <>
-      <RCInputNumber
+      <CounterInput
+        unit={MB_FORMAT}
         value={valueMB}
         id={id}
-        formatter={v => `${v} ${MB_FORMAT}`}
-        parser={str => str.replace(/\D/g, '')}
         onChange={handleChange}
+        handlePlus={handlePlus}
+        handleMinus={handleMinus}
         disabled={disabled}
-        min={minValue && minValue / BYTES_PER_MB}
-        step={1}
-        precision={0}
+        min={minValue ? Math.round(minValue / BYTES_PER_MB) : undefined}
+        max={maxValue ? Math.round(maxValue / BYTES_PER_MB) : undefined}
         name=""
-        prefixCls="foreman-numeric-input"
+        setError={setError}
+        setWarning={setWarning}
+        recommendedMaxValue={
+          recommendedMaxValue
+            ? Math.round(recommendedMaxValue / BYTES_PER_MB)
+            : undefined
+        }
       />
       <input type="hidden" name={name} value={valueMB * BYTES_PER_MB} />
     </>

--- a/webpack/assets/javascripts/react_app/components/MemoryAllocationInput/__tests__/MemoryAllocationInput.test.js
+++ b/webpack/assets/javascripts/react_app/components/MemoryAllocationInput/__tests__/MemoryAllocationInput.test.js
@@ -1,31 +1,47 @@
 import React from 'react';
-import { mount } from 'enzyme';
-import { Provider } from 'react-redux';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import { BYTES_PER_MB } from '../constants';
 import MemoryAllocationInput from '../';
 
-
 describe('MemoryAllocationInput', () => {
-
-  it('warning alert', async () => {
-      const setWarning = jest.fn();
-      const component = mount(
-        <MemoryAllocationInput
-          value={11264*BYTES_PER_MB}
-          recommendedMaxValue={10240}
-          setWarning={setWarning}
-        />
-      );
-      expect(component.find('.foreman-numeric-input-input').prop('value')).toEqual('11264 MB');
-      expect(setWarning.mock.calls.length).toBe(1);
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('error alert', async () => {
-      const setError = jest.fn();
-      const component = mount(
-        <MemoryAllocationInput value={21504*BYTES_PER_MB} maxValue={20480*BYTES_PER_MB} setError={setError} />
-      );
-      expect(component.find('.foreman-numeric-input-input').prop('value')).toEqual('21504 MB');
-      expect(setError.mock.calls.length).toBe(1);
+  it('calls setWarning when value exceeds recommendedMaxValue', async () => {
+    const setWarning = jest.fn();
+    render(
+      <MemoryAllocationInput
+        value={11264 * BYTES_PER_MB}
+        recommendedMaxValue={10240}
+        setWarning={setWarning}
+      />
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveValue(11264);
+
+    await waitFor(() => {
+      expect(setWarning).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('calls setError when value exceeds maxValue', async () => {
+    const setError = jest.fn();
+    render(
+      <MemoryAllocationInput
+        value={21504 * BYTES_PER_MB}
+        maxValue={20480 * BYTES_PER_MB}
+        setError={setError}
+      />
+    );
+
+    const input = screen.getByRole('spinbutton');
+    expect(input).toHaveValue(21504);
+
+    await waitFor(() => {
+      expect(setError).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/common/forms/CounterInput/CounterInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CounterInput/CounterInput.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
-import RCInputNumber from 'rc-input-number';
+import { NumberInput } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
-import { translate as __ } from '../../../../common/I18n';
+import { translate as __, sprintf } from '../../../../common/I18n';
 import { noop } from '../../../../common/helpers';
 
 const CounterInput = ({
@@ -16,37 +16,104 @@ const CounterInput = ({
   onChange,
   setError,
   setWarning,
+  widthChars,
+  unit,
+  handlePlus,
+  handleMinus,
 }) => {
-  const [innerValue, setInnerValue] = useState(value);
+  const parseValue = v => {
+    if (v === '' || v == null) return v;
+    const parsed = Number(v);
+    return Number.isNaN(parsed) ? v : parsed;
+  };
+
+  const [innerValue, setInnerValue] = useState(() => parseValue(value));
+
   useEffect(() => {
-    if (max && innerValue > max) {
+    setInnerValue(parseValue(value));
+  }, [value]);
+
+  const getValidated = () => {
+    if (max && innerValue > max) return 'error';
+    if (recommendedMaxValue && innerValue > recommendedMaxValue)
+      return 'warning';
+    return 'default';
+  };
+  const validated = getValidated();
+
+  useEffect(() => {
+    if (validated === 'error') {
       setWarning(null);
-      setError(__('Specified value is higher than maximum value'));
-    } else if (recommendedMaxValue && innerValue > recommendedMaxValue) {
+      setError(
+        sprintf(
+          __('Specified value is higher than maximum value %s%s'),
+          max,
+          unit ? ` ${unit}` : ''
+        )
+      );
+    } else if (validated === 'warning') {
       setError(null);
-      setWarning(__('Specified value is higher than recommended maximum'));
+      setWarning(
+        sprintf(
+          __('Specified value is higher than recommended maximum %s%s'),
+          recommendedMaxValue,
+          unit ? ` ${unit}` : ''
+        )
+      );
     } else {
       setError(null);
       setWarning(null);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [recommendedMaxValue, max, innerValue]);
+  }, [validated, max, recommendedMaxValue, setError, setWarning, unit]);
+  const setValue = newValue => {
+    setInnerValue(newValue);
+    onChange(newValue);
+  };
+  const handleChange = event => {
+    const inputValue = event.target.value;
+    if (inputValue === '') {
+      setValue('');
+    } else {
+      const parsed = parseInt(inputValue, 10);
+      const clamped = Number.isNaN(parsed) ? min : parsed;
+      setValue(min != null ? Math.max(min, clamped) : clamped);
+    }
+  };
 
-  const handleChange = v => {
-    setInnerValue(v);
-    onChange(v);
+  const defaultHandlePlus = () => {
+    if (handlePlus) {
+      handlePlus(innerValue);
+    } else {
+      const newValue = (innerValue || 0) + (step || 1);
+      setValue(newValue);
+    }
+  };
+
+  const defaultHandleMinus = () => {
+    if (handleMinus) {
+      handleMinus(innerValue);
+    } else {
+      const current = innerValue || 0;
+      if (min != null && current <= min) return;
+      const newValue = current - (step || 1);
+      setValue(min != null ? Math.max(min, newValue) : newValue);
+    }
   };
 
   return (
-    <RCInputNumber
-      value={innerValue}
-      name={name}
-      id={id}
+    <NumberInput
+      value={innerValue ?? 0}
+      inputName={name}
+      inputProps={{ id, name }}
       min={min}
-      disabled={disabled}
+      max={max}
+      isDisabled={disabled}
       onChange={handleChange}
-      step={step}
-      prefixCls="foreman-numeric-input"
+      onPlus={defaultHandlePlus}
+      onMinus={defaultHandleMinus}
+      validated={validated}
+      widthChars={widthChars}
+      unit={unit}
     />
   );
 };
@@ -60,20 +127,28 @@ CounterInput.propTypes = {
   recommendedMaxValue: PropTypes.number,
   /** Set the max value of the numeric input */
   max: PropTypes.number,
-  /** Set the min value of the numeric input */
+  /** Set the min value of the numeric input, undefined will be defaulted to 0 */
   min: PropTypes.number,
   /** Set whether the numeric input will be disabled or not */
   disabled: PropTypes.bool,
   /** Set the onChange function of the numeric input */
   onChange: PropTypes.func,
   /** Set the default value of the numeric input */
-  value: PropTypes.number,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   /** Set the step, the counter will increase and decrease by */
   step: PropTypes.number,
   /** Component passes the validation error to this function */
   setError: PropTypes.func,
   /** Component passes the validation warning to this function */
   setWarning: PropTypes.func,
+  /** Set the width of the numeric input in characters */
+  widthChars: PropTypes.number,
+  /** Set the unit of the numeric input */
+  unit: PropTypes.string,
+  /** Override the default handlePlus function */
+  handlePlus: PropTypes.func,
+  /** Override the default handleMinus function */
+  handleMinus: PropTypes.func,
 };
 
 CounterInput.defaultProps = {
@@ -83,11 +158,15 @@ CounterInput.defaultProps = {
   value: 1,
   step: 1,
   min: 1,
-  max: null,
+  max: undefined,
   recommendedMaxValue: null,
   onChange: noop,
   setError: noop,
   setWarning: noop,
+  widthChars: 10,
+  unit: '',
+  handlePlus: null,
+  handleMinus: null,
 };
 
 export default CounterInput;

--- a/webpack/assets/javascripts/react_app/components/common/forms/CounterInput/__tests__/CounterInput.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CounterInput/__tests__/CounterInput.test.js
@@ -1,24 +1,258 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import CounterInput from '../';
-
+import FormField from '../../FormField';
 
 describe('CounterInput', () => {
-  it('warning alert', () => {
-    const setWarning = jest.fn();
-    const component = mount(
-      <CounterInput value={11} recommendedMaxValue={10} inputKey={'cpus'} setWarning={setWarning} />
-    );
-    expect(component.find('input').prop('value')).toEqual('11');
-    expect(setWarning.mock.calls.length).toBe(1);
+  const defaultProps = {
+    id: 'test-counter',
+    name: 'test-counter',
+    value: 1,
+    onChange: jest.fn(),
+    setError: jest.fn(),
+    setWarning: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('error alert', async () => {
-    const setError = jest.fn();
-    const component = mount(
-      <CounterInput value={21} max={20} inputKey={'cpus'} setError={setError} />
-    );
-    expect(component.find('input').prop('value')).toEqual('21');
-    expect(setError.mock.calls.length).toBe(1);
+  describe('rendering', () => {
+    it('should render with default props', () => {
+      render(<CounterInput {...defaultProps} />);
+      const input = screen.getByRole('spinbutton');
+      expect(input).toBeInTheDocument();
+      expect(input).toHaveValue(1);
+      expect(input).not.toBeDisabled();
+    });
+
+    it('should render with id and name attributes', () => {
+      render(
+        <CounterInput {...defaultProps} id="custom-id" name="custom-name" />
+      );
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveAttribute('id', 'custom-id');
+      expect(input).toHaveAttribute('name', 'custom-name');
+    });
+
+    it('should render disabled state', () => {
+      render(<CounterInput {...defaultProps} disabled />);
+      const input = screen.getByRole('spinbutton');
+      expect(input).toBeDisabled();
+    });
+  });
+  describe('validation', () => {
+    const renderFormField = (props = {}) =>
+      render(
+        <FormField
+          type="counter"
+          id="test-counter"
+          name="test-counter"
+          label="CPU Count"
+          {...props}
+        />
+      );
+
+    it('should display warning message when value exceeds recommendedMaxValue', () => {
+      renderFormField({ value: 11, recommendedMaxValue: 10 });
+
+      expect(
+        screen.getByText(/Specified value is higher than recommended maximum 10/)
+      ).toBeInTheDocument();
+    });
+
+    it('should display error message when value exceeds max', () => {
+      renderFormField({ value: 21, max: 20 });
+
+      expect(
+        screen.getByText(/Specified value is higher than maximum value 20/)
+      ).toBeInTheDocument();
+      expect(screen.getByRole('spinbutton')).toBeInvalid();
+    });
+
+    it('should prioritize error over warning when both conditions are met', () => {
+      renderFormField({ value: 25, max: 20, recommendedMaxValue: 15 });
+
+      expect(
+        screen.getByText(/Specified value is higher than maximum value 20/)
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Specified value is higher than recommended maximum/)
+      ).not.toBeInTheDocument();
+    });
+
+    it('should clear warning when value becomes valid', () => {
+      renderFormField({ value: 11, recommendedMaxValue: 10 });
+
+      expect(
+        screen.getByText(/Specified value is higher than recommended maximum 10/)
+      ).toBeInTheDocument();
+
+      fireEvent.change(screen.getByRole('spinbutton'), {
+        target: { value: '8' },
+      });
+
+      expect(
+        screen.queryByText(/Specified value is higher than recommended maximum/)
+      ).not.toBeInTheDocument();
+    });
+
+    it('should clear error when value becomes valid', () => {
+      renderFormField({ value: 21, max: 20 });
+
+      expect(screen.getByRole('spinbutton')).toBeInvalid();
+
+      fireEvent.change(screen.getByRole('spinbutton'), {
+        target: { value: '15' },
+      });
+
+      expect(screen.getByRole('spinbutton')).toBeValid();
+      expect(
+        screen.queryByText(/Specified value is higher than maximum value/)
+      ).not.toBeInTheDocument();
+    });
+
+    it('should not display error or warning when value is within limits', () => {
+      renderFormField({ value: 5, max: 20, recommendedMaxValue: 10 });
+
+      expect(screen.getByRole('spinbutton')).toBeValid();
+      expect(
+        screen.queryByText(/Specified value is higher than maximum value/)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Specified value is higher than recommended maximum/)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('user interactions', () => {
+    it('should call onChange when input value changes', () => {
+      const onChange = jest.fn();
+      render(<CounterInput {...defaultProps} onChange={onChange} />);
+      const input = screen.getByRole('spinbutton');
+
+      fireEvent.change(input, { target: { value: '5' } });
+
+      expect(onChange).toHaveBeenCalledWith(5);
+    });
+
+    it('should handle empty input by setting to min value', () => {
+      const onChange = jest.fn();
+      render(<CounterInput {...defaultProps} onChange={onChange} min={1} />);
+      const input = screen.getByRole('spinbutton');
+
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(onChange).toHaveBeenCalledWith('');
+      fireEvent.blur(input);
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it('should increment value when plus button is clicked', () => {
+      const onChange = jest.fn();
+      render(<CounterInput {...defaultProps} value={5} onChange={onChange} />);
+      const plusButton = screen.getByLabelText('Plus');
+
+      fireEvent.click(plusButton);
+
+      expect(onChange).toHaveBeenCalledWith(6);
+    });
+
+    it('should decrement value when minus button is clicked', () => {
+      const onChange = jest.fn();
+      render(<CounterInput {...defaultProps} value={5} onChange={onChange} />);
+      const minusButton = screen.getByLabelText('Minus');
+
+      fireEvent.click(minusButton);
+
+      expect(onChange).toHaveBeenCalledWith(4);
+    });
+
+    it('should use custom step when incrementing', () => {
+      const onChange = jest.fn();
+      render(
+        <CounterInput
+          {...defaultProps}
+          value={5}
+          step={3}
+          onChange={onChange}
+        />
+      );
+      const plusButton = screen.getByLabelText('Plus');
+
+      fireEvent.click(plusButton);
+
+      expect(onChange).toHaveBeenCalledWith(8);
+    });
+
+    it('should use custom step when decrementing', () => {
+      const onChange = jest.fn();
+      render(
+        <CounterInput
+          {...defaultProps}
+          value={10}
+          step={3}
+          onChange={onChange}
+        />
+      );
+      const minusButton = screen.getByLabelText('Minus');
+
+      fireEvent.click(minusButton);
+
+      expect(onChange).toHaveBeenCalledWith(7);
+    });
+
+    it('should handle null value in increment', () => {
+      const onChange = jest.fn();
+      render(
+        <CounterInput {...defaultProps} value={null} onChange={onChange} />
+      );
+      const plusButton = screen.getByLabelText('Plus');
+
+      fireEvent.click(plusButton);
+
+      expect(onChange).toHaveBeenCalledWith(1);
+    });
+
+    it('should handle null value in decrement', () => {
+      const onChange = jest.fn();
+      render(
+        <CounterInput
+          {...defaultProps}
+          min={-10}
+          value={null}
+          onChange={onChange}
+        />
+      );
+      const minusButton = screen.getByLabelText('Minus');
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveValue(0);
+      expect(minusButton).not.toBeDisabled();
+      fireEvent.click(minusButton);
+      expect(input).toHaveValue(-1);
+      expect(onChange).toHaveBeenCalledWith(-1);
+    });
+  });
+
+  describe('step', () => {
+    it('should handle decimal step values', () => {
+      const onChange = jest.fn();
+      render(
+        <CounterInput
+          {...defaultProps}
+          value={5}
+          step={0.5}
+          onChange={onChange}
+        />
+      );
+      const plusButton = screen.getByLabelText('Plus');
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveValue(5);
+      fireEvent.click(plusButton);
+      expect(input).toHaveValue(5.5);
+
+      expect(onChange).toHaveBeenCalledWith(5.5);
+    });
   });
 });

--- a/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/FormField.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import {
@@ -77,8 +77,14 @@ const FormField = ({
 }) => {
   const [innerError, setError] = useState(error);
   const [innerWarning, setWarning] = useState(null);
+  const isInitialMount = useRef(true);
 
   useEffect(() => {
+    if (isInitialMount.current) {
+      // Already set the error in the constructor, and can cause a race condition
+      isInitialMount.current = false;
+      return;
+    }
     setError(error);
   }, [error]);
 

--- a/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/NumericInput.js
@@ -1,10 +1,11 @@
 import RCInputNumber from 'rc-input-number';
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import './NumericInput.scss';
 
 import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
+import { deprecate } from '../../../common/DeprecationService';
 
 const NumericInput = ({
   label,
@@ -20,24 +21,33 @@ const NumericInput = ({
   readOnly,
   name,
   id,
-}) => (
-  <CommonForm label={label} className={className}>
-    <RCInputNumber
-      formatter={format}
-      parser={parser}
-      step={step}
-      min={minValue}
-      value={value}
-      precision={precision}
-      onChange={onChange}
-      disabled={disabled}
-      readOnly={readOnly}
-      prefixCls="foreman-numeric-input"
-      name={name}
-      id={id}
-    />
-  </CommonForm>
-);
+}) => {
+  useEffect(() => {
+    deprecate(
+      'forms/NumericInput',
+      'components/common/forms/CounterInput/CounterInput.js, or NumberInput from @patternfly/react-core',
+      '3.20'
+    );
+  }, []);
+  return (
+    <CommonForm label={label} className={className}>
+      <RCInputNumber
+        formatter={format}
+        parser={parser}
+        step={step}
+        min={minValue}
+        value={value}
+        precision={precision}
+        onChange={onChange}
+        disabled={disabled}
+        readOnly={readOnly}
+        prefixCls="foreman-numeric-input"
+        name={name}
+        id={id}
+      />
+    </CommonForm>
+  );
+};
 
 NumericInput.propTypes = {
   label: PropTypes.string,

--- a/webpack/assets/javascripts/react_app/components/common/forms/__tests__/FormField.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__tests__/FormField.test.js
@@ -55,7 +55,7 @@ describe('FormField', () => {
     );
 
     expect(
-      await screen.findByText('Specified value is higher than recommended maximum')
+      await screen.findByText(/Specified value is higher than recommended maximum 10/)
     ).toBeInTheDocument();
     expect(
       document.querySelector('.form-group.has-warning')

--- a/webpack/assets/javascripts/react_app/components/common/forms/__tests__/InputFactory.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/__tests__/InputFactory.test.js
@@ -83,7 +83,7 @@ describe('InputFactory', () => {
 
     it('should render MemoryAllocationInput for type="memory"', () => {
       render(<InputFactory type="memory" name="test" id="test-memory" />);
-      expect(screen.getByDisplayValue('2048 MB')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('2048')).toBeInTheDocument();
     });
 
     it('should render CounterInput for type="counter"', () => {


### PR DESCRIPTION
WIP as there is an update the vmware page counter usage, https://github.com/theforeman/foreman/pull/10817  and it might be best to use the wrapper instead. anyway after the vmware page changes this pr should deprecate `common/forms/NumericInput.js`

The component is defined in `webpack/assets/javascripts/react_app/components/common/forms/CounterInput/CounterInput.js`

It uses rc-input-number library as it's base. Even though the library seems to be still maintained, it would be better to get rid of one more dependency, especially given that PF5 already has similar capabilities: https://v5-archive.patternfly.org/components/number-input/html

Used in create host -> select compute resource vmware -> virtual machines
create host -> select compute resource libvirt -> virtual machines
discovery_rules/new
and plugins

Tested were generated with AI help