### PR TITLE
Fixes #31560 - Bump uuid to v13 and replace v1 with v7

### DIFF
--- a/config/webpack.vendor.js
+++ b/config/webpack.vendor.js
@@ -71,10 +71,6 @@ module.exports = [
    * UUID
    */
   'uuid',
-  'uuid/v1',
-  'uuid/v3',
-  'uuid/v4',
-  'uuid/v5',
 
   'jstz',
   'diff',

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "unidiff": "^1.0.0",
     "unleash-proxy-client": "^3.7.6",
     "urijs": "^1.19.4",
-    "uuid": "^3.3.2",
+    "uuid": "^13.0.0",
     "yup": "^0.29.3"
   },
   "devDependencies": {

--- a/webpack/__mocks__/uuid.js
+++ b/webpack/__mocks__/uuid.js
@@ -1,0 +1,61 @@
+/* eslint-disable */
+// CJS shim for uuid v13 (pure ESM) - required for Jest 26 compatibility
+const crypto = require('crypto');
+
+function rng() {
+  return crypto.randomBytes(16);
+}
+
+function v1() {
+  const rnds = rng();
+  // Set version (4 bits) and variant (2 bits)
+  rnds[6] = (rnds[6] & 0x0f) | 0x10;
+  rnds[8] = (rnds[8] & 0x3f) | 0x80;
+  const hex = Buffer.from(rnds).toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+function v4() {
+  const rnds = rng();
+  rnds[6] = (rnds[6] & 0x0f) | 0x40;
+  rnds[8] = (rnds[8] & 0x3f) | 0x80;
+  const hex = Buffer.from(rnds).toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+function v7() {
+  const rnds = rng();
+  const now = Date.now();
+  // Encode timestamp in first 48 bits
+  rnds[0] = (now / 2 ** 40) & 0xff;
+  rnds[1] = (now / 2 ** 32) & 0xff;
+  rnds[2] = (now / 2 ** 24) & 0xff;
+  rnds[3] = (now / 2 ** 16) & 0xff;
+  rnds[4] = (now / 2 ** 8) & 0xff;
+  rnds[5] = now & 0xff;
+  // Set version 7 and variant
+  rnds[6] = (rnds[6] & 0x0f) | 0x70;
+  rnds[8] = (rnds[8] & 0x3f) | 0x80;
+  const hex = Buffer.from(rnds).toString('hex');
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join('-');
+}
+
+module.exports = { v1, v4, v7 };

--- a/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
+++ b/webpack/assets/javascripts/react_app/common/hooks/API/APIHooks.js
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useSelector, useDispatch, shallowEqual } from 'react-redux';
 import { isEqual } from 'lodash';
-import uuid from 'uuid/v1';
+import { v7 as uuid } from 'uuid';
 import {
   selectAPIResponse,
   selectAPIStatus,

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.js
@@ -2,7 +2,7 @@
 /* eslint no-case-declarations:0 */
 import { difference, head } from 'lodash';
 import Immutable from 'seamless-immutable';
-import uuidV1 from 'uuid/v1';
+import { v7 as uuidV7 } from 'uuid';
 
 import {
   VMWARE_CLUSTER_CHANGE,
@@ -58,7 +58,7 @@ export default (state = initialState, { type, payload, response }) => {
               {},
               payload.volume,
               { controllerKey: availableKey },
-              { key: uuidV1() }
+              { key: uuidV7() }
             )
           )
         );
@@ -67,7 +67,7 @@ export default (state = initialState, { type, payload, response }) => {
         'volumes',
         state.volumes.concat({
           ...payload.data,
-          key: uuidV1(),
+          key: uuidV7(),
           controllerKey: payload.controllerKey,
         })
       );
@@ -107,7 +107,7 @@ export default (state = initialState, { type, payload, response }) => {
         storagePods: [],
         storagePodsLoading: false,
         storagePodsError: undefined,
-        volumes: payload.volumes.map(volume => ({ ...volume, key: uuidV1() })),
+        volumes: payload.volumes.map(volume => ({ ...volume, key: uuidV7() })),
         cluster: payload.cluster,
       };
       return initialState

--- a/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.test.js
+++ b/webpack/assets/javascripts/react_app/redux/reducers/hosts/storage/vmware.test.js
@@ -1,5 +1,3 @@
-import uuidV1 from 'uuid/v1';
-
 import * as types from '../../../consts';
 
 import {
@@ -13,8 +11,7 @@ import {
 
 import reducer from './vmware';
 
-jest.mock('uuid/v1');
-uuidV1.mockImplementation(() => '1547e1c0-309a-11e9-98f5-5f761412a4c2');
+jest.mock('uuid', () => ({ v7: jest.fn(() => '1547e1c0-309a-11e9-98f5-5f761412a4c2') }));
 
 describe('vmware storage reducer', () => {
   it('returns the initial state', () => {

--- a/webpack/assets/javascripts/services/charts/AreaChartService.js
+++ b/webpack/assets/javascripts/services/charts/AreaChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import { v7 as uuidV7 } from 'uuid';
 import { getChartConfig } from './ChartService';
 
 export const getAreaChartConfig = ({
@@ -8,7 +8,7 @@ export const getAreaChartConfig = ({
   yAxisLabel,
   xAxisDataLabel = 'time',
   stacked = true,
-  id = uuidV1(),
+  id = uuidV7(),
   size = undefined,
 }) => {
   const chartConfig = getChartConfig({

--- a/webpack/assets/javascripts/services/charts/BarChartService.js
+++ b/webpack/assets/javascripts/services/charts/BarChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import { v7 as uuidV7 } from 'uuid';
 import { getChartConfig } from './ChartService';
 
 export const getBarChartConfig = ({
@@ -7,7 +7,7 @@ export const getBarChartConfig = ({
   onclick,
   xAxisLabel,
   yAxisLabel,
-  id = uuidV1(),
+  id = uuidV7(),
 }) => {
   const chartConfig = getChartConfig({
     type: 'bar',

--- a/webpack/assets/javascripts/services/charts/ChartService.js
+++ b/webpack/assets/javascripts/services/charts/ChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import { v7 as uuidV7 } from 'uuid';
 import Immutable from 'seamless-immutable';
 import {
   donutChartConfig,
@@ -56,7 +56,7 @@ export const getChartConfig = ({
   data,
   config,
   onclick,
-  id = uuidV1(),
+  id = uuidV7(),
 }) => {
   const chartConfigForType = chartsSizeConfig[type][config];
   const colors = getColors(data);
@@ -113,7 +113,7 @@ export const getDonutChartConfigPF5 = ({
   searchUrl,
   searchFilters,
   title,
-  id = uuidV1(),
+  id = uuidV7(),
 }) => {
   const chartConfigForType = chartsSizeConfig.donut[config];
   const dataExists = doDataExist(data);

--- a/webpack/assets/javascripts/services/charts/DonutChartService.js
+++ b/webpack/assets/javascripts/services/charts/DonutChartService.js
@@ -1,4 +1,4 @@
-import uuidV1 from 'uuid/v1';
+import { v7 as uuidV7 } from 'uuid';
 import { getDonutChartConfigPF5 } from './ChartService';
 
 export const getDonutChartConfig = ({
@@ -8,7 +8,7 @@ export const getDonutChartConfig = ({
   searchUrl,
   searchFilters,
   title,
-  id = uuidV1(),
+  id = uuidV7(),
 }) =>
   getDonutChartConfigPF5({
     data,

--- a/webpack/assets/javascripts/services/charts/LineChartService.js
+++ b/webpack/assets/javascripts/services/charts/LineChartService.js
@@ -1,11 +1,11 @@
-import uuidV1 from 'uuid/v1';
+import { v7 as uuidV7 } from 'uuid';
 import { getChartConfig } from './ChartService';
 
 export const getLineChartConfig = ({
   data,
   config,
   onclick,
-  id = uuidV1(),
+  id = uuidV7(),
   xAxisDataLabel,
   axisOpts,
 }) => {

--- a/webpack/jest.config.js
+++ b/webpack/jest.config.js
@@ -64,6 +64,7 @@ module.exports = {
     '^@theforeman/test$': foremanTest,
     '^react-redux-test-utils$': foremanTest,
     '^victory(.*)$': `${nodeModules}/victory$1`,
+    '^uuid$': path.resolve(__dirname, '__mocks__/uuid.js'),
   },
   globals: {
     __testing__: true,


### PR DESCRIPTION
Fixes https://projects.theforeman.org/issues/31560

## Summary

- Bump `uuid` package from 3.3.2 to 13.0.0
- Migrate all imports from deprecated deep paths (`uuid/v1`) to named exports (`{ v7 } from 'uuid'`)
- Replace UUID v1 (timestamp+MAC based) with v7 (RFC 9562, timestamp+random) - the modern standard for unique ID generation
- Remove obsolete deep import entries from webpack vendor config
- Add explicit Jest module mapping for uuid v13 ESM exports
- Update test mocks to use the new import style

This supersedes #10934 and addresses the version bump suggested in its review. Deep import paths like `uuid/v1` were removed in uuid v7, so this change is necessary for the upgrade.

## Changes across 11 files

- `package.json`: `^3.3.2` → `^13.0.0`
- `config/webpack.vendor.js`: removed `uuid/v1`, `uuid/v3`, `uuid/v4`, `uuid/v5` entries
- `webpack/jest.config.js`: added explicit module mapping for uuid ESM exports
- `APIHooks.js`: `import uuid from 'uuid/v1'` → `import { v7 as uuid } from 'uuid'`
- `vmware.js`: `import uuidV1` → `import { v7 as uuidV7 }`, all call sites updated
- `vmware.test.js`: mock rewritten for named exports
- 5 chart services: same import migration

## Test plan

- [ ] CI passes (units, functionals, integration, webpack compile)
- [ ] Katello plugin tests pass
- [ ] VMware storage volume operations work correctly
- [ ] Charts render with unique IDs