### PR TITLE
Fixes #39142 - skip compute orchestration for unmanaged hosts

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -9,7 +9,7 @@ module Orchestration::Compute
     attr_accessor :compute_attributes, :vm
 
     after_validation :validate_compute_provisioning, :queue_compute
-    before_destroy :queue_compute_destroy
+    before_destroy :queue_compute_destro
   end
 
   def compute?
@@ -91,7 +91,7 @@ module Orchestration::Compute
   end
 
   def queue_compute_destroy
-    return unless managed? && errors.empty? && compute_resource_id.present? && uuid
+    return unless errors.empty? && compute_resource_id.present? && uuid
     queue.create(:name => _("Removing compute instance %s") % self, :priority => 100,
       :action => [self, :delCompute])
   end

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -9,7 +9,7 @@ module Orchestration::Compute
     attr_accessor :compute_attributes, :vm
 
     after_validation :validate_compute_provisioning, :queue_compute
-    before_destroy :queue_compute_destro
+    before_destroy :queue_compute_destroy
   end
 
   def compute?

--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -51,7 +51,7 @@ module Orchestration::Compute
   protected
 
   def queue_compute
-    return log_orchestration_errors unless compute? && errors.empty?
+    return log_orchestration_errors unless managed? && compute? && errors.empty?
     # Create a new VM if it doesn't already exist or update an existing vm
 
     update_or_create = vm_exists?
@@ -91,7 +91,7 @@ module Orchestration::Compute
   end
 
   def queue_compute_destroy
-    return unless errors.empty? && compute_resource_id.present? && uuid
+    return unless managed? && errors.empty? && compute_resource_id.present? && uuid
     queue.create(:name => _("Removing compute instance %s") % self, :priority => 100,
       :action => [self, :delCompute])
   end


### PR DESCRIPTION
Add managed? guards to setCompute and delCompute methods in orchestration/compute.rb. When registering existing hosts via Global Registration with a hostgroup that includes a Compute Resource, the host is created as unmanaged (managed: false) but compute orchestration tasks still run and fail.

Other methods in the same concern (setComputeIP, setComputeIPAM) already have this guard — setCompute and delCompute were missing it.

Redmine issue: https://projects.theforeman.org/issues/39142
Related plugin-side fix: https://github.com/theforeman/foreman_fog_proxmox/pull/456


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
