### PR TITLE
Fixes #39521 - Add parameter to use redhat_register snippet for all R…

### DIFF
--- a/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
+++ b/app/views/unattended/provisioning_templates/provision/kickstart_default.erb
@@ -53,6 +53,7 @@ description: |
   - use_graphical_installer: boolean (default=false)
   - enable-remote-execution-pull: boolean (default=false)
   - additional-packages: string (default=undef)
+  - use-redhat-register-snippet: boolean (default=false)
 
   Reference links:
   - https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/installation_guide/s1-kickstart2-options
@@ -74,7 +75,7 @@ description: |
   use_ntp = host_param_true?('use-ntp')
   iface = @host.provision_interface
   appstream_present = false
-  use_rhsm = (@host.operatingsystem.name == 'RedHat' || @host.operatingsystem.name == 'RHEL') && os_major >= 9
+  use_rhsm = host_param_false?('use-redhat-register-snippet', false) && (@host.operatingsystem.name == 'RedHat' || @host.operatingsystem.name == 'RHEL') && os_major >= 9
 -%>
 # This kickstart file was rendered from the Foreman provisioning template "<%= @template_name %>".
 # for <%= @host %> running <%= @host.operatingsystem.name %> <%= os_major %> <%= @arch %>


### PR DESCRIPTION
…HEL hosts

We found that many users prefer to use the `redhat_register` snippet rather than using the `kickstart_rhsm` snippet and change their templates accordingly. This patch add a host parameter
'use-redhat-register-snippet' to control whether the 'kickstart_rhsm' or the 'redhat_register' snippet should be used. If the parameter is not set, the 'kickstart_rhsm' snippet is used by default.


<!---

Thank you for contributing to The Foreman, please read the
[following guide](https://www.theforeman.org/contribute.html), in short:

* [Create an issue](https://projects.theforeman.org/projects/foreman/issues)
* Reference the issue via `Fixes #1234` in the commit message
* Prefer present-tense, imperative-style commit messages
* Mark all strings for translation, see [1]
* Suggest prerequisites for testing and testing scenarios following example above.
* Prepend `[WIP]` for work in progress to prevent bots from triggering actions
* Be patient, we will do our best to take a look as soon as we can
* Explain the purpose of the PR, attach screenshots if applicable
* List all prerequisites for testing (e.g. VMware cluster, two smart proxies...)
* Reviewers often use extensive list of items to check, have a look prior submitting [2]
* Be nice and respectful

1: https://projects.theforeman.org/projects/foreman/wiki/Translating#Translating-for-developers
2: https://github.com/theforeman/foreman/blob/develop/developer_docs/pr_review.asciidoc
-->
