### PR TITLE
Fixes #39272 - Remove outdated references from redhat_register snippet

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/autoyast_sles_default.erb
@@ -15,7 +15,6 @@ description: |
   puppet_enabled = !host_param_true?('skip-puppet-setup') && (host_puppet_server.present? || host_param_true?('force-puppet'))
   salt_enabled = host_param('salt_master') ? true : false
   sles_minor_string = (os_minor == 0) ? '' : "_SP#{os_minor}"
-  spacewalk_enabled = host_param('spacewalk_host') ? true : false
 
   primary_interface_identifier = @host.primary_interface.identifier.blank? ? 'eth0' : @host.primary_interface.identifier
   primary_interface_subnet = @host.primary_interface.subnet
@@ -189,9 +188,6 @@ description: |
       <package>rubygem-puppet</package>
 <% end -%>
 <% end -%>
-<% if spacewalk_enabled -%>
-      <package>rhn-setup</package>
-<% end -%>
 <% if host_param('additional-packages').present? -%>
       <%= host_param('additional-packages').split(" ").collect{|x| "<package>#{x}</package>" }.join("\n") %>
 <% end -%>
@@ -247,10 +243,6 @@ cp /etc/resolv.conf /mnt/etc
 <%= snippet('remote_execution_ssh_keys') %>
 
 <%= snippet "blacklist_kernel_modules" %>
-
-<% if spacewalk_enabled -%>
-<%= snippet 'redhat_register' %>
-<% end -%>
 
 <% if puppet_enabled -%>
 <%= snippet 'puppet_setup' %>
@@ -413,28 +405,6 @@ rm /etc/resolv.conf
             <all config:type="boolean">false</all>
             <keys config:type="list">
               <keyid>27163A4EEDF0D733</keyid>
-            </keys>
-          </import_gpg_key>
-        </signature-handling>
-      </listentry>
-<% end -%>
-<% if spacewalk_enabled -%>
-      <listentry>
-        <media_url><![CDATA[http://download.opensuse.org/repositories/systemsmanagement:/spacewalk/SLE_<%= os_major %><%= sles_minor_string %>/]]></media_url>
-        <name>systemsmanagement_spacewalk</name>
-        <product>systemsmanagement_spacewalk</product>
-        <product_dir>/</product_dir>
-        <signature-handling>
-          <accept_non_trusted_gpg_key>
-            <all config:type="boolean">false</all>
-            <keys config:type="list">
-              <keyid>2ABFA143A0E46E11</keyid>
-            </keys>
-          </accept_non_trusted_gpg_key>
-          <import_gpg_key>
-            <all config:type="boolean">false</all>
-            <keys config:type="list">
-              <keyid>2ABFA143A0E46E11</keyid>
             </keys>
           </import_gpg_key>
         </signature-handling>

--- a/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
+++ b/app/views/unattended/provisioning_templates/snippet/redhat_register.erb
@@ -19,8 +19,6 @@ description: |
 
     subscription_manager = 'true'               You're going to use subscription-manager
 
-    subscription_manager_auto_attach = 'false'  Run attach --auto after registering.
-
     subscription_manager_status = 'true'        Show status of subscription-manager
 
     subscription_manager_refresh = 'true'       Run refresh after registering host.
@@ -41,8 +39,6 @@ description: |
 
     subscription_manager_override_repos_cost = <cost>  Override repository cost
 
-    subscription_manager_pool = <pool>          Specific subscription pool to use
-
     only_subscription_manager_repos = 'true'    dnf/yum should only use repos managed by sub-man
 
     http-proxy = <host>                         Proxy hostname to be used for registration
@@ -58,18 +54,11 @@ description: |
     syspurpose_usage                            Sets the system purpose usage
 
     syspurpose_sla                              Sets the system purpose SLA
-
-  Set these parameters if you're using rhnreg_ks:
-
-    spacewalk_host = <hostname>                 Hostname of Spacewalk server
 -%>
 <%
   # Katello or subscription-manager:
   if host_param_true?('subscription_manager') || host_param('kt_activation_keys')
     registration_type = 'subscription_manager'
-  # Spacewalk:
-  elsif host_param('spacewalk_host')
-    registration_type = 'spacewalk'
   else
     registration_type = nil
   end
@@ -101,27 +90,15 @@ description: |
   # Set up subscription-manager
   <%= snippet("subscription_manager_setup", variables: { subman_setup_scenario: 'provisioning' }).strip -%>
 
-  <%- if (host_param('syspurpose_role') || host_param('syspurpose_usage') || host_param('syspurpose_sla')) -%>
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
-
-    if [ -f /usr/sbin/syspurpose ]; then
-      <%- if host_param('syspurpose_role') -%>
-        syspurpose set-role "<%= host_param('syspurpose_role') %>"
-      <%- end -%>
-      <%- if host_param('syspurpose_usage') -%>
-        syspurpose set-usage "<%= host_param('syspurpose_usage') %>"
-      <%- end -%>
-      <%- if host_param('syspurpose_sla') -%>
-        syspurpose set-sla "<%= host_param('syspurpose_sla') %>"
-      <%- end -%>
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  <% end -%>
+  <%- if host_param('syspurpose_role') -%>
+    subscription-manager syspurpose role --set "<%= host_param('syspurpose_role') %>"
+  <%- end -%>
+  <%- if host_param('syspurpose_usage') -%>
+    subscription-manager syspurpose usage --set "<%= host_param('syspurpose_usage') %>"
+  <%- end -%>
+  <%- if host_param('syspurpose_sla') -%>
+    subscription-manager syspurpose service-level --set "<%= host_param('syspurpose_sla') %>"
+  <%- end -%>
 
   <% if host_param('http-proxy') -%>
     subscription-manager config --server.proxy_hostname='<%= host_param("http-proxy") %>'
@@ -137,12 +114,7 @@ description: |
   <% end -%>
 
   <% if host_param('subscription_manager_username') && host_param('subscription_manager_password') -%>
-    <% if host_param('subscription_manager_pool') -%>
-      subscription-manager register --name="<%= @host.name %>" --username='<%= host_param("subscription_manager_username") %>' --password='<%= host_param("subscription_manager_password") %>'
-      subscription-manager attach --pool='<%= host_param('subscription_manager_pool') %>'
-    <% else -%>
-      subscription-manager register --name="<%= @host.name %>" --username='<%= host_param("subscription_manager_username") %>' --password='<%= host_param("subscription_manager_password") %>' --auto-attach
-    <% end -%>
+    subscription-manager register --name="<%= @host.name %>" --username='<%= host_param("subscription_manager_username") %>' --password='<%= host_param("subscription_manager_password") %>'
 
   <% elsif activation_key -%>
     subscription-manager register --name="<%= @host.name %>" --org='<%= subscription_manager_org %>' --activationkey='<%= activation_key %>'
@@ -164,11 +136,6 @@ description: |
     done
   <% end -%>
 
-  <% if host_param_true?('subscription_manager_auto_attach', false) -%>
-    subscription-manager attach --auto
-
-  <% end -%>
-
   <% if host_param_true?('subscription_manager_refresh', false) -%>
   subscription-manager refresh <% if host_param_true?('subscription_manager_refresh_force', false) %> --force<% end %>
   <% end -%>
@@ -178,7 +145,6 @@ description: |
   <% end -%>
 
   <% if host_param('subscription_manager_repos') -%>
-    # workaround for RHEL 6.4 bug https://bugzilla.redhat.com/show_bug.cgi?id=1008016
     subscription-manager repos --list > /dev/null
     <%= "subscription-manager repos --enable #{host_param('subscription_manager_repos').gsub(/,\s*/, ' --enable ')}" %>
   <% end -%>
@@ -195,66 +161,5 @@ description: |
 
   <% if redhat_install_host_tracer_tools -%>
     $PKG_MANAGER_INSTALL katello-host-tools-tracer
-  <% end -%>
-<% end -%>
-
-<% if registration_type == 'spacewalk' -%>
-  echo "##############################################################"
-  echo "################ SPACEWALK REGISTRATION ######################"
-  echo "##############################################################"
-
-  <% if host_param('activation_key') -%>
-    rhn_activation_key="<%= host_param('activation_key') -%>"
-    satellite_hostname="<%= host_param('spacewalk_host') -%>"
-    rhn_cert_file="RHN-ORG-TRUSTED-SSL-CERT"
-
-    echo "Registering to RHN Satellite at [$satellite_hostname]"
-    echo "Using Registration Key [$rhn_activation_key]"
-
-    # Obtain our RHN Satellite Certificate
-    echo "Obtaining RHN SSL certificate"
-    curl -o /usr/share/rhn/$rhn_cert_file -k https://$satellite_hostname/pub/$rhn_cert_file
-
-    <% if @host.operatingsystem.name == 'SLES' -%>
-      # If SLES then add CA Cert to CA Certs for curl
-      cp /usr/share/rhn/$rhn_cert_file /etc/ssl/certs/
-      ln -s /etc/ssl/certs/$rhn_cert_file /etc/ssl/certs/`openssl x509 -hash -noout -in /etc/ssl/certs/$rhn_cert_file`.0
-    <% end -%>
-
-    # Update our up2date configuration file
-    echo "Updating SSL CA Certificate to /usr/share/rhn/$rhn_cert_file"
-    sed -i -e "s|^sslCACert=.*$|sslCACert=/usr/share/rhn/$rhn_cert_file|" /etc/sysconfig/rhn/up2date
-
-    # Update our Satellite Hostname
-    echo "Updating Satellite Hostname to [$satellite_hostname]"
-    sed -i -e "s|^serverURL=.*$|serverURL=https://$satellite_hostname/XMLRPC|" /etc/sysconfig/rhn/up2date
-    sed -i -e "s|^noSSLServerURL=.*$|noSSLServerURL=https://$satellite_hostname/XMLRPC|" /etc/sysconfig/rhn/up2date
-
-    # Restart messagebus/HAL to try and prevent hardware detection errors in rhnreg_ks
-    echo "Restarting services..."
-    <% if @host.operatingsystem.name == 'SLES' && @host.operatingsystem.major.to_i < 12 -%>
-      service haldaemon restart
-    <% else -%>
-      service messagebus restart
-      service hald restart
-    <% end -%>
-
-    # Now, perform our registration
-    #  (might get hardware errors here, due to dbus/messagebus lameness. These are safe to ignore.)
-    echo -n "Performing RHN Registration... "
-    rhnreg_ks --activationkey=$rhn_activation_key
-    echo "done."
-
-    # Check we registered
-    echo -n "Checking System Registration... "
-    if ! rhn_check; then
-        echo "FAILED"
-        echo " >> RHN Registration FAILED. Please Investigate. <<"
-    else
-        echo "registration successful."
-    fi
-
-  <% else -%>
-    echo "No activation key found: Not registering"
   <% end -%>
 <% end -%>

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -128,23 +128,12 @@ runcmd:
   
   # Restart yggdrasild if installed and running
   systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-      # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-      #  assuming subscription-manager-syspurpose is installed in custom packages section.
-      if ! rpm --query --quiet subscription-manager-syspurpose ; then
-        $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-      fi
+      subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+      subscription-manager syspurpose usage --set "Development/Test"
+      subscription-manager syspurpose service-level --set "Self-Support"
   
-      if [ -f /usr/sbin/syspurpose ]; then
-          syspurpose set-role "Red Hat Enterprise Linux Server"
-          syspurpose set-usage "Development/Test"
-          syspurpose set-sla "Self-Support"
-      else
-        echo "Syspurpose CLI not found."
-      fi
-    
     
         subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
-    
     
     
       subscription-manager refresh  --force
@@ -154,8 +143,7 @@ runcmd:
     
     
     
-    
-- |
+    - |
   freeipa_client=ipa-client
   /usr/sbin/sshd-keygen
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -109,23 +109,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -136,7 +125,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 freeipa_client=ipa-client
 /usr/sbin/sshd-keygen

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -138,7 +138,6 @@ fi
 echo "blacklist amodule" >> /etc/modprobe.d/blacklist.conf
 
 
-
 if [ -f /usr/bin/dnf ]; then
   dnf -y install puppet
 else

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -174,23 +174,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-6-dhcp-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -201,7 +190,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -174,23 +174,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -201,7 +190,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 freeipa_client=ipa-client
 /usr/sbin/sshd-keygen
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -174,23 +174,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-static-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -201,7 +190,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -174,23 +174,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv6-dhcp-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -201,7 +190,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -174,23 +174,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv6-static-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -201,7 +190,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
@@ -173,23 +173,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-dhcp-rocky10" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -200,7 +189,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -172,23 +172,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-dhcp-rocky8" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -199,7 +188,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -173,23 +173,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-dhcp-rocky9" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -200,7 +189,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 # update all the base packages from the updates repository
 if [ -f /usr/bin/dnf ]; then

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -123,23 +123,12 @@ fi
 
 # Restart yggdrasild if installed and running
 systemctl try-restart yggdrasil >/dev/null 2>&1 || true
-    # Avoid timeout accessing unreachable repo on air gapped infrastructure,
-    #  assuming subscription-manager-syspurpose is installed in custom packages section.
-    if ! rpm --query --quiet subscription-manager-syspurpose ; then
-      $PKG_MANAGER_INSTALL subscription-manager-syspurpose
-    fi
+    subscription-manager syspurpose role --set "Red Hat Enterprise Linux Server"
+    subscription-manager syspurpose usage --set "Development/Test"
+    subscription-manager syspurpose service-level --set "Self-Support"
 
-    if [ -f /usr/sbin/syspurpose ]; then
-        syspurpose set-role "Red Hat Enterprise Linux Server"
-        syspurpose set-usage "Development/Test"
-        syspurpose set-sla "Self-Support"
-    else
-      echo "Syspurpose CLI not found."
-    fi
-  
   
       subscription-manager register --name="snapshot-ipv4-dhcp-el7" --org='Org' --activationkey='key'
-  
   
   
     subscription-manager refresh  --force
@@ -150,7 +139,6 @@ systemctl try-restart yggdrasil >/dev/null 2>&1 || true
   
   
   
-
 
 freeipa_client=ipa-client
 /usr/sbin/sshd-keygen


### PR DESCRIPTION
Remove obsolete Spacewalk/RHN, auto-attach, and subscription pool references from the `redhat_register` provisioning template snippet, and modernize syspurpose CLI usage.

## Changes
- Remove entire Spacewalk/RHN registration section (`rhnreg_ks`, RHN certs, `up2date` config) — Spacewalk/RHN Satellite 5 is long obsolete
- Remove `subscription_manager_pool` and `subscription_manager_auto_attach` support — all orgs are now SCA-only
- Remove `--auto-attach` flag from username/password registration
- Update syspurpose to use `subscription-manager syspurpose` subcommands instead of the deprecated standalone `/usr/sbin/syspurpose` CLI binary (no longer requires installing `subscription-manager-syspurpose` package)
- Remove outdated RHEL 6.4 bug workaround comment

## How to test
### Prerequisites
A provisioning setup with a RHEL-compatible host, or review the template rendering output.

### Steps
1. Review the diff to confirm only obsolete functionality was removed
2. Verify snapshot test output shows the expected changes:
   - Old `syspurpose set-role/set-usage/set-sla` commands replaced with `subscription-manager syspurpose role/usage/service-level --set`
   - `subscription-manager-syspurpose` package install block removed
   - `/usr/sbin/syspurpose` binary check removed
3. Confirm RHEL 9/10 snapshots are unaffected (they use `kickstart_rhsm` instead of `redhat_register`)
4. Run `bundle exec rake test TEST=test/unit/foreman/renderer_test.rb` — all 168 tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)