### PR TITLE
Fixes #39340 - use ids for css rules in order to be prioritized

### DIFF
--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -66,8 +66,8 @@ const PageLayout = ({
 
       {showStandaloneTitleSection && (
         <PageSection
+          id="page-layout-title-section"
           variant={PageSectionVariants.light}
-          className="page-layout-title-section"
         >
           <div id="page-title">{titleSectionBody}</div>
         </PageSection>
@@ -77,11 +77,11 @@ const PageLayout = ({
 
       {showToolbarSection && (
         <PageSection
+          id="page-layout-toolbar-section"
           variant={PageSectionVariants.light}
-          className="page-layout-toolbar-section"
         >
           {customToolbar || (
-            <Toolbar ouiaId="page-toolbar" className="page-layout-toolbar">
+            <Toolbar ouiaId="page-toolbar" id="page-layout-toolbar">
               <ToolbarContent>
                 <ToolbarGroup
                   className="page-layout-toolbar-group-search"
@@ -89,7 +89,7 @@ const PageLayout = ({
                 >
                   {!searchable && toolbarButtons && titleSectionBody}
                   {searchable && (
-                    <ToolbarItem className="page-layout-toolbar-search">
+                    <ToolbarItem id="page-layout-toolbar-search">
                       <SearchBar
                         data={{
                           ...searchProps,
@@ -117,7 +117,7 @@ const PageLayout = ({
         </PageSection>
       )}
       <PageSection
-        className="page-layout-content-section"
+        id="page-layout-content-section"
         variant={PageSectionVariants.light}
         type={pageSectionType}
       >

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.scss
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.scss
@@ -1,17 +1,17 @@
-.page-layout-title-section,
-.page-layout-toolbar-section,
-.page-layout-content-section {
+#page-layout-title-section,
+#page-layout-toolbar-section,
+#page-layout-content-section {
   padding-left: var(--pf-v5-global--spacer--lg);
   padding-right: var(--pf-v5-global--spacer--lg);
 }
 
-.page-layout-title-section {
+#page-layout-title-section {
   padding-bottom: var(--pf-v5-global--spacer--md);
 }
 
-.page-layout-toolbar-section {
-  .page-layout-toolbar {
-    .page-layout-toolbar-search {
+#page-layout-toolbar-section {
+  #page-layout-toolbar {
+    #page-layout-toolbar-search {
       flex-grow: 1;
       display: block;
     }
@@ -33,23 +33,23 @@
   }
 }
 
-.page-layout-title-section ~ .page-layout-toolbar-section {
+#page-layout-title-section ~ #page-layout-toolbar-section {
   padding-top: 0;
   padding-bottom: 0;
 }
 
-.page-layout-toolbar-section:not(.page-layout-title-section ~ .page-layout-toolbar-section) {
+#page-layout-toolbar-section:not(#page-layout-title-section ~ #page-layout-toolbar-section) {
   padding-left: var(--pf-v5-global--spacer--lg);
   padding-right: var(--pf-v5-global--spacer--lg);
   padding-bottom: var(--pf-v5-global--spacer--md);
 
-  .page-layout-toolbar {
+  #page-layout-toolbar {
     padding-top: 0;
     padding-bottom: 0;
   }
 }
 
-.page-layout-content-section {
+#page-layout-content-section {
   padding-bottom: 0;
   padding-top: 0;
 }


### PR DESCRIPTION
Fixes #39340 - use ids for css rules in order to be prioritized

Before:
<img width="1949" height="1072" alt="image" src="https://github.com/user-attachments/assets/097be015-ee3c-4627-bb87-0f3e3572ac02" />
After:
<img width="1955" height="1049" alt="image" src="https://github.com/user-attachments/assets/af837143-abac-48b8-ba25-dd720eaaf15c" />
