### PR TITLE
Fixes #38749 - Power status icon in new All Hosts page needs to be centered

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/generalColumns.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/generalColumns.js
@@ -25,6 +25,7 @@ const generalColumns = [
     wrapper: ({ name }) => <HostPowerStatus hostName={name} />,
     isSorted: false,
     weight: 0,
+    textCenter: true,
   },
   {
     columnName: 'name',

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -532,7 +532,11 @@ const HostsIndex = () => {
                   />
                 }
                 {columnNamesKeys.map(k => (
-                  <Td key={k} dataLabel={keysToColumnNames[k]}>
+                  <Td
+                    key={k}
+                    dataLabel={keysToColumnNames[k]}
+                    textCenter={columns[k]?.textCenter}
+                  >
                     {columns[k].wrapper
                       ? columns[k].wrapper(result)
                       : result[k]}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/Table.js
@@ -145,6 +145,7 @@ export const Table = ({
               <Th
                 key={k}
                 modifier="wrap"
+                textCenter={columns[k]?.textCenter}
                 sort={
                   Object.values(columnsToSortParams).includes(k) &&
                   pfSortParams(keysToColumnNames[k])
@@ -214,7 +215,11 @@ export const Table = ({
                       />
                     )}
                     {columnNamesKeys.map(k => (
-                      <Td key={k} dataLabel={keysToColumnNames[k]}>
+                      <Td
+                        key={k}
+                        dataLabel={keysToColumnNames[k]}
+                        textCenter={columns[k]?.textCenter}
+                      >
                         {columns[k].wrapper
                           ? columns[k].wrapper(result)
                           : result[k]}

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -50,6 +50,7 @@ A page component that displays a table with data fetched from the API. It provid
 @param {function} columns[].wrapper - a function that returns a React component to be rendered in the column
 @param {boolean} columns[].isSorted - whether or not the column is sortable by its columnName. Only works if ORDER BY <columnName> will work.
 @param {function} columns[].isRelevant - optional function that takes in ForemanContext and returns a boolean. The column will be hidden from the column selector if isRelevant returns false. If the isRelevant key is omitted, columns are always relevant.
+@param {boolean} columns[].textCenter - optional boolean to center-align the column header and cell content. Uses PatternFly's textCenter prop on Th and Td.
 @param {string}{controller} - the name of the controller for the API
 @param {boolean} {creatable} - whether or not to show create button
 @param {Array<Object>} {customActionButtons} - an array of custom action buttons to be displayed in the toolbar


### PR DESCRIPTION
Center the power status icon and header on the all hosts page. 

Steps to reproduce:
1. Navigate to Hosts -> All Hosts page 
2. Toggle the "power" column under manage columns
3. Verify icon and header are now centered

Before: The icon and header were aligned to the left of the column making the table look "unpolished" 