### PR TITLE
Fixes #39311 - Allow selection clearance for AutocompleteInput

### DIFF
--- a/webpack/assets/javascripts/react_app/components/Editor/components/EditorNavbar.js
+++ b/webpack/assets/javascripts/react_app/components/Editor/components/EditorNavbar.js
@@ -167,6 +167,7 @@ const EditorNavbar = ({
                   }
                   onBlur={() => onHostSearch({ target: { value: '' } })}
                   onSelect={resolveHostById}
+                  allowClear={false}
                 />
                 {isFetchingHosts && (
                   <div id="editor-host-fetch-spinner">

--- a/webpack/assets/javascripts/react_app/components/common/AutocompleteInput/AutocompleteInput.js
+++ b/webpack/assets/javascripts/react_app/components/common/AutocompleteInput/AutocompleteInput.js
@@ -28,6 +28,7 @@ export const AutocompleteInputComponent = ({
   isDisabled,
   fieldId,
   onBlur,
+  allowClear,
 }) => {
   if (validationStatus === 'error') validationStatus = 'danger';
   const NO_RESULTS = __('No matches found');
@@ -49,13 +50,12 @@ export const AutocompleteInputComponent = ({
   const [inputValue, setInputValue] = useState(displayValue);
   const [filterValue, setFilterValue] = useState('');
   const [selectOptions, setSelectOptions] = useState(displayOptions);
-  const [focusedItemIndex, setFocusedItemIndex] = useState(null);
-  const [activeItemId, setActiveItemId] = useState(null);
   const textInputRef = useRef(null);
-  const wrapperRef = useRef(null);
+  const inputValueRef = useRef(inputValue);
 
   useEffect(() => {
     setInputValue(displayValue);
+    inputValueRef.current = displayValue;
   }, [displayValue]);
 
   useEffect(() => {
@@ -86,29 +86,26 @@ export const AutocompleteInputComponent = ({
     setSelectOptions(newSelectOptions);
   }, [filterValue, displayOptions, NO_RESULTS, options]);
 
-  const createItemId = value => `select-typeahead-${value}`;
-  const setActiveAndFocusedItem = itemIndex => {
-    setFocusedItemIndex(itemIndex);
-    const focusedItem = selectOptions[itemIndex];
-    setActiveItemId(createItemId(focusedItem.value));
-  };
-  const resetActiveAndFocusedItem = () => {
-    setFocusedItemIndex(null);
-    setActiveItemId(null);
-  };
   const closeMenu = () => {
     setIsOpen(false);
-    resetActiveAndFocusedItem();
   };
 
-  const handleBlurCapture = e => {
-    const next = e.relatedTarget;
-    if (!wrapperRef.current?.contains(next)) {
-      closeMenu();
-    }
-    setInputValue(displayValue);
+  const onClose = () => {
+    closeMenu();
     setFilterValue('');
-    onBlur(displayValue);
+    if (
+      allowClear &&
+      !inputValueRef.current &&
+      selected != null &&
+      selected !== ''
+    ) {
+      onSelect('');
+      onBlur('');
+    } else {
+      setInputValue(displayValue);
+      inputValueRef.current = displayValue;
+      onBlur(displayValue);
+    }
   };
 
   const onInputClick = () => {
@@ -120,6 +117,7 @@ export const AutocompleteInputComponent = ({
   };
   const selectOption = (value, content) => {
     setInputValue(String(content));
+    inputValueRef.current = String(content);
     setFilterValue('');
     onSelect(value);
     closeMenu();
@@ -134,71 +132,10 @@ export const AutocompleteInputComponent = ({
   const onTextInputChange = (_event, value) => {
     onChange(value);
     setInputValue(value);
+    inputValueRef.current = value;
     setFilterValue(value);
-    resetActiveAndFocusedItem();
-  };
-  const handleMenuArrowKeys = key => {
-    let indexToFocus = 0;
-    if (!isOpen) {
-      setIsOpen(true);
-    }
-    if (selectOptions.every(option => option.isDisabled)) {
-      return;
-    }
-    if (key === 'ArrowUp') {
-      if (focusedItemIndex === null || focusedItemIndex === 0) {
-        indexToFocus = selectOptions.length - 1;
-      } else {
-        indexToFocus = focusedItemIndex - 1;
-      }
-      while (selectOptions[indexToFocus].isDisabled) {
-        indexToFocus--;
-        if (indexToFocus === -1) {
-          indexToFocus = selectOptions.length - 1;
-        }
-      }
-    }
-    if (key === 'ArrowDown') {
-      if (
-        focusedItemIndex === null ||
-        focusedItemIndex === selectOptions.length - 1
-      ) {
-        indexToFocus = 0;
-      } else {
-        indexToFocus = focusedItemIndex + 1;
-      }
-      while (selectOptions[indexToFocus].isDisabled) {
-        indexToFocus++;
-        if (indexToFocus === selectOptions.length) {
-          indexToFocus = 0;
-        }
-      }
-    }
-    setActiveAndFocusedItem(indexToFocus);
-  };
-  const onInputKeyDown = event => {
-    const focusedItem =
-      focusedItemIndex !== null ? selectOptions[focusedItemIndex] : null;
-    // eslint-disable-next-line default-case
-    switch (event.key) {
-      case 'Enter':
-        if (
-          isOpen &&
-          focusedItem &&
-          focusedItem.value !== NO_RESULTS &&
-          !focusedItem.isAriaDisabled
-        ) {
-          selectOption(focusedItem.value, focusedItem.label);
-        }
-        if (!isOpen) {
-          setIsOpen(true);
-        }
-        break;
-      case 'ArrowUp':
-      case 'ArrowDown':
-        event.preventDefault();
-        handleMenuArrowKeys(event.key);
-        break;
+    if (allowClear && !value && selected != null && selected !== '') {
+      onSelect('');
     }
   };
   const onToggleClick = () => {
@@ -224,14 +161,10 @@ export const AutocompleteInputComponent = ({
           value={inputValue}
           onClick={onInputClick}
           onChange={onTextInputChange}
-          onKeyDown={onInputKeyDown}
           inputId={fieldId ?? `id-${name}`}
           id={`typeahead-select-input-${name}`}
           innerRef={textInputRef}
           placeholder={placeholder}
-          {...(activeItemId && {
-            'aria-activedescendant': activeItemId,
-          })}
           role="combobox"
           isExpanded={isOpen}
           aria-controls={`id-${name}`}
@@ -250,11 +183,7 @@ export const AutocompleteInputComponent = ({
     </MenuToggle>
   );
   return (
-    <div
-      ref={wrapperRef}
-      onBlurCapture={handleBlurCapture}
-      className="autocomplete-input-wrapper"
-    >
+    <div className="autocomplete-input-wrapper">
       <Select
         name={name}
         ouiaId={`autocomplete-select-${name}`}
@@ -263,20 +192,18 @@ export const AutocompleteInputComponent = ({
         selected={selected}
         onSelect={onSelectLocal}
         onOpenChange={nextIsOpen => {
-          if (!nextIsOpen) closeMenu();
+          if (!nextIsOpen) onClose();
           else setIsOpen(true);
         }}
         toggle={toggle}
         shouldFocusFirstItemOnOpen={false}
       >
         <SelectList id="select-typeahead-listbox">
-          {selectOptions.map((option, index) => (
+          {selectOptions.map(option => (
             <SelectOption
               key={option.value || option.label}
-              isFocused={focusedItemIndex === index}
               className={option.className}
               isDisabled={option.disabled || false}
-              id={createItemId(option.value)}
               {...option}
               ref={null}
             >
@@ -318,6 +245,7 @@ AutocompleteInputComponent.propTypes = {
   isDisabled: PropTypes.bool,
   fieldId: PropTypes.string,
   onBlur: PropTypes.func,
+  allowClear: PropTypes.bool,
 };
 
 AutocompleteInputComponent.defaultProps = {
@@ -331,6 +259,7 @@ AutocompleteInputComponent.defaultProps = {
   isDisabled: false,
   fieldId: undefined,
   onBlur: () => {},
+  allowClear: true,
 };
 
 export default AutocompleteInputComponent;

--- a/webpack/assets/javascripts/react_app/components/common/AutocompleteInput/__tests__/AutocompleteInput.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/AutocompleteInput/__tests__/AutocompleteInput.test.js
@@ -124,14 +124,32 @@ describe('AutocompleteInput RTL Tests', () => {
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
       });
     });
-  });
 
-  describe('Keyboard Navigation', () => {
-    test('opens dropdown on Enter key', async () => {
+    test('selects option after typing to filter', async () => {
       render(<AutocompleteInput {...defaultProps} />);
 
       const input = screen.getByRole('combobox');
-      fireEvent.keyDown(input, { key: 'Enter' });
+      fireEvent.change(input, { target: { value: 'Option 2' } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Option 2')).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText('Option 2'));
+
+      await waitFor(() => {
+        expect(setSelected).toHaveBeenCalledWith('option2');
+      });
+      expect(input).toHaveValue('Option 2');
+    });
+  });
+
+  describe('Keyboard Navigation', () => {
+    test('opens dropdown on click', async () => {
+      render(<AutocompleteInput {...defaultProps} />);
+
+      const input = screen.getByRole('combobox');
+      fireEvent.click(input);
 
       await waitFor(() => {
         expect(screen.getByRole('listbox')).toBeInTheDocument();
@@ -149,6 +167,153 @@ describe('AutocompleteInput RTL Tests', () => {
         expect(screen.getByText('Option 1')).toHaveClass(
           'pf-v5-c-menu__item-text'
         );
+      });
+    });
+  });
+
+  describe('allowClear', () => {
+    test('clears selection when input is emptied with allowClear=true (default)', async () => {
+      const onSelect = jest.fn();
+      render(
+        <AutocompleteInput
+          {...defaultProps}
+          selected="option1"
+          onSelect={onSelect}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveValue('Option 1');
+
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(onSelect).toHaveBeenCalledWith('');
+    });
+
+    test('does not clear selection when input is emptied with allowClear=false', async () => {
+      const onSelect = jest.fn();
+      render(
+        <AutocompleteInput
+          {...defaultProps}
+          selected="option1"
+          onSelect={onSelect}
+          allowClear={false}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveValue('Option 1');
+
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    test('clears selection for numeric selected value with allowClear=true', async () => {
+      const numericOptions = [
+        { value: 0, label: 'Zero' },
+        { value: 1, label: 'One' },
+      ];
+      const onSelect = jest.fn();
+      render(
+        <AutocompleteInput
+          {...defaultProps}
+          options={numericOptions}
+          selected={0}
+          onSelect={onSelect}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveValue('Zero');
+
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(onSelect).toHaveBeenCalledWith('');
+    });
+
+    test('does not call onSelect when selected is already empty', () => {
+      const onSelect = jest.fn();
+      render(
+        <AutocompleteInput
+          {...defaultProps}
+          selected=""
+          onSelect={onSelect}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: '' } });
+
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onClose behavior', () => {
+    test('calls onBlur on close', async () => {
+      const onBlur = jest.fn();
+      render(
+        <AutocompleteInput
+          {...defaultProps}
+          selected="option1"
+          onBlur={onBlur}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      fireEvent.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByRole('listbox')).toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(onBlur).toHaveBeenCalledWith('Option 1');
+      });
+    });
+
+    test('restores input value on close when allowClear=false', async () => {
+      render(
+        <AutocompleteInput
+          {...defaultProps}
+          selected="option1"
+          allowClear={false}
+        />
+      );
+
+      const input = screen.getByRole('combobox');
+      expect(input).toHaveValue('Option 1');
+
+      fireEvent.change(input, { target: { value: 'typed text' } });
+      expect(input).toHaveValue('typed text');
+
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      await waitFor(() => {
+        expect(input).toHaveValue('Option 1');
+      });
+    });
+
+    test('resets filter on close', async () => {
+      render(<AutocompleteInput {...defaultProps} />);
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, { target: { value: 'Option 1' } });
+
+      await waitFor(() => {
+        expect(screen.queryByText('Option 2')).not.toBeInTheDocument();
+      });
+
+      fireEvent.keyDown(input, { key: 'Escape' });
+
+      fireEvent.click(input);
+
+      await waitFor(() => {
+        expect(screen.getByText('Option 1')).toBeInTheDocument();
+        expect(screen.getByText('Option 2')).toBeInTheDocument();
+        expect(screen.getByText('Option 3')).toBeInTheDocument();
       });
     });
   });
@@ -184,21 +349,6 @@ describe('AutocompleteInput RTL Tests', () => {
 
       const input = screen.getByRole('combobox');
       expect(input).toHaveValue('true');
-    });
-
-  });
-
-  describe('Accessibility', () => {
-    test('has proper ARIA attributes when focused', async () => {
-      render(<AutocompleteInput {...defaultProps} />);
-
-      const input = screen.getByRole('combobox');
-      fireEvent.click(input);
-
-      await waitFor(() => {
-        fireEvent.keyDown(input, { key: 'ArrowDown' });
-        expect(input).toHaveAttribute('aria-activedescendant');
-      });
     });
   });
 });


### PR DESCRIPTION
Fixes: 47dca75e8c530937a771df0f39f5a1190e75577f

Before:
[before.webm](https://github.com/user-attachments/assets/08c4c66b-9e79-4881-a348-45c4a24214b3)
After:
[after.webm](https://github.com/user-attachments/assets/cbcfda7a-4777-45bd-91c3-28d504178271)

For context please see the attachments or the ticket.

I believe this is a regression caused by https://github.com/theforeman/foreman/pull/10777, but since the only consumer outside is webhooks plugin, the issue was missed and caught by CI runs of the plugin. We could fix that in the plugin, but since that commit changed behavior by essentially breaking functionality, I'd rather return back what was changed.

I'm not sure about the approach of the fix much, I've tried to make it in a way that it leaves what EditorHostSelect needs, but at the same time the same behavior might be re-used by other consumers via `allowClear` prop if needed.

I doubt we'll manage to get this before branching, so I treat it as a separate issue that follows the previous PR, thus Fixes instead of Refs. If we won't manage to get this before branching, we'll need to cherry-pick it into 3.19-stable.


cc @adamlazik1, @Lukshio, @MariaAga

UPD: The CI with this patch is green: https://github.com/theforeman/foreman_webhooks/pull/101