### PR TITLE
Fixes #39133 - Switch puppet doc links to point to docs

### DIFF
--- a/app/views/common_parameters/index.html.erb
+++ b/app/views/common_parameters/index.html.erb
@@ -1,7 +1,7 @@
 <% title _("Global Parameters") %>
 
 <% title_actions new_link(_("Create Parameter")),
-                 documentation_button('4.2.3Parameters') %>
+                 documentation_button('Managing_Configurations_Puppet', type: 'docs', chapter: 'Configuring_Puppet_Smart_Class_Parameters_managing-configurations-puppet' ) %>
 
 
 <table class="<%= table_css_classes('table-hover table-fixed')%>">

--- a/app/views/fact_values/index.html.erb
+++ b/app/views/fact_values/index.html.erb
@@ -5,7 +5,7 @@ else
   title(_("Fact Values"))
 end
 %>
-<% title_actions csv_link, documentation_button('3.5.5FactsandtheENC') %>
+<% title_actions csv_link, documentation_button('Managing_Configurations_Puppet', type: 'docs', chapter: 'high-level-steps-for-configuration-management-with-puppet') %>
 
 <table class="<%= table_css_classes('table-fixed factsTable') %>">
   <thead>

--- a/app/views/fact_values/welcome.html.erb
+++ b/app/views/fact_values/welcome.html.erb
@@ -4,5 +4,5 @@
                                     :icon => 'list-alt',
                                     :header => _('Fact Values'),
                                     :description => description,
-                                    :documentation => { :url => documentation_url("3.5.5FactsandtheENC") },
+                                    :documentation => { :url => documentation_url('Managing_Configurations_Puppet', type: 'docs', chapter: 'high-level-steps-for-configuration-management-with-puppet') },
                                   }) %>


### PR DESCRIPTION
instead of the "old" manual


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
