### PR TITLE
Fixes #39243 - navigation placeholder reveals the shortcut

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Layout/NavigationSearch.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/NavigationSearch.js
@@ -172,7 +172,7 @@ export const NavigationSearch = ({ items, clickAndNavigate }) => {
   const searchInput = (
     <SearchInput
       value={value}
-      placeholder={__('Search and go')}
+      placeholder={__('Search (Ctrl+Shift+F)')}
       onChange={(_e, newValue) => {
         onChange(newValue);
       }}

--- a/webpack/assets/javascripts/react_app/components/Layout/__tests__/NavigationSearch.test.js
+++ b/webpack/assets/javascripts/react_app/components/Layout/__tests__/NavigationSearch.test.js
@@ -29,7 +29,7 @@ describe('NavigationSearch', () => {
         <NavigationSearch items={items} clickAndNavigate={() => {}} />
       </div>
     );
-    const input = getByPlaceholderText('Search and go');
+    const input = getByPlaceholderText('Search (Ctrl+Shift+F)');
     act(() => input.focus());
     await act(async () => {
       await fireEvent.change(input, { target: { value: 'a' } });


### PR DESCRIPTION
@MariSvirik - please take a look. 

This has been discussed in the pull request, that has introduced this, [link](https://github.com/theforeman/foreman/pull/9681#discussion_r1385451322) but I would like to reopen this. The experience is not great and even after several releases, I find myself needing to remind myself the shortcut. Looking at github, which shows the shortcut in placeholder, I think it's not a bad pattern. Please reconsider this.

Pre
<img width="1660" height="944" alt="image" src="https://github.com/user-attachments/assets/a3b3a488-ecef-4ff6-8983-cea98fb7141e" />

Post
<img width="1660" height="944" alt="image" src="https://github.com/user-attachments/assets/60fab73c-c359-446d-abcc-dd45c90a7c3c" />

