### PR TITLE
Fixes #39198 - Bulk-insert new facts and add additive import mode

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -28,17 +28,17 @@ class FactImporter
     @error    = false
     @host     = host
     @facts    = normalize(facts)
-    @counters = {}
+    @counters = { added: 0, updated: 0, deleted: 0 }
   end
 
   # expect a facts hash
-  def import!
+  def import!(additive: false)
     # This function uses its own transactions that should not be included
     # in the transaction that handles fact values
     ensure_fact_names
 
     ActiveRecord::Base.transaction do
-      delete_removed_facts
+      delete_removed_facts unless additive
       update_facts
       add_new_facts
     end
@@ -120,7 +120,6 @@ class FactImporter
   end
 
   def add_new_fact(name)
-    # if the host does not exist yet, we don't have an host_id to use the fact_values table.
     method = host.new_record? ? :build : :create!
     fact_name = fact_names[name]
     host.fact_values.send(method, :value => facts[name], :fact_name => fact_name)
@@ -130,8 +129,31 @@ class FactImporter
   end
 
   def add_new_facts
-    facts_to_create.each { |f| add_new_fact(f) }
+    # Compose/parent facts (nil values, produced by StructuredFactImporter's
+    # fill_hierarchy) are always handled individually to preserve per-fact
+    # error handling. Regular facts use bulk insert for persisted hosts.
+    compose_names, regular_names = facts_to_create.partition { |name| facts[name].nil? }
+    compose_names.each { |f| add_new_fact(f) }
+
+    if host.new_record?
+      regular_names.each { |f| add_new_fact(f) }
+    else
+      bulk_insert_new_facts(regular_names)
+    end
     @counters[:added] = facts_to_create.size
+  end
+
+  def bulk_insert_new_facts(names)
+    return if names.empty?
+    time = Time.now.utc
+    records = names.map do |name|
+      { value: facts[name], fact_name_id: fact_names[name].id, host_id: host.id,
+        created_at: time, updated_at: time }
+    end
+    FactValue.insert_all(records, unique_by: [:fact_name_id, :host_id])
+  rescue => e
+    logger.error("Facts could not be imported because of #{e.message}")
+    @error = e
   end
 
   def update_facts

--- a/app/services/foreman_ansible/structured_fact_importer.rb
+++ b/app/services/foreman_ansible/structured_fact_importer.rb
@@ -19,7 +19,7 @@ module ForemanAnsible
                                     facts[:ansible_facts][:fqdn]) ||
               host
       @facts = normalize(facts[:ansible_facts])
-      @counters = {}
+      @counters = { added: 0, updated: 0, deleted: 0 }
     end
   end
 end

--- a/app/services/host_fact_importer.rb
+++ b/app/services/host_fact_importer.rb
@@ -11,7 +11,7 @@ class HostFactImporter
     Setting[:create_new_host_when_facts_are_uploaded]
   end
 
-  def import_facts(facts, source_proxy = nil)
+  def import_facts(facts, source_proxy = nil, additive: false)
     return false if !create_new_record_when_facts_are_uploaded? && host.new_record?
 
     # we are not importing facts for hosts in build state (e.g. waiting for a re-installation)
@@ -24,7 +24,7 @@ class HostFactImporter
     facts_importer = Foreman::Plugin.fact_importer_registry.get(type).new(host, facts)
     telemetry_observe_histogram(:importer_facts_import_duration, facts.size, type: type)
     telemetry_duration_histogram(:importer_facts_import_duration, 1000, type: type) do
-      facts_importer.import!
+      facts_importer.import!(additive: additive)
     end
 
     skipping_orchestration do

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -143,6 +143,25 @@ class FactImporterTest < ActiveSupport::TestCase
       assert_equal 0, importer.counters[:added]
     end
 
+    test 'additive import preserves existing facts not in the new set' do
+      # baseline: two facts in DB
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+
+      # additive import of a single new fact — existing facts must survive
+      @importer = FactImporter.new(host, 'uptime' => '1 day')
+      allow_transactions_for @importer
+      @importer.stubs(:fact_name_class).returns(FactName)
+      @importer.import!(additive: true)
+
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+      assert_equal '1 day', value('uptime')
+      assert_equal 0, @importer.counters[:deleted]
+      assert_equal 1, @importer.counters[:added]
+      assert_equal 0, @importer.counters[:updated]
+    end
+
     test 'importer updates fact values' do
       assert_equal '2.6.9', value('kernelversion')
       assert_equal '10.0.19.33', value('ipaddress')

--- a/test/unit/host_fact_importer_test.rb
+++ b/test/unit/host_fact_importer_test.rb
@@ -47,7 +47,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'import_facts only needs operatingsystem and operatingsystemrelease fact' do
     host = Host.import_host('host', 'puppet')
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS'})
   end
 
   test 'should import facts from json of a new host when certname is not specified' do
@@ -70,7 +70,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
   test 'domain updated from facts' do
     host = FactoryBot.create(:host, :with_operatingsystem)
     FactoryBot.create(:domain, :name => 'foo.bar')
-    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts({:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name})
     assert_equal 'foo.bar', host.domain.to_s
   end
 
@@ -78,9 +78,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
     domain = FactoryBot.create(:domain)
     host = FactoryBot.create(:host, :managed, :domain => domain)
     FactoryBot.create(:domain, :name => 'foo.bar')
-    assert HostFactImporter.new(host).import_facts(:domain => domain.name, :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts({:domain => domain.name, :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name})
     Setting[:ignore_facts_for_domain] = true
-    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts({:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name})
     assert_equal domain.name, host.domain.name
     Setting[:ignore_facts_for_domain] =
       Setting.find_by_name('ignore_facts_for_domain').default
@@ -236,13 +236,13 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'comment updated from facts when present' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(foreman_comment: 'new comment', operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
+    assert HostFactImporter.new(host).import_facts({foreman_comment: 'new comment', operatingsystemrelease: '6.7', operatingsystem: 'CentOS'})
     assert_equal 'new comment', host.comment
   end
 
   test 'operatingsystem updated from facts' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS'})
     assert_equal 'CentOS 6.7', host.operatingsystem.to_s
   end
 
@@ -251,7 +251,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
     os2 = FactoryBot.create(:operatingsystem)
     medium = os1.media.first
     host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
-    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s)
+    HostFactImporter.new(host).import_facts({:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s})
 
     assert_equal host.operatingsystem, os2
     assert_nil host.medium
@@ -264,7 +264,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
     medium.operatingsystems << os2
 
     host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
-    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s)
+    HostFactImporter.new(host).import_facts({:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s})
 
     assert_equal host.operatingsystem, os2
     assert_equal host.medium, medium
@@ -272,9 +272,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'operatingsystem not updated from facts when ignore_facts_for_operatingsystem false' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS'})
     Setting[:ignore_facts_for_operatingsystem] = true
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.8', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.8', :operatingsystem => 'CentOS'})
     assert_equal 'CentOS 6.7', host.operatingsystem.to_s
     Setting[:ignore_facts_for_operatingsystem] =
       Setting.find_by_name('ignore_facts_for_operatingsystem').default
@@ -360,7 +360,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
           payload[:object].operatingsystem.name == 'CentOS'
         end
 
-        HostFactImporter.new(host).import_facts(operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
+        HostFactImporter.new(host).import_facts({operatingsystemrelease: '6.7', operatingsystem: 'CentOS'})
       end
     end
   end


### PR DESCRIPTION
## What are the changes introduced in this pull request?

Two related improvements to the fact import pipeline:

**1. Bulk inserts for new facts on persisted hosts**

`FactImporter#add_new_facts` currently inserts each new fact individually via `create!` inside a loop. This PR replaces that with a single `FactValue.insert_all` call for non-nil facts on persisted hosts, reducing N INSERT statements to 1.

Nil-value compose facts (parent/hierarchy nodes produced by `StructuredFactImporter#fill_hierarchy`) are separated at the `add_new_facts` level and handled individually via the existing `add_new_fact` path. This preserves per-fact error handling semantics and keeps `bulk_insert_new_facts` with a single, clean responsibility: bulk insert a pre-filtered list of non-nil facts.

The `host.new_record?` path is preserved unchanged since bulk insert requires a known `host_id`.

**2. Additive import mode**

`FactImporter#import!` and `HostFactImporter#import_facts` now accept an `additive: false` keyword argument. When `additive: true`, the `delete_removed_facts` step is skipped — facts in the new set are added or updated, but facts already in the DB that are absent from the new set are preserved rather than deleted.

This enables callers to import a small, targeted subset of facts (e.g. only the facts needed for OS detection during host registration) without wiping the host's existing fact set. Katello uses this in the registration flow to import only the 3 facts needed for `RhelLifecycleStatus` to be immediately correct, deferring the full sync to the subsequent `PUT /rhsm/consumers/:id` call.

## Considerations taken when implementing this change?

During host registration, ~193 RHSM facts are imported synchronously as part of the critical `POST /rhsm/consumers` path (which already takes ~3,256ms under no load). Under concurrent bulk registration, 193 individual INSERTs per host compounds significantly. The bulk insert reduces this to 1 INSERT per registration.

`FactValue` has no `after_create` callbacks — only a uniqueness validation enforced at the DB level — making `insert_all` safe here. `unique_by: [:fact_name_id, :host_id]` is specified explicitly.

The `additive:` keyword defaults to `false`, so all existing callers are unaffected.

## What are the testing steps for this pull request?

- Register a host and verify all facts are correctly imported, including compose/parent facts from structured fact importers
- Verify `host.new_record?` path still builds facts correctly (e.g. during unattended provisioning)
- Verify that `additive: true` preserves existing facts not present in the new set
- Run existing fact importer tests including `StructuredFactImporterTest`

Fixes #39198
