### PR TITLE
Fixes #39106 - Fix taxonomy creation for unprivileged users

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,8 +1,6 @@
 class Taxonomy < ApplicationRecord
   validates_lengths_from_database
 
-  after_create :assign_taxonomy_to_user
-
   include Authorizable
   include NestedAncestryCommon
   include TopbarCacheExpiry
@@ -10,6 +8,7 @@ class Taxonomy < ApplicationRecord
   serialize :ignore_types, Array
 
   before_create :assign_default_templates
+  after_create :assign_taxonomy_to_user
   before_validation :sanitize_ignored_types
 
   has_many :taxable_taxonomies, :dependent => :destroy
@@ -246,7 +245,10 @@ class Taxonomy < ApplicationRecord
 
   def assign_taxonomy_to_user
     return if User.current.nil? || User.current.admin
+
     User.current.public_send(self.class.to_s.downcase.pluralize) << self
+    User.current.reload
+    User.current.invalidate_cache
   end
 
   def parent_id_does_not_escalate

--- a/test/integration/location_test.rb
+++ b/test/integration/location_test.rb
@@ -52,6 +52,32 @@ class LocationIntegrationTest < ActionDispatch::IntegrationTest
     assert page.has_link? "Raleigh"
   end
 
+  test "create a location with an unprivileged user with admin usergroup" do
+    ug = FactoryBot.create(:usergroup, :admin => true)
+    user = FactoryBot.create(:user, :usergroups => [ug])
+
+    set_request_user(user)
+    assert_new_button(locations_path, "New Location", new_location_path)
+    fill_in "location_name", :with => "Raleigh"
+    click_button "Submit"
+    assert_current_path step2_location_path(Location.unscoped.order(:id).last)
+  end
+
+  test "create a location with an unprivileged user with create_locations permission" do
+    user = setup_user('view', 'locations')
+    setup_user('create', 'locations', 'name ~ "R*"')
+    set_request_user(user)
+    assert_new_button(locations_path, "New Location", new_location_path)
+    fill_in "location_name", :with => "aleigh2"
+    click_button "Submit"
+    error = find('div.alert')
+    assert_match "You don't have permission create_locations", error.text
+
+    fill_in "location_name", :with => "Raleigh2"
+    click_button "Submit"
+    assert_current_path edit_location_path(Location.unscoped.order(:id).last)
+  end
+
   # PENDING
   # test "mismatches report" do
   # end


### PR DESCRIPTION
There are two parts to this. One is reordering of the callbacks and the other are various cache cleanups in both explicit cache and various active record caches.

Fixes 3a2b959 (https://github.com/theforeman/foreman/pull/10701)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
