### PR TITLE
Replace per-request settings DB polling with cache generation counter

### DIFF
--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -51,6 +51,7 @@ class Setting < ApplicationRecord
   # Custom validations are added from SettingManager class
   after_find :readonly_when_overridden
   after_save :refresh_registry_value
+  after_commit :invalidate_settings_generation, on: [:create, :update, :destroy]
   default_scope -> { order(:name) }
 
   scope :order_by, ->(attr) { except(:order).order(attr) }
@@ -279,6 +280,10 @@ class Setting < ApplicationRecord
       definition.updated_at = updated_at
       definition.value_from_db = value
     end
+  end
+
+  def invalidate_settings_generation
+    SettingRegistry.increment_generation!
   end
 
   def remove_whitespaces

--- a/app/registries/setting_registry.rb
+++ b/app/registries/setting_registry.rb
@@ -82,7 +82,7 @@ class SettingRegistry
   end
 
   def loaded?
-    !!@values_loaded_at
+    !!@last_reload_at
   end
 
   def logger
@@ -176,20 +176,34 @@ class SettingRegistry
     end
   end
 
+  # Two-tier settings cache:
+  # - Same-process: Setting#after_save updates the in-memory SettingPresenter directly
+  # - Cross-process: Setting#after_commit bumps a shared cache counter so other
+  #   Puma workers know to reload from DB on their next request
+  # - Safety net: reload from DB every GENERATION_MAX_STALENESS seconds even if
+  #   the generation counter appears current (guards against lost cache writes)
+  SETTINGS_GENERATION_KEY = 'setting_registry:generation'
+  GENERATION_MAX_STALENESS = 30.seconds
+
   def load_values(ignore_cache: false)
-    # we are loading only known STIs as we load settings fairly early the first time and plugin classes might not be loaded yet.
-    settings = Setting.unscoped
-    settings = settings.where('updated_at >= ?', @values_loaded_at) unless ignore_cache || @values_loaded_at.nil?
-    settings.each do |s|
+    return unless reload_required?(ignore_cache)
+
+    Setting.unscoped.each do |s|
       unless (definition = find(s.name))
         logger.debug("Setting #{s.name} has no definition, clean up your database")
         next
       end
       definition.updated_at = s.updated_at
       definition.value_from_db = s.value
-      logger.debug("Updated cached value for setting=#{s.name}") unless ignore_cache
     end
-    @values_loaded_at = Time.zone.now if settings.any?
+    @last_reload_at = Time.zone.now
+    @last_seen_generation = current_generation
+  end
+
+  def self.increment_generation!
+    Rails.cache.increment(SETTINGS_GENERATION_KEY, 1, raw: true)
+  rescue StandardError
+    # Cache unavailable — next load_values will fall through to DB
   end
 
   def _add(name, category:, type:, default:, description:, full_name:, context:, encrypted: false, collection: nil, options: {})
@@ -213,5 +227,29 @@ class SettingRegistry
 
   def _new_db_record(definition)
     Setting.new(name: definition.name, value: definition.value)
+  end
+
+  private
+
+  def reload_required?(ignore_cache)
+    return true if ignore_cache || @last_reload_at.nil?
+    return true if stale?
+    !generation_current?
+  end
+
+  def generation_current?
+    gen = current_generation
+    return false if gen.nil?
+    gen == @last_seen_generation
+  end
+
+  def current_generation
+    Rails.cache.read(SETTINGS_GENERATION_KEY, raw: true)
+  rescue StandardError
+    nil
+  end
+
+  def stale?
+    Time.zone.now - @last_reload_at > GENERATION_MAX_STALENESS
   end
 end

--- a/test/unit/setting_registry_test.rb
+++ b/test/unit/setting_registry_test.rb
@@ -22,9 +22,10 @@ class SettingRegistryTest < ActiveSupport::TestCase
 
     it "updates definitions for changed settings" do
       setting.update(value: 100)
-      registry.expects(:find).once
 
       registry.load_values
+
+      assert_equal 100, registry['foo']
     end
 
     it "updates definitions for settings which were changed to their default values" do
@@ -32,14 +33,92 @@ class SettingRegistryTest < ActiveSupport::TestCase
       registry.load_values
 
       setting.update(value: nil)
-      registry.expects(:find).once
-      assert registry.load_values
+      registry.load_values
+
+      assert_equal default, registry['foo']
     end
 
     it "can be forced to load all values" do
       registry.expects(:find).times(Setting.count)
 
       registry.load_values(ignore_cache: true)
+    end
+
+    context 'generation counter' do
+      it "skips DB query when generation is current" do
+        Setting.expects(:unscoped).never
+
+        registry.load_values
+      end
+
+      it "queries DB when generation changes" do
+        SettingRegistry.increment_generation!
+
+        setting.update(value: 999)
+        registry.load_values
+
+        assert_equal 999, registry['foo']
+      end
+
+      it "queries DB when generation is nil (cache unavailable)" do
+        Rails.cache.delete(SettingRegistry::SETTINGS_GENERATION_KEY)
+        registry.instance_variable_set(:@last_seen_generation, nil)
+
+        setting.update(value: 888)
+        registry.load_values
+
+        assert_equal 888, registry['foo']
+      end
+
+      it "bypasses generation check with ignore_cache" do
+        registry.expects(:generation_current?).never
+
+        registry.load_values(ignore_cache: true)
+      end
+
+      it "increments generation when a setting is saved" do
+        before = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+        setting.update(value: 777)
+        after = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+
+        refute_equal before, after
+      end
+
+      it "reloads from DB when staleness threshold exceeded despite matching generation" do
+        setting.update(value: 555)
+        registry.load_values
+
+        registry.instance_variable_set(:@last_reload_at, Time.zone.now - SettingRegistry::GENERATION_MAX_STALENESS - 1.second)
+
+        setting.update_column(:value, 444.to_yaml)
+
+        registry.load_values
+
+        assert_equal 444, registry['foo']
+      end
+
+      it "increments generation when a setting is destroyed" do
+        before = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+        setting.destroy!
+        after = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+
+        refute_equal before, after
+      end
+
+      it "increments generation after commit, not during save" do
+        before = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+        mid_transaction_generation = nil
+
+        Setting.transaction do
+          setting.update(value: 666)
+          mid_transaction_generation = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+        end
+
+        after = Rails.cache.read(SettingRegistry::SETTINGS_GENERATION_KEY, raw: true)
+
+        assert_equal before, mid_transaction_generation, "generation should not change before commit"
+        refute_equal before, after, "generation should change after commit"
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

Replace the per-request `SELECT * FROM settings WHERE updated_at >= ...` with a shared cache generation counter that skips the DB entirely when nothing has changed.

## Problem

Every HTTP request triggers `before_action :load_settings`, which executes a query against the `settings` table to detect changes. During registration performance testing at 912+ concurrent registrations:

| Metric | Value |
|---|---|
| Sequential scans on `settings` | 488K |
| Sequential scan rate | 100% |
| Avg query time at 152 concurrency | 0.9ms |
| Avg query time at 912 concurrency | 20.6ms (**23x inflation**) |
| Total DB time in 30s window (912 conc) | 17.6s |

99.99% of these queries return zero rows — settings almost never change during normal operation.

## Design

Two-tier cache with a safety net:

- **Same-process**: `Setting#after_save` updates the in-memory `SettingPresenter` directly (existing behavior, unchanged)
- **Cross-process**: `Setting#after_commit` bumps a shared `Rails.cache` generation counter. Other Puma workers check the counter before querying DB — if it matches their last-seen value, skip the query entirely.
- **Safety net**: 30-second staleness fallback reloads from DB even if the generation appears current, guarding against lost cache writes during transient Redis outages.

The generation counter is the **sole** cross-process coherence signal — no split between generation and `updated_at` watermarks. On generation mismatch, all settings are reloaded (7 rows — negligible cost).

### Why `after_commit`, not `after_save`

`after_save` fires before the transaction commits. Another worker could see the bumped generation, query the DB, get the old value (transaction not yet visible), cache it as seen, and serve stale settings indefinitely. `after_commit` ensures the generation only bumps after the new value is visible to all readers.

### Cache backend compatibility

Works with both `:redis_cache_store` (atomic `increment`) and `:file_store` (non-atomic but safe — worst case is one extra DB poll, not stale data). Falls back to DB polling if cache is entirely unavailable.

## Changes

- `app/models/setting.rb`: Add `after_commit :invalidate_settings_generation` callback
- `app/registries/setting_registry.rb`:
  - `load_values`: check generation counter before querying DB
  - `reload_required?`: extracted predicate (ignore_cache → nil check → staleness → generation)
  - `increment_generation!`: class method to bump the shared counter
  - `stale?`: 30-second fallback guard
  - Full reload on mismatch (no incremental `updated_at` filtering)

## Test plan

- [x] Skips DB query when generation is current
- [x] Queries DB when generation changes
- [x] Queries DB when generation is nil (cache unavailable)
- [x] Bypasses generation check with `ignore_cache: true`
- [x] Increments generation on save
- [x] Increments generation on destroy
- [x] Staleness fallback reloads despite matching generation
- [x] Generation bumps after commit, not during save (regression test)
- [ ] Deploy on test Satellite, verify settings queries drop from N×requests to ~0

Found via `pg_stat_user_tables` during registration performance testing at 1368 concurrent registrations with SQL debug logging enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)