### PR TITLE
Fixes #39290 - Add :registration logger and registration session markers

### DIFF
--- a/app/controllers/api/v2/registration_controller.rb
+++ b/app/controllers/api/v2/registration_controller.rb
@@ -47,6 +47,10 @@ module Api
           return
         end
 
+        Foreman::Logging.logger('registration').info(
+          "session_start org=#{params[:organization_id]} loc=#{params[:location_id]} hostgroup=#{params[:hostgroup_id]}"
+        )
+
         render plain: @provisioning_template.render(variables: @global_registration_vars).html_safe
       end
 
@@ -87,9 +91,13 @@ module Api
       param :setup_insights, :bool, desc: N_("Set 'host_registration_insights' parameter for the host. If it is set to true, insights client will be installed and registered on Red Hat family operating systems")
       param :setup_remote_execution, :bool, desc: N_("Set 'host_registration_remote_execution' parameter for the host. If it is set to true, SSH keys will be installed on the host")
       def host
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        host_action = nil
+
         begin
           ActiveRecord::Base.transaction do
             find_host
+            host_action = @host.new_record? ? 'created' : 'updated'
             prepare_host
             setup_host_params
             host_setup_extension
@@ -105,6 +113,11 @@ module Api
           not_found N_("Unable to find 'Host initial configuration' template for host %{host} running %{os}, associate the 'Host initial configuration' template for this OS first") % { host: @host.name, os: @host.operatingsystem }
           return
         end
+
+        duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).to_i
+        Foreman::Logging.logger('registration').info(
+          "session_complete host=#{@host.name} action=#{host_action} duration_ms=#{duration_ms}"
+        )
 
         # Do not rebuild managed hosts
         # Hosts registered with subscription-manager are created

--- a/config/application.rb
+++ b/config/application.rb
@@ -277,7 +277,8 @@ module Foreman
       :blob => {:enabled => false},
       :taxonomy => {:enabled => true},
       :api_deprecations => {:enabled => true},
-      :sidekiq => {:enabled => true, :level => :warn}
+      :sidekiq => {:enabled => true, :level => :warn},
+      :registration => {:enabled => true}
     ))
 
     config.logger = Foreman::Logging.logger('app')

--- a/test/controllers/api/v2/registration_controller_test.rb
+++ b/test/controllers/api/v2/registration_controller_test.rb
@@ -362,5 +362,41 @@ class Api::V2::RegistrationControllerTest < ActionController::TestCase
         assert hostgroups(:common).operatingsystem_id, host.operatingsystem_id
       end
     end
+
+    context 'session markers' do
+      test 'logs session_complete with action=created for a new host' do
+        reg_logger = mock('registration_logger')
+        reg_logger.expects(:info).with { |msg| msg.include?('session_complete') && msg.include?('action=created') }
+        Foreman::Logging.stubs(:logger).returns(stub_everything('null_logger'))
+        Foreman::Logging.stubs(:logger).with('registration').returns(reg_logger)
+
+        post :host, params: host_params, session: set_session_user
+        assert_response :success
+      end
+
+      test 'logs session_complete with action=updated for an existing host' do
+        Host.create(host_params[:host])
+
+        reg_logger = mock('registration_logger')
+        reg_logger.expects(:info).with { |msg| msg.include?('session_complete') && msg.include?('action=updated') }
+        Foreman::Logging.stubs(:logger).returns(stub_everything('null_logger'))
+        Foreman::Logging.stubs(:logger).with('registration').returns(reg_logger)
+
+        post :host, params: host_params, session: set_session_user
+        assert_response :success
+      end
+    end
+  end
+
+  describe 'registration logger' do
+    test 'logs session_start on global registration' do
+      reg_logger = mock('registration_logger')
+      reg_logger.expects(:info).with { |msg| msg.include?('session_start') }
+      Foreman::Logging.stubs(:logger).returns(stub_everything('null_logger'))
+      Foreman::Logging.stubs(:logger).with('registration').returns(reg_logger)
+
+      get :global
+      assert_response :success
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds a dedicated `:registration` named logger to Foreman's logging infrastructure — a single knob to enable registration-specific debug output without enabling all-Rails debug logging
- Emits two structured INFO-level log lines through this logger:
  - `session_start` on `GET /register` — org, location, hostgroup context
  - `session_complete` on `POST /register` — host name, created/updated action, wall-clock duration

The `session_complete` line surfaces the bimodal timing distribution between new registrations and re-registrations. Both events are visible at the default INFO level with no configuration change needed.

## Log output

```
# GET /register (script delivery)
[registration] session_start org=Default loc=Default hostgroup=RHEL9

# POST /register (host record creation)
[registration] session_complete host=server.example.com action=created duration_ms=234
```

## Why a dedicated logger

The `:registration` named logger lets operators enable `debug` level for registration events without flooding the log with SQL queries or view rendering:

```yaml
:logging:
  :loggers:
    :registration:
      :level: debug
```

At `debug` level, companion Katello PRs emit Candlepin per-call timing and cache HIT/MISS decisions using the same logger.

## Requirements

- No infrastructure requirements beyond standard Foreman/Rails stack.
- Katello companion PR (registration observability) uses `Foreman::Logging.logger('registration')` — both should merge together or Katello's PR should merge after this one.

## How to test

1. `bundle exec rake test TEST=test/controllers/api/v2/registration_controller_test.rb`
2. Register a host and check production.log for `session_start` and `session_complete` lines
3. Setting `:registration: :level: debug` enables Candlepin per-call timing without enabling all-Rails SQL logging