### PR TITLE
spike: boot order with data list

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -409,6 +409,13 @@ module FormHelper
     react_form_input('orderableSelect', f, attr, html_options.merge(input_props: input_props))
   end
 
+  def orderable_data_list_f(f, attr, choices, select_options = {}, html_options = {})
+    options = choices.collect { |choice| { label: choice[0], value: choice[1] } } if choices.is_a?(Array)
+    options = choices.collect { |(key, val)| { label: val, value: key } } if choices.is_a?(Hash)
+    input_props = select_options.merge(options: options)
+    react_form_input('orderableDataList', f, attr, html_options.merge(input_props: input_props))
+  end
+
   def react_form_input(type, f, attr, options = {})
     options[:label] ||= get_attr_label(f, attr)
     options[:error] ||= get_attr_error(f, attr)

--- a/app/views/compute_resources_vms/form/vmware/_base.html.erb
+++ b/app/views/compute_resources_vms/form/vmware/_base.html.erb
@@ -27,7 +27,7 @@ end %>
 <%= checkbox_f f, :memoryHotAddEnabled, { :help_inline => _("Memory hot add lets you add memory resources for a virtual machine while the machine is powered on."), :label => _('Memory hot add'), :label_size => "col-md-2", :disabled => !new_vm } %>
 <%= checkbox_f f, :cpuHotAddEnabled, { :help_inline => _("CPU hot add lets you add CPU resources for a virtual machine while the machine is powered on."), :label => _('CPU hot add'), :label_size => "col-md-2", :disabled => !new_vm } %>
 <%= checkbox_f f, :add_cdrom, { :checked => f.object.attributes[:cdroms].present?, :help_inline => _("Add a CD-ROM drive to the virtual machine."), :label => _('CD-ROM drive'), :label_size => "col-md-2" } if new_vm %>
-<%= orderable_select_f f, :boot_order, compute_resource.boot_devices, {}, {
+<%= orderable_data_list_f f, :boot_order, compute_resource.boot_devices, {}, {
                                                                             :label => _("Boot order"),
                                                                             :label_help => _("Has effect only for network based provisioning"),
                                                                             :class => "col-md-2",

--- a/webpack/assets/javascripts/react_app/components/common/forms/InputFactory.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/InputFactory.js
@@ -7,6 +7,7 @@ import SearchBar from '../../SearchBar';
 import DateTimePicker from '../DateTimePicker/DateTimePicker';
 import DatePicker from '../DateTimePicker/DatePicker';
 import OrderableSelect from './OrderableSelect';
+import OrderableDataList from './OrderableDataList';
 import MemoryAllocationInput from '../../MemoryAllocationInput';
 import CounterInput from './CounterInput';
 import TimePicker from '../DateTimePicker/TimePicker';
@@ -18,6 +19,7 @@ const inputComponents = {
   date: DatePicker,
   dateTime: DateTimePicker,
   orderableSelect: OrderableSelect,
+  orderableDataList: OrderableDataList,
   time: TimePicker,
   memory: MemoryAllocationInput,
   counter: CounterInput,

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/OrderableDataList.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/OrderableDataList.js
@@ -1,0 +1,260 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button,
+  DataList,
+  DataListItem,
+  DataListCell,
+  DataListItemRow,
+  DataListControl,
+  DataListDragButton,
+  DataListItemCells,
+  DataListAction,
+  DragDrop,
+  Draggable,
+  Droppable,
+  getUniqueId,
+  MenuToggle,
+  Select,
+  SelectList,
+  SelectOption,
+} from '@patternfly/react-core';
+import { TrashIcon } from '@patternfly/react-icons';
+
+import { translate as __, sprintf } from '../../../../common/I18n';
+import { noop } from '../../../../common/helpers';
+import {
+  createInitialChosen,
+  getAvailableToAdd,
+  reorderChosen,
+  chosenValues,
+  addToChosen,
+  removeFromChosen,
+  normalizeSelectedValues,
+} from './helpers';
+
+const OrderableDataList = ({
+  id,
+  name,
+  options,
+  value,
+  defaultValue,
+  disabled,
+  onChange,
+}) => {
+  const resolvedValue = normalizeSelectedValues(
+    value != null && value !== '' ? value : defaultValue
+  );
+  const [chosen, setChosen] = useState(() =>
+    createInitialChosen(options, resolvedValue)
+  );
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [liveText, setLiveText] = useState('');
+  const uniqueId = getUniqueId();
+  const availableToAdd = getAvailableToAdd(options, chosen);
+
+  const updateChosen = nextChosen => {
+    setChosen(nextChosen);
+    onChange(chosenValues(nextChosen));
+  };
+
+  const addDevice = deviceValue => {
+    const option = options.find(
+      item => String(item.value) === String(deviceValue)
+    );
+    if (!option) {
+      return;
+    }
+
+    updateChosen(addToChosen(chosen, option));
+    setIsAddOpen(false);
+  };
+
+  const removeDevice = deviceValue => {
+    updateChosen(removeFromChosen(chosen, deviceValue));
+  };
+
+  const onDrag = source => {
+    setLiveText(
+      sprintf(__('Started dragging %s'), chosen[source.index].label)
+    );
+    return true;
+  };
+
+  const onDrop = (source, dest) => {
+    if (!dest) {
+      setLiveText(__('Dragging cancelled. Boot order unchanged.'));
+      return false;
+    }
+
+    updateChosen(reorderChosen(chosen, source.index, dest.index));
+    setLiveText(__('Boot order updated.'));
+    return true;
+  };
+
+  const renderChosenItems = () =>
+    chosen.map(item => (
+      <Draggable key={item.value} hasNoWrapper>
+        <DataListItem
+          aria-labelledby={`${id}-boot-${item.value}`}
+          id={`${id}-boot-item-${item.value}`}
+        >
+          <DataListItemRow>
+            <DataListControl>
+              <DataListDragButton
+                aria-label={__('Reorder')}
+                aria-labelledby={`${id}-boot-${item.value}`}
+                aria-describedby={`${id}-drag-help-${uniqueId}`}
+                isDisabled={disabled}
+              />
+            </DataListControl>
+            <DataListItemCells
+              dataListCells={[
+                <DataListCell key={item.value}>
+                  <span id={`${id}-boot-${item.value}`}>{item.label}</span>
+                </DataListCell>,
+              ]}
+            />
+            <DataListAction
+              aria-label={__('Remove boot device')}
+              aria-labelledby={`${id}-boot-${item.value} ${id}-remove-${item.value}`}
+              id={`${id}-remove-${item.value}`}
+            >
+              <Button
+                variant="plain"
+                isDisabled={disabled}
+                onClick={() => removeDevice(item.value)}
+                aria-label={sprintf(__('Remove %s'), item.label)}
+              >
+                <TrashIcon />
+              </Button>
+            </DataListAction>
+          </DataListItemRow>
+        </DataListItem>
+      </Draggable>
+    ));
+
+  const renderEmptyItem = () => (
+    <DataListItem aria-label={__('No boot devices selected')}>
+      <DataListItemRow>
+        <DataListItemCells
+          dataListCells={[
+            <DataListCell key="empty">
+              {__(
+                'No boot devices selected. Use "Add boot device" to build the boot sequence.'
+              )}
+            </DataListCell>,
+          ]}
+        />
+      </DataListItemRow>
+    </DataListItem>
+  );
+
+  return (
+    <div id={id}>
+      <Select
+        isOpen={isAddOpen}
+        selected={null}
+        onSelect={(_event, selection) => addDevice(selection)}
+        onOpenChange={setIsAddOpen}
+        toggle={toggleRef => (
+          <MenuToggle
+            ref={toggleRef}
+            onClick={() => setIsAddOpen(!isAddOpen)}
+            isExpanded={isAddOpen}
+            isDisabled={disabled || availableToAdd.length === 0}
+            aria-label={__('Add boot device')}
+          >
+            {__('Add boot device')}
+          </MenuToggle>
+        )}
+        aria-label={__('Add boot device')}
+        ouiaId={`${id}-add-select`}
+      >
+        <SelectList>
+          {availableToAdd.map(option => (
+            <SelectOption key={option.value} value={option.value}>
+              {option.label}
+            </SelectOption>
+          ))}
+        </SelectList>
+      </Select>
+
+      <div className="pf-v5-u-mt-sm">
+        <strong>{__('Boot order')}</strong>
+      </div>
+
+      {chosen.length === 0 ? (
+        <DataList
+          aria-label={__('Boot order')}
+          isCompact
+          className="pf-v5-u-mt-sm"
+        >
+          {renderEmptyItem()}
+        </DataList>
+      ) : (
+        <DragDrop onDrag={onDrag} onDrop={onDrop}>
+          <Droppable hasNoWrapper>
+            <DataList
+              aria-label={__('Boot order')}
+              isCompact
+              className="pf-v5-u-mt-sm"
+            >
+              {renderChosenItems()}
+            </DataList>
+          </Droppable>
+          <div className="pf-v5-screen-reader" aria-live="assertive">
+            {liveText}
+          </div>
+          <div
+            className="pf-v5-screen-reader"
+            id={`${id}-drag-help-${uniqueId}`}
+          >
+            {__(
+              'Press space or enter to begin dragging, and use the arrow keys to navigate up or down. Press enter to confirm the drag, or any other key to cancel the drag operation.'
+            )}
+          </div>
+        </DragDrop>
+      )}
+
+      {name &&
+        chosen.map(item => (
+          <input
+            key={item.value}
+            type="hidden"
+            name={name}
+            value={item.value}
+          />
+        ))}
+    </div>
+  );
+};
+
+OrderableDataList.propTypes = {
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.object),
+  value: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  defaultValue: PropTypes.oneOfType([
+    PropTypes.array,
+    PropTypes.string,
+    PropTypes.number,
+  ]),
+  disabled: PropTypes.bool,
+  onChange: PropTypes.func,
+};
+
+OrderableDataList.defaultProps = {
+  name: null,
+  options: [],
+  value: null,
+  defaultValue: [],
+  disabled: false,
+  onChange: noop,
+};
+
+export default OrderableDataList;

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/__tests__/OrderableDataList.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/__tests__/OrderableDataList.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { act } from 'react-dom/test-utils';
+
+import OrderableDataList from '../OrderableDataList';
+
+const bootDeviceOptions = [
+  { label: 'Harddisk', value: 'disk' },
+  { label: 'Network', value: 'network' },
+  { label: 'CD-ROM', value: 'cdrom' },
+];
+
+describe('OrderableDataList', () => {
+  it('always renders the boot order DataList', () => {
+    const wrapper = mount(
+      <OrderableDataList
+        id="boot-order"
+        options={bootDeviceOptions}
+        defaultValue={[]}
+      />
+    );
+
+    expect(wrapper.find('DataList')).toHaveLength(1);
+    expect(wrapper.text()).toContain('No boot devices selected');
+  });
+
+  it('renders hidden inputs in boot order when name is provided', () => {
+    const wrapper = mount(
+      <OrderableDataList
+        id="boot-order"
+        name="host[compute_attributes][boot_order][]"
+        options={bootDeviceOptions}
+        defaultValue={['network', 'disk']}
+      />
+    );
+
+    const inputs = wrapper.find('input[type="hidden"]');
+    expect(inputs).toHaveLength(2);
+    expect(inputs.at(0).prop('value')).toBe('network');
+    expect(inputs.at(1).prop('value')).toBe('disk');
+  });
+
+  it('removes a boot device from the list', () => {
+    const onChange = jest.fn();
+    const wrapper = mount(
+      <OrderableDataList
+        id="boot-order"
+        options={bootDeviceOptions}
+        defaultValue={['network', 'disk']}
+        onChange={onChange}
+      />
+    );
+
+    act(() => {
+      wrapper.find('#boot-order-remove-network Button').simulate('click');
+    });
+    wrapper.update();
+
+    expect(onChange).toHaveBeenLastCalledWith(['disk']);
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/__tests__/helpers.test.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/__tests__/helpers.test.js
@@ -1,0 +1,73 @@
+import {
+  createInitialChosen,
+  getAvailableToAdd,
+  reorderChosen,
+  chosenValues,
+  addToChosen,
+  removeFromChosen,
+  normalizeSelectedValues,
+} from '../helpers';
+
+describe('OrderableDataList helpers', () => {
+  const options = [
+    { label: 'Harddisk', value: 'disk' },
+    { label: 'Network', value: 'network' },
+    { label: 'CD-ROM', value: 'cdrom' },
+  ];
+
+  describe('normalizeSelectedValues', () => {
+    it('coerces symbol-like values to strings', () => {
+      expect(normalizeSelectedValues(['network', 'disk'])).toEqual([
+        'network',
+        'disk',
+      ]);
+    });
+  });
+
+  describe('createInitialChosen', () => {
+    it('preserves selected boot device order', () => {
+      const chosen = createInitialChosen(options, ['network', 'disk']);
+
+      expect(chosen).toEqual([
+        { label: 'Network', value: 'network' },
+        { label: 'Harddisk', value: 'disk' },
+      ]);
+    });
+  });
+
+  describe('getAvailableToAdd', () => {
+    it('returns options not already in boot order', () => {
+      const chosen = createInitialChosen(options, ['network', 'disk']);
+      const available = getAvailableToAdd(options, chosen);
+
+      expect(available).toEqual([{ label: 'CD-ROM', value: 'cdrom' }]);
+    });
+  });
+
+  describe('reorderChosen', () => {
+    it('moves an item within the list', () => {
+      const chosen = createInitialChosen(options, ['network', 'disk', 'cdrom']);
+      const reordered = reorderChosen(chosen, 2, 0);
+
+      expect(chosenValues(reordered)).toEqual(['cdrom', 'network', 'disk']);
+    });
+  });
+
+  describe('addToChosen', () => {
+    it('appends a device to boot order', () => {
+      const chosen = createInitialChosen(options, ['network']);
+      const nextChosen = addToChosen(chosen, options[0]);
+
+      expect(chosenValues(nextChosen)).toEqual(['network', 'disk']);
+    });
+  });
+
+  describe('removeFromChosen', () => {
+    it('removes a device from boot order', () => {
+      const chosen = createInitialChosen(options, ['network', 'disk']);
+      const nextChosen = removeFromChosen(chosen, 'network');
+
+      expect(chosenValues(nextChosen)).toEqual(['disk']);
+    });
+  });
+});

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/helpers.js
@@ -1,0 +1,44 @@
+export const normalizeSelectedValues = value => {
+  if (value == null || value === '') {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(String);
+  }
+
+  return [String(value)];
+};
+
+export const createInitialChosen = (options = [], selectedValues = []) => {
+  const optionByValue = Object.fromEntries(
+    options.map(option => [String(option.value), option])
+  );
+
+  return normalizeSelectedValues(selectedValues)
+    .map(value => optionByValue[value])
+    .filter(Boolean)
+    .map(({ label, value }) => ({ label, value: String(value) }));
+};
+
+export const getAvailableToAdd = (options, chosen) => {
+  const chosenValues = new Set(chosen.map(item => item.value));
+  return options.filter(option => !chosenValues.has(String(option.value)));
+};
+
+export const reorderChosen = (chosen, sourceIndex, destIndex) => {
+  const nextChosen = [...chosen];
+  const [removed] = nextChosen.splice(sourceIndex, 1);
+  nextChosen.splice(destIndex, 0, removed);
+  return nextChosen;
+};
+
+export const chosenValues = chosen => chosen.map(item => item.value);
+
+export const addToChosen = (chosen, option) => [
+  ...chosen,
+  { label: option.label, value: String(option.value) },
+];
+
+export const removeFromChosen = (chosen, value) =>
+  chosen.filter(item => item.value !== String(value));

--- a/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/index.js
+++ b/webpack/assets/javascripts/react_app/components/common/forms/OrderableDataList/index.js
@@ -1,0 +1,1 @@
+export { default } from './OrderableDataList';


### PR DESCRIPTION
This solution shows boot order using a select and a sortable data list.
<img width="571" height="233" alt="Screenshot 2026-06-11 at 10 36 03 AM" src="https://github.com/user-attachments/assets/ce80bb43-f889-4090-a8d4-89160fe2acf5" />

