### PR TITLE
Fixes #36455 - Remove unused bindMethods helper function

### DIFF
--- a/webpack/assets/javascripts/react_app/common/helpers.js
+++ b/webpack/assets/javascripts/react_app/common/helpers.js
@@ -1,6 +1,7 @@
 import { snakeCase, camelCase, debounce } from 'lodash';
 import URI from 'urijs';
 import { translate as __ } from './I18n';
+import { deprecate } from './DeprecationService';
 
 /**
  * Our API returns non-ISO8601 dates
@@ -35,11 +36,13 @@ export const debounceMethods = (context, time, methods) => {
 };
 
 /**
+ * @deprecated Use Function.prototype.bind() directly. Will be removed in Foreman 3.20.
  * Bind your methods to run in a specific context.
  * @param {Object} context - the context where your method should run.
  * @param {Array} methods - Array that contains the methods to run on.
  */
 export const bindMethods = (context, methods) => {
+  deprecate('bindMethods', 'Function.prototype.bind()', '3.20');
   methods.forEach(method => {
     // eslint-disable-next-line no-param-reassign
     context[method] = context[method].bind(context);

--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorOptions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorOptions.js
@@ -13,14 +13,13 @@ import {
 
 import { Tooltip, TooltipPosition, Icon } from '@patternfly/react-core';
 import { translate as __ } from '../../../common/I18n';
-import { bindMethods } from '../../../common/helpers';
 import DiffToggle from '../../DiffView/DiffToggle';
 import EditorSettings from './EditorSettings';
 
 class EditorOptions extends React.Component {
   constructor(props) {
     super(props);
-    bindMethods(this, ['fileDialog']);
+    this.fileDialog = this.fileDialog.bind(this);
     this.fileInput = React.createRef();
   }
 


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/36455

## Summary

The `bindMethods` helper in `react_app/common/helpers.js` was only used in a single place (`EditorOptions` component). Since native `.bind()` achieves the same result, this replaces the single usage with a direct `.bind()` call and removes the helper function entirely.

## Changes

- Replace `bindMethods(this, ["fileDialog"])` with `this.fileDialog = this.fileDialog.bind(this)` in `EditorOptions.js`
- Remove `bindMethods` function definition and export from `helpers.js`