### PR TITLE
Fixes #14823 - Add _timestamp to default excluded facts

### DIFF
--- a/config/initializers/f_foreman_settings_facts.rb
+++ b/config/initializers/f_foreman_settings_facts.rb
@@ -16,6 +16,7 @@ Foreman::SettingManager.define(:foreman) do
       # uptime_seconds is not here since the boot time fact is derived from it
       'uptime_hours',
       'uptime_days',
+      '_timestamp',
     ].freeze
 
     IGNORED_INTERFACES = [


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/14823

## Summary

The `_timestamp` fact changes on every Puppet run and provides no useful information when stored as a fact value. The timestamp is already extracted and saved as `host.last_compile` in `HostFactImporter#parse_facts` before fact filtering occurs in `FactImporter`, so excluding it from storage is safe.

## Changes

- Add `_timestamp` to the `IGNORED_FACTS` default list in the facts settings initializer

This prevents unnecessary database writes and audit noise from a fact that changes on every single Puppet run.