### PR TITLE
Fixes #39101 - add parameters "id" and "hostname" to all host hooks

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -46,9 +46,17 @@ class Host::Managed < Host::Base
     output
   end
 
-  set_hook :host_created, on: :create
-  set_hook :host_destroyed, on: :destroy
-  set_hook :host_updated, on: :update, unless: -> { anonymous_admin_context? }
+  set_hook :host_created, on: :create do |h|
+    { id: h.id, hostname: h.hostname }
+  end
+
+  set_hook :host_destroyed, on: :destroy do |h|
+    { id: h.id, hostname: h.hostname }
+  end
+
+  set_hook :host_updated, on: :update, unless: -> { anonymous_admin_context? } do |h|
+    { id: h.id, hostname: h.hostname }
+  end
 
   set_hook :build_entered, if: -> { saved_change_to_build? && build? } do |h|
     { id: h.id, hostname: h.hostname }


### PR DESCRIPTION
This commit adds the parameters "id" and "hostname" to the host_created, host_destroy and host_updated hook.

I would like to listen to the host_created hook and execute post-installation tasks there. However, the hook does not say which host has just been created. So far I have to use a workaround (e.g. “created >= 5 minutes ago”), but I would prefer to just get the id or the hostname passed to me.
