### PR TITLE
Fixes #39165 - Use host IP over FQDN for BMC connection target

### DIFF
--- a/app/services/proxy_api/bmc.rb
+++ b/app/services/proxy_api/bmc.rb
@@ -3,7 +3,7 @@ module ProxyAPI
     SUPPORTED_BOOT_DEVICES = %w[disk cdrom pxe bios]
 
     def initialize(args)
-      @target = args[:fqdn].presence || args[:host_ip] || '127.0.0.1'
+      @target = args[:host_ip].presence || args[:fqdn].presence || '127.0.0.1'
       @url = args[:url] + "/bmc"
       @provider = args[:bmc_provider]
       super args

--- a/test/services/proxy_api/bmc_test.rb
+++ b/test/services/proxy_api/bmc_test.rb
@@ -7,14 +7,14 @@ class ProxyAPI::BMCTest < ActiveSupport::TestCase
     @bmc_api = ProxyAPI::BMC.new(@options)
   end
 
-  test 'initialize should set target to fqdn if present' do
-    assert_equal 'bmc.example.com', @bmc_api.instance_variable_get(:@target)
+  test 'initialize should set target to host_ip if present' do
+    assert_equal '192.168.1.1', @bmc_api.instance_variable_get(:@target)
   end
 
-  test 'initialize should set target to host_ip if fqdn is not present' do
-    options = { url: @url, host_ip: '192.168.1.1' }
+  test 'initialize should set target to fqdn if host_ip is not present' do
+    options = { url: @url, fqdn: 'bmc.example.com' }
     bmc_api = ProxyAPI::BMC.new(options)
-    assert_equal '192.168.1.1', bmc_api.instance_variable_get(:@target)
+    assert_equal 'bmc.example.com', bmc_api.instance_variable_get(:@target)
   end
 
   test 'initialize should set target to 127.0.0.1 if fqdn and host_ip are not present' do
@@ -24,19 +24,19 @@ class ProxyAPI::BMCTest < ActiveSupport::TestCase
   end
 
   test 'power_on should call put with correct arguments' do
-    @bmc_api.expects(:put).with({ bmc_provider: 'Redfish', action: 'on' }, '/bmc.example.com/chassis/power/on').returns('fake response').once
+    @bmc_api.expects(:put).with({ bmc_provider: 'Redfish', action: 'on' }, '/192.168.1.1/chassis/power/on').returns('fake response').once
     @bmc_api.expects(:parse).with('fake response').returns({ 'result' => true })
     assert @bmc_api.power_on({})
   end
 
   test 'power_off should call put with correct arguments' do
-    @bmc_api.expects(:put).with({ bmc_provider: 'Redfish', action: 'off' }, '/bmc.example.com/chassis/power/off').returns('fake response').once
+    @bmc_api.expects(:put).with({ bmc_provider: 'Redfish', action: 'off' }, '/192.168.1.1/chassis/power/off').returns('fake response').once
     @bmc_api.expects(:parse).with('fake response').returns({ 'result' => true })
     assert @bmc_api.power_off({})
   end
 
   test 'power_status should call get with correct arguments' do
-    expected_path = '/bmc.example.com/chassis/power/status'
+    expected_path = '/192.168.1.1/chassis/power/status'
     expected_query = { bmc_provider: 'Redfish' }
     @bmc_api.expects(:get).with(expected_path, query: expected_query).returns('fake response')
     @bmc_api.expects(:parse).with('fake response').returns({ 'result' => 'on' })
@@ -44,7 +44,7 @@ class ProxyAPI::BMCTest < ActiveSupport::TestCase
   end
 
   test 'lan_ip should call get and return the result' do
-    expected_path = '/bmc.example.com/lan/ip'
+    expected_path = '/192.168.1.1/lan/ip'
     expected_query = { bmc_provider: 'Redfish' }
     @bmc_api.expects(:get).with(expected_path, query: expected_query).returns('fake response')
     @bmc_api.expects(:parse).with('fake response').returns({ 'result' => '192.168.1.100' })
@@ -54,7 +54,7 @@ class ProxyAPI::BMCTest < ActiveSupport::TestCase
   test 'boot_pxe should call boot with correct device' do
     args = { reboot: true }
     expected_args = { function: 'bootdevice', device: 'pxe', reboot: true, bmc_provider: 'Redfish' }
-    @bmc_api.expects(:put).with(expected_args, '/bmc.example.com/chassis/config/bootdevice/pxe').returns('{}')
+    @bmc_api.expects(:put).with(expected_args, '/192.168.1.1/chassis/config/bootdevice/pxe').returns('{}')
     @bmc_api.boot_pxe(args)
   end
 


### PR DESCRIPTION
Already merged fix of #38972 [1] could affect existing Foreman instance as discussed in [2]. That concern was pointed out, but there isn't enough debate on whether to deal with it.

Discussion with colleague concludes that priority of IP address & FQDN set by user via Foreman Web UI should be changed to **'IP address -> FQDN'** with following reason:

* If user specifies both IP address and FQDN, it's natural for IP address to take precedence. If user expects name resolution of FQDN through DNS, they may only specify FQDN. It's fair assumption that user expects IP address is used when user specifies IP address along with FQDN.


This patch deals with that concern through making IP address take precedence over FQDN if both configured in Foreman Web UI.

[1] https://github.com/theforeman/foreman/pull/10842
[2] https://github.com/theforeman/foreman/pull/10842#issuecomment-4003496506

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
