### PR TITLE
Fixes #39171 - Deprecate PF3-based common/SearchInput component

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/SearchInput/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/SearchInput/index.js
@@ -4,11 +4,17 @@ import { DebounceInput } from 'react-debounce-input';
 import { Icon, Button } from '@patternfly/react-core';
 import { SearchIcon, TimesIcon } from '@patternfly/react-icons';
 import { translate as __ } from '../../../../react_app/common/I18n';
+import { deprecate } from '../../../common/DeprecationService';
 import { noop } from '../../../common/helpers';
 import './searchInput.scss';
 
 class SearchInput extends React.Component {
   componentDidMount() {
+    deprecate(
+      'components/common/SearchInput',
+      'SearchInput from @patternfly/react-core or SearchBar from components/SearchBar or AutocompleteInput from components/common/AutocompleteInput',
+      '3.21'
+    );
     if (this.props.focus) {
       this.gainFocus();
     }


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
