### PR TITLE
Fixes #39142 - skip compute orchestration for unmanaged hosts

### DIFF
--- a/app/models/concerns/orchestration/compute.rb
+++ b/app/models/concerns/orchestration/compute.rb
@@ -52,6 +52,10 @@ module Orchestration::Compute
 
   def queue_compute
     return log_orchestration_errors unless compute? && errors.empty?
+    unless managed?
+      logger.info('Skipping compute orchestration for %s - host is not managed' % name)
+      return
+    end
     # Create a new VM if it doesn't already exist or update an existing vm
 
     update_or_create = vm_exists?

--- a/test/models/orchestration/compute_test.rb
+++ b/test/models/orchestration/compute_test.rb
@@ -250,6 +250,29 @@ class ComputeOrchestrationTest < ActiveSupport::TestCase
     end
   end
 
+  describe 'unmanaged host on compute resource' do
+    let(:host) do
+      FactoryBot.build(:host,
+        :on_compute_resource,
+        :with_compute_profile,
+        :managed => false)
+    end
+
+    test 'should skip compute orchestration for unmanaged host' do
+      host.stubs(:vm_exists?).returns(false)
+      assert_valid host
+      tasks = host.queue.all.map(&:name)
+      assert_empty tasks
+    end
+
+    test 'should log info when skipping compute orchestration for unmanaged host' do
+      host.stubs(:vm_exists?).returns(false)
+      host.expects(:logger).at_least_once.returns(mock_logger = mock)
+      mock_logger.expects(:info).with("Skipping compute orchestration for %s - host is not managed" % host.name)
+      host.send(:queue_compute)
+    end
+  end
+
   describe 'setting eui-64 ip address based on mac provided by compute resource' do
     let(:tax_organization) { FactoryBot.create(:organization) }
     let(:tax_location) { FactoryBot.create(:location) }


### PR DESCRIPTION
When a host is registered via Global Registration (managed: false), the compute orchestration in `queue_compute` still runs, attempting to create/update a VM on the compute resource. This causes errors for hosts that are not meant to be managed by Foreman's compute layer.

This patch adds a `managed?` guard to `queue_compute` so that compute orchestration is skipped for unmanaged hosts.

The `queue_compute_destroy` method intentionally does NOT get this guard — VM cleanup should work for all hosts regardless of managed status, as confirmed by existing tests in `Host::ManagedTest::deletion`.

**Testing:**
- Register a host via Global Registration with a compute resource assigned
- - Verify that compute orchestration does not run for the unmanaged host
- - Verify that managed hosts still get compute orchestration as expected
- - Verify that VM deletion still works for all hosts