### PR TITLE
Fixes #39249 - Recover from false registration failures caused by TCP reset

### DIFF
--- a/app/views/unattended/provisioning_templates/registration/global_registration.erb
+++ b/app/views/unattended/provisioning_templates/registration/global_registration.erb
@@ -166,7 +166,20 @@ register_katello_host(){
 
 subscription-manager register \
   --org='<%= @organization.label if @organization %>' \
-  --activationkey='<%= activation_keys %>' || <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
+  --activationkey='<%= activation_keys %>' || {
+  # At high registration concurrency the TCP connection is sometimes reset
+  # after the server commits the consumer record but before returning a
+  # response. Check whether registration actually succeeded server-side
+  # before deciding to fail or continue.
+  _SM_UUID=$(subscription-manager identity 2>/dev/null | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -1)
+  if [ -n "$_SM_UUID" ]; then
+    echo "REGISTRATION_SUCCESS recovered=true uuid=$_SM_UUID host=$(hostname --fqdn)"
+    echo "# Consumer already exists server-side; connection was reset during response delivery"
+  else
+    echo "REGISTRATION_FAILED reason=server_overload phase=rhsm_register host=$(hostname --fqdn)"
+    <%= truthy?(@ignore_subman_errors) ? 'true' : 'cleanup_and_exit 1' %>
+  fi
+}
 <% end -%>
 
 # Update / create the host record in Foreman and fetch the host initial configuration script


### PR DESCRIPTION
## Summary

At 320+ concurrent registrations, the server sometimes creates the Candlepin consumer but the TCP connection resets before the response reaches subscription-manager. `register` then exits non-zero even though registration succeeded, failing an already-registered host.

Since `register_katello_host` needs the consumer UUID either way, the fix checks **"does a UUID exist?"** instead of trusting `register`'s exit code:

- **Success:** reuse the UUID `register` already printed to stdout — no extra call needed.
- **Failure:** fall back to `subscription-manager identity` (local cert read, no server round trip). UUID found → false negative, continue. Not found → genuine failure, `cleanup_and_exit`.

## Why it's safe

`register` and `identity` read the same Candlepin response (`consumer["idCert"]`, both used to persist the cert and to print the ID in subscription-manager's own source). They can't disagree after a successful register.

## Why it's fast

`identity` costs ~660ms/call (Python startup) vs ~2ms to parse text already in memory. The original approach called `identity` on every host regardless of outcome; this only calls it on the rare failure path.

## Test plan

- [ ] TCP reset simulation: `register` fails, `identity` still resolves a UUID, script continues
- [ ] Genuine failure: no UUID either way, script exits (or continues if `ignore_subman_errors`)
- [ ] Normal success: only one `subscription-manager` call before `register_katello_host` runs
