### PR TITLE
Fixes #34735 - Default redhat_install_host_tools to true

### DIFF
--- a/app/services/foreman/template_snapshot_service.rb
+++ b/app/services/foreman/template_snapshot_service.rb
@@ -48,6 +48,7 @@ module Foreman
         "realm" => "true",
         "ntp-pools" => ['first.ntp-pool', 'second.ntp-pool'],
         "ntp-server" => "first.ntp.server",
+        "redhat_install_host_tools" => "false",
       }
       host_params.each_pair do |name, value|
         FactoryBot.build(:host_parameter, host: host, name: name, value: value)

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -87,7 +87,7 @@ description: |
       subscription_manager_certpkg_url = host_param('subscription_manager_certpkg_url')
       subscription_manager_org = host_param('subscription_manager_org')
       activation_key = host_param('activation_key')
-      redhat_install_host_tools = host_param_true?('redhat_install_host_tools')
+      redhat_install_host_tools = host_param_true?('redhat_install_host_tools', true)
       redhat_install_host_tracer_tools = host_param_true?('redhat_install_host_tracer_tools')
     end
   -%>


### PR DESCRIPTION
When using subscription_manager registration without kt_activation_keys, the redhat_install_host_tools parameter defaulted to false. This was inconsistent with the Katello activation key branch which already defaults to true.

Set the default to true for the non-Katello branch as well, so katello-host-tools are installed by default regardless of registration method.