### PR TITLE
Fixes #39374 - Add missing ipmi_boot parent permission mapping for taxonomy-scoped requests

### DIFF
--- a/app/controllers/api/v2/hosts_controller.rb
+++ b/app/controllers/api/v2/hosts_controller.rb
@@ -398,7 +398,7 @@ module Api
 
       def parent_permission(child_permission)
         case child_permission.to_s
-          when 'power', 'boot', 'console', 'vm_compute_attributes', 'get_status', 'template', 'enc', 'rebuild_config', 'inherited_parameters'
+          when 'power', 'boot', 'ipmi_boot', 'console', 'vm_compute_attributes', 'get_status', 'template', 'enc', 'rebuild_config', 'inherited_parameters'
             'view'
           when 'disassociate'
             'edit'

--- a/test/controllers/api/v2/hosts_controller_test.rb
+++ b/test/controllers/api/v2/hosts_controller_test.rb
@@ -894,6 +894,8 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
       setup do
         setup_user 'view', 'hosts'
         setup_user 'ipmi_boot', 'hosts'
+        setup_user 'view', 'locations'
+        setup_user 'view', 'organizations'
       end
 
       test 'returns error for non-admin user if BMC is not available' do
@@ -909,6 +911,23 @@ class Api::V2::HostsControllerTest < ActionController::TestCase
           returns({ "action" => "bios", "result" => true } .to_json)
         put :boot, params: { :id => @bmchost.to_param, :device => 'bios' },
           session: set_session_user.merge(:user => @one.id)
+        assert_response :success
+      end
+
+      test 'responds correctly for non-admin user with taxonomy context if BMC is available' do
+        ProxyAPI::BMC.any_instance.stubs(:boot).
+          with({ :function => 'bootdevice', :device => 'bios' }).
+          returns({ "action" => "bios", "result" => true } .to_json)
+
+        @bmchost.update!(:organization => taxonomies(:organization1), :location => taxonomies(:location1))
+
+        put :boot, params: {
+          :id => @bmchost.to_param,
+          :device => 'bios',
+          :organization_id => taxonomies(:organization1).id,
+          :location_id => taxonomies(:location1).id,
+        }, session: set_session_user.merge(:user => @one.id)
+
         assert_response :success
       end
     end


### PR DESCRIPTION
### Summary
Fixes an `unknown parent permission for api/v2/hosts#ipmi_boot` error that occurred when calling `hammer host boot` with `--organization-id` and `--location-id`. The root cause was a missing `ipmi_boot` entry in the parent permission mapping of `Api::V2::HostsController`.

### Background
When a taxonomy context is present, the authorization path differs from the default flow. Because `ipmi_boot` was not registered in the parent permission map, the permission resolution failed, causing the request to be rejected. Requests without taxonomy options succeeded as expected.

### Changes
- Added `ipmi_boot` to the parent permission mapping in `Api::V2::HostsController`
- Added a regression test to verify that boot API calls succeed when taxonomy context is provided

### Reproduction & Verification
1. **Failing case**
   `hammer host boot --id 3 --device bios --organization-id 1 --location-id 2`
2. **Passing case (no taxonomy)**
   `hammer host boot --id 3 --device bios`
3. After the fix, both commands return 200 OK. Regression test passes in CI.

### Expected outcome
Eliminates the `unknown parent permission for api/v2/hosts#ipmi_boot` error that only appeared when taxonomy options were specified.

