### PR TITLE
Fixes #39134 - Add bulk modal state helper to core

### DIFF
--- a/webpack/assets/javascripts/react_app/common/BulkModalStateHelper.js
+++ b/webpack/assets/javascripts/react_app/common/BulkModalStateHelper.js
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react';
+
+// Global states for storing modal open statuses and their listeners
+const modalState = {};
+
+// Object of React state setters ex:
+// {
+//     "bulk-assign-cves-modal": [setIsOpen],
+//     "bulk-packages-wizard": [setIsOpen],
+// }
+const modalStateOpeners = {};
+
+/**
+ * Register a modal to a listener:
+ * This helper should used only in situations where useState hook is not
+ * available, e.g. when the modal is mounted by global fill
+ * @param {String} id - an identifier for the modal
+ * @param {Boolean} isOpen - whether a modal is open
+ */
+export const openBulkModal = (id, isOpen) => {
+  // Avoid unnecessary updates
+  if (modalState[id] === isOpen) return;
+
+  if (isOpen) modalState[id] = true;
+  else delete modalState[id];
+
+  (modalStateOpeners[id] || []).forEach(listener => listener(isOpen));
+};
+
+/**
+ * Access modals and their helper functions
+ * @param {String} id - identifier of the modal
+ */
+export const useBulkModalOpen = id => {
+  const [isOpen, setIsOpen] = useState(() => Boolean(modalState[id]));
+
+  useEffect(() => {
+    if (!modalStateOpeners[id]) modalStateOpeners[id] = [];
+
+    // Prevent duplicate subscriptions
+    if (!modalStateOpeners[id].includes(setIsOpen)) {
+      modalStateOpeners[id].push(setIsOpen);
+    }
+
+    return () => {
+      modalStateOpeners[id] = modalStateOpeners[id].filter(
+        l => l !== setIsOpen
+      );
+      // Cleanup empty listener arrays
+      if (modalStateOpeners[id].length === 0) {
+        delete modalStateOpeners[id];
+      }
+    };
+  }, [id]);
+
+  // Return with helper functions
+  return {
+    isOpen,
+    open: () => openBulkModal(id, true),
+    close: () => openBulkModal(id, false),
+    toggle: () => openBulkModal(id, !isOpen),
+  };
+};


### PR DESCRIPTION
The fix was originally implemented in Katello but can also be used for other plugins, so it makes more sense to have it in Foreman core:

https://github.com/Katello/katello/pull/11626


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
