### PR TITLE
Fixes #38674 - align checkboxes on host registration form

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPage.scss
+++ b/webpack/assets/javascripts/react_app/routes/RegistrationCommands/RegistrationCommandsPage/RegistrationCommandsPage.scss
@@ -1,5 +1,15 @@
 .registration_commands_form {
-  input[type='checkbox'] {
-    margin: auto;
+  .pf-v5-c-check {
+    align-items: center;
+  }
+
+  .pf-v5-c-check__input {
+    align-self: center;
+    transform: none;
+    -moz-transform: none;
+  }
+
+  .pf-v5-c-check__label .pf-v5-c-form__group-label-help {
+    vertical-align: middle;
   }
 }


### PR DESCRIPTION
# Fix checkbox alignment on Register Host page

## Summary

Fixes #38674 — aligns checkboxes on the Register Host page (`/hosts/register`), including **Insecure** and **Update packages**.

The registration form applied `margin: auto` to checkbox inputs, which caused the checkbox to appear vertically misaligned with the label text. This was especially noticeable for labels that include a help icon (`LabelIcon`), where PatternFly's default checkbox positioning (`translateY`) made the issue more pronounced.

This change removes the problematic override and adds scoped PatternFly alignment adjustments under `.registration_commands_form` only.

---

## Changes

### `RegistrationCommandsPage.scss`

- Removed:

  ```scss
  input[type='checkbox'] {
    margin: auto;
  }
  ```

- Added:
  - `align-items: center` for `.pf-v5-c-check`
  - `align-self: center` for `.pf-v5-c-check__input`
  - `transform: none` and `-moz-transform: none` to disable PatternFly's default vertical offset
  - `vertical-align: middle` for the help icon

---

## Scope

- CSS-only change
- No React component changes
- No new files
- No new strings
- Scoped only to `.registration_commands_form`

---

## Screenshots

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/71f8e855-f560-4d1f-9a8d-a896dcbbe1fe) | ![After](https://github.com/user-attachments/assets/1a9cf65d-ce4b-4940-90e2-d47c889fc82a) |

General → Insecure (the same fix also applies to Advanced → Update packages).

---
