### PR TITLE
Fixes #39117 - Support generating registration command via REST API in isolated networks managed by external capsules

### DIFF
--- a/app/controllers/api/v2/registration_commands_controller.rb
+++ b/app/controllers/api/v2/registration_commands_controller.rb
@@ -3,6 +3,9 @@ module Api
     class RegistrationCommandsController < V2::BaseController
       include Api::Version2
       include Foreman::Controller::RegistrationCommands
+      include Foreman::Controller::SmartProxyAuth
+
+      add_smart_proxy_filters :create, :features => ['Registration', 'Templates']
 
       before_action :find_smart_proxy, if: -> { registration_params['smart_proxy_id'] }
       api :POST, "/registration_commands", N_("Generate global registration command")

--- a/test/controllers/api/v2/registration_commands_controller_test.rb
+++ b/test/controllers/api/v2/registration_commands_controller_test.rb
@@ -93,4 +93,82 @@ class Api::V2::RegistrationCommandsControllerTest < ActionController::TestCase
       assert_includes response, "--header 'Authorization: Bearer"
     end
   end
+
+  describe 'Smart Proxy authentication' do
+    test 'smart proxy with Registration and Templates features can generate registration command' do
+      Setting[:restrict_registered_smart_proxies] = true
+
+      features = [FactoryBot.create(:feature, name: 'Registration'), FactoryBot.create(:feature, name: 'Templates')]
+      proxy = FactoryBot.create(:smart_proxy, features: features, url: 'https://proxy.example.com')
+
+      @request.env['HTTPS'] = 'on'
+      @request.env['SSL_CLIENT_S_DN'] = 'CN=proxy.example.com'
+      @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
+
+      post :create
+      assert_response :success
+      assert_equal proxy, @controller.detected_proxy
+    end
+
+    test 'smart proxy without Registration feature cannot generate registration command' do
+      Setting[:restrict_registered_smart_proxies] = true
+      reset_api_credentials
+      User.current = nil
+
+      features = [FactoryBot.create(:feature, name: 'Templates')]
+      FactoryBot.create(:smart_proxy, features: features, url: 'https://proxy.example.com')
+
+      @request.env['HTTPS'] = 'on'
+      @request.env['SSL_CLIENT_S_DN'] = 'CN=proxy.example.com'
+      @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
+
+      post :create
+      assert_response :forbidden
+    end
+
+    test 'smart proxy without Templates feature cannot generate registration command' do
+      Setting[:restrict_registered_smart_proxies] = true
+      reset_api_credentials
+      User.current = nil
+
+      features = [FactoryBot.create(:feature, name: 'Registration')]
+      FactoryBot.create(:smart_proxy, features: features, url: 'https://proxy.example.com')
+
+      @request.env['HTTPS'] = 'on'
+      @request.env['SSL_CLIENT_S_DN'] = 'CN=proxy.example.com'
+      @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
+
+      post :create
+      assert_response :forbidden
+    end
+
+    test 'unregistered smart proxy cannot generate registration command' do
+      Setting[:restrict_registered_smart_proxies] = true
+      reset_api_credentials
+      User.current = nil
+
+      @request.env['HTTPS'] = 'on'
+      @request.env['SSL_CLIENT_S_DN'] = 'CN=unknown.example.com'
+      @request.env['SSL_CLIENT_VERIFY'] = 'SUCCESS'
+
+      post :create
+      assert_response :forbidden
+    end
+
+    test 'smart proxy with unverified SSL cert cannot generate registration command' do
+      Setting[:restrict_registered_smart_proxies] = true
+      reset_api_credentials
+      User.current = nil
+
+      features = [FactoryBot.create(:feature, name: 'Registration'), FactoryBot.create(:feature, name: 'Templates')]
+      FactoryBot.create(:smart_proxy, features: features, url: 'https://proxy.example.com')
+
+      @request.env['HTTPS'] = 'on'
+      @request.env['SSL_CLIENT_S_DN'] = 'CN=proxy.example.com'
+      @request.env['SSL_CLIENT_VERIFY'] = 'FAILED'
+
+      post :create
+      assert_response :forbidden
+    end
+  end
 end


### PR DESCRIPTION
To be able to generate the registration command for hosts in an isolated network.

Required smart proxy patch: https://github.com/theforeman/smart-proxy/pull/934
Required installer fix: https://github.com/theforeman/puppet-foreman_proxy_content/pull/534

**Before**
```
$ curl -k -X POST "https://capsule.redhat.com/api/registration_commands" \
  --user "userid:password" \
  -H "Content-Type: application/json" \
  -d '{
    "registration_command": {
      "activation_keys": ["AK1"],
      "insecure": false
    }
  }'
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>404 Not Found</title>
</head><body>
<h1>Not Found</h1>
<p>The requested URL was not found on this server.</p>
</body></html>
```

**Steps to apply patches**

**Satellite**

- Apply this foreman patch in /usr/share/foreman
- `foreman-maintain service restart`

**Capsule**

- Apply related smart proxy patch in /usr/share/foreman-proxy
- Apply related installer fix from foreman_proxy_content in /usr/share/foreman-installer/modules/foreman_proxy_content
- `systemctl restart foreman-proxy`
- `puppet resource package yard provider=puppet_gem`
- `puppet resource package puppet-strings provider=puppet_gem`
- `foreman-installer -l info`

**After**
```
$ curl -k -X POST "https://capsule.redhat.com/api/registration_commands" \
  --user "userid:password" \
  -H "Content-Type: application/json" \
  -d '{
    "registration_command": {
      "activation_keys": ["AK1"],
      "insecure": false
    }
  }'
{"registration_command":"set -o pipefail \u0026\u0026 curl --silent --show-error   'https://capsule.redhat.com/register?activation_keys=AK1' --header 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjozLCJpYXQiOjE3NzIxMzM5NjksImp0aSI6IjYxOTRkMmJjNjY2Mjk0YjQ5YjY4ODFkNTU2YjE3MTRkOWYxOWYyM2VjZjdkNDkwZTc3ZmUyNzg5OWI4MjAyNjEiLCJleHAiOjE3NzIxNDgzNjksInNjb3BlIjoicmVnaXN0cmF0aW9uI2dsb2JhbCByZWdpc3RyYXRpb24jaG9zdCJ9.7iRQLub-VrLOfGDPxJaHURWVGXp5hd6ksE3WMzLamIw' | bash"}
```