### PR TITLE
Fixes #39143 - Drop redundant --location=mbr from bootloader verb

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -191,7 +191,7 @@ realm join --one-time-password='<%= @host.otp || "$HOST[OTP]" %>' <%= @host.real
 repo --name="Server-Mysql"
 <% end -%>
 
-bootloader --location=mbr --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %>" <%= grub_pass %>
+bootloader --append="<%= host_param('bootloader-append') || 'nofb quiet splash=quiet' %>" <%= grub_pass %>
 
 <% if @dynamic -%>
 %include /tmp/diskpart.cfg

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -25,7 +25,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -25,7 +25,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -25,7 +25,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -25,7 +25,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -25,7 +25,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
@@ -26,7 +26,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -26,7 +26,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
@@ -26,7 +26,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -24,7 +24,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -26,7 +26,7 @@ services --disabled gpm,sendmail,cups,pcmcia,isdn,rawdevices,hpoj,bluetooth,open
 
 
 
-bootloader --location=mbr --append="nofb quiet splash=quiet" 
+bootloader --append="nofb quiet splash=quiet" 
 
 zerombr
 clearpart --all    --initlabel


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/39143

## Summary

The `--location=mbr` argument in the kickstart `bootloader` command is the default value and is unnecessary. Removing it avoids confusion when debugging EFI systems where GPT is used instead of MBR.

Patch originally provided by @lzap in the Redmine issue.