### PR TITLE
Fixes #39158 - Exclude last_used_at from PersonalAccessToken auditing

### DIFF
--- a/app/models/personal_access_token.rb
+++ b/app/models/personal_access_token.rb
@@ -1,5 +1,5 @@
 class PersonalAccessToken < ApplicationRecord
-  audited :except => [:token], :associated_with => :user
+  audited :except => [:token, :last_used_at], :associated_with => :user
   include Authorizable
   include Expirable
   extend Foreman::TelemetryHelper

--- a/test/models/personal_access_token_test.rb
+++ b/test/models/personal_access_token_test.rb
@@ -88,4 +88,15 @@ class PersonalAccessTokenTest < ActiveSupport::TestCase
       assert token.valid?
     end
   end
+
+  test "authenticating with token should not create audit records" do
+    user = FactoryBot.create(:user)
+    token = FactoryBot.create(:personal_access_token, :user => user)
+    token_value = token.generate_token
+    token.save
+
+    assert_no_difference "Audit.count" do
+      PersonalAccessToken.authenticate_user(user, token_value)
+    end
+  end
 end


### PR DESCRIPTION
https://projects.theforeman.org/issues/39158

Every API authentication via a Personal Access Token triggers an update to last_used_at.
Since the model is audited, this creates an Audit record per authentication, and each audit
inherits taxonomy associations via taxable_taxonomies (N rows per auth, where N = orgs + locations).

On production instances with active API usage this causes massive taxable_taxonomies bloat -
reported case showed 93% of the table was PersonalAccessToken audit records (652k rows from 25k authentications).

This adds last_used_at to the auditing exception list. It is a usage-tracking timestamp
with no security or compliance value.

Cleanup SQL for existing instances is documented in the Redmine issue.
