### PR TITLE
Fixes #35375 - Add rake task to run seeder (with optional "force")

### DIFF
--- a/app/services/foreman_seeder.rb
+++ b/app/services/foreman_seeder.rb
@@ -34,10 +34,10 @@ class ForemanSeeder
     Digest::SHA256.base64digest(hashes.join)
   end
 
-  def execute
+  def execute(force: false)
     Foreman::AdvisoryLockManager.with_transaction_lock(ADVISORY_LOCK) do
       # if we had to wait for the lock it is likely that the seeding has already been done, no need to seed again
-      return unless hash_changed?
+      return unless hash_changed? || force
 
       self.class.is_seeding = true
       begin

--- a/lib/tasks/seed.rake
+++ b/lib/tasks/seed.rake
@@ -229,4 +229,11 @@ namespace :seed do
       puts "Import rate: #{reports.to_f / (total_time / (10**9))} r/s"
     end
   end
+
+  desc 'Force to run foreman seeder. Call via rake seed:force'
+  task :force => :environment do
+    puts "Running foreman seeder with attribute force"
+    seeder = ::ForemanSeeder.new
+    seeder.execute(force: true)
+  end
 end


### PR DESCRIPTION
From time to time I run into the issue, that I want to make 100% sure, that I have the latest templates available. Therefore, it would be very helpful to have a rake task to run the seeder in 'force' mode.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
