### PR TITLE
Fixes #39287 - validate domain name format

### DIFF
--- a/app/lib/net/validations.rb
+++ b/app/lib/net/validations.rb
@@ -7,9 +7,11 @@ module Net
     MAC_REGEXP ||= /\A([a-f0-9]{1,2}:){5}[a-f0-9]{1,2}\z/i
     MAC_REGEXP_64BIT ||= /\A([a-f0-9]{1,2}:){19}[a-f0-9]{1,2}\z/i
     HOST_REGEXP ||= /\A(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\z/
+    DOMAIN_NAME_REGEXP ||= /\A(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\z/
     MASK_REGEXP ||= /\A((255.){3}(0|128|192|224|240|248|252|254))|((255.){2}(0|128|192|224|240|248|252|254).0)|(255.(0|128|192|224|240|248|252|254)(.0){2})|((128|192|224|240|248|252|254)(.0){3})\z/
 
     HOST_REGEXP_ERR_MSG = N_("hostname can contain only lowercase letters, numbers, dashes and dots according to RFC921, RFC952 and RFC1123")
+    DOMAIN_NAME_FORMAT_ERR_MSG = N_("domain name can contain only letters, numbers, dashes and dots according to RFC 1035 and RFC 2181")
 
     class Error < RuntimeError
     end

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -37,6 +37,9 @@ class Domain < ApplicationRecord
   include ScopedSearchExtensions
   include ParameterSearch
   validates :name, :presence => true, :uniqueness => true
+  validates :name,
+    :format => {:with => Net::Validations::DOMAIN_NAME_REGEXP, :message => Net::Validations::DOMAIN_NAME_FORMAT_ERR_MSG},
+    :on => :create
   validates :fullname, :uniqueness => true, :allow_blank => true, :allow_nil => true
 
   scoped_search :on => [:name, :fullname], :complete_value => true

--- a/lib/tasks/foreman_name_validation_audit.rake
+++ b/lib/tasks/foreman_name_validation_audit.rake
@@ -1,0 +1,29 @@
+desc <<-END_DESC
+  List domains whose names do not match Net::Validations::DOMAIN_NAME_REGEXP.
+
+  Examples:
+    bundle exec rake foreman:audit_domain_names RAILS_ENV=production
+END_DESC
+
+namespace :foreman do
+  task audit_domain_names: :environment do
+    domain_re = Net::Validations::DOMAIN_NAME_REGEXP
+    invalid_domains = 0
+    domain_total = Domain.unscoped.count
+
+    Domain.unscoped.find_each do |domain|
+      next if domain.name =~ domain_re
+
+      invalid_domains += 1
+      puts "INVALID DOMAIN  id=#{domain.id}  name=#{domain.name}"
+    end
+
+    if invalid_domains.zero?
+      puts "Domains: all #{domain_total} records match DOMAIN_NAME_REGEXP."
+    else
+      puts "Domains: #{invalid_domains} invalid (of #{domain_total} total)"
+    end
+
+    exit(invalid_domains.zero? ? 0 : 1)
+  end
+end

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -726,7 +726,7 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       test 'created domain gets host taxonomies' do
         Setting[:default_location] = loc.title
         Setting[:default_organization] = org.title
-        domain_name = 'my_new_domain.com'
+        domain_name = 'my-new-domain.com'
         facts['domain'] = domain_name
         post :facts, params: { :name => hostname, :facts => facts }
         assert_response :success

--- a/test/models/domain_test.rb
+++ b/test/models/domain_test.rb
@@ -14,6 +14,33 @@ class DomainTest < ActiveSupport::TestCase
   should validate_uniqueness_of(:fullname).allow_blank
   should belong_to(:dns)
 
+  test 'accepts valid domain name characters and shapes' do
+    valid = [
+      'example.com',
+      'Example.com',
+      'Sub.EXAMPLE.co.uk',
+      'foo-bar.valid-domain.test',
+      'a1.b2.example.org',
+    ]
+    valid.each do |name|
+      domain = Domain.new(:name => name)
+      assert domain.valid?, "expected #{name.inspect} to be valid: #{domain.errors.full_messages.join(', ')}"
+    end
+  end
+
+  test 'rejects invalid domain name characters and shapes' do
+    invalid = [
+      '*', '*.*', '*.example.com', 'example.*.com',
+      '!!!', 'example..com', '-bad.example.com', 'bad-.example.com',
+      'example!.com', 'exam ple.com', '/example.com', 'example_domain.com'
+    ]
+    invalid.each do |name|
+      domain = Domain.new(:name => name)
+      refute domain.valid?, "expected #{name.inspect} to be invalid"
+      assert domain.errors[:name].present?, "expected :name errors for #{name.inspect}"
+    end
+  end
+
   test 'hooks are defined' do
     expected = [
       'domain_created.event.foreman',

--- a/test/unit/authorizer_test.rb
+++ b/test/unit/authorizer_test.rb
@@ -103,7 +103,7 @@ class AuthorizerTest < ActiveSupport::TestCase
             domain1     = FactoryBot.create(:domain)
             domain2     = FactoryBot.create(:domain, :name => 'a-domain.to-be-found.com')
             domain3     = FactoryBot.create(:domain, :name => 'another-domain.to-be-found.com')
-            domain4     = FactoryBot.create(:domain, :name => 'be_editable.to-be-found.com')
+            domain4     = FactoryBot.create(:domain, :name => 'be-editable.to-be-found.com')
             auth        = Authorizer.new(@user)
 
             collection = auth.find_collection(Domain, :permission => :view_domains)

--- a/test/unit/net/validations_test.rb
+++ b/test/unit/net/validations_test.rb
@@ -59,6 +59,39 @@ class ValidationsTest < ActiveSupport::TestCase
     end
   end
 
+  describe "domain name regexp" do
+    test "matches valid DNS-style domain names" do
+      %w[
+        example.com
+        Example.com
+        Sub.EXAMPLE.co.uk
+        a1.example.org
+        foo-bar.example.com
+        localhost
+      ].each do |name|
+        assert_match Net::Validations::DOMAIN_NAME_REGEXP, name,
+          "#{name.inspect} should match DOMAIN_NAME_REGEXP"
+      end
+    end
+
+    test "does not match invalid domain names" do
+      [
+        'example..com',
+        '-bad.example.com',
+        'bad-.example.com',
+        'example_domain.com',
+        'example!.com',
+        'exam ple.com',
+        '/example.com',
+        '*',
+        '*.*',
+      ].each do |name|
+        assert_no_match Net::Validations::DOMAIN_NAME_REGEXP, name,
+          "#{name.inspect} should not match DOMAIN_NAME_REGEXP"
+      end
+    end
+  end
+
   test "hostname should be valid" do
     assert_nothing_raised do
       Net::Validations.validate_hostname! "this.is.an.example.com"


### PR DESCRIPTION
## Why
Domain names were validated only for presence/uniqueness in the `Domain` model.  
This allowed invalid characters and malformed values to be accepted.

## What changed
- Added format validation for `Domain#name` using `Net::Validations::HOST_REGEXP`
- Added domain-specific validation message constant:
  - `Net::Validations::DOMAIN_NAME_FORMAT_ERR_MSG`
- Extended `domain_test` with:
  - accepted example (`example.com`)
  - rejected examples (`Example.com`, `example_domain.com`)
  - additional invalid cases (`*`, `*.*`, `*.example.com`, `example.*.com`, `!!!`, `example..com`, etc.)
- Normalized test fixtures/inputs to lowercase where needed

## Test plan
### Steps
- `bundle exec rails test test/models/domain_test.rb`

### Expected result
- Domain format validation rejects invalid names
- Existing domain behavior remains unchanged for valid lowercase dotted names