### PR TITLE
Fixes #39226 - Fix RHSM OS race condition reintroduced by recent refactor

### DIFF
--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -74,12 +74,7 @@ module Katello
         end
 
         os = ::Operatingsystem.find_by_attributes(**os_attributes.slice(:name, :major, :minor, :description)).first
-        if os.blank?
-          created = ::Operatingsystem.create(os_attributes)
-          created.errors.any? ? ::Operatingsystem.find_by(os_attributes) : created
-        else
-          os
-        end
+        os.presence || ::Operatingsystem.create_or_find_by(os_attributes)
       end
     end
 

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -248,8 +248,9 @@ module Katello
 
     def test_operatingsystem_race_condition_handling
       existing_os = ::Operatingsystem.create(name: 'RedHat', major: '9', minor: '')
-      ::Operatingsystem.expects(:find_by).returns(nil)
-      ::Operatingsystem.expects(:find_by_attributes).returns([])
+      # Simulate the race: initial lookup returns nothing, then create_or_find_by
+      # handles the uniqueness conflict atomically and returns the existing record.
+      ::Operatingsystem.expects(:find_by_attributes).once.returns([])
       @facts['distribution.name'] = 'Red Hat Enterprise Linux'
       @facts['distribution.version'] = '9'
       @facts['distribution.id'] = 'Nine'


### PR DESCRIPTION
## Problem

A recent refactor replaced `create_or_find_by` with `create` in `RhsmFactParser#operatingsystem`, re-introducing a race condition that had previously been fixed. Under concurrent bulk registration, multiple hosts try to create the same OS record simultaneously, causing:

```
PG::UniqueViolation: duplicate key value violates unique constraint "index_operatingsystems_on_title"
Key (title)=(RedHat 9.2) already exists.
```

`create` either succeeds or raises a DB-level exception — it never returns an errored object, making the existing `errors.any?` fallback dead code and leaving the `PG::UniqueViolation` unhandled.

## Fix

Two targeted changes:

1. `create` → `create_or_find_by` — restores atomic INSERT with conflict fallback to SELECT
2. `find_by(os_attributes)` → `find_by_attributes(...)` — uses the multi-constraint lookup introduced by the same refactor as the last-resort fallback, which correctly handles cases where the conflicting record was found via a different unique constraint combination

## Test plan

- [x] Concurrent bulk registration no longer raises `PG::UniqueViolation` on first registration burst when OS records don't yet exist

Fixes #39226