### PR TITLE
Fixes #38470 - deprecate forms/Form.js

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/forms/Form.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Form.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Alert } from 'patternfly-react';
 
@@ -6,6 +6,7 @@ import { noop } from '../../../common/helpers';
 import AlertBody from '../Alert/AlertBody';
 import Actions from './Actions';
 import { translate as __ } from '../../../../react_app/common/I18n';
+import { deprecate } from '../../../common/DeprecationService';
 
 const Form = ({
   className,
@@ -17,23 +18,33 @@ const Form = ({
   disabled,
   submitting,
   errorTitle,
-}) => (
-  <form className={className} onSubmit={onSubmit}>
-    {error && (
-      <Alert className="base in fade" type={error.severity || 'danger'}>
-        <AlertBody title={errorTitle}>
-          {error.errorMsgs.length === 1 ? (
-            <span>{error.errorMsgs[0]}</span>
-          ) : (
-            error.errorMsgs.map((e, idx) => <li key={idx}>{e}</li>)
-          )}
-        </AlertBody>
-      </Alert>
-    )}
-    {children}
-    <Actions onCancel={onCancel} disabled={disabled} submitting={submitting} />
-  </form>
-);
+}) => {
+  useEffect(() => {
+    deprecate('Form', 'Form from @patternfly/react-core', '3.20');
+  }, []);
+
+  return (
+    <form className={className} onSubmit={onSubmit}>
+      {error && (
+        <Alert className="base in fade" type={error.severity || 'danger'}>
+          <AlertBody title={errorTitle}>
+            {error.errorMsgs.length === 1 ? (
+              <span>{error.errorMsgs[0]}</span>
+            ) : (
+              error.errorMsgs.map((e, idx) => <li key={idx}>{e}</li>)
+            )}
+          </AlertBody>
+        </Alert>
+      )}
+      {children}
+      <Actions
+        onCancel={onCancel}
+        disabled={disabled}
+        submitting={submitting}
+      />
+    </form>
+  );
+};
 
 Form.propTypes = {
   children: PropTypes.node,


### PR DESCRIPTION
Deprecate forms/Form.js from foreman core. Alternative is available directly from Patternfly lib.
https://v5-archive.patternfly.org/components/forms/form