### PR TITLE
Fixes #39365 - Update preseed_autoinstall_cloud_init.erb

### DIFF
--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -49,7 +49,7 @@ autoinstall:
     disable_root: false
     chpasswd:
       list: |
-        root: <%= @host.root_pass %>
+        root:<%= @host.root_pass %>
       expire: false
     fqdn: <%= @host.name %>
     users:

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -48,8 +48,8 @@ autoinstall:
   user-data:
     disable_root: false
     chpasswd:
-      list: |
-        root:<%= @host.root_pass %>
+      users:
+      - { name: root, password: <%= @host.root_pass %> }
       expire: false
     fqdn: <%= @host.name %>
     users:

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -49,7 +49,7 @@ autoinstall:
     disable_root: false
     chpasswd:
       list: |
-        root:<%= password_to_create %>
+        root: <%= @host.root_pass %>
       expire: false
     fqdn: <%= @host.name %>
     users:

--- a/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
+++ b/app/views/unattended/provisioning_templates/user_data/preseed_autoinstall_cloud_init.erb
@@ -47,6 +47,10 @@ autoinstall:
 <%= indent(4) { snippet_if_exists(template_name + " custom apt") } -%>
   user-data:
     disable_root: false
+    chpasswd:
+      list: |
+        root:<%= password_to_create %>
+      expire: false
     fqdn: <%= @host.name %>
     users:
     - name: <%= username_to_create %>


### PR DESCRIPTION
Since Ubuntu 26, the root  password is not set with "hashed_passwd", but the chpasswd method still works.

With the current preseed, the root password is empty at the end of the installation of Ubuntu 26. Adding the chpasswd section solve the problem (and it works with Ubuntu 24 too).


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
