### PR TITLE
Fixes #39227 - Fix host delete toast disappearing before page refresh

### DIFF
--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/__tests__/actions.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/__tests__/actions.test.js
@@ -1,0 +1,149 @@
+import { deleteHost } from '../actions';
+import { openConfirmModal } from '../../../ConfirmModal';
+import { APIActions } from '../../../../redux/API';
+import { visit } from '../../../../common/helpers';
+
+jest.mock('../../../ConfirmModal', () => ({
+  openConfirmModal: jest.fn(payload => ({
+    type: 'OPEN_CONFIRM_MODAL',
+    payload,
+  })),
+}));
+
+jest.mock('../../../../redux/API', () => ({
+  APIActions: {
+    delete: jest.fn(params => ({
+      type: 'API_DELETE',
+      params,
+    })),
+  },
+}));
+
+jest.mock('../../../../common/helpers', () => ({
+  foremanUrl: jest.fn(path => path),
+  visit: jest.fn(),
+}));
+
+describe('deleteHost', () => {
+  const dispatch = jest.fn(action => {
+    if (typeof action === 'function') {
+      return action(dispatch);
+    }
+    return action;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const hostName = 'test-host.example.com';
+  const computeId = 123;
+  const destroyVmOnHostDelete = true;
+
+  it('dispatches openConfirmModal with correct parameters', () => {
+    deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+      hostsIndexUrl: '/hosts',
+    })(dispatch);
+
+    expect(openConfirmModal).toHaveBeenCalledTimes(1);
+    const modalPayload = openConfirmModal.mock.calls[0][0];
+
+    expect(modalPayload.isWarning).toBe(true);
+    expect(modalPayload.confirmButtonText).toBe('Delete');
+    expect(typeof modalPayload.onConfirm).toBe('function');
+  });
+
+  describe('onConfirm callback', () => {
+    it('calls visit with hostsIndexUrl when onDeleteSuccess is not provided', () => {
+      const hostsIndexUrl = '/new/hosts';
+
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+        hostsIndexUrl,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      expect(APIActions.delete).toHaveBeenCalledTimes(1);
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+
+      expect(deleteParams.url).toBe(`/api/hosts/${hostName}`);
+      expect(deleteParams.key).toBe(`${hostName}-DELETE`);
+      expect(typeof deleteParams.successToast).toBe('function');
+      expect(typeof deleteParams.errorToast).toBe('function');
+      expect(typeof deleteParams.handleSuccess).toBe('function');
+
+      deleteParams.handleSuccess();
+      expect(visit).toHaveBeenCalledWith(hostsIndexUrl);
+    });
+
+    it('calls onDeleteSuccess callback when provided instead of visit', () => {
+      const onDeleteSuccess = jest.fn();
+
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+        onDeleteSuccess,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      deleteParams.handleSuccess();
+
+      expect(onDeleteSuccess).toHaveBeenCalledTimes(1);
+      expect(visit).not.toHaveBeenCalled();
+    });
+
+    it('prefers onDeleteSuccess over hostsIndexUrl when both are provided', () => {
+      const onDeleteSuccess = jest.fn();
+      const hostsIndexUrl = '/hosts';
+
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+        hostsIndexUrl,
+        onDeleteSuccess,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      deleteParams.handleSuccess();
+
+      expect(onDeleteSuccess).toHaveBeenCalledTimes(1);
+      expect(visit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successToast', () => {
+    it('returns formatted success message with host name', () => {
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+        hostsIndexUrl: '/hosts',
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      const toastMessage = deleteParams.successToast();
+
+      expect(toastMessage).toContain(hostName);
+    });
+  });
+
+  describe('errorToast', () => {
+    it('returns error message from response', () => {
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+        hostsIndexUrl: '/hosts',
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      const errorMessage = 'Something went wrong';
+      const toastMessage = deleteParams.errorToast({ message: errorMessage });
+
+      expect(toastMessage).toBe(errorMessage);
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/actions.js
@@ -12,7 +12,7 @@ export const deleteHost = (
   hostName,
   compute,
   destroyVmOnHostDelete,
-  hostsIndexUrl
+  { hostsIndexUrl, onDeleteSuccess }
 ) => dispatch => {
   const successToast = () => sprintf(__('Host %s deleted'), hostName);
   const errorToast = ({ message }) => message;
@@ -32,6 +32,9 @@ export const deleteHost = (
     return null;
   };
 
+  const handleSuccess =
+    onDeleteSuccess || (() => visit(foremanUrl(hostsIndexUrl)));
+
   dispatch(
     openConfirmModal({
       isWarning: true,
@@ -44,7 +47,7 @@ export const deleteHost = (
             key: `${hostName}-DELETE`,
             successToast,
             errorToast,
-            handleSuccess: () => visit(foremanUrl(hostsIndexUrl)),
+            handleSuccess,
           })
         ),
       message: (

--- a/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostDetails/ActionsBar/index.js
@@ -64,7 +64,7 @@ const ActionsBar = ({
   const dispatch = useDispatch();
   const deleteHostHandler = () =>
     dispatch(
-      deleteHost(hostName, computeId, destroyVmOnHostDelete, hostsIndexUrl)
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, { hostsIndexUrl })
     );
 
   const isConsoleDisabled = !(computeId && isHostActive);

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/__tests__/bulkDelete.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/__tests__/bulkDelete.test.js
@@ -1,0 +1,141 @@
+import { bulkDeleteHosts } from '../bulkDelete';
+import { openConfirmModal } from '../../../ConfirmModal';
+import { APIActions } from '../../../../redux/API';
+import { visit } from '../../../../common/helpers';
+
+jest.mock('../../../ConfirmModal', () => ({
+  openConfirmModal: jest.fn(payload => ({
+    type: 'OPEN_CONFIRM_MODAL',
+    payload,
+  })),
+}));
+
+jest.mock('../../../../redux/API', () => ({
+  APIActions: {
+    delete: jest.fn(params => ({
+      type: 'API_DELETE',
+      params,
+    })),
+  },
+}));
+
+jest.mock('../../../../common/helpers', () => ({
+  foremanUrl: jest.fn(path => path),
+  visit: jest.fn(),
+}));
+
+describe('bulkDeleteHosts', () => {
+  const dispatch = jest.fn(action => {
+    if (typeof action === 'function') {
+      return action(dispatch);
+    }
+    return action;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const bulkParams = 'id ^ (1,2,3)';
+  const selectedCount = 3;
+  const destroyVmOnHostDelete = true;
+
+  it('dispatches openConfirmModal with correct parameters', () => {
+    bulkDeleteHosts({
+      bulkParams,
+      selectedCount,
+      destroyVmOnHostDelete,
+    })(dispatch);
+
+    expect(openConfirmModal).toHaveBeenCalledTimes(1);
+    const modalPayload = openConfirmModal.mock.calls[0][0];
+
+    expect(modalPayload.isWarning).toBe(true);
+    expect(modalPayload.isDireWarning).toBe(true);
+    expect(modalPayload.id).toBe('bulk-delete-hosts-modal');
+    expect(modalPayload.confirmButtonText).toBe('Delete');
+    expect(typeof modalPayload.onConfirm).toBe('function');
+  });
+
+  describe('onConfirm callback', () => {
+    it('calls visit with /new/hosts when onDeleteSuccess is not provided', () => {
+      bulkDeleteHosts({
+        bulkParams,
+        selectedCount,
+        destroyVmOnHostDelete,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      expect(APIActions.delete).toHaveBeenCalledTimes(1);
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+
+      expect(deleteParams.url).toBe(`/api/v2/hosts/bulk?search=${bulkParams}`);
+      expect(deleteParams.key).toBe('BULK-HOSTS-DELETE');
+      expect(typeof deleteParams.successToast).toBe('function');
+      expect(typeof deleteParams.errorToast).toBe('function');
+      expect(typeof deleteParams.handleSuccess).toBe('function');
+
+      deleteParams.handleSuccess();
+      expect(visit).toHaveBeenCalledWith('/new/hosts');
+    });
+
+    it('calls onDeleteSuccess callback when provided instead of visit', () => {
+      const onDeleteSuccess = jest.fn();
+
+      bulkDeleteHosts({
+        bulkParams,
+        selectedCount,
+        destroyVmOnHostDelete,
+        onDeleteSuccess,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      deleteParams.handleSuccess();
+
+      expect(onDeleteSuccess).toHaveBeenCalledTimes(1);
+      expect(visit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('successToast', () => {
+    it('returns formatted success message with host count', () => {
+      bulkDeleteHosts({
+        bulkParams,
+        selectedCount,
+        destroyVmOnHostDelete,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      const toastMessage = deleteParams.successToast();
+
+      expect(toastMessage).toContain(String(selectedCount));
+    });
+  });
+
+  describe('errorToast', () => {
+    it('returns error message from response', () => {
+      bulkDeleteHosts({
+        bulkParams,
+        selectedCount,
+        destroyVmOnHostDelete,
+      })(dispatch);
+
+      const modalPayload = openConfirmModal.mock.calls[0][0];
+      modalPayload.onConfirm();
+
+      const deleteParams = APIActions.delete.mock.calls[0][0];
+      const errorMessage = 'Bulk delete failed';
+      const toastMessage = deleteParams.errorToast({ message: errorMessage });
+
+      expect(toastMessage).toBe(errorMessage);
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDelete.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDelete.js
@@ -10,6 +10,7 @@ export const bulkDeleteHosts = ({
   bulkParams,
   selectedCount,
   destroyVmOnHostDelete,
+  onDeleteSuccess,
 }) => dispatch => {
   const successToast = () => sprintf(__('%s hosts deleted'), selectedCount);
   const errorToast = ({ message }) => message;
@@ -24,6 +25,9 @@ export const bulkDeleteHosts = ({
       : __(
           'For hosts with compute resources, VMs and their disks will not be deleted.'
         );
+
+  const handleSuccess =
+    onDeleteSuccess || (() => visit(foremanUrl('/new/hosts')));
 
   dispatch(
     openConfirmModal({
@@ -49,7 +53,7 @@ export const bulkDeleteHosts = ({
             key: `BULK-HOSTS-DELETE`,
             successToast,
             errorToast,
-            handleSuccess: () => visit(foremanUrl('/new/hosts')),
+            handleSuccess,
           })
         ),
       message: (

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -209,9 +209,16 @@ const HostsIndex = () => {
   const dispatch = useDispatch();
   const { destroyVmOnHostDelete } = useForemanSettings();
   const hostsIndexUrl = useForemanHostsPageUrl();
+  const refreshTableData = () =>
+    setAPIOptions({
+      ...apiOptions,
+      params: { search: urlSearchQuery },
+    });
   const deleteHostHandler = ({ hostName, computeId }) =>
     dispatch(
-      deleteHost(hostName, computeId, destroyVmOnHostDelete, hostsIndexUrl)
+      deleteHost(hostName, computeId, destroyVmOnHostDelete, {
+        onDeleteSuccess: refreshTableData,
+      })
     );
   const handleBulkDelete = () => {
     const bulkParams = fetchBulkParams();
@@ -220,6 +227,10 @@ const HostsIndex = () => {
         bulkParams,
         selectedCount,
         destroyVmOnHostDelete,
+        onDeleteSuccess: () => {
+          selectNone();
+          refreshTableData();
+        },
       })
     );
   };
@@ -520,12 +531,7 @@ const HostsIndex = () => {
           url={HOSTS_API_PATH}
           isDeleteable
           showCheckboxes
-          refreshData={() =>
-            setAPIOptions({
-              ...apiOptions,
-              params: { search: urlSearchQuery },
-            })
-          }
+          refreshData={refreshTableData}
           columns={columns}
           errorMessage={
             status === STATUS.ERROR && errorMessage ? errorMessage : null


### PR DESCRIPTION
When deleting a host from the new hosts index page, the success toast notification would appear briefly then disappear because the page performed a full browser redirect, losing the Redux state.

Instead of redirecting after delete on the hosts index page, refresh the table data in-place. This preserves the Redux state so the toast remains visible. The host details page still redirects since the host no longer exists.

- Add onDeleteSuccess callback option to deleteHost and bulkDeleteHosts
- HostsIndex passes a refresh callback instead of relying on redirect
- Clear selection after bulk delete before refreshing


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
