### PR TITLE
Fixes #39288 - puppet_conf.erb permit setting puppet server port

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -108,6 +108,11 @@ module HostCommon
   end
   alias_method :puppetmaster, :puppet_server
 
+  # The Puppet server port. Exposed as a provisioning macro.
+  def puppet_server_port
+    puppet_server_uri.try(:port)
+  end
+
   def puppet_ca_server_uri
     return unless puppet_ca_proxy
     url = puppet_ca_proxy.setting('Puppet CA', 'puppet_url')

--- a/app/services/foreman/renderer/configuration.rb
+++ b/app/services/foreman/renderer/configuration.rb
@@ -78,6 +78,7 @@ module Foreman
         :host_param_true?, :host_param_false?,
         :host_param, :host_param!,
         :host_puppet_server,
+        :host_puppet_server_port,
         :host_puppet_ca_server,
         :host_puppet_ca_server_port,
         :host_puppet_environment,

--- a/app/services/foreman/renderer/scope/macros/host_template.rb
+++ b/app/services/foreman/renderer/scope/macros/host_template.rb
@@ -60,6 +60,15 @@ module Foreman
             host.try(:puppet_server).presence || host_param('puppet_server')
           end
 
+          apipie :method, 'Returns Puppet server\'s port configured via the assigned Smart Proxy or the puppet_server_port host parameter' do
+            returns Integer, desc: 'Returns the configured Puppet server\'s port (1-65535), or nil if not configured'
+          end
+          def host_puppet_server_port
+            check_host
+            port = host.try(:puppet_server_port).presence || host_param('puppet_server_port')
+            validate_port(port, 'Puppet Server')
+          end
+
           apipie :method, 'Returns Puppet CA server\'s hostname configured through the ENC or the puppet_ca_server host parameter' do
             returns String, desc: 'Returns the configured Puppet CA server\'s hostname, or nil if not configured'
           end
@@ -74,7 +83,7 @@ module Foreman
           def host_puppet_ca_server_port
             check_host
             port = host.try(:puppet_ca_server_port).presence || host_param('puppet_ca_server_port')
-            validate_port(port)
+            validate_port(port, 'Puppet CA Server')
           end
 
           apipie :method, 'Returns the Puppet environment configured configured through the ENC or the puppet_environment host parameter' do
@@ -245,15 +254,15 @@ module Foreman
             raise HostParamUndefined.new(name: name, host: host) unless host.params.key?(name)
           end
 
-          def validate_port(value)
-            return nil if value.nil?
+          def validate_port(value, desc = 'This')
+            return nil if value.blank?
 
             unless value.to_s.match?(/^\d+$/)
-              raise ArgumentError, "Puppet CA server port must be an integer, got: #{value.inspect}"
+              raise ArgumentError, "#{desc} port must be an integer, got: #{value.inspect}"
             end
             port = value.to_i
             if port < 1 || port > 65535
-              raise ArgumentError, "Puppet CA server port must be between 1 and 65535, got: #{value.inspect}"
+              raise ArgumentError, "#{desc} port must be between 1 and 65535, got: #{value.inspect}"
             end
             port
           end

--- a/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
+++ b/app/views/unattended/provisioning_templates/snippet/puppet.conf.erb
@@ -31,6 +31,7 @@ description: |
     ssl_dir = '\$vardir/ssl'
   end
 
+  host_puppet_server_port_default = 8140
   host_puppet_ca_server_port_default = 8140
 -%>
 [main]
@@ -58,6 +59,11 @@ ca_port         = <%= host_puppet_ca_server_port %>
 certname        = <%= @host.certname %>
 <%- if host_puppet_server.present? -%>
 server          = <%= host_puppet_server %>
+<%- end -%>
+<%- if host_puppet_server_port.present? -%>
+<%- if host_puppet_server_port.to_i != host_puppet_server_port_default -%>
+port            = <%= host_puppet_server_port %>
+<%- end -%>
 <%- end -%>
 <%- if host_puppet_environment.present? -%>
 environment     = <%= host_puppet_environment %>

--- a/test/factories/feature.rb
+++ b/test/factories/feature.rb
@@ -45,5 +45,9 @@ FactoryBot.define do
     trait :external_ipam do
       name { 'External IPAM' }
     end
+
+    trait :puppet do
+      name { 'Puppet' }
+    end
   end
 end

--- a/test/factories/smart_proxy.rb
+++ b/test/factories/smart_proxy.rb
@@ -70,6 +70,15 @@ FactoryBot.define do
       end
     end
 
+    factory :puppet_smart_proxy do
+      before(:create, :build, :build_stubbed) do
+        ProxyAPI::V2::Features.any_instance.stubs(:features).returns(:puppet => {'state' => 'running'})
+      end
+      after(:build) do |smart_proxy, _evaluator|
+        smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :puppet, :smart_proxy => smart_proxy)
+      end
+    end
+
     factory :realm_smart_proxy do
       after(:build) do |smart_proxy, _evaluator|
         smart_proxy.smart_proxy_features << FactoryBot.build(:smart_proxy_feature, :realm, :smart_proxy => smart_proxy)
@@ -100,6 +109,10 @@ FactoryBot.define do
 
     trait :puppetca do
       association :feature, :puppetca
+    end
+
+    trait :puppet do
+      association :feature, :puppet
     end
 
     trait :bmc do

--- a/test/models/host_test.rb
+++ b/test/models/host_test.rb
@@ -369,6 +369,23 @@ class HostTest < ActiveSupport::TestCase
     assert_equal 8443, host.puppet_ca_server_port
   end
 
+  test "should read the Puppet Server port from its proxy settings" do
+    host = FactoryBot.build_stubbed(:host)
+    assert_nil host.puppet_server_port
+
+    proxy = FactoryBot.create(:puppet_smart_proxy, url: 'https://smartproxy.example.com:8443')
+    host.puppet_proxy = proxy
+    assert_equal 8140, host.puppet_server_port
+
+    features = {
+      'puppet' => {
+        settings: {'puppet_url': 'https://puppet.example.com:8443'},
+      },
+    }
+    SmartProxyFeature.import_features(proxy, features)
+    assert_equal 8443, host.puppet_server_port
+  end
+
   test "should populate primary interface attributes even without existing interface" do
     host = FactoryBot.build(:host, :managed => false)
     host.interfaces = []

--- a/test/unit/foreman/renderer/scope/macros/host_template_test.rb
+++ b/test/unit/foreman/renderer/scope/macros/host_template_test.rb
@@ -107,6 +107,101 @@ class HostTemplateTest < ActiveSupport::TestCase
     end
   end
 
+  describe '#validate_port' do
+    test 'accepts valid port number' do
+      assert_equal 8443, @scope.send(:validate_port, 8443)
+    end
+
+    test 'accepts valid port at lower boundary' do
+      assert_equal 1, @scope.send(:validate_port, 1)
+    end
+
+    test 'accepts valid port at upper boundary' do
+      assert_equal 65535, @scope.send(:validate_port, 65535)
+    end
+
+    test 'accepts string representation of port' do
+      assert_equal 8140, @scope.send(:validate_port, '8140')
+    end
+
+    test 'accepts string with leading zeros' do
+      assert_equal 8140, @scope.send(:validate_port, '08140')
+    end
+
+    test 'returns nil for nil input' do
+      assert_nil @scope.send(:validate_port, nil)
+    end
+
+    test 'returns nil for empty string' do
+      assert_nil @scope.send(:validate_port, '')
+    end
+
+    test 'rejects port 0' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, 0) }
+    end
+
+    test 'rejects port out of range (700000)' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, 700000) }
+    end
+
+    test 'rejects negative port' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, -1) }
+    end
+
+    test 'rejects negative port string' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, '-1') }
+    end
+
+    test 'rejects float with decimal' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, 8443.5) }
+    end
+
+    test 'rejects string with decimal notation' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, '8443.5') }
+    end
+
+    test 'rejects non-numeric string' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, 'invalid') }
+    end
+
+    test 'uses custom description for error messages' do
+      assert_raises(ArgumentError) { @scope.send(:validate_port, 0, 'Puppet Server') }
+      assert_raises(ArgumentError) { @scope.send(:validate_port, 0, 'Puppet CA Server') }
+    end
+  end
+
+  describe '#host_puppet_server_port' do
+    test 'returns integer from proxy port' do
+      host = stub(puppet_server_port: 8443)
+      @scope.instance_variable_set('@host', host)
+      result = @scope.host_puppet_server_port
+      assert_instance_of Integer, result
+    end
+
+    test 'validates port by calling validate_port' do
+      host = stub(puppet_server_port: 8443)
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:validate_port).with(8443, 'Puppet Server')
+      @scope.host_puppet_server_port
+    end
+
+    test 'returns port from host_param when proxy port is empty string' do
+      host = stub(puppet_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_server_port').returns('8443')
+      result = @scope.host_puppet_server_port
+      assert_instance_of Integer, result
+      assert_equal 8443, result
+    end
+
+    test 'returns nil when proxy port and host_param are empty strings' do
+      host = stub(puppet_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_server_port').returns('')
+      assert_nil @scope.host_puppet_server_port
+    end
+  end
+
   describe '#host_puppet_ca_server' do
     test 'should render puppet_ca_server' do
       host = stub(puppet_ca_server: 'myserver.example.com')
@@ -123,106 +218,34 @@ class HostTemplateTest < ActiveSupport::TestCase
   end
 
   describe '#host_puppet_ca_server_port' do
-    test 'should return integer from proxy port' do
+    test 'returns integer from proxy port' do
       host = stub(puppet_ca_server_port: 8443)
       @scope.instance_variable_set('@host', host)
       result = @scope.host_puppet_ca_server_port
+      assert_instance_of Integer, result
+    end
+
+    test 'validates port by calling validate_port' do
+      host = stub(puppet_ca_server_port: 8443)
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:validate_port).with(8443, 'Puppet CA Server')
+      @scope.host_puppet_ca_server_port
+    end
+
+    test 'returns port from host_param when proxy port is empty string' do
+      host = stub(puppet_ca_server_port: '')
+      @scope.instance_variable_set('@host', host)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8443')
+      result = @scope.host_puppet_ca_server_port
+      assert_instance_of Integer, result
       assert_equal 8443, result
-      assert_instance_of Integer, result
     end
 
-    test 'should convert string parameter to integer' do
+    test 'returns nil when proxy port and host_param are empty strings' do
       host = stub(puppet_ca_server_port: '')
       @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8080')
-      result = @scope.host_puppet_ca_server_port
-      assert_equal 8080, result
-      assert_instance_of Integer, result
-    end
-
-    test 'should convert string "8140" parameter to integer' do
-      host = stub(puppet_ca_server_port: '')
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8140')
-      result = @scope.host_puppet_ca_server_port
-      assert_equal 8140, result
-      assert_instance_of Integer, result
-    end
-
-    test 'should return nil when no port is set' do
-      host = stub(puppet_ca_server_port: nil)
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns(nil)
+      @scope.expects(:host_param).with('puppet_ca_server_port').returns('')
       assert_nil @scope.host_puppet_ca_server_port
-    end
-
-    test 'should return nil when port is empty string' do
-      host = stub(puppet_ca_server_port: '')
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns(nil)
-      assert_nil @scope.host_puppet_ca_server_port
-    end
-
-    test 'should reject port out of range (0)' do
-      host = stub(puppet_ca_server_port: 0)
-      @scope.instance_variable_set('@host', host)
-      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
-    end
-
-    test 'should reject port out of range (700000)' do
-      host = stub(puppet_ca_server_port: 700000)
-      @scope.instance_variable_set('@host', host)
-      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
-    end
-
-    test 'should reject negative port' do
-      host = stub(puppet_ca_server_port: '')
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns('-1')
-      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
-    end
-
-    test 'should reject float with decimal' do
-      host = stub(puppet_ca_server_port: 8443.5)
-      @scope.instance_variable_set('@host', host)
-      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
-    end
-
-    test 'should reject string with decimal notation' do
-      host = stub(puppet_ca_server_port: '')
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns('8443.5')
-      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
-    end
-
-    test 'should reject non-numeric string' do
-      host = stub(puppet_ca_server_port: '')
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns('invalid')
-      assert_raises(ArgumentError) { @scope.host_puppet_ca_server_port }
-    end
-
-    test 'should accept valid port at lower boundary' do
-      host = stub(puppet_ca_server_port: 1)
-      @scope.instance_variable_set('@host', host)
-      result = @scope.host_puppet_ca_server_port
-      assert_equal 1, result
-    end
-
-    test 'should accept valid port at upper boundary' do
-      host = stub(puppet_ca_server_port: 65535)
-      @scope.instance_variable_set('@host', host)
-      result = @scope.host_puppet_ca_server_port
-      assert_equal 65535, result
-    end
-
-    test 'should accept string that is whole number with leading zeros' do
-      host = stub(puppet_ca_server_port: '')
-      @scope.instance_variable_set('@host', host)
-      @scope.expects(:host_param).with('puppet_ca_server_port').returns('08140')
-      result = @scope.host_puppet_ca_server_port
-      assert_equal 8140, result
-      assert_instance_of Integer, result
     end
   end
 


### PR DESCRIPTION
This should make it easy to override the default puppet server port while keeping the config fairly clean.