### PR TITLE
Fixes #39212 - Add still_applicable column to errata report

### DIFF
--- a/app/views/unattended/report_templates/host_-_applied_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applied_errata.erb
@@ -8,6 +8,7 @@ template_inputs:
   description: Filter only errata of a given type. If you select all, errata are not
     filtered by type.
   options: "all\r\nsecurity\r\nbugfix\r\nrecommended\r\nenhancement\r\noptional"
+  default: "all"
   advanced: false
 - name: Hosts filter
   required: false
@@ -24,12 +25,14 @@ template_inputs:
     such as uptime reported by Puppet or Ansible. The computation might be performance
     heavy, if this value is not interesting, it can be omitted by choosing no.
   options: "yes\r\nno"
+  default: "no"
   advanced: false
 - name: Status
   required: false
   input_type: user
   description: Limit the search based on the application result.
-  options: "all\r\nsuccess\r\nwarning\r\nerror\r\ncancelled\r\npending"
+  options: "all\r\nsuccess\r\nwarning\r\nerror\r\ncancelled"
+  default: "all"
   advanced: false
 - name: Since
   required: false
@@ -40,6 +43,7 @@ template_inputs:
     By default, the search is unlimited.
   advanced: false
   value_type: date
+  default: ""
 - name: Up to
   required: false
   input_type: user
@@ -53,7 +57,7 @@ require:
 - plugin: katello
   version: 3.12.0
 -%>
-<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'issued', 'severity', 'status' -%>
+<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'issued', 'severity', 'status', 'still_applicable' -%>
 <%- load_errata_applications(filter_errata_type: input('Filter Errata Type'),
                              include_last_reboot: input('Include Last Reboot'),
                              since: input('Since'),


### PR DESCRIPTION
Adds a `still_applicable` column to the Host - Applied Errata report template. This column indicates whether an applied erratum is currently still showing as applicable to the host, helping admins identify potential issues like package downgrades or manual changes. Removes "pending" status from the Applied Errata report template because the new architecture only tracks completed errata applications.

### Related Issues
- Related Katello PR: https://github.com/Katello/katello/pull/11690
- Katello Issue: https://projects.theforeman.org/issues/39185

### Testing Steps                                                                                                                            
  1. Apply the Katello PR changes                                                                                                              
  2. Apply errata to a host                                                                                                                    
  3. Generate "Host - Applied Errata" report
  4. Verify "pending" is not available in the Status filter dropdown                                                                                              
  5. Verify `still_applicable` column shows `false` for successfully applied errata                                                            
  6. Downgrade a package and verify `still_applicable` shows `true`
