### PR TITLE
Fixes #39321 - Remove SSH providers from BMC

### DIFF
--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -728,7 +728,7 @@ autopart"', desc: 'to render the content of host partition table'
   def bmc_available?
     ipmi = bmc_nic
     return false if ipmi.nil?
-    (ipmi.credentials_present? && %w(IPMI Redfish).include?(ipmi.provider)) || ipmi.provider == 'SSH'
+    (ipmi.credentials_present? && %w(IPMI Redfish).include?(ipmi.provider))
   end
   alias_method :bmc_available, :bmc_available?
 

--- a/app/models/nic/bmc.rb
+++ b/app/models/nic/bmc.rb
@@ -1,6 +1,6 @@
 module Nic
   class BMC < Managed
-    PROVIDERS = %w(IPMI Redfish SSH)
+    PROVIDERS = %w(IPMI Redfish)
     before_validation :ensure_physical
     before_validation { |nic| nic.provider == 'Redfish' || nic.provider.try(:upcase!) }
     validates :provider, :presence => true, :inclusion => { :in => PROVIDERS }

--- a/test/models/nics/bmc_test.rb
+++ b/test/models/nics/bmc_test.rb
@@ -13,13 +13,6 @@ class BMCTest < ActiveSupport::TestCase
     assert host.bmc_available?
   end
 
-  test 'BMC SSH availability' do
-    host = FactoryBot.build_stubbed(:host, :managed)
-    nic = FactoryBot.build_stubbed(:nic_bmc, :host => host, :provider => 'SSH', :subnet => subnets(:one))
-    host.expects(:bmc_nic).returns(nic)
-    assert host.bmc_available?
-  end
-
   test 'upcasing provider does not fail if provider is not present' do
     host = FactoryBot.build_stubbed(:host, :managed)
     assert_nothing_raised do


### PR DESCRIPTION
In [RFC](https://community.theforeman.org/t/rfc-remove-support-for-ssh-and-shell-providers-for-bmc/46375?u=arvind4501) , there is proposal to remove SSH and Shell as BMC providers, “SSH” is exposed in the Foreman UI (even if not functional in the default config).
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
