### PR TITLE
Fixes #39334 - Add severity to applied errata report

### DIFF
--- a/app/views/unattended/report_templates/host_-_applied_errata.erb
+++ b/app/views/unattended/report_templates/host_-_applied_errata.erb
@@ -53,7 +53,7 @@ require:
 - plugin: katello
   version: 3.12.0
 -%>
-<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'issued', 'status' -%>
+<%- report_headers 'date', 'hostname', 'erratum_id', 'erratum_type', 'issued', 'severity', 'status' -%>
 <%- load_errata_applications(filter_errata_type: input('Filter Errata Type'),
                              include_last_reboot: input('Include Last Reboot'),
                              since: input('Since'),


### PR DESCRIPTION
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
Add a severity column to the "Host - Applied Errata" report which displays erratum severity. This PR requires https://github.com/Katello/katello/pull/11744 (companion PR in Katello) to function.

### How to test this PR
1. Register a host to your Foreman/Katello server.
2. Create and sync the "Needed Errata" product (https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/). Add this product to your host's content view and publish to the active lifecycle environment.
3. On the host, install walrus 0.71 using `dnf install walrus-0.71`. This is an outdated version of walrus which has one installable erratum.
4. Using the rails console, modify the erratum's severity to a severity you'd like to test with: `Katello::Erratum.find_by(errata_id: 'RHEA-2012:0055').update!(severity: 'Important')`
5. In Monitor -> Reports -> Report Templates, generate a "Host - Available Errata" report using the "Installable errata" option. The erratum should show up with the new severity.
6. Apply the erratum. Walrus will have updated to the newest version on the host.
7. Generate a "Host - Applied Errata" report. Make sure to modify the "Since" field to a date well before the erratum was created (I used 2000). The status will populate in the generated CSV.
8. Test with multiple hosts with multiple errata of different severity. Try the null case without severity. Try some of these:
    - "Critical"
    - "Low"
    - "None"