### PR TITLE
Refs #38173 - correct variable name to `ntp_server`

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/ntp.erb
+++ b/app/views/unattended/provisioning_templates/snippet/ntp.erb
@@ -46,11 +46,11 @@ echo "Updating system time"
   -%>
   <% if use_ntp -%>
     yum -y install ntpdate
-    <% if ntp-server -%>
+    <% if ntp_server -%>
       <% if ntp_server.respond_to?(:join) -%>
-    /usr/sbin/ntpdate -sub <%= ntp-server.first %>
+    /usr/sbin/ntpdate -sub <%= ntp_server.first %>
       <% else -%>
-    /usr/sbin/ntpdate -sub <%= ntp-server %>
+    /usr/sbin/ntpdate -sub <%= ntp_server %>
       <% end -%>
     <% end -%>
     systemctl enable --now ntpd


### PR DESCRIPTION
Fixes: c9d6db8900f82391cd7770848e92d2a8c118d380
(cherry picked from commit 7a2fc6c861e43da17cff61e00e010d54aaaefe27)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
