### PR TITLE
Fixes #39068 - Calculate global_status dynamically on new All Hosts page

### DIFF
--- a/app/views/api/v2/hosts/main.json.rabl
+++ b/app/views/api/v2/hosts/main.json.rabl
@@ -17,9 +17,14 @@ attributes :ip, :ip6, :last_report, :mac, :realm_id, :realm_name,
   :compute_resource_id, :compute_resource_name,
   :compute_profile_id, :compute_profile_name, :capabilities, :provision_method,
   :certname, :image_id, :image_name, :created_at, :updated_at,
-  :last_compile, :global_status, :global_status_label, :global_status_fulltext, :tags, :bmc_available
+  :last_compile, :global_status_label, :global_status_fulltext, :tags, :bmc_available
 attributes :organization_id, :organization_name
 attributes :location_id, :location_name
+
+# Calculate global_status dynamically to ensure it reflects current time (e.g., out_of_sync status changes as time passes)
+node :global_status do |host|
+  host.build_global_status(:last_reports => @last_reports).status
+end
 
 node :operatingsystem_icon do |host|
   icon(host.operatingsystem, size: "16x16", path: true) if host.operatingsystem

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -119,6 +119,62 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
     assert_equal Host.all.pluck(:id, :name), hosts['results'].map(&:values)
   end
 
+  test "index should return dynamically calculated global_status not stale database value" do
+    Setting['outofsync_interval'] = 30
+    # Create host with old report (out of sync)
+    travel_to 2.hours.ago do
+      @host.reports.create!(
+        reported_at: Time.now.utc,
+        status: {"applied" => 4, "restarted" => 0, "failed" => 0,
+                 "failed_restarts" => 0, "skipped" => 0, "pending" => 0}
+      )
+
+      # Refresh config status for host
+      @host.refresh_statuses([HostStatus::ConfigurationStatus])
+    end
+
+    # Mark Build status as irrelevant
+    HostStatus::BuildStatus.any_instance.stubs(:relevant?).returns(false)
+
+    # Manually set stale database value to OK
+    @host.update_column(:global_status, HostStatus::Global::OK)
+
+    # Fetch via API
+    get :index
+    assert_response :success
+
+    # Parse response
+    response_json = ActiveSupport::JSON.decode(@response.body)
+    host_data = response_json['results'].find { |h| h['id'] == @host.id }
+
+    # Assert global_status is WARN (calculated) not OK (stale DB value)
+    assert_equal HostStatus::Global::WARN, host_data['global_status'],
+      "global_status should be dynamically calculated as WARN for out-of-sync host"
+    assert_equal "Warning", host_data['global_status_label']
+
+    # Verify global_status differs from stale database column
+    refute_equal @host.read_attribute(:global_status), host_data['global_status'],
+      "API should not return stale database column value"
+  end
+
+  test "index should show ok status for hosts with recent reports" do
+    # Create report within outofsync_interval
+    @host.reports.create!(
+      reported_at: Time.now.utc,
+      status: {"applied" => 4, "restarted" => 2, "failed" => 0,
+               "failed_restarts" => 0, "skipped" => 0, "pending" => 0}
+    )
+
+    get :index
+    assert_response :success
+
+    response_json = ActiveSupport::JSON.decode(@response.body)
+    host_data = response_json['results'].find { |h| h['id'] == @host.id }
+
+    assert_equal HostStatus::Global::OK, host_data['global_status']
+    assert_equal "OK", host_data['global_status_label']
+  end
+
   test "subtotal should be the same as the search count with thin" do
     FactoryBot.create_list(:host, 2)
     Host.last.update_attribute(:name, 'test')


### PR DESCRIPTION
Hosts with configuration reports older than the outofsync_interval setting should show a status of WARN. Previously, the legacy UI was honoring this settting, while on the new UI, hosts were showing a status of OK despite having config reports older than the outofsync_interval.

This change recalculates global status dynamically in the new UI to avoid reporting a stale value from the database.

Testing steps:
1. Set the `Out of sync interval` and `Ansible report timeout` settings to a small value, such as 5 minutes.
2. Register a host to Foreman.
3. Ensure all of the host's statuses are OK (green).
4. Add an Ansible role to the host.
5. Run Ansible roles on the host.
6. Wait until the intervals set in step 1 have elapsed.
7. Navigate to Hosts > All Hosts.
8. On the All Hosts page, verify that the status icon for the host is WARN (yellow) and that the Configuration status is reporting `Out of sync`.