### PR TITLE
Fixes #39100 - Apply 'time-zone' parameter in Ubuntu template

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -16,6 +16,7 @@ description: |
   - keyboard: string (default="us")
   - package_upgrade: boolean (default=false)
   - remote_execution_ssh_keys: string (default="")
+  - time-zone: string (default="Etc/UTC")
   - username_to_create: string (default="root")
   - realname_to_create: string (default=username_to_create)
   - password_to_create: string (default=@host.root_pass)
@@ -64,6 +65,7 @@ autoinstall:
     toggle: null
     variant: ''
   locale: <%= host_param('lang', 'en_US') %>.UTF-8
+  timezone: <%= host_param('time-zone', 'Etc/UTC') %>
 <%= snippet 'preseed_netplan_setup' -%>
   ssh:
     allow-pw: true

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinst4dhcp.snap.txt
@@ -22,6 +22,7 @@ autoinstall:
     toggle: null
     variant: ''
   locale: en_US.UTF-8
+  timezone: Etc/UTC
   network:
     version: 2
     ethernets:

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinstmulti4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_Autoinstall_cloud-init_user_data.ubuntu_autoinstmulti4dhcp.snap.txt
@@ -22,6 +22,7 @@ autoinstall:
     toggle: null
     variant: ''
   locale: en_US.UTF-8
+  timezone: Etc/UTC
   network:
     version: 2
     ethernets:


### PR DESCRIPTION
Add timezone support to the "Preseed Autoinstall cloud-init user data" template.

This change passes the `time-zone` parameter (from Host Group or Host parameters)
to cloud-init:

  timezone: <%= host_param('time-zone', 'Etc/UTC') %>

If not set, `Etc/UTC` is used as default.