### PR TITLE
Fixes #39408 - Move FieldConstructor from webhooks plugin to core

### DIFF
--- a/webpack/assets/javascripts/react_app/components/common/FieldConstructor/FieldConstructor.js
+++ b/webpack/assets/javascripts/react_app/components/common/FieldConstructor/FieldConstructor.js
@@ -1,0 +1,315 @@
+/* eslint-disable max-lines */
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import AutocompleteInput from '../AutocompleteInput/AutocompleteInput';
+import { translate as __ } from '../../../common/I18n';
+import {
+  ExclamationCircleIcon,
+  HelpIcon,
+  PencilAltIcon,
+} from '@patternfly/react-icons';
+import {
+  TextInput,
+  Checkbox,
+  Button,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  Icon,
+  TextArea,
+  FormGroup,
+  Popover,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core';
+
+const FormField = ({
+  name,
+  type,
+  required,
+  options,
+  validated,
+  value,
+  disabled,
+  setValue,
+  placeholder,
+  errMsg,
+  fieldId,
+  setIsPasswordDisabled,
+  allowClear,
+  isLoading,
+  label,
+  rows,
+  ...inputProps
+}) => {
+  const [fieldValidated, setFieldValidated] = useState('default');
+  const [firstLoad, setFirstLoad] = useState(true);
+
+  const requiredValidate = () => {
+    if (firstLoad || !required) return;
+    if (!value || value === '' || validated === 'error')
+      setFieldValidated('error');
+    else setFieldValidated('success');
+  };
+
+  const localHandler = (_event, newValue) => {
+    setValue(name, newValue);
+  };
+
+  useEffect(() => {
+    setFirstLoad(false);
+  }, []);
+
+  useEffect(() => {
+    requiredValidate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+
+  if (type === 'checkbox') {
+    return (
+      <>
+        <Checkbox
+          ouiaId={name}
+          id={fieldId ?? `id-${name}`}
+          isChecked={value || false}
+          onChange={(_, newValue) => {
+            setValue(name, newValue);
+          }}
+          isDisabled={disabled}
+          isRequired={required}
+          {...inputProps}
+        />
+        <ValidationComponent localValidated={fieldValidated} errMsg={errMsg} />
+      </>
+    );
+  } else if (type === 'textarea') {
+    return (
+      <>
+        <TextArea
+          rows={rows || 6}
+          name={name}
+          id={fieldId ?? `id-${name}`}
+          value={value ?? ''}
+          onChange={(_, newValue) => setValue(name, newValue)}
+          isRequired={required}
+          isDisabled={disabled}
+          validated={fieldValidated}
+          placeholder={placeholder}
+          {...inputProps}
+        />
+        <ValidationComponent localValidated={fieldValidated} errMsg={errMsg} />
+      </>
+    );
+  } else if (options.length !== 0) {
+    return (
+      <>
+        <AutocompleteInput
+          options={options}
+          selected={value ?? ''}
+          onSelect={newValue => setValue(name, newValue)}
+          onChange={() => requiredValidate()}
+          name={name}
+          placeholder={placeholder}
+          validationStatus={fieldValidated}
+          validationMsg={errMsg}
+          fieldId={fieldId}
+          isDisabled={disabled || isLoading}
+          allowClear={allowClear}
+          {...inputProps}
+        />
+      </>
+    );
+  }
+  return (
+    <>
+      {name === 'password' && disabled && setIsPasswordDisabled ? (
+        <Grid hasGutter={false}>
+          <GridItem span={11}>
+            <TextInput
+              name={name}
+              value={value ?? ''}
+              id={fieldId ?? `id-${name}`}
+              onChange={localHandler}
+              isDisabled={disabled}
+              isRequired={required}
+              type={type}
+              validated={fieldValidated}
+              placeholder={placeholder}
+              onBlur={requiredValidate}
+              autoComplete="off"
+              {...inputProps}
+            />
+          </GridItem>
+          <GridItem span={1}>
+            <Button
+              ouiaId={`reset-${name}`}
+              onClick={() => setIsPasswordDisabled(!disabled)}
+              variant="control"
+              icon={<PencilAltIcon />}
+            />
+          </GridItem>
+        </Grid>
+      ) : (
+        <TextInput
+          name={name}
+          value={value ?? ''}
+          id={fieldId ?? `id-${name}`}
+          onChange={localHandler}
+          isRequired={required}
+          type={type}
+          validated={fieldValidated}
+          onBlur={requiredValidate}
+          autoComplete={type === 'password' ? 'new-password' : null}
+          {...inputProps}
+        />
+      )}
+
+      <ValidationComponent localValidated={fieldValidated} errMsg={errMsg} />
+    </>
+  );
+};
+
+const ValidationComponent = ({ localValidated, errMsg }) => (
+  <>
+    {localValidated === 'error' && (
+      <FormHelperText>
+        <HelperText>
+          <HelperTextItem
+            icon={
+              <Icon>
+                <ExclamationCircleIcon />
+              </Icon>
+            }
+            variant={localValidated}
+          >
+            {errMsg ?? __('Field is required')}
+          </HelperTextItem>
+        </HelperText>
+      </FormHelperText>
+    )}
+  </>
+);
+
+const FieldConstructor = ({
+  label,
+  value,
+  required,
+  labelHelp,
+  fieldId,
+  name,
+  ...props
+}) => (
+  <FormGroup
+    isInline
+    fieldId={fieldId ?? `id-${name}`}
+    label={label}
+    isRequired={required}
+    labelIcon={
+      labelHelp ? (
+        <Popover bodyContent={labelHelp}>
+          <Button
+            ouiaId={`label-${label}`}
+            type="button"
+            variant="plain"
+            onClick={e => e.preventDefault()}
+          >
+            <Icon>
+              <HelpIcon />
+            </Icon>
+          </Button>
+        </Popover>
+      ) : (
+        ''
+      )
+    }
+  >
+    <FormField
+      value={value}
+      required={required}
+      name={name}
+      fieldId={fieldId}
+      {...props}
+    />
+  </FormGroup>
+);
+
+FieldConstructor.propTypes = {
+  label: PropTypes.string.isRequired,
+  required: PropTypes.bool,
+  labelHelp: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.node,
+  ]),
+  setValue: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.bool,
+    PropTypes.number,
+  ]),
+  fieldId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+};
+
+FieldConstructor.defaultProps = {
+  labelHelp: undefined,
+  required: false,
+  disabled: false,
+  value: '',
+  fieldId: undefined,
+};
+
+FormField.propTypes = {
+  disabled: PropTypes.bool,
+  setValue: PropTypes.func.isRequired,
+  name: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  required: PropTypes.bool,
+  allowClear: PropTypes.bool,
+  isLoading: PropTypes.bool,
+  rows: PropTypes.number,
+  setIsPasswordDisabled: PropTypes.func,
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
+      label: PropTypes.string.isRequired,
+    })
+  ),
+  validated: PropTypes.string,
+  placeholder: PropTypes.string,
+  errMsg: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  fieldId: PropTypes.string,
+};
+
+FormField.defaultProps = {
+  label: '',
+  errMsg: null,
+  placeholder: '',
+  validated: 'default',
+  required: false,
+  allowClear: false,
+  options: [],
+  disabled: false,
+  value: '',
+  fieldId: undefined,
+};
+
+ValidationComponent.propTypes = {
+  localValidated: PropTypes.string.isRequired,
+  errMsg: PropTypes.string,
+};
+
+ValidationComponent.defaultProps = {
+  errMsg: null,
+};
+
+export default FieldConstructor;

--- a/webpack/assets/javascripts/react_app/components/common/FieldConstructor/__tests__/FieldConstructor.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/FieldConstructor/__tests__/FieldConstructor.test.js
@@ -1,0 +1,270 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import FieldConstructor from '../FieldConstructor';
+
+const defaultProps = {
+  name: 'test-field',
+  setValue: jest.fn(),
+  label: 'Test Field',
+  value: '',
+  type: 'text',
+};
+
+describe('FieldConstructor RTL Tests', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Text Input Fields', () => {
+    test('renders text input field', () => {
+      render(<FieldConstructor {...defaultProps} type="text" />);
+
+      expect(screen.getByText('Test Field')).toBeInTheDocument();
+      expect(document.getElementById('id-test-field')).toHaveAttribute(
+        'type',
+        'text'
+      );
+    });
+
+    test('renders password input field', () => {
+      render(<FieldConstructor {...defaultProps} type="password" />);
+
+      expect(screen.getByText('Test Field')).toBeInTheDocument();
+      expect(document.getElementById('id-test-field')).toHaveAttribute(
+        'type',
+        'password'
+      );
+    });
+
+    test('calls setValue when text input changes', () => {
+      render(<FieldConstructor {...defaultProps} type="text" />);
+
+      const input = document.getElementById('id-test-field');
+      fireEvent.change(input, { target: { value: 'test value' } });
+
+      expect(defaultProps.setValue).toHaveBeenCalledWith(
+        'test-field',
+        'test value'
+      );
+    });
+
+    test('renders with initial value', () => {
+      render(
+        <FieldConstructor {...defaultProps} type="text" value="initial value" />
+      );
+
+      expect(document.getElementById('id-test-field')).toHaveValue(
+        'initial value'
+      );
+    });
+
+    test('renders as enabled when loading', () => {
+      render(<FieldConstructor {...defaultProps} type="text" isLoading />);
+
+      expect(document.getElementById('id-test-field')).toBeEnabled();
+    });
+  });
+
+  describe('Password disabled state', () => {
+    test('renders edit button when password is disabled', () => {
+      render(
+        <FieldConstructor
+          {...defaultProps}
+          name="password"
+          type="password"
+          disabled
+          setIsPasswordDisabled={jest.fn()}
+        />
+      );
+
+      expect(
+        document.querySelector('[data-ouia-component-id="reset-password"]')
+      ).toBeInTheDocument();
+      expect(document.getElementById('id-password')).toBeDisabled();
+    });
+
+    test('calls setIsPasswordDisabled when edit button is clicked', () => {
+      const setIsPasswordDisabled = jest.fn();
+
+      render(
+        <FieldConstructor
+          {...defaultProps}
+          name="password"
+          type="password"
+          disabled
+          setIsPasswordDisabled={setIsPasswordDisabled}
+        />
+      );
+
+      fireEvent.click(
+        document.querySelector('[data-ouia-component-id="reset-password"]')
+      );
+
+      expect(setIsPasswordDisabled).toHaveBeenCalledWith(false);
+    });
+
+    test('does not render edit button when password is enabled', () => {
+      render(
+        <FieldConstructor
+          {...defaultProps}
+          name="password"
+          type="password"
+          setIsPasswordDisabled={jest.fn()}
+        />
+      );
+
+      expect(
+        document.querySelector('[data-ouia-component-id="reset-password"]')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Textarea Fields', () => {
+    test('renders textarea field', () => {
+      render(<FieldConstructor {...defaultProps} type="textarea" />);
+
+      expect(screen.getByText('Test Field')).toBeInTheDocument();
+      expect(document.getElementById('id-test-field').tagName).toBe('TEXTAREA');
+    });
+
+    test('calls setValue when textarea changes', () => {
+      render(<FieldConstructor {...defaultProps} type="textarea" />);
+
+      const textarea = document.getElementById('id-test-field');
+      fireEvent.change(textarea, { target: { value: 'textarea content' } });
+
+      expect(defaultProps.setValue).toHaveBeenCalledWith(
+        'test-field',
+        'textarea content'
+      );
+    });
+
+    test('renders with specified rows', () => {
+      render(<FieldConstructor {...defaultProps} type="textarea" rows={5} />);
+
+      expect(document.getElementsByTagName('textarea')).toHaveLength(1);
+    });
+  });
+
+  describe('Checkbox Fields', () => {
+    test('renders checkbox field', () => {
+      render(<FieldConstructor {...defaultProps} type="checkbox" />);
+
+      expect(screen.getByText('Test Field')).toBeInTheDocument();
+      expect(document.getElementById('id-test-field')).toHaveAttribute(
+        'type',
+        'checkbox'
+      );
+    });
+
+    test('renders unchecked checkbox', () => {
+      render(
+        <FieldConstructor {...defaultProps} type="checkbox" value={false} />
+      );
+
+      expect(document.getElementById('id-test-field')).not.toBeChecked();
+    });
+  });
+
+  describe('Autocomplete render test', () => {
+    test('renders autocomplete', () => {
+      const props = {
+        ...defaultProps,
+        onChange: defaultProps.setValue,
+        options: [
+          { value: 'host_created.event.foreman', label: 'Host Created' },
+          { value: 'host_updated.event.foreman', label: 'Host Updated' },
+        ],
+      };
+      render(<FieldConstructor {...props} type="select" />);
+
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+  });
+
+  describe('Label Help', () => {
+    test('renders help icon when labelHelp is provided', () => {
+      render(
+        <FieldConstructor {...defaultProps} labelHelp="This is help text" />
+      );
+
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    test('does not render help icon when labelHelp is not provided', () => {
+      render(<FieldConstructor {...defaultProps} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    test('renders help icon with JSX content', async () => {
+      const helpContent = <div>JSX help content</div>;
+      render(<FieldConstructor {...defaultProps} labelHelp={helpContent} />);
+
+      const button = screen.getByRole('button');
+      expect(button).toBeInTheDocument();
+
+      userEvent.click(button);
+
+      expect(await screen.findByText('JSX help content')).toBeInTheDocument();
+    });
+  });
+
+  describe('Validation', () => {
+    test('renders error message when validated is error', async () => {
+      render(
+        <>
+          <FieldConstructor {...defaultProps} required type="text" />
+          <button>Dummy</button>
+        </>
+      );
+
+      const input = document.getElementById('id-test-field');
+      await userEvent.click(input);
+      expect(input).toHaveFocus();
+
+      await userEvent.tab();
+      expect(input).not.toHaveFocus();
+
+      expect(screen.getByText('Field is required')).toBeInTheDocument();
+    });
+
+    test('does not render error message when validated is not error', () => {
+      render(
+        <FieldConstructor {...defaultProps} type="text" validated="success" />
+      );
+
+      expect(screen.queryByText('Field is required')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Edge Cases', () => {
+    test('handles undefined value', () => {
+      render(
+        <FieldConstructor {...defaultProps} type="text" value={undefined} />
+      );
+
+      expect(document.getElementById('id-test-field')).toHaveValue('');
+    });
+
+    test('handles null value', () => {
+      render(<FieldConstructor {...defaultProps} type="text" value={null} />);
+
+      expect(document.getElementById('id-test-field')).toHaveValue('');
+    });
+
+    test('handles numeric value', () => {
+      render(<FieldConstructor {...defaultProps} type="text" value={123} />);
+
+      expect(document.getElementById('id-test-field')).toHaveValue('123');
+    });
+
+    test('handles boolean value for checkbox', () => {
+      render(<FieldConstructor {...defaultProps} type="checkbox" value />);
+
+      expect(document.getElementById('id-test-field')).toBeChecked();
+    });
+  });
+});


### PR DESCRIPTION
Move FieldConstrutor from webhooks plugin to core so it can be reused across foreman 