### PR TITLE
Fixes #39420 - Use ParaVirtualSCSIController as the default SCSi controller for vmware deployments

### DIFF
--- a/app/models/compute_resources/foreman/model/vmware.rb
+++ b/app/models/compute_resources/foreman/model/vmware.rb
@@ -432,7 +432,7 @@ module Foreman::Model
     end
 
     def scsi_controller_default_type
-      "VirtualLsiLogicController"
+      "ParaVirtualSCSIController"
     end
 
     # vSphere guest H/W versions

--- a/webpack/assets/javascripts/react_app/redux/actions/hosts/storage/vmware.consts.js
+++ b/webpack/assets/javascripts/react_app/redux/actions/hosts/storage/vmware.consts.js
@@ -4,7 +4,7 @@ export const vmwareDiskNameForIndex = oneBasedIndex =>
 
 export const defaultControllerAttributes = 
   {
-    type: 'VirtualLsiLogicController',
+    type: 'ParaVirtualSCSIController',
   }
 
 const _defaultDiskAttributes = {


### PR DESCRIPTION
Default Controller in compute profile for VMware should be Paravirtual instead of LSI.
Since Vmware no longer supports the LSI controller, it should not be kept as a default option.

Dependent : https://github.com/fog/fog-vsphere/pull/318

Assisted-by: Claude Sonnet 4.6

