### PR TITLE
Fixes #39357 - deprecate LineChart component that uses PF3 LineChart

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/charts/LineChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/LineChart/index.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { LineChart as PfLineChart } from 'patternfly-react';
 
 import { translate as __ } from '../../../../../react_app/common/I18n';
+import { deprecate } from '../../../../common/DeprecationService';
 import { getLineChartConfig } from '../../../../../services/charts/LineChartService';
 
 import MessageBox from '../../MessageBox';
@@ -25,6 +26,14 @@ const LineChart = ({
   onclick,
   id,
 }) => {
+  useEffect(() => {
+    deprecate(
+      'common/charts/LineChart (patternfly-react LineChart)',
+      '@patternfly/react-charts ChartLine / Chart',
+      '5.1'
+    );
+  }, []);
+
   const chartConfig = getLineChartConfig({
     data,
     config,


### PR DESCRIPTION
## Summary

Add a developer-facing deprecation warning for the PF3 `patternfly-react` `LineChart` wrapper (`common/charts/LineChart`). The warning is emitted once per mount (same pattern as `common/table/components/Table`), points consumers toward `@patternfly/react-charts`, and states planned removal in Foreman 3.21.

_No user-visible UI changes; behaviour of the chart is unchanged._

## How to test

**Prerequisites**

- Running Foreman (or webpack dev server) with the React app loading a screen that mounts the registered **`LineChart`** component (plugin or core mount point that uses `foreman-react`/`componentRegistry` name `LineChart`).
- Browser devtools console open (`NODE_ENV` not `production` so the warning appears).

**Scenarios**

1. Navigate to a page that renders **`LineChart`** (if unsure, search mounts / `mount_react_component` / plugin usage for the `LineChart` component name).
2. Confirm a single deprecation warning per chart mount, similar in shape to other PF migrations, e.g.  
   `DEPRECATION WARNING: you are using deprecated common/charts/LineChart ... will be removed in Foreman 3.21`
3. Confirm the chart still renders and interacts as before (data present / empty states).
4. (Optional) Run `npm test` with the LineChart test path to ensure snapshots still pass.