### PR TITLE
Fixes #38526 - Document uuid parameter in hosts API

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -88,6 +88,7 @@ module Api
           param :ptable_id, :number, :desc => N_("required if host is managed and custom partition has not been defined")
           param :subnet_id, :number, :desc => N_("required if host is managed and value is not inherited from host group")
           param :compute_resource_id, :number, :desc => N_("nil means host is bare metal")
+          param :uuid, String, :desc => N_("UUID of a VM to import from a compute resource")
           param :root_pass, String, :desc => N_("required if host is managed and value is not inherited from host group or default password in settings")
           param :model_id, :number
           param :hostgroup_id, :number, :desc => N_("ID of the host group. Note: Changing the host group will re-apply attributes inherited from the new host group, unless you explicitly override them again in the update request")


### PR DESCRIPTION
The uuid parameter is used together with compute_resource_id to import an existing VM from a compute resource when creating a host via API, but it was not documented in the API param group. This made the feature effectively undiscoverable through the API documentation.