### PR TITLE
Fixes #39279 - use host_details_page_path for host_build_completed notification

### DIFF
--- a/db/migrate/20260504093412_update_host_build_completed_notification_blueprint_path.rb
+++ b/db/migrate/20260504093412_update_host_build_completed_notification_blueprint_path.rb
@@ -1,0 +1,21 @@
+class UpdateHostBuildCompletedNotificationBlueprintPath < ActiveRecord::Migration[7.0]
+  def update_path(old_path, new_path)
+    blueprint = NotificationBlueprint.find_by(name: 'host_build_completed')
+    return unless blueprint && blueprint.actions['links'].present?
+
+    links = blueprint.actions['links'].each do |link|
+      if link['path_method'] == old_path
+        link['path_method'] = new_path
+      end
+    end
+    blueprint.update_column(:actions, {links: links})
+  end
+
+  def up
+    update_path('host_path', 'host_details_page_path')
+  end
+
+  def down
+    update_path('host_details_page_path', 'host_path')
+  end
+end

--- a/db/seeds.d/170-notification_blueprints.rb
+++ b/db/seeds.d/170-notification_blueprints.rb
@@ -8,7 +8,7 @@ blueprints = [
     {
       links:
       [
-        path_method: :host_path,
+        path_method: :host_details_page_path,
         title: N_('Details'),
       ],
     },


### PR DESCRIPTION
Adapt the NotificationBlueprint for host_build_completed to use the new
host_details_page_path instead of the old host_path. Actually, I would
have prefered to use the current_host_details_path to differentiate
betweeen old/new path but its a) not accessible and b) hopefully we
switch pretty soon to the new host details page and remove the old.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
