### PR TITLE
Fixes #39099 - Fix keyword args for #encode and drop dead code

### DIFF
--- a/app/services/sso/apache.rb
+++ b/app/services/sso/apache.rb
@@ -69,7 +69,7 @@ module SSO
     def additional_attributes
       attrs = {}
       ENV_TO_ATTR_MAPPING.each do |header, attribute|
-        if request.env.has_key?(header)
+        if request.env[header].present?
           attrs[attribute] = convert_encoding(request.env[header].dup)
         end
       end
@@ -77,15 +77,10 @@ module SSO
     end
 
     def convert_encoding(value)
-      if value.respond_to?(:force_encoding)
-        value.force_encoding(Encoding::UTF_8)
-        unless value.valid_encoding?
-          value.encode(Encoding::UTF_8, Encoding::ISO_8859_1, { :invalid => :replace, :replace => '-' }).force_encoding(Encoding::UTF_8)
-        end
-      else
-        Iconv.new('UTF-8//IGNORE', 'UTF-8').iconv(value) rescue value
-      end
-      value
+      value.force_encoding(Encoding::UTF_8)
+      return value if value.valid_encoding?
+
+      value.encode(Encoding::UTF_8, Encoding::ISO_8859_1, invalid: :replace, replace: '-').force_encoding(Encoding::UTF_8)
     end
 
     def store

--- a/test/unit/sso/apache_test.rb
+++ b/test/unit/sso/apache_test.rb
@@ -76,6 +76,23 @@ class ApacheTest < ActiveSupport::TestCase
     assert apache.send(:convert_encoding, 'fó✗@e✗amp✓e.com')
   end
 
+  def test_additional_attributes_skips_nil_values
+    apache = get_apache_method
+    apache.controller.request.env['HTTP_REMOTE_USER_EMAIL'] = nil
+    apache.controller.request.env['HTTP_REMOTE_USER_FIRSTNAME'] = ''
+    attrs = apache.send(:additional_attributes)
+    assert_not_includes attrs.keys, :mail
+    assert_not_includes attrs.keys, :firstname
+  end
+
+  def test_convert_encoding_with_latin1_bytes
+    apache = get_apache_method
+    input = String.new("caf\xE9") # rubocop:disable Performance/UnfreezeString String.new.encoding => ASCII-8BIT
+    result = apache.send(:convert_encoding, input)
+    assert_equal Encoding::UTF_8, result.encoding
+    assert result.valid_encoding?
+  end
+
   def test_authenticate!
     apache = get_apache_method
     controller = apache.controller


### PR DESCRIPTION
This issue seems to be present for quite a long time, it's just we didn't catch it since we *just* added Ruby 3.3 support and we didn't have a test to cover it :/

The issue is simple, but contains 2 bugs described in the RM ticket.

The PR fixes Ruby 3.2 related bug (keywords arguments), bug that encoded value is discarded (`encode` returns a new string -> `force_encoding` is run on a new string which then gets discarded) and drops `Iconv` usage, which is no longer present since cca Ruby 2.0.