### PR TITLE
Fixes #39481 - CVE-2026-5138: Information disclosure via nested request parameters

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -373,8 +373,8 @@ class ApplicationController < ActionController::Base
 
   def taxonomy_scope
     if params[controller_name.singularize.to_sym]
-      @organization = Organization.find_by_id(params[controller_name.singularize.to_sym][:organization_id])
-      @location     = Location.find_by_id(params[controller_name.singularize.to_sym][:location_id])
+      @organization = find_user_taxonomy(Organization, params[controller_name.singularize.to_sym][:organization_id])
+      @location     = find_user_taxonomy(Location, params[controller_name.singularize.to_sym][:location_id])
     end
 
     if instance_variable_get("@#{controller_name}").present?
@@ -382,11 +382,18 @@ class ApplicationController < ActionController::Base
       @location     ||= instance_variable_get("@#{controller_name}").location
     end
 
-    @organization ||= Organization.find_by_id(params[:organization_id]) if params[:organization_id]
-    @location     ||= Location.find_by_id(params[:location_id])         if params[:location_id]
+    @organization ||= find_user_taxonomy(Organization, params[:organization_id])
+    @location     ||= find_user_taxonomy(Location, params[:location_id])
 
     @organization ||= Organization.current
     @location     ||= Location.current
+  end
+
+  def find_user_taxonomy(taxonomy_class, id)
+    return if id.blank? || User.current.nil?
+
+    user_taxonomies = User.current.public_send("my_#{taxonomy_class.to_s.underscore.pluralize}")
+    user_taxonomies.find_by(:id => id)
   end
 
   def parameter_filter_context

--- a/app/controllers/concerns/foreman/controller/host_form_common.rb
+++ b/app/controllers/concerns/foreman/controller/host_form_common.rb
@@ -33,8 +33,8 @@ module Foreman::Controller::HostFormCommon
 
   def taxonomy_scope
     if params[:host]
-      @organization = Organization.find_by_id(params[:host][:organization_id])
-      @location = Location.find_by_id(params[:host][:location_id])
+      @organization = find_user_taxonomy(Organization, params[:host][:organization_id])
+      @location     = find_user_taxonomy(Location, params[:host][:location_id])
     end
 
     if @host
@@ -42,8 +42,8 @@ module Foreman::Controller::HostFormCommon
       @location     ||= @host.location
     end
 
-    @organization ||= Organization.find_by_id(params[:organization_id]) if params[:organization_id]
-    @location     ||= Location.find_by_id(params[:location_id])         if params[:location_id]
+    @organization ||= find_user_taxonomy(Organization, params[:organization_id])
+    @location     ||= find_user_taxonomy(Location, params[:location_id])
 
     @organization ||= Organization.current
     @location     ||= Location.current

--- a/test/controllers/hostgroups_controller_test.rb
+++ b/test/controllers/hostgroups_controller_test.rb
@@ -145,6 +145,29 @@ class HostgroupsControllerTest < ActionController::TestCase
     assert_empty JSON.parse(response.body)
   end
 
+  test "domain_selected json must not allow nested organization outside user taxonomies" do
+    org1 = taxonomies(:organization1)
+    org2 = taxonomies(:organization2)
+    loc1 = taxonomies(:location1)
+    subnet_name = "foreign_subnet_taxonomy_scope"
+    domain_id = as_admin do
+      domain = FactoryBot.create(:domain, organizations: [org2], locations: [loc1])
+      subnet = FactoryBot.create(:subnet_ipv4, name: subnet_name, organizations: [org2], locations: [loc1])
+      domain.subnets << subnet
+      domain.save!
+      domain.id
+    end
+    setup_user "edit", "hostgroups"
+    post :domain_selected, params: {
+      organization_id: org1.id,
+      hostgroup: { organization_id: org2.id },
+      domain_id: domain_id,
+      format: :json,
+    }, session: set_session_user(:one), xhr: true
+    assert_response :success
+    refute_includes JSON.parse(response.body).map { |row| row["name"] }, subnet_name
+  end
+
   test "architecture_selected should not fail when no architecture selected" do
     post :architecture_selected, params: { :id => hostgroups(:common), :hostgroup => { :architecture_id => nil }}, session: set_session_user
     assert_response :success


### PR DESCRIPTION
## CVE-2026-5138

Information disclosure via improper validation of nested request parameters.

The `taxonomy_scope` controller method loads organization and location IDs from nested request parameters without checking the user's taxonomy membership. An authenticated user with host-edit permissions can supply a foreign organization ID in nested parameters to scope AJAX queries to a tenant they do not belong to, leaking infrastructure metadata such as domains, subnets, and IP availability.

- CVSS: 4.3 (Moderate)
- Redmine: https://projects.theforeman.org/issues/39481