### PR TITLE
Fixes #XXXXX - Run insights-client registration in background via systemd-run

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/insights.erb
+++ b/app/views/unattended/provisioning_templates/snippet/insights.erb
@@ -9,10 +9,15 @@ description: |
 -%>
 <% if @host.operatingsystem.name == 'RedHat' -%>
 echo '#'
-echo '# Installing Insights client'
+echo '# Installing and registering Insights client (runs in background)'
 echo '#'
 
 yum install -y insights-client
-insights-client --register < /dev/null
+
+# Run insights-client in a transient systemd unit so it does not block
+# host registration. The unit survives shell exit and logs to the journal.
+# To check status: systemctl status insights-register
+#                  journalctl -u insights-register
+systemd-run --unit=insights-register --no-block insights-client --register
 
 <% end -%>

--- a/test/models/provisioning_template_test.rb
+++ b/test/models/provisioning_template_test.rb
@@ -311,4 +311,34 @@ class ProvisioningTemplateTest < ActiveSupport::TestCase
     refute template.valid?
     assert_includes template.errors.attribute_names, :operatingsystems
   end
+
+  # insights snippet — non-blocking registration via systemd-run
+  test "insights snippet uses systemd-run --no-block for non-blocking insights registration on RHEL" do
+    snippet_path = Rails.root.join(
+      'app/views/unattended/provisioning_templates/snippet/insights.erb'
+    )
+    skip "insights snippet not found" unless File.exist?(snippet_path)
+
+    host = OpenStruct.new(operatingsystem: OpenStruct.new(name: 'RedHat'))
+    template_content = File.read(snippet_path).gsub(/\A<%#.*?-%>/m, '')
+    rendered = ERB.new(template_content).result(binding)
+
+    assert_match(/systemd-run --unit=insights-register --no-block/, rendered)
+    assert_no_match(/insights-client --register\s*<\s*\/dev\/null/, rendered,
+      "Old blocking insights-client call should not be present")
+  end
+
+  test "insights snippet renders nothing for non-RHEL hosts" do
+    snippet_path = Rails.root.join(
+      'app/views/unattended/provisioning_templates/snippet/insights.erb'
+    )
+    skip "insights snippet not found" unless File.exist?(snippet_path)
+
+    host = OpenStruct.new(operatingsystem: OpenStruct.new(name: 'Debian'))
+    template_content = File.read(snippet_path).gsub(/\A<%#.*?-%>/m, '')
+    rendered = ERB.new(template_content).result(binding)
+
+    assert_no_match(/systemd-run/, rendered)
+    assert_no_match(/insights-client/, rendered)
+  end
 end


### PR DESCRIPTION
## Summary

`insights-client --register` makes a network call to Red Hat Cloud that takes 15-24 seconds per host, blocking the entire host registration script. This PR replaces it with a transient systemd unit:

```bash
systemd-run --unit=insights-register --no-block insights-client --register
```

This saves 15-24 seconds per host from the host_init_config script wall time. The unit runs independently of the parent shell, survives shell exit, and logs to the system journal. Status is trackable on the host:

```
systemctl status insights-register
journalctl -u insights-register
```

## Why systemd-run instead of `& disown`

`& disown` is unreliable when the parent shell exits immediately after launching the background process. `systemd-run --no-block` creates a proper transient systemd service that is guaranteed to survive shell exit.

`< /dev/null` from the original call is not needed: systemd-run sets `StandardInput=null` for transient service units by default.

## Requirements

- `systemd-run` available (since RHEL 7 / systemd 208)
- Template already gated to `@host.operatingsystem.name == 'RedHat'` — no compatibility risk on non-RHEL systems

## Compatibility

Insights registration status is NOT reported back to Foreman in this PR — Foreman marks the host as registered before insights completes. A future Dynflow integration would close this observability gap.

## Test plan

- [ ] Register a RHEL host; verify host_init_config completes 15-20s faster
- [ ] `systemctl status insights-register` on the host shows the unit ran
- [ ] `journalctl -u insights-register` shows insights client output
- [ ] Non-RHEL hosts: no insights block rendered