### PR TITLE
Fixes #39092 - skip to manually import openvox rpm key

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet_setup.erb
@@ -48,6 +48,7 @@ else
   bin_path = '/usr/bin'
 end
 -%>
+<%= snippet_if_exists(template_name + " custom") -%>
 <% if os_family == 'Debian' -%>
 apt-get update
 apt-get install -y <%= linux_package %>
@@ -59,15 +60,8 @@ if [ -f /usr/bin/dnf ]; then
 else
   yum -t -y install <%= linux_package %>
 fi
-<% elsif os_family == 'Suse' -%>
-<% if aio_enabled -%>
-rpmkeys --import https://yum.puppet.com/RPM-GPG-KEY-puppet
-<% elsif aio_openvox_enabled -%>
-rpmkeys --import https://yum.voxpupuli.org/GPG-KEY-openvox.pub
-<% end -%>
-<% if @host.provision_method == 'image' -%>
+<% elsif os_family == 'Suse' && (@host.provision_method == 'image' || os_major >= 16) -%>
 /usr/bin/zypper -n --gpg-auto-import-keys install <%= linux_package %>
-<% end -%>
 <% elsif os_family == 'Windows' -%>
 $puppet_agent_msi = "${env:TEMP}\<%= windows_package %>"
 $puppet_install_args = @(


### PR DESCRIPTION
In case, someone need to have this section, it can be added to the new "custom pre" snippet. 

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
