### PR TITLE
Fixes #39583 - fix hide_taxonomy_options with subsequent resource_description

### DIFF
--- a/app/controllers/api/v2/base_controller.rb
+++ b/app/controllers/api/v2/base_controller.rb
@@ -164,10 +164,17 @@ module Api
 
       def self.hide_taxonomy_options
         prepend_before_action :drop_taxonomy_id_from_params
-        resource_description do
-          param :location_id, Integer, :show => false
-          param :organization_id, Integer, :show => false
+
+        original_method = method(:resource_description)
+        define_singleton_method(:resource_description) do |options = {}, &block|
+          original_method.call(options) do
+            instance_exec(&block) if block
+            param :location_id, Integer, :show => false
+            param :organization_id, Integer, :show => false
+          end
         end
+
+        resource_description
       end
 
       def drop_taxonomy_id_from_params

--- a/config/routes/test.rb
+++ b/config/routes/test.rb
@@ -5,6 +5,8 @@ if Rails.env.test?
     namespace :api do
       namespace :v2 do
         resources :testable, :only => [:create, :index, :new]
+        resources :hide_taxonomy_simple, :only => :index
+        resources :hide_taxonomy_with_description, :only => :index
       end
 
       resources :testable, :only => :index do

--- a/test/controllers/api/v2/hide_taxonomy_options_test.rb
+++ b/test/controllers/api/v2/hide_taxonomy_options_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+# Controller that calls hide_taxonomy_options WITHOUT a subsequent resource_description.
+# This simulates existing controllers like ArchitecturesController.
+class Api::V2::HideTaxonomySimpleController < Api::V2::BaseController
+  hide_taxonomy_options
+
+  def index
+    render :json => { :location_id => params[:location_id], :organization_id => params[:organization_id] }, :status => :ok
+  end
+end
+
+# Controller that calls hide_taxonomy_options WITH a subsequent resource_description.
+# This simulates plugin controllers (e.g. foreman_ansible) where resource_description
+# with api_base_url follows hide_taxonomy_options.
+class Api::V2::HideTaxonomyWithDescriptionController < Api::V2::BaseController
+  hide_taxonomy_options
+
+  resource_description do
+    api_version 'v2'
+    api_base_url '/test_plugin/api'
+  end
+
+  def index
+    render :json => { :location_id => params[:location_id], :organization_id => params[:organization_id] }, :status => :ok
+  end
+end
+
+class Api::V2::HideTaxonomySimpleControllerTest < ActionController::TestCase
+  tests Api::V2::HideTaxonomySimpleController
+
+  test 'should drop taxonomy params from request' do
+    get :index, params: { :location_id => 1, :organization_id => 2 }, session: set_session_user
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_nil body['location_id']
+    assert_nil body['organization_id']
+  end
+
+  test 'should succeed without taxonomy params' do
+    get :index, session: set_session_user
+    assert_response :success
+  end
+end
+
+class Api::V2::HideTaxonomyWithDescriptionControllerTest < ActionController::TestCase
+  tests Api::V2::HideTaxonomyWithDescriptionController
+
+  test 'should drop taxonomy params even when resource_description follows hide_taxonomy_options' do
+    get :index, params: { :location_id => 1, :organization_id => 2 }, session: set_session_user
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_nil body['location_id']
+    assert_nil body['organization_id']
+  end
+
+  test 'should succeed without taxonomy params' do
+    get :index, session: set_session_user
+    assert_response :success
+  end
+end

--- a/test/unit/foreman/access_permissions_test.rb
+++ b/test/unit/foreman/access_permissions_test.rb
@@ -37,6 +37,7 @@ class AccessPermissionsTest < ActiveSupport::TestCase
     "testable/index", "api/testable/index", "api/testable/raise_error",
     "api/testable/required_nested_values", "api/testable/optional_nested_values", "api/testable/nested_values",
     "api/v2/testable/index", "api/v2/testable/create", "api/v2/testable/new", "fake/index", "api/v2/fake/index",
+    "api/v2/hide_taxonomy_simple/index", "api/v2/hide_taxonomy_with_description/index",
 
     # test stubs
     "testable_resources/index",


### PR DESCRIPTION
## Summary

- Fix `hide_taxonomy_options` to wrap `resource_description` via `define_singleton_method`, so any subsequent `resource_description` call on the same controller automatically appends hidden `location_id` and `organization_id` params
- This fixes the issue where plugin controllers (e.g. foreman_ansible) that call `hide_taxonomy_options` followed by `resource_description` (to set `api_base_url`) had the hidden params overwritten by the second `resource_description` call
- Add tests covering both scenarios: `hide_taxonomy_options` alone and `hide_taxonomy_options` + subsequent `resource_description`

## Context

Suggested by @ofedoren in [foreman_ansible#788](https://github.com/theforeman/foreman_ansible/pull/788#pullrequestreview-2895927948) as a better fix than patching individual plugin controllers.

## Test plan

- [ ] Existing controllers with `hide_taxonomy_options` (ArchitecturesController, SettingsController, etc.) continue to work
- [ ] Plugin controllers that call `resource_description` after `hide_taxonomy_options` now correctly hide taxonomy params
- [ ] `drop_taxonomy_id_from_params` still silently drops taxonomy params from requests