### PR TITLE
Fixes #39200 - Migrate Model Pages to React

### DIFF
--- a/app/views/models/edit.html.erb
+++ b/app/views/models/edit.html.erb
@@ -1,3 +1,0 @@
-<% title _("Edit %s") % @model.to_s %>
-
-<%= render :partial => 'form' %>

--- a/app/views/models/new.html.erb
+++ b/app/views/models/new.html.erb
@@ -1,3 +1,0 @@
-<% title _("Create Model") %>
-
-<%= render :partial => 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -390,11 +390,16 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :models, except: [:show, :index] do
+  resources :models, except: [:show, :index, :new, :edit] do
+    member do
+      get 'edit', to: 'react#index'
+    end
     collection do
+      get 'new', to: 'react#index', as: 'new'
       get 'auto_complete_search'
     end
   end
+  get 'models/:id', to: 'react#index'
   match 'models' => 'react#index', :via => :get
 
   resources :architectures, except: [:show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -391,7 +391,11 @@ Foreman::Application.routes.draw do
   end
 
   resources :models, except: [:show, :index] do
+    member do
+      get 'edit', to: 'react#index'
+    end
     collection do
+      get 'new', to: 'react#index', as: 'new'
       get 'auto_complete_search'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -390,7 +390,7 @@ Foreman::Application.routes.draw do
     end
   end
 
-  resources :models, except: [:show, :index] do
+  resources :models, except: [:show, :index, :new, :edit] do
     member do
       get 'edit', to: 'react#index'
     end

--- a/test/controllers/api/v2/models_controller_test.rb
+++ b/test/controllers/api/v2/models_controller_test.rb
@@ -38,6 +38,18 @@ class Api::V2::ModelsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:model)
   end
 
+  test "should not create model with blank name" do
+    assert_difference('Model.count', 0) do
+      post :create, params: { :model => valid_attrs.merge(:name => '') }
+    end
+    assert_response :unprocessable_entity
+  end
+
+  test "should not update model with blank name" do
+    put :update, params: { :id => models(:one).to_param, :model => { :name => '' } }
+    assert_response :unprocessable_entity
+  end
+
   test "should update model" do
     name = Model.first.name
     put :update, params: { :id => Model.first.to_param, :name => name.to_s.to_param }

--- a/test/controllers/models_controller_test.rb
+++ b/test/controllers/models_controller_test.rb
@@ -1,32 +1,10 @@
 require 'test_helper'
 
 class ModelsControllerTest < ActionController::TestCase
-  def test_new
-    get :new, session: set_session_user
-    assert_template 'new'
-  end
-
-  def test_create_invalid
-    Model.any_instance.stubs(:valid?).returns(false)
-    post :create, params: { :model => {:name => nil} }, session: set_session_user
-    assert_template 'new'
-  end
-
   def test_create_valid
     Model.any_instance.stubs(:valid?).returns(true)
     post :create, params: { :model => {:name => "test"} }, session: set_session_user
     assert_redirected_to models_url
-  end
-
-  def test_edit
-    get :edit, params: { :id => Model.first }, session: set_session_user
-    assert_template 'edit'
-  end
-
-  def test_update_invalid
-    Model.any_instance.stubs(:valid?).returns(false)
-    put :update, params: { :id => Model.first, :model => {:name => nil} }, session: set_session_user
-    assert_template 'edit'
   end
 
   def test_update_valid
@@ -49,7 +27,7 @@ class ModelsControllerTest < ActionController::TestCase
 
   test 'user with viewer rights should fail to edit a model' do
     setup_user
-    get :edit, params: { :id => Model.first.id }, session: set_session_user.merge(:user => users(:one).id)
-    assert_equal @response.status, 403
+    put :update, params: { :id => Model.first.id, :model => { :name => 'x' } }, session: set_session_user.merge(:user => users(:one).id)
+    assert_response :forbidden
   end
 end

--- a/test/controllers/models_controller_test.rb
+++ b/test/controllers/models_controller_test.rb
@@ -27,7 +27,7 @@ class ModelsControllerTest < ActionController::TestCase
 
   test 'user with viewer rights should fail to edit a model' do
     setup_user
-    get :edit, params: { :id => Model.first.id }, session: set_session_user.merge(:user => users(:one).id)
-    assert_equal @response.status, 403
+    put :update, params: { :id => Model.first.id, :model => { :name => 'x' } }, session: set_session_user.merge(:user => users(:one).id)
+    assert_response :forbidden
   end
 end

--- a/test/controllers/models_controller_test.rb
+++ b/test/controllers/models_controller_test.rb
@@ -1,32 +1,10 @@
 require 'test_helper'
 
 class ModelsControllerTest < ActionController::TestCase
-  def test_new
-    get :new, session: set_session_user
-    assert_template 'new'
-  end
-
-  def test_create_invalid
-    Model.any_instance.stubs(:valid?).returns(false)
-    post :create, params: { :model => {:name => nil} }, session: set_session_user
-    assert_template 'new'
-  end
-
   def test_create_valid
     Model.any_instance.stubs(:valid?).returns(true)
     post :create, params: { :model => {:name => "test"} }, session: set_session_user
     assert_redirected_to models_url
-  end
-
-  def test_edit
-    get :edit, params: { :id => Model.first }, session: set_session_user
-    assert_template 'edit'
-  end
-
-  def test_update_invalid
-    Model.any_instance.stubs(:valid?).returns(false)
-    put :update, params: { :id => Model.first, :model => {:name => nil} }, session: set_session_user
-    assert_template 'edit'
   end
 
   def test_update_valid

--- a/test/integration/model_js_test.rb
+++ b/test/integration/model_js_test.rb
@@ -4,7 +4,7 @@ class ModelIntegrationTest < IntegrationTestWithJavascript
   test "create new page" do
     visit models_path
     click_on "Create new", class: 'pf-v5-c-button'
-    assert_current_path new_model_path
+    assert_current_path new_models_path
     fill_in "model_name", :with => "IBM 123"
     fill_in "model_hardware_model", :with => "IBMabcde"
     fill_in "model_vendor_class", :with => "ABCDE"
@@ -19,5 +19,23 @@ class ModelIntegrationTest < IntegrationTestWithJavascript
     fill_in "model_name", :with => "RHEV 123"
     assert_submit_button(models_path)
     assert page.has_link? 'RHEV 123'
+  end
+
+  test "delete model from index" do
+    model = FactoryBot.create(:model, :name => "ModelDelJsIntegration")
+    visit models_path
+    wait_for_ajax
+    row = page.find('tr', :text => model.name)
+    within row do
+      find('button[aria-label="Kebab toggle"]').click
+    end
+    find('button.pf-v5-c-menu__item', :text => 'Delete').click
+    within(:css, '[data-ouia-component-id="delete-modal"]') do
+      find('[data-ouia-component-id="confirm-delete"]').click
+    end
+    wait_for_ajax
+    refute Model.exists?(model.id)
+    model_row_xpath = "//tr[contains(.,'#{model.name}')]"
+    assert page.find('table > tbody').has_no_xpath?(model_row_xpath)
   end
 end

--- a/test/integration/model_js_test.rb
+++ b/test/integration/model_js_test.rb
@@ -20,4 +20,22 @@ class ModelIntegrationTest < IntegrationTestWithJavascript
     assert_submit_button(models_path)
     assert page.has_link? 'RHEV 123'
   end
+
+  test "delete model from index" do
+    model = FactoryBot.create(:model, :name => "ModelDelJsIntegration")
+    visit models_path
+    wait_for_ajax
+    row = page.find('tr', :text => model.name)
+    within row do
+      find('button[aria-label="Kebab toggle"]').click
+    end
+    find('button.pf-v5-c-menu__item', :text => 'Delete').click
+    within(:css, '[data-ouia-component-id="delete-modal"]') do
+      find('[data-ouia-component-id="confirm-delete"]').click
+    end
+    wait_for_ajax
+    refute Model.exists?(model.id)
+    model_row_xpath = "//tr[contains(.,'#{model.name}')]"
+    assert page.find('table > tbody').has_no_xpath?(model_row_xpath)
+  end
 end

--- a/test/integration/model_js_test.rb
+++ b/test/integration/model_js_test.rb
@@ -4,7 +4,7 @@ class ModelIntegrationTest < IntegrationTestWithJavascript
   test "create new page" do
     visit models_path
     click_on "Create new", class: 'pf-v5-c-button'
-    assert_current_path new_model_path
+    assert_current_path new_models_path
     fill_in "model_name", :with => "IBM 123"
     fill_in "model_hardware_model", :with => "IBMabcde"
     fill_in "model_vendor_class", :with => "ABCDE"

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePattern.js
@@ -22,6 +22,7 @@ const EmptyStatePattern = props => {
     icon,
     header,
     description,
+    variant,
   } = props;
 
   const DocumentationBlock = () => {
@@ -61,7 +62,7 @@ const EmptyStatePattern = props => {
   };
 
   return (
-    <EmptyState variant={EmptyStateVariant.xl}>
+    <EmptyState variant={variant}>
       <span className="empty-state-icon">
         <EmptyStateIcon />
       </span>
@@ -85,6 +86,7 @@ EmptyStatePattern.defaultProps = {
   secondaryActions: [],
   documentation: null,
   action: null,
+  variant: EmptyStateVariant.xl,
 };
 
 export default EmptyStatePattern;

--- a/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
+++ b/webpack/assets/javascripts/react_app/components/common/EmptyState/EmptyStatePropTypes.js
@@ -20,6 +20,7 @@ export const emptyStatePatternPropTypes = {
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   action: PropTypes.node,
   secondaryActions: PropTypes.node,
+  variant: PropTypes.oneOf(['xs', 'sm', 'lg', 'xl', 'full']),
 };
 
 export const defaultEmptyStatePropTypes = {

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -84,7 +84,13 @@ export const submitForm = ({
       });
     };
     const defaultSuccessToast = () =>
-      message || sprintf('%s was successfully created.', __(item));
+      message ||
+      sprintf(
+        method === 'put'
+          ? __('%s was successfully updated.')
+          : __('%s was successfully created.'),
+        __(item)
+      );
 
     const defaultErrorToast = error =>
       sprintf(

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -84,7 +84,13 @@ export const submitForm = ({
       });
     };
     const defaultSuccessToast = () =>
-      message || sprintf('%s was successfully created.', __(item));
+      message ||
+      sprintf(
+        method === 'put'
+          ? '%s was successfully updated.'
+          : '%s was successfully created.',
+        __(item)
+      );
 
     const defaultErrorToast = error =>
       sprintf(

--- a/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/common/forms.js
@@ -87,8 +87,8 @@ export const submitForm = ({
       message ||
       sprintf(
         method === 'put'
-          ? '%s was successfully updated.'
-          : '%s was successfully created.',
+          ? __('%s was successfully updated.')
+          : __('%s was successfully created.'),
         __(item)
       );
 

--- a/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
@@ -1,0 +1,145 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch, useSelector, shallowEqual } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import PageLayout from '../common/PageLayout/PageLayout';
+import { translate as __, sprintf } from '../../common/I18n';
+import { submitForm } from '../../redux/actions/common/forms';
+import { STATUS } from '../../constants';
+import { APIActions } from '../../redux/API';
+import {
+  selectAPIErrorMessage,
+  selectAPIResponse,
+  selectAPIStatus,
+} from '../../redux/API/APISelectors';
+import { MODELS_API_PATH, MODELS_PATH } from './constants';
+import { modelErrorToast } from './modelErrorToast';
+
+import ModelForm from './ModelForm';
+import ModelFormSkeleton from './ModelFormSkeleton';
+import ModelFormEmptyState from './ModelFormEmptyState';
+
+const modelToInitialValues = data => ({
+  name: data.name,
+  hardware_model: data.hardware_model || '',
+  vendor_class: data.vendor_class || '',
+  info: data.info || '',
+});
+
+const EditModelFormPage = ({
+  match: {
+    params: { id },
+  },
+}) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const fetchKey = `MODEL_EDIT_${id}`;
+  const status = useSelector(state => selectAPIStatus(state, fetchKey));
+  const apiResponse = useSelector(
+    state => selectAPIResponse(state, fetchKey),
+    shallowEqual
+  );
+  const initialValues =
+    status === STATUS.RESOLVED &&
+    apiResponse &&
+    typeof apiResponse.id !== 'undefined'
+      ? modelToInitialValues(apiResponse)
+      : null;
+  const errorMessage = useSelector(state =>
+    selectAPIErrorMessage(state, fetchKey)
+  );
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    dispatch(
+      APIActions.get({
+        url: `${MODELS_API_PATH}/${id}`,
+        key: fetchKey,
+      })
+    );
+  }, [dispatch, id, fetchKey]);
+
+  const handleSubmit = formValues => {
+    setIsSubmitting(true);
+    dispatch(
+      submitForm({
+        item: 'Model',
+        method: 'put',
+        url: `${MODELS_API_PATH}/${id}`,
+        values: { model: formValues },
+        actions: {},
+        errorToast: modelErrorToast,
+        successCallback: () => {
+          history.push(MODELS_PATH);
+        },
+        handleError: () => {
+          setIsSubmitting(false);
+        },
+      })
+    );
+  };
+
+  const breadcrumbOptions = {
+    breadcrumbItems: [
+      {
+        caption: __('Hardware Models'),
+        url: MODELS_PATH,
+        onClick: e => {
+          e.preventDefault();
+          history.push(MODELS_PATH);
+        },
+      },
+      {
+        caption: initialValues
+          ? sprintf(__('Edit %s'), initialValues.name || '')
+          : __('Edit'),
+      },
+    ],
+    isSwitchable: true,
+    resource: {
+      resourceUrl: MODELS_API_PATH,
+      nameField: 'name',
+      switcherItemUrl: `${MODELS_PATH}/:id/edit`,
+    },
+    onSwitcherItemClick: (e, href) => {
+      e.preventDefault();
+      history.push(href);
+    },
+  };
+
+  const isLoading = status !== STATUS.ERROR && initialValues === null;
+
+  let pageContent;
+  if (status === STATUS.ERROR) {
+    pageContent = (
+      <ModelFormEmptyState modelId={id} errorMessage={errorMessage} />
+    );
+  } else if (isLoading) {
+    pageContent = <ModelFormSkeleton />;
+  } else {
+    pageContent = (
+      <ModelForm
+        key={id}
+        initialValues={initialValues}
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+    );
+  }
+
+  return (
+    <PageLayout searchable={false} breadcrumbOptions={breadcrumbOptions}>
+      {pageContent}
+    </PageLayout>
+  );
+};
+
+EditModelFormPage.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default EditModelFormPage;

--- a/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import PageLayout from '../common/PageLayout/PageLayout';
 import { useAPI } from '../../common/hooks/API/APIHooks';
 import { translate as __, sprintf } from '../../common/I18n';
@@ -15,6 +16,7 @@ const EditModelFormPage = ({
   },
 }) => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const { response } = useAPI('get', `${MODELS_API_PATH}/${id}`);
   const [values, setValues] = useState({
     name: '',
@@ -46,7 +48,7 @@ const EditModelFormPage = ({
         values: { model: formValues },
         actions: {},
         successCallback: () => {
-          window.location.href = MODELS_PATH;
+          history.push(MODELS_PATH);
         },
         handleError: () => {
           setIsSubmitting(false);
@@ -60,7 +62,14 @@ const EditModelFormPage = ({
       searchable={false}
       breadcrumbOptions={{
         breadcrumbItems: [
-          { caption: __('Hardware Models'), url: MODELS_PATH },
+          {
+            caption: __('Hardware Models'),
+            url: MODELS_PATH,
+            onClick: e => {
+              e.preventDefault();
+              history.push(MODELS_PATH);
+            },
+          },
           { caption: sprintf(__('Edit %s'), values.name) },
         ],
         isSwitchable: true,
@@ -68,6 +77,10 @@ const EditModelFormPage = ({
           resourceUrl: MODELS_API_PATH,
           nameField: 'name',
           switcherItemUrl: `${MODELS_PATH}/:id/edit`,
+        },
+        onSwitcherItemClick: (e, href) => {
+          e.preventDefault();
+          history.push(href);
         },
       }}
     >

--- a/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import { useHistory } from 'react-router-dom';
@@ -6,6 +6,7 @@ import PageLayout from '../common/PageLayout/PageLayout';
 import { useAPI } from '../../common/hooks/API/APIHooks';
 import { translate as __, sprintf } from '../../common/I18n';
 import { submitForm } from '../../redux/actions/common/forms';
+import { STATUS } from '../../constants';
 import { MODELS_API_PATH, MODELS_PATH } from './constants';
 
 import ModelForm from './ModelForm';
@@ -17,26 +18,18 @@ const EditModelFormPage = ({
 }) => {
   const dispatch = useDispatch();
   const history = useHistory();
-  const { response } = useAPI('get', `${MODELS_API_PATH}/${id}`);
-  const [values, setValues] = useState({
-    name: '',
-    hardware_model: '',
-    vendor_class: '',
-    info: '',
-  });
+  const { response, status } = useAPI('get', `${MODELS_API_PATH}/${id}`);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  useEffect(() => {
-    if (!response) return;
-
-    setValues(prevValues => ({
-      ...prevValues,
+  const initialValues = useMemo(
+    () => ({
       name: response.name || '',
       hardware_model: response.hardware_model || '',
       vendor_class: response.vendor_class || '',
       info: response.info || '',
-    }));
-  }, [response]);
+    }),
+    [response]
+  );
 
   const handleSubmit = formValues => {
     setIsSubmitting(true);
@@ -57,35 +50,60 @@ const EditModelFormPage = ({
     );
   };
 
-  return (
-    <PageLayout
-      searchable={false}
-      breadcrumbOptions={{
-        breadcrumbItems: [
-          {
-            caption: __('Hardware Models'),
-            url: MODELS_PATH,
-            onClick: e => {
-              e.preventDefault();
-              history.push(MODELS_PATH);
-            },
-          },
-          { caption: sprintf(__('Edit %s'), values.name) },
-        ],
-        isSwitchable: true,
-        resource: {
-          resourceUrl: MODELS_API_PATH,
-          nameField: 'name',
-          switcherItemUrl: `${MODELS_PATH}/:id/edit`,
-        },
-        onSwitcherItemClick: (e, href) => {
+  const breadcrumbOptions = {
+    breadcrumbItems: [
+      {
+        caption: __('Hardware Models'),
+        url: MODELS_PATH,
+        onClick: e => {
           e.preventDefault();
-          history.push(href);
+          history.push(MODELS_PATH);
         },
-      }}
-    >
+      },
+      {
+        caption:
+          status === STATUS.RESOLVED
+            ? sprintf(__('Edit %s'), initialValues.name)
+            : __('Edit'),
+      },
+    ],
+    isSwitchable: true,
+    resource: {
+      resourceUrl: MODELS_API_PATH,
+      nameField: 'name',
+      switcherItemUrl: `${MODELS_PATH}/:id/edit`,
+    },
+    onSwitcherItemClick: (e, href) => {
+      e.preventDefault();
+      history.push(href);
+    },
+  };
+
+  if (status === STATUS.PENDING) {
+    return (
+      <PageLayout
+        searchable={false}
+        isLoading
+        breadcrumbOptions={breadcrumbOptions}
+      >
+        {null}
+      </PageLayout>
+    );
+  }
+
+  if (status === STATUS.ERROR) {
+    return (
+      <PageLayout searchable={false} breadcrumbOptions={breadcrumbOptions}>
+        {__('Something went wrong')}
+      </PageLayout>
+    );
+  }
+
+  return (
+    <PageLayout searchable={false} breadcrumbOptions={breadcrumbOptions}>
       <ModelForm
-        initialValues={values}
+        key={id}
+        initialValues={initialValues}
         handleSubmit={handleSubmit}
         isSubmitting={isSubmitting}
       />

--- a/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/EditModelFormPage.js
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import PageLayout from '../common/PageLayout/PageLayout';
+import { useAPI } from '../../common/hooks/API/APIHooks';
+import { translate as __, sprintf } from '../../common/I18n';
+import { submitForm } from '../../redux/actions/common/forms';
+import { MODELS_API_PATH, MODELS_PATH } from './constants';
+
+import ModelForm from './ModelForm';
+
+const EditModelFormPage = ({
+  match: {
+    params: { id },
+  },
+}) => {
+  const dispatch = useDispatch();
+  const { response } = useAPI('get', `${MODELS_API_PATH}/${id}`);
+  const [values, setValues] = useState({
+    name: '',
+    hardware_model: '',
+    vendor_class: '',
+    info: '',
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!response) return;
+
+    setValues(prevValues => ({
+      ...prevValues,
+      name: response.name || '',
+      hardware_model: response.hardware_model || '',
+      vendor_class: response.vendor_class || '',
+      info: response.info || '',
+    }));
+  }, [response]);
+
+  const handleSubmit = formValues => {
+    setIsSubmitting(true);
+    dispatch(
+      submitForm({
+        item: 'Model',
+        method: 'put',
+        url: `${MODELS_API_PATH}/${id}`,
+        values: { model: formValues },
+        actions: {},
+        successCallback: () => {
+          window.location.href = MODELS_PATH;
+        },
+        handleError: () => {
+          setIsSubmitting(false);
+        },
+      })
+    );
+  };
+
+  return (
+    <PageLayout
+      searchable={false}
+      breadcrumbOptions={{
+        breadcrumbItems: [
+          { caption: __('Hardware Models'), url: MODELS_PATH },
+          { caption: sprintf(__('Edit %s'), values.name) },
+        ],
+        isSwitchable: true,
+        resource: {
+          resourceUrl: MODELS_API_PATH,
+          nameField: 'name',
+          switcherItemUrl: `${MODELS_PATH}/:id/edit`,
+        },
+      }}
+    >
+      <ModelForm
+        initialValues={values}
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+    </PageLayout>
+  );
+};
+
+EditModelFormPage.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default EditModelFormPage;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  ActionGroup,
+  Button,
+} from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
+import { translate as __ } from '../../common/I18n';
+import LabelIcon from '../../components/common/LabelIcon';
+import { MODELS_PATH } from './constants';
+
+const HARDWARE_MODEL_HELP = __(
+  'The class of CPU supplied in this machine. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -m'
+);
+
+const VENDOR_CLASS_HELP = __(
+  'The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,'
+);
+
+const INFO_HELP = __(
+  'General useful description, for example this kind of hardware needs a special BIOS setup'
+);
+
+const ModelForm = ({ initialValues, handleSubmit, isSubmitting }) => {
+  const history = useHistory();
+  const [values, setValues] = useState(initialValues);
+
+  const handleChange = field => valueOrEvent => {
+    const value =
+      valueOrEvent && valueOrEvent.target
+        ? valueOrEvent.target.value
+        : valueOrEvent;
+
+    setValues(prevValues => ({ ...prevValues, [field]: value || '' }));
+  };
+
+  const onSubmit = event => {
+    event.preventDefault();
+    handleSubmit(values);
+  };
+
+  const handleCancel = () => {
+    history.push(MODELS_PATH);
+  };
+
+  const requiredFields = ['name'];
+
+  const isSubmitDisabled = requiredFields.some(
+    field => !(values[field] || '').trim()
+  );
+
+  return (
+    <Form id="model-create-form" isWidthLimited onSubmit={onSubmit}>
+      <FormGroup label={__('Name')} isRequired>
+        <TextInput
+          id="model_name"
+          name="model_name"
+          type="text"
+          ouiaId="model_name-input"
+          required
+          value={values.name}
+          onChange={handleChange('name')}
+        />
+      </FormGroup>
+      <FormGroup
+        label={__('Hardware model')}
+        labelIcon={<LabelIcon text={HARDWARE_MODEL_HELP} />}
+      >
+        <TextInput
+          id="model_hardware_model"
+          name="model_hardware_model"
+          type="text"
+          ouiaId="model_hardware_model-input"
+          value={values.hardware_model}
+          onChange={handleChange('hardware_model')}
+        />
+      </FormGroup>
+      <FormGroup
+        label={__('Vendor class')}
+        labelIcon={<LabelIcon text={VENDOR_CLASS_HELP} />}
+      >
+        <TextInput
+          id="model_vendor_class"
+          name="model_vendor_class"
+          type="text"
+          ouiaId="model_vendor_class-input"
+          value={values.vendor_class}
+          onChange={handleChange('vendor_class')}
+        />
+      </FormGroup>
+      <FormGroup label={__('Info')} labelIcon={<LabelIcon text={INFO_HELP} />}>
+        <TextArea
+          id="model_info"
+          name="model_info"
+          rows={7}
+          value={values.info}
+          onChange={handleChange('info')}
+        />
+      </FormGroup>
+
+      <ActionGroup>
+        <Button
+          variant="primary"
+          type="submit"
+          ouiaId="model_submit_button"
+          isDisabled={isSubmitDisabled || isSubmitting}
+        >
+          {__('Submit')}
+        </Button>
+        <Button
+          variant="link"
+          onClick={handleCancel}
+          ouiaId="model_cancel_button"
+        >
+          {__('Cancel')}
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};
+
+ModelForm.propTypes = {
+  initialValues: PropTypes.shape({
+    name: PropTypes.string,
+    hardware_model: PropTypes.string,
+    vendor_class: PropTypes.string,
+    info: PropTypes.string,
+  }).isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool,
+};
+
+ModelForm.defaultProps = {
+  isSubmitting: false,
+};
+
+export default ModelForm;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
@@ -79,7 +79,6 @@ const ModelForm = ({ initialValues, handleSubmit, isSubmitting }) => {
           name="model_hardware_model"
           type="text"
           ouiaId="model_hardware_model-input"
-          required
           value={values.hardware_model}
           onChange={handleChange('hardware_model')}
         />
@@ -93,7 +92,6 @@ const ModelForm = ({ initialValues, handleSubmit, isSubmitting }) => {
           name="model_vendor_class"
           type="text"
           ouiaId="model_vendor_class-input"
-          required
           value={values.vendor_class}
           onChange={handleChange('vendor_class')}
         />

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
@@ -8,6 +8,7 @@ import {
   ActionGroup,
   Button,
 } from '@patternfly/react-core';
+import { useHistory } from 'react-router-dom';
 import { translate as __ } from '../../common/I18n';
 import LabelIcon from '../../components/common/LabelIcon';
 import { MODELS_PATH } from './constants';
@@ -25,6 +26,7 @@ const INFO_HELP = __(
 );
 
 const ModelForm = ({ initialValues, handleSubmit, isSubmitting }) => {
+  const history = useHistory();
   const [values, setValues] = useState(initialValues);
 
   useEffect(() => {
@@ -46,7 +48,7 @@ const ModelForm = ({ initialValues, handleSubmit, isSubmitting }) => {
   };
 
   const handleCancel = () => {
-    window.location.href = MODELS_PATH;
+    history.push(MODELS_PATH);
   };
 
   const requiredFields = ['name'];

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.js
@@ -1,0 +1,146 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Form,
+  FormGroup,
+  TextInput,
+  TextArea,
+  ActionGroup,
+  Button,
+} from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+import LabelIcon from '../../components/common/LabelIcon';
+import { MODELS_PATH } from './constants';
+
+const HARDWARE_MODEL_HELP = __(
+  'The class of CPU supplied in this machine. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -m'
+);
+
+const VENDOR_CLASS_HELP = __(
+  'The class of the machine reported by the Open Boot Prom. This is primarily used by Sparc Solaris builds and can be left blank for other architectures. The value can be determined on Solaris via uname -i|cut -f2 -d,'
+);
+
+const INFO_HELP = __(
+  'General useful description, for example this kind of hardware needs a special BIOS setup'
+);
+
+const ModelForm = ({ initialValues, handleSubmit, isSubmitting }) => {
+  const [values, setValues] = useState(initialValues);
+
+  useEffect(() => {
+    setValues(initialValues);
+  }, [initialValues]);
+
+  const handleChange = field => valueOrEvent => {
+    const value =
+      valueOrEvent && valueOrEvent.target
+        ? valueOrEvent.target.value
+        : valueOrEvent;
+
+    setValues(prevValues => ({ ...prevValues, [field]: value || '' }));
+  };
+
+  const onSubmit = event => {
+    event.preventDefault();
+    handleSubmit(values);
+  };
+
+  const handleCancel = () => {
+    window.location.href = MODELS_PATH;
+  };
+
+  const requiredFields = ['name'];
+
+  const isSubmitDisabled = requiredFields.some(
+    field => !(values[field] || '').trim()
+  );
+
+  return (
+    <Form id="model-create-form" isWidthLimited onSubmit={onSubmit}>
+      <FormGroup label={__('Name')} isRequired>
+        <TextInput
+          id="model_name"
+          name="model_name"
+          type="text"
+          ouiaId="model_name-input"
+          required
+          value={values.name}
+          onChange={handleChange('name')}
+        />
+      </FormGroup>
+      <FormGroup
+        label={__('Hardware model')}
+        labelIcon={<LabelIcon text={HARDWARE_MODEL_HELP} />}
+      >
+        <TextInput
+          id="model_hardware_model"
+          name="model_hardware_model"
+          type="text"
+          ouiaId="model_hardware_model-input"
+          required
+          value={values.hardware_model}
+          onChange={handleChange('hardware_model')}
+        />
+      </FormGroup>
+      <FormGroup
+        label={__('Vendor class')}
+        labelIcon={<LabelIcon text={VENDOR_CLASS_HELP} />}
+      >
+        <TextInput
+          id="model_vendor_class"
+          name="model_vendor_class"
+          type="text"
+          ouiaId="model_vendor_class-input"
+          required
+          value={values.vendor_class}
+          onChange={handleChange('vendor_class')}
+        />
+      </FormGroup>
+      <FormGroup label={__('Info')} labelIcon={<LabelIcon text={INFO_HELP} />}>
+        <TextArea
+          id="model_info"
+          name="model_info"
+          rows={7}
+          ouiaId="info-textarea"
+          value={values.info}
+          onChange={handleChange('info')}
+        />
+      </FormGroup>
+
+      <ActionGroup>
+        <Button
+          variant="primary"
+          type="submit"
+          ouiaId="model_submit_button"
+          isDisabled={isSubmitDisabled || isSubmitting}
+        >
+          {__('Submit')}
+        </Button>
+        <Button
+          variant="link"
+          onClick={handleCancel}
+          ouiaId="model_cancel_button"
+        >
+          {__('Cancel')}
+        </Button>
+      </ActionGroup>
+    </Form>
+  );
+};
+
+ModelForm.propTypes = {
+  initialValues: PropTypes.shape({
+    name: PropTypes.string,
+    hardware_model: PropTypes.string,
+    vendor_class: PropTypes.string,
+    info: PropTypes.string,
+  }).isRequired,
+  handleSubmit: PropTypes.func.isRequired,
+  isSubmitting: PropTypes.bool,
+};
+
+ModelForm.defaultProps = {
+  isSubmitting: false,
+};
+
+export default ModelForm;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.test.js
@@ -1,0 +1,223 @@
+import React from 'react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import ModelForm from './ModelForm';
+import { MODELS_PATH } from './constants';
+
+jest.mock('@patternfly/react-core', () => {
+  const ReactLib = require('react');
+
+  const Form = ({ children, onSubmit, id }) => (
+    <form onSubmit={onSubmit} id={id}>
+      {children}
+    </form>
+  );
+
+  const FormGroup = ({ label, children }) => (
+    <div>
+      {label ? <label>{label}</label> : null}
+      {ReactLib.Children.map(children, child =>
+        ReactLib.isValidElement(child)
+          ? ReactLib.cloneElement(child, { 'aria-label': label })
+          : child
+      )}
+    </div>
+  );
+
+  const TextInput = ({
+    id,
+    name,
+    type,
+    required,
+    value,
+    onChange,
+    isDisabled,
+    'aria-label': ariaLabel,
+  }) => (
+    <input
+      id={id}
+      name={name}
+      type={type}
+      required={required}
+      value={value}
+      onChange={onChange}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+    />
+  );
+
+  const TextArea = ({
+    id,
+    name,
+    rows,
+    value,
+    onChange,
+    isDisabled,
+    'aria-label': ariaLabel,
+  }) => (
+    <textarea
+      id={id}
+      name={name}
+      rows={rows}
+      value={value}
+      onChange={onChange}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+    />
+  );
+
+  const ActionGroup = ({ children }) => <div>{children}</div>;
+
+  const Button = ({ children, isDisabled, type, onClick }) => (
+    <button type={type || 'button'} disabled={isDisabled} onClick={onClick}>
+      {children}
+    </button>
+  );
+
+  return { Form, FormGroup, TextInput, TextArea, ActionGroup, Button };
+});
+
+jest.mock('../../components/common/LabelIcon', () => () => null);
+
+const defaultInitialValues = {
+  name: '',
+  hardware_model: '',
+  vendor_class: '',
+  info: '',
+};
+
+const buildProps = overrides => ({
+  initialValues: defaultInitialValues,
+  handleSubmit: jest.fn(),
+  isSubmitting: false,
+  ...overrides,
+});
+
+const renderModelForm = propsOverrides => {
+  const history = createMemoryHistory({
+    initialEntries: ['/models/new'],
+  });
+  const utils = render(
+    <Router history={history}>
+      <ModelForm {...buildProps(propsOverrides)} />
+    </Router>
+  );
+  return { ...utils, history };
+};
+
+describe('ModelForm', () => {
+  it('renders initial values', () => {
+    renderModelForm({
+      initialValues: {
+        name: 'PowerEdge R760',
+        hardware_model: 'sun4u',
+        vendor_class: 'SUNW,Sun-Fire-V490',
+        info: 'Requires custom BIOS setup',
+      },
+    });
+
+    expect(screen.getByLabelText('Name')).toHaveValue('PowerEdge R760');
+    expect(screen.getByLabelText('Hardware model')).toHaveValue('sun4u');
+    expect(screen.getByLabelText('Vendor class')).toHaveValue(
+      'SUNW,Sun-Fire-V490'
+    );
+    expect(screen.getByLabelText('Info')).toHaveValue(
+      'Requires custom BIOS setup'
+    );
+  });
+
+  it('disables submit when required name is blank', () => {
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: '   ',
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('disables submit when creating with undefined name', () => {
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: undefined,
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('disables submit when update clears name to empty', () => {
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: 'KVM',
+      },
+    });
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: '' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('submits edited values when form is valid', () => {
+    const handleSubmit = jest.fn();
+
+    renderModelForm({ handleSubmit });
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'PowerEdge R760' },
+    });
+    fireEvent.change(screen.getByLabelText('Hardware model'), {
+      target: { value: 'sun4u' },
+    });
+    fireEvent.change(screen.getByLabelText('Vendor class'), {
+      target: { value: 'SUNW,Sun-Fire-V490' },
+    });
+    fireEvent.change(screen.getByLabelText('Info'), {
+      target: { value: 'Requires custom BIOS setup' },
+    });
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    expect(submitButton).not.toBeDisabled();
+    fireEvent.click(submitButton);
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      name: 'PowerEdge R760',
+      hardware_model: 'sun4u',
+      vendor_class: 'SUNW,Sun-Fire-V490',
+      info: 'Requires custom BIOS setup',
+    });
+  });
+
+  it('keeps submit disabled while submitting', () => {
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: 'PowerEdge R760',
+      },
+      isSubmitting: true,
+    });
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('navigates to models page on cancel', () => {
+    const { history } = renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: 'PowerEdge R760',
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(history.location.pathname).toBe(MODELS_PATH);
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.test.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 import { render, fireEvent, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 
@@ -94,31 +96,28 @@ const buildProps = overrides => ({
   ...overrides,
 });
 
+const renderModelForm = propsOverrides => {
+  const history = createMemoryHistory({
+    initialEntries: ['/models/new'],
+  });
+  const utils = render(
+    <Router history={history}>
+      <ModelForm {...buildProps(propsOverrides)} />
+    </Router>
+  );
+  return { ...utils, history };
+};
+
 describe('ModelForm', () => {
-  const originalLocation = window.location;
-
-  beforeEach(() => {
-    delete window.location;
-    window.location = new URL('http://localhost');
-  });
-
-  afterAll(() => {
-    window.location = originalLocation;
-  });
-
   it('renders initial values', () => {
-    render(
-      <ModelForm
-        {...buildProps({
-          initialValues: {
-            name: 'PowerEdge R760',
-            hardware_model: 'sun4u',
-            vendor_class: 'SUNW,Sun-Fire-V490',
-            info: 'Requires custom BIOS setup',
-          },
-        })}
-      />
-    );
+    renderModelForm({
+      initialValues: {
+        name: 'PowerEdge R760',
+        hardware_model: 'sun4u',
+        vendor_class: 'SUNW,Sun-Fire-V490',
+        info: 'Requires custom BIOS setup',
+      },
+    });
 
     expect(screen.getByLabelText('Name')).toHaveValue('PowerEdge R760');
     expect(screen.getByLabelText('Hardware model')).toHaveValue('sun4u');
@@ -131,46 +130,34 @@ describe('ModelForm', () => {
   });
 
   it('disables submit when required name is blank', () => {
-    render(
-      <ModelForm
-        {...buildProps({
-          initialValues: {
-            ...defaultInitialValues,
-            name: '   ',
-          },
-        })}
-      />
-    );
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: '   ',
+      },
+    });
 
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
   });
 
   it('disables submit when creating with undefined name', () => {
-    render(
-      <ModelForm
-        {...buildProps({
-          initialValues: {
-            ...defaultInitialValues,
-            name: undefined,
-          },
-        })}
-      />
-    );
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: undefined,
+      },
+    });
 
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
   });
 
   it('disables submit when update clears name to empty', () => {
-    render(
-      <ModelForm
-        {...buildProps({
-          initialValues: {
-            ...defaultInitialValues,
-            name: 'KVM',
-          },
-        })}
-      />
-    );
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: 'KVM',
+      },
+    });
 
     fireEvent.change(screen.getByLabelText('Name'), {
       target: { value: '' },
@@ -182,7 +169,7 @@ describe('ModelForm', () => {
   it('submits edited values when form is valid', () => {
     const handleSubmit = jest.fn();
 
-    render(<ModelForm {...buildProps({ handleSubmit })} />);
+    renderModelForm({ handleSubmit });
 
     fireEvent.change(screen.getByLabelText('Name'), {
       target: { value: 'PowerEdge R760' },
@@ -210,38 +197,27 @@ describe('ModelForm', () => {
   });
 
   it('keeps submit disabled while submitting', () => {
-    render(
-      <ModelForm
-        {...buildProps({
-          initialValues: {
-            ...defaultInitialValues,
-            name: 'PowerEdge R760',
-          },
-          isSubmitting: true,
-        })}
-      />
-    );
+    renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: 'PowerEdge R760',
+      },
+      isSubmitting: true,
+    });
 
     expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
   });
 
-  it('redirects to models page on cancel', () => {
-    delete window.location;
-    window.location = { href: 'http://localhost/' };
-
-    render(
-      <ModelForm
-        {...buildProps({
-          initialValues: {
-            ...defaultInitialValues,
-            name: 'PowerEdge R760',
-          },
-        })}
-      />
-    );
+  it('navigates to models page on cancel', () => {
+    const { history } = renderModelForm({
+      initialValues: {
+        ...defaultInitialValues,
+        name: 'PowerEdge R760',
+      },
+    });
 
     fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
 
-    expect(window.location.href).toBe(MODELS_PATH);
+    expect(history.location.pathname).toBe(MODELS_PATH);
   });
 });

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelForm.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelForm.test.js
@@ -1,0 +1,247 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import ModelForm from './ModelForm';
+import { MODELS_PATH } from './constants';
+
+jest.mock('@patternfly/react-core', () => {
+  const ReactLib = require('react');
+
+  const Form = ({ children, onSubmit, id }) => (
+    <form onSubmit={onSubmit} id={id}>
+      {children}
+    </form>
+  );
+
+  const FormGroup = ({ label, children }) => (
+    <div>
+      {label ? <label>{label}</label> : null}
+      {ReactLib.Children.map(children, child =>
+        ReactLib.isValidElement(child)
+          ? ReactLib.cloneElement(child, { 'aria-label': label })
+          : child
+      )}
+    </div>
+  );
+
+  const TextInput = ({
+    id,
+    name,
+    type,
+    required,
+    value,
+    onChange,
+    isDisabled,
+    'aria-label': ariaLabel,
+  }) => (
+    <input
+      id={id}
+      name={name}
+      type={type}
+      required={required}
+      value={value}
+      onChange={onChange}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+    />
+  );
+
+  const TextArea = ({
+    id,
+    name,
+    rows,
+    value,
+    onChange,
+    isDisabled,
+    'aria-label': ariaLabel,
+  }) => (
+    <textarea
+      id={id}
+      name={name}
+      rows={rows}
+      value={value}
+      onChange={onChange}
+      disabled={isDisabled}
+      aria-label={ariaLabel}
+    />
+  );
+
+  const ActionGroup = ({ children }) => <div>{children}</div>;
+
+  const Button = ({ children, isDisabled, type, onClick }) => (
+    <button type={type || 'button'} disabled={isDisabled} onClick={onClick}>
+      {children}
+    </button>
+  );
+
+  return { Form, FormGroup, TextInput, TextArea, ActionGroup, Button };
+});
+
+jest.mock('../../components/common/LabelIcon', () => () => null);
+
+const defaultInitialValues = {
+  name: '',
+  hardware_model: '',
+  vendor_class: '',
+  info: '',
+};
+
+const buildProps = overrides => ({
+  initialValues: defaultInitialValues,
+  handleSubmit: jest.fn(),
+  isSubmitting: false,
+  ...overrides,
+});
+
+describe('ModelForm', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    delete window.location;
+    window.location = new URL('http://localhost');
+  });
+
+  afterAll(() => {
+    window.location = originalLocation;
+  });
+
+  it('renders initial values', () => {
+    render(
+      <ModelForm
+        {...buildProps({
+          initialValues: {
+            name: 'PowerEdge R760',
+            hardware_model: 'sun4u',
+            vendor_class: 'SUNW,Sun-Fire-V490',
+            info: 'Requires custom BIOS setup',
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByLabelText('Name')).toHaveValue('PowerEdge R760');
+    expect(screen.getByLabelText('Hardware model')).toHaveValue('sun4u');
+    expect(screen.getByLabelText('Vendor class')).toHaveValue(
+      'SUNW,Sun-Fire-V490'
+    );
+    expect(screen.getByLabelText('Info')).toHaveValue(
+      'Requires custom BIOS setup'
+    );
+  });
+
+  it('disables submit when required name is blank', () => {
+    render(
+      <ModelForm
+        {...buildProps({
+          initialValues: {
+            ...defaultInitialValues,
+            name: '   ',
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('disables submit when creating with undefined name', () => {
+    render(
+      <ModelForm
+        {...buildProps({
+          initialValues: {
+            ...defaultInitialValues,
+            name: undefined,
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('disables submit when update clears name to empty', () => {
+    render(
+      <ModelForm
+        {...buildProps({
+          initialValues: {
+            ...defaultInitialValues,
+            name: 'KVM',
+          },
+        })}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: '' },
+    });
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('submits edited values when form is valid', () => {
+    const handleSubmit = jest.fn();
+
+    render(<ModelForm {...buildProps({ handleSubmit })} />);
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'PowerEdge R760' },
+    });
+    fireEvent.change(screen.getByLabelText('Hardware model'), {
+      target: { value: 'sun4u' },
+    });
+    fireEvent.change(screen.getByLabelText('Vendor class'), {
+      target: { value: 'SUNW,Sun-Fire-V490' },
+    });
+    fireEvent.change(screen.getByLabelText('Info'), {
+      target: { value: 'Requires custom BIOS setup' },
+    });
+
+    const submitButton = screen.getByRole('button', { name: 'Submit' });
+    expect(submitButton).not.toBeDisabled();
+    fireEvent.click(submitButton);
+
+    expect(handleSubmit).toHaveBeenCalledWith({
+      name: 'PowerEdge R760',
+      hardware_model: 'sun4u',
+      vendor_class: 'SUNW,Sun-Fire-V490',
+      info: 'Requires custom BIOS setup',
+    });
+  });
+
+  it('keeps submit disabled while submitting', () => {
+    render(
+      <ModelForm
+        {...buildProps({
+          initialValues: {
+            ...defaultInitialValues,
+            name: 'PowerEdge R760',
+          },
+          isSubmitting: true,
+        })}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('redirects to models page on cancel', () => {
+    delete window.location;
+    window.location = { href: 'http://localhost/' };
+
+    render(
+      <ModelForm
+        {...buildProps({
+          initialValues: {
+            ...defaultInitialValues,
+            name: 'PowerEdge R760',
+          },
+        })}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(window.location.href).toBe(MODELS_PATH);
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelFormEmptyState.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelFormEmptyState.js
@@ -1,0 +1,73 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
+import { Button, EmptyStateVariant } from '@patternfly/react-core';
+import { SearchIcon } from '@patternfly/react-icons';
+import EmptyStatePattern from '../../components/common/EmptyState/EmptyStatePattern';
+import { translate as __, sprintf } from '../../common/I18n';
+import { MODELS_PATH, MODELS_PATH_NEW } from './constants';
+
+const ModelFormEmptyState = ({ modelId, errorMessage }) => {
+  const history = useHistory();
+
+  const description = (
+    <>
+      <p>
+        {sprintf(
+          __(
+            'The hardware model with id %s could not be loaded. It may not exist or you may not have permission to view it.'
+          ),
+          modelId
+        )}
+      </p>
+      {errorMessage ? <p>{errorMessage}</p> : null}
+    </>
+  );
+
+  return (
+    <EmptyStatePattern
+      variant={EmptyStateVariant.lg}
+      icon={<SearchIcon />}
+      header={__('Unable to load hardware model')}
+      description={description}
+      action={
+        <Button
+          ouiaId="model-form-empty-state-models-list"
+          variant="primary"
+          onClick={() => history.push(MODELS_PATH)}
+        >
+          {__('Back to hardware models')}
+        </Button>
+      }
+      secondaryActions={
+        <>
+          <Button
+            ouiaId="model-form-empty-state-create-model"
+            variant="link"
+            onClick={() => history.push(MODELS_PATH_NEW)}
+          >
+            {__('Create a new hardware model')}
+          </Button>
+          <Button
+            ouiaId="model-form-empty-state-go-back"
+            variant="link"
+            onClick={() => history.goBack()}
+          >
+            {__('Return to the previous page')}
+          </Button>
+        </>
+      }
+    />
+  );
+};
+
+ModelFormEmptyState.propTypes = {
+  modelId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  errorMessage: PropTypes.string,
+};
+
+ModelFormEmptyState.defaultProps = {
+  errorMessage: null,
+};
+
+export default ModelFormEmptyState;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelFormSkeleton.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelFormSkeleton.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+  Form,
+  Skeleton,
+  Stack,
+  StackItem,
+  Flex,
+  FlexItem,
+} from '@patternfly/react-core';
+import { translate as __ } from '../../common/I18n';
+
+const labelSkeleton = <Skeleton height="14px" width="30%" />;
+
+const ModelFormSkeleton = () => (
+  <Form isWidthLimited id="model-form-skeleton">
+    <Stack hasGutter>
+      <StackItem>
+        {labelSkeleton}
+        <Skeleton height="36px" screenreaderText={__('Loading form')} />
+      </StackItem>
+      <StackItem>
+        {labelSkeleton}
+        <Skeleton height="36px" />
+      </StackItem>
+      <StackItem>
+        {labelSkeleton}
+        <Skeleton height="36px" />
+      </StackItem>
+      <StackItem>
+        {labelSkeleton}
+        <Skeleton height="36px" />
+      </StackItem>
+      <StackItem>
+        {labelSkeleton}
+        <Skeleton height="140px" />
+      </StackItem>
+      <StackItem>
+        <Flex gap={{ default: 'gapMd' }}>
+          <FlexItem>
+            <Skeleton height="36px" width="80px" />
+          </FlexItem>
+          <FlexItem>
+            <Skeleton height="36px" width="72px" />
+          </FlexItem>
+        </Flex>
+      </StackItem>
+    </Stack>
+  </Form>
+);
+
+export default ModelFormSkeleton;

--- a/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/ModelsPage/index.js
@@ -1,16 +1,22 @@
 import React from 'react';
+import { useHistory, Link } from 'react-router-dom';
 
 import { translate as __ } from '../../../common/I18n';
 import TableIndexPage from '../../../components/PF4/TableIndexPage/TableIndexPage';
-import { MODELS_API_PATH, API_REQUEST_KEY } from '../constants';
+import {
+  MODELS_API_PATH,
+  MODELS_PATH_NEW,
+  API_REQUEST_KEY,
+} from '../constants';
 
 const ModelsPage = () => {
+  const history = useHistory();
   const columns = {
     name: {
       title: __('Name'),
       wrapper: ({ can_edit: canEdit, id, name }) =>
         canEdit ? (
-          <a href={`/models/${id}/edit`}>{name}</a>
+          <Link to={`/models/${id}/edit`}>{name}</Link>
         ) : (
           <span>{name}</span>
         ),
@@ -33,6 +39,7 @@ const ModelsPage = () => {
       header={__('Hardware models')}
       controller="models"
       isDeleteable
+      customCreateAction={() => () => history.push(MODELS_PATH_NEW)}
       columns={columns}
     />
   );

--- a/webpack/assets/javascripts/react_app/routes/Models/NewModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/NewModelFormPage.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
+import PageLayout from '../common/PageLayout/PageLayout';
+import { translate as __ } from '../../common/I18n';
+import { submitForm } from '../../redux/actions/common/forms';
+import { MODELS_API_PATH, MODELS_PATH } from './constants';
+import { modelErrorToast } from './modelErrorToast';
+
+import ModelForm from './ModelForm';
+
+const EMPTY_MODEL_INITIAL_VALUES = {
+  name: '',
+  hardware_model: '',
+  vendor_class: '',
+  info: '',
+};
+
+const NewModelFormPage = () => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = formValues => {
+    setIsSubmitting(true);
+    dispatch(
+      submitForm({
+        item: 'Model',
+        method: 'post',
+        url: MODELS_API_PATH,
+        values: { model: formValues },
+        actions: {},
+        errorToast: modelErrorToast,
+        successCallback: () => {
+          history.push(MODELS_PATH);
+        },
+        handleError: () => {
+          setIsSubmitting(false);
+        },
+      })
+    );
+  };
+
+  return (
+    <PageLayout
+      searchable={false}
+      breadcrumbOptions={{
+        breadcrumbItems: [
+          {
+            caption: __('Hardware Models'),
+            url: MODELS_PATH,
+            onClick: e => {
+              e.preventDefault();
+              history.push(MODELS_PATH);
+            },
+          },
+          { caption: __('Create Model') },
+        ],
+      }}
+    >
+      <ModelForm
+        initialValues={EMPTY_MODEL_INITIAL_VALUES}
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+    </PageLayout>
+  );
+};
+
+export default NewModelFormPage;

--- a/webpack/assets/javascripts/react_app/routes/Models/NewModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/NewModelFormPage.js
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { useDispatch } from 'react-redux';
+import PageLayout from '../common/PageLayout/PageLayout';
+import { translate as __ } from '../../common/I18n';
+import { submitForm } from '../../redux/actions/common/forms';
+import { MODELS_API_PATH, MODELS_PATH } from './constants';
+
+import ModelForm from './ModelForm';
+
+const NewModelFormPage = () => {
+  const dispatch = useDispatch();
+  const values = {
+    name: '',
+    hardware_model: '',
+    vendor_class: '',
+    info: '',
+  };
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = formValues => {
+    setIsSubmitting(true);
+    dispatch(
+      submitForm({
+        item: 'Model',
+        method: 'post',
+        url: MODELS_API_PATH,
+        values: { model: formValues },
+        actions: {},
+        successCallback: () => {
+          window.location.href = MODELS_PATH;
+        },
+        handleError: () => {
+          setIsSubmitting(false);
+        },
+      })
+    );
+  };
+
+  return (
+    <PageLayout
+      searchable={false}
+      breadcrumbOptions={{
+        breadcrumbItems: [
+          { caption: __('Hardware Models'), url: MODELS_PATH },
+          { caption: __('Create Model') },
+        ],
+      }}
+    >
+      <ModelForm
+        initialValues={values}
+        handleSubmit={handleSubmit}
+        isSubmitting={isSubmitting}
+      />
+    </PageLayout>
+  );
+};
+
+export default NewModelFormPage;

--- a/webpack/assets/javascripts/react_app/routes/Models/NewModelFormPage.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/NewModelFormPage.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import PageLayout from '../common/PageLayout/PageLayout';
 import { translate as __ } from '../../common/I18n';
 import { submitForm } from '../../redux/actions/common/forms';
@@ -9,6 +10,7 @@ import ModelForm from './ModelForm';
 
 const NewModelFormPage = () => {
   const dispatch = useDispatch();
+  const history = useHistory();
   const values = {
     name: '',
     hardware_model: '',
@@ -27,7 +29,7 @@ const NewModelFormPage = () => {
         values: { model: formValues },
         actions: {},
         successCallback: () => {
-          window.location.href = MODELS_PATH;
+          history.push(MODELS_PATH);
         },
         handleError: () => {
           setIsSubmitting(false);
@@ -41,7 +43,14 @@ const NewModelFormPage = () => {
       searchable={false}
       breadcrumbOptions={{
         breadcrumbItems: [
-          { caption: __('Hardware Models'), url: MODELS_PATH },
+          {
+            caption: __('Hardware Models'),
+            url: MODELS_PATH,
+            onClick: e => {
+              e.preventDefault();
+              history.push(MODELS_PATH);
+            },
+          },
           { caption: __('Create Model') },
         ],
       }}

--- a/webpack/assets/javascripts/react_app/routes/Models/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/constants.js
@@ -1,3 +1,6 @@
 export const MODELS_API_PATH = '/api/models';
 export const MODELS_PATH = '/models';
 export const API_REQUEST_KEY = 'MODELS';
+export const MODELS_PATH_NEW = '/models/new';
+export const MODELS_PATH_EDIT = '/models/:id/edit';
+export const MODELS_PATH_BY_ID = `${MODELS_PATH}/:id`;

--- a/webpack/assets/javascripts/react_app/routes/Models/constants.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/constants.js
@@ -1,3 +1,5 @@
 export const MODELS_API_PATH = '/api/models';
 export const MODELS_PATH = '/models';
 export const API_REQUEST_KEY = 'MODELS';
+export const MODELS_PATH_NEW = '/models/new';
+export const MODELS_PATH_EDIT = '/models/:id/edit';

--- a/webpack/assets/javascripts/react_app/routes/Models/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/index.js
@@ -1,10 +1,42 @@
 import React from 'react';
+import { Redirect } from 'react-router-dom';
 
 import ModelsPage from './ModelsPage';
-import { MODELS_PATH } from './constants';
+import NewModelFormPage from './NewModelFormPage';
+import EditModelFormPage from './EditModelFormPage';
+import {
+  MODELS_PATH,
+  MODELS_PATH_NEW,
+  MODELS_PATH_BY_ID,
+  MODELS_PATH_EDIT,
+} from './constants';
 
-export default {
-  path: MODELS_PATH,
-  render: props => <ModelsPage {...props} />,
-  exact: true,
-};
+export default [
+  {
+    path: MODELS_PATH,
+    render: props => <ModelsPage {...props} />,
+    exact: true,
+  },
+  {
+    path: MODELS_PATH_NEW,
+    render: props => <NewModelFormPage {...props} />,
+    exact: true,
+  },
+  {
+    path: MODELS_PATH_EDIT,
+    render: props => <EditModelFormPage {...props} />,
+    exact: true,
+  },
+  {
+    path: MODELS_PATH_BY_ID,
+    exact: true,
+    render: ({ match, location }) => (
+      <Redirect
+        to={{
+          pathname: `${MODELS_PATH}/${match.params.id}/edit`,
+          search: location.search,
+        }}
+      />
+    ),
+  },
+];

--- a/webpack/assets/javascripts/react_app/routes/Models/index.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/index.js
@@ -1,10 +1,24 @@
 import React from 'react';
 
 import ModelsPage from './ModelsPage';
-import { MODELS_PATH } from './constants';
+import NewModelFormPage from './NewModelFormPage';
+import EditModelFormPage from './EditModelFormPage';
+import { MODELS_PATH, MODELS_PATH_NEW, MODELS_PATH_EDIT } from './constants';
 
-export default {
-  path: MODELS_PATH,
-  render: props => <ModelsPage {...props} />,
-  exact: true,
-};
+export default [
+  {
+    path: MODELS_PATH,
+    render: props => <ModelsPage {...props} />,
+    exact: true,
+  },
+  {
+    path: MODELS_PATH_NEW,
+    render: props => <NewModelFormPage {...props} />,
+    exact: true,
+  },
+  {
+    path: MODELS_PATH_EDIT,
+    render: props => <EditModelFormPage {...props} />,
+    exact: true,
+  },
+];

--- a/webpack/assets/javascripts/react_app/routes/Models/modelErrorToast.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/modelErrorToast.js
@@ -1,0 +1,38 @@
+import { translate as __ } from '../../common/I18n';
+
+const CUSTOM_DUPLICATE_MODEL_NAME_MESSAGE = __(
+  'A model with this name already exists. Please choose a different name.'
+);
+
+const getFullMessages = response =>
+  // eslint-disable-next-line camelcase
+  response?.data?.error?.full_messages?.filter(Boolean) || [];
+
+const hasDuplicateNameError = response => {
+  const nameErrors = response?.data?.error?.errors?.name;
+  const duplicateAttributeMessage = __('has already been taken');
+
+  if (Array.isArray(nameErrors)) {
+    return nameErrors.some(message => message === duplicateAttributeMessage);
+  }
+
+  return getFullMessages(response).some(
+    message =>
+      message.includes(__('Name')) &&
+      message.includes(duplicateAttributeMessage)
+  );
+};
+
+export const modelErrorToast = ({ response, message, statusText } = {}) => {
+  if (hasDuplicateNameError(response)) {
+    return CUSTOM_DUPLICATE_MODEL_NAME_MESSAGE;
+  }
+
+  const fullMessages = getFullMessages(response);
+  return (
+    fullMessages.join(', ') ||
+    response?.data?.error?.message ||
+    message ||
+    statusText
+  );
+};

--- a/webpack/assets/javascripts/react_app/routes/Models/modelErrorToast.test.js
+++ b/webpack/assets/javascripts/react_app/routes/Models/modelErrorToast.test.js
@@ -1,0 +1,54 @@
+import { modelErrorToast } from './modelErrorToast';
+
+describe('modelErrorToast', () => {
+  it('returns custom message for duplicate model name field errors', () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            errors: {
+              name: ['has already been taken'],
+            },
+            full_messages: ['Name has already been taken'],
+          },
+        },
+      },
+    };
+
+    expect(modelErrorToast(error)).toBe(
+      'A model with this name already exists. Please choose a different name.'
+    );
+  });
+
+  it('falls back to full_messages pattern matching for duplicate names', () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            full_messages: ['Name has already been taken'],
+          },
+        },
+      },
+    };
+
+    expect(modelErrorToast(error)).toBe(
+      'A model with this name already exists. Please choose a different name.'
+    );
+  });
+
+  it('returns full messages for non-duplicate validation errors', () => {
+    const error = {
+      response: {
+        data: {
+          error: {
+            full_messages: ['Info is too long (maximum is 255 characters)'],
+          },
+        },
+      },
+    };
+
+    expect(modelErrorToast(error)).toBe(
+      'Info is too long (maximum is 255 characters)'
+    );
+  });
+});

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
@@ -16,6 +16,24 @@ exports[`Routes rendering routes with children renders routes with chidlren 1`] 
     />
     <Route
       exact={true}
+      key="/models/new"
+      path="/models/new"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      key="/models/:id/edit"
+      path="/models/:id/edit"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      key="/models/:id"
+      path="/models/:id"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
       key="/new/hosts"
       path="/new/hosts"
       render={[Function]}

--- a/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
+++ b/webpack/assets/javascripts/react_app/routes/__test__/__snapshots__/Routes.test.js.snap
@@ -16,6 +16,18 @@ exports[`Routes rendering routes with children renders routes with chidlren 1`] 
     />
     <Route
       exact={true}
+      key="/models/new"
+      path="/models/new"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
+      key="/models/:id/edit"
+      path="/models/:id/edit"
+      render={[Function]}
+    />
+    <Route
+      exact={true}
       key="/new/hosts"
       path="/new/hosts"
       render={[Function]}

--- a/webpack/assets/javascripts/react_app/routes/routes.js
+++ b/webpack/assets/javascripts/react_app/routes/routes.js
@@ -10,7 +10,7 @@ import Upgrade from './Upgrade';
 
 export const routes = [
   Audits,
-  Models,
+  ...Models,
   Hosts,
   HostDetails,
   RegistrationCommands,


### PR DESCRIPTION
Converting HW models pages, I did this for learning purposes looking at some more recent rewrites elsewhere in the project, so don't judge me too hard. In a way a follow up to https://github.com/theforeman/foreman/pull/10910 that removed the PF3 button used in models. 

Tests are AI assisted