### PR TITLE
Fixes #39164 - Update PF3 components in PersonalAccessTokens with PF5 components

### DIFF
--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.js
@@ -1,28 +1,38 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { Alert } from 'patternfly-react';
-import { ClipboardCopy } from '@patternfly/react-core';
+import {
+  ClipboardCopy,
+  Alert,
+  AlertGroup,
+  AlertActionCloseButton,
+} from '@patternfly/react-core';
 import { translate as __ } from '../../../common/I18n';
 import './personalAccessToken.scss';
 
 const NewTokenInfo = ({ newPersonalAccessToken, onDismiss }) => (
   <Fragment>
     {newPersonalAccessToken && (
-      <Alert type="success" onDismiss={onDismiss}>
-        <strong>{__('Your New Personal Access Token')}</strong>
-        <ClipboardCopy
-          isReadOnly
-          hoverTip={__('Copy to clipboard')}
-          clickTip={__('Copied to clipboard')}
-          variant="inline-compact"
-          id="personal-token-clipboard"
+      <AlertGroup>
+        <Alert
+          variant="success"
+          ouiaId="new-token-info-alert"
+          actionClose={<AlertActionCloseButton onClose={onDismiss} />}
+          title={__('Your New Personal Access Token')}
         >
-          {newPersonalAccessToken}
-        </ClipboardCopy>
-        {__(
-          'Make sure to copy your new personal access token now. You won’t be able to see it again!'
-        )}
-      </Alert>
+          <ClipboardCopy
+            isReadOnly
+            hoverTip={__('Copy to clipboard')}
+            clickTip={__('Copied to clipboard')}
+            variant="inline-compact"
+            id="personal-token-clipboard"
+          >
+            {newPersonalAccessToken}
+          </ClipboardCopy>
+          {__(
+            'Make sure to copy your new personal access token now. You won’t be able to see it again!'
+          )}
+        </Alert>
+      </AlertGroup>
     )}
   </Fragment>
 );

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.test.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/NewPersonalAccessToken.test.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react';
+import { fireEvent, screen, render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import NewPersonalAccessToken from './NewPersonalAccessToken';
+
+describe('New personal access token', () => {
+
+  it('renders the success alert with the token value', async () => {
+    const onDismiss = jest.fn();
+    await act(async () => {
+      render(
+        <NewPersonalAccessToken
+          onDismiss={onDismiss}
+          newPersonalAccessToken="new-secret-token"
+        />
+      );
+    });
+
+    expect(
+      screen.getByText('Your New Personal Access Token')
+    ).toBeInTheDocument();
+    expect(screen.getByText('new-secret-token')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Make sure to copy your new personal access token now/
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('hides the alert after onDismiss clears the token', async () => {
+    const Harness = () => {
+      const [token, setToken] = useState('visible-token');
+      return (
+        <NewPersonalAccessToken
+          onDismiss={() => setToken(null)}
+          newPersonalAccessToken={token}
+        />
+      );
+    };
+
+    render(<Harness />);
+
+    expect(screen.getByText('visible-token')).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    });
+
+    expect(
+      screen.queryByText('Your New Personal Access Token')
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('visible-token')).not.toBeInTheDocument();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokensList/PersonalAccessToken.js
+++ b/webpack/assets/javascripts/react_app/components/users/PersonalAccessTokens/PersonalAccessTokensList/PersonalAccessToken.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button } from 'patternfly-react';
+import { Button } from '@patternfly/react-core';
 import RelativeDateTime from '../../../common/dates/RelativeDateTime';
 import { translate as __ } from '../../../../common/I18n';
 import { noop } from '../../../../common/helpers';
@@ -31,7 +31,10 @@ const PersonalAccessToken = ({
       {isActive && (
         <Button
           onClick={() => revokePersonalAccessToken(id)}
-          className="btn-sm btn-default"
+          size="sm"
+          variant="link"
+          isInline
+          ouiaId="revoke-personal-access-token-button"
         >
           {__('Revoke')}
         </Button>


### PR DESCRIPTION
PAT alert updated to PF5 style

<img width="1197" height="253" alt="image" src="https://github.com/user-attachments/assets/1ef5ea65-dbc5-42ea-afe8-e4cdb0677180" />

The revoke button also updated, using link style based on the design guide here https://v5-archive.patternfly.org/components/button/design-guidelines/#when-to-use