### PR TITLE
Fixes #39281 - puppet_conf.erb permit setting ca_port

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -120,6 +120,11 @@ module HostCommon
     puppet_ca_server_uri.try(:host) || ''
   end
 
+  # The Puppet CA server port. Exposed as a provisioning macro.
+  def puppet_ca_server_port
+    puppet_ca_server_uri.try(:port)
+  end
+
   # If the host/hostgroup has a medium then use the path from there
   # Else if the host/hostgroup's operatingsystem has only one media then use the image_path from that as this is automatically displayed when there is only one item
   # Else we cannot provide a default and it is cut and paste time

--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -78,6 +78,7 @@ module Foreman
         :host_param, :host_param!,
         :host_puppet_server,
         :host_puppet_ca_server,
+        :host_puppet_ca_server_port,
         :host_puppet_environment,
         :host_enc,
         :install_packages,

--- a/app/services/foreman/renderer/scope/macros/host_template.rb
+++ b/app/services/foreman/renderer/scope/macros/host_template.rb
@@ -68,6 +68,15 @@ module Foreman
             host.try(:puppet_ca_server).presence || host_param('puppet_ca_server')
           end
 
+          apipie :method, 'Returns Puppet CA server\'s port configured via the assigned Smart Proxy or the puppet_ca_server_port host parameter' do
+            returns Integer, desc: 'Returns the configured Puppet CA server\'s port (1-65535), or nil if not configured'
+          end
+          def host_puppet_ca_server_port
+            check_host
+            port = host.try(:puppet_ca_server_port).presence || host_param('puppet_ca_server_port')
+            validate_port(port)
+          end
+
           apipie :method, 'Returns the Puppet environment configured configured through the ENC or the puppet_environment host parameter' do
             returns String, desc: 'Returns the configured Puppet environment name, or nil if not configured'
           end
@@ -234,6 +243,19 @@ module Foreman
           def check_host_param(name)
             check_host
             raise HostParamUndefined.new(name: name, host: host) unless host.params.key?(name)
+          end
+
+          def validate_port(value)
+            return nil if value.nil?
+
+            unless value.to_s.match?(/^\d+$/)
+              raise ArgumentError, "Puppet CA server port must be an integer, got: #{value.inspect}"
+            end
+            port = value.to_i
+            if port < 1 || port > 65535
+              raise ArgumentError, "Puppet CA server port must be between 1 and 65535, got: #{value.inspect}"
+            end
+            port
           end
         end
       end

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -30,6 +30,8 @@ description: |
     run_dir = '/var/run/puppet'
     ssl_dir = '\$vardir/ssl'
   end
+
+  host_puppet_ca_server_port_default = 8140
 -%>
 [main]
 <%- unless host_param('dns_alt_names').to_s.empty? -%>
@@ -47,6 +49,11 @@ pluginsync      = true
 report          = true
 <%- if host_puppet_ca_server.present? -%>
 ca_server       = <%= host_puppet_ca_server %>
+<%- end -%>
+<%- if host_puppet_ca_server_port.present? -%>
+<%- if host_puppet_ca_server_port.to_i != host_puppet_ca_server_port_default -%>
+ca_port         = <%= host_puppet_ca_server_port %>
+<%- end -%>
 <%- end -%>
 certname        = <%= @host.certname %>
 <%- if host_puppet_server.present? -%>

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -352,6 +352,23 @@ class HostTest < ActiveSupport::TestCase
     assert_equal 'puppetca.example.com', host.puppet_ca_server
   end
 
+  test "should read the Puppet CA Server port from its proxy settings" do
+    host = FactoryBot.build_stubbed(:host)
+    assert_nil host.puppet_ca_server_port
+
+    proxy = FactoryBot.create(:puppet_ca_smart_proxy, url: 'https://smartproxy.example.com:8443')
+    host.puppet_ca_proxy = proxy
+    assert_equal 8140, host.puppet_ca_server_port
+
+    features = {
+      'puppetca' => {
+        settings: {'puppet_url': 'https://puppetca.example.com:8443'},
+      },
+    }
+    SmartProxyFeature.import_features(proxy, features)
+    assert_equal 8443, host.puppet_ca_server_port
+  end
+
   test "should populate primary interface attributes even without existing interface" do
     host = FactoryBot.build(:host, :managed => false)
     host.interfaces = []

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -122,6 +122,110 @@ class HostTemplateTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#host_puppet_ca_server_port' do
+    test 'should return integer from proxy port' do
+      host = stub(puppet_ca_server_port: 8443)
+      @scope.instance_variable_set('@host', host)
+      result = @scope.host_puppet_ca_server_port
+      assert_equal 8443, result
+      assert_instance_of Integer, result
+    end
+
+    test 'should convert string parameter to integer' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8080')
+      result = @scope.host_puppet_ca_server_port
+      assert_equal 8080, result
+      assert_instance_of Integer, result
+    end
+
+    test 'should convert string "8140" parameter to integer' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8140')
+      result = @scope.host_puppet_ca_server_port
+      assert_equal 8140, result
+      assert_instance_of Integer, result
+    end
+
+    test 'should return nil when no port is set' do
+      host = stub(puppet_ca_server_port: nil)
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns(nil)
+      assert_nil @scope.host_puppet_ca_server_port
+    end
+
+    test 'should return nil when port is empty string' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns(nil)
+      assert_nil @scope.host_puppet_ca_server_port
+    end
+
+    test 'should reject port out of range (0)' do
+      host = stub(puppet_ca_server_port: 0)
+      @scope.instance_variable_set('@host', host)
+      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
+    end
+
+    test 'should reject port out of range (700000)' do
+      host = stub(puppet_ca_server_port: 700000)
+      @scope.instance_variable_set('@host', host)
+      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
+    end
+
+    test 'should reject negative port' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('-1')
+      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
+    end
+
+    test 'should reject float with decimal' do
+      host = stub(puppet_ca_server_port: 8443.5)
+      @scope.instance_variable_set('@host', host)
+      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
+    end
+
+    test 'should reject string with decimal notation' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8443.5')
+      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
+    end
+
+    test 'should reject non-numeric string' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('invalid')
+      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
+    end
+
+    test 'should accept valid port at lower boundary' do
+      host = stub(puppet_ca_server_port: 1)
+      @scope.instance_variable_set('@host', host)
+      result = @scope.host_puppet_ca_server_port
+      assert_equal 1, result
+    end
+
+    test 'should accept valid port at upper boundary' do
+      host = stub(puppet_ca_server_port: 65535)
+      @scope.instance_variable_set('@host', host)
+      result = @scope.host_puppet_ca_server_port
+      assert_equal 65535, result
+    end
+
+    test 'should accept string that is whole number with leading zeros' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('08140')
+      result = @scope.host_puppet_ca_server_port
+      assert_equal 8140, result
+      assert_instance_of Integer, result
+    end
+  end
+
   describe '#host_puppet_environment' do
     test 'should render environment' do
       host = stub(environment: 'production')


### PR DESCRIPTION
This should permit me to run my puppet CA on an alternate port.