### PR TITLE
Fixes #39190 - backport CVE-2026-33176 fix for Rails 7.0

### DIFF
--- a/config/initializers/cve_2026_33176.rb
+++ b/config/initializers/cve_2026_33176.rb
@@ -1,0 +1,31 @@
+# Backport fix for CVE-2026-33176: Active Support DoS via large scientific notation strings
+#
+# BigDecimal accepts scientific notation (e.g. '1e10000'), which expands into
+# extremely large decimal representations causing excessive memory allocation
+# and CPU consumption when formatted by number helpers.
+#
+# Rails 7.0 is no longer maintained upstream. This backports the fix from Rails 7.2+.
+#
+# Upstream commit: https://github.com/rails/rails/commit/ebd6be18120d1136511eb516338e27af25ac0a1a
+# Advisory: https://github.com/rails/rails/security/advisories/GHSA-2j26-frm8-cmj9
+
+require 'active_support/number_helper/number_converter'
+
+module ActiveSupport
+  module NumberHelper
+    class NumberConverter
+      private
+
+      def valid_bigdecimal
+        case number
+        when Float, Rational
+          number.to_d(0)
+        when String
+          BigDecimal(number, exception: false) unless number.to_s.match?(/[de]/i)
+        else
+          number.to_d rescue nil
+        end
+      end
+    end
+  end
+end

--- a/test/unit/cve_2026_33176_test.rb
+++ b/test/unit/cve_2026_33176_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class CVE202633176Test < ActiveSupport::TestCase
+  # CVE-2026-33176: Active Support DoS via large scientific notation strings
+  # Verify that number helpers reject scientific notation strings instead of
+  # expanding them into huge BigDecimal values.
+
+  test 'number_to_currency rejects scientific notation string' do
+    result = ActiveSupport::NumberHelper.number_to_currency('1e10000')
+    assert_equal '$1e10000', result
+  end
+
+  test 'number_to_percentage rejects scientific notation string' do
+    result = ActiveSupport::NumberHelper.number_to_percentage('1e10000')
+    assert_equal '1e10000%', result
+  end
+
+  test 'number_to_currency handles normal numeric strings' do
+    result = ActiveSupport::NumberHelper.number_to_currency('1234.56')
+    assert_equal '$1,234.56', result
+  end
+
+  test 'number_to_currency handles strings with d as scientific notation' do
+    result = ActiveSupport::NumberHelper.number_to_currency('123481223d98989')
+    assert_equal '$123481223d98989', result
+  end
+
+  test 'number_to_currency handles negative scientific notation string' do
+    result = ActiveSupport::NumberHelper.number_to_currency('-888E89789')
+    assert_equal '-$888E89789', result
+  end
+end


### PR DESCRIPTION
## Summary

Backport of the upstream security fix for [CVE-2026-33176](https://github.com/rails/rails/security/advisories/GHSA-2j26-frm8-cmj9) (Active Support DoS via large scientific notation strings).

**Redmine:** https://projects.theforeman.org/issues/39190

ActiveSupport number helpers accept strings containing scientific notation (e.g. `1e10000`), which BigDecimal expands into extremely large decimal representations. This causes excessive memory allocation and CPU consumption, resulting in a potential DoS vulnerability.

Since Rails 7.0 is no longer maintained upstream, this patch monkey-patches `NumberConverter#valid_bigdecimal` via an initializer to reject strings containing scientific notation characters (`d`/`e`), matching the [upstream fix in Rails 7.2+](https://github.com/rails/rails/commit/ebd6be18120d1136511eb516338e27af25ac0a1a).

## Changes

- `config/initializers/cve_2026_33176.rb` - override `valid_bigdecimal` to skip `BigDecimal` conversion for strings matching `/[de]/i`
- `test/unit/cve_2026_33176_test.rb` - tests verifying scientific notation strings are returned unchanged by number helpers

## Test plan

- Verify that `number_to_currency("1e10000")` returns the string as-is instead of attempting to expand it
- Verify that normal numeric strings still work correctly
- Run full test suite to ensure no regressions