### PR TITLE
Fixes #39193 - Create cert dirs for LB backend proxies in container_certs_setup

### DIFF
--- a/app/controllers/concerns/foreman/controller/registration.rb
+++ b/app/controllers/concerns/foreman/controller/registration.rb
@@ -43,6 +43,7 @@ module Foreman::Controller::Registration
       repo_data: repo_data,
       download_utility: params['download_utility'],
       registration_host: registration_host,
+      lb_backend_hostnames: SmartProxy.respond_to?(:behind_load_balancer) ? SmartProxy.behind_load_balancer(registration_host).map(&:hostname) : [],
     }
 
     params.permit(permitted)

--- a/app/views/unattended/provisioning_templates/snippet/container_certs_setup.erb
+++ b/app/views/unattended/provisioning_templates/snippet/container_certs_setup.erb
@@ -42,4 +42,17 @@ ln -sf "$ca_cert" "$cert_dir/ca-bundle.crt"
 ln -sf "$key_file" "$cert_dir/client.key"
 ln -sf "$cert_file" "$cert_dir/client.cert"
 
+<%
+  backend_hostnames = @lb_backend_hostnames.to_a
+-%>
+<% if backend_hostnames.any? -%>
+<% backend_hostnames.each do |backend_hostname| -%>
+echo "Creating /etc/containers/certs.d/<%= backend_hostname %> directory (load balancer backend)"
+mkdir -p "/etc/containers/certs.d/<%= backend_hostname %>/"
+ln -sf "$cert_file" "/etc/containers/certs.d/<%= backend_hostname %>/client.cert"
+ln -sf "$key_file"  "/etc/containers/certs.d/<%= backend_hostname %>/client.key"
+ln -sf "$ca_cert"   "/etc/containers/certs.d/<%= backend_hostname %>/ca-bundle.crt"
+<% end -%>
+<% end -%>
+
 echo "Container certificate setup completed successfully."


### PR DESCRIPTION
## Problem

When a host registers to a load-balanced smart proxy, `container_certs_setup` creates a `/etc/containers/certs.d/` directory only for the LB hostname. However, `flatpak-oci-authenticator` uses the server TLS certificate CN (the individual backend proxy hostname) to look up client certificates in `/etc/containers/certs.d/<CN>/`. In the documented LB setup (`--certs-cname`), the backend cert CN is the backend hostname — not the LB hostname — so the directory is never found.

As a result, flatpak installation fails with `Authorization failed` on EL10 hosts registered to load-balanced smart proxies. The issue also affects failover: if HAProxy reroutes to a different backend, that backend cert directory would also be missing.

## Fix

After creating the cert directory for the registration hostname, use `SmartProxy.behind_load_balancer` to find all backend proxy hostnames and create symlinked cert directories for each. This ensures authentication works correctly regardless of which backend HAProxy routes to, including during failover, without requiring prior knowledge of backend hostnames.

The fix has no effect for non-LB registrations since `behind_load_balancer` returns an empty collection when no backends share the registration hostname.

## Testing

- Register an EL10 host to a load-balanced smart proxy
- Verify `/etc/containers/certs.d/<backend-hostname>/` directories are created with symlinks to the LB cert
- Verify `flatpak install` succeeds through the LB proxy
- Verify the fix has no effect for non-LB registrations

## Related

- Foreman #39193
- SAT-32491 — Flatpak cert auth epic