### PR TITLE
Fixes #39094 - Allow to overwrite libvirt boot_order

### DIFF
--- a/app/models/compute_resources/foreman/model/libvirt.rb
+++ b/app/models/compute_resources/foreman/model/libvirt.rb
@@ -132,6 +132,12 @@ module Foreman::Model
       template
     end
 
+    def set_boot_order(attr = {})
+      order = %w[hd]
+      order.unshift 'network' unless attr[:image_id]
+      order
+    end
+
     def new_vm(attr = { })
       test_connection
       libvirt_connection_error unless errors.empty?
@@ -144,9 +150,7 @@ module Foreman::Model
       end
 
       opts.reject! { |k, v| v.nil? }
-
-      opts[:boot_order] = %w[hd]
-      opts[:boot_order].unshift 'network' unless attr[:image_id]
+      opts[:boot_order] = set_boot_order(attr)
 
       firmware_type = opts.delete(:firmware_type).to_s
       opts.merge!(process_firmware_attributes(opts[:firmware], firmware_type))


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
