### PR TITLE
Fixes #39499 - pkg upgrade on debian should only upgrade a single pkg

### DIFF
--- a/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
+++ b/app/views/unattended/provisioning_templates/snippet/pkg_manager.erb
@@ -17,6 +17,7 @@ if [ "${NAME%.*}" = 'FreeBSD' ]; then
   PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
 elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
   PKG_MANAGER='dnf'
   if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -27,19 +28,27 @@ elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-
   PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  if [ "$PKG_MANAGER" = 'dnf' ]; then
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+  else
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+  fi
 elif [ -f /etc/debian_version ]; then
   PKG_MANAGER='apt-get'
   PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
 elif [ -f /etc/arch-release ]; then
   PKG_MANAGER='pacman'
   PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
 elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
   PKG_MANAGER='zypper'
   PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
 fi

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.debian4dhcp.snap.txt
@@ -44,6 +44,7 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
     elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
       PKG_MANAGER='dnf'
       if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -54,21 +55,29 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+      if [ "$PKG_MANAGER" = 'dnf' ]; then
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+      else
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+      fi
     elif [ -f /etc/debian_version ]; then
       PKG_MANAGER='apt-get'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
     elif [ -f /etc/arch-release ]; then
       PKG_MANAGER='pacman'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
     elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
       PKG_MANAGER='zypper'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
     fi
   fi
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.host4dhcp.snap.txt
@@ -53,6 +53,7 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
     elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
       PKG_MANAGER='dnf'
       if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -63,21 +64,29 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+      if [ "$PKG_MANAGER" = 'dnf' ]; then
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+      else
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+      fi
     elif [ -f /etc/debian_version ]; then
       PKG_MANAGER='apt-get'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
     elif [ -f /etc/arch-release ]; then
       PKG_MANAGER='pacman'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
     elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
       PKG_MANAGER='zypper'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
     fi
   fi
   
@@ -253,6 +262,7 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
     elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
       PKG_MANAGER='dnf'
       if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -263,21 +273,29 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+      if [ "$PKG_MANAGER" = 'dnf' ]; then
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+      else
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+      fi
     elif [ -f /etc/debian_version ]; then
       PKG_MANAGER='apt-get'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
     elif [ -f /etc/arch-release ]; then
       PKG_MANAGER='pacman'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
     elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
       PKG_MANAGER='zypper'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
     fi
   fi
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/cloud-init/CloudInit_default.ubuntu4dhcp.snap.txt
@@ -44,6 +44,7 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
     elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
       PKG_MANAGER='dnf'
       if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -54,21 +55,29 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+      if [ "$PKG_MANAGER" = 'dnf' ]; then
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+      else
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+      fi
     elif [ -f /etc/debian_version ]; then
       PKG_MANAGER='apt-get'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
     elif [ -f /etc/arch-release ]; then
       PKG_MANAGER='pacman'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
     elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
       PKG_MANAGER='zypper'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
     fi
   fi
   

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Agama_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Agama_default_finish.host4dhcp.snap.txt
@@ -15,6 +15,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -25,21 +26,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/FreeBSD_(mfsBSD)_finish.host4dhcp.snap.txt
@@ -70,6 +70,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -80,21 +81,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Kickstart_default_finish.host4dhcp.snap.txt
@@ -34,6 +34,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -44,21 +45,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -242,6 +251,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -252,21 +262,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.debian4dhcp.snap.txt
@@ -23,6 +23,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -33,21 +34,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/finish/Preseed_default_finish.ubuntu4dhcp.snap.txt
@@ -23,6 +23,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -33,21 +34,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Agama_sles_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Agama_sles_default.host4dhcp.snap.txt
@@ -165,6 +165,7 @@
                         PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
                         PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
                         PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+                        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
                       elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
                         PKG_MANAGER='dnf'
                         if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -175,21 +176,29 @@
                         PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
                         PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
                         PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+                        if [ "$PKG_MANAGER" = 'dnf' ]; then
+                          PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+                        else
+                          PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+                        fi
                       elif [ -f /etc/debian_version ]; then
                         PKG_MANAGER='apt-get'
                         PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
                         PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-                        PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+                        PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+                        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
                       elif [ -f /etc/arch-release ]; then
                         PKG_MANAGER='pacman'
                         PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
                         PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
                         PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+                        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
                       elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
                         PKG_MANAGER='zypper'
                         PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
                         PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
                         PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+                        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
                       fi
                     fi
                     

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_SLES_default.host4dhcp.snap.txt
@@ -105,6 +105,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -115,21 +116,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/AutoYaST_default.host4dhcp.snap.txt
@@ -108,6 +108,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -118,21 +119,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4and6dhcp.snap.txt
@@ -102,6 +102,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -112,21 +113,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -213,6 +222,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -223,21 +233,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4dhcp.snap.txt
@@ -102,6 +102,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -112,21 +113,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -309,6 +318,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -319,21 +329,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host4static.snap.txt
@@ -102,6 +102,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -112,21 +113,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -213,6 +222,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -223,21 +233,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6dhcp.snap.txt
@@ -102,6 +102,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -112,21 +113,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -213,6 +222,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -223,21 +233,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.host6static.snap.txt
@@ -102,6 +102,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -112,21 +113,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -213,6 +222,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -223,21 +233,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel10_dhcp.snap.txt
@@ -104,6 +104,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -114,21 +115,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rhel9_dhcp.snap.txt
@@ -104,6 +104,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -114,21 +115,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky10_dhcp.snap.txt
@@ -101,6 +101,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -111,21 +112,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -212,6 +221,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -222,21 +232,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky8_dhcp.snap.txt
@@ -100,6 +100,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -110,21 +111,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -211,6 +220,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -221,21 +231,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/provision/Kickstart_default.rocky9_dhcp.snap.txt
@@ -101,6 +101,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -111,21 +112,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -212,6 +221,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -222,21 +232,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/registration/Global_Registration.registration_template_default.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/registration/Global_Registration.registration_template_default.snap.txt
@@ -21,6 +21,7 @@ if [ "${NAME%.*}" = 'FreeBSD' ]; then
   PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
 elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
   PKG_MANAGER='dnf'
   if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -31,21 +32,29 @@ elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-
   PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+  if [ "$PKG_MANAGER" = 'dnf' ]; then
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+  else
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+  fi
 elif [ -f /etc/debian_version ]; then
   PKG_MANAGER='apt-get'
   PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+  PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
 elif [ -f /etc/arch-release ]; then
   PKG_MANAGER='pacman'
   PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
 elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
   PKG_MANAGER='zypper'
   PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
   PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
   PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+  PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
 fi
 
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/remote_execution_ssh_keys.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/snippet/remote_execution_ssh_keys.host4dhcp.snap.txt
@@ -10,6 +10,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -20,21 +21,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Agama_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Agama_default_user_data.host4dhcp.snap.txt
@@ -28,6 +28,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -38,21 +39,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/AutoYaST_default_user_data.host4dhcp.snap.txt
@@ -28,6 +28,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -38,21 +39,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Kickstart_default_user_data.host4dhcp.snap.txt
@@ -48,6 +48,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -58,21 +59,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 
@@ -256,6 +265,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -266,21 +276,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.debian4dhcp.snap.txt
@@ -31,6 +31,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -41,21 +42,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/Preseed_default_user_data.ubuntu4dhcp.snap.txt
@@ -31,6 +31,7 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
   elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
     PKG_MANAGER='dnf'
     if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -41,21 +42,29 @@ if [ -z "$PKG_MANAGER" ]; then
     PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+    if [ "$PKG_MANAGER" = 'dnf' ]; then
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+    else
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+    fi
   elif [ -f /etc/debian_version ]; then
     PKG_MANAGER='apt-get'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+    PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
   elif [ -f /etc/arch-release ]; then
     PKG_MANAGER='pacman'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
   elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
     PKG_MANAGER='zypper'
     PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
     PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
     PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+    PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
   fi
 fi
 

--- a/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
+++ b/test/unit/foreman/renderer/snapshots/ProvisioningTemplate/user_data/UserData_default.host4dhcp.snap.txt
@@ -34,6 +34,7 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} delete -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
     elif [ -f /etc/fedora-release -o -f /etc/redhat-release -o -f /etc/amazon-linux-release -o -f /etc/system-release ]; then
       PKG_MANAGER='dnf'
       if [ -f /etc/redhat-release -a "${VERSION_ID%.*}" -le 7 ]; then
@@ -44,21 +45,29 @@ runcmd:
       PKG_MANAGER_INSTALL="${PKG_MANAGER} install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} remove -y"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} upgrade -y"
+      if [ "$PKG_MANAGER" = 'dnf' ]; then
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} upgrade -y"
+      else
+        PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} update -y"
+      fi
     elif [ -f /etc/debian_version ]; then
       PKG_MANAGER='apt-get'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' install -y"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' remove -y"
-      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
+      PKG_MANAGER_UPGRADE="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' --only-upgrade install -y"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} -o 'Dpkg::Options::=--force-confdef' -o 'Dpkg::Options::=--force-confold' -o APT::Get::Upgrade-Allow-New='true' upgrade -y"
     elif [ -f /etc/arch-release ]; then
       PKG_MANAGER='pacman'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --noconfirm -S"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --noconfirm -R"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --noconfirm -S"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --noconfirm -Syu"
     elif [ x$ID = xopensuse-tumbleweed -o x$ID = xsles ]; then
       PKG_MANAGER='zypper'
       PKG_MANAGER_INSTALL="${PKG_MANAGER} --non-interactive install --auto-agree-with-licenses"
       PKG_MANAGER_REMOVE="${PKG_MANAGER} --non-interactive remove"
       PKG_MANAGER_UPGRADE="${PKG_MANAGER} --non-interactive update"
+      PKG_MANAGER_UPGRADE_ALL_PACKAGES="${PKG_MANAGER} --non-interactive update"
     fi
   fi
   


### PR DESCRIPTION
Additionally, I have added a routine which can be used to run package upgrade for all packages of a system.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
