### PR TITLE
Test pagination on role filters page

### DIFF
--- a/test/integration/role_js_test.rb
+++ b/test/integration/role_js_test.rb
@@ -1,7 +1,29 @@
 require 'integration_test_helper'
+require_relative '../test_helper'
 
 class RoleJSTest < IntegrationTestWithJavascript
   test "index page" do
     assert_index_page(roles_path, "Roles", "Create Role")
+  end
+
+  # BZ: 1277444
+  # Expected results: more than one page of filters can be displayed on the role filters page
+  test "filters page supports pagination" do
+    with_temporary_settings(entries_per_page: 1) do
+      role = FactoryBot.create(:role)
+      permissions = FactoryBot.create_list(:permission, 2, :host)
+      permissions.each do |permission|
+        FactoryBot.create(:filter, role: role, permissions: [permission], search: nil)
+      end
+
+      visit filters_path(role_id: role.id)
+      assert_breadcrumb_text("#{role.name} filters")
+
+      assert_selector('.tfm-pagination[data-total="2"][data-per-page="1"]')
+      assert_equal 1, all('table tbody tr').size
+
+      find('button[data-action="next"]').click
+      assert_equal 1, all('table tbody tr').size
+    end
   end
 end

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -11,6 +11,7 @@ require 'active_support_test_case_helper'
 require 'minitest/retry'
 require 'selenium/webdriver'
 require 'test_report_helper'
+require 'temporary_settings_test_helper'
 
 retry_count = (ENV['MINITEST_RETRY_COUNT'] || 3).to_i rescue 1
 Minitest::Retry.use!(retry_count: retry_count) if retry_count > 1
@@ -85,6 +86,7 @@ class ActionDispatch::IntegrationTest
   include Capybara::DSL
   include Capybara::Minitest::Assertions
   include ShowMeTheCookies
+  include TemporarySettingsTestHelper
 
   class << self
     alias_method :test, :it

--- a/test/temporary_settings_test_helper.rb
+++ b/test/temporary_settings_test_helper.rb
@@ -1,0 +1,12 @@
+module TemporarySettingsTestHelper
+  def with_temporary_settings(**kwargs)
+    old_settings = SETTINGS.dup
+    begin
+      SETTINGS.update(kwargs)
+
+      yield
+    ensure
+      SETTINGS.replace(old_settings)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ require 'webmock/minitest'
 require 'webmock'
 require 'robottelo/reporter/attributes'
 require 'test_report_helper'
+require 'temporary_settings_test_helper'
 
 # FactoryBot 5 changed the default to 'true'
 FactoryBot.use_parent_strategy = false
@@ -167,6 +168,7 @@ end
 class ActionController::TestCase
   extend Robottelo::Reporter::TestAttributes
   include ::BasicRestResponseTest
+  include TemporarySettingsTestHelper
   setup :setup_set_script_name, :set_api_user, :turn_off_login, :set_admin
 
   class << self
@@ -199,17 +201,6 @@ class ActionController::TestCase
     @request.env['HTTP_AUTHORIZATION'] = ActionController::HttpAuthentication::Basic.encode_credentials(login, password)
     @request.env['CONTENT_TYPE'] = 'application/json'
     @request.env['HTTP_ACCEPT'] = 'application/json'
-  end
-
-  def with_temporary_settings(**kwargs)
-    old_settings = SETTINGS.dup
-    begin
-      SETTINGS.update(kwargs)
-
-      yield
-    ensure
-      SETTINGS.replace(old_settings)
-    end
   end
 end
 


### PR DESCRIPTION
This test is currently located in robottelo, I would like to move it
here for efficiency reasons (32 minutes vs 1 minute execution time).
With the updated pagination setting it is sufficient to just create two
filters and verify that both are displayed.

Made with: Cursor

Please cherry-pick to 3.18-stable.