### PR TITLE
Refs #39336 - Fix batch_subtree_ids ordering with Taxonomy default scope

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -109,7 +109,7 @@ class Taxonomy < ApplicationRecord
       binds << ca
     end
 
-    klass.where(sql_parts.join(' OR '), *binds).order(:id).pluck(:id)
+    klass.where(sql_parts.join(' OR '), *binds).reorder(:id).pluck(:id)
   end
 
   def self.ignore?(taxable_type)


### PR DESCRIPTION
Taxonomy has a default_scope ordering by title. Using .order(:id) appended to it, resulting in ORDER BY title, id. Switch to .reorder(:id) to replace the default ordering and guarantee results are sorted by id.

Update filter tests to build expected taxonomy ID strings with .sort so they are seed-order independent.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
