### PR TITLE
Fixes #39176 - Allow cloning of partition tables

### DIFF
--- a/app/controllers/api/v2/ptables_controller.rb
+++ b/app/controllers/api/v2/ptables_controller.rb
@@ -99,9 +99,16 @@ module Api
       param_group :ptable_clone, :as => :create
 
       def clone
-        @ptable = @ptable.clone
-        load_vars_from_ptable
+        original = @ptable
+        @ptable = original.dup
+        @ptable.cloned_from = original
+        @ptable.organizations = original.organizations
+        @ptable.locations = original.locations
+        @ptable.operatingsystems = original.operatingsystems
         @ptable.name = params[:ptable][:name]
+        @ptable.vendor = '' # for consistency with WebUI which sets vendor field to blank
+        @ptable.locked = false
+
         process_response @ptable.save
       end
 
@@ -112,14 +119,6 @@ module Api
       end
 
       private
-
-      def load_vars_from_ptable
-        return unless @ptable
-
-        @locations        = @ptable.locations
-        @organizations    = @ptable.organizations
-        @operatingsystems = @ptable.operatingsystems
-      end
 
       def allowed_nested_id
         %w(operatingsystem_id)

--- a/test/controllers/api/v2/ptables_controller_test.rb
+++ b/test/controllers/api/v2/ptables_controller_test.rb
@@ -217,13 +217,16 @@ class Api::V2::PtablesControllerTest < ActionController::TestCase
   end
 
   test 'should clone template' do
-    original_ptable = FactoryBot.create(:ptable)
+    original_ptable = FactoryBot.create(:ptable, :locked => true)
     post :clone, params: { :id => original_ptable.to_param,
                            :ptable => {:name => 'MyClone'} }
     assert_response :success
     template = ActiveSupport::JSON.decode(@response.body)
     assert_equal(template['name'], 'MyClone')
     assert_equal(template['template'], original_ptable.template)
+    refute_equal(template['id'], original_ptable.id, 'Clone ID different from original')
+    assert_equal(template['cloned_from_id'], original_ptable.id)
+    assert_equal(template['locked'], false)
   end
 
   test 'export should export the erb of the template' do


### PR DESCRIPTION
It was impossible to clone a locked ptable. That doesn't make sense
because a template being locked is one of the primary reasons to clone.
A cloned report template should be unlocked even though the original
was locked, that is the correct behaviour
and will make the saving possible.
Additionally, cloning using 'clone' keeps the ID so instead of creating
new, the original was overwritten. Fix that by using dup instead.