### PR TITLE
Fixes #39144 - Allow plugins to import core js test config

### DIFF
--- a/developer_docs/ui-testing-guidelines.asciidoc
+++ b/developer_docs/ui-testing-guidelines.asciidoc
@@ -91,3 +91,20 @@ For React Testing Library tests, you can use:
 * `jest.useFakeTimers();` in the setup, and then `await act(async () => jest.advanceTimersByTime(1000));` after a timed action has taken place (for example, popover closed).
 
 * For Capybara tests, you can use `wait_for_ajax`
+
+=== Plugin test configuration and setup
+Foreman core has two test setup files:
+
+* `webpack/global_test_setup.js` - This is the global test setup file that is used for all tests.
+* `webpack/core_test_setup.js` - This is the core test setup file that is used for all tests in Foreman core.
+
+In plugins, Foreman will look for a test setup file in the plugin's webpack directory:
+`plugin_name/webpack/test_setup.js`. If it exists, it will be used with the global test setup file.
+
+If a plugin wants to just use the core test setup, it can use the following import in the test setup file (`plugin_name/webpack/test_setup.js`):
+```js
+import 'foremanJSTestSetup';
+```
+
+For jest configuration, Foreman will look for a jest configuration file in the plugin's webpack directory: (`plugin_name/jest.config.js`).
+If it exists, it will be used with the global jest configuration file.

--- a/script/lint/@theforeman/eslint-plugin-foreman/index.js
+++ b/script/lint/@theforeman/eslint-plugin-foreman/index.js
@@ -8,13 +8,13 @@ module.exports = {
         'import/no-unresolved': [
           'error',
           {
-            ignore: ['foremanReact/.*'],
+            ignore: ['foremanReact/.*', '^foremanJSTestSetup$'],
           },
         ],
         'import/extensions': [
           'error',
           {
-            ignore: ['foremanReact/.*'],
+            ignore: ['foremanReact/.*', '^foremanJSTestSetup$'],
           },
         ],
       },

--- a/script/lint/@theforeman/eslint-plugin-foreman/lint_generic_config.js
+++ b/script/lint/@theforeman/eslint-plugin-foreman/lint_generic_config.js
@@ -50,13 +50,13 @@ module.exports = {
     'import/no-unresolved': [
       'error',
       {
-        ignore: ['foremanReact/.*', ...vendorEntry],
+        ignore: ['foremanReact/.*', '^foremanJSTestSetup$', ...vendorEntry],
       },
     ],
     'import/extensions': [
       'error',
       {
-        ignore: ['foremanReact/.*'],
+        ignore: ['foremanReact/.*', '^foremanJSTestSetup$'],
       },
     ],
     'import/no-extraneous-dependencies': [

--- a/script/lint/lint_core_config.js
+++ b/script/lint/lint_core_config.js
@@ -215,13 +215,13 @@ module.exports = {
     'import/no-unresolved': [
       'error',
       {
-        ignore: ['foremanReact/.*'],
+        ignore: ['foremanReact/.*', '^foremanJSTestSetup$'],
       },
     ],
     'import/extensions': [
       'error',
       {
-        ignore: ['foremanReact/.*'],
+        ignore: ['foremanReact/.*', '^foremanJSTestSetup$'],
       },
     ],
     '@theforeman/rules/require-ouiaid': 'error',

--- a/webpack/jest.config.js
+++ b/webpack/jest.config.js
@@ -60,6 +60,7 @@ module.exports = {
     '^react-dnd-test-backend$': `${nodeModules}/react-dnd-test-backend/dist/cjs`,
     '^react-dnd-test-utils$': `${nodeModules}/react-dnd-test-utils/dist/cjs`,
     '^foremanReact(.*)$': `${foremanReactFull}/$1`,
+    '^foremanJSTestSetup$': path.resolve(__dirname, 'core_test_setup.js'),
     '^@theforeman/test$': foremanTest,
     '^react-redux-test-utils$': foremanTest,
     '^victory(.*)$': `${nodeModules}/victory$1`,


### PR DESCRIPTION
We have the core test setup with mocks specific for core, since now plugins dont have to mock the core anymore, they can choose to use the core test setup or not.

The core test setup is in `foreman/webpack/core_test_setup.js`.

The global test setup is in `foreman/webpack/global_test_setup.js`.

The plugin test setup is in `plugin_name/webpack/test_setup.js`.

The plugin test setup can import the core test setup or not. and if it does, it will be used with the global test setup.
They can expand the core test setup by importing the core test setup in the plugin test setup. Or plugins can write their own.