### PR TITLE
Fixes #39224 - Properly identify device of vlan interface on kickstart

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
+++ b/app/views/unattended/provisioning_templates/snippet/kickstart_network_interface.erb
@@ -25,7 +25,11 @@ os_major = @host.operatingsystem.major.to_i
 if @iface.bond? || @iface.bridge?
   network_options.push("--device=#{@iface.identifier}")
 else
-  network_options.push("--device=#{@iface.mac || @iface.identifier}")
+  if @iface.virtual? && @iface.tag.present? && @iface.attached_to.present?
+    network_options.push("--device=#{@iface.attached_to}")
+  else
+    network_options.push("--device=#{@iface.mac || @iface.identifier}")
+  end
 end
 network_options.push("--hostname #{@host.name}")
 


### PR DESCRIPTION
This PR modify the snippet that builds the network configuration line of the kickstart.

See details on the redmine issue being fixed. 