### PR TITLE
Fixes #39520 - Remove deprecated compute_resource endpoints

### DIFF
--- a/app/controllers/api/v2/compute_resources_controller.rb
+++ b/app/controllers/api/v2/compute_resources_controller.rb
@@ -145,18 +145,11 @@ module Api
       end
 
       api :GET, "/compute_resources/:id/available_storage_domains", N_("List storage domains for a compute resource")
-      api :GET, "/compute_resources/:id/available_storage_domains/:storage_domain", N_("List attributes for a given storage domain"), deprecated: true
       api :GET, "/compute_resources/:id/available_clusters/:cluster_id/available_storage_domains", N_("List storage domains for a compute resource")
       param :id, :identifier, :required => true
       param :cluster_id, String
-      param :storage_domain, String, deprecated: true
       def available_storage_domains
-        if params[:storage_domain]
-          Foreman::Deprecation.api_deprecation_warning("use /compute_resources/:id/storage_domain/:storage_domain_id endpoind instead")
-          @available_storage_domains = [@compute_resource.storage_domain(params[:storage_domain])]
-        else
-          @available_storage_domains = @compute_resource.available_storage_domains(cluster_id)
-        end
+        @available_storage_domains = @compute_resource.available_storage_domains(cluster_id)
         @total = @available_storage_domains&.size
         render :available_storage_domains, :layout => 'api/v2/layouts/index_layout'
       end
@@ -169,18 +162,11 @@ module Api
       end
 
       api :GET, "/compute_resources/:id/available_storage_pods", N_("List storage pods for a compute resource")
-      api :GET, "/compute_resources/:id/available_storage_pods/:storage_pod", N_("List attributes for a given storage pod"), deprecated: true
       api :GET, "/compute_resources/:id/available_clusters/:cluster_id/available_storage_pods", N_("List storage pods for a compute resource")
       param :id, :identifier, :required => true
       param :cluster_id, String
-      param :storage_pod, String, deprecated: true
       def available_storage_pods
-        if params[:storage_pod]
-          Foreman::Deprecation.api_deprecation_warning("use /compute_resources/:id/storage_pod/:storage_pod_id endpoind instead")
-          @available_storage_pods = [@compute_resource.storage_pod(params[:storage_pod])]
-        else
-          @available_storage_pods = @compute_resource.available_storage_pods(cluster_id)
-        end
+        @available_storage_pods = @compute_resource.available_storage_pods(cluster_id)
         @total = @available_storage_pods&.size
         render :available_storage_pods, :layout => 'api/v2/layouts/index_layout'
       end

--- a/config/routes/api/v2.rb
+++ b/config/routes/api/v2.rb
@@ -260,11 +260,9 @@ Foreman::Application.routes.draw do
           get :available_security_groups, :on => :member
           get :available_storage_domains, :on => :member
           get 'storage_domains/(:storage_domain_id)', :to => 'compute_resources#storage_domain', :on => :member
-          get 'available_storage_domains/(:storage_domain)', :to => 'compute_resources#available_storage_domains', :on => :member
           get :available_storage_pods, :on => :member
           get 'storage_pods/(:storage_pod_id)', :to => 'compute_resources#storage_pod', :on => :member
           get 'available_virtual_machines/(:vm_id)', :to => 'compute_resources#show_vm', :on => :member, :vm_id => /[^\/]+/
-          get 'available_storage_pods/(:storage_pod)', :to => 'compute_resources#available_storage_pods', :on => :member
           get 'available_clusters/(:cluster_id)/available_networks', :to => 'compute_resources#available_networks', :on => :member, :cluster_id => /[^\/]+/
           get 'available_clusters/(:cluster_id)/available_resource_pools', :to => 'compute_resources#available_resource_pools', :on => :member, :cluster_id => /[^\/]+/
           get 'available_clusters/(:cluster_id)/available_storage_domains', :to => 'compute_resources#available_storage_domains', :on => :member, :cluster_id => /[^\/]+/

--- a/test/controllers/api/v2/compute_resources_controller_test.rb
+++ b/test/controllers/api/v2/compute_resources_controller_test.rb
@@ -275,19 +275,6 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     end
   end
 
-  test "should get specific vmware storage domain - the deprecated way" do
-    storage_domain = OpenStruct.new(id: 'my11-test35-uuid99', name: 'test_vmware_datastore')
-
-    Foreman::Model::Vmware.any_instance.expects(:storage_domain).with('test_vmware_datastore').returns(storage_domain)
-
-    Foreman::Deprecation.expects(:api_deprecation_warning)
-
-    get :available_storage_domains, params: { :id => compute_resources(:vmware).to_param, :storage_domain => 'test_vmware_datastore' }
-    assert_response :success
-    available_storage_domains = ActiveSupport::JSON.decode(@response.body)
-    assert_equal storage_domain.id, available_storage_domains['results'].first.try(:[], 'id')
-  end
-
   test "should get specific vmware storage domain" do
     storage_domain = OpenStruct.new(id: 'my11-test35-uuid99', name: 'test_vmware_datastore')
 
@@ -297,19 +284,6 @@ class Api::V2::ComputeResourcesControllerTest < ActionController::TestCase
     assert_response :success
     storage_domain_response = ActiveSupport::JSON.decode(@response.body)
     assert_equal storage_domain.id, storage_domain_response.try(:[], 'id')
-  end
-
-  test "should get specific vmware storage pod - the deprecated way" do
-    storage_pod = OpenStruct.new(id: 'group-p123456', name: 'test_vmware_pod')
-
-    Foreman::Model::Vmware.any_instance.expects(:storage_pod).with('test_vmware_pod').returns(storage_pod)
-
-    Foreman::Deprecation.expects(:api_deprecation_warning)
-
-    get :available_storage_pods, params: { :id => compute_resources(:vmware).to_param, :storage_pod => 'test_vmware_pod' }
-    assert_response :success
-    available_storage_pods = ActiveSupport::JSON.decode(@response.body)
-    assert_equal storage_pod.id, available_storage_pods['results'].first.try(:[], 'id')
   end
 
   test "should get specific vmware storage pod" do


### PR DESCRIPTION
I stumbled across that typo and actually was wondering if it is not time to remove that whole depreciation warning altogether :) 

I don't see the parameter in there and the warning has been around since 2019!
<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
