### PR TITLE
Fixes #39181 - Add "Manage notifications" bulk action

### DIFF
--- a/app/controllers/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/api/v2/hosts_bulk_actions_controller.rb
@@ -5,7 +5,7 @@ module Api
       include Api::V2::BulkHostsExtension
 
       before_action :find_deletable_hosts, :only => [:bulk_destroy]
-      before_action :find_editable_hosts, :only => [:build, :reassign_hostgroup, :change_owner, :disassociate, :change_power_state]
+      before_action :find_editable_hosts, :only => [:build, :reassign_hostgroup, :change_owner, :disassociate, :change_power_state, :manage_notifications]
       before_action :validate_power_action, :only => [:change_power_state]
 
       def_param_group :bulk_host_ids do
@@ -173,11 +173,35 @@ module Api
         end
       end
 
+      api :PUT, "/hosts/bulk/manage_notifications", N_("Manage notifications")
+      param_group :bulk_host_ids
+      param :enabled, :bool, :required => true, :desc => N_("Whether to enable or disable notification alerts for the selected hosts")
+      def manage_notifications
+        enabled = Foreman::Cast.to_bool(params[:enabled])
+        # Load hosts into an array so .length is not affected by the update
+        hosts = @hosts.to_a
+        missed_hosts = hosts.reject { |host| host.update(enabled: enabled) }
+        action = enabled ? _("enabled") : _("disabled")
+
+        if missed_hosts.empty?
+          process_response(true, { :message => n_("Notifications %{action} for %{count} host",
+            "Notifications %{action} for %{count} hosts",
+            hosts.length) % { action: action, count: hosts.length } })
+        else
+          render_error(:bulk_hosts_error, :status => :unprocessable_entity,
+                       :locals => { :message => n_("Failed to update notifications for %s host",
+                         "Failed to update notifications for %s hosts",
+                         missed_hosts.count) % missed_hosts.count,
+                                    :failed_host_ids => missed_hosts.map(&:id),
+                                  })
+        end
+      end
+
       protected
 
       def action_permission
         case params[:action]
-        when 'build', 'change_power_state'
+        when 'build', 'change_power_state', 'manage_notifications'
           'edit'
         else
           super

--- a/app/views/hosts/_form.html.erb
+++ b/app/views/hosts/_form.html.erb
@@ -127,7 +127,8 @@
           @host.owner_suggestion.id_and_type), { :include_blank => _("Select an owner") }, { :label => _("Owned By") }
         %>
         <%= checkbox_f f, :enabled,
-          :help_inline => _("Include this host within Foreman reporting")
+          :label => _("Notifications enabled"),
+          :help_inline => _("Send email notifications when configuration errors are reported")
         %>
         <div id='model_name'>
           <%= select_f f, :model_id, accessible_resource(@host, :model), :id, :to_label, { :include_blank => true }, {:label => _("Hardware Model")} unless @host.compute_resource_id%>

--- a/config/initializers/f_foreman_permissions.rb
+++ b/config/initializers/f_foreman_permissions.rb
@@ -271,7 +271,7 @@ Foreman::AccessControl.map do |permission_set|
                                     :"api/v2/hosts" => [:update, :disassociate, :forget_status],
                                     :"api/v2/interfaces" => [:create, :update, :destroy],
                                     :"api/v2/compute_resources" => [:associate],
-                                    :"api/v2/hosts_bulk_actions" => [:assign_organization, :assign_location, :build, :reassign_hostgroup, :change_owner, :disassociate, :change_power_state],
+                                    :"api/v2/hosts_bulk_actions" => [:assign_organization, :assign_location, :build, :reassign_hostgroup, :change_owner, :disassociate, :change_power_state, :manage_notifications],
                                   }
     map.permission :destroy_hosts, {:hosts => [:destroy, :multiple_actions, :reset_multiple, :multiple_destroy, :submit_multiple_destroy],
                                     :"api/v2/hosts" => [:destroy],

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -11,6 +11,7 @@ Foreman::Application.routes.draw do
       put 'hosts/bulk/change_power_state', :to => 'hosts_bulk_actions#change_power_state'
       put 'hosts/bulk/disassociate', :to => 'hosts_bulk_actions#disassociate'
       match 'hosts/bulk/reassign_hostgroup', :to => 'hosts_bulk_actions#reassign_hostgroup', :via => [:put]
+      put 'hosts/bulk/manage_notifications', :to => 'hosts_bulk_actions#manage_notifications'
 
       resources :architectures, :except => [:new, :edit] do
         constraints(:id => /[^\/]+/) do

--- a/script/lint/lint_core_config.js
+++ b/script/lint/lint_core_config.js
@@ -57,6 +57,7 @@ module.exports = {
           'dropdowns',
           'dsmorse',
           'ec2',
+          'enablement',
           'erb',
           'fieldset',
           'fnc',

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -189,6 +189,47 @@ class Api::V2::HostsBulkActionsControllerTest < ActionController::TestCase
     end
   end
 
+  context "manage_notifications" do
+    test "should enable notifications for all hosts" do
+      @hosts = [@host1, @host2, @host3]
+      @hosts.each { |host| host.update_attribute(:enabled, false) }
+
+      put :manage_notifications, params: valid_bulk_params.merge(:enabled => true)
+
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_match(/Notifications enabled for 3 hosts/, body['message'])
+
+      @hosts.each do |host|
+        host.reload
+        assert host.enabled?, "Expected #{host.name} to be enabled"
+      end
+    end
+
+    test "should disable notifications for all hosts" do
+      put :manage_notifications, params: valid_bulk_params.merge(:enabled => false)
+
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_match(/Notifications disabled for 3 hosts/, body['message'])
+
+      [@host1, @host2, @host3].each do |host|
+        host.reload
+        refute host.enabled?, "Expected #{host.name} to be disabled"
+      end
+    end
+
+    test "should handle single host notification change" do
+      single_host_params = valid_bulk_params([@host1.id])
+
+      put :manage_notifications, params: single_host_params.merge(:enabled => true)
+
+      assert_response :success
+      body = ActiveSupport::JSON.decode(@response.body)
+      assert_match(/Notifications enabled for 1 host/, body['message'])
+    end
+  end
+
   private
 
   def set_session_user

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/BulkManageNotificationsModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/BulkManageNotificationsModal.js
@@ -1,0 +1,184 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import {
+  Modal,
+  ModalVariant,
+  Button,
+  TextContent,
+  Text,
+  FormGroup,
+  ToggleGroup,
+  ToggleGroupItem,
+} from '@patternfly/react-core';
+import { FormattedMessage } from 'react-intl';
+import { translate as __ } from '../../../../common/I18n';
+import { bulkManageNotifications } from './actions';
+import { BULK_MANAGE_NOTIFICATIONS_KEY } from './constants';
+import { failedHostsToastParams } from '../helpers';
+import { addToast } from '../../../ToastsList/slice';
+
+const BulkManageNotificationsModal = ({
+  selectedCount,
+  fetchBulkParams,
+  isOpen,
+  closeModal,
+  onSuccess: onSuccessCallback,
+}) => {
+  const [notificationsEnabled, setNotificationsEnabled] = useState(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const dispatch = useDispatch();
+
+  const handleModalClose = () => {
+    setNotificationsEnabled(null);
+    setIsLoading(false);
+    closeModal();
+  };
+
+  const handleSuccess = response => {
+    dispatch(
+      addToast({
+        type: 'success',
+        message: response.data.message,
+      })
+    );
+    // Refresh the hosts table while preserving the current search query
+    if (onSuccessCallback) onSuccessCallback();
+    handleModalClose();
+  };
+
+  const handleError = error => {
+    const apiError = error?.response?.data?.error;
+    if (apiError) {
+      dispatch(
+        addToast(
+          failedHostsToastParams({
+            ...apiError,
+            key: BULK_MANAGE_NOTIFICATIONS_KEY,
+          })
+        )
+      );
+    }
+    handleModalClose();
+  };
+
+  const handleSubmit = () => {
+    setIsLoading(true);
+    const payload = {
+      included: {
+        search: fetchBulkParams(),
+      },
+      enabled: notificationsEnabled,
+    };
+    dispatch(bulkManageNotifications(payload, handleSuccess, handleError));
+  };
+
+  return (
+    <Modal
+      variant={ModalVariant.small}
+      title={__('Manage notifications')}
+      isOpen={isOpen}
+      onClose={handleModalClose}
+      ouiaId="bulk-manage-notifications-modal"
+      aria-labelledby="manage-notifications-modal"
+      actions={[
+        <Button
+          key="confirm"
+          variant="primary"
+          onClick={handleSubmit}
+          isDisabled={isLoading || notificationsEnabled === null}
+          isLoading={isLoading}
+          spinnerAriaLabel={__('Loading')}
+          ouiaId="bulk-manage-notifications-confirm"
+        >
+          {__('Confirm')}
+        </Button>,
+        <Button
+          key="cancel"
+          variant="link"
+          onClick={handleModalClose}
+          isDisabled={isLoading}
+          ouiaId="bulk-manage-notifications-cancel"
+        >
+          {__('Cancel')}
+        </Button>,
+      ]}
+    >
+      <TextContent className="pf-v5-u-mb-md">
+        <Text
+          component="p"
+          className="pf-v5-u-font-size-md"
+          ouiaId="manage-notifications-hosts-count"
+        >
+          <FormattedMessage
+            id="bulk-manage-notifications-description"
+            defaultMessage="Enable or disable email notification alerts for {boldCount} selected {count, plural, one {host} other {hosts}}."
+            values={{
+              count: selectedCount,
+              boldCount: <strong>{selectedCount}</strong>,
+            }}
+          />
+        </Text>
+        <Text
+          component="small"
+          className="pf-v5-u-color-200 pf-v5-u-font-size-sm"
+          ouiaId="manage-notifications-explanation"
+        >
+          {__(
+            'Notifications are sent when a host reports a configuration error via Puppet, Ansible, or another configuration management tool.'
+          )}
+        </Text>
+        <Text
+          component="small"
+          className="pf-v5-u-color-200 pf-v5-u-font-size-sm"
+          ouiaId="manage-notifications-enablement-state-notice"
+        >
+          {__('Enablement state of the selected hosts may vary.')}
+        </Text>
+      </TextContent>
+      <FormGroup fieldId="manage-notifications-toggle">
+        <ToggleGroup aria-label={__('Notification state')}>
+          <ToggleGroupItem
+            text={__('Enable')}
+            buttonId="manage-notifications-enable"
+            isSelected={notificationsEnabled === true}
+            onChange={() =>
+              setNotificationsEnabled(
+                notificationsEnabled === true ? null : true
+              )
+            }
+            isDisabled={isLoading}
+          />
+          <ToggleGroupItem
+            text={__('Disable')}
+            buttonId="manage-notifications-disable"
+            isSelected={notificationsEnabled === false}
+            onChange={() =>
+              setNotificationsEnabled(
+                notificationsEnabled === false ? null : false
+              )
+            }
+            isDisabled={isLoading}
+          />
+        </ToggleGroup>
+      </FormGroup>
+    </Modal>
+  );
+};
+
+BulkManageNotificationsModal.propTypes = {
+  selectedCount: PropTypes.number,
+  fetchBulkParams: PropTypes.func.isRequired,
+  isOpen: PropTypes.bool,
+  closeModal: PropTypes.func,
+  onSuccess: PropTypes.func,
+};
+
+BulkManageNotificationsModal.defaultProps = {
+  selectedCount: 0,
+  isOpen: false,
+  closeModal: () => {},
+  onSuccess: undefined,
+};
+
+export default BulkManageNotificationsModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/BulkManageNotificationsModal.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/BulkManageNotificationsModal.test.js
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Provider } from 'react-redux';
+import { IntlProvider } from 'react-intl';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import BulkManageNotificationsModal from './BulkManageNotificationsModal';
+
+jest.mock('../../../../common/I18n');
+
+const mockStore = configureMockStore([thunk]);
+const store = mockStore({ API: {} });
+
+const defaultProps = {
+  selectedCount: 5,
+  fetchBulkParams: jest.fn(() => 'id ^ (1,2,3,4,5)'),
+  isOpen: true,
+  closeModal: jest.fn(),
+};
+
+const renderModal = (props = {}) =>
+  render(
+    <IntlProvider locale="en">
+      <Provider store={store}>
+        <BulkManageNotificationsModal {...defaultProps} {...props} />
+      </Provider>
+    </IntlProvider>
+  );
+
+describe('BulkManageNotificationsModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store.clearActions();
+  });
+
+  it('renders modal with title and toggle group', () => {
+    renderModal();
+    expect(screen.getByText('Manage notifications')).toBeInTheDocument();
+    expect(screen.getByText('Enable')).toBeInTheDocument();
+    expect(screen.getByText('Disable')).toBeInTheDocument();
+  });
+
+  it('displays host count in description', () => {
+    renderModal();
+    const description = document.querySelector('[data-ouia-component-id="manage-notifications-hosts-count"]');
+    expect(description).toBeInTheDocument();
+    expect(description.textContent).toBe('Enable or disable email notification alerts for 5 selected hosts.');
+  });
+
+  it('uses singular form for single host', () => {
+    renderModal({ selectedCount: 1 });
+    const description = document.querySelector('[data-ouia-component-id="manage-notifications-hosts-count"]');
+    expect(description).toBeInTheDocument();
+    expect(description.textContent).toBe('Enable or disable email notification alerts for 1 selected host.');
+  });
+
+  it('has Confirm disabled by default until a selection is made', () => {
+    renderModal();
+    const confirmBtn = screen.getByText('Confirm').closest('button');
+    expect(confirmBtn).toBeDisabled();
+
+    fireEvent.click(screen.getByText('Enable'));
+    expect(confirmBtn).not.toBeDisabled();
+  });
+
+  it('calls closeModal on Cancel', () => {
+    const closeModal = jest.fn();
+    renderModal({ closeModal });
+
+    fireEvent.click(screen.getByText('Cancel'));
+    expect(closeModal).toHaveBeenCalled();
+  });
+
+  it('dispatches action on Confirm', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByText('Enable'));
+    fireEvent.click(screen.getByText('Confirm'));
+    const actions = store.getActions();
+    expect(actions.length).toBeGreaterThan(0);
+  });
+
+  it('does not render when isOpen is false', () => {
+    renderModal({ isOpen: false });
+    expect(screen.queryByText('Manage notifications')).not.toBeInTheDocument();
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/actions.js
@@ -1,0 +1,15 @@
+import { APIActions } from '../../../../redux/API';
+import { foremanUrl } from '../../../../common/helpers';
+import {
+  BULK_MANAGE_NOTIFICATIONS_KEY,
+  BULK_MANAGE_NOTIFICATIONS_URL,
+} from './constants';
+
+export const bulkManageNotifications = (params, handleSuccess, handleError) =>
+  APIActions.put({
+    key: BULK_MANAGE_NOTIFICATIONS_KEY,
+    url: foremanUrl(BULK_MANAGE_NOTIFICATIONS_URL),
+    handleSuccess,
+    handleError,
+    params,
+  });

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/constants.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/constants.js
@@ -1,0 +1,3 @@
+export const BULK_MANAGE_NOTIFICATIONS_KEY = 'BULK_MANAGE_NOTIFICATIONS';
+export const BULK_MANAGE_NOTIFICATIONS_URL =
+  '/api/v2/hosts/bulk/manage_notifications';

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/manageNotifications/index.js
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { ForemanActionsBarContext } from '../../../../components/HostDetails/ActionsBar';
+import BulkManageNotificationsModal from './BulkManageNotificationsModal';
+
+const BulkManageNotificationsModalScene = ({
+  isOpen,
+  closeModal,
+  onSuccess,
+}) => {
+  const { fetchBulkParams, selectedCount = 0 } = useContext(
+    ForemanActionsBarContext
+  );
+  return (
+    <BulkManageNotificationsModal
+      selectedCount={selectedCount}
+      fetchBulkParams={fetchBulkParams}
+      isOpen={isOpen}
+      closeModal={closeModal}
+      onSuccess={onSuccess}
+    />
+  );
+};
+
+export default BulkManageNotificationsModalScene;
+
+BulkManageNotificationsModalScene.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func,
+};
+
+BulkManageNotificationsModalScene.defaultProps = {
+  onSuccess: undefined,
+};

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -56,6 +56,7 @@ import BulkReassignHostgroupModal from './BulkActions/reassignHostGroup';
 import BulkChangeOwnerModal from './BulkActions/changeOwner';
 import BulkDisassociateModal from './BulkActions/disassociate';
 import BulkPowerStateModal from './BulkActions/powerState/index';
+import BulkManageNotificationsModal from './BulkActions/manageNotifications';
 import { foremanUrl } from '../../common/helpers';
 import Slot from '../common/Slot';
 import forceSingleton from '../../common/forceSingleton';
@@ -230,6 +231,7 @@ const HostsIndex = () => {
   const [changeOwnerModalOpen, setChangeOwnerModalOpen] = useState(false);
   const [disassociateModalOpen, setDisassociateModalOpen] = useState(false);
   const [powerStateModalOpen, setPowerStateModalOpen] = useState(false);
+  const [notificationsModalOpen, setNotificationsModalOpen] = useState(false);
 
   const dropdownItems = [
     <MenuItem
@@ -255,6 +257,14 @@ const HostsIndex = () => {
       isDisabled={selectedCount === 0}
     >
       {__('Change power state')}
+    </MenuItem>,
+    <MenuItem
+      itemId="manage-notifications-dropdown-item"
+      key="manage-notifications-dropdown-item"
+      onClick={() => setNotificationsModalOpen(true)}
+      isDisabled={selectedCount === 0}
+    >
+      {__('Manage notifications')}
     </MenuItem>,
     <MenuItem
       itemId="host-association-dropdown-item"
@@ -594,6 +604,18 @@ const HostsIndex = () => {
             key="bulk-disassociate-modal"
             isOpen={disassociateModalOpen}
             closeModal={() => setDisassociateModalOpen(false)}
+          />
+          <BulkManageNotificationsModal
+            key="bulk-manage-notifications-modal"
+            isOpen={notificationsModalOpen}
+            closeModal={() => setNotificationsModalOpen(false)}
+            // Re-fetch hosts with the current search so the table stays in sync
+            onSuccess={() =>
+              setAPIOptions({
+                ...apiOptions,
+                params: { search: urlSearchQuery },
+              })
+            }
           />
           <Slot id="_all-hosts-modals" multi />
         </ForemanActionsBarContext.Provider>


### PR DESCRIPTION
## Summary
  - Adds a `Manage notifications` bulk action to the All Hosts page
  - New API endpoint `PUT /api/v2/hosts/bulk/manage_notifications` to enable/disable host notifications in bulk
  - React modal with toggle switch, integrated into the hosts page kebab menu

## Backend
  - New route `PUT /api/v2/hosts/bulk/manage_notifications` mapped to `HostsBulkActionsController#manage_notifications`
  - Uses existing `find_editable_hosts` before_action for permission checks (`edit_hosts` permission required)
  - Updates `enabled` attribute on each selected host, returns success/failure message with host count
  - Handles partial failures by reporting which hosts failed to update
  - Supports pluralized and translatable response messages via `n_()` and `N_()`
  - Apipie documentation and `action_permission` mapping included

## Frontend
  - PatternFly modal (`ModalVariant.small`) with a `Switch` toggle for enabling/disabling notifications
  - Uses `FormattedMessage` from react-intl for proper singular/plural host count display
  - Includes notice that enablement state of selected hosts may vary
  - Redux action using Foreman's `APIActions.put` with success toast and error handling via `failedHostsToastParams`
  - On success, refreshes the hosts table via an `onSuccess` callback from `HostsIndex` that preserves the current search query
  - Scene wrapper reads `selectedCount` and `fetchBulkParams` from `ForemanActionsBarContext`
  - Wired into HostsIndex bulk actions dropdown as a `MenuItem`, disabled when no hosts are selected

## Tests
  - 3 Ruby controller tests (enable, disable, singular message)
  - 7 Jest component tests (rendering, toggle, submit, cancel, singular/plural)

 ## Test plan
  - [ ] Select multiple hosts → Manage notifications → toggle Enabled → Confirm → green toast
  - [ ] Repeat with Disabled → toast says "disabled"
  - [ ] Single host → modal says "1 selected host" (singular)
  - [ ] No hosts selected → menu item is greyed out
  - [ ] Cancel/X/Escape closes modal without changes
  - [ ] Row kebab actions remain enabled after confirming
  - [ ] With a search filter active, confirm the table refreshes without losing the filter
 
 ## Additional notes
<img width="1913" height="601" alt="image" src="https://github.com/user-attachments/assets/4f1402d4-ed73-4478-bbe1-2d40fc697029" />
<img width="561" height="287" alt="image" src="https://github.com/user-attachments/assets/cdfca7ce-b4bc-4ee9-bf5e-ca27a13f5acd" />
<img width="561" height="287" alt="image" src="https://github.com/user-attachments/assets/950a5df9-51bc-4a2e-a57d-ad260f0ca9e7" />

I have performed all the testing steps locally, and I have also been continuously checking that the database entries are changing upon UI action using the Rails console.
Welcoming all the suggestions from everyone, as this is my first foreman PR.:)