### PR TITLE
Refs #39340 - remove pageLayout div wrapper

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -50,7 +50,7 @@ const PageLayout = ({
     toolbarSectionShowsDefaultToolbar || Boolean(customToolbar);
 
   return (
-    <div className="page-layout">
+    <>
       <Head>
         <title>{header}</title>
       </Head>
@@ -67,7 +67,7 @@ const PageLayout = ({
       {showStandaloneTitleSection && (
         <PageSection
           variant={PageSectionVariants.light}
-          className="page-title-section"
+          className="page-layout-title-section"
         >
           <div id="page-title">{titleSectionBody}</div>
         </PageSection>
@@ -78,18 +78,18 @@ const PageLayout = ({
       {showToolbarSection && (
         <PageSection
           variant={PageSectionVariants.light}
-          className="page-toolbar-section"
+          className="page-layout-toolbar-section"
         >
           {customToolbar || (
-            <Toolbar ouiaId="page-toolbar" className="page-toolbar">
+            <Toolbar ouiaId="page-toolbar" className="page-layout-toolbar">
               <ToolbarContent>
                 <ToolbarGroup
-                  className="toolbar-group-search"
+                  className="page-layout-toolbar-group-search"
                   variant="filter-group"
                 >
                   {!searchable && toolbarButtons && titleSectionBody}
                   {searchable && (
-                    <ToolbarItem className="toolbar-search">
+                    <ToolbarItem className="page-layout-toolbar-search">
                       <SearchBar
                         data={{
                           ...searchProps,
@@ -117,13 +117,13 @@ const PageLayout = ({
         </PageSection>
       )}
       <PageSection
-        className="page-content-section"
+        className="page-layout-content-section"
         variant={PageSectionVariants.light}
         type={pageSectionType}
       >
         {children}
       </PageSection>
-    </div>
+    </>
   );
 };
 

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.scss
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.scss
@@ -1,57 +1,55 @@
-.page-layout {
-    .page-title-section,
-    .page-toolbar-section,
-    .page-content-section {
-      padding-left: var(--pf-v5-global--spacer--lg);
-      padding-right: var(--pf-v5-global--spacer--lg);
-    }
-  
-    .page-title-section {
-      padding-bottom: var(--pf-v5-global--spacer--md);
-    }
-  
-    .page-toolbar-section {
-      .page-toolbar {
-        .toolbar-search {
-          flex-grow: 1;
-          display: block;
-        }
+.page-layout-title-section,
+.page-layout-toolbar-section,
+.page-layout-content-section {
+  padding-left: var(--pf-v5-global--spacer--lg);
+  padding-right: var(--pf-v5-global--spacer--lg);
+}
 
-        .table-toolbar-actions {
-          padding-left: var(--pf-v5-global--spacer--md);
-        }
-      }
+.page-layout-title-section {
+  padding-bottom: var(--pf-v5-global--spacer--md);
+}
 
-      .pf-v5-c-toolbar__group {
-        flex-grow: 1;
-        &.pf-m-align-right {
-          justify-content: flex-end;
-        }
-      }
-  
-      .pf-v5-c-toolbar__content {
-        padding: 0;
-      }
+.page-layout-toolbar-section {
+  .page-layout-toolbar {
+    .page-layout-toolbar-search {
+      flex-grow: 1;
+      display: block;
     }
 
-    .page-title-section ~ .page-toolbar-section {
-      padding-top: 0;
-      padding-bottom: 0;
+    .table-toolbar-actions {
+      padding-left: var(--pf-v5-global--spacer--md);
     }
+  }
 
-    .page-toolbar-section:not(.page-title-section ~ .page-toolbar-section) {
-      padding-left: var(--pf-v5-global--spacer--lg);
-      padding-right: var(--pf-v5-global--spacer--lg);
-      padding-bottom: var(--pf-v5-global--spacer--md);
+  .pf-v5-c-toolbar__group {
+    flex-grow: 1;
+    &.pf-m-align-right {
+      justify-content: flex-end;
+    }
+  }
 
-      .page-toolbar {
-        padding-top: 0;
-        padding-bottom: 0;
-      }
-    }
-  
-    .page-content-section {
-      padding-bottom: 0;
-      padding-top: 0;
-    }
+  .pf-v5-c-toolbar__content {
+    padding: 0;
+  }
+}
+
+.page-layout-title-section ~ .page-layout-toolbar-section {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.page-layout-toolbar-section:not(.page-layout-title-section ~ .page-layout-toolbar-section) {
+  padding-left: var(--pf-v5-global--spacer--lg);
+  padding-right: var(--pf-v5-global--spacer--lg);
+  padding-bottom: var(--pf-v5-global--spacer--md);
+
+  .page-layout-toolbar {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+}
+
+.page-layout-content-section {
+  padding-bottom: 0;
+  padding-top: 0;
 }


### PR DESCRIPTION
The wrapper was added to make sure we only target PageLayout components, instead I just used custom css classes for each rule. 
Adding a div causes other css behave un-unexpectedly: 
<img width="1240" height="722" alt="image" src="https://github.com/user-attachments/assets/f37c5eb5-afe5-4bc4-87f6-f71f75c89422" />

After this change: 
<img width="1240" height="994" alt="image" src="https://github.com/user-attachments/assets/eff23035-43fd-4f2a-a0b8-66586ed5e33b" />
