### PR TITLE
Fixes #39098 - Deprecate multiple components in common/forms/* folder

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/forms/Actions.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Actions.js
@@ -1,26 +1,41 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'patternfly-react';
 
 import { noop } from '../../../common/helpers';
 import { simpleLoader } from '../Loader';
 import { translate as __ } from '../../../../react_app/common/I18n';
+import { deprecate } from '../../../common/DeprecationService';
 
-const FormActions = ({ onCancel, disabled, submitting }) => (
-  <div className="clearfix">
-    <div className="form-actions">
-      <Button bsStyle="primary" type="submit" disabled={disabled || submitting}>
-        &nbsp;
-        {__('Submit')}
-        {submitting && <span className="fr">{simpleLoader('sm')}</span>}
-      </Button>
-      {' ' /* adds whitespace between the buttons */}
-      <Button bsStyle="default" onClick={onCancel} disabled={submitting}>
-        {__('Cancel')}
-      </Button>
+const FormActions = ({ onCancel, disabled, submitting }) => {
+  useEffect(() => {
+    deprecate(
+      'forms/Actions',
+      'ActionGroup from @patternfly/react-core',
+      '3.21'
+    );
+  }, []);
+
+  return (
+    <div className="clearfix">
+      <div className="form-actions">
+        <Button
+          bsStyle="primary"
+          type="submit"
+          disabled={disabled || submitting}
+        >
+          &nbsp;
+          {__('Submit')}
+          {submitting && <span className="fr">{simpleLoader('sm')}</span>}
+        </Button>
+        {' ' /* adds whitespace between the buttons */}
+        <Button bsStyle="default" onClick={onCancel} disabled={submitting}>
+          {__('Cancel')}
+        </Button>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 FormActions.propTypes = {
   disabled: PropTypes.bool,

--- a/webpack/assets/javascripts/react_app/components/common/forms/Checkbox.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Checkbox.js
@@ -1,19 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
+import { deprecate } from '../../../common/DeprecationService';
 
-const Checkbox = ({ className, checked, onChange, label, disabled }) => (
-  <CommonForm label={label} className={`common-checkbox ${className}`}>
-    <input
-      disabled={disabled}
-      type="checkbox"
-      checked={checked}
-      onChange={onChange}
-    />
-  </CommonForm>
-);
+const Checkbox = ({ className, checked, onChange, label, disabled }) => {
+  useEffect(() => {
+    deprecate('forms/Checkbox', 'Checkbox from @patternfly/react-core', '3.21');
+  }, []);
+  return (
+    <CommonForm label={label} className={`common-checkbox ${className}`}>
+      <input
+        disabled={disabled}
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+      />
+    </CommonForm>
+  );
+};
 
 Checkbox.propTypes = {
   className: PropTypes.string,

--- a/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/CommonForm.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { deprecate } from '../../../common/DeprecationService';
 
 const CommonForm = ({
   className,
@@ -10,23 +11,31 @@ const CommonForm = ({
   children,
   inputClassName,
   tooltipHelp,
-}) => (
-  <div
-    className={`form-group ${className} ${touched && error ? 'has-error' : ''}`}
-  >
-    <label className="col-md-2 control-label">
-      {label}
-      {required && ' *'}
-      {tooltipHelp}
-    </label>
-    <div className={inputClassName}>{children}</div>
-    {touched && error && (
-      <span className="help-block help-inline">
-        <span className="error-message">{error}</span>
-      </span>
-    )}
-  </div>
-);
+}) => {
+  useEffect(() => {
+    deprecate('forms/CommonForm', 'Form from @patternfly/react-core', '3.21');
+  }, []);
+
+  return (
+    <div
+      className={`form-group ${className} ${
+        touched && error ? 'has-error' : ''
+      }`}
+    >
+      <label className="col-md-2 control-label">
+        {label}
+        {required && ' *'}
+        {tooltipHelp}
+      </label>
+      <div className={inputClassName}>{children}</div>
+      {touched && error && (
+        <span className="help-block help-inline">
+          <span className="error-message">{error}</span>
+        </span>
+      )}
+    </div>
+  );
+};
 
 CommonForm.propTypes = {
   className: PropTypes.string,

--- a/webpack/assets/javascripts/react_app/components/common/forms/SelectHelpers.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/SelectHelpers.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { deprecate } from '../../../common/DeprecationService';
 
 const renderOption = (val, text, key = null) => {
   const optValue = val === null || val === undefined ? '' : val;
@@ -17,6 +18,11 @@ const renderOptGroup = group => (
 );
 
 export const renderOptions = opts => {
+  deprecate(
+    'forms/SelectHelpers',
+    'Select from @patternfly/react-core',
+    '3.21'
+  );
   if (Array.isArray(opts)) {
     return opts.map((opt, index) => {
       if (opt.children) {

--- a/webpack/assets/javascripts/react_app/components/common/forms/TextInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/TextInput.js
@@ -1,18 +1,29 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import CommonForm from './CommonForm';
 import { noop } from '../../../common/helpers';
+import { deprecate } from '../../../common/DeprecationService';
 
-const TextInput = ({ label, className, value, onChange }) => (
-  <CommonForm label={label} className={`common-textInput ${className}`}>
-    <input
-      type="text"
-      className="form-control"
-      value={value}
-      onChange={onChange}
-    />
-  </CommonForm>
-);
+const TextInput = ({ label, className, value, onChange }) => {
+  useEffect(() => {
+    deprecate(
+      'forms/TextInput',
+      'TextInput from @patternfly/react-core',
+      '3.21'
+    );
+  }, []);
+
+  return (
+    <CommonForm label={label} className={`common-textInput ${className}`}>
+      <input
+        type="text"
+        className="form-control"
+        value={value}
+        onChange={onChange}
+      />
+    </CommonForm>
+  );
+};
 
 TextInput.propTypes = {
   label: PropTypes.string,


### PR DESCRIPTION
Deprecate multiple components from common/forms/* folder, use PF5 components instead.


- Actions.js
- Checkbox.js
- CommonForm.js
- TextInput.js
- SelectHelpers.js