### PR TITLE
Add explicit permissions to Foreman workflow

### DIFF
--- a/.github/workflows/foreman.yml
+++ b/.github/workflows/foreman.yml
@@ -8,6 +8,9 @@ on:
       - 'develop'
       - '*-stable'
 
+permissions:
+  contents: read
+
 env:
   RAILS_ENV: test
   DATABASE_URL: postgresql://postgres:password@localhost/test


### PR DESCRIPTION
## Summary

Adds explicit `permissions: contents: read` to the main Foreman workflow, restricting the GitHub Actions token to read-only access. This follows security best practices by limiting permissions to the minimum necessary for workflows that don't need to write to the repository.

This matches the change made to Katello's dependent plugins workflow in https://github.com/Katello/katello/pull/11648.

## Test plan

- [ ] Verify CI passes with the new permissions block
- [ ] Confirm workflow behavior is unchanged (read-only access is already the default for most operations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)