### PR TITLE
Fixes #31239 - Validate root password length even outside build mode

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -317,7 +317,8 @@ class Host::Managed < Host::Base
 
   validates :architecture_id, :presence => true, :if => proc { |host| host.managed }
   validates :root_pass, :length => {:minimum => 8, :message => N_('should be 8 characters or more')},
-                        :presence => {:message => N_('should not be blank - consider setting a global or host group default')},
+                        :if => proc { |host| host.managed && !host.image_build? && host.root_pass.present? }
+  validates :root_pass, :presence => {:message => N_('should not be blank - consider setting a global or host group default')},
                         :if => proc { |host| host.managed && !host.image_build? && build? }
   validates :ptable_id, :presence => {:message => N_("can't be blank unless a custom partition has been defined")},
                         :if => proc { |host| host.managed && host.disk.empty? && !Foreman.in_rake? && !host.image_build? && host.build? }

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -900,6 +900,21 @@ class HostTest < ActiveSupport::TestCase
     assert h.errors[:root_pass].include?("should be 8 characters or more")
   end
 
+  test "should not allow short root passwords for managed host outside build mode" do
+    h = FactoryBot.create(:host, :managed)
+    h.build = false
+    h.root_pass = "2short"
+    h.valid?
+    assert h.errors[:root_pass].include?("should be 8 characters or more")
+  end
+
+  test "should allow blank root password for managed host outside build mode" do
+    h = FactoryBot.create(:host, :managed)
+    h.build = false
+    h.root_pass = ""
+    assert h.valid?
+  end
+
   test "should allow build mode for managed hosts" do
     h = FactoryBot.build(:host, :managed)
     assert h.valid?


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/31239

## Summary

When a managed host is not in build mode, the `root_pass` validation was completely skipped. This allowed setting short passwords like "123" when editing an already-built host.

This splits the validation into two separate checks:
- **Length** (min 8 chars): validated whenever `root_pass` is present, regardless of build mode
- **Presence**: only required in build mode (preserves Katello use case where blank password is allowed outside build)

## Test plan

- Edit an already-built host, set root password to "123" -> should now fail validation
- Edit an already-built host, clear root password -> should succeed (blank allowed outside build)
- Create a new host in build mode without root password -> should still fail (presence required)