### PR TITLE
Fixes #31560 - Replace UUID v1 with v4 in JavaScript code

### DIFF
--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { isEqual } from 'lodash';
-import uuid from 'uuid/v1';
+import uuid from 'uuid/v4';
 import {
   selectAPIResponse,
   selectAPIStatus,

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.js
@@ -2,7 +2,7 @@
 /* eslint no-case-declarations:0 */
 import { difference, head } from 'lodash';
 import Immutable from 'seamless-immutable';
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 
 import {
   VMWARE_CLUSTER_CHANGE,
@@ -58,7 +58,7 @@ export default (state = initialState, { type, payload, response }) => {
               {},
               payload.volume,
               { controllerKey: availableKey },
-              { key: uuidV1() }
+              { key: uuidV4() }
             )
           )
         );
@@ -67,7 +67,7 @@ export default (state = initialState, { type, payload, response }) => {
         'volumes',
         state.volumes.concat({
           ...payload.data,
-          key: uuidV1(),
+          key: uuidV4(),
           controllerKey: payload.controllerKey,
         })
       );
@@ -107,7 +107,7 @@ export default (state = initialState, { type, payload, response }) => {
         storagePods: [],
         storagePodsLoading: false,
         storagePodsError: undefined,
-        volumes: payload.volumes.map(volume => ({ ...volume, key: uuidV1() })),
+        volumes: payload.volumes.map(volume => ({ ...volume, key: uuidV4() })),
         cluster: payload.cluster,
       };
       return initialState

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.test.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 
 import * as types from '../../../consts';
 
@@ -13,8 +13,8 @@ import {
 
 import reducer from './vmware';
 
-jest.mock('uuid/v1');
-uuidV1.mockImplementation(() => '1547e1c0-309a-11e9-98f5-5f761412a4c2');
+jest.mock('uuid/v4');
+uuidV4.mockImplementation(() => '1547e1c0-309a-11e9-98f5-5f761412a4c2');
 
 describe('vmware storage reducer', () => {
   it('returns the initial state', () => {

--- a/webpack/assets/javascripts/services/charts/AreaChartService.js
+++ b/webpack/assets/javascripts/services/charts/AreaChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 import { getChartConfig } from './ChartService';
 
 export const getAreaChartConfig = ({
@@ -8,7 +8,7 @@ export const getAreaChartConfig = ({
   yAxisLabel,
   xAxisDataLabel = 'time',
   stacked = true,
-  id = uuidV1(),
+  id = uuidV4(),
   size = undefined,
 }) => {
   const chartConfig = getChartConfig({

--- a/webpack/assets/javascripts/services/charts/BarChartService.js
+++ b/webpack/assets/javascripts/services/charts/BarChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 import { getChartConfig } from './ChartService';
 
 export const getBarChartConfig = ({
@@ -7,7 +7,7 @@ export const getBarChartConfig = ({
   onclick,
   xAxisLabel,
   yAxisLabel,
-  id = uuidV1(),
+  id = uuidV4(),
 }) => {
   const chartConfig = getChartConfig({
     type: 'bar',

--- a/webpack/assets/javascripts/services/charts/ChartService.js
+++ b/webpack/assets/javascripts/services/charts/ChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 import Immutable from 'seamless-immutable';
 import {
   donutChartConfig,
@@ -56,7 +56,7 @@ export const getChartConfig = ({
   data,
   config,
   onclick,
-  id = uuidV1(),
+  id = uuidV4(),
 }) => {
   const chartConfigForType = chartsSizeConfig[type][config];
   const colors = getColors(data);
@@ -113,7 +113,7 @@ export const getDonutChartConfigPF5 = ({
   searchUrl,
   searchFilters,
   title,
-  id = uuidV1(),
+  id = uuidV4(),
 }) => {
   const chartConfigForType = chartsSizeConfig.donut[config];
   const dataExists = doDataExist(data);

--- a/webpack/assets/javascripts/services/charts/DonutChartService.js
+++ b/webpack/assets/javascripts/services/charts/DonutChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 import { getDonutChartConfigPF5 } from './ChartService';
 
 export const getDonutChartConfig = ({
@@ -8,7 +8,7 @@ export const getDonutChartConfig = ({
   searchUrl,
   searchFilters,
   title,
-  id = uuidV1(),
+  id = uuidV4(),
 }) =>
   getDonutChartConfigPF5({
     data,

--- a/webpack/assets/javascripts/services/charts/LineChartService.js
+++ b/webpack/assets/javascripts/services/charts/LineChartService.js
@@ -1,11 +1,11 @@
-import uuidV1 from 'uuid/v1';
+import uuidV4 from 'uuid/v4';
 import { getChartConfig } from './ChartService';
 
 export const getLineChartConfig = ({
   data,
   config,
   onclick,
-  id = uuidV1(),
+  id = uuidV4(),
   xAxisDataLabel,
   axisOpts,
 }) => {


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/31560

## Summary

UUID v1 is timestamp-based and includes MAC address information, which is unnecessary and potentially a minor privacy concern for generating React component keys and chart element IDs. UUID v4 is random-based and more appropriate for these use cases.

## Changes

- Replace all `uuid/v1` imports with `uuid/v4` across 8 files
- Rename `uuidV1` variable references to `uuidV4` for consistency
- Update test mocks to use `uuid/v4`

No functional change — both produce valid UUIDs suitable for unique key generation.