### PR TITLE
Fixes #39480 - CVE-2026-5135: Unauthorized modification of host configurations

### DIFF
--- a/app/models/concerns/host_common.rb
+++ b/app/models/concerns/host_common.rb
@@ -54,7 +54,8 @@ module HostCommon
           lookup_value = lookup_values.to_a.find { |i| i.id.to_i == id.to_i }
           if lookup_value
             mark_for_destruction = Foreman::Cast.to_bool(attr.delete(:_destroy))
-            lookup_value.attributes = attr
+            attr.delete(:match)
+            lookup_value.attributes = attr.merge(:host_or_hostgroup => self)
             lookup_value.mark_for_destruction if mark_for_destruction
           end
         elsif !Foreman::Cast.to_bool(attr.delete(:_destroy))

--- a/test/models/host_lookup_value_access_control_test.rb
+++ b/test/models/host_lookup_value_access_control_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class HostLookupValueAccessControlTest < ActiveSupport::TestCase
+  test 'nested lookup_values_attributes cannot retarget existing override match to another host' do
+    host_source = FactoryBot.create(:host)
+    host_destination = FactoryBot.create(:host)
+    source_match = host_source.lookup_value_match
+    destination_match = host_destination.lookup_value_match
+
+    refute_equal source_match, destination_match, 'fixture hosts must resolve to different fqdn matchers'
+
+    lkey = FactoryBot.create(:lookup_key, :integer, override: true, path: 'fqdn')
+
+    as_admin do
+      assert_difference('LookupValue.count', 1) do
+        assert host_source.update!(
+          lookup_values_attributes: { '0' => { lookup_key_id: lkey.id, value: 111 } }
+        )
+      end
+
+      lvalue = host_source.lookup_values.first
+      assert_equal source_match, lvalue.match
+
+      assert host_source.update!(
+        lookup_values_attributes: {
+          '0' => {
+            id: lvalue.id,
+            match: destination_match,
+            value: 999,
+          },
+        }
+      )
+    end
+
+    lvalue = host_source.lookup_values.first.reload
+    assert_equal source_match, lvalue.match,
+      'nested host update cannot retarget lookup value match to another host - broken access control'
+    assert_equal 999, lvalue.value
+  end
+end


### PR DESCRIPTION
## CVE-2026-5135

Unauthorized modification of host configurations via broken access control.

When lookup values are submitted as nested attributes during host or hostgroup updates, the match field is permitted and applied without ownership validation. A user with host-edit rights can retarget an existing lookup value override to point at a different host, injecting configuration values into hosts they are not authorized to edit.

- CVSS: 6.5 (Moderate)
- Redmine: https://projects.theforeman.org/issues/39480