### PR TITLE
Fixes #39235 - Deprecate PF3-based table implementation

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/table/components/Table.js
+++ b/webpack/assets/javascripts/react_app/components/common/table/components/Table.js
@@ -1,9 +1,18 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Table as PfTable } from 'patternfly-react';
 import TableBody from './TableBody';
+import { deprecate } from '../../../../common/DeprecationService';
 
 const Table = ({ columns, rows, bodyMessage, children, ...props }) => {
+  useEffect(() => {
+    deprecate(
+      'common/table/components/Table',
+      'TableIndexPage from foremanReact/components/PF4/TableIndexPage/TableIndexPage or Table from @patternfly/react-table',
+      '3.21'
+    );
+  }, []);
+
   const body = children || [
     <PfTable.Header key="header" />,
     <TableBody


### PR DESCRIPTION
Adding the deprecate warning. The only implementation is handled in https://github.com/theforeman/foreman_webhooks/pull/99


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
