### PR TITLE
Fixes #39293 - Allow custom pre-install script in kickstart default template

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -239,6 +239,10 @@ wget
 %end
 <% end -%>
 
+%pre-install
+<%= snippet_if_exists(template_name + " custom pre-install") %>
+%end
+
 %post --nochroot
 exec < /dev/tty3 > /dev/tty3
 chvt 3


### PR DESCRIPTION
This pull request adds a `%pre-install` section to the Kickstart default, allowing to include a `custom pre-install` snippet, when the section is required.

<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
