### PR TITLE
Add smart_proxy_id index to smart_proxy_features

### DIFF
--- a/db/migrate/20260522000000_add_smart_proxy_id_index_to_smart_proxy_features.rb
+++ b/db/migrate/20260522000000_add_smart_proxy_id_index_to_smart_proxy_features.rb
@@ -1,0 +1,5 @@
+class AddSmartProxyIdIndexToSmartProxyFeatures < ActiveRecord::Migration[6.1]
+  def change
+    add_index :smart_proxy_features, :smart_proxy_id
+  end
+end


### PR DESCRIPTION
## Summary

Add smart_proxy_id index to smart_proxy_features.

## Problem

smart_proxy_features has no index besides the primary key. At high concurrency, proxy feature lookups generate sequential scans on every request.

On small deployments (1 proxy, 5 rows), PostgreSQL's planner prefers seq scan regardless — the index has no measurable impact. On larger deployments with 50-100 proxies (250-500 rows), the index becomes relevant as the planner switches to index lookups.

Found via pg_stat_user_tables during registration performance testing at 1368 concurrent registrations.

## Test plan

- [x] Migration runs without errors
- [ ] No regression on small deployments (planner ignores the index on tiny tables)
- [ ] pg_stat_user_tables shows idx_scan usage on deployments with many proxies