### PR TITLE
Fixes #31205 - Add host_parameters_attributes to GraphQL CreateHostMutation

### DIFF
--- a/app/graphql/mutations/hosts/create.rb
+++ b/app/graphql/mutations/hosts/create.rb
@@ -30,6 +30,7 @@ module Mutations
       argument :puppet_ca_proxy_id, ID, loads: Types::SmartProxy
       argument :compute_attributes, Types::RawJson, required: false
       argument :interfaces_attributes, [Types::InterfaceAttributesInput], required: false
+      argument :host_parameters_attributes, [Types::HostParameterAttributesInput], required: false
 
       field :host, Types::Host, 'The new host.', null: true
 
@@ -53,6 +54,7 @@ module Mutations
         return {} if params.nil?
 
         params[:interfaces_attributes] = params[:interfaces_attributes].map(&:to_h) if params[:interfaces_attributes]
+        params[:host_parameters_attributes] = params[:host_parameters_attributes].map(&:to_h) if params[:host_parameters_attributes]
         params = params.deep_clone
         parse_volumes_attributes(params)
 

--- a/app/graphql/types/host_parameter_attributes_input.rb
+++ b/app/graphql/types/host_parameter_attributes_input.rb
@@ -1,0 +1,8 @@
+module Types
+  class HostParameterAttributesInput < BaseInputObject
+    argument :name, String, required: true
+    argument :value, String, required: true
+    argument :parameter_type, String, required: false
+    argument :hidden_value, Boolean, required: false
+  end
+end

--- a/test/graphql/mutations/hosts/create_mutation_test.rb
+++ b/test/graphql/mutations/hosts/create_mutation_test.rb
@@ -72,7 +72,8 @@ module Mutations
               $ownerId: ID,
               $ptableId: ID!,
               $rootPass: String,
-              $subnetId: ID
+              $subnetId: ID,
+              $hostParametersAttributes: [HostParameterAttributesInput!]
             ) {
             createHost(input: {
               architectureId: $architectureId,
@@ -93,6 +94,7 @@ module Mutations
               ptableId: $ptableId,
               rootPass: $rootPass,
               subnetId: $subnetId,
+              hostParametersAttributes: $hostParametersAttributes,
             }) {
               host {
                 id,
@@ -279,8 +281,46 @@ module Mutations
             end
           end
         end
-      end
 
+        context 'with host parameters' do
+          let(:variables) do
+            base_variables.merge(
+              mac: mac,
+              hostParametersAttributes: [
+                {
+                  name: 'my_param',
+                  value: 'my_value',
+                  parameterType: 'string',
+                },
+                {
+                  name: 'hidden_param',
+                  value: 'secret',
+                  hiddenValue: true,
+                },
+              ]
+            )
+          end
+
+          it 'creates a host with parameters' do
+            assert_difference(-> { Host.count }, +1) do
+              assert_empty result['errors']
+              assert_empty result['data']['createHost']['errors']
+              assert_not_nil data
+            end
+            host = Host.find_by(name: "my-graphql-host.#{domain.name}")
+            assert_not_nil host
+            assert_equal 2, host.host_parameters.count
+            param = host.host_parameters.find_by(name: 'my_param')
+            assert_not_nil param
+            assert_equal 'my_value', param.value
+            assert_equal 'string', param.key_type
+            hidden = host.host_parameters.find_by(name: 'hidden_param')
+            assert_not_nil hidden
+            assert_equal 'secret', hidden.value
+            assert hidden.hidden_value?
+          end
+        end
+      end
       context 'with create permission' do
         let(:context_user) do
           setup_user('create', 'hosts') do |user|


### PR DESCRIPTION
Add support for specifying host parameters when creating hosts via the GraphQL API.

This introduces a new HostParameterAttributesInput GraphQL input type with fields: name (String, required), value (String, required), parameter_type (String, optional), hidden_value (Boolean, optional).

The host_parameters_attributes argument is added to CreateHostMutation, following the same pattern as interfaces_attributes.

Includes a test that verifies creating a host with both regular and hidden parameters.

https://projects.theforeman.org/issues/31205