### PR TITLE
Fixes #39063 - JS lint in plugins fails if package is only defined in core

### DIFF
--- a/script/lint/@theforeman/eslint-plugin-foreman/lint_generic_config.js
+++ b/script/lint/@theforeman/eslint-plugin-foreman/lint_generic_config.js
@@ -1,4 +1,5 @@
 const packageJsonDirectories = ['./'];
+const vendorEntry = require('../../../../config/webpack.vendor');
 
 module.exports = {
   plugins: [
@@ -49,7 +50,7 @@ module.exports = {
     'import/no-unresolved': [
       'error',
       {
-        ignore: ['foremanReact/.*'],
+        ignore: ['foremanReact/.*', ...vendorEntry],
       },
     ],
     'import/extensions': [


### PR DESCRIPTION
Since were moving away from using @theforeman/* packages, lint will show ` error Unable to resolve path to module X import/no-unresolved`
For packages that are defined in foreman core and not in the plugins. This error should not show up as npm packages are shared from core to plugins.

All the packages that are included in `config/webpack.vendor.js` are shared. It is not enough to have them in `package.json`.

Most plugins still have theforeman* packages in package.json so its not a visible issue yet, but since we recently added `@patternfly/react-templates'` to foreman core, if a plugin tries to use it there is lint error. 
` error  Unable to resolve path to module '@patternfly/react-templates'  import/no-unresolved`

I tested this by running lint with and without this PR and it fixed the issue. I also tried to use a package thats not defined in core or the plugin and lint failed as expected 