### PR TITLE
Fixes #39174 - Deprecate unused PF3 buttons

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/table/components/DeleteButton.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/components/DeleteButton.js
@@ -1,14 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'patternfly-react';
 import { translate as __ } from '../../../../common/I18n';
+import { deprecate } from '../../../../common/DeprecationService';
 
-const DeleteButton = ({ active, onClick }) =>
-  active ? (
+const DeleteButton = ({ active, onClick }) => {
+  useEffect(() => {
+    deprecate(
+      'table/components/DeleteButton',
+      'Button from @patternfly/react-core',
+      '3.21'
+    );
+  }, []);
+
+  return active ? (
     <Button bsStyle="default" onClick={onClick}>
       {__('Delete')}
     </Button>
   ) : null;
+};
 
 DeleteButton.propTypes = {
   active: PropTypes.bool,

--- a/webpack/assets/javascripts/react_app/components/common/table/formatters/deleteActionCellFormatter.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/formatters/deleteActionCellFormatter.js
@@ -1,8 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import DeleteButton from '../components/DeleteButton';
+import { deprecate } from '../../../../common/DeprecationService';
 
 export const deleteActionCellFormatter = onClick => (_, { rowData }) => {
   const { canDelete } = rowData;
+
+  useEffect(() => {
+    deprecate(
+      'table/formatters/deleteActionCellFormatter',
+      'Table Actions from @patternfly/react-core',
+      '3.21'
+    );
+  }, []);
 
   return <DeleteButton active={canDelete} onClick={() => onClick(rowData)} />;
 };

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/components/ExportButton/ExportButton.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/components/ExportButton/ExportButton.js
@@ -1,14 +1,25 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Button } from 'patternfly-react';
 import PropTypes from 'prop-types';
 import { translate as __ } from '../../../../../common/I18n';
 import { exportURL } from '../../../../../common/urlHelpers';
+import { deprecate } from '../../../../../common/DeprecationService';
 
-const ExportButton = ({ url, title, text }) => (
-  <Button className="export-csv" href={url} title={title}>
-    {text}
-  </Button>
-);
+const ExportButton = ({ url, title, text }) => {
+  useEffect(() => {
+    deprecate(
+      'PageLayout/components/ExportButton',
+      'Button from @patternfly/react-core',
+      '3.21'
+    );
+  }, []);
+
+  return (
+    <Button className="export-csv" href={url} title={title}>
+      {text}
+    </Button>
+  );
+};
 
 ExportButton.propTypes = {
   url: PropTypes.string,


### PR DESCRIPTION
Deprecation of unused PF3 buttons
- delete btn is used only in unused formatter
- export btn replaced in https://github.com/theforeman/foreman-tasks/pull/798