### PR TITLE
Fixes #39159 - strip CIDR prefix from subnet network address

### DIFF
--- a/app/models/subnet.rb
+++ b/app/models/subnet.rb
@@ -390,7 +390,15 @@ class Subnet < ApplicationRecord
       val = send(f)
       send("#{f}=", normalize_ip(val)) if val.present?
     end
+    strip_network_cidr
     self
+  end
+
+  def strip_network_cidr
+    return unless network.present? && network.include?('/')
+    parts = network.split('/')
+    self.network = parts[0]
+    self.cidr = parts[1].to_i if mask.blank? || cidr.nil?
   end
 
   def ensure_ip_addrs_valid

--- a/test/models/subnet_test.rb
+++ b/test/models/subnet_test.rb
@@ -163,4 +163,31 @@ class SubnetTest < ActiveSupport::TestCase
     results = Subnet.search_for(%{params.#{parameter.name} ~ "192"})
     assert results.include?(subnet)
   end
+  describe '#strip_network_cidr' do
+    test 'should strip CIDR prefix from network address' do
+      subnet = FactoryBot.build(:subnet_ipv4, :network => '192.168.1.0/24', :mask => '255.255.255.0')
+      subnet.valid?
+      assert_equal '192.168.1.0', subnet.network
+    end
+
+    test 'should not modify network address without CIDR' do
+      subnet = FactoryBot.build(:subnet_ipv4, :network => '192.168.1.0', :mask => '255.255.255.0')
+      subnet.valid?
+      assert_equal '192.168.1.0', subnet.network
+    end
+
+    test 'should set cidr from network CIDR when mask is blank' do
+      subnet = Subnet::Ipv4.new(:name => 'test', :network => '10.0.0.0/8')
+      subnet.valid?
+      assert_equal '10.0.0.0', subnet.network
+      assert_equal 8, subnet.cidr
+    end
+
+    test 'should not produce duplicated prefix after save' do
+      subnet = FactoryBot.build(:subnet_ipv4, :network => '192.168.1.0/24', :mask => '255.255.255.0')
+      subnet.valid?
+      assert_equal '192.168.1.0/24', subnet.network_address
+      refute_match %r{/24/24}, subnet.network_address
+    end
+  end
 end


### PR DESCRIPTION
## Summary

**Redmine:** https://projects.theforeman.org/issues/39159

When creating a subnet in the UI with CIDR notation in the Network Address field (e.g. `192.168.1.0/24`) while also specifying the Network Prefix, Foreman stored and displayed a duplicated prefix like `192.168.1.0/24/24`.

## Changes

- Added `strip_network_cidr` method called from `normalize_addresses` that strips `/prefix` from the network field during validation
- If no mask is set yet, the extracted CIDR value is used to populate it automatically
- Added 4 tests covering: stripping CIDR, no-op without CIDR, auto-setting cidr from network notation, and verifying no duplicate prefix in `network_address`

## Test plan

- Create subnet with Network Address `192.168.1.0/24` and Network Prefix `24` - verify it saves as `192.168.1.0/24` (not `/24/24`)
- Create subnet with Network Address `10.0.0.0/8` and blank mask - verify mask is auto-populated
- Create subnet normally without CIDR in network - verify no change in behavior
