### PR TITLE
Fixes #39220 - Exclude host taxonomies that don't match the capsule t…

### DIFF
--- a/app/assets/javascripts/jquery.multi-select.js
+++ b/app/assets/javascripts/jquery.multi-select.js
@@ -7,6 +7,9 @@ function multiSelectOnLoad(){
     $(item).multiSelect({
       selectableHeader: $("<div class='ms-header'>" + __('All items') + " <input placeholder='" + __('Filter') + "' class='form-control ms-filter' type='text'><a href='#' title='" + __('Select All') + "' class='ms-select-all pull-right glyphicon glyphicon-plus'></a></div>"),
       selectionHeader: $("<div class='ms-header'>" + __('Selected items') + "<a href='#' title='" + __('Deselect All') + "' class='ms-deselect-all pull-right glyphicon glyphicon-minus'></a></div>"),
+      afterSelect: function(){
+        multiSelectToolTips();
+      },
       afterDeselect: function(value){
         var current_select = $(item).closest('.tab-pane').find('select[multiple]');
         current_select.data('descendants', null);
@@ -24,6 +27,7 @@ function multiSelectToolTips(){
     var inheriteds = $(item).attr('data-inheriteds');
     var descendants = $(item).attr('data-descendants');
     var useds = $(item).attr('data-useds');
+    var hostTaxonomyOutsideProxy = $(item).attr('data-host-taxonomy-outside-proxy');
     var msid = '#ms-'+item.id;
     // it an <li> items match multiple tooltips, then only the first tooltip will show
     if (!(mismatches == null || mismatches == 'undefined')) {
@@ -33,12 +37,35 @@ function multiSelectToolTips(){
         $(msid).find('li#'+opt_id+'-selectable').addClass('delete').tooltip({container: 'body', title: __("Select this since it belongs to a host"), placement: "left"});
       })
     }
-    if (!(useds == null || descendants == 'useds')) {
+    if (!(useds == null || useds == 'undefined')) {
       var used_ids = JSON.parse(useds);
       $.each(used_ids, function(index,used_id){
         opt_id = sanitize(used_id+'');
         $(msid).find('li#'+opt_id+'-selection').addClass('used_by_hosts').tooltip({container: 'body', title: __("This is used by a host"), placement: "right"});
       })
+    }
+    if (!(hostTaxonomyOutsideProxy == null || hostTaxonomyOutsideProxy == 'undefined')) {
+      var outside_ids = JSON.parse(hostTaxonomyOutsideProxy);
+      $.each(outside_ids, function(index, outside_id) {
+        opt_id = sanitize(outside_id + '');
+        var $selectableLi = $(msid).find('li#' + opt_id + '-selectable');
+        if ($selectableLi.length) {
+          $selectableLi.addClass('host_taxonomy_outside_proxy');
+          if (!$selectableLi.find('.host-taxonomy-outside-proxy-icon').length) {
+            $selectableLi.find('span').first().after(
+              "<span class='glyphicon glyphicon-exclamation-sign text-warning host-taxonomy-outside-proxy-icon' aria-hidden='true'></span>"
+            );
+          }
+          if ($selectableLi.data('bs.tooltip')) {
+            $selectableLi.tooltip('destroy');
+          }
+          $selectableLi.tooltip({
+            container: 'body',
+            title: __("Hosts use this Smart Proxy in this taxonomy, but the proxy is not assigned to it."),
+            placement: "left"
+          });
+        }
+      });
     }
     if (!(inheriteds == null || inheriteds == 'undefined')) {
       var inherited_ids = JSON.parse(inheriteds);

--- a/app/assets/stylesheets/multi-select-overrides.scss
+++ b/app/assets/stylesheets/multi-select-overrides.scss
@@ -14,6 +14,11 @@
     min-width: 100%;
   }
 
+  .ms-selectable li.host_taxonomy_outside_proxy .host-taxonomy-outside-proxy-icon {
+    margin-left: 6px;
+    vertical-align: middle;
+  }
+
   .ms-header {
     padding: 4px 10px;
     border: 1px solid #d1d1d1;

--- a/app/helpers/smart_proxies_helper.rb
+++ b/app/helpers/smart_proxies_helper.rb
@@ -1,6 +1,17 @@
 module SmartProxiesHelper
   TABBED_FEATURES = ["Puppet CA", "Logs"]
 
+  def smart_proxy_taxonomies_html_options(smart_proxy)
+    {
+      :location => {
+        'data-host-taxonomy-outside-proxy' => smart_proxy.host_taxonomy_ids_outside_proxy_assignment(:location_id).to_json,
+      },
+      :organization => {
+        'data-host-taxonomy-outside-proxy' => smart_proxy.host_taxonomy_ids_outside_proxy_assignment(:organization_id).to_json,
+      },
+    }
+  end
+
   def proxy_actions(proxy, authorizer)
     actions = []
     actions << display_link_if_authorized(_("Edit"), hash_for_edit_smart_proxy_path(:id => proxy))

--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -77,8 +77,15 @@ class SmartProxy < ApplicationRecord
   def used_taxonomy_ids(type)
     return [] if new_record? || !respond_to?(:hosts)
 
-    conditions = "#{id} IN (#{Host::Managed.proxy_column_list})"
-    ::Host::Managed.with_smart_proxies.where(conditions).distinct.pluck(type).compact
+    host_taxonomy_ids_for_proxy(type) & allowed_taxonomy_ids_for_proxy(type)
+  end
+
+  # Host taxonomies where managed hosts still reference this proxy, but the proxy
+  # is not assigned to those taxonomies (subset of host_taxonomy_ids_for_proxy).
+  def host_taxonomy_ids_outside_proxy_assignment(type)
+    return [] if new_record? || !respond_to?(:hosts)
+
+    host_taxonomy_ids_for_proxy(type) - allowed_taxonomy_ids_for_proxy(type)
   end
 
   def taxonomy_foreign_conditions
@@ -153,6 +160,19 @@ class SmartProxy < ApplicationRecord
   end
 
   private
+
+  def host_taxonomy_ids_for_proxy(type)
+    conditions = "#{id} IN (#{Host::Managed.proxy_column_list})"
+    ::Host::Managed.with_smart_proxies.where(conditions).distinct.pluck(type).compact.uniq
+  end
+
+  def allowed_taxonomy_ids_for_proxy(type)
+    case type
+    when :location_id then location_ids
+    when :organization_id then organization_ids
+    else raise ArgumentError, "type must be :location_id or :organization_id"
+    end
+  end
 
   def sanitize_url
     self.url = url.chomp('/') unless url.empty?

--- a/app/views/smart_proxies/_form.html.erb
+++ b/app/views/smart_proxies/_form.html.erb
@@ -16,7 +16,8 @@
       <%= text_f(f, :url, :label => _("URL"), :help_inline => _("HTTPS endpoint"), :label_help => _("Hostname and client certificate must be valid. Ports are typically 8443 or 9090."), :size => "col-md-8" ) %>
     </div>
 
-    <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @smart_proxy %>
+    <%= render 'taxonomies/loc_org_tabs', :f => f, :obj => @smart_proxy,
+               :html_options => smart_proxy_taxonomies_html_options(@smart_proxy) %>
 
     <%= submit_or_cancel f %>
   </div>

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -38,6 +38,48 @@ class SmartProxyTest < ActiveSupport::TestCase
     assert_equal [taxonomies(:location1).id], smart_proxies(:puppetmaster).used_or_selected_location_ids
   end
 
+  describe '#used_taxonomy_ids' do
+    let(:location1) { taxonomies(:location1) }
+    let(:location2) { taxonomies(:location2) }
+    let(:organization1) { taxonomies(:organization1) }
+    let(:organization2) { taxonomies(:organization2) }
+    let(:organization3) { taxonomies(:empty_organization) }
+
+    test 'returns empty array for a new unsaved proxy' do
+      proxy = SmartProxy.new(:name => 'New', :url => 'https://new.proxy:8443')
+      assert_empty proxy.used_taxonomy_ids(:location_id)
+      assert_empty proxy.used_taxonomy_ids(:organization_id)
+    end
+
+    test 'returns empty array when no managed host references the proxy' do
+      proxy = FactoryBot.create(:smart_proxy,
+        :locations => [location1],
+        :organizations => [organization1])
+      assert_empty proxy.used_taxonomy_ids(:location_id)
+      assert_empty proxy.used_taxonomy_ids(:organization_id)
+    end
+
+    test 'returns intersection of organizations on proxy and organizations of hosts using the proxy' do
+      as_admin do
+        proxy = FactoryBot.create(:smart_proxy,
+          :locations => [location1],
+          :organizations => [organization1, organization2])
+        FactoryBot.create(:host, :managed,
+          :puppet_proxy => proxy,
+          :location => location1,
+          :organization => organization2)
+        FactoryBot.create(:host, :managed,
+          :puppet_proxy => proxy,
+          :location => location1,
+          :organization => organization3)
+
+        assert_equal [organization2.id], proxy.reload.used_taxonomy_ids(:organization_id)
+        assert_includes proxy.host_taxonomy_ids_outside_proxy_assignment(:organization_id), organization3.id
+        refute_includes proxy.host_taxonomy_ids_outside_proxy_assignment(:organization_id), organization2.id
+      end
+    end
+  end
+
   describe "with older smart proxy on v1 api" do
     before do
       ProxyAPI::V2::Features.any_instance.stubs(:features).raises(NotImplementedError.new('not supported'))


### PR DESCRIPTION
…axonomies from used_taxonomy_ids

SAT-35949 - the the taxonomies listed in the smart proxy edit dialog could exceed the actual taxonomies assigned to proxy
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
