### PR TITLE
Fixes #39173 - Unlock a clone of report template

### DIFF
--- a/app/controllers/api/v2/report_templates_controller.rb
+++ b/app/controllers/api/v2/report_templates_controller.rb
@@ -99,6 +99,7 @@ module Api
 
         @report_template = original.dup
         @report_template.name = params[:report_template][:name]
+        @report_template.locked = false
         @report_template.cloned_from = original
 
         process_response @report_template.save

--- a/test/controllers/api/v2/provisioning_templates_controller_test.rb
+++ b/test/controllers/api/v2/provisioning_templates_controller_test.rb
@@ -118,7 +118,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
   end
 
   test 'should clone template' do
-    original_provisioning_template = templates(:pxekickstart)
+    original_provisioning_template = templates(:locked)
     post :clone, params: { :id => original_provisioning_template.to_param,
                            :provisioning_template => {:name => 'MyClone'} }
     assert_response :success
@@ -126,6 +126,7 @@ class Api::V2::ProvisioningTemplatesControllerTest < ActionController::TestCase
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_provisioning_template.template)
     assert_equal(template['cloned_from_id'], original_provisioning_template.id)
+    assert_equal(template['locked'], false)
   end
 
   test 'clone name should not be blank' do

--- a/test/controllers/api/v2/report_templates_controller_test.rb
+++ b/test/controllers/api/v2/report_templates_controller_test.rb
@@ -165,7 +165,7 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
   end
 
   test 'should clone template' do
-    original_report_template = FactoryBot.create(:report_template)
+    original_report_template = FactoryBot.create(:report_template, :locked => true)
     post :clone, params: { :id => original_report_template.to_param,
                            :report_template => {:name => 'MyClone'} }
     assert_response :success
@@ -173,6 +173,7 @@ class Api::V2::ReportTemplatesControllerTest < ActionController::TestCase
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_report_template.template)
     assert_equal(template['cloned_from_id'], original_report_template.id)
+    assert_equal(template['locked'], false)
     refute_equal(template['id'], original_report_template.id)
   end
 


### PR DESCRIPTION
Fix for report templates, a cloned report template should be unlocked even though the original was locked.
Add tests for {provisioning,report} templates that locked template's clone is unlocked after being cloned.