### PR TITLE
Fixes #39413 - Track and surface unrecognized Smart Proxy features

### DIFF
--- a/app/models/smart_proxy.rb
+++ b/app/models/smart_proxy.rb
@@ -6,6 +6,8 @@ class SmartProxy < ApplicationRecord
   include Taxonomix
   include Parameterizable::ByIdName
 
+  serialize :unrecognized_features, Array
+
   validates_lengths_from_database
   before_destroy EnsureNotUsedBy.new(:hosts, :hostgroups, :subnets, :domains, [:puppet_ca_hosts, :hosts], [:puppet_ca_hostgroups, :hostgroups], :realms)
   # TODO check if there is a way to look into the tftp_id too
@@ -168,15 +170,21 @@ class SmartProxy < ApplicationRecord
       end
 
       feature_name_map = Feature.name_map
-      valid_features = reply.select { |feature, options| feature_name_map.key?(feature) }
+      valid_features, unknown_features = reply.partition { |feature, _options| feature_name_map.key?(feature) }
+      valid_features = valid_features.to_h
+      self.unrecognized_features = unknown_features.map(&:first)
 
       if valid_features.any?
         SmartProxyFeature.import_features(self, valid_features)
+        if unrecognized_features.any?
+          logger.warn("Proxy #{name} has features not recognized by Foreman: #{unrecognized_features.to_sentence}. "\
+                      "This may indicate missing Foreman plugins, a version mismatch, or custom proxy extensions.")
+        end
       else
         smart_proxy_features.clear
         if reply.any?
           errors.add :base, _('Features "%s" in this proxy are not recognized by Foreman. '\
-                              'If these features come from a Smart Proxy plugin, make sure Foreman has the plugin installed too.') % reply.keys.to_sentence
+                              'If these features come from a Smart Proxy plugin, make sure Foreman has the plugin installed too.') % unrecognized_features.to_sentence
         else
           errors.add :base, _('No features found on this proxy, please make sure you enable at least one feature')
         end
@@ -213,8 +221,9 @@ class SmartProxy < ApplicationRecord
     property :httpboot_http_port!, Integer, desc: 'Same as httpboot_http_port, but raises Foreman::Exception if no port is set'
     property :httpboot_https_port, Integer, desc: 'Returns proxy port for HTTPS boot'
     property :httpboot_https_port!, Integer, desc: 'Same as httpboot_https_port, but raises Foreman::Exception if no port is set'
+    property :unrecognized_features, Array, desc: 'Returns array of feature names reported by proxy but not recognized by Foreman'
   end
   class Jail < ::Safemode::Jail
-    allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port, :httpboot_http_port!, :httpboot_https_port!, :url
+    allow :id, :name, :hostname, :httpboot_http_port, :httpboot_https_port, :httpboot_http_port!, :httpboot_https_port!, :url, :unrecognized_features
   end
 end

--- a/app/views/api/v2/smart_proxies/main.json.rabl
+++ b/app/views/api/v2/smart_proxies/main.json.rabl
@@ -2,7 +2,7 @@ object @smart_proxy
 
 extends "api/v2/smart_proxies/base"
 
-attributes :created_at, :updated_at, :hosts_count
+attributes :created_at, :updated_at, :hosts_count, :unrecognized_features
 
 child :smart_proxy_features => :features do
   attributes :capabilities

--- a/app/views/smart_proxies/index.html.erb
+++ b/app/views/smart_proxies/index.html.erb
@@ -20,7 +20,12 @@
         <td class="nbsp ellipsis"><%= link_to_if_authorized proxy.name, {:action => :show, :id => proxy} %></td>
         <td class="hidden-sm hidden-xs nbsp ellipsis"><%= generate_links_for(proxy.locations).html_safe %></td>
         <td class="hidden-sm hidden-xs nbsp ellipsis"><%= generate_links_for(proxy.organizations).html_safe %></td>
-        <td class="ellipsis"><%= proxy.features.map(&:name).sort.to_sentence %></td>
+        <td class="ellipsis">
+          <%= proxy.features.map(&:name).sort.to_sentence %>
+          <% if proxy.unrecognized_features.present? %>
+            <span class="pficon pficon-warning-triangle-o" title="<%= _('This Smart Proxy has features not recognized by Foreman: %s') % proxy.unrecognized_features.to_sentence %>"></span>
+          <% end %>
+        </td>
         <td>
           <span class="proxy-show-status"><%= spinner %></span>
         </td>

--- a/app/views/smart_proxies/show.html.erb
+++ b/app/views/smart_proxies/show.html.erb
@@ -64,6 +64,22 @@
           <% end %>
         </div>
 
+        <% if @smart_proxy.unrecognized_features.present? %>
+          <div class="row">
+            <div class="col-md-4">
+              <strong><span class="pficon pficon-warning-triangle-o"></span> <%= _('Unrecognized features') %></strong>
+            </div>
+            <div class="col-md-8">
+              <p><%= _('The following features are reported by this Smart Proxy but are not recognized by Foreman. This is usually because the corresponding Foreman plugins are not installed, but may also occur due to version mismatches or custom proxy extensions.') %></p>
+              <ul>
+                <% @smart_proxy.unrecognized_features.each do |feature| %>
+                  <li><%= feature %></li>
+                <% end %>
+              </ul>
+            </div>
+          </div>
+        <% end %>
+
         <div class="row">
           <div class="col-md-4"></div>
           <div class="col-md-8">

--- a/db/migrate/20260610120000_add_unrecognized_features_to_smart_proxies.rb
+++ b/db/migrate/20260610120000_add_unrecognized_features_to_smart_proxies.rb
@@ -1,0 +1,5 @@
+class AddUnrecognizedFeaturesToSmartProxies < ActiveRecord::Migration[7.0]
+  def change
+    add_column :smart_proxies, :unrecognized_features, :text
+  end
+end

--- a/test/controllers/api/v2/smart_proxies_controller_test.rb
+++ b/test/controllers/api/v2/smart_proxies_controller_test.rb
@@ -202,6 +202,31 @@ class Api::V2::SmartProxiesControllerTest < ActionController::TestCase
   #   assert_response :unprocessable_entity
   # end
 
+  test "should include unrecognized_features in show response" do
+    features_with_unknown = Feature.name_map.keys.index_with { {'state' => 'running'} }
+    features_with_unknown['unknown_plugin'] = {'state' => 'running'}
+    ProxyAPI::V2::Features.any_instance.stubs(:features).returns(features_with_unknown)
+    proxy = smart_proxies(:one)
+    proxy.save!
+    get :show, params: { :id => proxy.to_param }
+    assert_response :success
+    show_response = ActiveSupport::JSON.decode(@response.body)
+    assert_equal ['unknown_plugin'], show_response['unrecognized_features']
+  end
+
+  test "should include unrecognized_features in index response" do
+    features_with_unknown = Feature.name_map.keys.index_with { {'state' => 'running'} }
+    features_with_unknown['unknown_plugin'] = {'state' => 'running'}
+    ProxyAPI::V2::Features.any_instance.stubs(:features).returns(features_with_unknown)
+    proxy = smart_proxies(:one)
+    proxy.save!
+    get :index
+    assert_response :success
+    index_response = ActiveSupport::JSON.decode(@response.body)
+    proxy_response = index_response['results'].find { |p| p['id'] == proxy.id }
+    assert_equal ['unknown_plugin'], proxy_response['unrecognized_features']
+  end
+
   test "should refresh smart proxy features" do
     proxy = smart_proxies(:one)
     post :refresh, params: { :id => proxy }

--- a/test/models/smart_proxy_test.rb
+++ b/test/models/smart_proxy_test.rb
@@ -69,6 +69,7 @@ class SmartProxyTest < ActiveSupport::TestCase
       ProxyAPI::Features.any_instance.stubs(:features => ["feature"])
       refute proxy.save
       assert_equal(error_message, proxy.errors[:base].first)
+      assert_equal ['feature'], proxy.unrecognized_features
     end
 
     test "should not be saved if features are not array" do
@@ -113,6 +114,73 @@ class SmartProxyTest < ActiveSupport::TestCase
       ProxyAPI::V2::Features.any_instance.stubs(:features).returns({'feature' => {'state' => 'running'}})
       refute proxy.save
       assert_equal(error_message, proxy.errors[:base].first)
+    end
+
+    test "should store unrecognized features when proxy has mix of known and unknown" do
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(
+        'tftp' => {'state' => 'running'},
+        'unknown_plugin' => {'state' => 'running'},
+        'another_unknown' => {'state' => 'running'}
+      )
+      proxy = FactoryBot.build(:smart_proxy)
+      assert proxy.save
+      proxy.reload
+      assert_include(proxy.features, features(:tftp))
+      assert_equal %w[unknown_plugin another_unknown].sort, proxy.unrecognized_features.sort
+    end
+
+    test "should clear unrecognized features when all proxy features are known" do
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(
+        'tftp' => {'state' => 'running'}
+      )
+      proxy = FactoryBot.build(:smart_proxy)
+      assert proxy.save
+      proxy.reload
+      assert_empty proxy.unrecognized_features
+    end
+
+    test "should populate unrecognized features even when no valid features exist" do
+      proxy = SmartProxy.new(:name => 'Proxy', :url => 'https://some.where.net:8443')
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns({'unknown_feature' => {'state' => 'running'}})
+      refute proxy.save
+      assert_equal ['unknown_feature'], proxy.unrecognized_features
+    end
+
+    test "should clear previously stored unrecognized features on re-save" do
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(
+        'tftp' => {'state' => 'running'},
+        'unknown_plugin' => {'state' => 'running'}
+      )
+      proxy = FactoryBot.build(:smart_proxy)
+      assert proxy.save
+      proxy.reload
+      assert_equal ['unknown_plugin'], proxy.unrecognized_features
+
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns(
+        'tftp' => {'state' => 'running'}
+      )
+      assert proxy.save
+      proxy.reload
+      assert_empty proxy.unrecognized_features
+    end
+
+    test "should return empty array for unrecognized_features when column is NULL" do
+      proxy = FactoryBot.build(:smart_proxy)
+      ProxyAPI::V2::Features.any_instance.stubs(:features).returns('tftp' => {'state' => 'running'})
+      proxy.save!
+      SmartProxy.where(id: proxy.id).update_all(unrecognized_features: nil)
+      proxy.reload
+      assert_empty proxy.unrecognized_features
+    end
+
+    test "should store unrecognized features with v1 api when proxy has mix of known and unknown" do
+      proxy = FactoryBot.build(:smart_proxy)
+      ProxyAPI::V2::Features.any_instance.stubs(:features).raises(NotImplementedError)
+      ProxyAPI::Features.any_instance.stubs(:features => ["tftp", "unknown_v1_plugin"])
+      assert proxy.save
+      proxy.reload
+      assert_include(proxy.features.map(&:name), "TFTP")
+      assert_equal ['unknown_v1_plugin'], proxy.unrecognized_features
     end
 
     test "can import and access capabilities and settings" do


### PR DESCRIPTION
When a Smart Proxy reports features that Foreman doesn't recognize (e.g. a plugin installed on the proxy but not on the server), those features were silently dropped. Now they are persisted and surfaced to the user via the API, UI, and server logs.

A draft until all the other pieces are assembled

Index
<img width="1216" height="247" alt="image" src="https://github.com/user-attachments/assets/2b20b44e-55d6-4904-b1dd-ba801f58c973" />

Show
<img width="1227" height="698" alt="image" src="https://github.com/user-attachments/assets/de7e9dac-f1ef-419e-a75c-77098a6c1c53" />

To be squashed before merging