### PR TITLE
Refs #38760 - Default hostgroup status to PENDING in reassign modal

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
@@ -87,9 +87,9 @@ const BulkReassignHostgroupModal = ({
   const hostgroups = useSelector(state =>
     selectAPIResponse(state, HOSTGROUP_KEY)
   );
-  const hostgroupStatus = useSelector(state =>
-    selectAPIStatus(state, HOSTGROUP_KEY)
-  );
+  const hostgroupStatus =
+    useSelector(state => selectAPIStatus(state, HOSTGROUP_KEY)) ||
+    STATUS.PENDING;
   const hostUpdateStatus = useSelector(state =>
     selectAPIStatus(state, BULK_REASSIGN_HOSTGROUP_KEY)
   );


### PR DESCRIPTION
When the BulkReassignHostgroupModal first renders, the API status for hostgroups is undefined since the fetch hasn't completed yet. This caused a PropTypes warning because SkeletonLoader requires a string status prop.

Default to STATUS.PENDING when undefined, following the same pattern used in HostDetails. This ensures the skeleton loader displays correctly while waiting for the API response.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
