### PR TITLE
Fixes #39273 - removed showHide prop and its functionality, since it is not used anymore

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/Editor.fixtures.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/Editor.fixtures.js
@@ -44,7 +44,6 @@ export const showBooleans = {
   showPreview: true,
   showHostSelector: true,
   showImport: true,
-  showHide: true,
 };
 
 export const editorOptions = {

--- a/webpack/assets/javascripts/react_app/components/Editor/Editor.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/Editor.js
@@ -51,7 +51,6 @@ class Editor extends React.Component {
         isSafemodeEnabled,
         renderPath,
         safemodeRenderPath,
-        showHide,
         showImport,
         showPreview,
         showHostSelector,
@@ -94,7 +93,6 @@ class Editor extends React.Component {
       theme,
       autocompletion,
       liveAutocompletion,
-      toggleMaskValue,
       toggleModal,
       toggleRenderView,
       value,
@@ -151,7 +149,6 @@ class Editor extends React.Component {
           template={template}
           selectedView={selectedView}
           isDiff={template ? value !== template : false}
-          isMasked={isMasked}
           isRendering={isRendering}
           isLoading={isLoading}
           isFetchingHosts={isFetchingHosts}
@@ -160,7 +157,6 @@ class Editor extends React.Component {
           showImport={showImport}
           showPreview={showPreview}
           showHostSelector={showHostSelector}
-          showHide={showHide}
           revertChanges={revertChanges}
           previewTemplate={previewTemplate}
           hosts={hosts}
@@ -169,7 +165,6 @@ class Editor extends React.Component {
           isSafemodeEnabled={isSafemodeEnabled}
           renderPath={renderPath}
           safemodeRenderPath={safemodeRenderPath}
-          toggleMaskValue={toggleMaskValue}
           toggleRenderView={toggleRenderView}
           toggleModal={toggleModal}
           previewResult={previewResult}
@@ -237,7 +232,6 @@ class Editor extends React.Component {
 
 Editor.propTypes = {
   data: PropTypes.shape({
-    showHide: PropTypes.bool,
     showImport: PropTypes.bool,
     showPreview: PropTypes.bool,
     showHostSelector: PropTypes.bool,
@@ -285,7 +279,6 @@ Editor.propTypes = {
   theme: PropTypes.string.isRequired,
   autocompletion: PropTypes.bool.isRequired,
   liveAutocompletion: PropTypes.bool.isRequired,
-  toggleMaskValue: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
   toggleRenderView: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,

--- a/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/Editor.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/Editor.test.js.snap
@@ -41,7 +41,6 @@ exports[`Editor rendering renders editor 1`] = `
     isDiff={true}
     isFetchingHosts={false}
     isLoading={false}
-    isMasked={false}
     isRendering={false}
     isSafemodeEnabled={true}
     isSearchingHosts={false}
@@ -85,7 +84,6 @@ exports[`Editor rendering renders editor 1`] = `
     }
     selectedView="input"
     showError={true}
-    showHide={true}
     showHostSelector={true}
     showImport={true}
     showPreview={true}
@@ -98,7 +96,6 @@ exports[`Editor rendering renders editor 1`] = `
         "Monokai",
       ]
     }
-    toggleMaskValue={[Function]}
     toggleModal={[Function]}
     toggleRenderView={[Function]}
     value="value"

--- a/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/EditorSelectors.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/__tests__/__snapshots__/EditorSelectors.test.js.snap
@@ -47,7 +47,6 @@ Object {
     },
     "renderPath": "/render/path",
     "safemodeRenderPath": "/safemoderender/path",
-    "showHide": true,
     "showHostSelector": true,
     "showImport": true,
     "showPreview": true,

--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorNavbar.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorNavbar.js
@@ -18,7 +18,6 @@ const EditorNavbar = ({
   importFile,
   isDiff,
   isLoading,
-  isMasked,
   isRendering,
   isFetchingHosts,
   isSearchingHosts,
@@ -33,7 +32,6 @@ const EditorNavbar = ({
   revertChanges,
   selectedHost,
   selectedView,
-  showHide,
   showImport,
   showPreview,
   showHostSelector,
@@ -42,7 +40,6 @@ const EditorNavbar = ({
   themes,
   autocompletion,
   liveAutocompletion,
-  toggleMaskValue,
   toggleModal,
   toggleRenderView,
   value,
@@ -218,18 +215,15 @@ const EditorNavbar = ({
         value={value}
         renderPath={renderPath}
         showImport={showImport}
-        showHide={showHide}
         showPreview={showPreview}
         showHostSelector={showHostSelector}
         isDiff={isDiff}
         diffViewType={diffViewType}
-        isMasked={isMasked}
         isRendering={isRendering}
         importFile={importFile}
         template={template}
         revertChanges={revertChanges}
         changeDiffViewType={changeDiffViewType}
-        toggleMaskValue={toggleMaskValue}
         changeSetting={changeSetting}
         changeTab={changeTab}
         toggleModal={toggleModal}
@@ -259,7 +253,6 @@ EditorNavbar.propTypes = {
   isDiff: PropTypes.bool.isRequired,
   isFetchingHosts: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
-  isMasked: PropTypes.bool.isRequired,
   isRendering: PropTypes.bool.isRequired,
   isSearchingHosts: PropTypes.bool.isRequired,
   isSelectOpen: PropTypes.bool.isRequired,
@@ -286,14 +279,12 @@ EditorNavbar.propTypes = {
   }).isRequired,
   selectedView: PropTypes.string.isRequired,
   showError: PropTypes.bool.isRequired,
-  showHide: PropTypes.bool,
   showImport: PropTypes.bool.isRequired,
   showPreview: PropTypes.bool.isRequired,
   showHostSelector: PropTypes.bool,
   template: PropTypes.string,
   theme: PropTypes.string.isRequired,
   themes: PropTypes.array.isRequired,
-  toggleMaskValue: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
   toggleRenderView: PropTypes.func.isRequired,
   value: PropTypes.string.isRequired,
@@ -305,7 +296,6 @@ EditorNavbar.defaultProps = {
   filteredHosts: [],
   renderPath: '',
   safemodeRenderPath: '',
-  showHide: false,
   template: '',
   showHostSelector: true,
   templateKindId: '',

--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorOptions.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorOptions.js
@@ -3,13 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { Button, FormControl } from 'patternfly-react';
-import {
-  ArrowsAltIcon,
-  EyeIcon,
-  EyeSlashIcon,
-  UndoIcon,
-  UploadIcon,
-} from '@patternfly/react-icons';
+import { ArrowsAltIcon, UndoIcon, UploadIcon } from '@patternfly/react-icons';
 
 import { Tooltip, TooltipPosition, Icon } from '@patternfly/react-core';
 import { translate as __ } from '../../../common/I18n';
@@ -35,21 +29,18 @@ class EditorOptions extends React.Component {
       diffViewType,
       importFile,
       isDiff,
-      isMasked,
       keyBinding,
       keyBindings,
       mode,
       modes,
       revertChanges,
       selectedView,
-      showHide,
       showImport,
       template,
       theme,
       themes,
       autocompletion,
       liveAutocompletion,
-      toggleMaskValue,
       toggleModal,
     } = this.props;
 
@@ -63,19 +54,6 @@ class EditorOptions extends React.Component {
         )}
 
         <h4 id="divider">|</h4>
-        {showHide && (
-          <Tooltip content={__('Hide Content')} position={TooltipPosition.top}>
-            <Button
-              disabled={selectedView !== 'input'}
-              className="editor-button"
-              id="hide-btn"
-              onClick={() => toggleMaskValue(isMasked)}
-              bsStyle="link"
-            >
-              <Icon size="md">{isMasked ? <EyeIcon /> : <EyeSlashIcon />}</Icon>
-            </Button>
-          </Tooltip>
-        )}
         {isDiff ? ( // fixing tooltip showing sometimes for disabled icon
           <Tooltip
             content={__('Revert Local Changes')}
@@ -172,26 +150,22 @@ EditorOptions.propTypes = {
   diffViewType: PropTypes.string.isRequired,
   importFile: PropTypes.func.isRequired,
   isDiff: PropTypes.bool.isRequired,
-  isMasked: PropTypes.bool.isRequired,
   keyBinding: PropTypes.string.isRequired,
   keyBindings: PropTypes.array.isRequired,
   mode: PropTypes.string.isRequired,
   modes: PropTypes.array.isRequired,
   revertChanges: PropTypes.func.isRequired,
   selectedView: PropTypes.string.isRequired,
-  showHide: PropTypes.bool,
   showImport: PropTypes.bool.isRequired,
   template: PropTypes.string,
   theme: PropTypes.string.isRequired,
   themes: PropTypes.array.isRequired,
   autocompletion: PropTypes.bool.isRequired,
   liveAutocompletion: PropTypes.bool.isRequired,
-  toggleMaskValue: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
 };
 
 EditorOptions.defaultProps = {
-  showHide: false,
   template: '',
 };
 

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/EditorOptions.test.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/EditorOptions.test.js
@@ -16,7 +16,6 @@ describe('EditorOptions', () => {
     testComponentSnapshotsWithFixtures(EditorOptions, fixtures));
 
   describe('simulate onClick', () => {
-    const toggleMaskValue = jest.fn();
     const changeTab = jest.fn();
     const revertChanges = jest.fn();
     jest.mock('../EditorOptions');
@@ -26,20 +25,9 @@ describe('EditorOptions', () => {
       <EditorOptions
         {...props}
         changeTab={changeTab}
-        toggleMaskValue={toggleMaskValue}
         revertChanges={revertChanges}
         isDiff
         selectedView="diff"
-      />
-    );
-
-    const inputWrapper = mount(
-      <EditorOptions
-        {...props}
-        changeTab={changeTab}
-        toggleMaskValue={toggleMaskValue}
-        revertChanges={revertChanges}
-        isDiff
       />
     );
 
@@ -47,16 +35,11 @@ describe('EditorOptions', () => {
       .find('#undo-btn')
       .at(0)
       .simulate('click');
-    inputWrapper
-      .find('#hide-btn')
-      .at(0)
-      .simulate('click');
     diffWrapper
       .find('#import-btn')
       .at(0)
       .simulate('click');
 
-    expect(toggleMaskValue).toHaveBeenCalledTimes(1);
     expect(changeTab).toHaveBeenCalledTimes(1);
     expect(window.confirm).toHaveBeenCalledTimes(1);
   });

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorNavbar.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorNavbar.test.js.snap
@@ -63,7 +63,6 @@ exports[`EditorNavbar rendring renders EditorNavbar 1`] = `
     }
     importFile={[Function]}
     isDiff={true}
-    isMasked={false}
     isRendering={false}
     keyBinding="Default"
     keyBindings={
@@ -89,7 +88,6 @@ exports[`EditorNavbar rendring renders EditorNavbar 1`] = `
     renderPath="/render/path"
     revertChanges={[Function]}
     selectedView="input"
-    showHide={true}
     showHostSelector={true}
     showImport={true}
     showPreview={true}
@@ -101,7 +99,6 @@ exports[`EditorNavbar rendring renders EditorNavbar 1`] = `
         "Monokai",
       ]
     }
-    toggleMaskValue={[Function]}
     toggleModal={[Function]}
     value="value"
   />

--- a/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorOptions.test.js.snap
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/__tests__/__snapshots__/EditorOptions.test.js.snap
@@ -10,27 +10,6 @@ exports[`EditorOptions EditorOptions renders EditorOptions 1`] = `
     |
   </h4>
   <Tooltip
-    content="Hide Content"
-    position="top"
-  >
-    <Button
-      active={false}
-      block={false}
-      bsClass="btn"
-      bsStyle="link"
-      className="editor-button"
-      disabled={false}
-      id="hide-btn"
-      onClick={[Function]}
-    >
-      <Icon
-        size="md"
-      >
-        <EyeSlashIcon />
-      </Icon>
-    </Button>
-  </Tooltip>
-  <Tooltip
     content="Revert Local Changes"
     position="top"
   >


### PR DESCRIPTION
Remove the obsolete showHide prop and any logic that depended on it from the Foreman template Editor UI. The prop was never supplied from Rails (react_component('Editor', …) in templates/_form.html.erb only passes showImport, showPreview, and showHostSelector), so this is dead-code cleanup with no change to server-rendered props.

## Changes

Drop showHide from the Editor component tree (props, conditionals, and defaults as applicable).
Update Editor unit tests and Jest snapshots so they no longer reference showHide.
No changes to provisioning templates, renderer_test, or snapshot content for redhat_register—this is React-only.
How to test

## Prerequisites
Foreman dev environment with Node deps installed, or CI that runs the JS test suite.

## Steps

Review the diff and confirm only showHide (and related wiring) was removed—not showPreview / showHostSelector / showImport.
Open Hosts → Provisioning Templates (or another screen that uses the same Editor), edit a template, and confirm Editor / Preview / Changes tabs and the toolbar still behave normally.
Run the Editor tests, for example:
npm test -- webpack/assets/javascripts/react_app/components/Editor
(or the subset of tests/snapshots your branch touches, e.g. Editor.test.js, EditorNavbar.test.js, EditorOptions.test.js, integration.test.js).