### PR TITLE
Fixes #39437 - Apply taxonomies to UI bulk actions - CP 3.19

### DIFF
--- a/app/controllers/api/v2/hosts_bulk_actions_controller.rb
+++ b/app/controllers/api/v2/hosts_bulk_actions_controller.rb
@@ -9,7 +9,6 @@ module Api
       before_action :validate_power_action, :only => [:change_power_state]
 
       def_param_group :bulk_host_ids do
-        param :organization_id, :number, :required => true, :desc => N_("ID of the organization")
         param :included, Hash, :desc => N_("Hosts to include in the action"), :required => true, :action_aware => true do
           param :search, String, :required => false, :desc => N_("Search string describing which hosts to perform the action on")
           param :ids, Array, :required => false, :desc => N_("List of host ids to perform the action on")

--- a/app/controllers/concerns/api/v2/bulk_hosts_extension.rb
+++ b/app/controllers/concerns/api/v2/bulk_hosts_extension.rb
@@ -1,9 +1,10 @@
 module Api::V2::BulkHostsExtension
   extend ActiveSupport::Concern
 
-  def bulk_hosts_relation(permission, org)
+  def bulk_hosts_relation(permission, org, location)
     relation = ::Host::Managed.authorized(permission)
     relation = relation.where(organization: org) if org
+    relation = relation.where(location: location) if location
     relation
   end
 
@@ -18,7 +19,8 @@ module Api::V2::BulkHostsExtension
     end
 
     find_organization
-    @hosts = bulk_hosts_relation(permission, @organization)
+    find_location
+    @hosts = bulk_hosts_relation(permission, @organization, @location)
 
     if bulk_params[:included][:ids].present?
       @hosts = @hosts.where(id: bulk_params[:included][:ids])
@@ -41,5 +43,9 @@ module Api::V2::BulkHostsExtension
 
   def find_organization
     @organization ||= Organization.find_by_id(params[:organization_id])
+  end
+
+  def find_location
+    @location ||= Location.find_by_id(params[:location_id])
   end
 end

--- a/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
+++ b/test/controllers/api/v2/hosts_bulk_actions_controller_test.rb
@@ -17,6 +17,7 @@ class Api::V2::HostsBulkActionsControllerTest < ActionController::TestCase
   def valid_bulk_params(host_ids = @host_ids)
     {
       :organization_id => @organization.id,
+      :location_id => @location.id,
       :included => {
         :ids => host_ids,
       },
@@ -105,6 +106,33 @@ class Api::V2::HostsBulkActionsControllerTest < ActionController::TestCase
       # Should use plural form "hosts"
       assert_match(/Updated hosts: changed owner/, response['message'])
     end
+  end
+
+  test "should scope searched hosts by organization and location" do
+    other_location = FactoryBot.create(:location)
+    other_host = FactoryBot.create(:host, :managed, :organization => @organization, :location => other_location)
+
+    put :change_owner, params: {
+      :organization_id => @organization.id,
+      :location_id => @location.id,
+      :included => {
+        :search => 'name ~ *',
+      },
+      :excluded => {
+        :ids => [],
+      },
+      :owner_id => @user.id_and_type,
+    }
+
+    assert_response :success
+
+    [@host1, @host2, @host3].each do |host|
+      host.reload
+      assert_equal @user.id_and_type, host.is_owned_by
+    end
+
+    other_host.reload
+    refute_equal @user.id_and_type, other_host.is_owned_by
   end
 
   context "change_power_state" do

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/__tests__/bulkDelete.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/__tests__/bulkDelete.test.js
@@ -37,12 +37,16 @@ describe('bulkDeleteHosts', () => {
   });
 
   const bulkParams = 'id ^ (1,2,3)';
+  const organizationId = 1;
+  const locationId = 2;
   const selectedCount = 3;
   const destroyVmOnHostDelete = true;
 
   it('dispatches openConfirmModal with correct parameters', () => {
     bulkDeleteHosts({
       bulkParams,
+      organizationId,
+      locationId,
       selectedCount,
       destroyVmOnHostDelete,
     })(dispatch);
@@ -61,6 +65,8 @@ describe('bulkDeleteHosts', () => {
     it('calls visit with /new/hosts when onDeleteSuccess is not provided', () => {
       bulkDeleteHosts({
         bulkParams,
+        organizationId,
+        locationId,
         selectedCount,
         destroyVmOnHostDelete,
       })(dispatch);
@@ -70,8 +76,16 @@ describe('bulkDeleteHosts', () => {
 
       expect(APIActions.delete).toHaveBeenCalledTimes(1);
       const deleteParams = APIActions.delete.mock.calls[0][0];
+      const requestUrl = new URL(deleteParams.url, 'https://example.test');
 
-      expect(deleteParams.url).toBe(`/api/v2/hosts/bulk?search=${bulkParams}`);
+      expect(requestUrl.pathname).toBe('/api/v2/hosts/bulk');
+      expect(requestUrl.searchParams.get('search')).toBe(bulkParams);
+      expect(requestUrl.searchParams.get('organization_id')).toBe(
+        String(organizationId)
+      );
+      expect(requestUrl.searchParams.get('location_id')).toBe(
+        String(locationId)
+      );
       expect(deleteParams.key).toBe('BULK-HOSTS-DELETE');
       expect(typeof deleteParams.successToast).toBe('function');
       expect(typeof deleteParams.errorToast).toBe('function');
@@ -86,6 +100,8 @@ describe('bulkDeleteHosts', () => {
 
       bulkDeleteHosts({
         bulkParams,
+        organizationId,
+        locationId,
         selectedCount,
         destroyVmOnHostDelete,
         onDeleteSuccess,
@@ -106,6 +122,8 @@ describe('bulkDeleteHosts', () => {
     it('returns formatted success message with host count', () => {
       bulkDeleteHosts({
         bulkParams,
+        organizationId,
+        locationId,
         selectedCount,
         destroyVmOnHostDelete,
       })(dispatch);
@@ -124,6 +142,8 @@ describe('bulkDeleteHosts', () => {
     it('returns error message from response', () => {
       bulkDeleteHosts({
         bulkParams,
+        organizationId,
+        locationId,
         selectedCount,
         destroyVmOnHostDelete,
       })(dispatch);

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/BulkAssignTaxonomyModal.js
@@ -38,6 +38,7 @@ import {
   API_REQUEST_KEY,
 } from '../../../../routes/Hosts/constants';
 import TaxonomySelect from './TaxonomySelect';
+import { buildBulkRequestBody } from '../helpers';
 
 export const BulkAssignOrganizationModal = props => (
   <BulkAssignTaxonomyModal modalType={MODAL_TYPES.ORGANIZATION} {...props} />
@@ -52,6 +53,8 @@ const BulkAssignTaxonomyModal = ({
   selectAllHostsMode,
   selectedCount,
   fetchBulkParams,
+  organizationId,
+  locationId,
   modalType,
 }) => {
   const org = modalType === MODAL_TYPES.ORGANIZATION;
@@ -136,13 +139,13 @@ const BulkAssignTaxonomyModal = ({
   };
 
   const handleSave = () => {
-    const requestBody = {
-      included: {
-        search: fetchBulkParams(),
-      },
+    const requestBody = buildBulkRequestBody({
+      fetchBulkParams,
+      organizationId,
+      locationId,
       id: taxId,
       mismatch_setting: fixRadioChecked,
-    };
+    });
 
     org
       ? dispatch(
@@ -243,10 +246,14 @@ BulkAssignTaxonomyModal.propTypes = {
   selectedCount: PropTypes.number.isRequired,
   selectAllHostsMode: PropTypes.bool.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
+  organizationId: PropTypes.number,
+  locationId: PropTypes.number,
   modalType: PropTypes.string.isRequired,
 };
 
 BulkAssignTaxonomyModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
+  organizationId: undefined,
+  locationId: undefined,
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/assignTaxonomy/index.js
@@ -7,15 +7,21 @@ import {
 } from './BulkAssignTaxonomyModal';
 
 export const BulkAssignOrganizationModalScene = ({ isOpen, closeModal }) => {
-  const { selectAllHostsMode, selectedCount, fetchBulkParams } = useContext(
-    ForemanActionsBarContext
-  );
+  const {
+    selectAllHostsMode,
+    selectedCount,
+    fetchBulkParams,
+    organizationId,
+    locationId,
+  } = useContext(ForemanActionsBarContext);
   return (
     <BulkAssignOrganizationModal
       key="bulk-assign-organization-modal"
       selectAllHostsMode={selectAllHostsMode}
       selectedCount={selectedCount}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />
@@ -23,15 +29,21 @@ export const BulkAssignOrganizationModalScene = ({ isOpen, closeModal }) => {
 };
 
 export const BulkAssignLocationModalScene = ({ isOpen, closeModal }) => {
-  const { selectAllHostsMode, selectedCount, fetchBulkParams } = useContext(
-    ForemanActionsBarContext
-  );
+  const {
+    selectAllHostsMode,
+    selectedCount,
+    fetchBulkParams,
+    organizationId,
+    locationId,
+  } = useContext(ForemanActionsBarContext);
   return (
     <BulkAssignLocationModal
       key="bulk-assign-location-modal"
       selectAllHostsMode={selectAllHostsMode}
       selectedCount={selectedCount}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/BulkBuildHostModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/BulkBuildHostModal.js
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { addToast } from '../../../ToastsList/slice';
 import { translate as __ } from '../../../../common/I18n';
-import { failedHostsToastParams } from '../helpers';
+import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 import { STATUS } from '../../../../constants';
 import { selectAPIStatus } from '../../../../redux/API/APISelectors';
 import { bulkBuildHosts, HOST_BUILD_KEY } from './actions';
@@ -22,6 +22,8 @@ const BulkBuildHostModal = ({
   closeModal,
   selectedCount,
   fetchBulkParams,
+  organizationId,
+  locationId,
 }) => {
   const dispatch = useDispatch();
   const [buildRadioChecked, setBuildRadioChecked] = useState(true);
@@ -44,13 +46,13 @@ const BulkBuildHostModal = ({
     );
   };
   const handleSave = () => {
-    const requestBody = {
-      included: {
-        search: fetchBulkParams(),
-      },
+    const requestBody = buildBulkRequestBody({
+      fetchBulkParams,
+      organizationId,
+      locationId,
       reboot: rebootChecked,
       rebuild_configuration: !buildRadioChecked,
-    };
+    });
 
     dispatch(bulkBuildHosts(requestBody, handleModalClose, handleError));
   };
@@ -156,11 +158,15 @@ BulkBuildHostModal.propTypes = {
   closeModal: PropTypes.func,
   selectedCount: PropTypes.number.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
+  organizationId: PropTypes.number,
+  locationId: PropTypes.number,
 };
 
 BulkBuildHostModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
+  organizationId: undefined,
+  locationId: undefined,
 };
 
 export default BulkBuildHostModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/buildHosts/index.js
@@ -4,14 +4,19 @@ import { ForemanActionsBarContext } from '../../../../components/HostDetails/Act
 import BulkBuildHostModal from './BulkBuildHostModal';
 
 const BulkBuildHostModalScene = ({ isOpen, closeModal }) => {
-  const { selectedCount, fetchBulkParams } = useContext(
-    ForemanActionsBarContext
-  );
+  const {
+    selectedCount,
+    fetchBulkParams,
+    organizationId,
+    locationId,
+  } = useContext(ForemanActionsBarContext);
   return (
     <BulkBuildHostModal
       key="bulk-build-hosts-modal"
       selectedCount={selectedCount}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDelete.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/bulkDelete.js
@@ -4,17 +4,24 @@ import { visit, foremanUrl } from '../../../common/helpers';
 import { sprintf, translate as __ } from '../../../common/I18n';
 import { openConfirmModal } from '../../ConfirmModal';
 import { APIActions } from '../../../redux/API';
+import { bulkActionTaxonomyParams } from './helpers';
 import './bulkDeleteModal.scss';
 
 export const bulkDeleteHosts = ({
   bulkParams,
+  organizationId,
+  locationId,
   selectedCount,
   destroyVmOnHostDelete,
   onDeleteSuccess,
 }) => dispatch => {
   const successToast = () => sprintf(__('%s hosts deleted'), selectedCount);
   const errorToast = ({ message }) => message;
-  const url = foremanUrl(`/api/v2/hosts/bulk?search=${bulkParams}`);
+  const queryParams = new URLSearchParams({
+    search: bulkParams,
+    ...bulkActionTaxonomyParams({ organizationId, locationId }),
+  });
+  const url = foremanUrl(`/api/v2/hosts/bulk?${queryParams.toString()}`);
 
   // TODO: Replace with a checkbox instead of a global setting for cascade host destroy
   const cascadeMessage = () =>

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/BulkChangeOwnerModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/BulkChangeOwnerModal.js
@@ -34,7 +34,7 @@ import {
   HOSTS_API_PATH,
   API_REQUEST_KEY,
 } from '../../../../routes/Hosts/constants';
-import { failedHostsToastParams } from '../helpers';
+import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 
 const BulkChangeOwnerModal = ({
   isOpen,
@@ -42,6 +42,8 @@ const BulkChangeOwnerModal = ({
   selectAllHostsMode,
   selectedCount,
   fetchBulkParams,
+  organizationId,
+  locationId,
 }) => {
   const dispatch = useDispatch();
   const [ownerId, setOwnerId] = useState('');
@@ -131,12 +133,12 @@ const BulkChangeOwnerModal = ({
   };
 
   const handleConfirm = () => {
-    const requestBody = {
-      included: {
-        search: fetchBulkParams(),
-      },
+    const requestBody = buildBulkRequestBody({
+      fetchBulkParams,
+      organizationId,
+      locationId,
       owner_id: ownerId,
-    };
+    });
 
     dispatch(bulkChangeOwner(requestBody, handleSuccess, handleError));
   };
@@ -250,11 +252,15 @@ BulkChangeOwnerModal.propTypes = {
   fetchBulkParams: PropTypes.func.isRequired,
   selectedCount: PropTypes.number.isRequired,
   selectAllHostsMode: PropTypes.bool.isRequired,
+  organizationId: PropTypes.number,
+  locationId: PropTypes.number,
 };
 
 BulkChangeOwnerModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
+  organizationId: undefined,
+  locationId: undefined,
 };
 
 export default BulkChangeOwnerModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/changeOwner/index.js
@@ -9,6 +9,8 @@ const BulkChangeOwnerModalScene = ({ isOpen, closeModal }) => {
     selectedCount,
     selectedResults,
     fetchBulkParams,
+    organizationId,
+    locationId,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkChangeOwnerModal
@@ -17,6 +19,8 @@ const BulkChangeOwnerModalScene = ({ isOpen, closeModal }) => {
       selectedCount={selectedCount}
       selectedResults={selectedResults}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/BulkDisassociateModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/BulkDisassociateModal.js
@@ -18,7 +18,7 @@ import {
   HOSTS_API_PATH,
   API_REQUEST_KEY,
 } from '../../../../routes/Hosts/constants';
-import { failedHostsToastParams } from '../helpers';
+import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 
 const BulkDisassociateModal = ({
   isOpen,
@@ -27,6 +27,8 @@ const BulkDisassociateModal = ({
   selectedCount,
   selectedResults,
   fetchBulkParams,
+  organizationId,
+  locationId,
 }) => {
   const dispatch = useDispatch();
   const hostsWithComputeResource = selectedResults?.filter(
@@ -91,11 +93,12 @@ const BulkDisassociateModal = ({
     const queryString = selectedResultsEmpty
       ? fetchBulkParams()
       : `id ^ (${hostsWithComputeResource.map(h => h.id).join(',')})`;
-    const requestBody = {
-      included: {
-        search: queryString,
-      },
-    };
+    const requestBody = buildBulkRequestBody({
+      fetchBulkParams,
+      organizationId,
+      locationId,
+      includedSearch: queryString,
+    });
 
     dispatch(bulkDisassociate(requestBody, handleSuccess, handleError));
   };
@@ -188,12 +191,16 @@ BulkDisassociateModal.propTypes = {
   fetchBulkParams: PropTypes.func.isRequired,
   selectedCount: PropTypes.number.isRequired,
   selectAllHostsMode: PropTypes.bool.isRequired,
+  organizationId: PropTypes.number,
+  locationId: PropTypes.number,
 };
 
 BulkDisassociateModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
   selectedResults: [],
+  organizationId: undefined,
+  locationId: undefined,
 };
 
 export default BulkDisassociateModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/disassociate/index.js
@@ -9,6 +9,8 @@ const BulkDisassociateModalScene = ({ isOpen, closeModal }) => {
     selectedCount,
     selectedResults,
     fetchBulkParams,
+    organizationId,
+    locationId,
   } = useContext(ForemanActionsBarContext);
   return (
     <BulkDisassociateModal
@@ -17,6 +19,8 @@ const BulkDisassociateModalScene = ({ isOpen, closeModal }) => {
       selectedCount={selectedCount}
       selectedResults={selectedResults}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/helpers.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/helpers.js
@@ -8,6 +8,28 @@ export const searchLink = ({ query, message, baseUrl }) => ({
   href: urlWithSearch(baseUrl, query),
 });
 
+export const bulkActionTaxonomyParams = ({
+  organizationId,
+  locationId,
+} = {}) => ({
+  ...(organizationId != null ? { organization_id: organizationId } : {}),
+  ...(locationId != null ? { location_id: locationId } : {}),
+});
+
+export const buildBulkRequestBody = ({
+  fetchBulkParams,
+  organizationId,
+  locationId,
+  includedSearch,
+  ...params
+}) => ({
+  included: {
+    search: includedSearch || fetchBulkParams(),
+  },
+  ...bulkActionTaxonomyParams({ organizationId, locationId }),
+  ...params,
+});
+
 export const failedHostsToastParams = ({
   message,
   failed_host_ids: failedHostIds,

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/BulkPowerStateModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/BulkPowerStateModal.js
@@ -19,7 +19,7 @@ import './BulkPowerStateModal.scss';
 import { HostsPowerRefreshContext } from '../../HostsPowerRefreshContext';
 import { POWER_STATES, BULK_POWER_STATE_KEY } from './constants';
 import { bulkChangePowerState } from './actions';
-import { failedHostsToastParams } from '../helpers';
+import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 import { addToast } from '../../../ToastsList/slice';
 import {
   HOSTS_API_PATH,
@@ -31,6 +31,8 @@ import { APIActions } from '../../../../redux/API';
 const BulkPowerStateModal = ({
   selectedHostsCount,
   fetchBulkParams,
+  organizationId,
+  locationId,
   isOpen,
   closeModal,
 }) => {
@@ -102,12 +104,12 @@ const BulkPowerStateModal = ({
 
   const handleSubmit = () => {
     setIsLoading(true);
-    const payload = {
-      included: {
-        search: fetchBulkParams(),
-      },
+    const payload = buildBulkRequestBody({
+      fetchBulkParams,
+      organizationId,
+      locationId,
       power: selectedPowerState,
-    };
+    });
     dispatch(bulkChangePowerState(payload, handleSuccess, handleError));
   };
 
@@ -206,12 +208,16 @@ const BulkPowerStateModal = ({
 BulkPowerStateModal.propTypes = {
   selectedHostsCount: PropTypes.number,
   fetchBulkParams: PropTypes.func.isRequired,
+  organizationId: PropTypes.number,
+  locationId: PropTypes.number,
   isOpen: PropTypes.bool,
   closeModal: PropTypes.func,
 };
 
 BulkPowerStateModal.defaultProps = {
   selectedHostsCount: 0,
+  organizationId: undefined,
+  locationId: undefined,
   isOpen: false,
   closeModal: () => {},
 };

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/powerState/index.js
@@ -4,13 +4,18 @@ import { ForemanActionsBarContext } from '../../../../components/HostDetails/Act
 import BulkPowerStateModal from './BulkPowerStateModal';
 
 const BulkPowerStateModalScene = ({ isOpen, closeModal }) => {
-  const { fetchBulkParams, selectedCount = 0 } = useContext(
-    ForemanActionsBarContext
-  );
+  const {
+    fetchBulkParams,
+    selectedCount = 0,
+    organizationId,
+    locationId,
+  } = useContext(ForemanActionsBarContext);
   return (
     <BulkPowerStateModal
       selectedHostsCount={selectedCount}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/BulkReassignHostgroupModal.js
@@ -11,7 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { addToast } from '../../../ToastsList/slice';
 import { translate as __ } from '../../../../common/I18n';
-import { failedHostsToastParams } from '../helpers';
+import { buildBulkRequestBody, failedHostsToastParams } from '../helpers';
 import { STATUS } from '../../../../constants';
 import {
   selectAPIStatus,
@@ -77,6 +77,8 @@ const BulkReassignHostgroupModal = ({
   closeModal,
   selectedCount,
   fetchBulkParams,
+  organizationId,
+  locationId,
 }) => {
   const dispatch = useDispatch();
   const [hostgroupId, setHostgroupId] = useState('');
@@ -151,12 +153,12 @@ const BulkReassignHostgroupModal = ({
     handleModalClose();
   };
   const handleSave = () => {
-    const requestBody = {
-      included: {
-        search: fetchBulkParams(),
-      },
+    const requestBody = buildBulkRequestBody({
+      fetchBulkParams,
+      organizationId,
+      locationId,
       hostgroup_id: hostgroupId,
-    };
+    });
 
     dispatch(bulkReassignHostgroups(requestBody, handleSuccess, handleError));
   };
@@ -285,11 +287,15 @@ BulkReassignHostgroupModal.propTypes = {
   closeModal: PropTypes.func,
   selectedCount: PropTypes.number.isRequired,
   fetchBulkParams: PropTypes.func.isRequired,
+  organizationId: PropTypes.number,
+  locationId: PropTypes.number,
 };
 
 BulkReassignHostgroupModal.defaultProps = {
   isOpen: false,
   closeModal: () => {},
+  organizationId: undefined,
+  locationId: undefined,
 };
 
 export default BulkReassignHostgroupModal;

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/BulkActions/reassignHostGroup/index.js
@@ -4,14 +4,19 @@ import { ForemanActionsBarContext } from '../../../../components/HostDetails/Act
 import BulkReassignHostgroupModal from './BulkReassignHostgroupModal';
 
 const BulkReassignHostgroupModalScene = ({ isOpen, closeModal }) => {
-  const { selectedCount, fetchBulkParams } = useContext(
-    ForemanActionsBarContext
-  );
+  const {
+    selectedCount,
+    fetchBulkParams,
+    organizationId,
+    locationId,
+  } = useContext(ForemanActionsBarContext);
   return (
     <BulkReassignHostgroupModal
       key="bulk-reassign-hg-modal"
       selectedCount={selectedCount}
       fetchBulkParams={fetchBulkParams}
+      organizationId={organizationId}
+      locationId={locationId}
       isOpen={isOpen}
       closeModal={closeModal}
     />

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.js
@@ -45,6 +45,8 @@ import {
   useForemanSettings,
   useForemanHostsPageUrl,
   useForemanContext,
+  useForemanOrganization,
+  useForemanLocation,
 } from '../../Root/Context/ForemanContext';
 import { bulkDeleteHosts } from './BulkActions/bulkDelete';
 import {
@@ -104,6 +106,8 @@ const HostsIndex = () => {
     syncWithOptions: true,
   });
   const contextData = useForemanContext();
+  const currentOrganization = useForemanOrganization();
+  const currentLocation = useForemanLocation();
 
   const {
     response: {
@@ -225,6 +229,8 @@ const HostsIndex = () => {
     dispatch(
       bulkDeleteHosts({
         bulkParams,
+        organizationId: currentOrganization?.id,
+        locationId: currentLocation?.id,
         selectedCount,
         destroyVmOnHostDelete,
         onDeleteSuccess: () => {
@@ -574,6 +580,8 @@ const HostsIndex = () => {
             selectedCount,
             selectedResults,
             fetchBulkParams,
+            organizationId: currentOrganization?.id,
+            locationId: currentLocation?.id,
           }}
         >
           <BulkAssignOrganizationModal

--- a/webpack/assets/javascripts/react_app/components/HostsIndex/index.test.js
+++ b/webpack/assets/javascripts/react_app/components/HostsIndex/index.test.js
@@ -85,6 +85,8 @@ jest.mock('../../Root/Context/ForemanContext', () => ({
   })),
   useForemanHostsPageUrl: jest.fn(() => '/hosts'),
   useForemanContext: jest.fn(() => ({})),
+  useForemanOrganization: jest.fn(() => undefined),
+  useForemanLocation: jest.fn(() => undefined),
 }));
 
 jest.mock('../common/Slot', () => ({


### PR DESCRIPTION
Before this patch, the Foreman UI did not send any information about taxonomies on the 'All Hosts' page for bulk actions. This could cause bulk actions to be applied to different hosts than the ones that were actually selected in the UI because the session in the backend would calculate the hosts independent from UI input.

Assisted-by: OpenAI Codex
(cherry picked from commit 34ee2c5b7d1810ced6607b14bd37d3d02b12a87d)


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
