### PR TITLE
Pin Katello CI to KATELLO-4.21 on 3.19-stable

### DIFF
--- a/.github/workflows/foreman.yml
+++ b/.github/workflows/foreman.yml
@@ -148,6 +148,7 @@ jobs:
     with:
       plugin: katello
       plugin_repository: Katello/katello
+      plugin_version: KATELLO-4.21
       foreman_version: ${{ github.ref }}
 
   result:


### PR DESCRIPTION
Without `plugin_version`, the reusable workflow defaults to Katello `develop` which now requires Foreman 5.0+, causing all Katello CI jobs to fail with `PluginRequirementError`.