### PR TITLE
Fixes #39278 - Add rake task to clean all notifications

### DIFF
--- a/app/services/ui_notifications/clean_all.rb
+++ b/app/services/ui_notifications/clean_all.rb
@@ -1,0 +1,20 @@
+module UINotifications
+  class CleanAll
+    def initialize(blueprint: nil)
+      @blueprint = blueprint.presence
+    end
+
+    def clean!
+      UINotifications::Base.logger.info("Removing #{@blueprint || 'all'} notifications")
+      scope = Notification.joins(:notification_blueprint)
+      scope = scope.where(notification_blueprints: { name: @blueprint }) if @blueprint
+      @deleted_count = scope.destroy_all.size
+      self
+    end
+
+    def deleted_count
+      raise 'cleaner has not cleaned anything yet, run #clean! first' if @deleted_count.nil?
+      @deleted_count
+    end
+  end
+end

--- a/lib/tasks/notifications_cleaner.rake
+++ b/lib/tasks/notifications_cleaner.rake
@@ -21,4 +21,25 @@ namespace :notifications do
       puts "Failed to clean notification: #{error}"
     end
   end
+
+  desc "Clean all notifications regardless of expiry
+        Optionally pass a blueprint name to only clean notifications of that blueprint
+        With no arguments, all notifications will be removed
+        Examples:
+        rake notifications:clean_all -
+          - Will clean all notifications
+        rake notifications:clean_all['blueprint_name'] -
+          - Will clean all notifications belonging to the given blueprint name"
+
+  task :clean_all, [:blueprint] => :environment do |t, args|
+    message = args.blueprint.present? ? "Starting full notifications clean up for blueprint '#{args.blueprint}'..." : 'Starting full notifications clean up...'
+    puts message
+    begin
+      cleaner = UINotifications::CleanAll.new(blueprint: args.blueprint)
+      cleaner.clean!
+      puts "Finished, cleaned #{cleaner.deleted_count} notifications"
+    rescue => error
+      puts "Failed to clean notifications: #{error}"
+    end
+  end
 end

--- a/test/unit/ui_notifications/clean_all_test.rb
+++ b/test/unit/ui_notifications/clean_all_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+class CleanAllTest < ActiveSupport::TestCase
+  test "clean should remove all notifications including non-expired ones" do
+    blueprint = create_blueprint(5.minutes)
+    blueprint2 = create_blueprint(-5.minutes)
+    create_notification(blueprint)
+    create_notification(blueprint2)
+    assert_equal 2, Notification.all.size
+    cleaner = UINotifications::CleanAll.new
+    assert_equal 2, cleaner.clean!.deleted_count
+    assert_equal 0, Notification.all.size
+  end
+
+  test "clean by blueprint should remove only notifications belonging to that blueprint" do
+    blueprint = create_blueprint(5.minutes)
+    blueprint2 = create_blueprint(5.minutes)
+    create_notification(blueprint)
+    create_notification(blueprint)
+    create_notification(blueprint2)
+    assert_equal 3, Notification.all.size
+    cleaner = UINotifications::CleanAll.new(blueprint: blueprint.name)
+    assert_equal 2, cleaner.clean!.deleted_count
+    assert_equal 1, Notification.all.size
+    assert_equal blueprint2, Notification.first.notification_blueprint
+  end
+
+  test "clean by blueprint that does not exist should remove no notifications" do
+    blueprint = create_blueprint(5.minutes)
+    create_notification(blueprint)
+    assert_equal 1, Notification.all.size
+    cleaner = UINotifications::CleanAll.new(blueprint: 'nonexistent_blueprint')
+    assert_equal 0, cleaner.clean!.deleted_count
+    assert_equal 1, Notification.all.size
+  end
+
+  test "deleted_count raises before clean! is called" do
+    cleaner = UINotifications::CleanAll.new
+    assert_raise RuntimeError do
+      cleaner.deleted_count
+    end
+  end
+
+  private
+
+  def create_notification(blueprint)
+    FactoryBot.create(:notification,
+      :audience => Notification::AUDIENCE_ADMIN,
+      :notification_blueprint => blueprint)
+  end
+
+  def create_blueprint(expired_time)
+    blueprint = FactoryBot.build(:notification_blueprint, :expires_in => expired_time)
+    blueprint.save(:validate => false)
+    blueprint
+  end
+end


### PR DESCRIPTION
Introduces UINotifications::CleanAll service and the notifications:clean_all rake task which removes all notifications, optionally filtered by blueprint name, without requiring them to be expired first.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
