### PR TITLE
Fixes #38760 - Add loading skeleton to Change host group modal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
@@ -26,6 +26,7 @@ import {
 import { foremanUrl } from '../../../../common/helpers';
 import { APIActions } from '../../../../redux/API';
 import HostGroupSelect from './HostGroupSelect';
+import SkeletonLoader from '../../../common/SkeletonLoader';
 import {
   HOSTS_API_PATH,
   API_REQUEST_KEY,
@@ -197,7 +198,10 @@ const BulkReassignHostgroupModal = ({
       ouiaId="bulk-reassign-hg-modal-add-button"
       variant="primary"
       onClick={handleSave}
-      isDisabled={hostUpdateStatus === STATUS.PENDING}
+      isDisabled={
+        hostUpdateStatus === STATUS.PENDING ||
+        hostgroupStatus !== STATUS.RESOLVED
+      }
       isLoading={hostUpdateStatus === STATUS.PENDING}
     >
       {__('Save')}
@@ -249,7 +253,7 @@ const BulkReassignHostgroupModal = ({
           />
         </Text>
       </TextContent>
-      {hostgroups && hostgroupStatus === STATUS.RESOLVED && (
+      <SkeletonLoader status={hostgroupStatus} skeletonProps={{ count: 3 }}>
         <HostGroupSelect
           onClear={handleClear}
           headerText={__('Select host group')}
@@ -270,7 +274,7 @@ const BulkReassignHostgroupModal = ({
             );
           })}
         </HostGroupSelect>
-      )}
+      </SkeletonLoader>
       <hr />
     </Modal>
   );

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.test.js
@@ -9,8 +9,7 @@ import HostsIndex from './index';
 
 const mockStore = configureMockStore([thunk]);
 
-// Mock useSelector and useDispatch
-jest.spyOn(ReactRedux, 'useSelector').mockImplementation(() => []);
+// Mock useDispatch
 jest.spyOn(ReactRedux, 'useDispatch').mockImplementation(() => jest.fn());
 
 // Mock the API hook to return a controlled response
@@ -128,6 +127,10 @@ jest.mock('../PF4/TableIndexPage/TableIndexPage', () => ({
 describe('HostsIndex', () => {
   const store = mockStore({
     foremanModals: {},
+    API: {
+      HOSTGROUP_KEY: { status: 'RESOLVED', response: { results: [] } },
+      BULK_REASSIGN_HOSTGROUP_KEY: { status: undefined },
+    },
   });
 
   beforeEach(() => {


### PR DESCRIPTION
The BulkReassignHostgroupModal now displays a skeleton loader while fetching hostgroup data, improving user experience by providing visual feedback during the loading state.

⚠️ **Note to reviewers:** The last commit is for testing purposes only and should be dropped before merging. It ensures the skeleton loader is visible during review/QA by forcing a fetch on modal open.

**Steps to Reproduce:**

1. Open Chrome DevTools (F12 or right-click > Inspect)
2. Go to the Network tab
3. Set network throttling to "Slow 3G" (dropdown next to "No throttling")
4. Navigate to the All Hosts page (Hosts > All Hosts)
5. Select one or more hosts using the checkboxes
6. Click on the kebab menu (three dots) in the toolbar
7. Click on "Change association"
8. Click on "Change host group"
9. Observe the modal that appears

**Before the fix:**
- The modal opens with the title "Change host group" but the host group dropdown area is blank/empty while data is loading
- No visual indication that data is being fetched
- The Save button is enabled while data is loading, allowing users to click it prematurely

**After the fix:**
- The modal displays a skeleton loading indicator (3 animated lines) while the hostgroup data is being fetched
- Once loaded, the skeleton is replaced with the host group dropdown selector
- The Save button is disabled while data is loading, preventing premature submission


https://github.com/user-attachments/assets/143fc621-a12a-49b3-90a3-14fb8b7ddba6


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
