### PR TITLE
Fixes #39160 - Deprecate RedirectCancelButton

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -248,7 +248,7 @@ module FormHelper
 
   def submit_or_cancel(f, overwrite = false, args = { })
     args[:cancel_path] ||= resource_path(controller_name)
-    cancel_btn = args[:react_cancel_button] ? react_cancel_button(args) : link_to(_("Cancel"), args[:cancel_path], :class => "btn btn-default")
+    cancel_btn = link_to(_("Cancel"), args[:cancel_path], :class => "btn btn-default")
     content_tag(:div, :class => "clearfix") do
       content_tag(:div, :class => "form-actions") do
         text    = overwrite ? _("Overwrite") : args.delete(:button_text) || _("Submit")
@@ -256,10 +256,6 @@ module FormHelper
         f.submit(text, options) + " " + cancel_btn
       end
     end
-  end
-
-  def react_cancel_button(args)
-    react_component('RedirectCancelButton', { :cancelPath => args[:cancel_path] })
   end
 
   def options_for_submit_or_cancel(f, overwrite, args)

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -4,5 +4,5 @@
   <%= text_f f, :hardware_model, :help_block => _("The class of CPU supplied in this machine. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -m") %>
   <%= text_f f, :vendor_class, :help_block => _("The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,") %>
   <%= textarea_f f, :info, :rows=> 7, :size => "col-md-8", :help_block => _("General useful description, for example this kind of hardware needs a special BIOS setup") %>
-  <%= submit_or_cancel(f, false, { :react_cancel_button => true }) %>
+  <%= submit_or_cancel(f, false) %>
 <% end %>

--- a/webpack/assets/javascripts/react_app/components/common/RedirectCancelButton/RedirectCancelButton.js
+++ b/webpack/assets/javascripts/react_app/components/common/RedirectCancelButton/RedirectCancelButton.js
@@ -1,16 +1,27 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button } from 'patternfly-react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import withReactRoutes from '../../../common/withReactRoutes';
 import { translate as __ } from '../../../common/I18n';
+import { deprecate } from '../../../common/DeprecationService';
 
-const RedirectCancelButton = props => (
-  <Link to={props.cancelPath}>
-    <Button>{__('Cancel')}</Button>
-  </Link>
-);
+const RedirectCancelButton = props => {
+  useEffect(() => {
+    deprecate(
+      'common/RedirectCancelButton',
+      'Button from @patternfly/react-core',
+      '3.21'
+    );
+  }, []);
+
+  return (
+    <Link to={props.cancelPath}>
+      <Button>{__('Cancel')}</Button>
+    </Link>
+  );
+};
 
 RedirectCancelButton.propTypes = {
   cancelPath: PropTypes.string,

--- a/webpack/assets/javascripts/react_app/components/common/RedirectCancelButton/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/RedirectCancelButton/index.js
@@ -1,1 +1,3 @@
-export { default } from './RedirectCancelButton';
+import RedirectCancelButton from './RedirectCancelButton';
+
+export default RedirectCancelButton;


### PR DESCRIPTION
added the deprecation msg, removed the only usage in models form and the form helper

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
