### PR TITLE
Fixes #39277 - Fix TopbarSweeper thread-safety race condition under Puma

### DIFF
--- a/app/controllers/concerns/foreman/controller/topbar_sweeper.rb
+++ b/app/controllers/concerns/foreman/controller/topbar_sweeper.rb
@@ -8,10 +8,10 @@ module Foreman
       end
 
       def set_topbar_sweeper_controller
-        ::TopbarSweeper.instance.controller = self
+        ::TopbarSweeper.controller = self
         yield
       ensure
-        ::TopbarSweeper.instance.controller = nil
+        ::TopbarSweeper.controller = nil
       end
     end
   end

--- a/app/models/concerns/topbar_cache_expiry.rb
+++ b/app/models/concerns/topbar_cache_expiry.rb
@@ -8,6 +8,6 @@ module TopbarCacheExpiry
   end
 
   def expire_topbar_cache_within_controller
-    expire_topbar_cache if TopbarSweeper.instance.controller.present?
+    expire_topbar_cache if TopbarSweeper.controller
   end
 end

--- a/app/services/topbar_sweeper.rb
+++ b/app/services/topbar_sweeper.rb
@@ -1,13 +1,18 @@
 class TopbarSweeper
-  include Singleton
-  attr_accessor :controller
-
-  def expire_cache(user = User.current)
-    controller.expire_fragment(self.class.fragment_name(user.id)) if controller.present? && user.present?
-  end
+  THREAD_KEY = :topbar_sweeper_controller
 
   class << self
-    delegate :expire_cache, to: :instance
+    def controller
+      Thread.current[THREAD_KEY]
+    end
+
+    def controller=(ctrl)
+      Thread.current[THREAD_KEY] = ctrl
+    end
+
+    def expire_cache(user = User.current)
+      controller&.expire_fragment(fragment_name(user.id)) if user.present?
+    end
 
     def fragment_name(id = User.current.id)
       "tabs_and_title_records-#{id}"

--- a/test/unit/topbar_sweeper_test.rb
+++ b/test/unit/topbar_sweeper_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class TopbarSweeperTest < ActiveSupport::TestCase
+  def teardown
+    TopbarSweeper.controller = nil
+  end
+
+  test "controller is thread-local" do
+    TopbarSweeper.controller = "main"
+    thread_value = nil
+    Thread.new { thread_value = TopbarSweeper.controller }.join
+    assert_nil thread_value, "Other thread should not see main thread's controller"
+    assert_equal "main", TopbarSweeper.controller
+  end
+
+  test "expire_cache calls expire_fragment on controller" do
+    mock_controller = Minitest::Mock.new
+    user = FactoryBot.create(:user)
+    mock_controller.expect :expire_fragment, nil, [TopbarSweeper.fragment_name(user.id)]
+    TopbarSweeper.controller = mock_controller
+    TopbarSweeper.expire_cache(user)
+    mock_controller.verify
+  end
+
+  test "expire_cache does not raise when controller is nil" do
+    TopbarSweeper.controller = nil
+    user = FactoryBot.create(:user)
+    assert_nothing_raised { TopbarSweeper.expire_cache(user) }
+  end
+end


### PR DESCRIPTION
TopbarSweeper uses `include Singleton` with a shared `controller` attribute
across all Puma threads within each worker. Under concurrent requests, one
thread ensure block nils the controller while another thread is actively
using it:

```
Thread A                           Thread B
set_topbar_sweeper_controller:
  controller = self
  yield -> action runs...
                                   set_topbar_sweeper_controller:
                                     controller = self
                                     yield -> action runs...
                                   ensure:
                                     controller = nil  <- clobbers Thread A
  set_taxonomy -> expire_cache:
    controller.expire_fragment(...)
    -> NoMethodError: undefined method expire_fragment for nil:NilClass
```

The existing `if controller.present?` guard has a TOCTOU (time-of-check
to time-of-use) race: the check passes, then another thread nils the
value before `expire_fragment` is called.

This bug is hard to reproduce under typical load because the Singleton is
per-process (each Puma worker has its own), so only the threads within a
single worker compete. With the default 5 threads per worker, the race
window is extremely narrow. It becomes observable under high concurrency
(many simultaneous registrations) or with increased threads per worker,
where more threads share the same Singleton and the interleaving becomes
likely. When it does trigger, it produces a single 500 error that is
easily dismissed as transient noise in production logs.

Discovered during concurrent host registration performance testing.
The error appears in production.log at `topbar_sweeper.rb:6`.

## Changes

Replace the Singleton with `Thread.current` storage, following the same
pattern already used by `ThreadSession` for `User.current`,
`Organization.current`, and `Location.current`. Each Puma thread gets
its own controller reference - no cross-thread clobbering.

- `app/services/topbar_sweeper.rb` - Remove `include Singleton`, store
  controller in `Thread.current[:topbar_sweeper_controller]`, use safe
  navigation (`&.`) instead of TOCTOU `if controller.present?` guard
- `app/controllers/concerns/foreman/controller/topbar_sweeper.rb` -
  `.instance.controller` -> `.controller`
- `app/models/concerns/topbar_cache_expiry.rb` - same
- `test/unit/topbar_sweeper_test.rb` - NEW: thread isolation and nil
  safety tests

## How to test

### Prerequisites
Foreman environment with Puma in multi-threaded mode (default).

### Steps
1. Run the new unit test:
   `bundle exec rake test TEST=test/unit/topbar_sweeper_test.rb`
2. Run the existing integration test:
   `bundle exec rake test TEST=test/integration/top_bar_test.rb`
3. To reproduce the original race condition: register many hosts
   concurrently and grep for `expire_fragment` errors in production.log
   - should no longer appear.
