### PR TITLE
Fixes #36714 - Add hostcert_renewal_interval to puppet.conf template

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -6,7 +6,7 @@ snippet: true
 description: |
   Generates a puppet.conf file which is required for the puppet agent bootstraping.
   The puppet server and CA is configured based on the host configuration. It supports
-  Puppet 5 and newer.
+  Puppet 5 and newer. Supports hostcert_renewal_interval for Puppet 8+.
 -%>
 <%
   os_family = @host.operatingsystem.family
@@ -67,4 +67,7 @@ port            = <%= host_puppet_server_port %>
 <%- end -%>
 <%- if host_puppet_environment.present? -%>
 environment     = <%= host_puppet_environment %>
+<%- end -%>
+<%- if host_param('puppet_hostcert_renewal_interval').present? -%>
+hostcert_renewal_interval = <%= host_param('puppet_hostcert_renewal_interval') %>
 <%- end -%>


### PR DESCRIPTION
Puppet 8 added support for `hostcert_renewal_interval`, which allows automatic certificate renewal when the host certificate approaches expiration.

Add support for configuring the Puppet setting through the `puppet_hostcert_renewal_interval` host parameter in the `puppet.conf` provisioning template snippet. The rendered Puppet configuration continues to use the upstream `hostcert_renewal_interval` setting name.

## AI usage disclosure

Per the [community discussion on AI policy](https://community.theforeman.org/t/could-foreman-benefit-from-an-ai-usage-policy/44638), the issue was investigated and the changes, tests, and PR wording were prepared with the assistance of Codex 5.6 Sol High. The resulting changes were reviewed before submitting. The commit also includes an Assisted-By trailer.
