### PR TITLE
Fixes #39401 - deprecate messagebox and use emptystate instead

### DIFF
--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.js
@@ -10,12 +10,15 @@ import {
   Modal,
   ModalVariant,
   Spinner,
+  Icon,
 } from '@patternfly/react-core';
+import { ErrorCircleOIcon } from '@patternfly/react-icons';
 import classNames from 'classnames';
 import DonutChart from '../common/charts/DonutChart';
 import BarChart from '../common/charts/BarChart';
 import MessageBox from '../common/MessageBox';
 import { STATUS } from '../../constants';
+import EmptyState from '../common/EmptyState';
 import { translate as __ } from '../../common/I18n';
 import './ChartBox.css';
 
@@ -105,10 +108,15 @@ const ChartBox = ({
 
   const panelChart = <Chart {...chartPropsForType[type]} config={config} />;
   const error = (
-    <MessageBox
-      msg={errorText}
+    <EmptyState
       key={`${chart.id}-error`}
-      icontype="error-circle-o"
+      variant="xs"
+      icon={
+        <Icon iconSize="lg">
+          <ErrorCircleOIcon />
+        </Icon>
+      }
+      header={errorText}
     />
   );
 

--- a/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.test.js
+++ b/webpack/assets/javascripts/react_app/components/ChartBox/ChartBox.test.js
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ChartBox from './ChartBox';
 
-// Mock DonutChart to avoid CSS import issues from MessageBox
+// Mock DonutChart to avoid CSS import issues from EmptyState
 jest.mock('../common/charts/DonutChart', () => ({
   __esModule: true,
   default: ({ data, noDataMsg }) => (
@@ -29,10 +29,10 @@ jest.mock('../common/charts/BarChart', () => ({
   ),
 }));
 
-// Mock MessageBox to avoid CSS import issues in Jest
-jest.mock('../common/MessageBox', () => ({
+// Mock EmptyState to avoid Redux/CSS import issues in Jest
+jest.mock('../common/EmptyState', () => ({
   __esModule: true,
-  default: ({ msg }) => <div data-testid="message-box">{msg}</div>,
+  default: ({ header }) => <div data-testid="empty-state">{header}</div>,
 }));
 
 describe('ChartBox', () => {

--- a/webpack/assets/javascripts/react_app/components/common/MessageBox/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/MessageBox/index.js
@@ -1,19 +1,26 @@
-// temporary component
-// will be replaced by patternfly markup when available
-// temporary component
-// will be replaced by patternfly markup when available
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { deprecate } from '../../../common/DeprecationService';
 import './MessageBox.css';
 
-const MessageBox = ({ msg, icontype }) => (
-  <div className="message-box-root">
-    <div
-      className={`pficon pficon-${icontype} message-box-content message-box-icon`}
-    />
-    <div className="message-box-content message-box-message">{msg}</div>
-  </div>
-);
+const MessageBox = ({ msg, icontype }) => {
+  useEffect(() => {
+    deprecate(
+      'common/MessageBox',
+      'EmptyState from components/common/EmptyState or @patternfly/react-core',
+      '5.1'
+    );
+  }, []);
+
+  return (
+    <div className="message-box-root">
+      <div
+        className={`pficon pficon-${icontype} message-box-content message-box-icon`}
+      />
+      <div className="message-box-content message-box-message">{msg}</div>
+    </div>
+  );
+};
 
 MessageBox.propTypes = {
   icontype: PropTypes.string.isRequired,

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/AreaChart.test.js
@@ -9,6 +9,12 @@ import {
 } from '../helpers/LegendHelpers';
 import { areaChartData, areaChartDataDenseSameMinute } from './AreaChart.fixtures';
 
+// Mock EmptyState to avoid Redux/CSS import issues in Jest
+jest.mock('../../EmptyState', () => ({
+  __esModule: true,
+  default: ({ header }) => <div data-testid="empty-state">{header}</div>,
+}));
+
 jest.unmock('./');
 
 /** Build chartData shape from fixture (same as AreaChart does). */

--- a/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/AreaChart/index.js
@@ -18,8 +18,10 @@ import {
   createContainer,
   getTheme,
 } from '@patternfly/react-charts';
-import MessageBox from '../../MessageBox';
+import { Icon } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { processChartData, getYTickValues } from './AreaChartHelpers';
+import EmptyState from '../../EmptyState';
 import {
   buildLegendData,
   formatAxisTick,
@@ -145,7 +147,17 @@ const AreaChart = ({
   }, []);
 
   if (!chartData) {
-    return <MessageBox msg={noDataMsg} icontype="info" />;
+    return (
+      <EmptyState
+        variant="xs"
+        icon={
+          <Icon iconSize="lg">
+            <InfoCircleIcon />
+          </Icon>
+        }
+        header={noDataMsg}
+      />
+    );
   }
 
   const chartHeight = size?.height ?? observedSize.height;

--- a/webpack/assets/javascripts/react_app/components/common/charts/BarChart/BarChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/BarChart/BarChart.test.js
@@ -8,6 +8,12 @@ import {
   emptyData,
 } from './BarChart.fixtures';
 
+// Mock EmptyState to avoid Redux/CSS import issues in Jest
+jest.mock('../../EmptyState', () => ({
+  __esModule: true,
+  default: ({ header }) => <div data-testid="empty-state">{header}</div>,
+}));
+
 describe('BarChart', () => {
   it('renders bar chart with data', () => {
     const { container } = render(<BarChart data={barChartData.data} />);

--- a/webpack/assets/javascripts/react_app/components/common/charts/BarChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/BarChart/index.js
@@ -10,9 +10,11 @@ import {
   ChartVoronoiContainer,
   getTheme,
 } from '@patternfly/react-charts';
+import { Icon } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { noop } from '../../../../common/helpers';
 import { translate as __ } from '../../../../common/I18n';
-import MessageBox from '../../MessageBox';
+import EmptyState from '../../EmptyState';
 import BarChartHtmlTooltip from './BarChartHtmlTooltip';
 import './BarChart.scss';
 
@@ -97,7 +99,17 @@ const BarChart = ({
 
   // Handle empty data
   if (!chartData.length) {
-    return <MessageBox msg={noDataMsg} icontype="info" />;
+    return (
+      <EmptyState
+        variant="xs"
+        icon={
+          <Icon iconSize="lg">
+            <InfoCircleIcon />
+          </Icon>
+        }
+        header={noDataMsg}
+      />
+    );
   }
 
   const dimensions = {

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/DonutChart.test.js
@@ -12,10 +12,10 @@ import * as chartService from '../../../../../services/charts/DonutChartService'
 // Mock the DonutChartService
 jest.mock('../../../../../services/charts/DonutChartService');
 
-// Mock MessageBox to avoid CSS import issues in Jest
-jest.mock('../../MessageBox', () => ({
+// Mock EmptyState to avoid Redux/CSS import issues in Jest
+jest.mock('../../EmptyState', () => ({
   __esModule: true,
-  default: ({ msg }) => <div data-testid="message-box">{msg}</div>,
+  default: ({ header }) => <div data-testid="empty-state">{header}</div>,
 }));
 
 describe('DonutChart', () => {
@@ -152,12 +152,12 @@ describe('DonutChart', () => {
   });
 
   describe('with empty data', () => {
-    it('renders MessageBox when no data is available', () => {
+    it('renders EmptyState when no data is available', () => {
       chartService.getDonutChartConfig.mockReturnValue(emptyChartConfig);
 
       const { container } = render(<DonutChart data={[]} />);
 
-      expect(screen.getByTestId('message-box')).toBeInTheDocument();
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
       expect(screen.getByText('No data available')).toBeInTheDocument();
       // Should not render chart container
       expect(
@@ -170,7 +170,7 @@ describe('DonutChart', () => {
 
       render(<DonutChart data={[]} noDataMsg="Custom empty message" />);
 
-      expect(screen.getByTestId('message-box')).toBeInTheDocument();
+      expect(screen.getByTestId('empty-state')).toBeInTheDocument();
       expect(screen.getByText('Custom empty message')).toBeInTheDocument();
     });
   });

--- a/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/DonutChart/index.js
@@ -5,8 +5,10 @@ import {
   ChartThemeColor,
   ChartTooltip,
 } from '@patternfly/react-charts';
+import { Icon } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { getDonutChartConfig } from '../../../../../services/charts/DonutChartService';
-import MessageBox from '../../MessageBox';
+import EmptyState from '../../EmptyState';
 import { translate as __ } from '../../../../../react_app/common/I18n';
 import { noop } from '../../../../common/helpers';
 
@@ -87,7 +89,17 @@ const DonutChart = ({
       </div>
     );
   }
-  return <MessageBox msg={noDataMsg} icontype="info" />;
+  return (
+    <EmptyState
+      variant="xs"
+      icon={
+        <Icon iconSize="lg">
+          <InfoCircleIcon />
+        </Icon>
+      }
+      header={noDataMsg}
+    />
+  );
 };
 
 DonutChart.propTypes = {

--- a/webpack/assets/javascripts/react_app/components/common/charts/LineChart/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/charts/LineChart/index.js
@@ -1,12 +1,13 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { LineChart as PfLineChart } from 'patternfly-react';
+import { Icon } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { translate as __ } from '../../../../../react_app/common/I18n';
 import { deprecate } from '../../../../common/DeprecationService';
 import { getLineChartConfig } from '../../../../../services/charts/LineChartService';
-
-import MessageBox from '../../MessageBox';
+import EmptyState from '../../EmptyState';
 
 /* Data format example:
   data={[
@@ -52,7 +53,17 @@ const LineChart = ({
       />
     );
   }
-  return <MessageBox msg={noDataMsg} icontype="info" />;
+  return (
+    <EmptyState
+      variant="xs"
+      icon={
+        <Icon iconSize="lg">
+          <InfoCircleIcon />
+        </Icon>
+      }
+      header={noDataMsg}
+    />
+  );
 };
 
 LineChart.propTypes = {

--- a/webpack/assets/javascripts/react_app/components/common/forms/Select.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/Select.js
@@ -1,6 +1,8 @@
 import $ from 'jquery';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Icon } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { Spinner } from 'patternfly-react';
 
 import { deprecate } from '../../../common/DeprecationService';
@@ -8,7 +10,7 @@ import { translate as __ } from '../../../common/I18n';
 import { noop } from '../../../common/helpers';
 import CommonForm from './CommonForm';
 import { STATUS } from '../../../constants';
-import MessageBox from '../MessageBox';
+import EmptyState from '../EmptyState';
 import { renderOptions } from './SelectHelpers';
 
 class Select extends React.Component {
@@ -94,11 +96,31 @@ class Select extends React.Component {
         break;
       }
       case STATUS.ERROR: {
-        content = <MessageBox icontype="error-circle-o" msg={errorMessage} />;
+        content = (
+          <EmptyState
+            variant="xs"
+            icon={
+              <Icon iconSize="lg">
+                <ExclamationCircleIcon />
+              </Icon>
+            }
+            header={errorMessage}
+          />
+        );
         break;
       }
       default:
-        content = <MessageBox icontype="error-circle-o" msg="Invalid Status" />;
+        content = (
+          <EmptyState
+            variant="xs"
+            icon={
+              <Icon iconSize="lg">
+                <ExclamationCircleIcon />
+              </Icon>
+            }
+            header={__('Invalid status')}
+          />
+        );
         break;
     }
 


### PR DESCRIPTION
## Summary

Replace the legacy `MessageBox` component with PatternFly `EmptyState` in chart-related UI, and deprecate `MessageBox` for remaining callers.

The temporary `MessageBox` component used custom PF3-style markup. Chart empty and error states now use the shared `EmptyState` component (`DefaultEmptyState`) for consistent PatternFly styling. `MessageBox` is deprecated via `DeprecationService` and will be removed in Foreman 5.1.

**Changes**

- Deprecate `common/MessageBox` with a console warning in non-production builds (replacement: `Alert from @patternfly/react-core`)
- Replace `MessageBox` with `EmptyState` in `ChartBox`, `AreaChart`, `BarChart`, `DonutChart`, and `LineChart`
- Update `ChartBox.test.js` and `DonutChart.test.js` mocks for `EmptyState`

## Screenshots

Before is top, After is bottom:

<img width="410" height="298" alt="Screenshot 2026-06-05 at 10 36 20" src="https://github.com/user-attachments/assets/e6c04cd8-507c-4468-9eb9-a65eba313d05" />


## Prerequisites for testing

- Foreman development environment with webpack assets built
- A dashboard or page that renders chart widgets (donut/bar charts)