### PR TITLE
Fixes #39180 - Add cloud_provider stub to base FactParser

### DIFF
--- a/app/services/fact_parser.rb
+++ b/app/services/fact_parser.rb
@@ -134,6 +134,10 @@ class FactParser
     {}
   end
 
+  # Cloud provider (e.g., AWS, Azure, GCP)
+  def cloud_provider
+  end
+
   # AWS cloud billing fields
   def aws_account_id
   end

--- a/test/unit/fact_parser_test.rb
+++ b/test/unit/fact_parser_test.rb
@@ -388,6 +388,11 @@ class FactParserTest < ActiveSupport::TestCase
     end
   end
 
+  test "base class responds to cloud_provider" do
+    parser = get_parser
+    assert_nil parser.cloud_provider
+  end
+
   def get_parser(facts = {})
     FactParser.new(facts)
   end


### PR DESCRIPTION
### Description

Fixes Redmine #39180 - Facts upload fails with `NoMethodError: undefined method 'cloud_provider'` for non-core fact parsers.

### Root Cause

Commit bc8a381 added `cloud_provider` to `ReportedDataFacet.populate_fields_from_facts` and implemented it in `PuppetFactParser`, `AnsibleFactParser`, and `Katello::RhsmFactParser`. However, it missed adding the default nil-returning stub to the base `FactParser` class.

This causes any fact parser that does not explicitly define `cloud_provider` (e.g. third-party plugins like foreman_salt when loaded from an older gem version, or any custom fact parser) to raise `NoMethodError` when facts are uploaded, since `ReportedDataFacet.populate_fields_from_facts` calls `parser.cloud_provider` unconditionally.

### Fix

Add `def cloud_provider; end` to the base `FactParser` class, placed alongside the existing cloud billing field stubs (`aws_account_id`, `azure_instance_id`, `gcp_instance_id`, etc.) for consistency.

### Test

Added a test to verify the base `FactParser` class responds to `cloud_provider` and returns `nil` by default.