### PR TITLE
Fixes #39523 - Fix React tables toolbar alignment

### DIFF
--- a/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
+++ b/webpack/assets/javascripts/react_app/components/PF4/TableIndexPage/TableIndexPage.js
@@ -222,12 +222,19 @@ const TableIndexPage = ({
   ].filter(item => item);
 
   const customToolbar = (
-    <Toolbar ouiaId="page-toolbar" className="page-toolbar">
+    <Toolbar
+      ouiaId="page-toolbar"
+      className="page-toolbar"
+      id="page-layout-toolbar"
+    >
       <ToolbarContent>
         {searchable && (
-          <ToolbarGroup className="toolbar-group-search" variant="filter-group">
+          <ToolbarGroup
+            className="page-layout-toolbar-group-search"
+            variant="filter-group"
+          >
             {selectionToolbar}
-            <ToolbarItem className="toolbar-search">
+            <ToolbarItem id="page-layout-toolbar-search">
               <SearchBar
                 data={searchProps}
                 initialQuery=""
@@ -237,7 +244,7 @@ const TableIndexPage = ({
               />
             </ToolbarItem>
             {status === STATUS.PENDING && (
-              <ToolbarItem>
+              <ToolbarItem id="toolbar-spinner">
                 <Spinner size="sm" />
               </ToolbarItem>
             )}

--- a/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
+++ b/webpack/assets/javascripts/react_app/routes/common/PageLayout/PageLayout.js
@@ -81,7 +81,11 @@ const PageLayout = ({
           variant={PageSectionVariants.light}
         >
           {customToolbar || (
-            <Toolbar ouiaId="page-toolbar" id="page-layout-toolbar">
+            <Toolbar
+              ouiaId="page-toolbar"
+              className="page-toolbar"
+              id="page-layout-toolbar"
+            >
               <ToolbarContent>
                 <ToolbarGroup
                   className="page-layout-toolbar-group-search"


### PR DESCRIPTION
Adjusting the class names and ids in table index page, to match the page layout component.

after 
<img width="945" height="133" alt="image" src="https://github.com/user-attachments/assets/8a770159-edd7-454c-aaa7-f6e16d77cb04" />
before
<img width="1062" height="136" alt="image" src="https://github.com/user-attachments/assets/b4de793a-573c-42b9-be7f-5257efec3a57" />
