### PR TITLE
Fixes #39299 - Add additive fact import mode

### DIFF
--- a/app/services/fact_importer.rb
+++ b/app/services/fact_importer.rb
@@ -28,17 +28,17 @@ class FactImporter
     @error    = false
     @host     = host
     @facts    = normalize(facts)
-    @counters = {}
+    @counters = { added: 0, updated: 0, deleted: 0 }
   end
 
   # expect a facts hash
-  def import!
+  def import!(additive: false)
     # This function uses its own transactions that should not be included
     # in the transaction that handles fact values
     ensure_fact_names
 
     ActiveRecord::Base.transaction do
-      delete_removed_facts
+      delete_removed_facts unless additive
       update_facts
       add_new_facts
     end

--- a/app/services/host_fact_importer.rb
+++ b/app/services/host_fact_importer.rb
@@ -11,7 +11,7 @@ class HostFactImporter
     Setting[:create_new_host_when_facts_are_uploaded]
   end
 
-  def import_facts(facts, source_proxy = nil)
+  def import_facts(facts, source_proxy = nil, additive: false)
     return false if !create_new_record_when_facts_are_uploaded? && host.new_record?
 
     # we are not importing facts for hosts in build state (e.g. waiting for a re-installation)
@@ -24,7 +24,7 @@ class HostFactImporter
     facts_importer = Foreman::Plugin.fact_importer_registry.get(type).new(host, facts)
     telemetry_observe_histogram(:importer_facts_import_duration, facts.size, type: type)
     telemetry_duration_histogram(:importer_facts_import_duration, 1000, type: type) do
-      facts_importer.import!
+      facts_importer.import!(additive: additive)
     end
 
     skipping_orchestration do

--- a/test/unit/fact_importer_test.rb
+++ b/test/unit/fact_importer_test.rb
@@ -152,6 +152,25 @@ class FactImporterTest < ActiveSupport::TestCase
       assert_equal 0, importer.counters[:added]
     end
 
+    test 'additive import preserves existing facts not in the new set' do
+      # baseline: two facts in DB
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+
+      # additive import of a single new fact — existing facts must survive
+      @importer = FactImporter.new(host, 'uptime' => '1 day')
+      allow_transactions_for @importer
+      @importer.stubs(:fact_name_class).returns(FactName)
+      @importer.import!(additive: true)
+
+      assert_equal '2.6.9', value('kernelversion')
+      assert_equal '10.0.19.33', value('ipaddress')
+      assert_equal '1 day', value('uptime')
+      assert_equal 0, @importer.counters[:deleted]
+      assert_equal 1, @importer.counters[:added]
+      assert_equal 0, @importer.counters[:updated]
+    end
+
     test 'importer updates fact values' do
       assert_equal '2.6.9', value('kernelversion')
       assert_equal '10.0.19.33', value('ipaddress')

--- a/test/unit/host_fact_importer_test.rb
+++ b/test/unit/host_fact_importer_test.rb
@@ -47,7 +47,51 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'import_facts only needs operatingsystem and operatingsystemrelease fact' do
     host = Host.import_host('host', 'puppet')
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS'})
+  end
+
+  test 'import_facts forwards additive mode to the fact importer' do
+    host = FactoryBot.create(:host, :managed)
+    importer = mock('fact importer')
+    importer_class = mock('fact importer class')
+    facts = { _type: 'puppet', operatingsystem: 'CentOS', operatingsystemrelease: '6.7' }
+    captured_facts = nil
+    source_proxy = FactoryBot.build(:smart_proxy)
+
+    Foreman::Plugin.fact_importer_registry.expects(:get).with('puppet').returns(importer_class)
+    importer_class.expects(:new).with do |actual_host, actual_facts|
+      captured_facts = actual_facts
+      actual_host == host
+    end.returns(importer)
+    importer.expects(:import!).with(additive: true)
+
+    host.stubs(:save).returns(true)
+    host.stubs(:trigger_hook)
+    HostFactImporter.any_instance.expects(:parse_facts).with do |actual_facts, type, actual_source_proxy|
+      actual_facts == captured_facts && type == 'puppet' && actual_source_proxy == source_proxy
+    end.returns(true)
+
+    assert HostFactImporter.new(host).import_facts(facts, source_proxy, additive: true)
+    assert_equal 'CentOS', captured_facts[:operatingsystem]
+    assert_equal '6.7', captured_facts[:operatingsystemrelease]
+    refute captured_facts.key?(:_type)
+  end
+
+  test 'import_facts defaults additive mode to false' do
+    host = FactoryBot.create(:host, :managed)
+    importer = mock('fact importer')
+    importer_class = mock('fact importer class')
+    facts = { _type: 'puppet', operatingsystem: 'CentOS', operatingsystemrelease: '6.7' }
+
+    Foreman::Plugin.fact_importer_registry.expects(:get).with('puppet').returns(importer_class)
+    importer_class.stubs(:new).returns(importer)
+    importer.expects(:import!).with(additive: false)
+
+    host.stubs(:save).returns(true)
+    host.stubs(:trigger_hook)
+    HostFactImporter.any_instance.stubs(:parse_facts).returns(true)
+
+    assert HostFactImporter.new(host).import_facts(facts)
   end
 
   test 'should import facts from json of a new host when certname is not specified' do
@@ -70,7 +114,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
   test 'domain updated from facts' do
     host = FactoryBot.create(:host, :with_operatingsystem)
     FactoryBot.create(:domain, :name => 'foo.bar')
-    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts({:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name})
     assert_equal 'foo.bar', host.domain.to_s
   end
 
@@ -78,9 +122,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
     domain = FactoryBot.create(:domain)
     host = FactoryBot.create(:host, :managed, :domain => domain)
     FactoryBot.create(:domain, :name => 'foo.bar')
-    assert HostFactImporter.new(host).import_facts(:domain => domain.name, :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts({:domain => domain.name, :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name})
     Setting[:ignore_facts_for_domain] = true
-    assert HostFactImporter.new(host).import_facts(:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name)
+    assert HostFactImporter.new(host).import_facts({:domain => 'foo.bar', :operatingsystemrelease => host.operatingsystem.release, :operatingsystem => host.operatingsystem.name})
     assert_equal domain.name, host.domain.name
     Setting[:ignore_facts_for_domain] =
       Setting.find_by_name('ignore_facts_for_domain').default
@@ -236,13 +280,13 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'comment updated from facts when present' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(foreman_comment: 'new comment', operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
+    assert HostFactImporter.new(host).import_facts({foreman_comment: 'new comment', operatingsystemrelease: '6.7', operatingsystem: 'CentOS'})
     assert_equal 'new comment', host.comment
   end
 
   test 'operatingsystem updated from facts' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS'})
     assert_equal 'CentOS 6.7', host.operatingsystem.to_s
   end
 
@@ -251,7 +295,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
     os2 = FactoryBot.create(:operatingsystem)
     medium = os1.media.first
     host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
-    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s)
+    HostFactImporter.new(host).import_facts({:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s})
 
     assert_equal host.operatingsystem, os2
     assert_nil host.medium
@@ -264,7 +308,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
     medium.operatingsystems << os2
 
     host = FactoryBot.create(:host, :operatingsystem => os1, :medium => medium)
-    HostFactImporter.new(host).import_facts(:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s)
+    HostFactImporter.new(host).import_facts({:operatingsystem => os2.name, :operatingsystemrelease => os2.major.to_s})
 
     assert_equal host.operatingsystem, os2
     assert_equal host.medium, medium
@@ -272,9 +316,9 @@ class HostFactImporterTest < ActiveSupport::TestCase
 
   test 'operatingsystem not updated from facts when ignore_facts_for_operatingsystem false' do
     host = Host.import_host('host')
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.7', :operatingsystem => 'CentOS'})
     Setting[:ignore_facts_for_operatingsystem] = true
-    assert HostFactImporter.new(host).import_facts(:operatingsystemrelease => '6.8', :operatingsystem => 'CentOS')
+    assert HostFactImporter.new(host).import_facts({:operatingsystemrelease => '6.8', :operatingsystem => 'CentOS'})
     assert_equal 'CentOS 6.7', host.operatingsystem.to_s
     Setting[:ignore_facts_for_operatingsystem] =
       Setting.find_by_name('ignore_facts_for_operatingsystem').default
@@ -360,7 +404,7 @@ class HostFactImporterTest < ActiveSupport::TestCase
           payload[:object].operatingsystem.name == 'CentOS'
         end
 
-        HostFactImporter.new(host).import_facts(operatingsystemrelease: '6.7', operatingsystem: 'CentOS')
+        HostFactImporter.new(host).import_facts({operatingsystemrelease: '6.7', operatingsystem: 'CentOS'})
       end
     end
   end


### PR DESCRIPTION
## Summary

Add `additive:` keyword argument to `FactImporter#import!` and `HostFactImporter#import_facts`. When `true`, existing facts not in the new set are preserved (`delete_removed_facts` is skipped).

This enables importing a subset of facts without wiping facts from other sources, needed by Katello (katello#11701) to import only OS-detection facts at registration time.

## Changes

- `fact_importer.rb`: `import!(additive: false)` — skips `delete_removed_facts` when true
- `host_fact_importer.rb`: `import_facts(facts, source_proxy = nil, additive: false)` — passes through
- Test: verifies additive import preserves existing facts
- Test brace fixes for Ruby keyword argument disambiguation

## How to test

1. `bundle exec rake test TEST=test/unit/fact_importer_test.rb`
2. `bundle exec rake test TEST=test/unit/host_fact_importer_test.rb`