### PR TITLE
Fixes #39347 - Support loading config from settings.d

### DIFF
--- a/config/settings.rb
+++ b/config/settings.rb
@@ -35,7 +35,9 @@ SETTINGS[:hosts] ||= []
 
 SETTINGS[:trusted_redirect_domains] ||= ['theforeman.org', 'redhat.com', 'orcharhino.com'].freeze
 
-# Load plugin config, if any
-Dir["#{__dir__}/settings.plugins.d/*.yaml"].each do |f|
-  SETTINGS.merge! YAML.load(ERB.new(File.read(f)).result)
+# Load local and plugin config overrides, if any
+["#{__dir__}/settings.plugins.d/*.yaml", "#{__dir__}/settings.d/*.yaml"].each do |pattern|
+  Dir[pattern].sort.each do |f|
+    SETTINGS.merge! YAML.load(ERB.new(File.read(f)).result)
+  end
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,4 +1,4 @@
-%w(
+(%w(
   .ruby-version
   .rbenv-vars
   config/ignored_environments.yml
@@ -6,4 +6,6 @@
   config/settings.yaml
   tmp/restart.txt
   tmp/caching-dev.txt
-) + Dir["config/settings.plugins.d/*.yaml"].each { |path| Spring.watch(path) }
+) +
+  Dir["config/settings.plugins.d/*.yaml"] +
+  Dir["config/settings.d/*.yaml"]).each { |path| Spring.watch(path) }

--- a/developer_docs/how_to_create_a_plugin.asciidoc
+++ b/developer_docs/how_to_create_a_plugin.asciidoc
@@ -1955,9 +1955,9 @@ end
 ==== Config files
 
 Config files are in YAML format and can contain simple or complex data.
-They are read from config/settings.yaml and config/settings.plugins.d/
-(aka /etc/foreman/plugins/) at startup and all contents are merged
-together and stored in the global `SETTINGS` hash.
+They are read from config/settings.yaml, config/settings.plugins.d/
+(aka /etc/foreman/plugins/) and config/settings.d/ at startup. All
+contents are merged together and stored in the global `SETTINGS` hash.
 
 It's recommended to put all settings in a hash named after the plugin so
 they don't conflict with others, e.g.
@@ -1978,7 +1978,8 @@ to see what the possible options are.
 
 Tip: database settings can be overridden from a config file out of the
 box, making the value read-only in the UI. Just set
-`:example_string: foo` in settings.yaml or settings.plugins.d/.
+`:example_string: foo` in settings.yaml, settings.plugins.d/ or
+settings.d/.
 
 [[provision-method]]
 === Provision Method

--- a/test/unit/config_settings_test.rb
+++ b/test/unit/config_settings_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+require 'fileutils'
+
+class ConfigSettingsTest < ActiveSupport::TestCase
+  let(:settings_d_file) { Rails.root.join('config/settings.d/settings_loader_test.yaml') }
+  let(:settings_plugins_d_file) { Rails.root.join('config/settings.plugins.d/settings_loader_test.yaml') }
+
+  teardown do
+    cleanup_test_file(settings_d_file)
+    cleanup_test_file(settings_plugins_d_file)
+    reload_settings
+  end
+
+  test 'loads settings from settings.plugins.d before settings.d' do
+    FileUtils.mkdir_p(settings_d_file.dirname)
+    File.write(settings_d_file, <<~YAML)
+      :settings_d_only_test: from_settings_d
+      :settings_loader_precedence_test: from_settings_d
+    YAML
+
+    FileUtils.mkdir_p(settings_plugins_d_file.dirname)
+    File.write(settings_plugins_d_file, <<~YAML)
+      :settings_loader_precedence_test: from_settings_plugins_d
+    YAML
+
+    reload_settings
+
+    assert_equal 'from_settings_d', SETTINGS[:settings_d_only_test]
+    assert_equal 'from_settings_d', SETTINGS[:settings_loader_precedence_test]
+  end
+
+  private
+
+  def reload_settings
+    silence_warnings { load Rails.root.join('config/settings.rb').to_s }
+  end
+
+  def cleanup_test_file(path)
+    File.delete(path) if File.exist?(path)
+    Dir.rmdir(path.dirname) if Dir.exist?(path.dirname) && Dir.empty?(path.dirname)
+  rescue SystemCallError
+    nil
+  end
+end


### PR DESCRIPTION
Add support for `config/settings.d/*.yaml` in Foreman startup config loading while keeping `config/settings.plugins.d/*.yaml` supported. Load `settings.plugins.d` first and `settings.d` afterward so local overrides can take precedence.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
