### PR TITLE
Fixes #39417 - adjust sudoers configuration

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
+++ b/app/views/unattended/provisioning_templates/snippet/remote_execution_ssh_keys.erb
@@ -89,15 +89,11 @@ EOF
 if [ ! -x "$(command -v sudo)" ]; then
   $PKG_MANAGER_INSTALL sudo
 fi
-<% if @host.operatingsystem.family == 'Redhat' || @host.operatingsystem.family == 'Debian' -%>
 echo "<%= ssh_user %> ALL = (ALL) NOPASSWD : ALL" > /etc/sudoers.d/<%= ssh_user %>
-echo "Defaults:<%= ssh_user %> !requiretty" >> /etc/sudoers.d/<%= ssh_user %>
-chmod 440 /etc/sudoers.d/<%= ssh_user %>
-<% elsif @host.operatingsystem.family == 'Suse' -%>
-echo "<%= ssh_user %> ALL = (ALL) NOPASSWD : ALL" >> /etc/sudoers
-echo "Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers
-chmod 440 /etc/sudoers.d/<%= ssh_user %>
+<% if @host.operatingsystem.family == 'Suse' -%>
+echo "Defaults:<%= ssh_user %> !targetpw" >> /etc/sudoers.d/<%= ssh_user %>
 <% end -%>
+chmod 440 /etc/sudoers.d/<%= ssh_user %>
 <% end -%>
 else
   echo 'The remote_execution_ssh_user does not exist and remote_execution_create_user is not set to true.  remote_execution_ssh_keys snippet will not install keys'


### PR DESCRIPTION
/etc/sudoers.d/ is used for all modern linux systems.

requiretty is not supported by sudo-rs. Additionally, requiretty is by default off - so no need to add this default.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
