### PR TITLE
Fixes #39209 - Drop superfluous includes 

### DIFF
--- a/app/services/authorizer.rb
+++ b/app/services/authorizer.rb
@@ -109,7 +109,8 @@ class Authorizer
       find_options = ScopedSearch::QueryBuilder.build_query(resource_class.scoped_search_definition, search_string, options)
 
       result[:where] << find_options[:conditions]
-      result[:includes].push(*find_options[:include])
+      includes = Array.wrap(find_options[:include]) - [:organizations, :locations]
+      result[:includes].push(*includes)
       result[:joins].push(*find_options[:joins])
     rescue ScopedSearch::QueryNotSupported => e
       Foreman::Logging.logger('permissions').error "Scoped search query not supported: #{e.message}"


### PR DESCRIPTION
The authorizer builds a query like where taxonomy scoping is done by subqueries. Including includes for taxonomies feels superfluous and in some places can lead to returning duplicate results.

Opening as a draft to see what the tests would say.