### PR TITLE
Fixes #39226 - Fix RHSM OS TOCTOU race during concurrent registration

### DIFF
--- a/app/services/katello/rhsm_fact_parser.rb
+++ b/app/services/katello/rhsm_fact_parser.rb
@@ -73,8 +73,21 @@ module Katello
           os_attributes[:name] = "CentOS"
         end
 
-        os = ::Operatingsystem.find_by_attributes(**os_attributes.slice(:name, :major, :minor, :description)).first
-        os.presence || ::Operatingsystem.create_or_find_by(os_attributes)
+        lookup_attrs = os_attributes.slice(:name, :major, :minor, :description)
+        find_existing_os = -> { ::Operatingsystem.find_by_attributes(**lookup_attrs).first }
+
+        os = find_existing_os.call
+        if os.nil?
+          begin
+            os = ::Operatingsystem.create!(os_attributes)
+          rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique => e
+            # Concurrent registrations can lose the create race after the initial lookup.
+            # Re-read the canonical OS record and only suppress the exception if it now exists.
+            os = find_existing_os.call
+            raise e if os.nil?
+          end
+        end
+        os
       end
     end
 

--- a/test/unit/katello/rhsm_fact_parser_test.rb
+++ b/test/unit/katello/rhsm_fact_parser_test.rb
@@ -246,18 +246,51 @@ module Katello
       assert_nil bios[:release_date]
     end
 
-    def test_operatingsystem_race_condition_handling
-      existing_os = ::Operatingsystem.create(name: 'RedHat', major: '9', minor: '')
-      # Simulate the race: initial lookup returns nothing, then create_or_find_by
-      # handles the uniqueness conflict atomically and returns the existing record.
-      ::Operatingsystem.expects(:find_by_attributes).once.returns([])
+    def test_operatingsystem_returns_existing_os_after_record_not_unique
+      existing_os = ::Operatingsystem.create!(name: 'RedHat', major: '9', minor: '')
+      # DB-level race: initial lookup misses, create! hits the unique index,
+      # rescue retries the find.
+      find_seq = sequence('find')
+      ::Operatingsystem.expects(:find_by_attributes).in_sequence(find_seq).returns([])
+      ::Operatingsystem.expects(:create!).raises(ActiveRecord::RecordNotUnique)
+      ::Operatingsystem.expects(:find_by_attributes).in_sequence(find_seq).returns([existing_os])
       @facts['distribution.name'] = 'Red Hat Enterprise Linux'
       @facts['distribution.version'] = '9'
-      @facts['distribution.id'] = 'Nine'
 
-      assert_nothing_raised do
+      os = parser.operatingsystem
+      assert os.persisted?, "Expected a persisted OS"
+      assert_equal existing_os.id, os.id
+    end
+
+    def test_operatingsystem_returns_existing_os_after_uniqueness_validation_conflict
+      existing_os = ::Operatingsystem.create!(name: 'RedHat', major: '9', minor: '')
+      # TOCTOU race: initial lookup misses (OS not yet committed by another
+      # thread), create! hits the model-level uniqueness validation (OS now
+      # committed), rescue retries the find.
+      find_seq = sequence('find')
+      ::Operatingsystem.expects(:find_by_attributes).in_sequence(find_seq).returns([])
+      ::Operatingsystem.expects(:create!).raises(ActiveRecord::RecordInvalid.new(existing_os))
+      ::Operatingsystem.expects(:find_by_attributes).in_sequence(find_seq).returns([existing_os])
+      @facts['distribution.name'] = 'Red Hat Enterprise Linux'
+      @facts['distribution.version'] = '9'
+
+      os = parser.operatingsystem
+      assert os.persisted?, "Expected a persisted OS, got id=#{os&.id}"
+      assert_equal existing_os.id, os.id
+    end
+
+    def test_operatingsystem_raises_non_race_validation_failure
+      # Non-race validation failure: create! fails and the retry find also
+      # returns nil, so the original exception must propagate.
+      ::Operatingsystem.expects(:find_by_attributes).twice.returns([])
+      invalid_os = ::Operatingsystem.new
+      invalid_os.errors.add(:name, :blank)
+      ::Operatingsystem.expects(:create!).raises(ActiveRecord::RecordInvalid.new(invalid_os))
+      @facts['distribution.name'] = 'Red Hat Enterprise Linux'
+      @facts['distribution.version'] = '9'
+
+      assert_raises(ActiveRecord::RecordInvalid) do
         parser.operatingsystem
-        existing_os.destroy
       end
     end
   end


### PR DESCRIPTION
## Summary

- Under concurrent bulk registration, `create_or_find_by` in `RhsmFactParser#operatingsystem` can return an unpersisted `Operatingsystem` object when the model-level uniqueness validation catches a duplicate committed between the initial `find_by_attributes` lookup and the create attempt
- Rails `create_or_find_by` only rescues `RecordNotUnique` (DB constraint), not `RecordInvalid` (model validation). Assigning the invalid object to the host silently sets `operatingsystem_id=NULL`, causing step 3 `POST /register` to fail with 422 "Must provide an operating system"
- Replace `create_or_find_by` with `create!` + rescue for both `RecordInvalid` and `RecordNotUnique`, retrying the find on either. Re-raise if the retry also returns nil (genuine validation failure, not a race)

## Root cause

`Operatingsystem` has three model-level uniqueness validations (`name` scoped to `major`/`minor`, `description`, and `title`). During the first registration burst when the OS record does not yet exist:

1. Thread A: `find_by_attributes` → nil, `create_or_find_by` → creates OS (id=4), commits
2. Thread B: `find_by_attributes` → nil (Thread A not yet committed), `create_or_find_by` → internal `create` runs model validations → SELECT finds OS (Thread A now committed) → validation fails → returns unpersisted object (id=nil) → **no `RecordNotUnique` raised** → `create_or_find_by` returns the invalid object
3. `host.operatingsystem = invalid_os` → `host.operatingsystem_id = nil`
4. `host.save` persists `architecture_id` but `operatingsystem_id` stays NULL
5. Step 3 `POST /register` → `initial_configuration_template` → 422

## Test plan

- [x] `test_operatingsystem_returns_existing_os_after_record_not_unique` — DB constraint race path
- [x] `test_operatingsystem_returns_existing_os_after_uniqueness_validation_conflict` — model validation race path (the confirmed production failure)
- [x] `test_operatingsystem_raises_non_race_validation_failure` — genuine validation errors propagate instead of being silently swallowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)