### PR TITLE
Refs #39068 - Check for persisted statuses when building global status

### DIFF
--- a/app/helpers/hosts_helper.rb
+++ b/app/helpers/hosts_helper.rb
@@ -97,7 +97,7 @@ module HostsHelper
   # method that reformat the hostname column by adding the status icons
   def name_column(host)
     style = host_global_status_icon_class_for_host(host)
-    displayable_statuses = host.host_statuses.select { |status| status.relevant? && !status.substatus? }
+    displayable_statuses = host.host_statuses.select { |status| status.persisted? && status.relevant? && !status.substatus? }
     tooltip = displayable_statuses.sort_by(&:type).map { |status| "#{_(status.name)}: #{_(status.to_label)}" }.join(', ')
 
     content = content_tag(:span, "", {:rel => "twipsy", :class => style, :"data-original-title" => tooltip})

--- a/app/models/host/managed.rb
+++ b/app/models/host/managed.rb
@@ -817,7 +817,7 @@ autopart"', desc: 'to render the content of host partition table'
   end
 
   def global_status_fulltext
-    host_statuses.select { |s| s.relevant? && !s.substatus? }.sort_by(&:type).map { |s| "#{_(s.name)}: #{_(s.to_label)}" }
+    host_statuses.select { |s| s.persisted? && s.relevant? && !s.substatus? }.sort_by(&:type).map { |s| "#{_(s.name)}: #{_(s.to_label)}" }
   end
 
   def configuration_status(options = {})

--- a/app/models/host_status/global.rb
+++ b/app/models/host_status/global.rb
@@ -14,7 +14,7 @@ module HostStatus
 
     def self.build(statuses, options = {})
       relevant_statuses = statuses.select do |s|
-        s.relevant?(options) && !s.substatus?
+        s.persisted? && s.relevant?(options) && !s.substatus?
       end
 
       max_status = relevant_statuses.map { |s| s.to_global(options) }.max

--- a/test/models/host_status/global_test.rb
+++ b/test/models/host_status/global_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class GlobalTest < ActiveSupport::TestCase
-  class StatusMock < Struct.new(:global, :relevant, :substatus)
+  class StatusMock < Struct.new(:global, :relevant, :substatus, :is_persisted)
     def relevant?(options = {})
       relevant
     end
@@ -12,6 +12,10 @@ class GlobalTest < ActiveSupport::TestCase
 
     def substatus?(options = {})
       substatus
+    end
+
+    def persisted?
+      is_persisted.nil? ? true : is_persisted
     end
   end
 
@@ -38,10 +42,29 @@ class GlobalTest < ActiveSupport::TestCase
   test '.build(statuses, :last_reports => [reports]) uses reports cache for configuration statuses' do
     status = HostStatus::ConfigurationStatus.new
     report = Report.new(:host => Host.last)
+    status.stubs(:persisted?).returns(true)
     status.expects(:relevant?).with({ :last_reports => [report] }).returns(true)
     status.expects(:to_global).returns(:result)
     global = HostStatus::Global.build([status], :last_reports => [report])
     assert_equal :result, global.status
+  end
+
+  test '.build(statuses) ignores non-persisted statuses' do
+    persisted_ok = StatusMock.new(HostStatus::Global::OK, true, false, true)
+    non_persisted_error = StatusMock.new(HostStatus::Global::ERROR, true, false, false)
+
+    global = HostStatus::Global.build([persisted_ok, non_persisted_error])
+
+    assert_equal HostStatus::Global::OK, global.status
+  end
+
+  test '.build(statuses) returns OK when only non-persisted statuses exist' do
+    non_persisted_warn = StatusMock.new(HostStatus::Global::WARN, true, false, false)
+    non_persisted_error = StatusMock.new(HostStatus::Global::ERROR, true, false, false)
+
+    global = HostStatus::Global.build([non_persisted_warn, non_persisted_error])
+
+    assert_equal HostStatus::Global::OK, global.status
   end
 
   test '.to_label returns string representation of status code' do


### PR DESCRIPTION
After #10962 was merged, a failure was found downstream in which a host showed a WARN status on the All Hosts page immediately after registration, although the same host showed OK for all statuses on its host details page. The cause of this appears to be that, at registration time, the host has a nil value for its execution status. When the `get_status()` method in `app/models/host/managed.rb` reads this nil status, it calls `host_statuses.new()` for the status. Because the host has no config reports, its status is eventually returned as status type `WARN` by the `to_global()` method in `app/models/host_status/configuration_status.rb`.

This PR addresses this issue by checking whether all relevant statuses are also persisted when building global status for a host.

Testing Steps:
1. Register a host to a Foreman server with the remote execution plugin enabled.
2. On the All Hosts page, verify that the status icon for the host is OK (green).