### PR TITLE
Fixes #39131 - Force HTTPS for Global Registration built endpoint

### DIFF
--- a/app/services/foreman/foreman_url_renderer.rb
+++ b/app/services/foreman/foreman_url_renderer.rb
@@ -54,6 +54,18 @@ module Foreman
       result
     end
 
+    apipie :method, 'Converts a URL to use HTTPS' do
+      desc 'Converts an HTTP URL to HTTPS, handling port conversion (80 -> 443). Used by Global Registration to enforce HTTPS when port 80 is blocked.'
+      required :url, String, desc: 'URL to convert to HTTPS'
+      returns String, desc: "HTTPS URL"
+    end
+    def force_url_https(url)
+      uri = URI.parse(url)
+      uri.scheme = 'https'
+      uri.port = nil if uri.port == 80 # Use default HTTPS port (443)
+      uri.to_s
+    end
+
     private
 
     def foreman_url_options

--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -5,6 +5,7 @@ module Foreman
 
       DEFAULT_ALLOWED_GENERIC_HELPERS = [
         :foreman_url,
+        :force_url_https,
         :snippet, :snippets,
         :snippet_if_exists,
         :indent,

--- a/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
+++ b/app/views/unattended/provisioning_templates/host_init_config/host_init_config_default.erb
@@ -34,7 +34,8 @@ exit_and_cancel_build() {
   <%= indent(2, skip1: true, skip_content: 'EOF') { snippet('built', :variables => {
     :endpoint => 'failed',
     :method => 'POST',
-    :post_data => 'Host initial configuration failed, please see the registration log for more details.' }) }
+    :post_data => 'Host initial configuration failed, please see the registration log for more details.',
+    :force_https => true }) }
   -%>
   exit 1
 }
@@ -89,7 +90,7 @@ fi
 # Call home to exit build mode
 
 trap - ERR
-<%= snippet 'built' %>
+<%= snippet('built', :variables => { :force_https => true }) %>
 
 if [[ $? == 0 ]] ; then
   echo "Host [<%= @host.name %>] successfully configured."

--- a/app/views/unattended/provisioning_templates/snippet/built.erb
+++ b/app/views/unattended/provisioning_templates/snippet/built.erb
@@ -13,6 +13,10 @@ description: |
   endpoint = @endpoint || 'built'
   method = @method || 'POST'
   url = foreman_url(endpoint)
+
+  # Force HTTPS for Global Registration (when port 80 is blocked)
+  url = force_url_https(url) if @force_https
+
   built_https = url.start_with?('https')
   curl_opts = ["-H 'Content-Type: text/plain'"]
   curl_opts << "--fail"

--- a/test/unit/foreman/templates/snippets/built_test.rb
+++ b/test/unit/foreman/templates/snippets/built_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class BuiltSnippetTest < ActiveSupport::TestCase
+  def renderer
+    @renderer ||= Foreman::Renderer::SafeModeRenderer
+  end
+
+  def render_snippet(host:, variables: {})
+    @snippet ||= File.read(Rails.root.join('app', 'views', 'unattended', 'provisioning_templates', 'snippet', 'built.erb'))
+
+    source = OpenStruct.new(
+      name: 'built',
+      content: @snippet
+    )
+
+    scope = Class.new(Foreman::Renderer::Scope::Provisioning).send(
+      :new,
+      host: host,
+      source: source,
+      variables: variables)
+
+    renderer.render(source, scope)
+  end
+
+  setup do
+    disable_orchestration
+    os = FactoryBot.create(:operatingsystem, :with_associations)
+    @host = FactoryBot.create(:host, :managed, :build => true, :operatingsystem => os)
+    @host.build_token(:value => 'test_token', :expires => Time.zone.now + 5.minutes)
+    Setting[:unattended_url] = 'http://foreman.example.com'
+    # Use actual test certificate for HTTPS tests
+    Setting[:ssl_ca_file] = Rails.root.join('test/static_fixtures/certificates/example.com.crt')
+  end
+
+  test 'should use HTTP URL by default' do
+    result = render_snippet(host: @host)
+    assert_match %r{http://foreman.example.com/unattended/built}, result
+    assert_match(/test_token/, result)
+  end
+
+  test 'should convert to HTTPS when force_https is true' do
+    result = render_snippet(host: @host, variables: { force_https: true })
+    assert_match %r{https://foreman.example.com/unattended/built}, result
+    assert_no_match %r{http://foreman.example.com}, result
+  end
+
+  test 'should use curl when available' do
+    result = render_snippet(host: @host)
+    assert_match(%r{if \[ -x /usr/bin/curl \]}, result)
+    assert_match(%r{/usr/bin/curl}, result)
+  end
+
+  test 'should use HTTPS URL and set SSL_CA_CERT when force_https is true' do
+    result = render_snippet(host: @host, variables: { force_https: true })
+    assert_match(/SSL_CA_CERT/, result)
+    assert_match(/--cacert \$SSL_CA_CERT/, result)
+  end
+
+  test 'should use failed endpoint when specified' do
+    result = render_snippet(host: @host, variables: { endpoint: 'failed' })
+    assert_match %r{http://foreman.example.com/unattended/failed}, result
+  end
+
+  test 'should convert failed endpoint to HTTPS when force_https is true' do
+    result = render_snippet(host: @host, variables: { endpoint: 'failed', force_https: true })
+    assert_match %r{https://foreman.example.com/unattended/failed}, result
+    assert_no_match %r{http://foreman.example.com}, result
+  end
+
+  test 'should include post data when specified' do
+    post_data = 'Host configuration failed'
+    result = render_snippet(host: @host, variables: { post_data: post_data })
+    assert_match(/#{post_data}/, result)
+  end
+
+  test 'should preserve HTTPS when unattended_url is already HTTPS' do
+    Setting[:unattended_url] = 'https://foreman.example.com'
+    result = render_snippet(host: @host, variables: { force_https: true })
+    assert_match %r{https://foreman.example.com/unattended/built}, result
+  end
+
+  test 'should handle custom port with force_https' do
+    Setting[:unattended_url] = 'http://foreman.example.com:8080'
+    result = render_snippet(host: @host, variables: { force_https: true })
+    assert_match %r{https://foreman.example.com:8080/unattended/built}, result
+  end
+
+  test 'should remove port 80 when converting to HTTPS' do
+    Setting[:unattended_url] = 'http://foreman.example.com:80'
+    result = render_snippet(host: @host, variables: { force_https: true })
+    assert_match %r{https://foreman.example.com/unattended/built}, result
+    assert_no_match(/:80/, result)
+  end
+end

--- a/test/unit/foreman_url_renderer_test.rb
+++ b/test/unit/foreman_url_renderer_test.rb
@@ -87,4 +87,48 @@ class ForemanURLRendererTest < ActiveSupport::TestCase
       assert_equal "www.example.com", renderer.foreman_request_addr
     end
   end
+
+  context '#force_url_https' do
+    test "should convert HTTP to HTTPS" do
+      url = "http://satellite.example.com/unattended/built?token=abc123"
+      expected = "https://satellite.example.com/unattended/built?token=abc123"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+
+    test "should remove port 80 when converting to HTTPS" do
+      url = "http://satellite.example.com:80/unattended/built?token=abc123"
+      expected = "https://satellite.example.com/unattended/built?token=abc123"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+
+    test "should preserve custom HTTP port when converting to HTTPS" do
+      url = "http://satellite.example.com:8080/unattended/built?token=abc123"
+      expected = "https://satellite.example.com:8080/unattended/built?token=abc123"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+
+    test "should not modify already HTTPS URL" do
+      url = "https://satellite.example.com/unattended/built?token=abc123"
+      expected = "https://satellite.example.com/unattended/built?token=abc123"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+
+    test "should preserve custom HTTPS port" do
+      url = "https://satellite.example.com:8443/unattended/built?token=abc123"
+      expected = "https://satellite.example.com:8443/unattended/built?token=abc123"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+
+    test "should handle URL with path" do
+      url = "http://satellite.example.com/some/path/built?token=abc123"
+      expected = "https://satellite.example.com/some/path/built?token=abc123"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+
+    test "should handle URL without query parameters" do
+      url = "http://satellite.example.com/unattended/built"
+      expected = "https://satellite.example.com/unattended/built"
+      assert_equal expected, renderer.force_url_https(url)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Fixes Global Registration failures when port 80 is blocked. The built endpoint now uses HTTPS during registration while traditional provisioning workflows remain unchanged.

## Changes
- Added `force_url_https` helper method to convert HTTP URLs to HTTPS
- Modified built snippet to accept `force_https` variable
- Global Registration passes `force_https: true` when calling built snippet
- Traditional provisioning continues using `Setting[:unattended_url]`

## Testing
Tested Global Registration with port 80 blocked - completes successfully over HTTPS.