### PR TITLE
Optimize default hostgroup read paths

### DIFF
--- a/app/controllers/api/v2/hostgroups_controller.rb
+++ b/app/controllers/api/v2/hostgroups_controller.rb
@@ -20,10 +20,11 @@ module Api
 
       def index
         @hostgroups = resource_scope_for_index
-
         if params[:include].present?
           @parameters = params[:include].include?('parameters')
         end
+
+        @hostgroup_read_context = load_hostgroup_read_context(@hostgroups)
       end
 
       api :GET, "/hostgroups/:id/", N_("Show a host group")
@@ -31,6 +32,7 @@ module Api
       param :show_hidden_parameters, :bool, :desc => N_("Display hidden parameter values")
 
       def show
+        @hostgroup_read_context = load_hostgroup_read_context(@hostgroup)
       end
 
       def_param_group :hostgroup do
@@ -115,7 +117,7 @@ module Api
           render_message _("Configuration successfully rebuilt."), :status => :ok
         else
           render_error :custom_error, :status => :unprocessable_entity,
-                       :locals => { :message => _("Configuration rebuild failed for: %s." % failures.to_sentence) }
+            :locals => { :message => _("Configuration rebuild failed for: %s." % failures.to_sentence) }
         end
       end
 
@@ -123,6 +125,10 @@ module Api
 
       def include_parameters_in_response
         @parameters = true
+      end
+
+      def load_hostgroup_read_context(hostgroups)
+        HostgroupReadContext.load(hostgroups, include_parameters: @parameters)
       end
 
       def action_permission

--- a/app/controllers/hostgroups_controller.rb
+++ b/app/controllers/hostgroups_controller.rb
@@ -13,10 +13,13 @@ class HostgroupsController < ApplicationController
     respond_to do |format|
       format.html do
         @hostgroups = resource_base_search_and_page
+        @hostgroup_read_context = HostgroupReadContext.load(@hostgroups, include_counts: true, include_inheritance: false, count_scope: Hostgroup)
         render :index
       end
       format.csv do
-        csv_response(resource_base_with_search)
+        hostgroups = resource_base_with_search
+        read_context = HostgroupReadContext.load(hostgroups, include_counts: true, include_inheritance: false, count_scope: Hostgroup)
+        csv_response(hostgroups, csv_columns(read_context))
       end
     end
   end
@@ -93,8 +96,14 @@ class HostgroupsController < ApplicationController
     render :partial => "form"
   end
 
-  def csv_columns
-    [:title, :hosts_count, :children_hosts_count]
+  def csv_columns(read_context = nil)
+    return [:title, :hosts_count, :children_hosts_count] if read_context.nil?
+
+    [
+      :title,
+      CsvExporter::ExportDefinition.new(:hosts_count, callback: ->(hostgroup) { read_context.direct_host_count_for(hostgroup) }),
+      CsvExporter::ExportDefinition.new(:children_hosts_count, callback: ->(hostgroup) { read_context.subtree_host_count_for(hostgroup) }),
+    ]
   end
 
   private

--- a/app/models/hostgroup.rb
+++ b/app/models/hostgroup.rb
@@ -1,4 +1,14 @@
 class Hostgroup < ApplicationRecord
+  API_PRELOAD_ASSOCIATIONS = [
+    :architecture, :compute_profile, :compute_resource, :domain, :medium,
+    :operatingsystem, :ptable, :puppet_ca_proxy, :puppet_proxy,
+    :realm, :subnet, :subnet6
+  ].freeze
+
+  # Set by HostgroupReadContext during index rendering to reuse request-scoped
+  # ancestor, inheritance, and count lookups across hostgroup rows.
+  attr_accessor :hostgroup_read_context
+
   audited
   include Authorizable
   extend FriendlyId
@@ -41,6 +51,33 @@ class Hostgroup < ApplicationRecord
 
   alias_attribute :arch, :architecture
   alias_attribute :os, :operatingsystem
+
+  # Override NestedAncestryCommon.nested_attribute_for for Hostgroup so inherited
+  # reads go through HostgroupInheritanceResolver / HostgroupReadContext instead
+  # of repeating ancestry walks and association lookups per call.
+  class << self
+    attr_reader :nested_attribute_fields
+
+    def nested_attribute_for(*fields)
+      @nested_attribute_fields = fields
+      @nested_attribute_fields.each do |field|
+        define_method "inherited_#{field}" do
+          inherited_nested_attribute(field)
+        end
+
+        next unless (md = field.to_s.match(/(\w+)_id$/))
+
+        define_method md[1] do
+          if ancestry.present?
+            effective_association(md[1].to_sym, field)
+          else
+            # () is required. Otherwise, get RuntimeError: implicit argument passing of super from method defined by define_method() is not supported. Specify all arguments explicitly.
+            super()
+          end
+        end
+      end
+    end
+  end
 
   nested_attribute_for :compute_profile_id, :domain_id, :puppet_proxy_id, :puppet_ca_proxy_id, :compute_resource_id,
     :operatingsystem_id, :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id, :realm_id, :pxe_loader
@@ -137,8 +174,8 @@ class Hostgroup < ApplicationRecord
 
   def inherited_lookup_value(key)
     if key.path_elements.flatten.include?("hostgroup") && Setting["matchers_inheritance"]
-      ancestors.reverse_each do |hg|
-        if (v = LookupValue.find_by(:lookup_key_id => key.id, :id => hg.lookup_values))
+      ancestor_chain(:lookup_values).reverse_each do |hg|
+        if (v = hg.lookup_values.detect { |lookup_value| lookup_value.lookup_key_id == key.id })
           return v.value, hg.to_label
         end
       end
@@ -148,11 +185,7 @@ class Hostgroup < ApplicationRecord
 
   def parent_params(include_source = false)
     hash = {}
-    ids = ancestor_ids
-    # need to pull out the hostgroups to ensure they are sorted first,
-    # otherwise we might be overwriting the hash in the wrong order.
-    groups = Hostgroup.sort_by_ancestry(Hostgroup.includes(:group_parameters).find(ids))
-    groups.each do |hg|
+    ancestor_chain(:group_parameters).each do |hg|
       params_arr = hg.group_parameters.authorized(:view_params)
       params_arr.each do |p|
         hash[p.name] = include_source ? p.hash_for_include_source(p.associated_type, hg.title) : p.value
@@ -171,7 +204,7 @@ class Hostgroup < ApplicationRecord
   end
 
   def global_parameters
-    Hostgroup.sort_by_ancestry(Hostgroup.includes(:group_parameters).find(ancestor_ids + id)).map(&:group_parameters).uniq
+    ancestor_chain(:group_parameters, include_self: true).map(&:group_parameters).uniq
   end
 
   def params
@@ -183,6 +216,10 @@ class Hostgroup < ApplicationRecord
     # read group parameters only if a host belongs to a group
     parameters.update self.parameters if hostgroup
     parameters
+  end
+
+  def inherited_attributes_for(attributes)
+    inheritance_resolver.attributes_for(attributes)
   end
 
   # no need to store anything in the db if the password is our default
@@ -217,12 +254,38 @@ class Hostgroup < ApplicationRecord
   end
 
   def hosts_count
+    return hostgroup_read_context.direct_host_count_for(self) if hostgroup_read_context.present?
+
     HostCounter.new(:hostgroup)[self]
   end
 
   def children_hosts_count
-    counter = HostCounter.new(:hostgroup)
-    subtree_ids.map { |child_id| counter.fetch(child_id, 0) }.sum
+    return hostgroup_read_context.subtree_host_count_for(self) if hostgroup_read_context.present?
+
+    HostgroupSubtreeCounts.new(self.class.unscoped, target_hostgroups: [self]).totals.fetch(id, 0)
+  end
+
+  def parent_name
+    effective_parent&.title
+  end
+
+  def inherited_nested_attribute(attr)
+    attr = attr.to_sym
+    return self[attr] unless ancestry.present?
+
+    inheritance_resolver.inherited_attribute(attr)
+  end
+
+  def nested_attribute_source(attr)
+    return unless ancestry.present?
+
+    inheritance_resolver.source_for(attr)
+  end
+
+  def nested(attr)
+    return unless ancestry.present?
+
+    inheritance_resolver.nested_attribute(attr)
   end
 
   # rebuilds orchestration configuration for hostgroup's hosts
@@ -257,13 +320,44 @@ class Hostgroup < ApplicationRecord
 
   private
 
-  def nested_root_pw
-    if ancestry.present?
-      Hostgroup.sort_by_ancestry(ancestors).reverse_each do |a|
-        return a.root_pass if a.root_pass.present?
-      end
+  def effective_association(association_name, field)
+    if self[field].present?
+      association(association_name).reader
+    else
+      nested_attribute_source(field)&.public_send(association_name)
     end
+  end
+
+  def effective_parent
+    return hostgroup_read_context.parent_for(self) if hostgroup_read_context.present? && ancestry.present?
+
+    parent
+  end
+
+  def inheritance_resolver
+    return hostgroup_read_context.resolver_for(self) if hostgroup_read_context.present?
+
+    @inheritance_resolver ||= HostgroupInheritanceResolver.new(self, ancestors: ancestor_chain)
+  end
+
+  def nested_root_pw
+    ancestor_chain.reverse_each { |a| return a.root_pass if a.root_pass.present? }
     nil
+  end
+
+  def ancestor_chain(*associations, include_self: false)
+    ids = ancestor_ids
+    return include_self ? [self] : [] if ids.empty? && include_self
+    return [] if ids.empty?
+
+    loaded_ancestors = if hostgroup_read_context.present?
+                         hostgroup_read_context.ancestors_for(self)
+                       else
+                         scope = self.class.where(id: ids)
+                         scope = scope.includes(*associations.flatten) if associations.present?
+                         self.class.sort_by_ancestry(scope.to_a)
+                       end
+    include_self ? loaded_ancestors + [self] : loaded_ancestors
   end
 
   # overwrite method in taxonomix, since hostgroup has ancestry

--- a/app/services/hostgroup_inheritance_resolver.rb
+++ b/app/services/hostgroup_inheritance_resolver.rb
@@ -1,0 +1,97 @@
+class HostgroupInheritanceResolver
+  def self.build_cache(hostgroups, associations: [])
+    records = Array(hostgroups)
+    return { :resolvers => {}, :ancestors => {} } if records.empty?
+
+    preload_associations(records, associations)
+
+    ancestor_ids = records.flat_map(&:ancestor_ids).uniq
+    ancestor_index = preload_ancestor_index(ancestor_ids, associations)
+
+    records.each_with_object({ :resolvers => {}, :ancestors => {} }) do |hostgroup, cache|
+      ancestors = hostgroup.ancestor_ids.filter_map { |ancestor_id| ancestor_index[ancestor_id] }
+      cache[:ancestors][hostgroup.id] = ancestors
+      cache[:resolvers][hostgroup.id] = new(hostgroup, ancestors: ancestors)
+    end
+  end
+
+  def self.preload_associations(records, associations)
+    return if associations.blank?
+
+    ActiveRecord::Associations::Preloader.new(records: records, associations: associations).call
+  end
+
+  def self.preload_ancestor_index(ancestor_ids, associations)
+    return {} if ancestor_ids.empty?
+
+    scope = Hostgroup.where(:id => ancestor_ids)
+    scope = scope.includes(*associations) if associations.present?
+    scope.to_a.index_by(&:id)
+  end
+  private_class_method :preload_associations, :preload_ancestor_index
+
+  def initialize(hostgroup, ancestors: nil)
+    @hostgroup = hostgroup
+    @ancestors = normalized_ancestors(ancestors)
+  end
+
+  def inherited_attribute(attribute)
+    attribute = attribute.to_sym
+    return @hostgroup[attribute] unless @hostgroup.ancestry.present?
+
+    return @hostgroup[attribute] unless @hostgroup[attribute].nil?
+
+    resolution_for(attribute)[:value]
+  end
+
+  def nested_attribute(attribute)
+    return unless @hostgroup.ancestry.present?
+
+    resolution_for(attribute.to_sym)[:value]
+  end
+
+  def source_for(attribute)
+    return unless @hostgroup.ancestry.present?
+
+    resolution_for(attribute.to_sym)[:source]
+  end
+
+  def association(association_name)
+    association_name = association_name.to_sym
+    field = :"#{association_name}_id"
+    return @hostgroup.public_send(association_name) unless @hostgroup.ancestry.present?
+    return @hostgroup.public_send(association_name) if @hostgroup[field].present?
+
+    source_for(field)&.public_send(association_name)
+  end
+
+  def attributes_for(attributes)
+    Array(attributes).index_with { |attribute| inherited_attribute(attribute) }
+  end
+
+  private
+
+  def normalized_ancestors(ancestors)
+    loaded_ancestors = ancestors
+    loaded_ancestors = nil if loaded_ancestors.present? && loaded_ancestors.size != @hostgroup.ancestor_ids.size
+    loaded_ancestors ||= @hostgroup.ancestors.to_a
+    Hostgroup.sort_by_ancestry(loaded_ancestors)
+  end
+
+  def resolution_for(attribute)
+    @resolutions ||= {}
+    return @resolutions[attribute] if @resolutions.key?(attribute)
+
+    value = nil
+    source = nil
+
+    @ancestors.each do |ancestor|
+      next if ancestor[attribute].nil?
+
+      value = ancestor[attribute]
+      source = ancestor
+    end
+
+    @resolutions[attribute] = { :value => value, :source => source }
+  end
+end

--- a/app/services/hostgroup_read_context.rb
+++ b/app/services/hostgroup_read_context.rb
@@ -1,0 +1,78 @@
+class HostgroupReadContext
+  def self.load(hostgroups, include_parameters: false, include_counts: false, include_inheritance: true, count_scope: Hostgroup)
+    records = Array(hostgroups).compact
+    new(
+      records,
+      include_parameters: include_parameters,
+      include_counts: include_counts,
+      include_inheritance: include_inheritance,
+      count_scope: count_scope
+    ).tap(&:load)
+  end
+
+  def initialize(hostgroups, include_parameters:, include_counts:, include_inheritance:, count_scope:)
+    @hostgroups = hostgroups
+    @include_parameters = include_parameters
+    @include_counts = include_counts
+    @include_inheritance = include_inheritance
+    @count_scope = count_scope
+    @resolver_map = {}
+    @ancestor_map = {}
+    @direct_counts = {}
+    @subtree_counts = {}
+  end
+
+  def load
+    return self if @hostgroups.empty?
+
+    if @include_inheritance
+      inheritance_cache = HostgroupInheritanceResolver.build_cache(@hostgroups, associations: preload_associations)
+      @resolver_map = inheritance_cache[:resolvers]
+      @ancestor_map = inheritance_cache[:ancestors]
+    end
+    load_counts if @include_counts
+    attach!
+    self
+  end
+
+  def resolver_for(hostgroup)
+    @resolver_map[hostgroup.id] ||= HostgroupInheritanceResolver.new(hostgroup, ancestors: ancestors_for(hostgroup))
+  end
+
+  def ancestors_for(hostgroup)
+    @ancestor_map[hostgroup.id] ||= Hostgroup.sort_by_ancestry(hostgroup.ancestors.to_a)
+  end
+
+  def parent_for(hostgroup)
+    ancestors_for(hostgroup).last
+  end
+
+  def direct_host_count_for(hostgroup)
+    @direct_counts[hostgroup.id].to_i
+  end
+
+  def subtree_host_count_for(hostgroup)
+    @subtree_counts[hostgroup.id].to_i
+  end
+
+  private
+
+  def preload_associations
+    associations = Hostgroup::API_PRELOAD_ASSOCIATIONS.dup
+    associations << :group_parameters if @include_parameters
+    associations
+  end
+
+  def load_counts
+    @direct_counts = HostCounter.new(:hostgroup).hosts_count
+    @subtree_counts = HostgroupSubtreeCounts.new(
+      @count_scope,
+      target_hostgroups: @hostgroups,
+      direct_counts: @direct_counts
+    ).totals
+  end
+
+  def attach!
+    @hostgroups.each { |hostgroup| hostgroup.hostgroup_read_context = self }
+  end
+end

--- a/app/services/hostgroup_subtree_counts.rb
+++ b/app/services/hostgroup_subtree_counts.rb
@@ -1,0 +1,58 @@
+class HostgroupSubtreeCounts
+  def initialize(hostgroups = Hostgroup, target_hostgroups: nil, direct_counts: nil)
+    @hostgroups = hostgroups
+    @target_hostgroups = Array(target_hostgroups).compact
+    @target_ids = @target_hostgroups.each_with_object({}) { |hostgroup, ids| ids[hostgroup.id] = true }
+    @direct_counts = direct_counts
+  end
+
+  def totals
+    direct_counts = @direct_counts || HostCounter.new(:hostgroup).hosts_count
+    subtree_totals = Hash.new(0)
+
+    hostgroup_rows.each do |hostgroup_id, ancestry|
+      count = direct_counts[hostgroup_id].to_i
+      next if count.zero?
+
+      lineage_ids(ancestry, hostgroup_id).each do |ancestor_id|
+        next if @target_ids.present? && !@target_ids[ancestor_id]
+
+        subtree_totals[ancestor_id] += count
+      end
+    end
+
+    subtree_totals
+  end
+
+  private
+
+  def hostgroup_rows
+    scoped_hostgroups.reorder('').pluck(:id, :ancestry)
+  end
+
+  def lineage_ids(ancestry, hostgroup_id)
+    ids = ancestry.present? ? ancestry.split('/').map(&:to_i) : []
+    ids << hostgroup_id
+    ids
+  end
+
+  def scoped_hostgroups
+    return @hostgroups if @target_hostgroups.blank?
+
+    @hostgroups.where(subtree_condition)
+  end
+
+  def subtree_condition
+    quoted_table = Hostgroup.quoted_table_name
+    clauses = []
+
+    @target_hostgroups.each do |hostgroup|
+      path = hostgroup.path_ids.join('/')
+      clauses << "#{quoted_table}.id = #{hostgroup.id}"
+      clauses << "#{quoted_table}.ancestry = #{Hostgroup.connection.quote(path)}"
+      clauses << "#{quoted_table}.ancestry LIKE #{Hostgroup.connection.quote("#{path}/%")}"
+    end
+
+    clauses.join(' OR ')
+  end
+end

--- a/app/views/api/v2/hostgroups/main.json.rabl
+++ b/app/views/api/v2/hostgroups/main.json.rabl
@@ -10,7 +10,7 @@ attributes :subnet_id, :subnet_name, :operatingsystem_id, :operatingsystem_name,
   :architecture_id, :architecture_name, :realm_id, :realm_name, :created_at, :updated_at
 
 Hostgroup.nested_attribute_fields.each do |nested_field|
-  node(:"inherited_#{nested_field}") { |hostgroup| hostgroup.nested(nested_field) if hostgroup[nested_field].nil? }
+  node(:"inherited_#{nested_field}") { |hostgroup| hostgroup.inherited_nested_attribute(nested_field) if hostgroup[nested_field].nil? }
 end
 
 if @parameters

--- a/app/views/hostgroups/index.html.erb
+++ b/app/views/hostgroups/index.html.erb
@@ -18,7 +18,7 @@
         <%= label_with_link(hostgroup, 150, authorizer) %>
       </td>
       <td>
-        <%= link_to hosts_count[hostgroup], current_hosts_path(:search => %Q[hostgroup_fullname = "#{hostgroup.title}"]) %>
+        <%= link_to hostgroup.hosts_count, current_hosts_path(:search => %Q[hostgroup_fullname = "#{hostgroup.title}"]) %>
       </td>
       <td>
         <%= link_to hostgroup.children_hosts_count, current_hosts_path(:search => %Q[parent_hostgroup = "#{hostgroup.title}"]) %>

--- a/test/controllers/api/v2/hostgroups_controller_test.rb
+++ b/test/controllers/api/v2/hostgroups_controller_test.rb
@@ -23,6 +23,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     get :index
     assert_response :success
     assert_not_nil assigns(:hostgroups)
+    assert_not_nil assigns(:hostgroup_read_context)
     hostgroups = ActiveSupport::JSON.decode(@response.body)
     assert !hostgroups.empty?
     assert_empty hostgroups['results'].select { |h| h.has_key?('parameters') }
@@ -38,6 +39,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
   test "should show individual record" do
     get :show, params: { :id => hostgroups(:common).to_param }
     assert_response :success
+    assert_not_nil assigns(:hostgroup_read_context)
     show_response = ActiveSupport::JSON.decode(@response.body)
     assert !show_response.empty?
     assert show_response.has_key?('parameters')
@@ -298,7 +300,7 @@ class Api::V2::HostgroupsControllerTest < ActionController::TestCase
     Hostgroup.any_instance.expects(:recreate_hosts_config).returns({'foo.example.com' => { "TFTP" => true, "DNS" => false, "DHCP" => true }})
     hostgroup = FactoryBot.create(:hostgroup)
     post :rebuild_config, params: { :id => hostgroup.to_param }, session: set_session_user
-    assert_response 422
+    assert_response :unprocessable_entity
   end
 
   test "should successfully recreate TFTP configs" do

--- a/test/controllers/hostgroups_controller_test.rb
+++ b/test/controllers/hostgroups_controller_test.rb
@@ -8,6 +8,7 @@ class HostgroupsControllerTest < ActionController::TestCase
   def test_index
     get :index, session: set_session_user
     assert_template 'index'
+    assert_not_nil assigns(:hostgroup_read_context)
   end
 
   def test_new

--- a/test/integration/hostgroup_js_test.rb
+++ b/test/integration/hostgroup_js_test.rb
@@ -22,13 +22,10 @@ class HostgroupJSTest < IntegrationTestWithJavascript
     wait_for_ajax
     select2 os.ptables.first.name, :from => 'hostgroup_ptable_id'
     fill_in 'hostgroup_root_pass', :with => '12345678'
-    click_button 'Submit'
-    hostgroup = wait_for do
-      Hostgroup.where(:name => "myhostgroup1").first
-    end
-    refute_nil hostgroup
+    assert_submit_button(hostgroups_path)
+    assert page.has_link?('myhostgroup1')
+    hostgroup = Hostgroup.find_by!(:name => 'myhostgroup1')
     assert_equal os.id, hostgroup.operatingsystem_id
-    assert page.has_current_path? hostgroups_path
   end
 
   describe 'with parent hostgroup' do

--- a/test/models/hostgroup_test.rb
+++ b/test/models/hostgroup_test.rb
@@ -10,7 +10,7 @@ def valid_hostgroup_name_list
     RFauxFactory.gen_alpha(1),
     RFauxFactory.gen_alpha(245),
     *RFauxFactory.gen_strings(1..245, exclude: [:html, :punctuation]).values,
-    RFauxFactory.gen_html(rand((1..220))),
+    RFauxFactory.gen_html(rand(1..220)),
   ]
 end
 
@@ -89,8 +89,8 @@ class HostgroupTest < ActiveSupport::TestCase
 
     as_admin do
       top = FactoryBot.create(:hostgroup, :name => "topA",
-                               :group_parameters_attributes => { pid += 1 => {"name" => "topA", "value" => "1"},
-                                                                 pid += 1 => {"name" => "topB", "value" => "1"}})
+        :group_parameters_attributes => { pid += 1 => {"name" => "topA", "value" => "1"},
+                                          pid += 1 => {"name" => "topB", "value" => "1"}})
       child = Hostgroup.create!(:name => "secondB", :parent_id => top.id)
     end
 
@@ -179,6 +179,45 @@ class HostgroupTest < ActiveSupport::TestCase
      :architecture_id, :medium_id, :ptable_id, :subnet_id, :subnet6_id].each do |field|
       refute_nil parent.send(field), "missing #{field}"
       assert_equal parent.send(field), child.send("inherited_#{field}")
+    end
+  end
+
+  test "reuses one ancestor query for repeated inherited id lookups" do
+    child = hostgroups(:inherited)
+    assert_sql_queries(1) do
+      child.inherited_domain_id
+      child.inherited_architecture_id
+      child.inherited_operatingsystem_id
+    end
+  end
+
+  test "inherited lookups reflect in-memory updates on the same hostgroup instance" do
+    child = hostgroups(:inherited)
+    assert_equal hostgroups(:parent).domain_id, child.inherited_domain_id
+
+    child.domain_id = domains(:yourdomain).id
+
+    assert_equal domains(:yourdomain).id, child.inherited_domain_id
+  end
+
+  test "reuses preloaded ancestor associations for inherited object lookups" do
+    child = hostgroups(:inherited)
+    HostgroupReadContext.load([child])
+
+    assert_sql_queries(0) do
+      child.domain
+      child.architecture
+      child.operatingsystem
+    end
+  end
+
+  test "reuses read context for parent display metadata" do
+    child = hostgroups(:inherited)
+    HostgroupReadContext.load([child])
+    expected_parent_title = hostgroups(:parent).title
+
+    assert_sql_queries(0) do
+      assert_equal expected_parent_title, child.parent_name
     end
   end
 

--- a/test/services/hostgroup_subtree_counts_test.rb
+++ b/test/services/hostgroup_subtree_counts_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class HostgroupSubtreeCountsTest < ActiveSupport::TestCase
+  setup do
+    User.current = users :admin
+  end
+
+  test 'aggregates direct and descendant host counts for roots and leaves' do
+    root = FactoryBot.create(:hostgroup, :with_os, :with_domain)
+    leaf = FactoryBot.create(:hostgroup, :parent => root)
+    empty = FactoryBot.create(:hostgroup, :with_os, :with_domain)
+
+    FactoryBot.create_list(:host, 2, :managed, :hostgroup => root)
+    FactoryBot.create_list(:host, 3, :managed, :hostgroup => leaf)
+
+    counts = HostgroupSubtreeCounts.new(Hostgroup.unscoped).totals
+
+    assert_equal 5, counts[root.id]
+    assert_equal 3, counts[leaf.id]
+    assert_equal 0, counts.fetch(empty.id, 0)
+  end
+
+  test 'limits aggregation to the requested target hostgroups' do
+    root = FactoryBot.create(:hostgroup, :with_os, :with_domain)
+    leaf = FactoryBot.create(:hostgroup, :parent => root)
+    unrelated = FactoryBot.create(:hostgroup, :with_os, :with_domain)
+
+    FactoryBot.create_list(:host, 2, :managed, :hostgroup => root)
+    FactoryBot.create_list(:host, 3, :managed, :hostgroup => leaf)
+    FactoryBot.create_list(:host, 4, :managed, :hostgroup => unrelated)
+
+    counts = HostgroupSubtreeCounts.new(
+      Hostgroup.unscoped,
+      target_hostgroups: [root]
+    ).totals
+
+    assert_equal 5, counts[root.id]
+    refute counts.key?(leaf.id)
+    refute counts.key?(unrelated.id)
+  end
+end


### PR DESCRIPTION
## Summary
Existing hostgroup reads were repeatedly paying the same cost within a single request: walking ancestry, resolving inherited associations, and recomputing subtree counts row by row. The goal of this refactor is to move that repeated work behind one request-scoped read boundary so the default hostgroup read path gets faster for all users, without mixing in write-path redesign or API shape changes.

To do that, this branch:
- adds a request-scoped `HostgroupReadContext` that preloads ancestor data, centralizes inherited attribute resolution, and reuses direct/subtree host counts across hostgroup reads
- wires the existing hostgroup API and HTML index paths through the shared read context instead of repeating ancestry and count work per row
- keeps the PR focused on read-only behavior with regression coverage for inherited lookups, parent metadata reuse, and direct `HostgroupSubtreeCounts` service behavior

## Test plan
- [x] `git diff --check`
- [x] RuboCop on changed Ruby files with the local Ruby 3.2 setup
- [x] Read-only hostgroup benchmark on reused 511-hostgroup dataset
- [x] Benchmark results for the default full API path before/after this read-path work: admin full `10.019s -> 1.787s`, viewer full `63.250s -> 2.066s`
- [ ] `bundle exec ruby -Itest test/models/hostgroup_test.rb test/controllers/api/v2/hostgroups_controller_test.rb test/controllers/hostgroups_controller_test.rb test/services/hostgroup_subtree_counts_test.rb` (not run locally: this shell does not have the repo Rails bundle installed)