### PR TITLE
Fixes #39110 - Fix hosts pagination when filtering by report origin

### DIFF
--- a/app/models/concerns/hostext/search.rb
+++ b/app/models/concerns/hostext/search.rb
@@ -22,7 +22,7 @@ module Hostext
       scoped_search :on => :id,            :complete_enabled => false, :only_explicit => true, :validator => ScopedSearch::Validators::INTEGER
       scoped_search :on => :pxe_loader, :complete_value => Operatingsystem.all_loaders_map.to_h { |k, _v| [k.tr(' ', '_').to_sym, k] }.except(:None), :only_explicit => true, :operators => ['=']
 
-      scoped_search :relation => :last_report_object, :on => :origin, :only_explicit => true
+      scoped_search :relation => :last_report_object, :on => :origin, :only_explicit => true, :ext_method => :search_by_origin
 
       scoped_search :relation => :configuration_status_object, :on => :status, :offset => 0, :word_size => ConfigReport::BIT_NUM * 4, :rename => :'status.interesting', :complete_value => {:true => true, :false => false}, :only_explicit => true, :aliases => [:'configuration_status.interesting']
       scoped_search_status "applied",         :relation => :configuration_status_object, :on => :status, :rename => :'status.applied', :aliases => ['configuration_status.applied']
@@ -123,6 +123,15 @@ module Hostext
     end
 
     module ClassMethods
+      def search_by_origin(key, operator, value)
+        condition = sanitize_sql_for_conditions(["#{Report.table_name}.origin #{operator} ?", value_to_sql(operator, value)])
+        host_ids = Report.select(:host_id).where(condition).distinct.pluck(:host_id)
+
+        return { conditions: '1 = 0' } if host_ids.empty?
+
+        { conditions: "#{Host.table_name}.id IN (#{host_ids.join(',')})" }
+      end
+
       def search_by_user(key, operator, value)
         clean_key = key.sub(/^.*\./, '')
         if value == "current_user"

--- a/test/models/concerns/hostext/search_test.rb
+++ b/test/models/concerns/hostext/search_test.rb
@@ -272,6 +272,49 @@ module Hostext
         it { assert_not_includes(subject, build_failed_status.host) }
       end
 
+      context "search by origin" do
+        let(:host1) { FactoryBot.create(:host) }
+        let(:host2) { FactoryBot.create(:host) }
+        let(:host3) { FactoryBot.create(:host) }
+
+        setup do
+          # Create multiple reports for host1 with Puppet origin
+          55.times do
+            FactoryBot.create(:config_report, host: host1, origin: 'Puppet')
+          end
+          # Create a few reports for host2 with Puppet origin
+          3.times do
+            FactoryBot.create(:config_report, host: host2, origin: 'Puppet')
+          end
+          # Create reports for host3 with Ansible origin
+          5.times do
+            FactoryBot.create(:config_report, host: host3, origin: 'Ansible')
+          end
+        end
+
+        test "searching by origin returns distinct hosts not report rows" do
+          result = Host.search_for("origin = Puppet")
+          assert_equal 2, result.count
+          assert_includes result, host1
+          assert_includes result, host2
+          assert_not_includes result, host3
+        end
+
+        test "pagination works correctly with many reports per host" do
+          # Even with 55 reports for host1 and 3 for host2, pagination should work on hosts
+          result = Host.search_for("origin = Puppet").limit(20).to_a
+          assert_equal 2, result.count
+          assert_includes result, host1
+          assert_includes result, host2
+        end
+
+        test "searching by origin = Ansible returns correct host" do
+          result = Host.search_for("origin = Ansible")
+          assert_equal 1, result.count
+          assert_includes result, host3
+        end
+      end
+
       context "search by parameters" do
         let(:hostgroup) { FactoryBot.create(:hostgroup) }
         let(:group_param) { FactoryBot.create(:hostgroup_parameter, name: 'test_param', value: 'test_value', hostgroup: hostgroup) }

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
+import { isEqual } from 'lodash';
 import uuid from 'uuid/v1';
 import {
   selectAPIResponse,
@@ -17,13 +18,23 @@ import { APIActions } from '../../../redux/API';
 
 export const useAPI = (method, url, options = {}) => {
   const dispatch = useDispatch();
-  const { key, ...rest } = options;
+  const { key, syncWithOptions = false, ...rest } = options;
   const [keyState, setKeyState] = useState(key || uuid());
   const [APIoptions, setAPIOptions] = useState(rest);
 
   useEffect(() => {
     if (key) setKeyState(key);
   }, [key]);
+
+  // Optionally sync APIoptions when the options parameter changes (e.g., URL params change)
+  // Set syncWithOptions: true to enable this behavior
+  const prevOptionsRef = useRef(rest);
+  useEffect(() => {
+    if (syncWithOptions && !isEqual(prevOptionsRef.current, rest)) {
+      prevOptionsRef.current = rest;
+      setAPIOptions(rest);
+    }
+  }, [rest, syncWithOptions]);
 
   useEffect(() => {
     if (url && method) {

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -100,6 +100,7 @@ const HostsIndex = () => {
     apiUrl: HOSTS_API_PATH,
     apiOptions,
     defaultParams,
+    syncWithOptions: true,
   });
   const contextData = useForemanContext();
 

--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/TableIndexHooks.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/Table/TableIndexHooks.js
@@ -1,4 +1,5 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { isEqual } from 'lodash';
 import URI from 'urijs';
 import { useHistory } from 'react-router-dom';
 import { useAPI } from '../../../../common/hooks/API/APIHooks';
@@ -19,6 +20,7 @@ export const useTableIndexAPIResponse = ({
   apiUrl,
   apiOptions = {},
   defaultParams = {},
+  syncWithOptions = false,
 }) => {
   let response = useAPI(
     replacementResponse ? null : 'get',
@@ -28,6 +30,7 @@ export const useTableIndexAPIResponse = ({
     {
       ...apiOptions,
       params: defaultParams,
+      syncWithOptions,
     }
   );
 
@@ -59,6 +62,16 @@ export const useSetParamsAndApiAndSearch = ({
 }) => {
   const [params, setParams] = useState(defaultParams);
   const history = useHistory();
+
+  // Sync params state when defaultParams changes (e.g., URL params change externally)
+  const prevDefaultParamsRef = useRef(defaultParams);
+  useEffect(() => {
+    if (!isEqual(prevDefaultParamsRef.current, defaultParams)) {
+      prevDefaultParamsRef.current = defaultParams;
+      setParams(defaultParams);
+    }
+  }, [defaultParams]);
+
   const setParamsAndAPI = newParams => {
     // add url edit params to the new params
     if (pushToHistory) {
@@ -71,13 +84,14 @@ export const useSetParamsAndApiAndSearch = ({
   };
 
   const setSearch = newSearch => {
-    if (pushToHistory) {
-      const uri = new URI();
-      uri.setSearch(newSearch);
-      history.push({ search: uri.search() });
-    }
+    // Only preserve per_page from existing params, not all params
+    // This prevents breaking existing behavior while still fixing the pagination issue
+    const searchParams =
+      params.per_page && !newSearch.per_page
+        ? { ...newSearch, per_page: params.per_page }
+        : newSearch;
     updateSearchQuery(newSearch.search);
-    setParamsAndAPI({ ...params, ...newSearch });
+    setParamsAndAPI(searchParams);
   };
 
   return {


### PR DESCRIPTION
When filtering hosts by report origin (e.g., "origin = Puppet"), the UI displayed a wrong number of hosts.

Two issues were identified and fixed:

1. Frontend: The useAPI hook stores options in React state which only initializes once. When URL parameters change via React Router navigation, the API request wasn't triggered with the new pagination params. Fixed by adding a useEffect that detects URL param changes and calls setAPIOptions to trigger a new API request.

2. Backend: The scoped_search for origin joined with reports, producing duplicate host rows when a host has multiple reports with the same origin. Fixed by adding an ext_method that queries with DISTINCT to return unique host IDs.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
