### PR TITLE
Fixes #39147 - Fix the redirect issue with host links from Packages Details page

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -49,6 +49,10 @@ class HostsController < ApplicationController
     end
     respond_to do |format|
       format.html do
+        if Setting[:new_hosts_page]
+          redirect_to new_hosts_index_page_path(search: params[:search])
+          return
+        end
         @hosts = search.includes(included_associations).paginate(:page => params[:page], :per_page => params[:per_page])
         # SQL optimization
         preload_reports

--- a/test/controllers/hosts_controller_test.rb
+++ b/test/controllers/hosts_controller_test.rb
@@ -33,9 +33,22 @@ class HostsControllerTest < ActionController::TestCase
   end
 
   test "should get index" do
+    Setting[:new_hosts_page] = false
     get :index, session: set_session_user
     assert_response :success
     assert_template 'index'
+  end
+
+  test "should redirect index to new hosts page when new_hosts_page setting is enabled" do
+    Setting[:new_hosts_page] = true
+    get :index, session: set_session_user
+    assert_redirected_to new_hosts_index_page_path
+  end
+
+  test "should redirect index to new hosts page with search parameter" do
+    Setting[:new_hosts_page] = true
+    get :index, params: { :search => "name ~ foo" }, session: set_session_user
+    assert_redirected_to new_hosts_index_page_path(search: "name ~ foo")
   end
 
   test "should get csv index with data" do


### PR DESCRIPTION
`Hosts` page should open in either New UI or Legacy UI based on the setting `new_hosts_page`.

**Test steps**
- Navigate to: GUI → Content → Content Type → Packages
- Select the "Upgradable" checkbox.
- After the packages are listed, click on any listed package.
- Go to the Details tab.
- On "Upgradable For", click on a Host link.

**Before**
The Host page opens in the Legacy UI, even though the system default is set to New UI.

The same behavior occurs when clicking Host links under:
- Installed On
- Applicable To

**After**
All Host links should open in the New UI, respecting the default GUI setting.