### PR TITLE
Fixes #39103 - Add context based permission to new hosts index page

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostsIndex/HostsIndexWrapper.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/HostsIndexWrapper.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Permitted from '../Permitted/Permitted';
+import HostsIndex from './index';
+
+const REQUIRED_PERMISSIONS = ['view_hosts'];
+
+const HostsIndexWrapper = props => (
+  <Permitted requiredPermissions={REQUIRED_PERMISSIONS}>
+    <HostsIndex {...props} />
+  </Permitted>
+);
+
+export default HostsIndexWrapper;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/__tests__/HostsIndexWrapper.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/__tests__/HostsIndexWrapper.test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import HostsIndexWrapper from '../HostsIndexWrapper';
+
+const mockUseForemanPermissions = jest.fn();
+
+jest.mock('../../../Root/Context/ForemanContext', () => ({
+  useForemanPermissions: () => mockUseForemanPermissions(),
+}));
+
+jest.mock('../../PermissionDenied', () => ({
+  __esModule: true,
+  default: ({ missingPermissions }) => (
+    <div data-testid="permission-denied">
+      Permission Denied: {missingPermissions.join(', ')}
+    </div>
+  ),
+}));
+
+jest.mock('../index', () => ({
+  __esModule: true,
+  default: props => (
+    <div data-testid="hosts-index" data-props={JSON.stringify(props)}>
+      HostsIndex
+    </div>
+  ),
+}));
+
+describe('HostsIndexWrapper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with view_hosts permission', () => {
+    beforeEach(() => {
+      mockUseForemanPermissions.mockReturnValue(new Set(['view_hosts']));
+    });
+
+    test('renders HostsIndex component', () => {
+      render(<HostsIndexWrapper />);
+
+      expect(screen.getByTestId('hosts-index')).toBeInTheDocument();
+      expect(screen.queryByTestId('permission-denied')).not.toBeInTheDocument();
+    });
+
+    test('passes props to HostsIndex component', () => {
+      const testProps = {
+        foo: 'bar',
+        baz: 123,
+      };
+
+      render(<HostsIndexWrapper {...testProps} />);
+
+      const hostsIndex = screen.getByTestId('hosts-index');
+      const receivedProps = JSON.parse(hostsIndex.getAttribute('data-props'));
+
+      expect(receivedProps).toEqual(testProps);
+    });
+  });
+
+  describe('without view_hosts permission', () => {
+    beforeEach(() => {
+      mockUseForemanPermissions.mockReturnValue(new Set(['some_other_permission']));
+    });
+
+    test('renders PermissionDenied component', () => {
+      render(<HostsIndexWrapper />);
+
+      expect(screen.getByTestId('permission-denied')).toBeInTheDocument();
+      expect(screen.getByText(/Permission Denied: view_hosts/)).toBeInTheDocument();
+    });
+
+    test('does not render HostsIndex component', () => {
+      render(<HostsIndexWrapper />);
+
+      expect(screen.queryByTestId('hosts-index')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with no permissions', () => {
+    beforeEach(() => {
+      mockUseForemanPermissions.mockReturnValue(new Set());
+    });
+
+    test('renders PermissionDenied component', () => {
+      render(<HostsIndexWrapper />);
+
+      expect(screen.getByTestId('permission-denied')).toBeInTheDocument();
+      expect(screen.queryByTestId('hosts-index')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/Hosts/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Hosts/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import HostsIndex from '../../components/HostsIndex';
+import HostsIndexWrapper from '../../components/HostsIndex/HostsIndexWrapper';
 import { HOSTS_PATH } from './constants';
 
 export default {
   path: HOSTS_PATH,
-  render: props => <HostsIndex {...props} />,
+  render: props => <HostsIndexWrapper {...props} />,
   exact: true,
 };


### PR DESCRIPTION
Use Context-based frontend permission management for new hosts index page.

Based on https://github.com/theforeman/foreman/pull/10338.

**Steps to Reproduce:**
1. Have a user without any permissions
2. Log in as that user
3. Navigate to /new/hosts

**Before**
The table body contains text "Request failed with status code 403"

**After**
A  page stating the user doesn't have view_hosts permission