### PR TITLE
Fixes #39474 - add enable/disable actions to users

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -39,6 +39,18 @@ module UsersHelper
         hash_for_invalidate_jwt_user_path(:id => user.id).merge(:auth_object => user, :permission => "edit_users"),
         :method => :patch, :id => user.id,
         :data => { :confirm => _("Invalidate all JSON Web Tokens for %s?") % user.name })
+
+      if user.disabled?
+        additional_actions << display_link_if_authorized(_("Enable"),
+          hash_for_user_path(:id => user).merge(:auth_object => user, :permission => "edit_users", :user => { :disabled => false }),
+          :method => :put,
+          :data => { :confirm => _("Enable %s?") % user.name })
+      else
+        additional_actions << display_link_if_authorized(_("Disable"),
+          hash_for_user_path(:id => user).merge(:auth_object => user, :permission => "edit_users", :user => { :disabled => true }),
+          :method => :put,
+          :data => { :confirm => _("Disable %s?") % user.name })
+      end
     end
 
     delete_btn = display_delete_if_authorized(

--- a/test/integration/user_test.rb
+++ b/test/integration/user_test.rb
@@ -16,6 +16,32 @@ class UserIntegrationTest < IntegrationTestWithJavascript
     assert page.has_content? 'user12345'
   end
 
+  test "disable a user from index page" do
+    user = FactoryBot.create(:user, :with_mail)
+    visit users_path
+    within(:xpath, "//tr[contains(.,'#{user.login}')]") do
+      find("a.dropdown-toggle").click
+      click_link("Disable")
+    end
+    click_button("Confirm")
+
+    assert page.has_content?('Successfully updated'), "Expected success flash message"
+    assert user.reload.disabled?, "User should be disabled"
+  end
+
+  test "enable a disabled user from index page" do
+    user = FactoryBot.create(:user, :with_mail, :disabled => true)
+    visit users_path
+    within(:xpath, "//tr[contains(.,'#{user.login}')]") do
+      find("a.dropdown-toggle").click
+      click_link("Enable")
+    end
+    click_button("Confirm")
+
+    assert page.has_content?('Successfully updated'), "Expected success flash message"
+    refute user.reload.disabled?, "User should be enabled"
+  end
+
   context "without automatic login" do
     test "login" do
       login_user(users(:admin).login, "secret")


### PR DESCRIPTION
The users list now includes Enable/Disable actions for individual users so on does not have to edit the user to check/uncheck the checkbox.

<img width="2644" height="1492" alt="image" src="https://github.com/user-attachments/assets/595c568a-5b7d-40e7-9e11-fd7b2824acf9" />
