### PR TITLE
Fixes #39422 - fix padding in register host page

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.scss
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.scss
@@ -11,9 +11,6 @@
     }
   
     .page-toolbar-section {
-      padding-bottom: 0;
-      padding-top: 0;
-
       .page-toolbar {
         .toolbar-search {
           flex-grow: 1;
@@ -34,6 +31,22 @@
   
       .pf-v5-c-toolbar__content {
         padding: 0;
+      }
+    }
+
+    .page-title-section ~ .page-toolbar-section {
+      padding-top: 0;
+      padding-bottom: 0;
+    }
+
+    .page-toolbar-section:not(.page-title-section ~ .page-toolbar-section) {
+      padding-left: var(--pf-v5-global--spacer--lg);
+      padding-right: var(--pf-v5-global--spacer--lg);
+      padding-bottom: var(--pf-v5-global--spacer--md);
+
+      .page-toolbar {
+        padding-top: 0;
+        padding-bottom: 0;
       }
     }
   


### PR DESCRIPTION
## Summary

Make sure Padding for the title is the same when there is no standalone title section:
Before:
<img width="1643" height="951" alt="image" src="https://github.com/user-attachments/assets/de5bc07a-e20d-4189-ab14-61cec325b9f0" />
After:
<img width="1648" height="950" alt="image" src="https://github.com/user-attachments/assets/e2d35fb3-2329-4aea-b907-45f7650568e6" />

