### PR TITLE
Refs #32652 - Add 'edit_classes' permission to Puppet cleanup

### DIFF
--- a/lib/cleanup_helper.rb
+++ b/lib/cleanup_helper.rb
@@ -63,7 +63,8 @@ class CleanupHelper
       cfgs = %w[view_config_groups create_config_groups edit_config_groups destroy_config_groups]
       plks = %w[view_external_parameters create_external_parameters edit_external_parameters
                 destroy_external_parameters]
-      pcls = %w[view_puppetclasses create_puppetclasses edit_puppetclasses destroy_puppetclasses import_puppetclasses]
+      pcls = %w[view_puppetclasses create_puppetclasses edit_puppetclasses destroy_puppetclasses import_puppetclasses
+                edit_classes]
       perms = Permission.where(name: envs + cfgs + plks + pcls)
       perms.destroy_all
       Filter.where.not(id: Filtering.distinct.select(:filter_id)).destroy_all


### PR DESCRIPTION
It was added forgotten in the initial implementation and later added to the foreman_puppet plugin, but not added to the clean-up script

https://github.com/theforeman/foreman/commit/07c6107ab8b5c206c63ee5471e849617aab91aed

https://github.com/theforeman/foreman/commit/07c6107ab8b5c206c63ee5471e849617aab91aed

cc @adamruzicka 


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
