### PR TITLE
[cp 3.18] Fixes #39069 - Notifications title is cut by the header

### DIFF
--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -2,29 +2,21 @@ html {
   height: 100%;
   width: 100%;
   display: table;
+  --header-height: 70px;
+  --banner-height: 0px;
 }
 
 #rails-app-content {
-  --header-height: 70px;
   position: absolute;
-  top: var(--header-height);
   left: 0;
   right: 0;
   bottom: 0;
   overflow: auto;
-  height: calc(100% - var(--header-height));
   margin-left: 250px;
-  &.user-banner-present {
-    --banner-height: calc(
-      2 * var(--pf-v5-global--spacer--xs) +
-        (var(--pf-v5-global--LineHeight--md) * var(--pf-v5-global--FontSize--sm))
-    ); // banner height is line height and a small padding
-    top: calc(
-      var(--header-height) + var(--banner-height)
-    );
-
-    height: calc(100% - var(--header-height) - var(--banner-height));
-  }
+  top: calc(
+    var(--header-height) + var(--banner-height)
+  );
+  height: calc(100% - var(--header-height) - var(--banner-height));
   .rails-table-toolbar {
     padding-bottom: 0;
     display: flex;
@@ -684,4 +676,11 @@ span.btn a.disabled {
       padding:0;
     }
   }
+}
+
+.user-banner-present {
+  --banner-height: calc(
+    2 * var(--pf-v5-global--spacer--xs) +
+      (var(--pf-v5-global--LineHeight--md) * var(--pf-v5-global--FontSize--sm))
+  ); // banner height is line height and a small padding
 }

--- a/app/helpers/layout_helper.rb
+++ b/app/helpers/layout_helper.rb
@@ -269,7 +269,10 @@ module LayoutHelper
   end
 
   def all_body_css_classes
-    body_css_classes + ' ' + (User.current&.ui_compact_mode ? 'compact-ui' : '')
+    classes = body_css_classes
+    classes += ' compact-ui' if User.current&.ui_compact_mode
+    classes += ' user-banner-present' if Setting[:instance_title].present?
+    classes
   end
 
   private

--- a/app/views/layouts/base.html.erb
+++ b/app/views/layouts/base.html.erb
@@ -61,7 +61,7 @@
       <% end %>
       <div
         id="rails-app-content"
-        class="pf-v5-c-page <%= Foreman.settings.find('instance_title') ? 'user-banner-present' : '' %>"
+        class="pf-v5-c-page"
       >
 
       <%= yield(:content) %>

--- a/webpack/assets/javascripts/react_app/components/notifications/notifications.scss
+++ b/webpack/assets/javascripts/react_app/components/notifications/notifications.scss
@@ -2,9 +2,9 @@
 
 .notifications, #pf-drawer-panel-0{
   position: absolute;
-  top: 70px;
+  top: calc(var(--header-height) + var(--banner-height));
   right: 0;
-  height: calc(100vh - 70px);
+  height: calc(100vh - var(--header-height) - var(--banner-height));
   width: 450px;
   z-index: 120;
 


### PR DESCRIPTION
when instance title is set

CP for https://github.com/theforeman/foreman/pull/10863

(cherry picked from commit 29bdc276bec6f7d4cfce484c952682875e7d4d17)

