### PR TITLE
Fixes #39381 - Optimize hosts controller query: use pluck instead of map for hostgroup_ids

### DIFF
--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -53,7 +53,7 @@ class HostsController < ApplicationController
         # SQL optimization
         preload_reports
         # rendering index page for non index page requests (out of sync hosts etc)
-        @hostgroup_authorizer = Authorizer.new(User.current, :collection => @hosts.map(&:hostgroup_id).compact.uniq)
+        @hostgroup_authorizer = Authorizer.new(User.current, :collection => @hosts.pluck(:hostgroup_id).compact.uniq)
         render :index if title && (@title = title)
       end
       format.csv do


### PR DESCRIPTION
## Description

Optimize database query in hosts controller to reduce unnecessary memory allocation.

### Change

**`app/controllers/hosts_controller.rb` - Use `pluck` instead of `map`**

```ruby
# Before
@hosts.map(&:hostgroup_id).compact.uniq

# After
@hosts.pluck(:hostgroup_id).compact.uniq
```

`map(&:hostgroup_id)` loads all Host ActiveRecord objects into memory and extracts the attribute in Ruby. `pluck(:hostgroup_id)` generates a `SELECT hostgroup_id FROM ...` query that returns only the needed column values directly from the database, avoiding unnecessary object instantiation. This is particularly impactful on the hosts index page which can display many hosts.

### Note on previous user.rb change

The original PR also included a `.where().any?` → `.exists?()` change in `user.rb`. As correctly pointed out by @adamruzicka, Rails already optimizes `.any?` to generate the same efficient `SELECT 1 AS one ... LIMIT 1` query, so that change was reverted.