### PR TITLE
Fixes #39137 - TypeScript support for the frontend

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -96,7 +96,7 @@ const supportedLanguagesRE = new RegExp(
   `/(${supportedLanguages().join('|')})$`
 );
 
-const commonConfig = function(buildName = 'core') {
+const commonConfig = function(buildName = 'core', tsConfig = 'tsconfig.json') {
   var production =
     process.env.RAILS_ENV === 'production' ||
     process.env.NODE_ENV === 'production';
@@ -159,12 +159,41 @@ const commonConfig = function(buildName = 'core') {
           'node_modules/datatables.net/js/jquery.dataTables.js'
         ), // otherwise we get datatables.net-bs Cannot read properties of undefined (reading 'classes') since dataTables.mjs is a module.
       },
+      extensions: ['.ts', '.tsx', '.js', '.jsx'],
     },
     resolveLoader: {
       modules: [path.resolve(root, 'node_modules')],
     },
     module: {
       rules: [
+        {
+          test: /\.tsx?$/,
+          exclude: /node_modules(?!\/(@novnc|unidiff))/,
+          loader: 'ts-loader',
+          options: {
+            configFile: tsConfig,
+            ...(production && {
+              compilerOptions: {
+                moduleResolution: 'node',
+                baseUrl: '.',
+                paths: {
+                  '*': [
+                    '/usr/lib/node_modules/@types/*',
+                    '/usr/lib/node_modules/*',
+                    path.resolve(root, 'node_modules/@types/*'),
+                    path.resolve(root, 'node_modules/*')
+                  ]
+                },
+                types: [],
+                typeRoots: [],
+                skipLibCheck: true,
+                skipDefaultLibCheck: true,
+              },
+              transpileOnly: false,
+              onlyCompileBundledFiles: true,
+            })
+          },
+        },
         {
           test: /\.js$/,
           /* Include novnc, unidiff in webpack, transpiling is needed for phantomjs (which does not support ES6) to run tests
@@ -296,7 +325,14 @@ const coreConfig = function() {
 const pluginConfig = function(plugin) {
   const pluginRoot = plugin.root;
   const pluginName = plugin.name.replace('-', '_'); // module federation doesnt like -
-  var config = commonConfig(pluginName);
+  const tsConfigPath = path.join(pluginRoot, 'tsconfig.json')
+  let config;
+  if (fs.existsSync(tsConfigPath)) {
+    config = commonConfig(pluginName, tsConfigPath);
+  }
+  else {
+    config = commonConfig(pluginName);
+  }
   config.context = path.join(pluginRoot, 'webpack');
   config.entry = {};
 

--- a/lib/tasks/gettext.rake
+++ b/lib/tasks/gettext.rake
@@ -5,7 +5,7 @@ begin
   require "gettext_i18n_rails_js/task"
   require File.expand_path('../../lib/foreman/gettext/support.rb', __dir__)
 
-  FILE_GLOB = '{app,db/seeds.d,lib,config,locale,webpack}/**/*.{rb,erb,haml,slim,rhtml,js,rabl}'
+  FILE_GLOB = '{app,db/seeds.d,lib,config,locale,webpack}/**/*.{rb,erb,haml,slim,rhtml,js,ts,tsx,rabl}'
 
   namespace :gettext do
     # redefine locale path to be taken from current directory (for plugins)

--- a/package.json
+++ b/package.json
@@ -153,6 +153,8 @@
     "stylelint": "^9.3.0",
     "stylelint-config-standard": "^18.0.0",
     "tabbable": "^6.2.0",
+    "ts-loader": "^9.5.2",
+    "typescript": "^5.8.2",
     "webpack": "^5.75.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-cli": "^5.0.1",


### PR DESCRIPTION
This commit adapts the Webpack config to allow compilation of .ts/.tsx files by Webpack.

- Added packages:
  - typescript: 5.8.2
  - ts-loader: 9.5.2
- Use ts-loader to load .ts/.tsx files during webpack compilation
- Use plugin specific tsconfig.json file during compilation
- Override module resolution of tsconfig.json from webpack config

This is the accompanying Pull-Request to the [RFC](https://community.theforeman.org/t/rfc-opt-in-typescript-support-for-the-foreman-frontend-stack/45928) in the community forum.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
